### PR TITLE
ci(core): fix path filtering on ci_skipped workflow.

### DIFF
--- a/.github/workflows/ci_skipped.yaml
+++ b/.github/workflows/ci_skipped.yaml
@@ -7,6 +7,14 @@ on:
       - 'LICENSE'
       - "**/README.md"
       - "**/docs/**"
+      - '!**/*.rs'
+      - '!**/*.toml'
+      - '!**/*.yaml'
+      - '!**/*.sh'
+      - '!**/*.json'
+      - '!**/*.rlp'
+      - '!**Dockefile'
+      - '!**Makefile'
 jobs:
   lint:
     # "Lint" is a required check, don't change the name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ dependencies = [
  "ethrex-core",
  "ethrex-rlp",
  "ethrex-storage",
+ "ethrex-trie",
  "hex",
  "hex-literal",
  "hmac",
@@ -3610,7 +3611,8 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 name = "loc"
 version = "0.1.0"
 dependencies = [
- "colored",
+ "serde",
+ "serde_json",
  "tokei",
 ]
 


### PR DESCRIPTION
**Motivation**
We want `ci_skipped` to run whenever there were changes to doc files, but we don't want to run it if there are changes to code.

See documentation: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths

