### PR TITLE
refactor: change `RLPEncode` impls to use `structs::Encoder`

### DIFF
--- a/crates/core/src/types/account.rs
+++ b/crates/core/src/types/account.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use ethereum_types::{H256, U256};
 
-use crate::rlp::encode::RLPEncode;
+use crate::rlp::{encode::RLPEncode, structs::Encoder};
 
 use super::GenesisAccount;
 
@@ -42,9 +42,11 @@ fn code_hash(code: &Bytes) -> H256 {
 
 impl RLPEncode for AccountInfo {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.code_hash.encode(buf);
-        self.balance.encode(buf);
-        self.nonce.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.code_hash)
+            .encode_field(&self.balance)
+            .encode_field(&self.nonce)
+            .finish();
     }
 }
 

--- a/crates/core/src/types/block.rs
+++ b/crates/core/src/types/block.rs
@@ -1,4 +1,7 @@
-use crate::{rlp::encode::RLPEncode, Address, H256, U256};
+use crate::{
+    rlp::{encode::RLPEncode, structs::Encoder},
+    Address, H256, U256,
+};
 use bytes::Bytes;
 
 pub type BlockNumber = u64;
@@ -31,26 +34,28 @@ pub struct BlockHeader {
 
 impl RLPEncode for BlockHeader {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.parent_hash.encode(buf);
-        self.ommers_hash.encode(buf);
-        self.coinbase.encode(buf);
-        self.state_root.encode(buf);
-        self.transactions_root.encode(buf);
-        self.receipt_root.encode(buf);
-        self.logs_bloom.encode(buf);
-        self.difficulty.encode(buf);
-        self.number.encode(buf);
-        self.gas_limit.encode(buf);
-        self.gas_used.encode(buf);
-        self.timestamp.encode(buf);
-        self.extra_data.encode(buf);
-        self.prev_randao.encode(buf);
-        self.nonce.encode(buf);
-        self.base_fee_per_gas.encode(buf);
-        self.withdrawals_root.encode(buf);
-        self.blob_gas_used.encode(buf);
-        self.excess_blob_gas.encode(buf);
-        self.parent_beacon_block_root.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.parent_hash)
+            .encode_field(&self.ommers_hash)
+            .encode_field(&self.coinbase)
+            .encode_field(&self.state_root)
+            .encode_field(&self.transactions_root)
+            .encode_field(&self.receipt_root)
+            .encode_field(&self.logs_bloom)
+            .encode_field(&self.difficulty)
+            .encode_field(&self.number)
+            .encode_field(&self.gas_limit)
+            .encode_field(&self.gas_used)
+            .encode_field(&self.timestamp)
+            .encode_field(&self.extra_data)
+            .encode_field(&self.prev_randao)
+            .encode_field(&self.nonce)
+            .encode_field(&self.base_fee_per_gas)
+            .encode_field(&self.withdrawals_root)
+            .encode_field(&self.blob_gas_used)
+            .encode_field(&self.excess_blob_gas)
+            .encode_field(&self.parent_beacon_block_root)
+            .finish();
     }
 }
 
@@ -64,9 +69,11 @@ pub struct Body {
 
 impl RLPEncode for Body {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.transactions.encode(buf);
-        self.ommers.encode(buf);
-        self.withdrawals.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.transactions)
+            .encode_field(&self.ommers)
+            .encode_field(&self.withdrawals)
+            .finish();
     }
 }
 
@@ -80,10 +87,12 @@ pub struct Withdrawal {
 
 impl RLPEncode for Withdrawal {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.index.encode(buf);
-        self.validator_index.encode(buf);
-        self.address.encode(buf);
-        self.amount.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.index)
+            .encode_field(&self.validator_index)
+            .encode_field(&self.address)
+            .encode_field(&self.amount)
+            .finish();
     }
 }
 
@@ -117,15 +126,17 @@ pub struct LegacyTransaction {
 
 impl RLPEncode for LegacyTransaction {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.nonce.encode(buf);
-        self.gas_price.encode(buf);
-        self.gas.encode(buf);
-        self.to.encode(buf);
-        self.value.encode(buf);
-        self.data.encode(buf);
-        self.v.encode(buf);
-        self.r.encode(buf);
-        self.s.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.nonce)
+            .encode_field(&self.gas_price)
+            .encode_field(&self.gas)
+            .encode_field(&self.to)
+            .encode_field(&self.value)
+            .encode_field(&self.data)
+            .encode_field(&self.v)
+            .encode_field(&self.r)
+            .encode_field(&self.s)
+            .finish();
     }
 }
 
@@ -147,17 +158,19 @@ pub struct EIP1559Transaction {
 
 impl RLPEncode for EIP1559Transaction {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.chain_id.encode(buf);
-        self.signer_nonce.encode(buf);
-        self.max_priority_fee_per_gas.encode(buf);
-        self.max_fee_per_gas.encode(buf);
-        self.gas_limit.encode(buf);
-        self.destination.encode(buf);
-        self.amount.encode(buf);
-        self.payload.encode(buf);
-        self.access_list.encode(buf);
-        self.signature_y_parity.encode(buf);
-        self.signature_r.encode(buf);
-        self.signature_s.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.chain_id)
+            .encode_field(&self.signer_nonce)
+            .encode_field(&self.max_priority_fee_per_gas)
+            .encode_field(&self.max_fee_per_gas)
+            .encode_field(&self.gas_limit)
+            .encode_field(&self.destination)
+            .encode_field(&self.amount)
+            .encode_field(&self.payload)
+            .encode_field(&self.access_list)
+            .encode_field(&self.signature_y_parity)
+            .encode_field(&self.signature_r)
+            .encode_field(&self.signature_s)
+            .finish();
     }
 }

--- a/crates/core/src/types/receipt.rs
+++ b/crates/core/src/types/receipt.rs
@@ -1,4 +1,4 @@
-use crate::rlp::encode::RLPEncode;
+use crate::rlp::{encode::RLPEncode, structs::Encoder};
 use crate::types::Bloom;
 use bytes::Bytes;
 use ethereum_types::{Address, H256};
@@ -15,10 +15,12 @@ pub struct Receipt {
 
 impl RLPEncode for Receipt {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.succeeded.encode(buf);
-        self.cumulative_gas_used.encode(buf);
-        self.bloom.encode(buf);
-        self.logs.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.succeeded)
+            .encode_field(&self.cumulative_gas_used)
+            .encode_field(&self.bloom)
+            .encode_field(&self.logs)
+            .finish();
     }
 }
 
@@ -32,8 +34,10 @@ pub struct Log {
 
 impl RLPEncode for Log {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        self.address.encode(buf);
-        self.topics.encode(buf);
-        self.data.encode(buf);
+        Encoder::new(buf)
+            .encode_field(&self.address)
+            .encode_field(&self.topics)
+            .encode_field(&self.data)
+            .finish();
     }
 }


### PR DESCRIPTION
**Motivation**

That will make the code easier to understand, and also fixes some of the impls, which weren't prepending the size header to the encoding.

**Description**

Change each `RLPEncode` trait in `crates/core/types` to use `structs::Encoder`

Closes #101 

