### PR TITLE
feat(levm): add job that runs LEVM EF Tests and publishes the report in Slack

### DIFF
--- a/.github/scripts/publish_levm_ef_tests_summary.sh
+++ b/.github/scripts/publish_levm_ef_tests_summary.sh
@@ -1,7 +1,7 @@
 curl -X POST $url \
 -H 'Content-Type: application/json; charset=utf-8' \
 --data @- <<EOF
-$(jq -n --arg text "$(cat levm_ef_tests_summary.txt)" '{
+$(jq -n --arg text "$(cat levm_ef_tests_summary_slack.txt)" '{
     "blocks": [
         {
             "type": "header",

--- a/.github/scripts/publish_levm_ef_tests_summary.sh
+++ b/.github/scripts/publish_levm_ef_tests_summary.sh
@@ -11,6 +11,9 @@ $(jq -n --arg text "$(cat levm_ef_tests_summary.txt)" '{
             }
         },
         {
+            "type": "divider"
+        },
+        {
             "type": "section",
             "text": {
                 "type": "mrkdwn",

--- a/.github/scripts/publish_levm_ef_tests_summary.sh
+++ b/.github/scripts/publish_levm_ef_tests_summary.sh
@@ -1,0 +1,22 @@
+curl -X POST $url \
+-H 'Content-Type: application/json; charset=utf-8' \
+--data @- <<EOF
+$(jq -n --arg text "$(cat levm_ef_tests_summary.txt)" '{
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Daily LEVM EF Tests Run Report"
+            }
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": $text
+            }             
+        }
+    ]
+}')
+EOF

--- a/.github/workflows/levm_reporter.yaml
+++ b/.github/workflows/levm_reporter.yaml
@@ -1,0 +1,56 @@
+name: Daily LEVM Reporter
+
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  RUST_VERSION: 1.80.1
+
+jobs:
+  ef-test:
+    name: Generate Report for EF Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Download EF Tests
+        run: |
+          cd crates/vm/levm
+          make download-evm-ef-tests
+
+      - name: Run tests
+        run: |
+          cd crates/vm/levm
+          make generate-evm-ef-tests-report
+
+      - name: Post results in summary
+        run: |
+          echo "# `ethrex` lines of code report" >> $GITHUB_STEP_SUMMARY
+          cat levm_ef_tests_summary.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Post results to ethrex L1 slack channel
+        env:
+          url: ${{ secrets.ETHREX_L1_SLACK_WEBHOOK }}
+        run: sh .github/scripts/publish_levm_ef_tests_summary.sh
+
+      - name: Post results to ethrex L2 slack channel
+        env:
+          url: ${{ secrets.ETHREX_L2_SLACK_WEBHOOK }}
+        run: sh .github/scripts/publish_levm_ef_tests_summary.sh
+
+      - name: Post results to levm slack channel
+        env:
+          url: ${{ secrets.LEVM_SLACK_WEBHOOK }}
+        run: sh .github/scripts/publish_levm_ef_tests_summary.sh

--- a/.github/workflows/levm_reporter.yaml
+++ b/.github/workflows/levm_reporter.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Post results in summary
         run: |
-          echo "# `ethrex` lines of code report" >> $GITHUB_STEP_SUMMARY
+          echo "# Daily LEVM EF Tests Run Report" >> $GITHUB_STEP_SUMMARY
           cat levm_ef_tests_summary.txt >> $GITHUB_STEP_SUMMARY
 
       - name: Post results to ethrex L1 slack channel

--- a/.github/workflows/levm_reporter.yaml
+++ b/.github/workflows/levm_reporter.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Post results in summary
         run: |
           echo "# Daily LEVM EF Tests Run Report" >> $GITHUB_STEP_SUMMARY
-          cat levm_ef_tests_summary.txt >> $GITHUB_STEP_SUMMARY
+          cat levm_ef_tests_summary_github.txt >> $GITHUB_STEP_SUMMARY
 
       - name: Post results to ethrex L1 slack channel
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tests_v3.0.0.tar.gz
 
 .env
 
+levm_ef_tests_report.txt
 levm_ef_tests_summary_slack.txt
 levm_ef_tests_summary_github.txt
 levm_ef_tests_summary.txt

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,5 @@ tests_v3.0.0.tar.gz
 .env
 
 levm_ef_tests_report.txt
-
+levm_ef_tests_summary.txt
 loc_report.md

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tests_v3.0.0.tar.gz
 
 .env
 
-levm_ef_tests_report.txt
+levm_ef_tests_summary_slack.txt
+levm_ef_tests_summary_github.txt
 levm_ef_tests_summary.txt
 loc_report.md

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -90,11 +90,12 @@ fn run_with_levm(
     levm_run_spinner.success(&report::progress(reports, levm_run_time.elapsed()));
 
     if opts.summary {
-        report::write_summary(reports)?;
+        report::write_summary_for_slack(reports)?;
+        report::write_summary_for_github(reports)?;
     }
 
     let mut summary_spinner = Spinner::new(Dots, "Loading summary...".to_owned(), Color::Cyan);
-    summary_spinner.success(&report::summary_pretty(reports));
+    summary_spinner.success(&report::summary_for_shell(reports));
     Ok(())
 }
 

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -44,15 +44,20 @@ pub struct EFTestRunnerOptions {
     pub fork: Vec<SpecId>,
     #[arg(short, long, value_name = "TESTS")]
     pub tests: Vec<String>,
+    #[arg(short, long, value_name = "SUMMARY", default_value = "false")]
+    pub summary: bool,
 }
 
 pub fn run_ef_tests(
     ef_tests: Vec<EFTest>,
-    _opts: &EFTestRunnerOptions,
+    opts: &EFTestRunnerOptions,
 ) -> Result<(), EFTestRunnerError> {
     let mut reports = report::load()?;
     if reports.is_empty() {
-        run_with_levm(&mut reports, &ef_tests)?;
+        run_with_levm(&mut reports, &ef_tests, opts)?;
+    }
+    if opts.summary {
+        return Ok(());
     }
     re_run_with_revm(&mut reports, &ef_tests)?;
     write_report(&reports)
@@ -61,6 +66,7 @@ pub fn run_ef_tests(
 fn run_with_levm(
     reports: &mut Vec<EFTestReport>,
     ef_tests: &[EFTest],
+    opts: &EFTestRunnerOptions,
 ) -> Result<(), EFTestRunnerError> {
     let levm_run_time = std::time::Instant::now();
     let mut levm_run_spinner = Spinner::new(
@@ -83,8 +89,12 @@ fn run_with_levm(
     }
     levm_run_spinner.success(&report::progress(reports, levm_run_time.elapsed()));
 
+    if opts.summary {
+        report::write_summary(reports)?;
+    }
+
     let mut summary_spinner = Spinner::new(Dots, "Loading summary...".to_owned(), Color::Cyan);
-    summary_spinner.success(&report::summary(reports));
+    summary_spinner.success(&report::summary_pretty(reports));
     Ok(())
 }
 

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -35,6 +35,10 @@ run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	cd ../../../ && \
 	time cargo test -p ef_tests-levm --test ef_tests_levm
 
+generate-evm-ef-tests-report: ## 📊 Generate EF Tests Report
+	cd ../../../ && \
+	cargo test -p ef_tests-levm --test ef_tests_levm -- --summary
+
 clean-evm-ef-tests: ## 🗑️  Clean test vectors
 	rm -rf $(SPECTEST_VECTORS_DIR)
 


### PR DESCRIPTION
This is how the slack message will look like:

# Daily LEVM EF Tests Run Report
**Summary**: 718/4101 (17.51%)

**Cancun**: 634/3578 (17.72%)
**Shanghai**: 33/221 (14.93%)
**Homestead**: 0/17 (0.00%)
**Istanbul**: 0/34 (0.00%)
**London**: 17/39 (43.59%)
**Byzantium**: 0/33 (0.00%)
**Berlin**: 17/35 (48.57%)
**Constantinople**: 0/66 (0.00%)
**Merge**: 17/62 (27.42%)
**Frontier**: 0/16 (0.00%)
