### PR TITLE
fix(levm): add release flag to generate-evm-ef-tests-report

### DIFF
--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -41,7 +41,7 @@ run-evm-ef-tests-ci: ## 🏃‍♂️ Run EF Tests only with LEVM and without sp
 
 generate-evm-ef-tests-report: ## 📊 Generate EF Tests Report
 	cd ../../../ && \
-	cargo test -p ef_tests-levm --test ef_tests_levm -- --summary
+	cargo test -p ef_tests-levm --test ef_tests_levm --release -- --summary
 
 clean-evm-ef-tests: ## 🗑️  Clean test vectors
 	rm -rf $(SPECTEST_VECTORS_DIR)


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- We need to run with optimizations because otherwise some tests related to call depth will fail and halt execution of EFTests.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

