### PR TITLE
fix(l1, l2, levm): slack message publishing

### DIFF
--- a/.github/scripts/publish_loc.sh
+++ b/.github/scripts/publish_loc.sh
@@ -17,7 +17,7 @@ $(jq -n --arg text "$(cat loc_report_slack.txt)" '{
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": $text
+                "text": "$text"
             }             
         }
     ]


### PR DESCRIPTION
The slack message payload was missing some `"` in the text and it was being sent as:
<img width="604" alt="image" src="https://github.com/user-attachments/assets/0f89c3b9-c95e-4a93-ab9a-146dcd78d567">
