### PR TITLE
fix(levm): memory size calculations

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -261,6 +261,10 @@ pub fn log(
     size: usize,
     number_of_topics: u8,
 ) -> Result<U256, VMError> {
+    println!(
+        "new_memory_size: {}, current_memory_size: {}, size: {}",
+        new_memory_size, current_memory_size, size
+    );
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
 
     let topics_cost = LOGN_DYNAMIC_BASE

--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -207,3 +207,14 @@ fn cost(memory_size: usize) -> Result<usize, VMError> {
         )
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?)
 }
+
+pub fn calculate_memory_size(offset: usize, size: usize) -> Result<usize, VMError> {
+    if size == 0 {
+        return Ok(0);
+    }
+
+    offset
+        .checked_add(size)
+        .and_then(|sum| sum.checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE))
+        .ok_or(VMError::OutOfOffset)
+}

--- a/crates/vm/levm/src/opcode_handlers/logging.rs
+++ b/crates/vm/levm/src/opcode_handlers/logging.rs
@@ -1,8 +1,8 @@
 use crate::{
     call_frame::CallFrame,
-    constants::WORD_SIZE_IN_BYTES_USIZE,
     errors::{OpcodeSuccess, VMError},
-    gas_cost, memory,
+    gas_cost,
+    memory::{self, calculate_memory_size},
     vm::VM,
 };
 use bytes::Bytes;
@@ -40,14 +40,12 @@ impl VM {
             topics.push(H256::from_slice(&topic_bytes));
         }
 
+        let new_memory_size = calculate_memory_size(offset, size)?;
+
         self.increase_consumed_gas(
             current_call_frame,
             gas_cost::log(
-                offset
-                    .checked_add(size)
-                    .ok_or(VMError::OutOfOffset)?
-                    .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-                    .ok_or(VMError::OutOfOffset)?,
+                new_memory_size,
                 current_call_frame.memory.len(),
                 size,
                 number_of_topics,

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -288,3 +288,14 @@ fn test_non_compliance_codecopy_memory_resize() {
         &U256::from(14400)
     );
 }
+
+#[test]
+fn test_non_compliance_log_gas_cost() {
+    let mut vm = new_vm_with_bytecode(Bytes::copy_from_slice(&[56, 68, 68, 68, 131, 163])).unwrap();
+    vm.env.gas_price = U256::zero();
+    vm.env.gas_limit = U256::from(100_000_000);
+    vm.env.block_gas_limit = U256::from(100_000_001);
+    let res = vm.transact().unwrap();
+    println!("gas used: {}", res.gas_used);
+    // assert_eq!(res.gas_used, 54511);
+}


### PR DESCRIPTION
…log opcode

**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- Currently we have some errors in gas calculations related to memory when "size" is set to 0. Memory shouldn't ever expand on that scenario.
- Tidy code for calculating memory size.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

