### PR TITLE
fix(l1): fix encoding and decoding of `StorageRanges` (p2p snap message)

### DIFF
--- a/crates/networking/p2p/rlpx/snap.rs
+++ b/crates/networking/p2p/rlpx/snap.rs
@@ -444,7 +444,7 @@ impl RLPDecode for StorageSlot {
         let decoder = Decoder::new(rlp)?;
         let (hash, decoder) = decoder.decode_field("hash")?;
         let (data, decoder) = decoder.get_encoded_item()?;
-        let data = U256::decode(&ethrex_rlp::decode::decode_bytes(&data)?.0)?;
+        let data = U256::decode(ethrex_rlp::decode::decode_bytes(&data)?.0)?;
         Ok((Self { hash, data }, decoder.finish()?))
     }
 }

--- a/crates/networking/p2p/rlpx/snap.rs
+++ b/crates/networking/p2p/rlpx/snap.rs
@@ -443,7 +443,8 @@ impl RLPDecode for StorageSlot {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
         let decoder = Decoder::new(rlp)?;
         let (hash, decoder) = decoder.decode_field("hash")?;
-        let (data, decoder) = decoder.decode_field("data")?;
+        let (data, decoder) = decoder.get_encoded_item()?;
+        let data = U256::decode(&ethrex_rlp::decode::decode_bytes(&data)?.0)?;
         Ok((Self { hash, data }, decoder.finish()?))
     }
 }

--- a/crates/networking/p2p/rlpx/snap.rs
+++ b/crates/networking/p2p/rlpx/snap.rs
@@ -434,7 +434,7 @@ impl RLPEncode for StorageSlot {
     fn encode(&self, buf: &mut dyn BufMut) {
         Encoder::new(buf)
             .encode_field(&self.hash)
-            .encode_field(&self.data)
+            .encode_bytes(&self.data.encode_to_vec())
             .finish();
     }
 }


### PR DESCRIPTION
**Motivation**
When attempting to sync with a geth node I got different storage values than the ones expected. Upon further investigation it looks like our encoding of storage values is incorrect. We send the RLP-encoded U256 values while they send the RLP-encoding of the bytes obtained from RLP-encoding the storage value.

**Description**
* Fixes encoding and decoding of storage values in `StorageRanges` message to match the encoding used by geth

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

This fix is needed to fully support snap-syncing against other nodes

