### PR TITLE
Fix(levm): set calldata as empty bytes at contract creation

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -134,7 +134,7 @@ impl VM {
                     new_contract_address,
                     code,
                     value,
-                    calldata.clone(),
+                    Bytes::new(),
                     false,
                     env.gas_limit.min(MAX_BLOCK_GAS_LIMIT),
                     TX_BASE_COST,


### PR DESCRIPTION
**Motivation**

Fixes a bug found by [FuzzingLabs](https://github.com/FuzzingLabs) in creation type transactions.

**Description**

Previously, in create transactions the calldata field was set with a copy of the bytecode, which was wrong, as it should be an empty set of bytes.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1223 

