### PR TITLE
fix(levm): return error in returndatacopy in unexpected behavior

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -404,7 +404,7 @@ impl VM {
                     .min(sub_return_data_len),
             )
         } else {
-            vec![0u8; size].into()
+            return Err(VMError::VeryLargeNumber); // Maybe can create a new error instead of using this one
         };
 
         current_call_frame.memory.store_bytes(dest_offset, &data)?;

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -393,19 +393,19 @@ impl VM {
         }
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
-        let data = if returndata_offset < sub_return_data_len {
-            current_call_frame.sub_return_data.slice(
-                returndata_offset
-                    ..(returndata_offset
-                        .checked_add(size)
-                        .ok_or(VMError::Internal(
-                            InternalError::ArithmeticOperationOverflow,
-                        ))?)
-                    .min(sub_return_data_len),
-            )
-        } else {
+
+        if returndata_offset >= sub_return_data_len {
             return Err(VMError::VeryLargeNumber); // Maybe can create a new error instead of using this one
-        };
+        }
+        let data = current_call_frame.sub_return_data.slice(
+            returndata_offset
+                ..(returndata_offset
+                    .checked_add(size)
+                    .ok_or(VMError::Internal(
+                        InternalError::ArithmeticOperationOverflow,
+                    ))?)
+                .min(sub_return_data_len),
+        );
 
         current_call_frame.memory.store_bytes(dest_offset, &data)?;
 

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use ethrex_core::U256;
 use ethrex_levm::{
+    errors::{TxResult, VMError},
     operations::Operation,
     utils::{new_vm_with_bytecode, new_vm_with_ops},
 };
@@ -100,4 +101,13 @@ fn test_is_negative() {
     let mut vm = new_vm_with_bytecode(Bytes::copy_from_slice(&[58, 63, 58, 5])).unwrap();
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
+}
+
+#[test]
+fn test_non_compliance_returndatacopy() {
+    let mut vm =
+        new_vm_with_bytecode(Bytes::copy_from_slice(&[56, 56, 56, 56, 56, 56, 62, 56])).unwrap();
+    let mut current_call_frame = vm.call_frames.pop().unwrap();
+    let txreport = vm.execute(&mut current_call_frame);
+    assert_eq!(txreport.result, TxResult::Revert(VMError::VeryLargeNumber));
 }


### PR DESCRIPTION
**Motivation**

Fixes a bug found by [FuzzingLabs](https://github.com/FuzzingLabs) in returndatacopy opcode implementation.

**Description**

Now returns an error in `returndatacopy` if offset is larger than the return data size.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1232
