### PR TITLE
feat(levm): add precompiled contracts addresses to cache

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -147,6 +147,10 @@ impl VM {
             default_touched_storage_slots.insert(address, warm_slots);
         }
 
+        for i in 1..10 {
+            default_touched_accounts.insert(Address::from_low_u64_be(i));
+        }
+
         match to {
             TxKind::Call(address_to) => {
                 default_touched_accounts.insert(address_to);

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -148,7 +148,8 @@ impl VM {
             default_touched_storage_slots.insert(address, warm_slots);
         }
 
-        // Add precompiled contracts addresses to cache
+        // Add precompiled contracts addresses to cache.
+        // TODO: Use the addresses from precompiles.rs in a future
         for i in 1..10 {
             default_touched_accounts.insert(Address::from_low_u64_be(i));
         }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -138,6 +138,7 @@ impl VM {
 
         let mut default_touched_storage_slots: HashMap<Address, HashSet<H256>> = HashMap::new();
 
+        // Add access lists contents to cache
         for (address, keys) in access_list.clone() {
             default_touched_accounts.insert(address);
             let mut warm_slots = HashSet::new();
@@ -147,6 +148,7 @@ impl VM {
             default_touched_storage_slots.insert(address, warm_slots);
         }
 
+        // Add precompiled contracts addresses to cache
         for i in 1..10 {
             default_touched_accounts.insert(Address::from_low_u64_be(i));
         }


### PR DESCRIPTION
**Motivation**

Precompiles are not implemented yet, but some tests test sideways those addresses are cached, so this makes those tests (8 tests) pass.

**Description**

Just adds addresses between 1 and 9 to the cached addresses.