### PR TITLE
ci(core): fix CI skipped triggering.

### DIFF
--- a/.github/workflows/ci_skipped.yaml
+++ b/.github/workflows/ci_skipped.yaml
@@ -2,11 +2,15 @@ name: CI Skipped
 on:
   pull_request:
     branches: ["**"]
-    paths:
-      - 'README.md'
-      - 'LICENSE'
-      - "**/README.md"
-      - "**/docs/**"
+    paths-ignore:
+      - '**/*.rs'
+      - '**/*.toml'
+      - '**/*.yaml'
+      - '**/*.sh'
+      - '**/*.json'
+      - '**/*.rlp'
+      - 'Dockefile*'
+
 jobs:
   lint:
     # "Lint" is a required check, don't change the name


### PR DESCRIPTION
**Motivation**
We want to skip this on any code changes, and have it if there is **only** doc changes. Dunno if there's a better way to do it.

