### PR TITLE
build(core): Separate docker job and only build once.

### DIFF
--- a/.github/workflows/asertoor.yaml
+++ b/.github/workflows/asertoor.yaml
@@ -1,13 +1,10 @@
 name: "Assertoor"
 on:
   merge_group:
-  pull_request:
-    branches: ["**"]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - "**/README.md"
-      - "**/docs/**"
+  workflow_run:
+    workflows: ["Docker build"]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -17,13 +14,10 @@ env:
   RUST_VERSION: 1.80.1
 
 jobs:
-  build:
-    uses: ./.github/workflows/docker_build.yaml
-
   run-assertoor:
     name: Stability Check
     runs-on: ubuntu-latest
-    needs: [build]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,17 +71,3 @@ jobs:
       - name: Run tests
         run: |
           make test
-
-  docker_build:
-    name: Build Docker image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          load: true # Important for building without pushing

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -1,7 +1,13 @@
 name: Docker build
 
 on:
-    workflow_call:
+    pull_request:
+      branches: ["**"]
+      paths-ignore:
+        - 'README.md'
+        - 'LICENSE'
+        - "**/README.md"
+        - "**/docs/**"
 
 jobs:
     docker_build:

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -1,13 +1,10 @@
 name: "Hive"
 on:
   merge_group:
-  pull_request:
-    branches: ["**"]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - "**/README.md"
-      - "**/docs/**"
+  workflow_run:
+    workflows: ["Docker build"]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -17,13 +14,10 @@ env:
   RUST_VERSION: 1.80.1
 
 jobs:
-  build:
-    uses: ./.github/workflows/docker_build.yaml
-
   run-hive:
     name: ${{ matrix.name }}
-    needs: [build]
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
**Motivation**
Only build docker once.

**Description**
- We only build docker once in a single job (instead of one job for hive and another for asertoor)
- We only execute the following hive and asertoor job if the docker build job suceeds.
