### PR TITLE
chore(l2): replace solidity custom errors with `require()`

### DIFF
--- a/crates/l2/contracts/src/l1/CommonBridge.sol
+++ b/crates/l2/contracts/src/l1/CommonBridge.sol
@@ -55,9 +55,8 @@ contract CommonBridge is ICommonBridge, Ownable, ReentrancyGuard {
 
     /// @inheritdoc ICommonBridge
     function deposit(address to) public payable {
-        if (msg.value == 0) {
-            revert AmountToDepositIsZero();
-        }
+        require(msg.value > 0, "CommonBridge: amount to deposit is zero");
+
         // TODO: Build the tx.
         bytes32 l2MintTxHash = keccak256(abi.encodePacked("dummyl2MintTxHash"));
         emit DepositInitiated(msg.value, to, l2MintTxHash);

--- a/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
+++ b/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
@@ -41,9 +41,6 @@ interface ICommonBridge {
         uint256 indexed claimedAmount
     );
 
-    /// @notice Error for when the deposit amount is 0.
-    error AmountToDepositIsZero();
-
     /// @notice Initializes the contract.
     /// @dev This method is called only once after the contract is deployed.
     /// @dev It sets the OnChainProposer address.


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
It's easier to parse a string error rather than have the function selector for all posible custom errors.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Replace `AmountToDepositIsZero` custom error with a `require()`

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #999 

