### PR TITLE
chore(core): fixed geth version to avoid latest issues on the CI run

### DIFF
--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -4,10 +4,12 @@ participants:
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -4,6 +4,7 @@ participants:
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32

--- a/test_data/network_params.yaml
+++ b/test_data/network_params.yaml
@@ -4,10 +4,12 @@ participants:
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32
   - el_type: geth
+    el_image: ethereum/client-go:v1.14.12
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v5.3.0
     validator_count: 32


### PR DESCRIPTION
**Motivation**

We've been having some issues related to new versions of clients breaking kurtosis, this was the last dependency not yet fixed

**Description**

Fixes geth version the the current latest, which is working without issues.
