### PR TITLE
fix(levm): ginitcodeword specification, fix gas

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -142,7 +142,7 @@ impl VM {
                     env.origin,
                     new_contract_address,
                     new_contract_address,
-                    Bytes::new(), // Bytecode is assigned after passing initcode validation.
+                    Bytes::new(), // Bytecode is assigned after passing validations.
                     value,
                     calldata, // Calldata is removed after passing validations.
                     false,
@@ -576,6 +576,12 @@ impl VM {
 
         let cache_before_execution = self.cache.clone();
         self.validate_transaction(&mut initial_call_frame)?;
+
+        if self.is_create() {
+            // Assign bytecode to context and empty calldata
+            initial_call_frame.bytecode = initial_call_frame.calldata.clone();
+            initial_call_frame.calldata = Bytes::new();
+        }
 
         // Maybe can be done in validate_transaction
         let sender = initial_call_frame.msg_sender;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -478,13 +478,7 @@ impl VM {
             ));
         }
 
-        // (4) INTRINSIC_GAS_TOO_LOW
-        self.add_intrinsic_gas(initial_call_frame)?;
-
-        // (5) NONCE_IS_MAX
-        self.increment_account_nonce(sender_address)?;
-
-        // (6) INITCODE_SIZE_EXCEEDED
+        // (4) INITCODE_SIZE_EXCEEDED
         if self.is_create() {
             // INITCODE_SIZE_EXCEEDED
             if initial_call_frame.calldata.len() > INIT_CODE_MAX_SIZE {
@@ -493,6 +487,12 @@ impl VM {
                 ));
             }
         }
+
+        // (5) INTRINSIC_GAS_TOO_LOW
+        self.add_intrinsic_gas(initial_call_frame)?;
+
+        // (6) NONCE_IS_MAX
+        self.increment_account_nonce(sender_address)?;
 
         // (7) PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS
         if let (Some(tx_max_priority_fee), Some(tx_max_fee_per_gas)) = (

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use bytes::Bytes;
-use ethrex_core::U256;
+use ethrex_core::{types::TxKind, U256};
 use ethrex_levm::{
     errors::{TxResult, VMError},
     operations::Operation,
@@ -273,4 +273,17 @@ fn test_non_compliance_codecopy_memory_resize() {
         current_call_frame.stack.stack.first().unwrap(),
         &U256::from(14400)
     );
+}
+
+#[test]
+fn test_non_compliance_gas_cost_initcode() {
+    let mut vm = new_vm_with_bytecode(Bytes::copy_from_slice(&[0])).unwrap();
+    vm.tx_kind = TxKind::Create;
+    vm.env.gas_price = U256::zero();
+    vm.env.gas_limit = U256::from(100_000_000);
+    vm.env.block_gas_limit = U256::from(100_000_001);
+    let res = vm.transact().unwrap();
+    println!("Actual gas used: {}", res.gas_used);
+    println!("Desired gas used: {}", 53006);
+    assert_eq!(res.gas_used, 53006);
 }

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use bytes::Bytes;
-use ethrex_core::{types::TxKind, U256};
+use ethrex_core::U256;
 use ethrex_levm::{
     errors::{TxResult, VMError},
     operations::Operation,

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -1,3 +1,5 @@
+// Here add #![allow(clippy::<lint_name>)] if necessary, we don't want to lint the test code.
+
 use std::str::FromStr;
 
 use bytes::Bytes;

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -274,16 +274,3 @@ fn test_non_compliance_codecopy_memory_resize() {
         &U256::from(14400)
     );
 }
-
-#[test]
-fn test_non_compliance_gas_cost_initcode() {
-    let mut vm = new_vm_with_bytecode(Bytes::copy_from_slice(&[0])).unwrap();
-    vm.tx_kind = TxKind::Create;
-    vm.env.gas_price = U256::zero();
-    vm.env.gas_limit = U256::from(100_000_000);
-    vm.env.block_gas_limit = U256::from(100_000_001);
-    let res = vm.transact().unwrap();
-    println!("Actual gas used: {}", res.gas_used);
-    println!("Desired gas used: {}", 53006);
-    assert_eq!(res.gas_used, 53006);
-}


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- `number_of_words` is now calculated in a more performant way, without iterating calldata.
- The initial_call_frame in Create is now initialized with empty bytecode and the corresponding calldata send in the transaction. -> After validations the calldata will be assigned to the bytecode and it will be erased. This is mostly for using calldata for calculating some gas costs.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1362, #1363 

Running tests:
- ✓ Summary: 1547/4100 (37.73)
