### PR TITLE
fix(levm): ef tests run summary file paths

### DIFF
--- a/.github/scripts/publish_levm_ef_tests_summary.sh
+++ b/.github/scripts/publish_levm_ef_tests_summary.sh
@@ -1,7 +1,7 @@
 curl -X POST $url \
 -H 'Content-Type: application/json; charset=utf-8' \
 --data @- <<EOF
-$(jq -n --arg text "$(cat crates/vm/levm/levm_ef_tests_summary_slack.txt)" '{
+$(jq -n --arg text "$(cat cmd/ef_tests/levm/levm_ef_tests_summary_slack.txt)" '{
     "blocks": [
         {
             "type": "header",

--- a/.github/scripts/publish_levm_ef_tests_summary.sh
+++ b/.github/scripts/publish_levm_ef_tests_summary.sh
@@ -17,7 +17,7 @@ $(jq -n --arg text "$(cat cmd/ef_tests/levm/levm_ef_tests_summary_slack.txt)" '{
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": $text
+                "text": "$text"
             }             
         }
     ]

--- a/.github/workflows/levm_reporter.yaml
+++ b/.github/workflows/levm_reporter.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Post results in summary
         run: |
           echo "# Daily LEVM EF Tests Run Report" >> $GITHUB_STEP_SUMMARY
-          cat crates/vm/levm/levm_ef_tests_summary_github.txt >> $GITHUB_STEP_SUMMARY
+          cat cmd/ef_tests/levm/levm_ef_tests_summary_github.txt >> $GITHUB_STEP_SUMMARY
 
       - name: Post results to ethrex L1 slack channel
         env:


### PR DESCRIPTION
I run the script locally, and the summary files are being written at `cmd/ef_tests/levm`