### PR TITLE
feat: implement `FindNodeMessage` decoding

### DIFF
--- a/crates/net/src/discv4.rs
+++ b/crates/net/src/discv4.rs
@@ -85,7 +85,10 @@ impl Message {
                 let (find_node_msg, _rest) = FindNodeMessage::decode_unfinished(msg)?;
                 Ok(Message::FindNode(find_node_msg))
             }
-            _ => todo!(),
+            0x04 => todo!(),
+            0x05 => todo!(),
+            0x06 => todo!(),
+            _ => Err(RLPDecodeError::MalformedData),
         }
     }
 


### PR DESCRIPTION
**Motivation**

Have some functionality of the discv4 protocol

**Description**

Enables RLP decoding for `FindNodeMessage`

Closes #83 

