### PR TITLE
fix(levm): Fix EF test of past PR

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -159,15 +159,16 @@ pub const CALLDATA_COST_NON_ZERO_BYTE: U256 = U256([16, 0, 0, 0]);
 pub const BLOB_GAS_PER_BLOB: U256 = U256([131072, 0, 0, 0]);
 
 pub fn exp(exponent: U256) -> Result<U256, OutOfGasError> {
-    let exponent_byte_size = exponent
-        .checked_add(U256::from(7))
-        .ok_or(OutOfGasError::GasCostOverflow)?
-        .checked_div(U256::from(8))
-        .ok_or(OutOfGasError::ArithmeticOperationDividedByZero)?; // '8' will never be zero
+    let exponent_byte_size = (exponent
+        .bits()
+        .checked_add(7)
+        .ok_or(OutOfGasError::GasCostOverflow)?)
+        / 8;
 
     let exponent_byte_size_cost = EXP_DYNAMIC_BASE
-        .checked_mul(exponent_byte_size)
+        .checked_mul(exponent_byte_size.into())
         .ok_or(OutOfGasError::GasCostOverflow)?;
+
     EXP_STATIC
         .checked_add(exponent_byte_size_cost)
         .ok_or(OutOfGasError::GasCostOverflow)

--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -76,11 +76,18 @@ impl VM {
             return Ok(OpcodeSuccess::Continue);
         }
 
-        let dividend = abs(dividend);
-        let divisor = abs(divisor);
+        let abs_dividend = abs(dividend);
+        let abs_divisor = abs(divisor);
 
-        let quotient = match dividend.checked_div(divisor) {
-            Some(quot) => quot,
+        let quotient = match abs_dividend.checked_div(abs_divisor) {
+            Some(quot) => {
+                let quotient_is_negative = is_negative(dividend) ^ is_negative(divisor);
+                if quotient_is_negative {
+                    negate(quot)
+                } else {
+                    quot
+                }
+            }
             None => U256::zero(),
         };
 


### PR DESCRIPTION
**Motivation**

This PR increases the amount of EF test passed. There was some mistakes in PR #[1398](https://github.com/lambdaclass/ethrex/pull/1398) above. 

**Description**

- Check if the "quotient" is negative and negate it in that case.
- Transform the `exponent` to `usize` using `U256::bits()` and then proceed with the addition.