### PR TITLE
feat(l1): c-kzg feature

### DIFF
--- a/.github/workflows/l2_prover_ci.yaml
+++ b/.github/workflows/l2_prover_ci.yaml
@@ -1,13 +1,8 @@
 name: L2 Prover CI
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - "crates/l2/prover/**"
+  merge_group:
   pull_request:
     branches: ["**"]
-    paths:
-      - "crates/l2/prover/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -27,10 +27,11 @@ hex = "0.4.3"
 path = "./blockchain.rs"
 
 [features]
-default = ["libmdbx"]
+default = ["libmdbx", "c-kzg"]
 libmdbx = [
     "ethereum_rust-core/libmdbx",
     "ethereum_rust-storage/default",
     "ethereum_rust-vm/libmdbx",
 ]
 levm = ["ethereum_rust-vm/levm"]
+c-kzg =["ethereum_rust-core/c-kzg"]

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -18,13 +18,13 @@ use ethereum_rust_core::{
 use ethereum_rust_storage::{error::StoreError, Store};
 
 /// Add a blob transaction and its blobs bundle to the mempool
+#[cfg(feature = "c-kzg")] // WARN: if c-kzg is disabled, then there's no blob bundle validation
 pub fn add_blob_transaction(
     transaction: EIP4844Transaction,
     blobs_bundle: BlobsBundle,
     store: Store,
 ) -> Result<H256, MempoolError> {
     // Validate blobs bundle
-    #[cfg(feature = "c-kzg")] // WARN: if c-kzg is disabled, then there's no blob bundle validation
     blobs_bundle.validate(&transaction)?;
 
     // Validate transaction

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -24,6 +24,7 @@ pub fn add_blob_transaction(
     store: Store,
 ) -> Result<H256, MempoolError> {
     // Validate blobs bundle
+    #[cfg(feature = "c-kzg")]
     blobs_bundle.validate(&transaction)?;
 
     // Validate transaction

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -18,7 +18,7 @@ use ethereum_rust_core::{
 use ethereum_rust_storage::{error::StoreError, Store};
 
 /// Add a blob transaction and its blobs bundle to the mempool
-#[cfg(feature = "c-kzg")] // WARN: if c-kzg is disabled, then there's no blob bundle validation
+#[cfg(feature = "c-kzg")]
 pub fn add_blob_transaction(
     transaction: EIP4844Transaction,
     blobs_bundle: BlobsBundle,

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -24,7 +24,7 @@ pub fn add_blob_transaction(
     store: Store,
 ) -> Result<H256, MempoolError> {
     // Validate blobs bundle
-    #[cfg(feature = "c-kzg")]
+    #[cfg(feature = "c-kzg")] // WARN: if c-kzg is disabled, then there's no blob bundle validation
     blobs_bundle.validate(&transaction)?;
 
     // Validate transaction

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 k256.workspace = true
 # TODO(#1102): Move to Lambdaworks in the future
-c-kzg = "^1.0.3"
+c-kzg = { version = "^1.0.3", optional = true }
 keccak-hash = "0.10.0"
 sha3.workspace = true
 secp256k1.workspace = true
@@ -30,8 +30,9 @@ lazy_static.workspace = true
 hex-literal.workspace = true
 
 [features]
-default = ["libmdbx"]
+default = ["libmdbx", "c-kzg"]
 libmdbx = ["ethereum_rust-trie/libmdbx"]
+c-kzg = ["dep:c-kzg"]
 
 [lib]
 path = "./core.rs"

--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "c-kzg")]
 use lazy_static::lazy_static;
 use std::ops::AddAssign;
 
@@ -6,7 +7,10 @@ use crate::{
     types::{constants::VERSIONED_HASH_VERSION_KZG, transaction::EIP4844Transaction},
     Bytes, H256,
 };
+
+#[cfg(feature = "c-kzg")]
 use c_kzg::{ethereum_kzg_settings, KzgCommitment, KzgProof, KzgSettings};
+
 use ethereum_rust_rlp::{
     decode::RLPDecode,
     encode::RLPEncode,
@@ -22,6 +26,7 @@ pub type Blob = [u8; BYTES_PER_BLOB];
 pub type Commitment = Bytes48;
 pub type Proof = Bytes48;
 
+#[cfg(feature = "c-kzg")]
 lazy_static! {
     static ref KZG_SETTINGS: &'static KzgSettings = ethereum_kzg_settings();
 }
@@ -65,6 +70,7 @@ fn kzg_commitment_to_versioned_hash(data: &Commitment) -> H256 {
     versioned_hash.into()
 }
 
+#[cfg(feature = "c-kzg")]
 fn blob_to_kzg_commitment_and_proof(blob: &Blob) -> Result<(Commitment, Proof), BlobsBundleError> {
     let blob: c_kzg::Blob = (*blob).into();
 
@@ -81,6 +87,7 @@ fn blob_to_kzg_commitment_and_proof(blob: &Blob) -> Result<(Commitment, Proof), 
     Ok((commitment_bytes.into_inner(), proof_bytes.into_inner()))
 }
 
+#[cfg(feature = "c-kzg")]
 fn verify_blob_kzg_proof(
     blob: Blob,
     commitment: Commitment,
@@ -96,6 +103,7 @@ fn verify_blob_kzg_proof(
 
 impl BlobsBundle {
     // In the future we might want to provide a new method that calculates the commitments and proofs using the following.
+    #[cfg(feature = "c-kzg")]
     pub fn create_from_blobs(blobs: &Vec<Blob>) -> Result<Self, BlobsBundleError> {
         let mut commitments = Vec::new();
         let mut proofs = Vec::new();
@@ -121,6 +129,7 @@ impl BlobsBundle {
             .collect()
     }
 
+    #[cfg(feature = "c-kzg")]
     pub fn validate(&self, tx: &EIP4844Transaction) -> Result<(), BlobsBundleError> {
         let blob_count = self.blobs.len();
 


### PR DESCRIPTION
**Motivation**

The crate `c-kzg` is used as a dependency for the `core` crate, which is a dep. of the zkVM execution program. Currently this crate does not compile for the risc0 target, so this was breaking the prover.

**Description**

- add a `c-kzg` feature to optionally compile the dependency and all the logic that makes use of it
- re-enable the test and make it run on merge group
