### PR TITLE
fix(levm): `mulmod` implementation

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -194,31 +194,22 @@ impl VM {
     ) -> Result<OpcodeSuccess, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::MULMOD)?;
 
-        let multiplicand = U512::from(current_call_frame.stack.pop()?);
-        let multiplier = U512::from(current_call_frame.stack.pop()?);
-        let divisor = U512::from(current_call_frame.stack.pop()?);
-        if divisor.is_zero() {
+        let multiplicand = current_call_frame.stack.pop()?;
+        let multiplier = current_call_frame.stack.pop()?;
+        let modulus = current_call_frame.stack.pop()?;
+
+        if modulus.is_zero() {
             current_call_frame.stack.push(U256::zero())?;
             return Ok(OpcodeSuccess::Continue);
         }
 
-        let (product, overflow) = multiplicand.overflowing_mul(multiplier);
-        let mut remainder = product.checked_rem(divisor).ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationDividedByZero,
-        ))?; // Cannot be zero bc if above
-        if overflow || remainder > divisor {
-            remainder = remainder.overflowing_sub(divisor).0;
-        }
-        let mut result = Vec::new();
-        for byte in remainder.0.iter().take(4) {
-            let bytes = byte.to_le_bytes();
-            result.extend_from_slice(&bytes);
-        }
-        // before reverse we have something like [120, 255, 0, 0....]
-        // after reverse we get the [0, 0, ...., 255, 120] which is the correct order for the little endian u256
-        result.reverse();
-        let remainder = U256::from(result.as_slice());
-        current_call_frame.stack.push(remainder)?;
+        let multiplicand = multiplicand.checked_rem(modulus).unwrap_or_default();
+        let multiplier = multiplier.checked_rem(modulus).unwrap_or_default();
+
+        let (product, _overflowed) = multiplicand.overflowing_mul(multiplier);
+        let product_mod = product.checked_rem(modulus).unwrap_or_default();
+
+        current_call_frame.stack.push(product_mod)?;
 
         Ok(OpcodeSuccess::Continue)
     }

--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -5,7 +5,7 @@ use crate::{
     opcode_handlers::bitwise_comparison::checked_shift_left,
     vm::VM,
 };
-use ethrex_core::{U256, U512};
+use ethrex_core::U256;
 
 // Arithmetic Operations (11)
 // Opcodes: ADD, SUB, MUL, DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP, SIGNEXTEND


### PR DESCRIPTION
- `mulmod` implementation is refactored to a less error-prone version.
- The modular arithmetic was not being done correctly.