### PR TITLE
docs(levm): documentation

### DIFF
--- a/crates/vm/levm/README.md
+++ b/crates/vm/levm/README.md
@@ -29,6 +29,7 @@ Features:
 
 ### Documentation
 [CallFrame](./docs/callframe.md)
+[FAQ](./docs/faq.md)
 
 ### Testing
 To run the project's tests, do `make test`.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -2,13 +2,13 @@
 ## `usize` and `U256`
 In Rust, **accessing an index on a specific data structure requires a `usize` type variable.** This can be seen in methods like `get` and `get_mut`.
 
-<!-- TODO: Link in the documentation where the `U256` adresses are described -->
+<!-- TODO: Link in the documentation where the `U256` addresses are described -->
 On the other hand, the EVM specification requires all addresses to be in `U256`. Therefore, every opcode treats its arguments as `U256` values.
-The problem arises in the opcodes that need to acess a specific index on a data structure (e.g. `CALLDATA`, `CODECOPY`, `EXTCODECOPY`, etc).
-These operands receive offsets and indexes in `U256`, but the data structure they have to access (e.g. `Memory` or  `Calldata`) **require a `usize`**. Therefore, those paramenters need to be cast from `U256` to `usize`.
-The problem is, `U256`'s representation range is larger than `usize`'s; so not all numbers can be successfuly cast. In these cases, special attention is needed.
+The problem arises in the opcodes that need to access a specific index on a data structure (e.g. `CALLDATA`, `CODECOPY`, `EXTCODECOPY`, etc).
+These operands receive offsets and indexes in `U256`, but the data structure they have to access (e.g. `Memory` or  `Calldata`) **require a `usize`**. Therefore, those parameters need to be cast from `U256` to `usize`.
+The problem is, `U256`'s representation ranger is larger than `usize`'s; so not all numbers can be successfully cast. In these cases, special attention is needed.
 
-The main way to deal with these cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the datastructure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
+The main way to deal with theses cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the data structure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
 
 ```rust
 ///  bytecode: Represents the EVM bytecode array to be executed.
@@ -34,12 +34,12 @@ The main way to deal with these cases (at least, at the time of writing) is to *
 Some context: It is not important what this operand does. The only thing that matters for this example is that `EXTCODECOPY` stores a `data` vector in memory. The offset it receives will tell `EXTCODECOPY` which parts of the bytecode to skip, and which parts it will copy to memory. Skipped sections will be filled with 0's.
 
 - In line `1` we create the vector which we will return.
-- In line `3` we get the `bytecode` array length. Since `.len()` returns a `usize` we need to cast it to `U256`, in order to compare itwith `bytecode_offset`. Luckily, `usize` always fits into `U256`, so this will never fail.
+- In line `3` we get the `bytecode` array length. Since `.len()` returns a `usize` we need to cast it to `U256`, in order to compare it with `bytecode_offset`. Luckily, `usize` always fits into `U256`, so this will never fail.
 - In line `4` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
     -  Do note that, after this check we can safely cast the bytecode to `usize`. This is done in line `5`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
     -  We return an `InternalError` because line 5 should never fail. If it fails, then it means there's a problem with the VM itself.
 - Finally in line `10`, we store the resulting data vector in memory.
-    - If the `bytecode_offset` was larger than the actual contents of the bytecode array, we return a vector with only 0's. This is the intended behavior.
+    - If the bytecode_offset was larger than the actual contents of the bytecode array, we return a vector with only 0's. This is the intended behavior.
 
 
 This pattern is fairly common and is useful to keep in mind, especially when dealing with operands that deal with offsets and indexes.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -6,7 +6,7 @@ In Rust, **accessing an index on a specific data structure requires a `usize` ty
 On the other hand, the EVM specification requires all addresses to be in `U256`. Therefore, every opcode treats its arguments as `U256` values.
 The problem arises in the opcodes that need to acess a specific index on a data structure (e.g. `CALLDATA`, `CODECOPY`, `EXTCODECOPY`, etc).
 These operands receive offsets and indexes in `U256`, but the data structure they have to access (e.g. `Memory` or  `Calldata`) **require a `usize`**. Therefore, those paramenters need to be cast from `U256` to `usize`.
-The problem is, `U256`'s representation ranger is larger than `usize`'s; so not all numbers can be successfuly cast. In these cases, special attention is needed.
+The problem is, `U256`'s representation range is larger than `usize`'s; so not all numbers can be successfuly cast. In these cases, special attention is needed.
 
 The main way to deal with these cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the datastructure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
 

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -1,0 +1,46 @@
+# FAQ
+## `usize` and U256
+In Rust, accessing an index on a specific data structure requires a `usize` type variable. This can be seen in methods like `get` and `get_mut`.
+
+<!-- TODO: Link in the documentation where the U256 adresses are described -->
+On the other hand, the EVM specification requires all addresses to be in U256. Therefore, every opcode treats its arguments as U256 values.
+The problem arises in the opcodes that need to acces a specific index on a data structure (e.g. `CALLDATA`, `CODECOPY`, `EXTCODECOPY`, etc).
+These operands receive offsets and indexes in U256, but the data structure they have to access (e.g. `Memory` or  `Calldata`) require a `usize`. Therefore, those paramenters need to be cast from U256 to `usize`.
+The problem is, U256's representation ranger is larger than `usize`'s; so not all numbers can be successfuly cast. In these cases, special attention is needed.
+
+The main way to deal with theses cases (at least, at the time of writing) is to **delay the cast**. Before casting to `usize`, we compare the size of the index in U256 with the length of the datastructure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern):
+
+Some context: It is not important what this operand does. The only thing that matters for this example is that `EXTCODECOPY` returns a vector of bytes. That vector will copy a specific amount of bytes from `calldata` to `memory`. 
+Notably for this example, it can receive an offset. Which will tell the operand which parts of the `calldata` section it should skip. Skipped sections will be replaced with 0's.
+```rust
+0:   pub fn op_extcodecopy(
+
+        (...)
+
+1:        let offset: U256 = current_call_frame.stack.pop()?; // This represents a `calldata` offset.
+
+        (...)
+
+2:       let mut data = vec![0u8; size];
+3:       if offset < account_info.bytecode.len().into() {
+4:           let offset: usize = offset
+5:               .try_into()
+6:               .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
+7:           // After this the data vector is modified
+
+        (...)
+8:      }
+9:      memory::try_store_data(&mut current_call_frame.memory, dest_offset, &data)?;
+
+10:     Ok(OpcodeSuccess::Continue)
+```
+
+- In line `1` we get the offset, which is in U256.
+- In line `2` we create the vector which we will return.
+- In line `3` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
+    -  If it is not larger, we can safely cast it to usize (which is done in line `4`). This is because the `calldata` size is capped <!-- TODO: Add link to where this is specified. -->
+- Finally in line `9`, we store the data vector in memory.
+    - As stated previously, this can be a vector of all 0's if the calldata offset was larger than calldata itself.
+
+
+This pattern is fairly common and is useful to keep in mind when dealing with operands that deal with offsets and indexes.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -39,7 +39,7 @@ Some context: It is not important what this operand does. The only thing that ma
     -  Do note that, after this check we can safely cast the bytecode to `usize`. This is done in line `5`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
     -  We return an InternalError because line 5 should never fail. If it fails, then it means there's a problem with the VM itself.
 - Finally in line `10`, we store the resulting data vector in memory.
-    - If the bytecode_offset was larger than the actual contents of the bytecode array, we return a vector with only 0's. This is the intended behavior.
+    - If the `bytecode_offset` was larger than the actual contents of the bytecode array, we return a vector with only 0's. This is the intended behavior.
 
 
 This pattern is fairly common and is useful to keep in mind, especially when dealing with operands that deal with offsets and indexes.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -12,7 +12,7 @@ The main way to deal with theses cases (at least, at the time of writing) is to 
 
 ```rust
 ///  bytecode: Represents the EVM bytecode array to be executed.
-0:   pub fn op_extcodecopy(bytecode_offset: U256, bytecode: Bytes, vector_size: usize) {
+0:   pub fn op_extcodecopy(bytecode_offset: U256, bytecode: Bytes, vector_size: usize) -> Result<(), Err> {
 
         (...)
 
@@ -22,7 +22,7 @@ The main way to deal with theses cases (at least, at the time of writing) is to 
 4:       if bytecode_offset < bytecode_length {
 5:           let offset: usize = offset
 6:               .try_into()
-7:               .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
+7:               .map_err(|_| InternalError::ConversionError)?;
 8:           // After this the data vector is modified
 
         (...)
@@ -36,9 +36,10 @@ Some context: It is not important what this operand does. The only thing that ma
 - In line `1` we create the vector which we will return.
 - In line `3` we get the `bytecode` array length. Since `.len()` returns a `usize` we need to cast it to `U256`, in order to compare itwith `bytecode_offset`. Luckily, `usize` always fits into `U256`, so this will never fail.
 - In line `4` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
-    -  Do note that, after this check we can safely cast the bytecode to `usize`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
+    -  Do note that, after this check we can safely cast the bytecode to `usize`. This is done in line `5`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
+    -  We return an InternalError because line 5 should never fail. If it fails, then it means there's a problem with the VM itself.
 - Finally in line `10`, we store the resulting data vector in memory.
-    - If the bytecode_offset was larger than the actual contents of the bytecode array, we return an empty vector. This is the intended behavior.
+    - If the bytecode_offset was larger than the actual contents of the bytecode array, we return a vector with only 0's. This is the intended behavior.
 
 
 This pattern is fairly common and is useful to keep in mind, especially when dealing with operands that deal with offsets and indexes.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -37,7 +37,7 @@ Some context: It is not important what this operand does. The only thing that ma
 - In line `3` we get the `bytecode` array length. Since `.len()` returns a `usize` we need to cast it to `U256`, in order to compare itwith `bytecode_offset`. Luckily, `usize` always fits into `U256`, so this will never fail.
 - In line `4` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
     -  Do note that, after this check we can safely cast the bytecode to `usize`. This is done in line `5`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
-    -  We return an InternalError because line 5 should never fail. If it fails, then it means there's a problem with the VM itself.
+    -  We return an `InternalError` because line 5 should never fail. If it fails, then it means there's a problem with the VM itself.
 - Finally in line `10`, we store the resulting data vector in memory.
     - If the `bytecode_offset` was larger than the actual contents of the bytecode array, we return a vector with only 0's. This is the intended behavior.
 

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -12,31 +12,33 @@ The main way to deal with theses cases (at least, at the time of writing) is to 
 
 ```rust
 ///  bytecode: Represents the EVM bytecode array to be executed.
-0:   pub fn op_extcodecopy(bytecode_offset: U256, bytecode: Bytes) {
+0:   pub fn op_extcodecopy(bytecode_offset: U256, bytecode: Bytes, vector_size: usize) {
 
         (...)
 
-1:       let mut data = vec![0u8; size];
-2:       let bytecode_length: U256 = bytecode.len().into();
-3:       if bytecode_offset < bytecode_length {
-4:           let offset: usize = offset
-5:               .try_into()
-6:               .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
-7:           // After this the data vector is modified
+1:       let mut data = vec![0u8; vector_size];
+2:
+3:       let bytecode_length: U256 = bytecode.len().into();
+4:       if bytecode_offset < bytecode_length {
+5:           let offset: usize = offset
+6:               .try_into()
+7:               .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
+8:           // After this the data vector is modified
 
         (...)
 
-8:      }
-9:      memory.store_data(&data);
-10: }
+9:      }
+10:     memory.store_data(&data);
+11: }
 ```
 Some context: It is not important what this operand does. The only thing that matters for this example is that `EXTCODECOPY` stores a `data` vector in memory. The offset it receives will tell `EXTCODECOPY` which parts of the bytecode to skip, and which parts it will copy to memory. Skipped sections will be filled with 0's.
 
 - In line `1` we create the vector which we will return.
-- In line `2` we get the `bytecode` array length. Since `.len()` returns a `usize` we need to cast it to `U256`, in order to compare itwith `bytecode_offset`. Luckily, `usize` always fits into `U256`, so this will never fail.
-- In line `3` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
+- In line `3` we get the `bytecode` array length. Since `.len()` returns a `usize` we need to cast it to `U256`, in order to compare itwith `bytecode_offset`. Luckily, `usize` always fits into `U256`, so this will never fail.
+- In line `4` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
     -  Do note that, after this check we can safely cast the bytecode to `usize`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
-- Finally in line `9`, we store the resulting data vector in memory.
+- Finally in line `10`, we store the resulting data vector in memory.
+    - If the bytecode_offset was larger than the actual contents of the bytecode array, we return an empty vector. This is the intended behavior.
 
 
-This pattern is fairly common and is useful to keep in mind when dealing with operands that deal with offsets and indexes.
+This pattern is fairly common and is useful to keep in mind, especially when dealing with operands that deal with offsets and indexes.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -38,9 +38,8 @@ Notably for this example, it can receive an offset. Which will tell the operand 
 - In line `1` we get the offset, which is in U256.
 - In line `2` we create the vector which we will return.
 - In line `3` we check if the calldata offset is larger than the calldata itself. If this is the case, there's no data to copy. So we do not want to modify the vector.
-    -  If it is not larger, we can safely cast it to usize (which is done in line `4`). This is because the `calldata` size is capped <!-- TODO: Add link to where this is specified. -->
-- Finally in line `9`, we store the data vector in memory.
-    - As stated previously, this can be a vector of all 0's if the calldata offset was larger than calldata itself.
+    -  Do note that, after this check we can safely cast the bytecode to `usize`. This is because there is a limit to the contract's bytecode size. For more information, read [this article](https://ethereum.org/en/developers/docs/smart-contracts/#limitations).
+- Finally in line `9`, we store the resulting data vector in memory.
 
 
 This pattern is fairly common and is useful to keep in mind when dealing with operands that deal with offsets and indexes.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -8,7 +8,7 @@ The problem arises in the opcodes that need to acess a specific index on a data 
 These operands receive offsets and indexes in `U256`, but the data structure they have to access (e.g. `Memory` or  `Calldata`) **require a `usize`**. Therefore, those paramenters need to be cast from `U256` to `usize`.
 The problem is, `U256`'s representation ranger is larger than `usize`'s; so not all numbers can be successfuly cast. In these cases, special attention is needed.
 
-The main way to deal with theses cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the datastructure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
+The main way to deal with these cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the datastructure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
 
 ```rust
 ///  bytecode: Represents the EVM bytecode array to be executed.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -2,13 +2,13 @@
 ## `usize` and U256
 In Rust, accessing an index on a specific data structure requires a `usize` type variable. This can be seen in methods like `get` and `get_mut`.
 
-<!-- TODO: Link in the documentation where the U256 adresses are described -->
+<!-- TODO: Link in the documentation where the U256 addresses are described -->
 On the other hand, the EVM specification requires all addresses to be in U256. Therefore, every opcode treats its arguments as U256 values.
-The problem arises in the opcodes that need to acces a specific index on a data structure (e.g. `CALLDATA`, `CODECOPY`, `EXTCODECOPY`, etc).
-These operands receive offsets and indexes in U256, but the data structure they have to access (e.g. `Memory` or  `Calldata`) require a `usize`. Therefore, those paramenters need to be cast from U256 to `usize`.
-The problem is, U256's representation ranger is larger than `usize`'s; so not all numbers can be successfuly cast. In these cases, special attention is needed.
+The problem arises in the opcodes that need to access a specific index on a data structure (e.g. `CALLDATA`, `CODECOPY`, `EXTCODECOPY`, etc).
+These operands receive offsets and indexes in U256, but the data structure they have to access (e.g. `Memory` or  `Calldata`) require a `usize`. Therefore, those parameters need to be cast from U256 to `usize`.
+The problem is, U256's representation ranger is larger than `usize`'s; so not all numbers can be successfully cast. In these cases, special attention is needed.
 
-The main way to deal with theses cases (at least, at the time of writing) is to **delay the cast**. Before casting to `usize`, we compare the size of the index in U256 with the length of the datastructure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern):
+The main way to deal with theses cases (at least, at the time of writing) is to **delay the cast**. Before casting to `usize`, we compare the size of the index in U256 with the length of the data structure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern):
 
 Some context: It is not important what this operand does. The only thing that matters for this example is that `EXTCODECOPY` returns a vector of bytes. That vector will copy a specific amount of bytes from `calldata` to `memory`. 
 Notably for this example, it can receive an offset. Which will tell the operand which parts of the `calldata` section it should skip. Skipped sections will be replaced with 0's.


### PR DESCRIPTION
**Motivation**

We figured out that a common problem arises when offsets and indexes in U256 are cast to usize early on in the opcodes execution. These can sometimes cause errores if the value is larger than usize's representation range.

The best way we figured out to deal with this problem was to delay the usize cast as much as possible (or at least until we check that the offset represents a valid position).

However, we did not have this methodology written down in the repository. This PR adds documentation describing this approach, which should be especially useful for newcomers to the the project.

**Description**
Add a `faq.md` file where this approach is described.

Closes #1482


