### PR TITLE
feat(l1): make the hive report run daily

### DIFF
--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Run Hive Simulation
         run: make run-hive-on-latest SIMULATION=ethereum/engine
+        continue-on-error: true
 
       - name: Caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -1,9 +1,10 @@
-name: Weekly Hive Coverage
+name: Daily Hive Coverage
 
 on:
   schedule:
     # Every Friday at midnight
-    - cron: '0 0 * * 5'
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 env:
   RUST_VERSION: 1.80.1
@@ -41,3 +42,9 @@ jobs:
 
       - name: Run Hive Simulation
         run: make run-hive-on-latest SIMULATION=ethereum/engine
+
+      - name: Caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate the hive report
+        run: cargo run -p hive_report

--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -2,7 +2,7 @@ name: Daily Hive Coverage
 
 on:
   schedule:
-    # Every Friday at midnight
+    # Every day at UTC midnight
     - cron: '0 0 * * *'
   workflow_dispatch:
 


### PR DESCRIPTION
Changes:

- The action should now run daily instead of weekly.
- The action should be executable manually. We may remove this after testing.
- The action now includes the report output.
- The report runs even if the simulation fails.