### PR TITLE
fix(l2): continue if address is not present when creating ExecutionDB

### DIFF
--- a/crates/l2/prover/tests/perf_zkvm.rs
+++ b/crates/l2/prover/tests/perf_zkvm.rs
@@ -11,7 +11,7 @@ use ethereum_rust_vm::execution_db::ExecutionDB;
 async fn test_performance_zkvm() {
     tracing_subscriber::fmt::init();
 
-    let mut path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../test_data"));
+    let path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../test_data"));
 
     // Another use is genesis-execution-api.json in conjunction with chain.rlp(20 blocks not too loaded).
     let genesis_file_path = path.join("genesis-l2-old.json");

--- a/crates/vm/execution_db.rs
+++ b/crates/vm/execution_db.rs
@@ -72,12 +72,13 @@ impl ExecutionDB {
 
         for account_update in account_updates.iter() {
             let address = RevmAddress::from_slice(account_update.address.as_bytes());
-            let account_state = store
-                .get_account_state_by_hash(
-                    block.header.parent_hash,
-                    H160::from_slice(address.as_slice()),
-                )?
-                .ok_or(ExecutionDBError::NewMissingAccountInfo(address))?;
+            let account_state = match store.get_account_state_by_hash(
+                block.header.parent_hash,
+                H160::from_slice(address.as_slice()),
+            )? {
+                Some(state) => state,
+                None => continue,
+            };
             accounts.insert(address, account_state);
 
             let account_storage = account_update


### PR DESCRIPTION
**Motivation**

We were having this problem:
```
WARN ethereum_rust_l2::proposer::prover_server: Failed to handle request: ProverServer failed to create inputs for the Prover: Execution DB error: Missing account 0xB9e9A3651E41eDB1AceE24f58d743616dc8351c8 info while trying to create ExecutionDB
```

It was caused by sending a transaction to an account that isn't present in the genesis file.
When constructing the ExecutionDB we are using the state of the `block's parent`, this state doesn't have the account stored. 

**Description**

If we don't raise an error if the account is not present, we fix this problem.

