### PR TITLE
feat(l1): add basic hive report in rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "cmd/ef_tests/ethrex",
     "cmd/ef_tests/levm",
     "cmd/ethrex_l2",
+    "cmd/hive_report",
     "crates/vm/levm",
     "crates/vm/levm/bench/revm_comparison",
     "crates/l2/",
@@ -22,11 +23,7 @@ members = [
 ]
 resolver = "2"
 
-default-members = [
-    "cmd/ethrex",
-    "cmd/ethrex_l2",
-    "crates/l2/prover",
-]
+default-members = ["cmd/ethrex", "cmd/ethrex_l2", "crates/l2/prover"]
 
 [workspace.package]
 version = "0.1.0"

--- a/cmd/hive_report/Cargo.toml
+++ b/cmd/hive_report/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hive_report"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+serde_json.workspace = true
+serde.workspace = true

--- a/cmd/hive_report/src/main.rs
+++ b/cmd/hive_report/src/main.rs
@@ -1,0 +1,69 @@
+use serde::Deserialize;
+use std::fs::{self, File};
+use std::io::BufReader;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestCase {
+    summary_result: SummaryResult,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SummaryResult {
+    pass: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonFile {
+    name: String,
+    test_cases: std::collections::HashMap<String, TestCase>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut results = Vec::new();
+
+    for entry in fs::read_dir("hive/workspace/logs")? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_file()
+            && path.extension().and_then(|s| s.to_str()) == Some("json")
+            && path.file_name().and_then(|s| s.to_str()) != Some("hive.json")
+        {
+            let file_name = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .expect("Path should be a valid string");
+            let file = File::open(&path)?;
+            let reader = BufReader::new(file);
+
+            let json_data: JsonFile = match serde_json::from_reader(reader) {
+                Ok(data) => data,
+                Err(_) => {
+                    eprintln!("Error processing file: {}", file_name);
+                    continue;
+                }
+            };
+
+            let total_tests = json_data.test_cases.len();
+            let passed_tests = json_data
+                .test_cases
+                .values()
+                .filter(|test_case| test_case.summary_result.pass)
+                .count();
+
+            results.push((json_data.name, passed_tests, total_tests));
+        }
+    }
+
+    // Sort by file name.
+    results.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (file_name, passed, total) in results {
+        println!("{}: {}/{}", file_name, passed, total);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This reads the json files that hive outputs and shows how many tests passed for each simulator. Simply run with `cargo run -p hive_report`

Example report:

```
consensus: 59/65
engine-api: 1/129
engine-auth: 8/8
engine-cancun: 83/153
engine-exchange-capabilities: 5/5
engine-withdrawals: 1/36
```