### PR TITLE
fix(levm): RETURNDATACOPY return an error when the subreturndata offset is larger than the offset itself

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -384,19 +384,20 @@ impl VM {
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
 
+        if returndata_offset >= sub_return_data_len {
+            return Err(VMError::VeryLargeNumber); // Maybe can create a new error instead of using this one
+        }
 
         let mut data = vec![0u8; size];
-        if returndata_offset <= sub_return_data_len {
-            for (i, byte) in current_call_frame
-                .sub_return_data
-                .iter()
-                .skip(returndata_offset)
-                .take(size)
-                .enumerate()
-            {
-                if let Some(data_byte) = data.get_mut(i) {
-                    *data_byte = *byte;
-                }
+        for (i, byte) in current_call_frame
+            .sub_return_data
+            .iter()
+            .skip(returndata_offset)
+            .take(size)
+            .enumerate()
+        {
+            if let Some(data_byte) = data.get_mut(i) {
+                *data_byte = *byte;
             }
         }
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -384,20 +384,19 @@ impl VM {
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
 
-        if returndata_offset >= sub_return_data_len {
-            return Err(VMError::VeryLargeNumber); // Maybe can create a new error instead of using this one
-        }
 
         let mut data = vec![0u8; size];
-        for (i, byte) in current_call_frame
-            .sub_return_data
-            .iter()
-            .skip(returndata_offset)
-            .take(size)
-            .enumerate()
-        {
-            if let Some(data_byte) = data.get_mut(i) {
-                *data_byte = *byte;
+        if returndata_offset <= sub_return_data_len {
+            for (i, byte) in current_call_frame
+                .sub_return_data
+                .iter()
+                .skip(returndata_offset)
+                .take(size)
+                .enumerate()
+            {
+                if let Some(data_byte) = data.get_mut(i) {
+                    *data_byte = *byte;
+                }
             }
         }
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -360,11 +360,9 @@ impl VM {
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeSuccess, VMError> {
         let dest_offset = current_call_frame.stack.pop()?;
-        let returndata_offset: usize = current_call_frame
-            .stack
-            .pop()?
-            .try_into()
-            .map_err(|_| VMError::VeryLargeNumber)?;
+        let returndata_offset = current_call_frame.stack.pop()?;
+        // .try_into()
+        // .map_err(|_| VMError::VeryLargeNumber)?;
         let size: usize = current_call_frame
             .stack
             .pop()?
@@ -384,20 +382,25 @@ impl VM {
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
 
-        if returndata_offset >= sub_return_data_len {
-            return Err(VMError::VeryLargeNumber); // Maybe can create a new error instead of using this one
-        }
-
         let mut data = vec![0u8; size];
-        for (i, byte) in current_call_frame
-            .sub_return_data
-            .iter()
-            .skip(returndata_offset)
-            .take(size)
-            .enumerate()
-        {
-            if let Some(data_byte) = data.get_mut(i) {
-                *data_byte = *byte;
+        dbg!(size);
+        if returndata_offset < sub_return_data_len.into() {
+            //     return Err(VMError::VeryLargeNumber); // Maybe can create a new error instead of using this one
+            // }
+            let returndata_offset = returndata_offset
+                .try_into()
+                .map_err(|_| VMError::VeryLargeNumber)?;
+
+            for (i, byte) in current_call_frame
+                .sub_return_data
+                .iter()
+                .skip(returndata_offset)
+                .take(size)
+                .enumerate()
+            {
+                if let Some(data_byte) = data.get_mut(i) {
+                    *data_byte = *byte;
+                }
             }
         }
 


### PR DESCRIPTION
**Motivation**
`RETURNDATACOPY` returns an error of VeryLargeNumber. I tried solving it using the standard way of returning a vector filled with 0's. 
However this breaks *several* tests (~10).
<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/1474