### PR TITLE
fix(levm): change the checked_add to saturating_add in `CALL` and `CALLCODE`

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -63,8 +63,7 @@ impl VM {
 
         // We add the stipend gas for the subcall. This ensures that the callee has enough gas to perform basic operations
         let gas_for_subcall = if !value_to_transfer.is_zero() {
-            gas.checked_add(CALL_POSITIVE_VALUE_STIPEND)
-                .ok_or(InternalError::ArithmeticOperationOverflow)?
+            gas.saturating_add(CALL_POSITIVE_VALUE_STIPEND)
         } else {
             gas
         };
@@ -134,8 +133,7 @@ impl VM {
 
         // We add the stipend gas for the subcall. This ensures that the callee has enough gas to perform basic operations
         let gas_for_subcall = if !value_to_transfer.is_zero() {
-            gas.checked_add(CALLCODE_POSITIVE_VALUE_STIPEND)
-                .ok_or(InternalError::ArithmeticOperationOverflow)?
+            gas.saturating_add(CALLCODE_POSITIVE_VALUE_STIPEND)
         } else {
             gas
         };

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,6 +1,6 @@
 use crate::{
     call_frame::CallFrame,
-    errors::{InternalError, OpcodeSuccess, ResultReason, VMError},
+    errors::{OpcodeSuccess, ResultReason, VMError},
     gas_cost::{self, CALLCODE_POSITIVE_VALUE_STIPEND, CALL_POSITIVE_VALUE_STIPEND},
     memory::{self, calculate_memory_size},
     vm::{word_to_address, VM},


### PR DESCRIPTION
**Motivation**

Change implementation to prevent overflow by adding stipend value to gas input in `op_call` and `op_callcode`.

**Description**

Change from `checked_add` to `saturating_add`. With this change we avoid overflow when the input gas is `U256::MAX`.

PR Related [#1940](https://github.com/lambdaclass/ethrex/pull/1490)