### PR TITLE
fix(l1): renamed all `lambda_ethrex` references to `ethrex` as the repo name

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -152,7 +152,7 @@ async fn main() {
     let jwt_secret = read_jwtsecret_file(authrpc_jwtsecret);
 
     // TODO Learn how should the key be created
-    // https://github.com/lambdaclass/lambda_ethrex/issues/836
+    // https://github.com/lambdaclass/ethrex/issues/836
     //let signer = SigningKey::random(&mut OsRng);
     let key_bytes =
         H256::from_str("577d8278cc7748fad214b5378669b420f8221afb45ce930b7f22da49cbc545f3").unwrap();
@@ -186,7 +186,7 @@ async fn main() {
     .into_future();
 
     // TODO Find a proper place to show node information
-    // https://github.com/lambdaclass/lambda_ethrex/issues/836
+    // https://github.com/lambdaclass/ethrex/issues/836
     let enode = local_p2p_node.enode_url();
     info!("Node: {enode}");
 

--- a/crates/l2/docs/prover.md
+++ b/crates/l2/docs/prover.md
@@ -116,7 +116,7 @@ make perf_gpu
 Two servers are required: one for the `prover` and another for the `proposer`. If you run both components on the same machine, the `prover` may consume all available resources, leading to potential stuttering or performance issues for the `proposer`/`node`.
 
 1. `prover`/`zkvm` &rarr; prover with gpu, make sure to have all the required dependencies described at the beginning of [Gpu Mode](#gpu-mode) section.
-    1. `cd lambda_ethrex/crates/l2`
+    1. `cd ethrex/crates/l2`
     2. `cp .example.env` and change the `PROVER_CLIENT_PROVER_SERVER_ENDPOINT` with the ip of the other server.
 
 The env variables needed are:
@@ -131,7 +131,7 @@ Finally, to start the `prover_client`/`zkvm`, run:
 - `make init-l2-prover-gpu`
 
 2.  `proposer` &rarr; this server just needs rust installed.
-    1. `cd lambda_ethrex/crates/l2`
+    1. `cd ethrex/crates/l2`
     2. `cp .example.env` and change the addresses and the following fields:
        - `PROVER_SERVER_LISTEN_IP=0.0.0.0` &rarr; used to handle the tcp communication with the other server.
        - The `COMMITTER` and `PROVER_SERVER_VERIFIER` must be different accounts, the `DEPLOYER_ADDRESS` as well as the `L1_WATCHER` may be the same account used by the `COMMITTER`

--- a/crates/networking/p2p/bootnode.rs
+++ b/crates/networking/p2p/bootnode.rs
@@ -12,7 +12,7 @@ impl FromStr for BootNode {
     /// Takes a str with the format "enode://nodeID@IPaddress:port" and
     /// parses it to a BootNode
     // TODO: fix it to support different UDP and TCP ports, according to
-    // https://github.com/lambdaclass/lambda_ethrex/issues/905
+    // https://github.com/lambdaclass/ethrex/issues/905
     fn from_str(input: &str) -> Result<BootNode, ParseIntError> {
         // TODO: error handling
         let node_id = H512::from_str(&input[8..136]).expect("Failed to parse node id");

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -345,7 +345,7 @@ async fn discovery_startup(
             ip: bootnode.socket_address.ip(),
             udp_port: bootnode.socket_address.port(),
             // TODO: udp port can differ from tcp port.
-            // see https://github.com/lambdaclass/lambda_ethrex/issues/905
+            // see https://github.com/lambdaclass/ethrex/issues/905
             tcp_port: bootnode.socket_address.port(),
             node_id: bootnode.node_id,
         });

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -159,7 +159,7 @@ impl VM {
     }
 
     // SSTORE operation
-    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1087
+    // TODO: https://github.com/lambdaclass/ethrex/issues/1087
     pub fn op_sstore(
         &mut self,
         current_call_frame: &mut CallFrame,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -87,7 +87,7 @@ impl VM {
     }
 
     // CALLCODE operation
-    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1086
+    // TODO: https://github.com/lambdaclass/ethrex/issues/1086
     pub fn op_callcode(
         &mut self,
         current_call_frame: &mut CallFrame,
@@ -192,7 +192,7 @@ impl VM {
     }
 
     // DELEGATECALL operation
-    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1086
+    // TODO: https://github.com/lambdaclass/ethrex/issues/1086
     pub fn op_delegatecall(
         &mut self,
         current_call_frame: &mut CallFrame,
@@ -260,7 +260,7 @@ impl VM {
     }
 
     // STATICCALL operation
-    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1086
+    // TODO: https://github.com/lambdaclass/ethrex/issues/1086
     pub fn op_staticcall(
         &mut self,
         current_call_frame: &mut CallFrame,
@@ -328,7 +328,7 @@ impl VM {
     }
 
     // CREATE operation
-    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1086
+    // TODO: https://github.com/lambdaclass/ethrex/issues/1086
     pub fn op_create(
         &mut self,
         current_call_frame: &mut CallFrame,
@@ -357,7 +357,7 @@ impl VM {
     }
 
     // CREATE2 operation
-    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1086
+    // TODO: https://github.com/lambdaclass/ethrex/issues/1086
     pub fn op_create2(
         &mut self,
         current_call_frame: &mut CallFrame,

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -151,7 +151,7 @@ impl VM {
                 })
             }
         }
-        // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1088
+        // TODO: https://github.com/lambdaclass/ethrex/issues/1088
     }
 
     pub fn execute(&mut self, current_call_frame: &mut CallFrame) -> TransactionReport {
@@ -600,7 +600,7 @@ impl VM {
         ))
     }
 
-    // TODO: Improve and test REVERT behavior for XCALL opcodes. Issue: https://github.com/lambdaclass/lambda_ethrex/issues/1061
+    // TODO: Improve and test REVERT behavior for XCALL opcodes. Issue: https://github.com/lambdaclass/ethrex/issues/1061
     #[allow(clippy::too_many_arguments)]
     pub fn generic_call(
         &mut self,
@@ -782,7 +782,7 @@ impl VM {
     /// Common behavior for CREATE and CREATE2 opcodes
     ///
     /// Could be used for CREATE type transactions
-    // TODO: Improve and test REVERT behavior for CREATE. Issue: https://github.com/lambdaclass/lambda_ethrex/issues/1061
+    // TODO: Improve and test REVERT behavior for CREATE. Issue: https://github.com/lambdaclass/ethrex/issues/1061
     pub fn create(
         &mut self,
         value_in_wei_to_send: U256,

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -117,7 +117,7 @@ cfg_if::cfg_if! {
                     transaction.tx_type(),
                     matches!(result.result, TxResult::Success),
                     cumulative_gas_used,
-                    // TODO: https://github.com/lambdaclass/lambda_ethrex/issues/1089
+                    // TODO: https://github.com/lambdaclass/ethrex/issues/1089
                     vec![],
                 );
                 receipts.push(receipt);

--- a/test_data/network_params.yaml
+++ b/test_data/network_params.yaml
@@ -20,4 +20,4 @@ assertoor_params:
   run_block_proposal_check: false
   run_blob_transaction_test: true
   tests:
-    - 'https://raw.githubusercontent.com/lambdaclass/lambda_ethrex/refs/heads/main/test_data/el-stability-check.yml'
+    - 'https://raw.githubusercontent.com/lambdaclass/ethrex/refs/heads/main/test_data/el-stability-check.yml'


### PR DESCRIPTION
**Motivation**

Renaming incorrect repo references

