### PR TITLE
ci(core): add back docker build workflow

### DIFF
--- a/.github/workflows/asertoor.yaml
+++ b/.github/workflows/asertoor.yaml
@@ -1,6 +1,5 @@
 name: Assertoor
 on:
-  merge_group:
   workflow_run:
     workflows: [Docker build]
     types: [completed]

--- a/.github/workflows/asertoor.yaml
+++ b/.github/workflows/asertoor.yaml
@@ -1,14 +1,9 @@
 name: Assertoor
 on:
-  pull_request:
-    branches: ["**"]
-    paths-ignore:
-      - "README.md"
-      - "LICENSE"
-      - "**/README.md"
-      - "**/docs/**"
-      - "crates/vm/levm/**"
-      - "crates/l2/**"
+  merge_group:
+  workflow_run:
+    workflows: [Docker build]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -18,13 +13,10 @@ env:
   RUST_VERSION: 1.80.1
 
 jobs:
-  build:
-    uses: ./.github/workflows/docker_build.yaml
-
   run-assertoor:
     name: Stability Check
     runs-on: ubuntu-latest
-    needs: [build]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +25,8 @@ jobs:
         with:
           name: ethrex_image
           path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Load image
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  push:
+    branches: ["main"]
   merge_group:
   pull_request:
     branches: ["**"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,12 +5,12 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
-    paths-ignore:
-      - "README.md"
-      - "LICENSE"
-      - "**/README.md"
-      - "**/docs/**"
-      - "crates/vm/levm/**" # We run this in a separate workflow
+    # paths-ignore:
+    #   - "README.md"
+    #   - "LICENSE"
+    #   - "**/README.md"
+    #   - "**/docs/**"
+    #   - "crates/vm/levm/**" # We run this in a separate workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci_l2.yaml
+++ b/.github/workflows/ci_l2.yaml
@@ -1,5 +1,7 @@
 name: CI (L2)
 on:
+  push:
+    branches: ["main"]
   merge_group:
   pull_request:
     branches: ["**"]

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -1,9 +1,9 @@
 name: CI LEVM
 
 on:
+  push:
+    branches: ["main"]
   merge_group:
-    paths:
-      - "crates/vm/levm/**"
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -1,7 +1,9 @@
 name: Docker build
 
+# This workflow is later used in assertoor and hive workflows
 on:
-  workflow_call:
+  push:
+    branches: ["main"]
   merge_group:
   pull_request:
     branches: ["**"]

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -3,6 +3,13 @@ name: Docker build
 on:
   workflow_call:
   merge_group:
+  pull_request:
+    branches: ["**"]
+    paths-ignore:
+      - "README.md"
+      - "LICENSE"
+      - "**/README.md"
+      - "**/docs/**"
 
 jobs:
   docker_build:

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -7,11 +7,11 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
-    paths-ignore:
-      - "README.md"
-      - "LICENSE"
-      - "**/README.md"
-      - "**/docs/**"
+    # paths-ignore:
+    #   - "README.md"
+    #   - "LICENSE"
+    #   - "**/README.md"
+    #   - "**/docs/**"
 
 jobs:
   docker_build:

--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -44,12 +44,13 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -2,7 +2,7 @@ name: Publish docker image to Github Packages
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
 
 env:
   REGISTRY: ghcr.io
@@ -46,11 +46,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-      

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -1,6 +1,5 @@
 name: Hive
 on:
-  merge_group:
   workflow_run:
     workflows: [Docker build]
     types: [completed]

--- a/.github/workflows/hive.yaml
+++ b/.github/workflows/hive.yaml
@@ -1,14 +1,9 @@
 name: Hive
 on:
-  pull_request:
-    branches: ["**"]
-    paths-ignore:
-      - "README.md"
-      - "LICENSE"
-      - "**/README.md"
-      - "**/docs/**"
-      - "crates/vm/levm/**"
-      - "crates/l2/**"
+  merge_group:
+  workflow_run:
+    workflows: [Docker build]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -18,13 +13,10 @@ env:
   RUST_VERSION: 1.80.1
 
 jobs:
-  build:
-    uses: ./.github/workflows/docker_build.yaml
-
   run-hive:
     name: ${{ matrix.name }}
-    needs: [build]
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         include:
@@ -55,6 +47,8 @@ jobs:
         with:
           name: ethrex_image
           path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Load image
         run: |

--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -14,16 +14,10 @@ jobs:
     name: Daily Hive Coverage
     runs-on: ubuntu-latest
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Pull image
         run: |
           docker pull ghcr.io/lambdaclass/ethrex:main
+          docker tag ghcr.io/lambdaclass/ethrex:main ethrex:latest
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -10,24 +10,13 @@ env:
   RUST_VERSION: 1.80.1
 
 jobs:
-  build:
-    uses: ./.github/workflows/docker_build.yaml
-
   hive-coverage:
     name: Run engine hive simulator to gather coverage information.
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
-      # TODO: Maybe this can be reused as well.
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ethrex_image
-          path: /tmp
-
-      - name: Load image
+      - name: Pull image
         run: |
-          docker load --input /tmp/ethrex_image.tar
+          docker pull ghcr.io/lambdaclass/ethrex:main
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - name: Pull image
         run: |
-          docker pull ghcr.io/lambdaclass/ethrex:main
-          docker tag ghcr.io/lambdaclass/ethrex:main ethrex:latest
+          docker pull ghcr.io/lambdaclass/ethrex:latest
+          docker tag ghcr.io/lambdaclass/ethrex:latest ethrex:latest
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/hive_coverage.yaml
+++ b/.github/workflows/hive_coverage.yaml
@@ -3,7 +3,7 @@ name: Daily Hive Coverage
 on:
   schedule:
     # Every day at UTC midnight
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
@@ -11,9 +11,16 @@ env:
 
 jobs:
   hive-coverage:
-    name: Run engine hive simulator to gather coverage information.
+    name: Daily Hive Coverage
     runs-on: ubuntu-latest
     steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull image
         run: |
           docker pull ghcr.io/lambdaclass/ethrex:main

--- a/.github/workflows/l2_contracts.yaml
+++ b/.github/workflows/l2_contracts.yaml
@@ -1,8 +1,8 @@
 name: L2 Contracts CI
 on:
+  push:
+    branches: ["main"]
   merge_group:
-    paths:
-      - "crates/l2/contracts/**"
   pull_request:
     branches: ["**"]
     paths:

--- a/.github/workflows/l2_prover_ci.yaml
+++ b/.github/workflows/l2_prover_ci.yaml
@@ -1,5 +1,7 @@
 name: L2 Prover CI
 on:
+  push:
+    branches: ["main"]
   merge_group:
   pull_request:
     branches: ["**"]

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
 
 jobs:
   main:


### PR DESCRIPTION
Reverts lambdaclass/ethrex#1286

It turns out adding `workflow_run` for Hive and Assertor was working after all (it took some time, wtf github actions). Do I re-added it.

Merge queue only runs when the PR is not synced with main, so it does not work as a guarantee. Instead I moved most checks to be run as part of `push`, to at least be able to pin point if something breaks.