### PR TITLE
feat(levm): comment out EF Tests run in LEVM CI

### DIFF
--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -33,15 +33,16 @@ jobs:
       - name: Caching
         uses: Swatinem/rust-cache@v2
 
-      - name: Download EF Tests
-        run: |
-          cd crates/vm/levm
-          make download-evm-ef-tests
+      # TODO: Uncomment when there's at least one test suite passing https://github.com/lambdaclass/ethrex/issues/1376.
+      # - name: Download EF Tests
+      #   run: |
+      #     cd crates/vm/levm
+      #     make download-evm-ef-tests
 
-      - name: Run tests
-        run: |
-          cd crates/vm/levm
-          make run-evm-ef-tests
+      # - name: Run tests
+      #   run: |
+      #     cd crates/vm/levm
+      #     make run-evm-ef-tests
   test:
     # "Test" is a required check, don't change the name
     name: Test


### PR DESCRIPTION
Today the LEVM EF Tests job takes too much time to run, lowering the CI a lot. We will comment it out until there's at least one test suite passing entirely, and when so, we'll only run the passing suites https://github.com/lambdaclass/ethrex/issues/1376.