### PR TITLE
ci(levm): improve speed for tests (and CI) and solve depth problem

### DIFF
--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -38,10 +38,15 @@ jobs:
           cd crates/vm/levm
           make download-evm-ef-tests
 
-      - name: Run tests
+      - name: Run tests only LEVM
         run: |
           cd crates/vm/levm
           make run-evm-ef-tests-ci
+
+      - name: Run tests LEVM and REVM
+        run: |
+          cd crates/vm/levm
+          make run-evm-ef-tests
   test:
     # "Test" is a required check, don't change the name
     name: Test

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -38,7 +38,7 @@ jobs:
           cd crates/vm/levm
           make download-evm-ef-tests
 
-      - name: Run tests only LEVM
+      - name: Run tests
         run: |
           cd crates/vm/levm
           make run-evm-ef-tests-ci

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -42,11 +42,6 @@ jobs:
         run: |
           cd crates/vm/levm
           make run-evm-ef-tests-ci
-
-      - name: Run tests LEVM and REVM
-        run: |
-          cd crates/vm/levm
-          make run-evm-ef-tests
   test:
     # "Test" is a required check, don't change the name
     name: Test

--- a/cmd/ef_tests/levm/Makefile
+++ b/cmd/ef_tests/levm/Makefile
@@ -1,6 +1,8 @@
+.PHONY: all test clippy fmt usage lint run-evm-ef-tests
+
 run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	cd ../../../crates/vm/levm && \
-	make run-evm-ef-tests
+	make run-evm-ef-tests flags="$(flags)"
 
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/cmd/ef_tests/levm/Makefile
+++ b/cmd/ef_tests/levm/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test clippy fmt usage lint run-evm-ef-tests
+.PHONY: run-evm-ef-tests
 
 run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	cd ../../../crates/vm/levm && \

--- a/cmd/ef_tests/levm/Makefile
+++ b/cmd/ef_tests/levm/Makefile
@@ -1,0 +1,6 @@
+run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
+	cd ../../../crates/vm/levm && \
+	make run-evm-ef-tests
+
+help: ## 📚 Show help for each of the Makefile recipes
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/cmd/ef_tests/levm/parser.rs
+++ b/cmd/ef_tests/levm/parser.rs
@@ -25,7 +25,7 @@ pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestP
     let cargo_manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let ef_general_state_tests_path = cargo_manifest_dir.join("vectors/GeneralStateTests");
     let mut spinner = Spinner::new(Dots, "Parsing EF Tests".bold().to_string(), Color::Cyan);
-    if opts.disable_spinner {
+    if !opts.spinner {
         spinner.stop();
     }
     let mut tests = Vec::new();
@@ -47,7 +47,7 @@ pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestP
             "Parsed EF Tests in {}",
             format_duration_as_mm_ss(parsing_time.elapsed())
         ),
-        opts.disable_spinner,
+        opts.spinner,
     );
     Ok(tests)
 }
@@ -60,7 +60,7 @@ pub fn parse_ef_test_dir(
     spinner_update_text_or_print(
         directory_parsing_spinner,
         format!("Parsing directory {:?}", test_dir.file_name()),
-        opts.disable_spinner,
+        opts.spinner,
     );
 
     let mut directory_tests = Vec::new();
@@ -125,7 +125,7 @@ pub fn parse_ef_test_dir(
                     "Skipping test {:?} as it is in the folder of tests to skip",
                     test.path().file_name().unwrap()
                 ),
-                opts.disable_spinner,
+                opts.spinner,
             );
             continue;
         }
@@ -146,7 +146,7 @@ pub fn parse_ef_test_dir(
                     "Skipping test {:?} as it is in the list of tests to skip",
                     test.path().file_name().unwrap()
                 ),
-                opts.disable_spinner,
+                opts.spinner,
             );
             continue;
         }

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -49,8 +49,8 @@ pub struct EFTestRunnerOptions {
     pub summary: bool,
     #[arg(long, value_name = "SKIP", use_value_delimiter = true)]
     pub skip: Vec<String>,
-    #[arg(long, value_name = "DISABLE_SPINNER", default_value = "true")]
-    pub disable_spinner: bool, // Replaces spinner for normal prints.
+    #[arg(long, value_name = "SPINNER", default_value = "false")]
+    pub spinner: bool, // Replaces prints for spinner, but execution is slower.
 }
 
 pub fn run_ef_tests(
@@ -79,11 +79,11 @@ fn run_with_levm(
         report::progress(reports, levm_run_time.elapsed()),
         Color::Cyan,
     );
-    if opts.disable_spinner {
+    if !opts.spinner {
         levm_run_spinner.stop();
     }
     for test in ef_tests.iter() {
-        if opts.disable_spinner {
+        if !opts.spinner {
             println!("Running test: {:?}", test.name);
         }
         let ef_test_report = match levm_runner::run_ef_test(test) {
@@ -99,13 +99,13 @@ fn run_with_levm(
         spinner_update_text_or_print(
             &mut levm_run_spinner,
             report::progress(reports, levm_run_time.elapsed()),
-            opts.disable_spinner,
+            opts.spinner,
         );
     }
     spinner_success_or_print(
         &mut levm_run_spinner,
         report::progress(reports, levm_run_time.elapsed()),
-        opts.disable_spinner,
+        opts.spinner,
     );
 
     if opts.summary {
@@ -114,13 +114,13 @@ fn run_with_levm(
     }
 
     let mut summary_spinner = Spinner::new(Dots, "Loading summary...".to_owned(), Color::Cyan);
-    if opts.disable_spinner {
+    if !opts.spinner {
         summary_spinner.stop();
     }
     spinner_success_or_print(
         &mut summary_spinner,
         report::summary_for_shell(reports),
-        opts.disable_spinner,
+        opts.spinner,
     );
 
     Ok(())
@@ -139,11 +139,11 @@ fn _run_with_revm(
         "Running all tests with REVM...".to_owned(),
         Color::Cyan,
     );
-    if opts.disable_spinner {
+    if !opts.spinner {
         revm_run_spinner.stop();
     }
     for (idx, test) in ef_tests.iter().enumerate() {
-        if opts.disable_spinner {
+        if !opts.spinner {
             println!("Running test: {:?}", test.name);
         }
         let total_tests = ef_tests.len();
@@ -155,7 +155,7 @@ fn _run_with_revm(
                 idx + 1,
                 format_duration_as_mm_ss(revm_run_time.elapsed())
             ),
-            opts.disable_spinner,
+            opts.spinner,
         );
         let ef_test_report = match revm_runner::_run_ef_test_revm(test) {
             Ok(ef_test_report) => ef_test_report,
@@ -170,7 +170,7 @@ fn _run_with_revm(
         spinner_update_text_or_print(
             &mut revm_run_spinner,
             report::progress(reports, revm_run_time.elapsed()),
-            opts.disable_spinner,
+            opts.spinner,
         );
     }
     spinner_success_or_print(
@@ -179,7 +179,7 @@ fn _run_with_revm(
             "Ran all tests with REVM in {}",
             format_duration_as_mm_ss(revm_run_time.elapsed())
         ),
-        opts.disable_spinner,
+        opts.spinner,
     );
     Ok(())
 }
@@ -195,7 +195,7 @@ fn re_run_with_revm(
         "Running failed tests with REVM...".to_owned(),
         Color::Cyan,
     );
-    if opts.disable_spinner {
+    if !opts.spinner {
         revm_run_spinner.stop();
     }
     let failed_tests = reports.iter().filter(|report| !report.passed()).count();
@@ -206,7 +206,7 @@ fn re_run_with_revm(
         .filter(|report| !report.passed())
         .enumerate()
     {
-        if opts.disable_spinner {
+        if !opts.spinner {
             println!("Running test: {:?}", failed_test_report.name);
         }
         spinner_update_text_or_print(
@@ -217,7 +217,7 @@ fn re_run_with_revm(
                 idx + 1,
                 format_duration_as_mm_ss(revm_run_time.elapsed())
             ),
-            opts.disable_spinner,
+            opts.spinner,
         );
 
         match revm_runner::re_run_failed_ef_test(
@@ -251,7 +251,7 @@ fn re_run_with_revm(
             "Re-ran failed tests with REVM in {}",
             format_duration_as_mm_ss(revm_run_time.elapsed())
         ),
-        opts.disable_spinner,
+        opts.spinner,
     );
     Ok(())
 }

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -51,6 +51,8 @@ pub struct EFTestRunnerOptions {
     pub skip: Vec<String>,
     #[arg(long, value_name = "SPINNER", default_value = "false")]
     pub spinner: bool, // Replaces prints for spinner, but execution is slower.
+    #[arg(long, value_name = "VERBOSE", default_value = "false")]
+    pub verbose: bool,
 }
 
 pub fn run_ef_tests(
@@ -83,7 +85,7 @@ fn run_with_levm(
         levm_run_spinner.stop();
     }
     for test in ef_tests.iter() {
-        if !opts.spinner {
+        if !opts.spinner && opts.verbose {
             println!("Running test: {:?}", test.name);
         }
         let ef_test_report = match levm_runner::run_ef_test(test) {
@@ -143,7 +145,7 @@ fn _run_with_revm(
         revm_run_spinner.stop();
     }
     for (idx, test) in ef_tests.iter().enumerate() {
-        if !opts.spinner {
+        if !opts.spinner && opts.verbose {
             println!("Running test: {:?}", test.name);
         }
         let total_tests = ef_tests.len();
@@ -206,7 +208,7 @@ fn re_run_with_revm(
         .filter(|report| !report.passed())
         .enumerate()
     {
-        if !opts.spinner {
+        if !opts.spinner && opts.verbose {
             println!("Running test: {:?}", failed_test_report.name);
         }
         spinner_update_text_or_print(

--- a/cmd/ef_tests/levm/runner/mod.rs
+++ b/cmd/ef_tests/levm/runner/mod.rs
@@ -49,7 +49,7 @@ pub struct EFTestRunnerOptions {
     pub summary: bool,
     #[arg(long, value_name = "SKIP", use_value_delimiter = true)]
     pub skip: Vec<String>,
-    #[arg(long, value_name = "DISABLE_SPINNER", default_value = "false")]
+    #[arg(long, value_name = "DISABLE_SPINNER", default_value = "true")]
     pub disable_spinner: bool, // Replaces spinner for normal prints.
 }
 

--- a/cmd/ef_tests/levm/utils.rs
+++ b/cmd/ef_tests/levm/utils.rs
@@ -22,16 +22,16 @@ pub fn load_initial_state(test: &EFTest) -> (EvmState, H256) {
     )
 }
 
-pub fn spinner_update_text_or_print(spinner: &mut Spinner, text: String, no_spinner: bool) {
-    if no_spinner {
+pub fn spinner_update_text_or_print(spinner: &mut Spinner, text: String, spinner_enabled: bool) {
+    if !spinner_enabled {
         println!("{}", text);
     } else {
         spinner.update_text(text);
     }
 }
 
-pub fn spinner_success_or_print(spinner: &mut Spinner, text: String, no_spinner: bool) {
-    if no_spinner {
+pub fn spinner_success_or_print(spinner: &mut Spinner, text: String, spinner_enabled: bool) {
+    if !spinner_enabled {
         println!("{}", text);
     } else {
         spinner.success(&text);

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test clippy fmt usage lint eth-tests
+.PHONY: all test clippy fmt usage lint eth-tests run-evm-ef-tests
 
 all: test clippy fmt ## 🚀 Runs all tests, linter and formatter
 
@@ -33,7 +33,7 @@ download-evm-ef-tests: $(SPECTEST_VECTORS_DIR) ## 📥 Download EF Tests
 
 run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	cd ../../../ && \
-	time cargo test -p ef_tests-levm --test ef_tests_levm --release
+	time cargo test -p ef_tests-levm --test ef_tests_levm --release -- $(flags)
 
 run-evm-ef-tests-ci: ## 🏃‍♂️ Run EF Tests only with LEVM and without spinner, for CI.
 	cd ../../../ && \

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -33,11 +33,11 @@ download-evm-ef-tests: $(SPECTEST_VECTORS_DIR) ## 📥 Download EF Tests
 
 run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	cd ../../../ && \
-	time cargo test -p ef_tests-levm --test ef_tests_levm --release -- --disable-spinner
+	time cargo test -p ef_tests-levm --test ef_tests_levm --release
 
 run-evm-ef-tests-ci: ## 🏃‍♂️ Run EF Tests only with LEVM and without spinner, for CI.
 	cd ../../../ && \
-	time cargo test -p ef_tests-levm --test ef_tests_levm --release -- --disable-spinner --summary
+	time cargo test -p ef_tests-levm --test ef_tests_levm --release -- --summary
 
 generate-evm-ef-tests-report: ## 📊 Generate EF Tests Report
 	cd ../../../ && \

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -33,11 +33,11 @@ download-evm-ef-tests: $(SPECTEST_VECTORS_DIR) ## 📥 Download EF Tests
 
 run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	cd ../../../ && \
-	time cargo test -p ef_tests-levm --test ef_tests_levm
+	time cargo test -p ef_tests-levm --test ef_tests_levm --release -- --disable-spinner
 
 run-evm-ef-tests-ci: ## 🏃‍♂️ Run EF Tests only with LEVM and without spinner, for CI.
 	cd ../../../ && \
-	time cargo test -p ef_tests-levm --test ef_tests_levm -- --disable-spinner --summary
+	time cargo test -p ef_tests-levm --test ef_tests_levm --release -- --disable-spinner --summary
 
 generate-evm-ef-tests-report: ## 📊 Generate EF Tests Report
 	cd ../../../ && \


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- In some cases we run into stack overflow when executing ef tests. This can be solved by executing in a more optimized mode.

- Add things that I think convenient to EFTests and CI.

- This will be helpful for CI in general and for [this other PR](https://github.com/lambdaclass/ethrex/pull/1424) that I'm working on.

**Description**
- Disables spinner by default -> This is because it improves performance a lot
    - LEVM EF Tests Execution with spinner: 6 minutes
    - LEVM EF Tests Execution without spinner (with prints): 30 seconds
- Changes `Makefile` to use `release` mode for running tests
- Creates a `Makefile` for the folder in which the report is printed. This was made in order to access the report file from the same directory in which we ran `make run-evm-ef-tests`
- Adds verbose flag for printing tests names. This can be extended for printing more things but before they were being printed by default and we found that in a basic debugging scenario we don't usually look at those prints.
- Enables adding flags to `make run-evm-ef-tests` that facilitate the command for testing

Example of flags:
`make run-evm-ef-tests flags="--tests stEIP1559"`


<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Why use --release**
I tried to avoid using the --release profile and wanted to update our test profile for running with optimizations by default but I had issues doing it because LEVM is a crate of the repository, and:
[Cargo only looks at the profile settings in the Cargo.toml manifest at the root of the workspace. Profile settings defined in dependencies will be ignored.
](https://doc.rust-lang.org/cargo/reference/profiles.html)
I didn't find a simple way to override the test profile without affecting the rest of the crates from the repository, so I decided it wasn't worth the hassle because the benefits from it weren't as high.


Closes #issue_number

