### PR TITLE
refactor(levm): simplify U256 conversion logic

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -110,11 +110,8 @@ impl VM {
         self.increase_consumed_gas(current_call_frame, gas_cost::ISZERO)?;
 
         let operand = current_call_frame.stack.pop()?;
-        let result = if operand == U256::zero() {
-            U256::one()
-        } else {
-            U256::zero()
-        };
+        let result = u256_from_bool(operand.is_zero());
+
         current_call_frame.stack.push(result)?;
 
         Ok(OpcodeSuccess::Continue)

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -321,3 +321,7 @@ fn checked_shift_right(value: U256, shift: U256) -> Result<U256, VMError> {
 
     Ok(result)
 }
+
+fn u256_from_bool(value: bool) -> U256 {
+    U256::from(u8::from(value))
+}

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -16,7 +16,7 @@ impl VM {
         self.increase_consumed_gas(current_call_frame, gas_cost::LT)?;
         let lho = current_call_frame.stack.pop()?;
         let rho = current_call_frame.stack.pop()?;
-        let result = if lho < rho { U256::one() } else { U256::zero() };
+        let result = u256_from_bool(lho < rho);
         current_call_frame.stack.push(result)?;
 
         Ok(OpcodeSuccess::Continue)
@@ -27,7 +27,7 @@ impl VM {
         self.increase_consumed_gas(current_call_frame, gas_cost::GT)?;
         let lho = current_call_frame.stack.pop()?;
         let rho = current_call_frame.stack.pop()?;
-        let result = if lho > rho { U256::one() } else { U256::zero() };
+        let result = u256_from_bool(lho > rho);
         current_call_frame.stack.push(result)?;
 
         Ok(OpcodeSuccess::Continue)

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -42,18 +42,10 @@ impl VM {
         let rho_is_negative = rho.bit(255);
         let result = if lho_is_negative == rho_is_negative {
             // Compare magnitudes if signs are the same
-            if lho < rho {
-                U256::one()
-            } else {
-                U256::zero()
-            }
+            u256_from_bool(lho < rho)
         } else {
             // Negative is smaller if signs differ
-            if lho_is_negative {
-                U256::one()
-            } else {
-                U256::zero()
-            }
+            u256_from_bool(lho_is_negative)
         };
         current_call_frame.stack.push(result)?;
 

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -92,11 +92,8 @@ impl VM {
         self.increase_consumed_gas(current_call_frame, gas_cost::EQ)?;
         let lho = current_call_frame.stack.pop()?;
         let rho = current_call_frame.stack.pop()?;
-        let result = if lho == rho {
-            U256::one()
-        } else {
-            U256::zero()
-        };
+        let result = u256_from_bool(lho == rho);
+
         current_call_frame.stack.push(result)?;
 
         Ok(OpcodeSuccess::Continue)

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -69,18 +69,10 @@ impl VM {
         let rho_is_negative = rho.bit(255);
         let result = if lho_is_negative == rho_is_negative {
             // Compare magnitudes if signs are the same
-            if lho > rho {
-                U256::one()
-            } else {
-                U256::zero()
-            }
+            u256_from_bool(lho > rho)
         } else {
             // Positive is bigger if signs differ
-            if rho_is_negative {
-                U256::one()
-            } else {
-                U256::zero()
-            }
+            u256_from_bool(rho_is_negative)
         };
         current_call_frame.stack.push(result)?;
 


### PR DESCRIPTION
**Motivation**

- This PR aims to reduce the logic in some opcodes.

**Description**

- Add a new function `u256_from_bool(value: bool)` to convert boolean values into U256. Function return `U256::one()` if value is `True` and `U256::zero()` if value is `False`.
- This change simplifies existing code by removing repetitive conversion in `ISZERO`, `EQ`, `SGT`, `SLT`, `GT` and `LT`.

Closes [#1379](https://github.com/lambdaclass/ethrex/issues/1379)