### PR TITLE
fix(levm): state transition function

### DIFF
--- a/cmd/ef_tests/levm/runner/revm_runner.rs
+++ b/cmd/ef_tests/levm/runner/revm_runner.rs
@@ -271,9 +271,12 @@ pub fn ensure_post_state(
         Some(_expected_exception) => {}
         // We only want to compare account updates when no exception is expected.
         None => {
-            let (initial_state, _block_hash) = load_initial_state(test);
-            let levm_account_updates =
-                levm_runner::get_state_transitions(&initial_state, levm_execution_report);
+            let (initial_state, block_hash) = load_initial_state(test);
+            let levm_account_updates = levm_runner::get_state_transitions(
+                &initial_state,
+                block_hash,
+                levm_execution_report,
+            );
             let revm_account_updates = ethrex_vm::get_state_transitions(revm_state);
             let account_updates_report = compare_levm_revm_account_updates(
                 test,
@@ -355,7 +358,6 @@ pub fn compare_levm_revm_account_updates(
 }
 
 pub fn _run_ef_test_revm(test: &EFTest) -> Result<EFTestReport, EFTestRunnerError> {
-    dbg!(&test.name);
     let mut ef_test_report = EFTestReport::new(
         test.name.clone(),
         test.dir.clone(),


### PR DESCRIPTION
**Local Run**
```
✓ Ethereum Foundation Tests: 1747 passed 2353 failed 4100 total run - 13:26
✓ Summary: 1747/4100 (42.61)

Cancun: 1635/3577 (45.71%)
Shanghai: 57/221 (25.79%)
Homestead: 0/17 (0.00%)
Istanbul: 0/34 (0.00%)
London: 19/39 (48.72%)
Byzantium: 0/33 (0.00%)
Berlin: 17/35 (48.57%)
Constantinople: 0/66 (0.00%)
Merge: 19/62 (30.65%)
Frontier: 0/16 (0.00%)


stHomesteadSpecific: 2/5 (40.00%)
stEIP3860-limitmeterinitcode: 1/3 (33.33%)
stQuadraticComplexityTest: 6/17 (35.29%)
stStaticCall: 153/286 (53.50%)
eip3651_warm_coinbase: 8/40 (20.00%)
vmIOandFlowOperations: 10/15 (66.67%)
stSpecialTest: 3/15 (20.00%)
vmLogTest: 5/5 (100.00%)
eip2930_access_list: 0/5 (0.00%)
stEIP1559: 9/13 (69.23%)
opcodes: 86/188 (45.74%)
stZeroCallsTest: 11/24 (45.83%)
stLogTests: 0/46 (0.00%)
eip3855_push0: 14/14 (100.00%)
stCodeSizeLimit: 0/5 (0.00%)
stStackTests: 0/10 (0.00%)
stSolidityTest: 9/18 (50.00%)
stPreCompiledContracts2: 0/102 (0.00%)
stSystemOperationsTest: 25/67 (37.31%)
stEIP3855-push0: 3/3 (100.00%)
stZeroKnowledge: 0/134 (0.00%)
yul: 5/10 (50.00%)
stEIP5656-MCOPY: 2/4 (50.00%)
eip4844_blobs: 186/559 (33.27%)
stReturnDataTest: 27/41 (65.85%)
stCallCodes: 51/79 (64.56%)
vmArithmeticTest: 19/19 (100.00%)
stCodeCopyTest: 1/2 (50.00%)
stEIP3607: 4/5 (80.00%)
stEIP2930: 0/7 (0.00%)
stZeroCallsRevert: 4/16 (25.00%)
stEIP150singleCodeGasPrices: 8/40 (20.00%)
vmBitwiseLogicOperation: 11/11 (100.00%)
vmPerformance: 2/2 (100.00%)
eip1344_chainid: 0/6 (0.00%)
stBadOpcode: 2/120 (1.67%)
stEIP1153-transientStorage: 0/8 (0.00%)
stSStoreTest: 0/28 (0.00%)
eip198_modexp_precompile: 0/144 (0.00%)
eip3860_initcode: 52/108 (48.15%)
stEIP4844-blobtransactions: 4/10 (40.00%)
stExtCodeHash: 10/36 (27.78%)
stArgsZeroOneBalance: 38/46 (82.61%)
stPreCompiledContracts: 0/9 (0.00%)
stCallDelegateCodesCallCodeHomestead: 42/58 (72.41%)
eip5656_mcopy: 75/93 (80.65%)
stTransactionTest: 20/34 (58.82%)
stShift: 42/42 (100.00%)
stRevertTest: 18/46 (39.13%)
stWalletTest: 30/42 (71.43%)
stMemoryStressTest: 33/38 (86.84%)
stRefundTest: 22/22 (100.00%)
stCreate2: 5/51 (9.80%)
stInitCodeTest: 2/17 (11.76%)
stRecursiveCreate: 0/2 (0.00%)
stDelegatecallTestHomestead: 14/28 (50.00%)
stAttackTest: 0/2 (0.00%)
stTransitionTest: 3/6 (50.00%)
eip1153_tstore: 44/67 (65.67%)
stMemoryTest: 66/71 (92.96%)
eip6780_selfdestruct: 0/223 (0.00%)
eip7516_blobgasfee: 4/5 (80.00%)
stStaticFlagEnabled: 3/13 (23.08%)
stCallDelegateCodesHomestead: 43/58 (74.14%)
stEIP158Specific: 4/8 (50.00%)
stTimeConsuming: 0/14 (0.00%)
stRandom2: 176/220 (80.00%)
stRandom: 263/310 (84.84%)
stMemExpandingEIP150Calls: 6/9 (66.67%)
stCallCreateCallCodeTest: 14/43 (32.56%)
stEIP3651-warmcoinbase: 1/2 (50.00%)
stCreateTest: 5/47 (10.64%)
stEIP150Specific: 9/14 (64.29%)
stBugs: 1/4 (25.00%)
stExample: 7/12 (58.33%)
vmTests: 7/11 (63.64%)
stNonZeroCallsTest: 12/24 (50.00%)
stSLoadTest: 1/1 (100.00%)
stChainId: 1/2 (50.00%)
stZeroKnowledge2: 0/130 (0.00%)
stSelfBalance: 3/6 (50.00%)
```