### PR TITLE
fix(levm): fix gas refunds

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -178,7 +178,7 @@ impl VM {
         let mut gas_refunds = U256::zero();
         if new_storage_slot_value != storage_slot.current_value {
             if storage_slot.current_value == storage_slot.original_value {
-                if storage_slot.original_value.is_zero() && new_storage_slot_value.is_zero() {
+                if !storage_slot.original_value.is_zero() && new_storage_slot_value.is_zero() {
                     gas_refunds = gas_refunds
                         .checked_add(U256::from(4800))
                         .ok_or(VMError::GasRefundsOverflow)?;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -626,6 +626,12 @@ impl VM {
                 .checked_mul(self.env.gas_price)
                 .ok_or(VMError::GasLimitPriceProductOverflow)?,
         )?;
+        self.increase_account_balance(
+            sender,
+            U256::from(report.gas_refunded)
+                .checked_mul(self.env.gas_price)
+                .ok_or(VMError::GasLimitPriceProductOverflow)?,
+        )?;
 
         // Send coinbase fee
         let priority_fee_per_gas = self


### PR DESCRIPTION
**Motivation**

The gas refunds had a bug in the sstore calculation. Fixes all the tests from `stShift` folder.

**Description**

Also, this PR sums the refunds to the sender's balance.

