### PR TITLE
fix(levm): missing stipend gas for the subcall

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -124,6 +124,7 @@ impl VM {
         let to = current_call_frame.to;
         let is_static = current_call_frame.is_static;
 
+        // We add the stipend gas for the subcall. This ensures that the callee has enough gas to perform basic operations
         let gas_for_subcall = if !value_to_transfer.is_zero() {
             gas.checked_add(CALLCODE_POSITIVE_VALUE_STIPEND)
                 .ok_or(InternalError::ArithmeticOperationOverflow)?

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,6 +1,6 @@
 use crate::{
     call_frame::CallFrame,
-    errors::{OpcodeSuccess, ResultReason, VMError},
+    errors::{InternalError, OpcodeSuccess, ResultReason, VMError},
     gas_cost::{self, CALLCODE_POSITIVE_VALUE_STIPEND},
     memory::{self, calculate_memory_size},
     vm::{word_to_address, VM},
@@ -126,7 +126,7 @@ impl VM {
 
         let gas_for_subcall = if !value_to_transfer.is_zero() {
             gas.checked_add(CALLCODE_POSITIVE_VALUE_STIPEND)
-                .ok_or(VMError::VeryLargeNumber)?
+                .ok_or(InternalError::ArithmeticOperationOverflow)?
         } else {
             gas
         };


### PR DESCRIPTION
**Motivation**

The stipend value is not currently added to the input gas for the subcall. This addition is necessary to ensure that the subcall has enough gas for basic operations

**Description**
We need to ensure that when we do a subcall in `callcode`, it has enough gas for basic operations when `value_to_transfer > 0`. While the cost subtraction for the stipend is already implemented:

```rust
// gas_cost.rs -> fn callcode()

let positive_value_cost = if !value_to_transfer.is_zero() {
    CALLCODE_POSITIVE_VALUE
        .checked_sub(CALLCODE_POSITIVE_VALUE_STIPEND)
        .ok_or(InternalError::ArithmeticOperationUnderflow)?
} else {
    U256::zero()
};
```
The stipend gas was not being added to the input gas for the subcall.

- Add the `CALLCODE_POSITIVE_VALUE_STIPEND` to the gas available for the subcall when `value_to_transfer > 0`. We use this value in `generic_call()`.

[Reference](https://www.evm.codes/?fork=cancun#f2)

Closes #1488 

