### PR TITLE
feat(l1): assertoor local make tasks and documentation

### DIFF
--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -17,6 +17,7 @@ participants:
 additional_services:
   - assertoor
   - tx_spammer
+  - dora
 
 assertoor_params:
   run_stability_check: false

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -10,7 +10,10 @@ participants:
     validator_count: 32
 
 additional_services:
+  # In the future we may want to run the blob spammer in this check if possible 
+  # through the tx_spammer addition service config.
   - assertoor
+  - dora
 
 assertoor_params:
   run_stability_check: false

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,15 @@ localnet: stop-localnet-silent build-image checkout-ethereum-package ## 🌐 Sta
 	kurtosis run --enclave $(ENCLAVE) ethereum-package --args-file test_data/network_params.yaml
 	docker logs -f $$(docker ps -q --filter ancestor=ethrex)
 
+localnet-assertoor-blob: stop-localnet-silent build-image checkout-ethereum-package ## 🌐 Start local network with assertoor test
+	kurtosis run --enclave $(ENCLAVE) ethereum-package --args-file .github/config/assertoor/network_params_blob.yaml
+	docker logs -f $$(docker ps -q --filter ancestor=ethrex)
+
+
+localnet-assertoor-tx: stop-localnet-silent build-image checkout-ethereum-package ## 🌐 Start local network with assertoor test
+	kurtosis run --enclave $(ENCLAVE) ethereum-package --args-file .github/config/assertoor/network_params_tx.yaml
+	docker logs -f $$(docker ps -q --filter ancestor=ethrex)
+
 stop-localnet: ## 🛑 Stop local network
 	kurtosis enclave stop $(ENCLAVE)
 	kurtosis enclave rm $(ENCLAVE) --force

--- a/README.md
+++ b/README.md
@@ -234,6 +234,26 @@ make run-hive-debug SIMULATION=ethereum/rpc-compat TEST_PATTERN="*"
 ```
 This example runs **every** test under rpc, with debug output
 
+###### Assertoor
+
+We run some assertoot checks on our CI, to execute them locally you can run the following:
+```bash
+make localnet-assertoor-tx
+# or
+make localnet-assertoor-blob
+```
+
+Those are two different set of assertoor checks the details are as follows:
+
+*assertoor-tx*
+- [eoa-transaction-test](https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/eoa-transactions-test.yaml)
+
+*assertoor-blob*
+- [blob-transaction-test](https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/blob-transactions-test.yaml)
+- _Custom_ [el-stability-check](https://raw.githubusercontent.com/lambdaclass/ethrex/refs/heads/main/.github/config/assertoor/el-stability-check.yaml)
+
+For reference on each individual check see the [assertoor-wiki](https://github.com/ethpandaops/assertoor/wiki#supported-tasks-in-assertoor)
+
 ### Run
 
 Example run:


### PR DESCRIPTION
**Motivation**

It's useful to run assertoor locally when we see errors on the PRs, this wasn't straightforward.

**Description**

This Pr adds some make tasks for convinience as well as reactivate dora for the assertoor run for better debugging and add some lines in the README about how to run it.

