### PR TITLE
chore(l2): rename cli's binary

### DIFF
--- a/cmd/ethrex_l2/Cargo.toml
+++ b/cmd/ethrex_l2/Cargo.toml
@@ -34,5 +34,5 @@ ethrex-rlp.workspace = true
 ethrex-rpc.workspace = true
 
 [[bin]]
-name = "l2"
+name = "ethrex_l2"
 path = "./src/main.rs"


### PR DESCRIPTION
**Motivation**

Change the CLI's name so it has `ethrex` in the binary's name.

