### PR TITLE
fix(levm): revert transfer value when tx reverts in generic call

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -941,6 +941,11 @@ impl VM {
                     .push(U256::from(SUCCESS_FOR_CALL))?;
             }
             TxResult::Revert(_) => {
+                // Revert value transfer
+                if should_transfer_value {
+                    self.decrease_account_balance(to, value)?;
+                    self.increase_account_balance(msg_sender, value)?;
+                }
                 // Push 0 to stack
                 current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;
             }


### PR DESCRIPTION
**Motivation**

This change makes more tests pass, and makes sense.

**Description**

Previously, if the transaction was rolled back, we would just push a 0 to the stack, now we also roll back the transfer value. Maybe we should do other things too.

Note: This PR is complemented by #1490 