### PR TITLE
feat(levm): disable spinner tests

### DIFF
--- a/cmd/ef_tests/levm/parser.rs
+++ b/cmd/ef_tests/levm/parser.rs
@@ -1,6 +1,6 @@
 use crate::{
     report::format_duration_as_mm_ss,
-    runner::EFTestRunnerOptions,
+    runner::{spinner_success_or_print, spinner_update_text_or_print, EFTestRunnerOptions},
     types::{EFTest, EFTests},
 };
 use colored::Colorize;
@@ -37,12 +37,20 @@ pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestP
         let directory_tests = parse_ef_test_dir(test_dir, opts, &mut spinner)?;
         tests.extend(directory_tests);
     }
-    spinner.success(
-        &format!(
+    // spinner.success(
+    //     &format!(
+    //         "Parsed EF Tests in {}",
+    //         format_duration_as_mm_ss(parsing_time.elapsed())
+    //     )
+    //     .bold(),
+    // );
+    spinner_success_or_print(
+        &mut spinner,
+        format!(
             "Parsed EF Tests in {}",
             format_duration_as_mm_ss(parsing_time.elapsed())
-        )
-        .bold(),
+        ),
+        opts.disable_spinner,
     );
     Ok(tests)
 }
@@ -52,7 +60,12 @@ pub fn parse_ef_test_dir(
     opts: &EFTestRunnerOptions,
     directory_parsing_spinner: &mut Spinner,
 ) -> Result<Vec<EFTest>, EFTestParseError> {
-    directory_parsing_spinner.update_text(format!("Parsing directory {:?}", test_dir.file_name()));
+    // directory_parsing_spinner.update_text(format!("Parsing directory {:?}", test_dir.file_name()));
+    spinner_update_text_or_print(
+        directory_parsing_spinner,
+        format!("Parsing directory {:?}", test_dir.file_name()),
+        opts.disable_spinner,
+    );
 
     let mut directory_tests = Vec::new();
     for test in std::fs::read_dir(test_dir.path())
@@ -93,10 +106,18 @@ pub fn parse_ef_test_dir(
                 .tests
                 .contains(&test_dir.file_name().to_str().unwrap().to_owned())
         {
-            directory_parsing_spinner.update_text(format!(
-                "Skipping test {:?} as it is not in the list of tests to run",
-                test.path().file_name()
-            ));
+            // directory_parsing_spinner.update_text(format!(
+            //     "Skipping test {:?} as it is not in the list of tests to run",
+            //     test.path().file_name()
+            // ));
+            spinner_update_text_or_print(
+                directory_parsing_spinner,
+                format!(
+                    "Skipping test {:?} as it is not in the list of tests to run",
+                    test.path().file_name()
+                ),
+                opts.disable_spinner,
+            );
             return Ok(Vec::new());
         }
 
@@ -105,10 +126,18 @@ pub fn parse_ef_test_dir(
             .skip
             .contains(&test_dir.file_name().to_str().unwrap().to_owned())
         {
-            directory_parsing_spinner.update_text(format!(
-                "Skipping test {:?} as it is in the folder of tests to skip",
-                test.path().file_name()
-            ));
+            // directory_parsing_spinner.update_text(format!(
+            //     "Skipping test {:?} as it is in the folder of tests to skip",
+            //     test.path().file_name()
+            // ));
+            spinner_update_text_or_print(
+                directory_parsing_spinner,
+                format!(
+                    "Skipping test {:?} as it is in the folder of tests to skip",
+                    test.path().file_name()
+                ),
+                opts.disable_spinner,
+            );
             continue;
         }
 
@@ -122,10 +151,18 @@ pub fn parse_ef_test_dir(
                 .unwrap()
                 .to_owned(),
         ) {
-            directory_parsing_spinner.update_text(format!(
-                "Skipping test {:?} as it is in the list of tests to skip",
-                test.path().file_name()
-            ));
+            // directory_parsing_spinner.update_text(format!(
+            //     "Skipping test {:?} as it is in the list of tests to skip",
+            //     test.path().file_name()
+            // ));
+            spinner_update_text_or_print(
+                directory_parsing_spinner,
+                format!(
+                    "Skipping test {:?} as it is in the list of tests to skip",
+                    test.path().file_name()
+                ),
+                opts.disable_spinner,
+            );
             continue;
         }
 

--- a/cmd/ef_tests/levm/parser.rs
+++ b/cmd/ef_tests/levm/parser.rs
@@ -25,7 +25,6 @@ pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestP
     let ef_general_state_tests_path = cargo_manifest_dir.join("vectors/GeneralStateTests");
     let mut spinner = Spinner::new(Dots, "Parsing EF Tests".bold().to_string(), Color::Cyan);
     if opts.disable_spinner {
-        println!("Parsing EF Tests");
         spinner.stop();
     }
     let mut tests = Vec::new();

--- a/cmd/ef_tests/levm/parser.rs
+++ b/cmd/ef_tests/levm/parser.rs
@@ -24,6 +24,10 @@ pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestP
     let cargo_manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let ef_general_state_tests_path = cargo_manifest_dir.join("vectors/GeneralStateTests");
     let mut spinner = Spinner::new(Dots, "Parsing EF Tests".bold().to_string(), Color::Cyan);
+    if opts.disable_spinner {
+        println!("Parsing EF Tests");
+        spinner.stop();
+    }
     let mut tests = Vec::new();
     for test_dir in std::fs::read_dir(ef_general_state_tests_path.clone())
         .map_err(|err| {

--- a/cmd/ef_tests/levm/parser.rs
+++ b/cmd/ef_tests/levm/parser.rs
@@ -40,13 +40,6 @@ pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestP
         let directory_tests = parse_ef_test_dir(test_dir, opts, &mut spinner)?;
         tests.extend(directory_tests);
     }
-    // spinner.success(
-    //     &format!(
-    //         "Parsed EF Tests in {}",
-    //         format_duration_as_mm_ss(parsing_time.elapsed())
-    //     )
-    //     .bold(),
-    // );
     spinner_success_or_print(
         &mut spinner,
         format!(
@@ -63,7 +56,6 @@ pub fn parse_ef_test_dir(
     opts: &EFTestRunnerOptions,
     directory_parsing_spinner: &mut Spinner,
 ) -> Result<Vec<EFTest>, EFTestParseError> {
-    // directory_parsing_spinner.update_text(format!("Parsing directory {:?}", test_dir.file_name()));
     spinner_update_text_or_print(
         directory_parsing_spinner,
         format!("Parsing directory {:?}", test_dir.file_name()),
@@ -109,10 +101,6 @@ pub fn parse_ef_test_dir(
                 .tests
                 .contains(&test_dir.file_name().to_str().unwrap().to_owned())
         {
-            // directory_parsing_spinner.update_text(format!(
-            //     "Skipping test {:?} as it is not in the list of tests to run",
-            //     test.path().file_name()
-            // ));
             spinner_update_text_or_print(
                 directory_parsing_spinner,
                 format!(
@@ -129,10 +117,6 @@ pub fn parse_ef_test_dir(
             .skip
             .contains(&test_dir.file_name().to_str().unwrap().to_owned())
         {
-            // directory_parsing_spinner.update_text(format!(
-            //     "Skipping test {:?} as it is in the folder of tests to skip",
-            //     test.path().file_name()
-            // ));
             spinner_update_text_or_print(
                 directory_parsing_spinner,
                 format!(
@@ -154,10 +138,6 @@ pub fn parse_ef_test_dir(
                 .unwrap()
                 .to_owned(),
         ) {
-            // directory_parsing_spinner.update_text(format!(
-            //     "Skipping test {:?} as it is in the list of tests to skip",
-            //     test.path().file_name()
-            // ));
             spinner_update_text_or_print(
                 directory_parsing_spinner,
                 format!(

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -222,7 +222,8 @@ fn re_run_with_revm(
         revm_run_spinner.stop();
     }
     let failed_tests = reports.iter().filter(|report| !report.passed()).count();
-    for (idx, failed_test_report) in reports.iter_mut().enumerate() {
+    let mut progress_counter = 1;
+    for failed_test_report in reports.iter_mut() {
         if failed_test_report.passed() {
             continue;
         }
@@ -240,11 +241,13 @@ fn re_run_with_revm(
             format!(
                 "{} {}/{failed_tests} - {}",
                 "Re-running failed tests with REVM".bold(),
-                idx + 1,
+                progress_counter,
                 format_duration_as_mm_ss(revm_run_time.elapsed())
             ),
             opts.disable_spinner,
         );
+
+        progress_counter += 1;
 
         match revm_runner::re_run_failed_ef_test(
             ef_tests

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -110,14 +110,12 @@ fn run_with_levm(
             }
         };
         reports.push(ef_test_report);
-        // levm_run_spinner.update_text(report::progress(reports, levm_run_time.elapsed()));
         spinner_update_text_or_print(
             &mut levm_run_spinner,
             report::progress(reports, levm_run_time.elapsed()),
             opts.disable_spinner,
         );
     }
-    // levm_run_spinner.success(&report::progress(reports, levm_run_time.elapsed()));
     spinner_success_or_print(
         &mut levm_run_spinner,
         report::progress(reports, levm_run_time.elapsed()),
@@ -133,7 +131,6 @@ fn run_with_levm(
     if opts.disable_spinner {
         summary_spinner.stop();
     }
-    // summary_spinner.success(&report::summary_for_shell(reports));
     spinner_success_or_print(
         &mut summary_spinner,
         report::summary_for_shell(reports),
@@ -164,12 +161,6 @@ fn _run_with_revm(
             println!("Running test: {:?}", test.name);
         }
         let total_tests = ef_tests.len();
-        // revm_run_spinner.update_text(format!(
-        //     "{} {}/{total_tests} - {}",
-        //     "Running all tests with REVM".bold(),
-        //     idx + 1,
-        //     format_duration_as_mm_ss(revm_run_time.elapsed())
-        // ));
         spinner_update_text_or_print(
             &mut revm_run_spinner,
             format!(
@@ -190,12 +181,12 @@ fn _run_with_revm(
             }
         };
         reports.push(ef_test_report);
-        revm_run_spinner.update_text(report::progress(reports, revm_run_time.elapsed()));
+        spinner_update_text_or_print(
+            &mut revm_run_spinner,
+            report::progress(reports, revm_run_time.elapsed()),
+            opts.disable_spinner,
+        );
     }
-    // revm_run_spinner.success(&format!(
-    //     "Ran all tests with REVM in {}",
-    //     format_duration_as_mm_ss(revm_run_time.elapsed())
-    // ));
     spinner_success_or_print(
         &mut revm_run_spinner,
         format!(
@@ -222,32 +213,26 @@ fn re_run_with_revm(
         revm_run_spinner.stop();
     }
     let failed_tests = reports.iter().filter(|report| !report.passed()).count();
-    let mut progress_counter = 1;
-    for failed_test_report in reports.iter_mut() {
-        if failed_test_report.passed() {
-            continue;
-        }
+
+    // Iterate only over failed tests
+    for (idx, failed_test_report) in reports
+        .iter_mut()
+        .filter(|report| !report.passed())
+        .enumerate()
+    {
         if opts.disable_spinner {
             println!("Running test: {:?}", failed_test_report.name);
         }
-        // revm_run_spinner.update_text(format!(
-        //     "{} {}/{failed_tests} - {}",
-        //     "Re-running failed tests with REVM".bold(),
-        //     idx + 1,
-        //     format_duration_as_mm_ss(revm_run_time.elapsed())
-        // ));
         spinner_update_text_or_print(
             &mut revm_run_spinner,
             format!(
                 "{} {}/{failed_tests} - {}",
                 "Re-running failed tests with REVM".bold(),
-                progress_counter,
+                idx + 1,
                 format_duration_as_mm_ss(revm_run_time.elapsed())
             ),
             opts.disable_spinner,
         );
-
-        progress_counter += 1;
 
         match revm_runner::re_run_failed_ef_test(
             ef_tests
@@ -274,10 +259,6 @@ fn re_run_with_revm(
             }
         }
     }
-    // revm_run_spinner.success(&format!(
-    //     "Re-ran failed tests with REVM in {}",
-    //     format_duration_as_mm_ss(revm_run_time.elapsed())
-    // ));
     spinner_success_or_print(
         &mut revm_run_spinner,
         format!(

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -99,7 +99,6 @@ fn run_with_levm(
         Color::Cyan,
     );
     if opts.disable_spinner {
-        println!("{}", "Running all tests with LEVM...".bold());
         levm_run_spinner.stop();
     }
     for test in ef_tests.iter() {
@@ -139,7 +138,6 @@ fn run_with_levm(
 
     let mut summary_spinner = Spinner::new(Dots, "Loading summary...".to_owned(), Color::Cyan);
     if opts.disable_spinner {
-        println!("{}", "Loading summary...".bold());
         summary_spinner.stop();
     }
     // summary_spinner.success(&report::summary_for_shell(reports));
@@ -166,7 +164,6 @@ fn _run_with_revm(
         Color::Cyan,
     );
     if opts.disable_spinner {
-        println!("{}", "Running all tests with REVM...".bold());
         revm_run_spinner.stop();
     }
     for (idx, test) in ef_tests.iter().enumerate() {
@@ -208,7 +205,6 @@ fn re_run_with_revm(
         Color::Cyan,
     );
     if opts.disable_spinner {
-        println!("{}", "Running failed tests with REVM...".bold());
         revm_run_spinner.stop();
     }
     let failed_tests = reports.iter().filter(|report| !report.passed()).count();

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -102,11 +102,9 @@ fn run_with_levm(
         levm_run_spinner.stop();
     }
     for test in ef_tests.iter() {
-        // println!(
-        //     "Time elapsed: {:?}",
-        //     format_duration_as_mm_ss(levm_run_time.elapsed())
-        // );
-        // println!("Running test: {:?}", test.name);
+        if opts.disable_spinner {
+            println!("Running test: {:?}", test.name);
+        }
         let ef_test_report = match levm_runner::run_ef_test(test) {
             Ok(ef_test_report) => ef_test_report,
             Err(EFTestRunnerError::Internal(err)) => return Err(EFTestRunnerError::Internal(err)),
@@ -167,13 +165,26 @@ fn _run_with_revm(
         revm_run_spinner.stop();
     }
     for (idx, test) in ef_tests.iter().enumerate() {
+        if opts.disable_spinner {
+            println!("Running test: {:?}", test.name);
+        }
         let total_tests = ef_tests.len();
-        revm_run_spinner.update_text(format!(
-            "{} {}/{total_tests} - {}",
-            "Running all tests with REVM".bold(),
-            idx + 1,
-            format_duration_as_mm_ss(revm_run_time.elapsed())
-        ));
+        // revm_run_spinner.update_text(format!(
+        //     "{} {}/{total_tests} - {}",
+        //     "Running all tests with REVM".bold(),
+        //     idx + 1,
+        //     format_duration_as_mm_ss(revm_run_time.elapsed())
+        // ));
+        spinner_update_text_or_print(
+            &mut revm_run_spinner,
+            format!(
+                "{} {}/{total_tests} - {}",
+                "Running all tests with REVM".bold(),
+                idx + 1,
+                format_duration_as_mm_ss(revm_run_time.elapsed())
+            ),
+            opts.disable_spinner,
+        );
         let ef_test_report = match revm_runner::_run_ef_test_revm(test) {
             Ok(ef_test_report) => ef_test_report,
             Err(EFTestRunnerError::Internal(err)) => return Err(EFTestRunnerError::Internal(err)),
@@ -186,10 +197,18 @@ fn _run_with_revm(
         reports.push(ef_test_report);
         revm_run_spinner.update_text(report::progress(reports, revm_run_time.elapsed()));
     }
-    revm_run_spinner.success(&format!(
-        "Ran all tests with REVM in {}",
-        format_duration_as_mm_ss(revm_run_time.elapsed())
-    ));
+    // revm_run_spinner.success(&format!(
+    //     "Ran all tests with REVM in {}",
+    //     format_duration_as_mm_ss(revm_run_time.elapsed())
+    // ));
+    spinner_success_or_print(
+        &mut revm_run_spinner,
+        format!(
+            "Ran all tests with REVM in {}",
+            format_duration_as_mm_ss(revm_run_time.elapsed())
+        ),
+        opts.disable_spinner,
+    );
     Ok(())
 }
 
@@ -211,6 +230,9 @@ fn re_run_with_revm(
     for (idx, failed_test_report) in reports.iter_mut().enumerate() {
         if failed_test_report.passed() {
             continue;
+        }
+        if opts.disable_spinner {
+            println!("Running test: {:?}", failed_test_report.name);
         }
         // revm_run_spinner.update_text(format!(
         //     "{} {}/{failed_tests} - {}",

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -56,7 +56,7 @@ pub struct EFTestRunnerOptions {
 
 pub fn spinner_update_text_or_print(spinner: &mut Spinner, text: String, no_spinner: bool) {
     if no_spinner {
-        println!(" {}", text);
+        println!("{}", text);
     } else {
         spinner.update_text(text);
     }
@@ -64,7 +64,7 @@ pub fn spinner_update_text_or_print(spinner: &mut Spinner, text: String, no_spin
 
 pub fn spinner_success_or_print(spinner: &mut Spinner, text: String, no_spinner: bool) {
     if no_spinner {
-        println!(" {}", text);
+        println!("{}", text);
     } else {
         spinner.success(&text);
     }
@@ -98,6 +98,10 @@ fn run_with_levm(
         report::progress(reports, levm_run_time.elapsed()),
         Color::Cyan,
     );
+    if opts.disable_spinner {
+        println!("{}", "Running all tests with LEVM...".bold());
+        levm_run_spinner.stop();
+    }
     for test in ef_tests.iter() {
         // println!(
         //     "Time elapsed: {:?}",
@@ -134,6 +138,10 @@ fn run_with_levm(
     }
 
     let mut summary_spinner = Spinner::new(Dots, "Loading summary...".to_owned(), Color::Cyan);
+    if opts.disable_spinner {
+        println!("{}", "Loading summary...".bold());
+        summary_spinner.stop();
+    }
     // summary_spinner.success(&report::summary_for_shell(reports));
     spinner_success_or_print(
         &mut summary_spinner,
@@ -149,6 +157,7 @@ fn run_with_levm(
 fn _run_with_revm(
     reports: &mut Vec<EFTestReport>,
     ef_tests: &[EFTest],
+    opts: &EFTestRunnerOptions,
 ) -> Result<(), EFTestRunnerError> {
     let revm_run_time = std::time::Instant::now();
     let mut revm_run_spinner = Spinner::new(
@@ -156,6 +165,10 @@ fn _run_with_revm(
         "Running all tests with REVM...".to_owned(),
         Color::Cyan,
     );
+    if opts.disable_spinner {
+        println!("{}", "Running all tests with REVM...".bold());
+        revm_run_spinner.stop();
+    }
     for (idx, test) in ef_tests.iter().enumerate() {
         let total_tests = ef_tests.len();
         revm_run_spinner.update_text(format!(
@@ -194,6 +207,10 @@ fn re_run_with_revm(
         "Running failed tests with REVM...".to_owned(),
         Color::Cyan,
     );
+    if opts.disable_spinner {
+        println!("{}", "Running failed tests with REVM...".bold());
+        revm_run_spinner.stop();
+    }
     let failed_tests = reports.iter().filter(|report| !report.passed()).count();
     for (idx, failed_test_report) in reports.iter_mut().enumerate() {
         if failed_test_report.passed() {

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -48,8 +48,6 @@ pub struct EFTestRunnerOptions {
     pub summary: bool,
     #[arg(long, value_name = "SKIP", use_value_delimiter = true)]
     pub skip: Vec<String>,
-    #[arg(long, value_name = "LEVM_ONLY", default_value = "false")]
-    pub levm_only: bool,
     #[arg(long, value_name = "DISABLE_SPINNER", default_value = "false")]
     pub disable_spinner: bool, // Replaces spinner for normal prints.
 }
@@ -78,10 +76,7 @@ pub fn run_ef_tests(
     if reports.is_empty() {
         run_with_levm(&mut reports, &ef_tests, opts)?;
     }
-    if opts.summary {
-        return Ok(());
-    }
-    if !opts.levm_only {
+    if !opts.summary {
         re_run_with_revm(&mut reports, &ef_tests, opts)?;
     }
     write_report(&reports)


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- When running EFTests in CI the spinner is very annoying and it makes it hard to observe the output. The objective is to make the EFTests more suitable for the CI so that we can use that as a tool for checking when something stopped working (or simply tracking progress)

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Implements flag `disable-spinner`, if set, the main spinners will stop and it will replace the "spinner prints" for `println!`
- Fixes index error in REVM

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

