### PR TITLE
fix(levm): add memory alignment in extcodecopy

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -320,9 +320,13 @@ impl VM {
 
         let bytecode = self.get_account(&address).info.bytecode;
 
-        let new_memory_size = dest_offset.checked_add(size).ok_or(VMError::Internal(
+        let new_memory_size = (((!size).checked_add(1).ok_or(VMError::Internal(
             InternalError::ArithmeticOperationOverflow,
-        ))?;
+        ))?) & 31)
+            .checked_add(size)
+            .ok_or(VMError::Internal(
+                InternalError::ArithmeticOperationOverflow,
+            ))?;
         let current_memory_size = current_call_frame.memory.data.len();
         if current_memory_size < new_memory_size {
             current_call_frame.memory.data.resize(new_memory_size, 0);

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::indexing_slicing)]
-#![allow(clippy::unwrap_used)]
-
 use bytes::Bytes;
 use ethrex_core::U256;
 use ethrex_levm::{
@@ -126,5 +123,5 @@ fn test_non_compliance_extcodecopy_memory_resize() {
     .unwrap();
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
-    assert_eq!(current_call_frame.stack.stack[0], U256::from(32));
+    assert_eq!(current_call_frame.stack.pop().unwrap(), U256::from(32));
 }

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use ethrex_core::U256;
 use ethrex_levm::{
+    errors::{TxResult, VMError},
     operations::Operation,
     utils::{new_vm_with_bytecode, new_vm_with_ops},
 };
@@ -113,6 +114,23 @@ fn test_sdiv_zero_dividend_and_negative_divisor() {
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame);
     assert_eq!(current_call_frame.stack.pop().unwrap(), U256::zero());
+}
+
+#[test]
+fn test_non_compliance_returndatacopy() {
+    let mut vm =
+        new_vm_with_bytecode(Bytes::copy_from_slice(&[56, 56, 56, 56, 56, 56, 62, 56])).unwrap();
+    let mut current_call_frame = vm.call_frames.pop().unwrap();
+    let txreport = vm.execute(&mut current_call_frame);
+    assert_eq!(txreport.result, TxResult::Revert(VMError::VeryLargeNumber));
+}
+
+#[test]
+fn test_non_compliance_extcodecopy() {
+    let mut vm = new_vm_with_bytecode(Bytes::copy_from_slice(&[88, 88, 88, 89, 60, 89])).unwrap();
+    let mut current_call_frame = vm.call_frames.pop().unwrap();
+    vm.execute(&mut current_call_frame);
+    assert_eq!(current_call_frame.stack.stack.pop().unwrap(), U256::zero());
 }
 
 #[test]

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::indexing_slicing)]
+#![allow(clippy::unwrap_used)]
+
 use bytes::Bytes;
 use ethrex_core::U256;
 use ethrex_levm::{

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -114,3 +114,14 @@ fn test_sdiv_zero_dividend_and_negative_divisor() {
     vm.execute(&mut current_call_frame);
     assert_eq!(current_call_frame.stack.pop().unwrap(), U256::zero());
 }
+
+#[test]
+fn test_non_compliance_extcodecopy_memory_resize() {
+    let mut vm = new_vm_with_bytecode(Bytes::copy_from_slice(&[
+        0x60, 12, 0x5f, 0x5f, 0x5f, 0x3c, 89,
+    ]))
+    .unwrap();
+    let mut current_call_frame = vm.call_frames.pop().unwrap();
+    vm.execute(&mut current_call_frame);
+    assert_eq!(current_call_frame.stack.stack[0], U256::from(32));
+}


### PR DESCRIPTION
**Motivation**

Fixes an implementation error found by [FuzzingLabs](https://github.com/FuzzingLabs) in extcodecopy opcode implementation.

**Description**

Previously, in EXTCODECOPY the allocated memory size was not aligned to a multiple of 32 bytes, and was added in, for example, 12 bytes (should increase in blocks of 32). Now the increases are done in groups of 32.

Closes #1251 

