### PR TITLE
fix(levm): remove report double print 

### DIFF
--- a/cmd/ef_tests/levm/tests/test.rs
+++ b/cmd/ef_tests/levm/tests/test.rs
@@ -1,6 +1,5 @@
 use ef_tests_levm::runner;
 
 fn main() {
-    let report = runner::run_ef_tests().unwrap();
-    println!("{report}");
+    runner::run_ef_tests().unwrap();
 }


### PR DESCRIPTION
Report is already printed in the runner main function