### PR TITLE
chore: prefix crate names with ethrex-

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-consensus = { path = "./crates/consensus" }
-core = { path = "./crates/core" }
-evm = { path = "./crates/evm" }
-net = { path = "./crates/net" }
-rpc = { path = "./crates/rpc" }
-storage = { path = "./crates/storage" }
+ethrex-consensus = { path = "./crates/consensus" }
+ethrex-core = { path = "./crates/core" }
+ethrex-evm = { path = "./crates/evm" }
+ethrex-net = { path = "./crates/net" }
+ethrex-rpc = { path = "./crates/rpc" }
+ethrex-storage = { path = "./crates/storage" }
 
 tracing = "0.1"
 tracing-subscriber = "0.3.0"
-serde = {version = "1.0.203", features = ["derive"]}
+serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 libmdbx = { version = "0.5.0", features = ["orm"] }
 tokio = { version = "1.38.0", features = ["full"] }

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "consensus"
+name = "ethrex-consensus"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "core"
+name = "ethrex-core"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "evm"
+name = "ethrex-evm"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "net"
+name = "ethrex-net"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rpc"
+name = "ethrex-rpc"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "storage"
+name = "ethrex-storage"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-core.workspace = true
+ethrex-core.workspace = true
 
 libmdbx.workspace = true
 anyhow = "1.0.86"

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -6,7 +6,7 @@ use account::{
     AccountStorageValueRLP, AddressRLP,
 };
 use block::{BlockBodyRLP, BlockHeaderRLP};
-use core::types::BlockNumber;
+use ethrex_core::types::BlockNumber;
 use libmdbx::{
     dupsort,
     orm::{table, Database},

--- a/ethrex/Cargo.toml
+++ b/ethrex/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rpc.workspace = true
-core.workspace = true
-net.workspace = true
+ethrex-rpc.workspace = true
+ethrex-core.workspace = true
+ethrex-net.workspace = true
 
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/ethrex/src/main.rs
+++ b/ethrex/src/main.rs
@@ -1,4 +1,4 @@
-use core::types::Genesis;
+use ethrex_core::types::Genesis;
 use std::{
     io::{self, BufReader},
     net::{SocketAddr, ToSocketAddrs},
@@ -57,8 +57,8 @@ async fn main() {
 
     let _genesis = read_genesis_file(genesis_file_path);
 
-    let rpc_api = rpc::start_api(http_socket_addr, authrpc_socket_addr);
-    let networking = net::start_network(udp_socket_addr, tcp_socket_addr);
+    let rpc_api = ethrex_rpc::start_api(http_socket_addr, authrpc_socket_addr);
+    let networking = ethrex_net::start_network(udp_socket_addr, tcp_socket_addr);
 
     join!(rpc_api, networking);
 }


### PR DESCRIPTION
**Motivation**

Having a crate named `core` requires us to either rename it on each import or rename Rust's `core` crate.

**Description**

This PR prefixes each crate name with `ethrex-` to avoid any name collisions.
