### PR TITLE
fix: make bootnodes optional

### DIFF
--- a/ethrex/src/cli.rs
+++ b/ethrex/src/cli.rs
@@ -70,7 +70,6 @@ pub fn cli() -> Command {
         .arg(
             Arg::new("bootnodes")
                 .long("bootnodes")
-                .default_value("")
                 .value_name("BOOTNODE_LIST")
                 .value_delimiter(',')
                 .num_args(1..)

--- a/ethrex/src/main.rs
+++ b/ethrex/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use tokio::try_join;
 
-use tracing::Level;
+use tracing::{warn, Level};
 use tracing_subscriber::FmtSubscriber;
 mod cli;
 
@@ -51,15 +51,14 @@ async fn main() {
         .get_one::<String>("network")
         .expect("network is required");
 
-    let bootnode_list: Vec<_> = matches
-        .get_many::<String>("bootnodes")
-        .expect("bootnodes is required")
-        .collect();
+    let bootnodes: Vec<&BootNode> = matches
+        .get_many("bootnodes")
+        .map(Iterator::collect)
+        .unwrap_or_default();
 
-    let _bootnodes: Vec<BootNode> = bootnode_list
-        .iter()
-        .map(|s| BootNode::from_str(s).expect("Failed to parse bootnodes"))
-        .collect();
+    if bootnodes.is_empty() {
+        warn!("No bootnodes specified. This node will not be able to connect to the network.");
+    }
 
     let http_socket_addr =
         parse_socket_addr(http_addr, http_port).expect("Failed to parse http address and port");


### PR DESCRIPTION
**Motivation**

When running the node without specifying bootnodes, we fail because of deserialization errors. This PR fixes that.


