### PR TITLE
feat(l1): add success percentage to the hive report

### DIFF
--- a/cmd/hive_report/src/main.rs
+++ b/cmd/hive_report/src/main.rs
@@ -61,10 +61,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Sort by file name.
     results.sort_by(|a, b| a.0.cmp(&b.0));
 
-    for (file_name, passed, total) in results {
-        let success_percentage = (passed as f64 / total as f64) * 100.0;
+    for (file_name, passed, total) in &results {
+        let success_percentage = (*passed as f64 / *total as f64) * 100.0;
         println!("{file_name}: {passed}/{total} ({success_percentage:.02}%)");
     }
+    println!();
+    let total_passed = results.iter().map(|(_, p, _)| p).sum::<usize>();
+    let total_tests = results.iter().map(|(_, _, t)| t).sum::<usize>();
+    let total_percentage = (total_passed as f64 / total_tests as f64) * 100.0;
+    println!("Total: {total_passed}/{total_tests} ({total_percentage:.02}%)");
 
     Ok(())
 }

--- a/cmd/hive_report/src/main.rs
+++ b/cmd/hive_report/src/main.rs
@@ -62,7 +62,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     results.sort_by(|a, b| a.0.cmp(&b.0));
 
     for (file_name, passed, total) in results {
-        println!("- {}: {}/{}", file_name, passed, total);
+        let success_percentage = (passed as f64 / total as f64) * 100.0;
+        println!("{file_name}: {passed}/{total} ({success_percentage:.02}%)");
     }
 
     Ok(())


### PR DESCRIPTION
With these changes, the report should look like:

# Daily Hive Coverage report

discv4: 15/15 (100.00%)
discv5: 1/8 (12.50%)
engine-api: 1/129 (0.78%)
engine-auth: 8/8 (100.00%)
engine-cancun: 165/227 (72.69%)
engine-exchange-capabilities: 5/5 (100.00%)
engine-withdrawals: 1/36 (2.78%)
eth: 10/14 (71.43%)
rpc-compat: 89/90 (98.89%)
snap: 6/6 (100.00%)
sync: 0/1 (0.00%)

Total: 301/539 (55.84%)