### PR TITLE
feat(levm): ensure returned errors are correct

### DIFF
--- a/cmd/ef_tests/levm/deserialize.rs
+++ b/cmd/ef_tests/levm/deserialize.rs
@@ -16,7 +16,7 @@ where
 
     if let Some(value) = option {
         let exceptions = value
-            .split('|') 
+            .split('|')
             .map(|s| match s.trim() {
                 "TransactionException.INITCODE_SIZE_EXCEEDED" => {
                     TransactionExpectedException::InitcodeSizeExceeded

--- a/cmd/ef_tests/levm/deserialize.rs
+++ b/cmd/ef_tests/levm/deserialize.rs
@@ -1,10 +1,76 @@
-use crate::types::EFTest;
+use crate::types::{EFTest, TransactionExpectedException};
 use bytes::Bytes;
 use ethrex_core::U256;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::{collections::HashMap, str::FromStr};
 
 use crate::types::{EFTestRawTransaction, EFTestTransaction};
+
+pub fn deserialize_transaction_expected_exception<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<TransactionExpectedException>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let option: Option<String> = Option::deserialize(deserializer)?;
+
+    if let Some(value) = option {
+        let exceptions = value
+            .split('|') 
+            .map(|s| match s.trim() {
+                "TransactionException.INITCODE_SIZE_EXCEEDED" => {
+                    TransactionExpectedException::InitcodeSizeExceeded
+                }
+                "TransactionException.NONCE_IS_MAX" => TransactionExpectedException::NonceIsMax,
+                "TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED" => {
+                    TransactionExpectedException::Type3TxBlobCountExceeded
+                }
+                "TransactionException.TYPE_3_TX_ZERO_BLOBS" => {
+                    TransactionExpectedException::Type3TxZeroBlobs
+                }
+                "TransactionException.TYPE_3_TX_CONTRACT_CREATION" => {
+                    TransactionExpectedException::Type3TxContractCreation
+                }
+                "TransactionException.TYPE_3_TX_INVALID_BLOB_VERSIONED_HASH" => {
+                    TransactionExpectedException::Type3TxInvalidBlobVersionedHash
+                }
+                "TransactionException.INTRINSIC_GAS_TOO_LOW" => {
+                    TransactionExpectedException::IntrinsicGasTooLow
+                }
+                "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" => {
+                    TransactionExpectedException::InsufficientAccountFunds
+                }
+                "TransactionException.SENDER_NOT_EOA" => TransactionExpectedException::SenderNotEoa,
+                "TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS" => {
+                    TransactionExpectedException::PriorityGreaterThanMaxFeePerGas
+                }
+                "TransactionException.GAS_ALLOWANCE_EXCEEDED" => {
+                    TransactionExpectedException::GasAllowanceExceeded
+                }
+                "TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS" => {
+                    TransactionExpectedException::InsufficientMaxFeePerGas
+                }
+                "TransactionException.RLP_INVALID_VALUE" => {
+                    TransactionExpectedException::RlpInvalidValue
+                }
+                "TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW" => {
+                    TransactionExpectedException::GasLimitPriceProductOverflow
+                }
+                "TransactionException.TYPE_3_TX_PRE_FORK" => {
+                    TransactionExpectedException::Type3TxPreFork
+                }
+                "TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS" => {
+                    TransactionExpectedException::InsufficientMaxFeePerBlobGas
+                }
+                other => panic!("Unexpected error type: {}", other), // Should not fail, TODO is to return an error
+            })
+            .collect();
+
+        Ok(Some(exceptions))
+    } else {
+        Ok(None)
+    }
+}
 
 pub fn deserialize_ef_post_value_indexes<'de, D>(
     deserializer: D,

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -242,6 +242,7 @@ fn get_post_value(test: &EFTest, tx_id: usize) -> Option<EFTestPostValue> {
     }
 }
 
+// Exceptions not covered: RlpInvalidValue and Type3TxPreFork
 fn exception_is_expected(
     expected_exceptions: Vec<TransactionExpectedException>,
     returned_error: VMError,
@@ -273,6 +274,24 @@ fn exception_is_expected(
             ) | (
                 TransactionExpectedException::GasAllowanceExceeded,
                 VMError::GasAllowanceExceeded
+            ) | (
+                TransactionExpectedException::Type3TxBlobCountExceeded,
+                VMError::Type3TxBlobCountExceeded
+            ) | (
+                TransactionExpectedException::Type3TxZeroBlobs,
+                VMError::Type3TxZeroBlobs
+            ) | (
+                TransactionExpectedException::Type3TxContractCreation,
+                VMError::Type3TxContractCreation
+            ) | (
+                TransactionExpectedException::Type3TxInvalidBlobVersionedHash,
+                VMError::Type3TxInvalidBlobVersionedHash
+            ) | (
+                TransactionExpectedException::InsufficientMaxFeePerBlobGas,
+                VMError::InsufficientMaxFeePerBlobGas
+            ) | (
+                TransactionExpectedException::InitcodeSizeExceeded,
+                VMError::InitcodeSizeExceeded
             )
         ) {
             return true;

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -247,53 +247,38 @@ fn exception_is_expected(
     returned_error: VMError,
 ) -> bool {
     for expected_exception in expected_exceptions {
-        match expected_exception {
-            // Returned OutOfGas(MaxGasLimitExceeded) but expected IntrinsicGasTooLow
-            TransactionExpectedException::IntrinsicGasTooLow => {
-                if returned_error == VMError::IntrinsicGasTooLow {
-                    return true;
-                }
-            }
-            TransactionExpectedException::InsufficientAccountFunds => {
-                if returned_error == VMError::InsufficientAccountFunds {
-                    return true;
-                }
-            }
-            TransactionExpectedException::PriorityGreaterThanMaxFeePerGas => {
-                if returned_error == VMError::PriorityGreaterThanMaxFeePerGas {
-                    return true;
-                }
-            }
-            TransactionExpectedException::GasLimitPriceProductOverflow => {
-                if returned_error == VMError::GasLimitPriceProductOverflow {
-                    return true;
-                }
-            }
-            TransactionExpectedException::SenderNotEoa => {
-                if returned_error == VMError::SenderNotEOA {
-                    return true;
-                }
-            }
-            TransactionExpectedException::InsufficientMaxFeePerGas => {
-                if returned_error == VMError::InsufficientMaxFeePerGas {
-                    return true;
-                }
-            }
-            TransactionExpectedException::NonceIsMax => {
-                if returned_error == VMError::NonceIsMax {
-                    return true;
-                }
-            }
-            TransactionExpectedException::GasAllowanceExceeded => {
-                if returned_error == VMError::GasAllowanceExceeded {
-                    return true;
-                }
-            }
-            _ => {
-                return false;
-            }
+        if matches!(
+            (expected_exception, &returned_error),
+            (
+                TransactionExpectedException::IntrinsicGasTooLow,
+                VMError::IntrinsicGasTooLow
+            ) | (
+                TransactionExpectedException::InsufficientAccountFunds,
+                VMError::InsufficientAccountFunds
+            ) | (
+                TransactionExpectedException::PriorityGreaterThanMaxFeePerGas,
+                VMError::PriorityGreaterThanMaxFeePerGas
+            ) | (
+                TransactionExpectedException::GasLimitPriceProductOverflow,
+                VMError::GasLimitPriceProductOverflow
+            ) | (
+                TransactionExpectedException::SenderNotEoa,
+                VMError::SenderNotEOA
+            ) | (
+                TransactionExpectedException::InsufficientMaxFeePerGas,
+                VMError::InsufficientMaxFeePerGas
+            ) | (
+                TransactionExpectedException::NonceIsMax,
+                VMError::NonceIsMax
+            ) | (
+                TransactionExpectedException::GasAllowanceExceeded,
+                VMError::GasAllowanceExceeded
+            )
+        ) {
+            return true;
         }
     }
+
     false
 }
 

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -244,8 +244,23 @@ pub fn ensure_post_state(
         Ok(execution_report) => {
             match post_value.clone().map(|v| v.clone().expect_exception) {
                 // Execution result was successful but an exception was expected.
-                Some(Some(expected_exception)) => {
-                    let error_reason = format!("Expected exception: {expected_exception}");
+                Some(Some(expected_exceptions)) => {
+                    let error_reason = match expected_exceptions.get(1) {
+                        Some(second_exception) => {
+                            format!(
+                                "Expected exception: {:?} or {:?}",
+                                expected_exceptions.first().unwrap(),
+                                second_exception
+                            )
+                        }
+                        None => {
+                            format!(
+                                "Expected exception: {:?}",
+                                expected_exceptions.first().unwrap()
+                            )
+                        }
+                    };
+
                     return Err(format!("Post-state condition failed: {error_reason}").into());
                 }
                 // Execution result was successful and no exception was expected.

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -76,7 +76,7 @@ pub fn run_ef_test_tx(
     let mut evm = prepare_vm_for_tx(tx_id, test)?;
     ensure_pre_state(&evm, test)?;
     let execution_result = evm.transact();
-    // ensure_post_state(execution_result, test, report, tx_id)?;
+    ensure_post_state(execution_result, test, report, tx_id)?;
     Ok(())
 }
 
@@ -246,6 +246,54 @@ fn exception_is_expected(
     expected_exceptions: Vec<TransactionExpectedException>,
     returned_error: VMError,
 ) -> bool {
+    for expected_exception in expected_exceptions {
+        match expected_exception {
+            // Returned OutOfGas(MaxGasLimitExceeded) but expected IntrinsicGasTooLow
+            TransactionExpectedException::IntrinsicGasTooLow => {
+                if returned_error == VMError::IntrinsicGasTooLow {
+                    return true;
+                }
+            }
+            TransactionExpectedException::InsufficientAccountFunds => {
+                if returned_error == VMError::InsufficientAccountFunds {
+                    return true;
+                }
+            }
+            TransactionExpectedException::PriorityGreaterThanMaxFeePerGas => {
+                if returned_error == VMError::PriorityGreaterThanMaxFeePerGas {
+                    return true;
+                }
+            }
+            TransactionExpectedException::GasLimitPriceProductOverflow => {
+                if returned_error == VMError::GasLimitPriceProductOverflow {
+                    return true;
+                }
+            }
+            TransactionExpectedException::SenderNotEoa => {
+                if returned_error == VMError::SenderNotEOA {
+                    return true;
+                }
+            }
+            TransactionExpectedException::InsufficientMaxFeePerGas => {
+                if returned_error == VMError::InsufficientMaxFeePerGas {
+                    return true;
+                }
+            }
+            TransactionExpectedException::NonceIsMax => {
+                if returned_error == VMError::NonceIsMax {
+                    return true;
+                }
+            }
+            TransactionExpectedException::GasAllowanceExceeded => {
+                if returned_error == VMError::GasAllowanceExceeded {
+                    return true;
+                }
+            }
+            _ => {
+                return false;
+            }
+        }
+    }
     false
 }
 

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -247,9 +247,9 @@ fn exception_is_expected(
     expected_exceptions: Vec<TransactionExpectedException>,
     returned_error: VMError,
 ) -> bool {
-    for expected_exception in expected_exceptions {
-        if matches!(
-            (expected_exception, &returned_error),
+    expected_exceptions.iter().any(|exception| {
+        matches!(
+            (exception, &returned_error),
             (
                 TransactionExpectedException::IntrinsicGasTooLow,
                 VMError::IntrinsicGasTooLow
@@ -293,12 +293,8 @@ fn exception_is_expected(
                 TransactionExpectedException::InitcodeSizeExceeded,
                 VMError::InitcodeSizeExceeded
             )
-        ) {
-            return true;
-        }
-    }
-
-    false
+        )
+    })
 }
 
 pub fn ensure_post_state(

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -81,7 +81,7 @@ pub fn run_ef_test_tx(
 }
 
 pub fn run_ef_test(test: EFTest, report: &mut EFTestsReport) -> Result<(), Box<dyn Error>> {
-    println!("Running test: {}", &test.name);
+    //println!("Running test: {}", &test.name);
     let mut failed = false;
     for (tx_id, (tx_indexes, _tx)) in test.transactions.iter().enumerate() {
         // Code for debugging a specific case.
@@ -313,7 +313,6 @@ pub fn ensure_post_state(
                     return Err(format!("Post-state condition failed: {error_reason}").into());
                 }
                 // Execution result was successful and no exception was expected.
-                // TODO: Check that the post-state matches the expected post-state.
                 None | Some(None) => {
                     let pos_state_root = post_state_root(execution_report, test);
                     if let Some(expected_post_state_root_hash) = post_value {
@@ -336,10 +335,7 @@ pub fn ensure_post_state(
         Err(err) => {
             match post_value.map(|v| v.clone().expect_exception) {
                 // Execution result was unsuccessful and an exception was expected.
-                // TODO: Check that the exception matches the expected exception.
                 Some(Some(expected_exceptions)) => {
-                    println!("Expected exception is {:?}", expected_exceptions);
-
                     // Instead of cloning could use references
                     if !exception_is_expected(expected_exceptions.clone(), err.clone()) {
                         let error_reason = match expected_exceptions.get(1) {

--- a/cmd/ef_tests/levm/runner.rs
+++ b/cmd/ef_tests/levm/runner.rs
@@ -233,8 +233,11 @@ fn get_post_value(test: &EFTest, tx_id: usize) -> Option<EFTestPostValue> {
     }
 }
 
-fn exception_is_expected(expected_exceptions: Vec<TransactionExpectedException>, returned_error: VMError) -> bool {
-    true
+fn exception_is_expected(
+    expected_exceptions: Vec<TransactionExpectedException>,
+    returned_error: VMError,
+) -> bool {
+    false
 }
 
 pub fn ensure_post_state(

--- a/cmd/ef_tests/levm/types.rs
+++ b/cmd/ef_tests/levm/types.rs
@@ -1,7 +1,7 @@
 use crate::deserialize::{
     deserialize_ef_post_value_indexes, deserialize_hex_bytes, deserialize_hex_bytes_vec,
-    deserialize_u256_optional_safe, deserialize_u256_safe, deserialize_u256_valued_hashmap_safe,
-    deserialize_u256_vec_safe,
+    deserialize_transaction_expected_exception, deserialize_u256_optional_safe,
+    deserialize_u256_safe, deserialize_u256_valued_hashmap_safe, deserialize_u256_vec_safe,
 };
 use bytes::Bytes;
 use ethrex_core::{
@@ -100,9 +100,33 @@ impl EFTestPost {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+pub enum TransactionExpectedException {
+    InitcodeSizeExceeded,
+    NonceIsMax,
+    Type3TxBlobCountExceeded,
+    Type3TxZeroBlobs,
+    Type3TxContractCreation,
+    Type3TxInvalidBlobVersionedHash,
+    IntrinsicGasTooLow,
+    InsufficientAccountFunds,
+    SenderNotEoa,
+    PriorityGreaterThanMaxFeePerGas,
+    GasAllowanceExceeded,
+    InsufficientMaxFeePerGas,
+    RlpInvalidValue,
+    GasLimitPriceProductOverflow,
+    Type3TxPreFork,
+    InsufficientMaxFeePerBlobGas,
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct EFTestPostValue {
-    #[serde(rename = "expectException")]
-    pub expect_exception: Option<String>,
+    #[serde(
+        rename = "expectException",
+        default,
+        deserialize_with = "deserialize_transaction_expected_exception"
+    )]
+    pub expect_exception: Option<Vec<TransactionExpectedException>>,
     pub hash: H256,
     #[serde(deserialize_with = "deserialize_ef_post_value_indexes")]
     pub indexes: HashMap<String, U256>,

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -695,7 +695,8 @@ impl VM {
         // Access List Cost
         // TODO: Implement access list cost.
 
-        self.increase_consumed_gas(initial_call_frame, intrinsic_gas)?;
+        self.increase_consumed_gas(initial_call_frame, intrinsic_gas)
+            .map_err(|_| VMError::IntrinsicGasTooLow)?;
 
         Ok(())
     }


### PR DESCRIPTION
**Motivation**

Currently in EF tests we don't verify that the error returned by levm matches with the expected, the goal is to verify it, and print an error if it does not match.

**Description**

This PR includes:
- The logic of verifying the exception is the expected, in `exception_is_expected()`
- The print of the error (or errors) that the EVM may throw in case the error does not match or in case it does not return an error and one is expected.
