### PR TITLE
fix(l1): remove "inconsistent internal tree structure" panics

### DIFF
--- a/crates/l2/prover/zkvm/interface/src/lib.rs
+++ b/crates/l2/prover/zkvm/interface/src/lib.rs
@@ -100,9 +100,13 @@ pub mod trie {
             } else {
                 // Add or update AccountState in the trie
                 // Fetch current state or create a new state to be inserted
-                let mut account_state = match state_trie.get(&hashed_address)? {
-                    Some(encoded_state) => AccountState::decode(&encoded_state)?,
-                    None => AccountState::default(),
+                let mut account_state = match state_trie.get(&hashed_address) {
+                    Ok(option) => match option {
+                        Some(encoded_state) => AccountState::decode(&encoded_state)?,
+                        None => AccountState::default(),
+                    },
+                    Err(TrieError::InconsistentTree) => AccountState::default(),
+                    Err(err) => return Err(err.into()),
                 };
                 if let Some(info) = &update.info {
                     account_state.nonce = info.nonce;

--- a/crates/l2/prover/zkvm/interface/src/lib.rs
+++ b/crates/l2/prover/zkvm/interface/src/lib.rs
@@ -100,18 +100,10 @@ pub mod trie {
             } else {
                 // Add or update AccountState in the trie
                 // Fetch current state or create a new state to be inserted
-                let mut account_state =
-                    // we're catching a panic because the Trie library assumes that tries are
-                    // well-formed, but we're using pruned tries so this hypothesis doesn't hold, and
-                    // so the get() call panics in the case of a missing value (because there're
-                    // nodes missing in the path from the root into the missing value).
-                    match std::panic::catch_unwind(|| state_trie.get(&hashed_address)) {
-                        Ok(result) => match result? {
-                            Some(encoded_state) => AccountState::decode(&encoded_state)?,
-                            None => AccountState::default(),
-                        },
-                        Err(_) => AccountState::default(),
-                    };
+                let mut account_state = match state_trie.get(&hashed_address)? {
+                    Some(encoded_state) => AccountState::decode(&encoded_state)?,
+                    None => AccountState::default(),
+                };
                 if let Some(info) = &update.info {
                     account_state.nonce = info.nonce;
                     account_state.balance = info.balance;

--- a/crates/l2/prover/zkvm/interface/src/lib.rs
+++ b/crates/l2/prover/zkvm/interface/src/lib.rs
@@ -71,15 +71,8 @@ pub mod io {
 pub mod trie {
     use std::collections::HashMap;
 
-    use ethrex_core::{
-        types::{Account, AccountState},
-        H160,
-    };
-    use ethrex_rlp::{
-        decode::{self, RLPDecode},
-        encode::RLPEncode,
-        error::RLPDecodeError,
-    };
+    use ethrex_core::{types::AccountState, H160};
+    use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, error::RLPDecodeError};
     use ethrex_storage::{hash_address, hash_key, AccountUpdate};
     use ethrex_trie::{Trie, TrieError};
     use thiserror::Error;

--- a/crates/l2/prover/zkvm/interface/src/lib.rs
+++ b/crates/l2/prover/zkvm/interface/src/lib.rs
@@ -69,10 +69,7 @@ pub mod io {
 }
 
 pub mod trie {
-    use std::{
-        collections::{hash_map::Entry, HashMap},
-        default,
-    };
+    use std::collections::HashMap;
 
     use ethrex_core::{types::AccountState, H160};
     use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, error::RLPDecodeError};
@@ -135,9 +132,9 @@ pub mod trie {
                     };
                     for (storage_key, storage_value) in &update.added_storage {
                         let hashed_key = hash_key(storage_key);
-                        if storage_value.is_zero() {
+                        if storage_value.is_zero() && !is_account_new {
                             storage_trie.remove(hashed_key)?;
-                        } else {
+                        } else if !storage_value.is_zero() {
                             storage_trie.insert(hashed_key, storage_value.encode_to_vec())?;
                         }
                     }

--- a/crates/l2/prover/zkvm/interface/src/lib.rs
+++ b/crates/l2/prover/zkvm/interface/src/lib.rs
@@ -141,7 +141,6 @@ pub mod trie {
                     account_state.storage_root = storage_trie.hash_no_commit();
                 }
                 state_trie.insert(hashed_address, account_state.encode_to_vec())?;
-                println!("inserted new state");
             }
         }
         Ok(())

--- a/crates/l2/prover/zkvm/interface/src/lib.rs
+++ b/crates/l2/prover/zkvm/interface/src/lib.rs
@@ -71,8 +71,15 @@ pub mod io {
 pub mod trie {
     use std::collections::HashMap;
 
-    use ethrex_core::{types::AccountState, H160};
-    use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, error::RLPDecodeError};
+    use ethrex_core::{
+        types::{Account, AccountState},
+        H160,
+    };
+    use ethrex_rlp::{
+        decode::{self, RLPDecode},
+        encode::RLPEncode,
+        error::RLPDecodeError,
+    };
     use ethrex_storage::{hash_address, hash_key, AccountUpdate};
     use ethrex_trie::{Trie, TrieError};
     use thiserror::Error;

--- a/crates/storage/trie/error.rs
+++ b/crates/storage/trie/error.rs
@@ -9,4 +9,6 @@ pub enum TrieError {
     RLPDecode(#[from] RLPDecodeError),
     #[error("Verification Error: {0}")]
     Verify(String),
+    #[error("Inconsistent internal tree structure")]
+    InconsistentTree,
 }

--- a/crates/storage/trie/node/branch.rs
+++ b/crates/storage/trie/node/branch.rs
@@ -62,7 +62,7 @@ impl BranchNode {
             if child_hash.is_valid() {
                 let child_node = state
                     .get_node(child_hash.clone())?
-                    .expect("inconsistent internal tree structure");
+                    .ok_or(TrieError::InconsistentTree)?;
                 child_node.get(state, path)
             } else {
                 Ok(None)
@@ -94,7 +94,7 @@ impl BranchNode {
                 choice_hash => {
                     let child_node = state
                         .get_node(choice_hash.clone())?
-                        .expect("inconsistent internal tree structure");
+                        .ok_or(TrieError::InconsistentTree)?;
 
                     let child_node = child_node.insert(state, path, value)?;
                     *choice_hash = child_node.insert_self(state)?;
@@ -139,7 +139,7 @@ impl BranchNode {
             if self.choices[choice_index].is_valid() {
                 let child_node = state
                     .get_node(self.choices[choice_index].clone())?
-                    .expect("inconsistent internal tree structure");
+                    .ok_or(TrieError::InconsistentTree)?;
                 // Remove value from child node
                 let (child_node, old_value) = child_node.remove(state, path.clone())?;
                 if let Some(child_node) = child_node {
@@ -180,7 +180,7 @@ impl BranchNode {
                 let (choice_index, child_hash) = children[0];
                 let child = state
                     .get_node(child_hash.clone())?
-                    .expect("inconsistent internal tree structure");
+                    .ok_or(TrieError::InconsistentTree)?;
                 match child {
                     // Replace self with an extension node leading to the child
                     Node::Branch(_) => ExtensionNode::new(
@@ -254,7 +254,7 @@ impl BranchNode {
             if child_hash.is_valid() {
                 let child_node = state
                     .get_node(child_hash.clone())?
-                    .expect("inconsistent internal tree structure");
+                    .ok_or(TrieError::InconsistentTree)?;
                 child_node.get_path(state, path, node_path)?;
             }
         }

--- a/crates/storage/trie/node/extension.rs
+++ b/crates/storage/trie/node/extension.rs
@@ -29,7 +29,7 @@ impl ExtensionNode {
         if path.skip_prefix(&self.prefix) {
             let child_node = state
                 .get_node(self.child.clone())?
-                .expect("inconsistent internal tree structure");
+                .ok_or(TrieError::InconsistentTree)?;
 
             child_node.get(state, path)
         } else {
@@ -59,7 +59,7 @@ impl ExtensionNode {
             // Insert into child node
             let child_node = state
                 .get_node(self.child)?
-                .expect("inconsistent internal tree structure");
+                .ok_or(TrieError::InconsistentTree)?;
             let new_child_node =
                 child_node.insert(state, path.offset(match_index), value.clone())?;
             self.child = new_child_node.insert_self(state)?;
@@ -76,7 +76,7 @@ impl ExtensionNode {
                     Some(Node::Leaf(leaf)) => {
                         BranchNode::new_with_value(Box::new(choices), leaf.value)
                     }
-                    _ => panic!("inconsistent internal tree structure"),
+                    _ => return Err(TrieError::InconsistentTree),
                 }
             } else {
                 choices[self.prefix.at(0)] = new_node;
@@ -109,7 +109,7 @@ impl ExtensionNode {
         if path.skip_prefix(&self.prefix) {
             let child_node = state
                 .get_node(self.child)?
-                .expect("inconsistent internal tree structure");
+                .ok_or(TrieError::InconsistentTree)?;
             // Remove value from child subtrie
             let (child_node, old_value) = child_node.remove(state, path)?;
             // Restructure node based on removal
@@ -189,7 +189,7 @@ impl ExtensionNode {
         if path.skip_prefix(&self.prefix) {
             let child_node = state
                 .get_node(self.child.clone())?
-                .expect("inconsistent internal tree structure");
+                .ok_or(TrieError::InconsistentTree)?;
             child_node.get_path(state, path, node_path)?;
         }
         Ok(())

--- a/crates/storage/trie/trie.rs
+++ b/crates/storage/trie/trie.rs
@@ -80,7 +80,7 @@ impl Trie {
             let root_node = self
                 .state
                 .get_node(root.clone())?
-                .expect("inconsistent internal tree structure");
+                .ok_or(TrieError::InconsistentTree)?;
             root_node.get(&self.state, Nibbles::from_bytes(path))
         } else {
             Ok(None)
@@ -115,7 +115,7 @@ impl Trie {
             let root_node = self
                 .state
                 .get_node(root)?
-                .expect("inconsistent internal tree structure");
+                .ok_or(TrieError::InconsistentTree)?;
             let (root_node, old_value) =
                 root_node.remove(&mut self.state, Nibbles::from_bytes(&path))?;
             self.root = root_node
@@ -294,7 +294,7 @@ impl Trie {
                         let child_node = self
                             .state
                             .get_node(child_hash.clone())?
-                            .expect("inconsistent internal tree structure");
+                            .ok_or(TrieError::InconsistentTree)?;
                         self.get_node_inner(child_node, partial_path)
                     } else {
                         Ok(vec![])
@@ -309,7 +309,7 @@ impl Trie {
                     let child_node = self
                         .state
                         .get_node(extension_node.child.clone())?
-                        .expect("inconsistent internal tree structure");
+                        .ok_or(TrieError::InconsistentTree)?;
                     self.get_node_inner(child_node, partial_path)
                 } else {
                     Ok(vec![])

--- a/crates/vm/execution_db.rs
+++ b/crates/vm/execution_db.rs
@@ -148,9 +148,19 @@ impl ExecutionDB {
             let address = H160::from_slice(revm_address.as_slice());
 
             // check account is in state trie
-            if state_trie.get(&hash_address(&address))?.is_none() {
-                return Err(ExecutionDBError::MissingAccountInStateTrie(address));
-            }
+            //
+            // we're catching a panic because the Trie library assumes that tries are
+            // well-formed, but we're using pruned tries so this hypothesis doesn't hold, and
+            // so the get() call panics in the case of a missing value (because there're
+            // nodes missing in the path from the root into the missing value).
+            match std::panic::catch_unwind(|| state_trie.get(&hash_address(&address))) {
+                Ok(result) => {
+                    if result?.is_none() {
+                        return Err(ExecutionDBError::MissingAccountInStateTrie(address));
+                    }
+                }
+                Err(_) => return Err(ExecutionDBError::MissingAccountInStateTrie(address)),
+            };
 
             let (storage_trie_root, storage_trie_nodes) =
                 self.pruned_storage_tries
@@ -171,9 +181,17 @@ impl ExecutionDB {
             for (key, value) in storage {
                 let key = H256::from_slice(&key.to_be_bytes_vec());
                 let value = H256::from_slice(&value.to_be_bytes_vec());
-                let retrieved_value = storage_trie
-                    .get(&hash_key(&key))?
-                    .ok_or(ExecutionDBError::MissingKeyInStorageTrie(address, key))?;
+
+                // catching panic here because of the same reason as above
+                let retrieved_value = match std::panic::catch_unwind(|| {
+                    storage_trie.get(&hash_key(&key))
+                }) {
+                    Ok(result) => {
+                        result?.ok_or(ExecutionDBError::MissingKeyInStorageTrie(address, key))?
+                    }
+                    Err(_) => return Err(ExecutionDBError::MissingKeyInStorageTrie(address, key)),
+                };
+
                 if value.encode_to_vec() != retrieved_value {
                     return Err(ExecutionDBError::InvalidStorageTrieValue(address, key));
                 }


### PR DESCRIPTION
**Motivation**

The `Trie` library assumes that all tries are well-formed: this means that if some node contains the hash of a child, then that child is in the tire's database. If this doesn't hold, then a `get()` call panics with an `inconsistent internal tree structure` message.

For the L2 prover we're using "pruned tries" which only store the relevant nodes for the set of values touched in some execution, breaking the previous hypothesis. One option was to capture the panics on the get calls, but this wasn't safe because `Trie` has internal mutability. The path chosen is to remove the panics altogether and replace them with errors.

**Description**

- replaces mentioned panics for errors
