### PR TITLE
fix(levm): add function to assign bytecode to callframe

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -95,6 +95,12 @@ impl CallFrame {
         }
     }
 
+    pub fn assign_bytecode(&mut self, bytecode: Bytes) {
+        self.bytecode = bytecode;
+        self.valid_jump_destinations =
+            get_valid_jump_destinations(&self.bytecode).unwrap_or_default();
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         msg_sender: Address,

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -670,7 +670,7 @@ impl VM {
 
         if self.is_create() {
             // Assign bytecode to context and empty calldata
-            initial_call_frame.bytecode = initial_call_frame.calldata.clone();
+            initial_call_frame.assign_bytecode(initial_call_frame.calldata.clone());
             initial_call_frame.calldata = Bytes::new();
         }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- When changing the bytecode of current callframe we also have to calculate valid jump destinations of that bytecode. There is only one case in which we are doing this right now. In a Create type Transaction at the end of the validations the calldata is assigned to the bytecode.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

