### PR TITLE
fix(levm): avoid overflow in calldataload

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -164,11 +164,10 @@ impl VM {
     ) -> Result<OpcodeSuccess, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::BLOBHASH)?;
 
-        let index: usize = current_call_frame
-            .stack
-            .pop()?
-            .try_into()
-            .map_err(|_err| VMError::VeryLargeNumber)?;
+        let Ok(index) = TryInto::<usize>::try_into(current_call_frame.stack.pop()?) else {
+            current_call_frame.stack.push(U256::zero())?;
+            return Ok(OpcodeSuccess::Continue);
+        };
 
         let blob_hashes = &self.env.tx_blob_hashes;
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -93,11 +93,17 @@ impl VM {
     ) -> Result<OpcodeSuccess, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::CALLDATALOAD)?;
 
-        let offset: usize = current_call_frame
-            .stack
-            .pop()?
-            .try_into()
-            .map_err(|_| VMError::VeryLargeNumber)?;
+        let calldata_size: U256 = current_call_frame.calldata.len().into();
+
+        let offset = current_call_frame.stack.pop()?;
+
+        // If the offset is larger than the actual calldata, then you
+        // have no data to return.
+        if offset > calldata_size {
+            current_call_frame.stack.push(U256::zero())?;
+            return Ok(OpcodeSuccess::Continue);
+        };
+        let offset: usize = offset.try_into().map_err(|_| VMError::VeryLargeNumber)?;
 
         // All bytes after the end of the calldata are set to 0.
         let mut data = [0u8; 32];

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -103,7 +103,9 @@ impl VM {
             current_call_frame.stack.push(U256::zero())?;
             return Ok(OpcodeSuccess::Continue);
         };
-        let offset: usize = offset.try_into().map_err(|_| VMError::VeryLargeNumber)?;
+        let offset: usize = offset
+            .try_into()
+            .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
 
         // All bytes after the end of the calldata are set to 0.
         let mut data = [0u8; 32];


### PR DESCRIPTION
If the offset is larger than calldata, then there is no data to show. Return 0 to the stack

**Motivation**
The calldata operand tried to cast the value it got as an argument to usize everytime. However, that number could be larger than usize and an error is raised.

<!-- Why does this pull request exist? What are its goals? -->

**Description**
This tries to check the offset value before casting it to usize. If the offset value (in U256) is _larger_ than the actual length of contents of the calldata (also in U256), then we simply return 0 (since the offset would've removed all the values from calldata). 

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


