### PR TITLE
chore(l2): forbid index slicing

### DIFF
--- a/cmd/ethrex_l2/src/commands/wallet.rs
+++ b/cmd/ethrex_l2/src/commands/wallet.rs
@@ -245,6 +245,12 @@ async fn get_withdraw_merkle_proof(
             .collect(),
         tx_withdrawal_hash,
     )
+    .map_err(|err| {
+        eyre::eyre!(
+            "Failed to generate merkle proof in get_withdraw_merkle_proof: {:?}",
+            err
+        )
+    })?
     .ok_or_eyre("Transaction's WithdrawalData is not in block's WithdrawalDataMerkleRoot")?;
 
     Ok((index, path))

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -42,3 +42,4 @@ path = "./l2.rs"
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+indexing_slicing = "deny"

--- a/crates/l2/contracts/Cargo.toml
+++ b/crates/l2/contracts/Cargo.toml
@@ -28,3 +28,4 @@ path = "./deployer.rs"
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+indexing_slicing = "deny"

--- a/crates/l2/proposer/errors.rs
+++ b/crates/l2/proposer/errors.rs
@@ -1,5 +1,6 @@
 use std::sync::mpsc::SendError;
 
+use crate::utils::merkle_tree::MerkleError;
 use crate::utils::{config::errors::ConfigError, eth_client::errors::EthClientError};
 use ethereum_types::FromStrRadixErr;
 use ethrex_core::types::BlobsBundleError;
@@ -92,6 +93,10 @@ pub enum CommitterError {
     FailedToReExecuteBlock(#[from] EvmError),
     #[error("Committer failed to send transaction: {0}")]
     FailedToSendCommitment(String),
+    #[error("Commiter failed to decode deposit hash")]
+    FailedToDecodeDepositHash,
+    #[error("Commiter failed to merkelize: {0}")]
+    FailedToMerkelize(#[from] MerkleError),
     #[error("Withdrawal transaction was invalid")]
     InvalidWithdrawalTransaction,
     #[error("Blob estimation failed: {0}")]

--- a/crates/l2/proposer/errors.rs
+++ b/crates/l2/proposer/errors.rs
@@ -93,9 +93,9 @@ pub enum CommitterError {
     FailedToReExecuteBlock(#[from] EvmError),
     #[error("Committer failed to send transaction: {0}")]
     FailedToSendCommitment(String),
-    #[error("Commiter failed to decode deposit hash")]
+    #[error("Committer failed to decode deposit hash")]
     FailedToDecodeDepositHash,
-    #[error("Commiter failed to merkelize: {0}")]
+    #[error("Committer failed to merkelize: {0}")]
     FailedToMerkelize(#[from] MerkleError),
     #[error("Withdrawal transaction was invalid")]
     InvalidWithdrawalTransaction,

--- a/crates/l2/proposer/l1_watcher.rs
+++ b/crates/l2/proposer/l1_watcher.rs
@@ -79,14 +79,17 @@ impl L1Watcher {
 
     pub async fn get_pending_deposit_logs(&self) -> Result<Vec<H256>, L1WatcherError> {
         Ok(hex::decode(
-            &self
-                .eth_client
+            self.eth_client
                 .call(
                     self.address,
                     Bytes::copy_from_slice(&[0x35, 0x6d, 0xa2, 0x49]),
                     Overrides::default(),
                 )
-                .await?[2..],
+                .await?
+                .get(2..)
+                .ok_or(L1WatcherError::FailedToDeserializeLog(
+                    "Not a valid hex string".to_string(),
+                ))?,
         )
         .map_err(|_| L1WatcherError::FailedToDeserializeLog("Not a valid hex string".to_string()))?
         .chunks(32)
@@ -112,22 +115,28 @@ impl L1Watcher {
             self.last_block_fetched, new_last_block
         );
 
-        let logs = match self
-            .eth_client
-            .get_logs(
-                self.last_block_fetched + 1,
-                new_last_block,
-                self.address,
-                self.topics[0],
-            )
-            .await
-        {
-            Ok(logs) => logs,
-            Err(error) => {
-                warn!("Error when getting logs from L1: {}", error);
-                vec![]
-            }
-        };
+        let logs;
+        if let Some(first_topic) = self.topics.first() {
+            logs = match self
+                .eth_client
+                .get_logs(
+                    self.last_block_fetched + 1,
+                    new_last_block,
+                    self.address,
+                    *first_topic,
+                )
+                .await
+            {
+                Ok(logs) => logs,
+                Err(error) => {
+                    warn!("Error when getting logs from L1: {}", error);
+                    vec![]
+                }
+            };
+        } else {
+            warn!("Error when getting logs from L1: topics vector is empty");
+            logs = vec![];
+        }
 
         debug!("Logs: {:#?}", logs);
 
@@ -158,14 +167,31 @@ impl L1Watcher {
             .unwrap_or_default();
 
         for log in logs {
-            let mint_value = format!("{:#x}", log.log.topics[1])
-                .parse::<U256>()
-                .map_err(|e| {
-                    L1WatcherError::FailedToDeserializeLog(format!(
-                        "Failed to parse mint value from log: {e:#?}"
-                    ))
-                })?;
-            let beneficiary = format!("{:#x}", log.log.topics[2].into_uint())
+            let mint_value = format!(
+                "{:#x}",
+                log.log
+                    .topics
+                    .get(1)
+                    .ok_or(L1WatcherError::FailedToDeserializeLog(
+                        "Failed to parse mint value from log: log.topics[1] out of bounds"
+                            .to_owned()
+                    ))?
+            )
+            .parse::<U256>()
+            .map_err(|e| {
+                L1WatcherError::FailedToDeserializeLog(format!(
+                    "Failed to parse mint value from log: {e:#?}"
+                ))
+            })?;
+            let beneficiary_uint = log
+                .log
+                .topics
+                .get(2)
+                .ok_or(L1WatcherError::FailedToDeserializeLog(
+                    "Failed to parse beneficiary from log: log.topics[2] out of bounds".to_owned(),
+                ))?
+                .into_uint();
+            let beneficiary = format!("{:#x}", beneficiary_uint)
                 .parse::<Address>()
                 .map_err(|e| {
                     L1WatcherError::FailedToDeserializeLog(format!(

--- a/crates/l2/proposer/l1_watcher.rs
+++ b/crates/l2/proposer/l1_watcher.rs
@@ -129,7 +129,7 @@ impl L1Watcher {
             {
                 Ok(logs) => logs,
                 Err(error) => {
-                    warn!("Error when getting logs from L1: {}", error);
+                    warn!("Error when getting logs from L1: {error}");
                     vec![]
                 }
             };
@@ -191,7 +191,7 @@ impl L1Watcher {
                     "Failed to parse beneficiary from log: log.topics[2] out of bounds".to_owned(),
                 ))?
                 .into_uint();
-            let beneficiary = format!("{:#x}", beneficiary_uint)
+            let beneficiary = format!("{beneficiary_uint:#x}")
                 .parse::<Address>()
                 .map_err(|e| {
                     L1WatcherError::FailedToDeserializeLog(format!(

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -54,3 +54,4 @@ gpu = ["risc0-zkvm/cuda"]
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+indexing_slicing = "deny"

--- a/crates/l2/sdk/Cargo.toml
+++ b/crates/l2/sdk/Cargo.toml
@@ -23,3 +23,4 @@ path = "src/sdk.rs"
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
+indexing_slicing = "deny"

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -163,7 +163,14 @@ pub async fn claim_withdraw(
         let mut calldata = Vec::new();
 
         // Function selector
-        calldata.extend_from_slice(&keccak(CLAIM_WITHDRAWAL_SIGNATURE).as_bytes()[..4]);
+        calldata.extend_from_slice(
+            keccak(CLAIM_WITHDRAWAL_SIGNATURE)
+                .as_bytes()
+                .get(..4)
+                .ok_or(EthClientError::Custom(
+                    "failed to slice into the claim withdrawal signature".to_owned(),
+                ))?,
+        );
 
         // bytes32 l2WithdrawalTxHash
         calldata.extend_from_slice(l2_withdrawal_tx_hash.as_fixed_bytes());
@@ -271,6 +278,7 @@ pub async fn get_withdraw_merkle_proof(
             .collect(),
         tx_withdrawal_hash,
     )
+    .map_err(|err| EthClientError::Custom(format!("Failed to generate merkle proof: {err}")))?
     .ok_or(EthClientError::Custom(
         "Failed to generate merkle proof, element is not on the tree".to_string(),
     ))?;

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -226,7 +226,7 @@ async fn testito() {
     println!("Claiming funds on L1");
 
     while u64::from_str_radix(
-        &eth_client
+        eth_client
             .call(
                 Address::from_str(
                     &std::env::var("ON_CHAIN_PROPOSER_ADDRESS")
@@ -238,7 +238,9 @@ async fn testito() {
                 Overrides::default(),
             )
             .await
-            .unwrap()[2..],
+            .unwrap()
+            .get(2..)
+            .unwrap(),
         16,
     )
     .unwrap()

--- a/crates/l2/utils/eth_client/mod.rs
+++ b/crates/l2/utils/eth_client/mod.rs
@@ -366,7 +366,7 @@ impl EthClient {
         // Add the nonce just if present, otherwise the RPC will use the latest nonce
         if let Some(nonce) = transaction.nonce {
             if let Value::Object(ref mut map) = data {
-                map.insert("nonce".to_owned(), json!(format!("{:#x}", nonce)));
+                map.insert("nonce".to_owned(), json!(format!("{nonce:#x}")));
             }
         }
 

--- a/crates/l2/utils/merkle_tree.rs
+++ b/crates/l2/utils/merkle_tree.rs
@@ -1,7 +1,16 @@
 use keccak_hash::{keccak, H256};
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
-pub fn merkelize(data: Vec<H256>) -> H256 {
+#[derive(Debug, thiserror::Error, Clone, Serialize, Deserialize)]
+pub enum MerkleError {
+    #[error("Left element is None")]
+    LeftElementIsNone(),
+    #[error("Data vector is empty")]
+    DataVectorIsEmpty(),
+}
+
+pub fn merkelize(data: Vec<H256>) -> Result<H256, MerkleError> {
     info!("Merkelizing {:?}", data);
     let mut data = data;
     let mut first = true;
@@ -9,19 +18,21 @@ pub fn merkelize(data: Vec<H256>) -> H256 {
         first = false;
         data = data
             .chunks(2)
-            .map(|chunk| {
-                let left = chunk[0];
-                let right = *chunk.get(1).unwrap_or(&left);
-                keccak([left.as_bytes(), right.as_bytes()].concat())
+            .flat_map(|chunk| -> Result<H256, MerkleError> {
+                let left = chunk.first().ok_or(MerkleError::LeftElementIsNone())?;
+                let right = *chunk.get(1).unwrap_or(left);
+                Ok(keccak([left.as_bytes(), right.as_bytes()].concat()))
             })
             .collect();
     }
-    data[0]
+    data.first()
+        .copied()
+        .ok_or(MerkleError::DataVectorIsEmpty())
 }
 
-pub fn merkle_proof(data: Vec<H256>, base_element: H256) -> Option<Vec<H256>> {
+pub fn merkle_proof(data: Vec<H256>, base_element: H256) -> Result<Option<Vec<H256>>, MerkleError> {
     if !data.contains(&base_element) {
-        return None;
+        return Ok(None);
     }
 
     let mut proof = vec![];
@@ -34,9 +45,12 @@ pub fn merkle_proof(data: Vec<H256>, base_element: H256) -> Option<Vec<H256>> {
         let current_target = target_hash;
         data = data
             .chunks(2)
-            .map(|chunk| {
-                let left = chunk[0];
-                let right = *chunk.get(1).unwrap_or(&left);
+            .flat_map(|chunk| -> Result<H256, MerkleError> {
+                let left = chunk
+                    .first()
+                    .copied()
+                    .ok_or(MerkleError::LeftElementIsNone())?;
+                let right = chunk.get(1).copied().unwrap_or(left);
                 let result = keccak([left.as_bytes(), right.as_bytes()].concat());
                 if left == current_target {
                     proof.push(right);
@@ -45,10 +59,10 @@ pub fn merkle_proof(data: Vec<H256>, base_element: H256) -> Option<Vec<H256>> {
                     proof.push(left);
                     target_hash = result;
                 }
-                result
+                Ok(result)
             })
             .collect();
     }
 
-    Some(proof)
+    Ok(Some(proof))
 }

--- a/crates/l2/utils/mod.rs
+++ b/crates/l2/utils/mod.rs
@@ -31,7 +31,7 @@ pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, Et
         .serialize_uncompressed();
     let hash = keccak(&public_key[1..]);
 
-    // Get the lat 20 bytes of the hash
+    // Get the last 20 bytes of the hash
     let address_bytes: [u8; 20] = hash
         .as_ref()
         .get(12..32)

--- a/crates/l2/utils/mod.rs
+++ b/crates/l2/utils/mod.rs
@@ -1,5 +1,4 @@
-use std::array::TryFromSliceError;
-
+use crate::utils::eth_client::errors::EthClientError;
 use ethrex_core::Address;
 use keccak_hash::{keccak, H256};
 use secp256k1::SecretKey;
@@ -26,14 +25,23 @@ where
     hex.serialize(serializer)
 }
 
-pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, TryFromSliceError> {
+pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, EthClientError> {
     let public_key = secret_key
         .public_key(secp256k1::SECP256K1)
         .serialize_uncompressed();
     let hash = keccak(&public_key[1..]);
 
     // Get the lat 20 bytes of the hash
-    let address_bytes: [u8; 20] = hash[12..32].try_into()?;
+    let address_bytes: [u8; 20] = hash
+        .as_ref()
+        .get(12..32)
+        .ok_or(EthClientError::Custom(
+            "Failed to get_address_from_secret_key: error slicing address_bytes".to_owned(),
+        ))?
+        .try_into()
+        .map_err(|err| {
+            EthClientError::Custom(format!("Failed to get_address_from_secret_key: {err}"))
+        })?;
 
     Ok(Address::from(address_bytes))
 }


### PR DESCRIPTION
**Motivation**

We should not use direct indexing `var[idx]` or direct index slicing `var[0..2]` and instead use safe alternatives and handle the errors.

**Description**

- `indexing_slicing = "deny"` was added to `Cargo.toml` to forbid index slicing usage.
- All usages were removed in the `l2` crate

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1270 

