### PR TITLE
fix(levm): fix remaining tests from stMemoryStressTest

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -254,22 +254,26 @@ impl VM {
 
         let (_account_info, address_was_cold) = self.access_account(code_address);
 
-        let new_memory_size_for_args = (args_start_offset
-            .checked_add(args_size)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?)
-        .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-        .ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-        let new_memory_size_for_return_data = (return_data_start_offset
-            .checked_add(return_data_size)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?)
-        .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-        .ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-        let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
         let current_memory_size = current_call_frame.memory.len();
+        let new_memory_size_for_args = if args_size > 0 {
+            (args_start_offset
+                .checked_add(args_size)
+                .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?)
+            .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
+            .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?
+        } else {
+            current_memory_size
+        };
+        let new_memory_size_for_return_data = if return_data_size > 0 {
+            (return_data_start_offset
+                .checked_add(return_data_size)
+                .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?)
+            .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
+            .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?
+        } else {
+            current_memory_size
+        };
+        let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
 
         self.increase_consumed_gas(
             current_call_frame,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,7 +1,7 @@
 use crate::{
     call_frame::CallFrame,
     constants::WORD_SIZE_IN_BYTES_USIZE,
-    errors::{InternalError, OpcodeSuccess, OutOfGasError, ResultReason, VMError},
+    errors::{OpcodeSuccess, OutOfGasError, ResultReason, VMError},
     gas_cost,
     memory::{self, calculate_memory_size},
     vm::{word_to_address, VM},
@@ -328,22 +328,26 @@ impl VM {
 
         let (_account_info, address_was_cold) = self.access_account(code_address);
 
-        let new_memory_size_for_args = (args_start_offset
-            .checked_add(args_size)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?)
-        .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-        .ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-        let new_memory_size_for_return_data = (return_data_start_offset
-            .checked_add(return_data_size)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?)
-        .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-        .ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-        let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
         let current_memory_size = current_call_frame.memory.len();
+        let new_memory_size_for_args = if args_size > 0 {
+            (args_start_offset
+                .checked_add(args_size)
+                .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?)
+            .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
+            .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?
+        } else {
+            current_memory_size
+        };
+        let new_memory_size_for_return_data = if return_data_size > 0 {
+            (return_data_start_offset
+                .checked_add(return_data_size)
+                .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?)
+            .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
+            .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?
+        } else {
+            current_memory_size
+        };
+        let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
 
         self.increase_consumed_gas(
             current_call_frame,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -131,22 +131,27 @@ impl VM {
             .try_into()
             .map_err(|_err| VMError::VeryLargeNumber)?;
 
-        let new_memory_size_for_args = (args_start_offset
-            .checked_add(args_size)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?)
-        .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-        .ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-        let new_memory_size_for_return_data = (return_data_start_offset
-            .checked_add(return_data_size)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?)
-        .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
-        .ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-        let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
         let current_memory_size = current_call_frame.memory.len();
+        let new_memory_size_for_args = if args_size > 0 {
+            (args_start_offset
+                .checked_add(args_size)
+                .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?)
+            .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
+            .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?
+        } else {
+            current_memory_size
+        };
+
+        let new_memory_size_for_return_data = if return_data_size > 0 {
+            (return_data_start_offset
+                .checked_add(return_data_size)
+                .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?)
+            .checked_next_multiple_of(WORD_SIZE_IN_BYTES_USIZE)
+            .ok_or(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))?
+        } else {
+            current_memory_size
+        };
+        let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
 
         let (_account_info, address_was_cold) = self.access_account(code_address);
 


### PR DESCRIPTION
**Motivation**

Fix the remaining tests from the folder stMemoryStressTests with this PR `stMemoryStressTest: 38/38 (100.00%)`

**Description**

Added the following checks in `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`
- if the size of the args is zero don't calculate the new memory size for args
- if the size of return data is zero don't calculate the new memory size for return data

This fix works because in case of a zero size read/write, regardless of the offset, memory expansion does not happen.

Added the following check in `RETURN`
- if the return size is zero we can early return, there is no data to copy to memory