### PR TITLE
Fix(levm): add gas check from EIP-2200

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -194,6 +194,14 @@ impl VM {
         let (storage_slot, storage_slot_was_cold) =
             self.access_storage_slot(current_call_frame.to, key);
 
+        let potential_gas_consumed = current_call_frame
+            .gas_used
+            .checked_add(gas_cost::CALL_POSITIVE_VALUE_STIPEND)
+            .ok_or(VMError::VeryLargeNumber)?;
+        if potential_gas_consumed >= current_call_frame.gas_limit {
+            return Err(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded));
+        }
+
         self.increase_consumed_gas(
             current_call_frame,
             gas_cost::sstore(&storage_slot, new_storage_slot_value, storage_slot_was_cold)?,


### PR DESCRIPTION
**Motivation**

Add a missing check for remaining gas for the instruction SSTORE

**Description**

- Check if the remainding gas for SSTORE is greater than `Gcallstipend`, currently i'm using the constant from `CALL_POSITIVE_VALUE_STIPEND` but maybe it can be placed into its own constant

**References**
- https://eips.ethereum.org/EIPS/eip-2200

