### PR TITLE
fix(levm): fix implementation selfbalance

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -598,8 +598,8 @@ pub fn call(
     )?;
     let positive_value_cost = if !value_to_transfer.is_zero() {
         CALL_POSITIVE_VALUE
-            .checked_add(CALL_POSITIVE_VALUE_STIPEND)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?
+            .checked_sub(CALL_POSITIVE_VALUE_STIPEND)
+            .ok_or(InternalError::ArithmeticOperationUnderflow)?
     } else {
         U256::zero()
     };
@@ -640,8 +640,8 @@ pub fn callcode(
     )?;
     let positive_value_cost = if !value_to_transfer.is_zero() {
         CALLCODE_POSITIVE_VALUE
-            .checked_add(CALLCODE_POSITIVE_VALUE_STIPEND)
-            .ok_or(InternalError::ArithmeticOperationOverflow)?
+            .checked_sub(CALLCODE_POSITIVE_VALUE_STIPEND)
+            .ok_or(InternalError::ArithmeticOperationUnderflow)?
     } else {
         U256::zero()
     };

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -134,11 +134,7 @@ impl VM {
     ) -> Result<OpcodeSuccess, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::SELFBALANCE)?;
 
-        // the current account should have been cached when the contract was called
-        let balance = self
-            .get_account(current_call_frame.code_address)
-            .info
-            .balance;
+        let balance = self.get_account(current_call_frame.to).info.balance;
 
         current_call_frame.stack.push(balance)?;
         Ok(OpcodeSuccess::Continue)


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Selfbalance wants the balance of the callframe executing, and that would be the `current_call_frame.to`, not the `code_address`

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

