### PR TITLE
feat(l1, l2, levm): weekly loc report

### DIFF
--- a/.github/workflows/loc.yaml
+++ b/.github/workflows/loc.yaml
@@ -1,0 +1,30 @@
+name: Weekly LoC
+
+on:
+  schedule:
+    # Every Friday at midnight
+    - cron: "0 0 * * 5"
+  workflow_dispatch:
+
+env:
+  RUST_VERSION: 1.80.1
+
+jobs:
+  loc:
+    name: Count ethrex loc and generate report
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Add Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate the loc report
+        run: make loc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ members = [
     "crates/l2/prover",
     "crates/l2/contracts",
     "crates/l2/sdk",
+    "cmd/loc",
 ]
 resolver = "2"
 
-default-members = ["cmd/ethrex", "cmd/ethrex_l2", "crates/l2/prover"]
+default-members = ["cmd/ethrex", "cmd/ethrex_l2", "crates/l2/prover", "cmd/loc"]
 
 [workspace.package]
 version = "0.1.0"

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,6 @@ run-hive-debug: build-image setup-hive ## 🐞 Run Hive testing suite in debug m
 
 clean-hive-logs: ## 🧹 Clean Hive logs
 	rm -rf ./hive/workspace/logs
+
+loc:
+	cargo run -p loc

--- a/cmd/loc/Cargo.toml
+++ b/cmd/loc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "loc"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+tokei = "12.1.2"
+colored = "2.1.0"

--- a/cmd/loc/src/main.rs
+++ b/cmd/loc/src/main.rs
@@ -5,10 +5,9 @@ use tokei::{Config, LanguageType, Languages};
 const CARGO_MANIFEST_DIR: &str = std::env!("CARGO_MANIFEST_DIR");
 
 fn main() {
-    let ethrex = PathBuf::from(CARGO_MANIFEST_DIR).join("../../../lambda_ethereum_rust/");
-    let levm = PathBuf::from(CARGO_MANIFEST_DIR).join("../../../lambda_ethereum_rust/crates/vm");
-    let ethrex_l2 =
-        PathBuf::from(CARGO_MANIFEST_DIR).join("../../../lambda_ethereum_rust/crates/l2");
+    let ethrex = PathBuf::from(CARGO_MANIFEST_DIR).join("../../");
+    let levm = PathBuf::from(CARGO_MANIFEST_DIR).join("../../crates/vm");
+    let ethrex_l2 = PathBuf::from(CARGO_MANIFEST_DIR).join("../../crates/l2");
 
     let config = Config::default();
 

--- a/cmd/loc/src/main.rs
+++ b/cmd/loc/src/main.rs
@@ -1,0 +1,37 @@
+use colored::Colorize;
+use std::path::PathBuf;
+use tokei::{Config, LanguageType, Languages};
+
+const CARGO_MANIFEST_DIR: &str = std::env!("CARGO_MANIFEST_DIR");
+
+fn main() {
+    let ethrex = PathBuf::from(CARGO_MANIFEST_DIR).join("../../../lambda_ethereum_rust/");
+    let levm = PathBuf::from(CARGO_MANIFEST_DIR).join("../../../lambda_ethereum_rust/crates/vm");
+    let ethrex_l2 =
+        PathBuf::from(CARGO_MANIFEST_DIR).join("../../../lambda_ethereum_rust/crates/l2");
+
+    let config = Config::default();
+
+    let mut languages = Languages::new();
+    languages.get_statistics(&[ethrex.clone()], &[], &config);
+    let ethrex_loc = &languages.get(&LanguageType::Rust).unwrap();
+
+    let mut languages = Languages::new();
+    languages.get_statistics(&[levm], &[], &config);
+    let levm_loc = &languages.get(&LanguageType::Rust).unwrap();
+
+    let mut languages = Languages::new();
+    languages.get_statistics(&[ethrex_l2], &[], &config);
+    let ethrex_l2_loc = &languages.get(&LanguageType::Rust).unwrap();
+
+    println!("{}", "ethrex loc summary".bold());
+    println!("{}", "====================".bold());
+    println!(
+        "{}: {:?}",
+        "ethrex L1".bold(),
+        ethrex_loc.code - ethrex_l2_loc.code - levm_loc.code
+    );
+    println!("{}: {:?}", "ethrex L2".bold(), ethrex_l2_loc.code);
+    println!("{}: {:?}", "levm".bold(), levm_loc.code);
+    println!("{}: {:?}", "ethrex (total)".bold(), ethrex_loc.code);
+}


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

We want a weekly job that generates a report about the repository's loc (lines of code). We wish to discriminate between `levm`, `l2`, `l1`, and the whole repo.

**How to run locally**

```
make loc
```

![image](https://github.com/user-attachments/assets/5f12b104-63f2-417d-9887-82b361cb06bd)





