### PR TITLE
refactor(l1): modularize forkchoice updated code

### DIFF
--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Run tests
         run: |
           make test
-  
+
   docker_build:
     # "Build Docker" is a required check, don't change the name
     name: Build Docker
@@ -163,7 +163,7 @@ jobs:
             test_pattern: engine-(auth|exchange-capabilities)/
           - name: "Cancun Engine tests"
             simulation: ethereum/engine
-            test_pattern: engine-cancun/Blob Transactions On Block 1|Blob Transaction Ordering, Single|Blob Transaction Ordering, Multiple Accounts|Replace Blob Transactions|Parallel Blob Transactions|ForkchoiceUpdatedV3 Modifies Payload ID on Different Beacon Root|NewPayloadV3 After Cancun|NewPayloadV3 Versioned Hashes|Incorrect BlobGasUsed|Bad Hash|ParentHash equals BlockHash|RPC:|in ForkchoiceState|Unknown|Invalid PayloadAttributes|Unique|ForkchoiceUpdated Version on Payload Request|Re-Execute Payload|In-Order Consecutive Payload|Multiple New Payloads|Valid NewPayload->|NewPayload with|Payload Build after|Build Payload with|Invalid Missing Ancestor ReOrg, StateRoot|Re-Org Back to|Re-org to Previously|Safe Re-Org to Side Chain|Transaction Re-Org, Re-Org Back In|Re-Org Back into Canonical Chain, Depth=5|Suggested Fee Recipient Test|PrevRandao Opcode|Invalid NewPayload, [^R][^e]|Fork ID Genesis=0, Cancun=0|Fork ID Genesis=0, Cancun=1|Fork ID Genesis=1, Cancun=0|Fork ID Genesis=1, Cancun=2, Shanghai=2
+            test_pattern: engine-cancun/Blob Transactions On Block 1|Blob Transaction Ordering, Single|Blob Transaction Ordering, Multiple Accounts|Replace Blob Transactions|Parallel Blob Transactions|ForkchoiceUpdatedV3 Modifies Payload ID on Different Beacon Root|NewPayloadV3 After Cancun|NewPayloadV3 Versioned Hashes|Incorrect BlobGasUsed|Bad Hash|ParentHash equals BlockHash|RPC:|in ForkchoiceState|Unknown|Unique|ForkchoiceUpdated Version on Payload Request|Re-Execute Payload|In-Order Consecutive Payload|Multiple New Payloads|Valid NewPayload->|NewPayload with|Payload Build after|Build Payload with|Invalid Missing Ancestor ReOrg, StateRoot|Re-Org Back to|Re-org to Previously|Safe Re-Org to Side Chain|Transaction Re-Org, Re-Org Back In|Re-Org Back into Canonical Chain, Depth=5|Suggested Fee Recipient Test|PrevRandao Opcode|Invalid NewPayload, [^R][^e]|Fork ID Genesis=0, Cancun=0|Fork ID Genesis=0, Cancun=1|Fork ID Genesis=1, Cancun=0|Fork ID Genesis=1, Cancun=2, Shanghai=2
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -198,7 +198,7 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
     needs: [run-assertoor, run-hive]
-    # Make sure this job runs even if the previous jobs failed or were skipped  
+    # Make sure this job runs even if the previous jobs failed or were skipped
     if: ${{ always() && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
     steps:
       - name: Check if any job failed

--- a/crates/blockchain/dev/utils/engine_client/mod.rs
+++ b/crates/blockchain/dev/utils/engine_client/mod.rs
@@ -79,15 +79,10 @@ impl EngineClient {
         state: ForkChoiceState,
         payload_attributes: Option<PayloadAttributesV3>,
     ) -> Result<ForkChoiceResponse, EngineClientError> {
-        let request = ForkChoiceUpdatedV3 {
+        let request = RpcRequest::from(ForkChoiceUpdatedV3 {
             fork_choice_state: state,
             payload_attributes,
-        }
-        .try_into()
-        .map_err(|e| {
-            ForkChoiceUpdateError::ConversionError(format!("Failed to convert to RPC request: {e}"))
-        })
-        .map_err(EngineClientError::from)?;
+        });
 
         match self.send_request(request).await {
             Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)

--- a/crates/blockchain/dev/utils/engine_client/mod.rs
+++ b/crates/blockchain/dev/utils/engine_client/mod.rs
@@ -81,7 +81,7 @@ impl EngineClient {
     ) -> Result<ForkChoiceResponse, EngineClientError> {
         let request = ForkChoiceUpdatedV3 {
             fork_choice_state: state,
-            payload_attributes: Ok(payload_attributes),
+            payload_attributes,
         }
         .try_into()
         .map_err(|e| {

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -4,6 +4,7 @@ use ethrex_blockchain::{
     latest_canonical_block_hash,
     payload::{create_payload, BuildPayloadArgs},
 };
+use ethrex_core::types::BlockHeader;
 use serde_json::Value;
 use tracing::{info, warn};
 
@@ -19,24 +20,18 @@ use crate::{
 #[derive(Debug)]
 pub struct ForkChoiceUpdatedV3 {
     pub fork_choice_state: ForkChoiceState,
-    #[allow(unused)]
-    pub payload_attributes: Result<Option<PayloadAttributesV3>, String>,
+    pub payload_attributes: Option<PayloadAttributesV3>,
 }
 
-impl TryFrom<ForkChoiceUpdatedV3> for RpcRequest {
-    type Error = String;
-
-    fn try_from(val: ForkChoiceUpdatedV3) -> Result<Self, Self::Error> {
-        match val.payload_attributes {
-            Ok(attrs) => Ok(RpcRequest {
-                method: "engine_forkchoiceUpdatedV3".to_string(),
-                params: Some(vec![
-                    serde_json::json!(val.fork_choice_state),
-                    serde_json::json!(attrs),
-                ]),
-                ..Default::default()
-            }),
-            Err(err) => Err(err),
+impl From<ForkChoiceUpdatedV3> for RpcRequest {
+    fn from(val: ForkChoiceUpdatedV3) -> Self {
+        RpcRequest {
+            method: "engine_forkchoiceUpdatedV3".to_string(),
+            params: Some(vec![
+                serde_json::json!(val.fork_choice_state),
+                serde_json::json!(val.payload_attributes),
+            ]),
+            ..Default::default()
         }
     }
 }
@@ -50,10 +45,20 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
         if params.len() != 2 {
             return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
         }
+
+        let forkchoice_state: ForkChoiceState = serde_json::from_value(params[0].clone())?;
+        // if there is an error when parsing, set to None
+        let payload_attributes_v3: Option<PayloadAttributesV3> = if let Ok(attributes) =
+            serde_json::from_value::<PayloadAttributesV3>(params[1].clone())
+        {
+            Some(attributes)
+        } else {
+            None
+        };
+
         Ok(ForkChoiceUpdatedV3 {
-            fork_choice_state: serde_json::from_value(params[0].clone())?,
-            payload_attributes: serde_json::from_value(params[1].clone())
-                .map_err(|e| e.to_string()),
+            fork_choice_state: forkchoice_state,
+            payload_attributes: payload_attributes_v3,
         })
     }
 
@@ -65,94 +70,148 @@ impl RpcHandler for ForkChoiceUpdatedV3 {
             self.fork_choice_state.finalized_block_hash
         );
 
-        let head_block = match apply_fork_choice(
-            &context.storage,
+        let (head_block_opt, mut response) =
+            handle_forkchoice(&self.fork_choice_state, context.clone())?;
+
+        if let (Some(head_block), Some(attributes)) = (head_block_opt, &self.payload_attributes) {
+            let payload_id =
+                build_payload_v3(attributes, head_block, context, &self.fork_choice_state)?;
+            response.set_id(payload_id);
+        }
+
+        serde_json::to_value(response).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+fn handle_forkchoice(
+    forkchoice_state: &ForkChoiceState,
+    context: RpcApiContext,
+) -> Result<(Option<BlockHeader>, ForkChoiceResponse), RpcErr> {
+    match apply_fork_choice(
+        &context.storage,
+        forkchoice_state.head_block_hash,
+        forkchoice_state.safe_block_hash,
+        forkchoice_state.finalized_block_hash,
+    ) {
+        Ok(head) => Ok((
+            Some(head),
+            ForkChoiceResponse::from(PayloadStatus::valid_with_hash(
+                forkchoice_state.head_block_hash,
+            )),
+        )),
+        Err(forkchoice_error) => {
+            let forkchoice_response = match forkchoice_error {
+                InvalidForkChoice::NewHeadAlreadyCanonical => {
+                    ForkChoiceResponse::from(PayloadStatus::valid_with_hash(
+                        latest_canonical_block_hash(&context.storage).unwrap(),
+                    ))
+                }
+                InvalidForkChoice::Syncing => {
+                    // Start sync
+                    let current_number = context.storage.get_latest_block_number()?.unwrap();
+                    let Some(current_head) =
+                        context.storage.get_canonical_block_hash(current_number)?
+                    else {
+                        return Err(RpcErr::Internal(
+                            "Missing latest canonical block".to_owned(),
+                        ));
+                    };
+                    let sync_head = forkchoice_state.head_block_hash;
+                    tokio::spawn(async move {
+                        // If we can't get hold of the syncer, then it means that there is an active sync in process
+                        if let Ok(mut syncer) = context.syncer.try_lock() {
+                            syncer
+                                .start_sync(current_head, sync_head, context.storage.clone())
+                                .await
+                        }
+                    });
+                    ForkChoiceResponse::from(PayloadStatus::syncing())
+                }
+                reason => {
+                    warn!("Invalid fork choice state. Reason: {:#?}", reason);
+                    return Err(RpcErr::InvalidForkChoiceState(reason.to_string()));
+                }
+            };
+            Ok((None, forkchoice_response))
+        }
+    }
+}
+
+fn build_payload_v3(
+    attributes: &PayloadAttributesV3,
+    head_block: BlockHeader,
+    context: RpcApiContext,
+    fork_choice_state: &ForkChoiceState,
+) -> Result<u64, RpcErr> {
+    info!("Fork choice updated includes payload attributes. Creating a new payload.");
+    let chain_config = context.storage.get_chain_config()?;
+    if !chain_config.is_cancun_activated(attributes.timestamp) {
+        return Err(RpcErr::UnsuportedFork(
+            "forkChoiceV3 used to build pre-Cancun payload".to_string(),
+        ));
+    }
+    if attributes.timestamp <= head_block.timestamp {
+        return Err(RpcErr::InvalidPayloadAttributes(
+            "invalid timestamp".to_string(),
+        ));
+    }
+    let args = BuildPayloadArgs {
+        parent: fork_choice_state.head_block_hash,
+        timestamp: attributes.timestamp,
+        fee_recipient: attributes.suggested_fee_recipient,
+        random: attributes.prev_randao,
+        withdrawals: attributes.withdrawals.clone(),
+        beacon_root: Some(attributes.parent_beacon_block_root),
+        version: 3,
+    };
+    let payload_id = args.id();
+    let payload = match create_payload(&args, &context.storage) {
+        Ok(payload) => payload,
+        Err(ChainError::EvmError(error)) => return Err(error.into()),
+        // Parent block is guaranteed to be present at this point,
+        // so the only errors that may be returned are internal storage errors
+        Err(error) => return Err(RpcErr::Internal(error.to_string())),
+    };
+    context.storage.add_payload(payload_id, payload)?;
+
+    Ok(payload_id)
+}
+
+pub struct ForkChoiceUpdatedV2 {
+    pub fork_choice_state: ForkChoiceState,
+    pub payload_attributes: Option<PayloadAttributesV3>,
+}
+
+impl RpcHandler for ForkChoiceUpdatedV2 {
+    // TODO: Allow payload attributes
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 2 {
+            return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
+        }
+
+        let forkchoice_state: ForkChoiceState = serde_json::from_value(params[0].clone())?;
+
+        Ok(ForkChoiceUpdatedV2 {
+            fork_choice_state: forkchoice_state,
+            payload_attributes: None,
+        })
+    }
+
+    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        info!(
+            "New fork choice request v2 with head: {}, safe: {}, finalized: {}.",
             self.fork_choice_state.head_block_hash,
             self.fork_choice_state.safe_block_hash,
-            self.fork_choice_state.finalized_block_hash,
-        ) {
-            Ok(head) => head,
-            Err(error) => {
-                let fork_choice_response = match error {
-                    InvalidForkChoice::NewHeadAlreadyCanonical => {
-                        ForkChoiceResponse::from(PayloadStatus::valid_with_hash(
-                            latest_canonical_block_hash(&context.storage).unwrap(),
-                        ))
-                    }
-                    InvalidForkChoice::Syncing => {
-                        // Start sync
-                        let current_number = context.storage.get_latest_block_number()?.unwrap();
-                        let Some(current_head) =
-                            context.storage.get_canonical_block_hash(current_number)?
-                        else {
-                            return Err(RpcErr::Internal(
-                                "Missing latest canonical block".to_owned(),
-                            ));
-                        };
-                        let sync_head = self.fork_choice_state.head_block_hash;
-                        tokio::spawn(async move {
-                            // If we can't get hold of the syncer, then it means that there is an active sync in process
-                            if let Ok(mut syncer) = context.syncer.try_lock() {
-                                syncer
-                                    .start_sync(current_head, sync_head, context.storage.clone())
-                                    .await
-                            }
-                        });
-                        ForkChoiceResponse::from(PayloadStatus::syncing())
-                    }
-                    reason => {
-                        warn!("Invalid fork choice state. Reason: {:#?}", reason);
-                        return Err(RpcErr::InvalidForkChoiceState(reason.to_string()));
-                    }
-                };
-                return serde_json::to_value(fork_choice_response)
-                    .map_err(|error| RpcErr::Internal(error.to_string()));
-            }
-        };
+            self.fork_choice_state.finalized_block_hash
+        );
 
-        // Build block from received payload. This step is skipped if applying the fork choice state failed
-        let mut response = ForkChoiceResponse::from(PayloadStatus::valid_with_hash(
-            self.fork_choice_state.head_block_hash,
-        ));
+        let (_head_block_opt, response) =
+            handle_forkchoice(&self.fork_choice_state, context.clone())?;
 
-        match &self.payload_attributes {
-            // Payload may be invalid but we had to apply fork choice state nevertheless.
-            Err(e) => return Err(RpcErr::InvalidPayloadAttributes(e.into())),
-            Ok(None) => (),
-            Ok(Some(attributes)) => {
-                info!("Fork choice updated includes payload attributes. Creating a new payload.");
-                let chain_config = context.storage.get_chain_config()?;
-                if !chain_config.is_cancun_activated(attributes.timestamp) {
-                    return Err(RpcErr::UnsuportedFork(
-                        "forkChoiceV3 used to build pre-Cancun payload".to_string(),
-                    ));
-                }
-                if attributes.timestamp <= head_block.timestamp {
-                    return Err(RpcErr::InvalidPayloadAttributes(
-                        "invalid timestamp".to_string(),
-                    ));
-                }
-                let args = BuildPayloadArgs {
-                    parent: self.fork_choice_state.head_block_hash,
-                    timestamp: attributes.timestamp,
-                    fee_recipient: attributes.suggested_fee_recipient,
-                    random: attributes.prev_randao,
-                    withdrawals: attributes.withdrawals.clone(),
-                    beacon_root: Some(attributes.parent_beacon_block_root),
-                    version: 3,
-                };
-                let payload_id = args.id();
-                response.set_id(payload_id);
-                let payload = match create_payload(&args, &context.storage) {
-                    Ok(payload) => payload,
-                    Err(ChainError::EvmError(error)) => return Err(error.into()),
-                    // Parent block is guaranteed to be present at this point,
-                    // so the only errors that may be returned are internal storage errors
-                    Err(error) => return Err(RpcErr::Internal(error.to_string())),
-                };
-                context.storage.add_payload(payload_id, payload)?;
-            }
-        }
+        // TODO support payload attributes v2
 
         serde_json::to_value(response).map_err(|error| RpcErr::Internal(error.to_string()))
     }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -7,7 +7,7 @@ use axum_extra::{
 use bytes::Bytes;
 use engine::{
     exchange_transition_config::ExchangeTransitionConfigV1Req,
-    fork_choice::ForkChoiceUpdatedV3,
+    fork_choice::{ForkChoiceUpdatedV2, ForkChoiceUpdatedV3},
     payload::{GetPayloadV3Request, NewPayloadV3Request},
     ExchangeCapabilitiesRequest,
 };
@@ -253,6 +253,7 @@ pub fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Va
 pub fn map_engine_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "engine_exchangeCapabilities" => ExchangeCapabilitiesRequest::call(req, context),
+        "engine_forkchoiceUpdatedV2" => ForkChoiceUpdatedV2::call(req, context),
         "engine_forkchoiceUpdatedV3" => ForkChoiceUpdatedV3::call(req, context),
         "engine_newPayloadV3" => NewPayloadV3Request::call(req, context),
         "engine_exchangeTransitionConfigurationV1" => {

--- a/crates/networking/rpc/types/fork_choice.rs
+++ b/crates/networking/rpc/types/fork_choice.rs
@@ -13,7 +13,6 @@ pub struct ForkChoiceState {
 
 #[derive(Debug, Deserialize, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(unused)]
 pub struct PayloadAttributesV3 {
     #[serde(with = "serde_utils::u64::hex_str")]
     pub timestamp: u64,


### PR DESCRIPTION
**Motivation**
The motivation is to be able to reutilize code across the different versions of forkchoice updates, but without creating unnecesary abstractions and leaking them to the rest of the codebase.

This is a POC

**Description**
- Removed `payload_attributes` being a result. I think this was introduced to avoid erroing when we can parse `payload_attributes` succesfully (spec says we should move on with forkchoice updated)
- Refactored the code to simplify the flow and extract some functions.

