### PR TITLE
refactor(levm): organize callframe

### DIFF
--- a/crates/vm/levm/bench/revm_comparison/src/lib.rs
+++ b/crates/vm/levm/bench/revm_comparison/src/lib.rs
@@ -34,7 +34,7 @@ pub fn run_with_levm(program: &str, runs: usize, number_of_iterations: u32) {
 
     match tx_report.result {
         TxResult::Success => {
-            println!("\t\t0x{}", hex::encode(current_call_frame.returndata));
+            println!("\t\t0x{}", hex::encode(current_call_frame.output));
         }
         TxResult::Revert(error) => panic!("Execution failed: {:?}", error),
     }

--- a/crates/vm/levm/docs/callframe.md
+++ b/crates/vm/levm/docs/callframe.md
@@ -1,6 +1,6 @@
 ### CallFrame
 
-The CallFrame has attributes `returndata` and `sub_return_data` to store both the return data of the current context and of the sub-context.
+The CallFrame has attributes `output` and `sub_return_data` to store both the return data of the current context and of the sub-context.
 
 Opcodes like `RETURNDATACOPY` and `RETURNDATASIZE` access the return data of the subcontext (`sub_return_data`). 
-Meanwhile, opcodes like `RETURN` or `REVERT` modify the return data of the current context (`returndata`).
+Meanwhile, opcodes like `RETURN` or `REVERT` modify the return data of the current context (`output`).

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -55,8 +55,11 @@ impl Stack {
 /// A call frame, or execution environment, is the context in which
 /// the EVM is currently executing.
 pub struct CallFrame {
+    /// Max gas a callframe can use
     pub gas_limit: U256,
+    /// Keeps track of the gas that's been used in current context
     pub gas_used: U256,
+    /// Program Counter
     pub pc: usize,
     /// Address of the account that sent the message
     pub msg_sender: Address,
@@ -66,18 +69,23 @@ pub struct CallFrame {
     pub code_address: Address,
     /// Bytecode to execute
     pub bytecode: Bytes,
+    /// Value sent along the transaction
     pub msg_value: U256,
-    pub stack: Stack, // max 1024 in the future
+    pub stack: Stack,
     pub memory: Memory,
+    /// Data sent along the transaction. Empty in CREATE transactions.
     pub calldata: Bytes,
     /// Return data of the CURRENT CONTEXT (see docs for more details)
     pub output: Bytes,
     /// Return data of the SUB-CONTEXT (see docs for more details)
     pub sub_return_data: Bytes,
+    /// Indicates if current context is static (if it is, it can't change state)
     pub is_static: bool,
     pub transient_storage: TransientStorage,
     pub logs: Vec<Log>,
+    /// Call stack current depth
     pub depth: usize,
+    /// Set of valid jump destinations (where a JUMP or JUMPI can jump to)
     pub valid_jump_destinations: HashSet<usize>,
 }
 

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -74,9 +74,6 @@ pub struct CallFrame {
     pub returndata: Bytes,
     /// Return data of the SUB-CONTEXT (see docs for more details)
     pub sub_return_data: Bytes,
-    /// where to store return data of sub-context in memory
-    pub sub_return_data_offset: U256,
-    pub sub_return_data_size: usize,
     pub is_static: bool,
     pub transient_storage: TransientStorage,
     pub logs: Vec<Log>,

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -71,7 +71,7 @@ pub struct CallFrame {
     pub memory: Memory,
     pub calldata: Bytes,
     /// Return data of the CURRENT CONTEXT (see docs for more details)
-    pub returndata: Bytes,
+    pub output: Bytes,
     /// Return data of the SUB-CONTEXT (see docs for more details)
     pub sub_return_data: Bytes,
     pub is_static: bool,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -179,7 +179,7 @@ impl VM {
             memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?.into(),
         )?;
 
-        current_call_frame.returndata =
+        current_call_frame.output =
             memory::load_range(&mut current_call_frame.memory, offset, size)?
                 .to_vec()
                 .into();
@@ -393,7 +393,7 @@ impl VM {
             memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?.into(),
         )?;
 
-        current_call_frame.returndata =
+        current_call_frame.output =
             memory::load_range(&mut current_call_frame.memory, offset, size)?
                 .to_vec()
                 .into();

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -913,8 +913,6 @@ impl VM {
             current_call_frame.stack.push(U256::from(REVERT_FOR_CALL))?;
             return Ok(OpcodeSuccess::Continue);
         }
-        current_call_frame.sub_return_data_offset = ret_offset;
-        current_call_frame.sub_return_data_size = ret_size;
 
         let tx_report = self.execute(&mut new_call_frame)?;
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -377,7 +377,7 @@ impl VM {
                         new_state: self.cache.clone(),
                         gas_used: current_call_frame.gas_used.low_u64(),
                         gas_refunded: self.env.refunded_gas.low_u64(),
-                        output: current_call_frame.returndata.clone(),
+                        output: current_call_frame.output.clone(),
                         logs: current_call_frame.logs.clone(),
                         created_address: None,
                     });
@@ -405,7 +405,7 @@ impl VM {
                         new_state: self.cache.clone(),
                         gas_used: current_call_frame.gas_used.low_u64(),
                         gas_refunded: self.env.refunded_gas.low_u64(),
-                        output: current_call_frame.returndata.clone(), // Bytes::new() if error is not RevertOpcode
+                        output: current_call_frame.output.clone(), // Bytes::new() if error is not RevertOpcode
                         logs: current_call_frame.logs.clone(),
                         created_address: None,
                     });

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -1533,10 +1533,10 @@ fn mstore8() {
 fn mcopy() {
     let operations = [
         Operation::Push((32, U256::from(32))),      // size
-        Operation::Push((32, U256::zero())),       // source offset
+        Operation::Push((32, U256::zero())),        // source offset
         Operation::Push((32, U256::from(64))),      // destination offset
         Operation::Push((32, U256::from(0x33333))), // value
-        Operation::Push((32, U256::zero())),       // offset
+        Operation::Push((32, U256::zero())),        // offset
         Operation::Mstore,
         Operation::Mcopy,
         Operation::Msize,
@@ -1713,9 +1713,9 @@ fn call_returns_if_bytecode_empty() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::zero())),       // ret_offset
-        Operation::Push((32, U256::zero())),       // args_size
-        Operation::Push((32, U256::zero())),       // args_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -1761,8 +1761,8 @@ fn call_changes_callframe_and_stores() {
     let caller_ops = vec![
         Operation::Push((32, U256::from(ret_size))), // ret_size
         Operation::Push((32, ret_offset)),           // ret_offset
-        Operation::Push((32, U256::zero())),        // args_size
-        Operation::Push((32, U256::zero())),        // args_offset
+        Operation::Push((32, U256::zero())),         // args_size
+        Operation::Push((32, U256::zero())),         // args_offset
         Operation::Push((32, U256::zero())),         // value
         Operation::Push((32, callee_address_u256)),  // address
         Operation::Push((32, U256::from(100_000))),  // gas
@@ -1812,9 +1812,9 @@ fn nested_calls() {
 
     let mut callee2_ops = vec![
         Operation::Push((32, U256::from(32))),       // ret_size
-        Operation::Push((32, U256::zero())),        // ret_offset
-        Operation::Push((32, U256::zero())),        // args_size
-        Operation::Push((32, U256::zero())),        // args_offset
+        Operation::Push((32, U256::zero())),         // ret_offset
+        Operation::Push((32, U256::zero())),         // args_size
+        Operation::Push((32, U256::zero())),         // args_offset
         Operation::Push((32, U256::zero())),         // value
         Operation::Push((32, callee3_address_u256)), // address
         Operation::Push((32, U256::from(100_000))),  // gas
@@ -1849,9 +1849,9 @@ fn nested_calls() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from(64))),       // ret_size
-        Operation::Push((32, U256::zero())),        // ret_offset
-        Operation::Push((32, U256::zero())),        // args_size
-        Operation::Push((32, U256::zero())),        // args_offset
+        Operation::Push((32, U256::zero())),         // ret_offset
+        Operation::Push((32, U256::zero())),         // args_size
+        Operation::Push((32, U256::zero())),         // args_offset
         Operation::Push((32, U256::zero())),         // value
         Operation::Push((32, callee2_address_u256)), // address
         Operation::Push((32, U256::from(100_000))),  // gas
@@ -1929,9 +1929,9 @@ fn staticcall_changes_callframe_is_static() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::zero())),       // ret_offset
-        Operation::Push((32, U256::zero())),       // args_size
-        Operation::Push((32, U256::zero())),       // args_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -2449,12 +2449,12 @@ fn calldataload_being_set_by_parent() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from_big_endian(&calldata[..32]))), // value
-        Operation::Push((32, U256::zero())),                          // offset
+        Operation::Push((32, U256::zero())),                           // offset
         Operation::Mstore,
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::zero())),       // ret_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
         Operation::Push((32, U256::from(32))),      // args_size
-        Operation::Push((32, U256::zero())),       // args_offset
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -2523,7 +2523,7 @@ fn calldatacopy() {
     let ops = vec![
         Operation::Push((32, U256::from(2))), // size
         Operation::Push((32, U256::from(1))), // calldata_offset
-        Operation::Push((32, U256::zero())), // dest_offset
+        Operation::Push((32, U256::zero())),  // dest_offset
         Operation::CallDataCopy,
         Operation::Stop,
     ];
@@ -2563,7 +2563,7 @@ fn returndatacopy() {
     let ops = vec![
         Operation::Push((32, U256::from(2))), // size
         Operation::Push((32, U256::from(1))), // returndata_offset
-        Operation::Push((32, U256::zero())), // dest_offset
+        Operation::Push((32, U256::zero())),  // dest_offset
         Operation::ReturnDataCopy,
         Operation::Stop,
     ];
@@ -2590,17 +2590,17 @@ fn returndatacopy_being_set_by_parent() {
         .with_bytecode(callee_bytecode);
 
     let caller_ops = vec![
-        Operation::Push((32, U256::zero())),       // ret_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::zero())),       // args_size
-        Operation::Push((32, U256::zero())),       // args_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, U256::from(2))),       // callee address
         Operation::Push((32, U256::from(100_000))), // gas
         Operation::Call,
         Operation::Push((32, U256::from(32))), // size
-        Operation::Push((32, U256::zero())),  // returndata offset
-        Operation::Push((32, U256::zero())),  // dest offset
+        Operation::Push((32, U256::zero())),   // returndata offset
+        Operation::Push((32, U256::zero())),   // dest offset
         Operation::ReturnDataCopy,
         Operation::Stop,
     ];
@@ -3435,9 +3435,9 @@ fn logs_from_multiple_callers() {
 
     let mut caller_ops = vec![
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::zero())),       // ret_offset
-        Operation::Push((32, U256::zero())),       // args_size
-        Operation::Push((32, U256::zero())),       // args_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -1755,14 +1755,17 @@ fn call_changes_callframe_and_stores() {
         .with_balance(50000.into())
         .with_bytecode(callee_bytecode);
 
+    let ret_size = 32;
+    let ret_offset = U256::zero();
+
     let caller_ops = vec![
-        Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::from(0))),       // ret_offset
-        Operation::Push((32, U256::from(0))),       // args_size
-        Operation::Push((32, U256::from(0))),       // args_offset
-        Operation::Push((32, U256::zero())),        // value
-        Operation::Push((32, callee_address_u256)), // address
-        Operation::Push((32, U256::from(100_000))), // gas
+        Operation::Push((32, U256::from(ret_size))), // ret_size
+        Operation::Push((32, ret_offset)),           // ret_offset
+        Operation::Push((32, U256::from(0))),        // args_size
+        Operation::Push((32, U256::from(0))),        // args_offset
+        Operation::Push((32, U256::zero())),         // value
+        Operation::Push((32, callee_address_u256)),  // address
+        Operation::Push((32, U256::from(100_000))),  // gas
         Operation::Call,
         Operation::Stop,
     ];
@@ -1789,10 +1792,6 @@ fn call_changes_callframe_and_stores() {
 
     let success = current_call_frame.stack.pop().unwrap() == U256::one();
     assert!(success);
-
-    // These are ret_offset and ret_size used in CALL operation before.
-    let ret_offset = current_call_frame.sub_return_data_offset;
-    let ret_size = current_call_frame.sub_return_data_size;
 
     // Return data of the sub-context will be in the memory position of the current context reserved for that purpose (ret_offset and ret_size)
     let return_data =

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -840,7 +840,7 @@ fn byte_basic() {
 fn byte_edge_cases() {
     let mut vm = new_vm_with_ops(&[
         Operation::Push((32, U256::MAX)),
-        Operation::Push((32, U256::from(0))),
+        Operation::Push((32, U256::zero())),
         Operation::Byte,
         Operation::Stop,
     ])
@@ -999,7 +999,7 @@ fn byte_edge_cases() {
 fn shl_basic() {
     let mut vm = new_vm_with_ops(&[
         Operation::Push((32, U256::from(0xDDDD))),
-        Operation::Push((32, U256::from(0))),
+        Operation::Push((32, U256::zero())),
         Operation::Shl,
         Operation::Stop,
     ])
@@ -1110,7 +1110,7 @@ fn shl_edge_cases() {
 fn shr_basic() {
     let mut vm = new_vm_with_ops(&[
         Operation::Push((32, U256::from(0xDDDD))),
-        Operation::Push((32, U256::from(0))),
+        Operation::Push((32, U256::zero())),
         Operation::Shr,
         Operation::Stop,
     ])
@@ -1221,7 +1221,7 @@ fn shr_edge_cases() {
 fn sar_shift_by_0() {
     let mut vm = new_vm_with_ops(&[
         Operation::Push((32, U256::from(0x12345678))),
-        Operation::Push((32, U256::from(0))),
+        Operation::Push((32, U256::zero())),
         Operation::Sar,
         Operation::Stop,
     ])
@@ -1533,10 +1533,10 @@ fn mstore8() {
 fn mcopy() {
     let operations = [
         Operation::Push((32, U256::from(32))),      // size
-        Operation::Push((32, U256::from(0))),       // source offset
+        Operation::Push((32, U256::zero())),       // source offset
         Operation::Push((32, U256::from(64))),      // destination offset
         Operation::Push((32, U256::from(0x33333))), // value
-        Operation::Push((32, U256::from(0))),       // offset
+        Operation::Push((32, U256::zero())),       // offset
         Operation::Mstore,
         Operation::Mcopy,
         Operation::Msize,
@@ -1591,7 +1591,7 @@ fn msize() {
     vm.execute(&mut current_call_frame).unwrap();
 
     let initial_size = vm.current_call_frame_mut().unwrap().stack.pop().unwrap();
-    assert_eq!(initial_size, U256::from(0));
+    assert_eq!(initial_size, U256::zero());
     assert_eq!(current_call_frame.gas_used, U256::from(2));
 
     let operations = [
@@ -1713,9 +1713,9 @@ fn call_returns_if_bytecode_empty() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::from(0))),       // ret_offset
-        Operation::Push((32, U256::from(0))),       // args_size
-        Operation::Push((32, U256::from(0))),       // args_offset
+        Operation::Push((32, U256::zero())),       // ret_offset
+        Operation::Push((32, U256::zero())),       // args_size
+        Operation::Push((32, U256::zero())),       // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -1761,8 +1761,8 @@ fn call_changes_callframe_and_stores() {
     let caller_ops = vec![
         Operation::Push((32, U256::from(ret_size))), // ret_size
         Operation::Push((32, ret_offset)),           // ret_offset
-        Operation::Push((32, U256::from(0))),        // args_size
-        Operation::Push((32, U256::from(0))),        // args_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),         // value
         Operation::Push((32, callee_address_u256)),  // address
         Operation::Push((32, U256::from(100_000))),  // gas
@@ -1812,9 +1812,9 @@ fn nested_calls() {
 
     let mut callee2_ops = vec![
         Operation::Push((32, U256::from(32))),       // ret_size
-        Operation::Push((32, U256::from(0))),        // ret_offset
-        Operation::Push((32, U256::from(0))),        // args_size
-        Operation::Push((32, U256::from(0))),        // args_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),         // value
         Operation::Push((32, callee3_address_u256)), // address
         Operation::Push((32, U256::from(100_000))),  // gas
@@ -1849,9 +1849,9 @@ fn nested_calls() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from(64))),       // ret_size
-        Operation::Push((32, U256::from(0))),        // ret_offset
-        Operation::Push((32, U256::from(0))),        // args_size
-        Operation::Push((32, U256::from(0))),        // args_offset
+        Operation::Push((32, U256::zero())),        // ret_offset
+        Operation::Push((32, U256::zero())),        // args_size
+        Operation::Push((32, U256::zero())),        // args_offset
         Operation::Push((32, U256::zero())),         // value
         Operation::Push((32, callee2_address_u256)), // address
         Operation::Push((32, U256::from(100_000))),  // gas
@@ -1929,9 +1929,9 @@ fn staticcall_changes_callframe_is_static() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::from(0))),       // ret_offset
-        Operation::Push((32, U256::from(0))),       // args_size
-        Operation::Push((32, U256::from(0))),       // args_offset
+        Operation::Push((32, U256::zero())),       // ret_offset
+        Operation::Push((32, U256::zero())),       // args_size
+        Operation::Push((32, U256::zero())),       // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -1995,7 +1995,7 @@ fn pc_op() {
 
     assert_eq!(
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
-        U256::from(0)
+        U256::zero()
     );
     assert_eq!(current_call_frame.gas_used, U256::from(2));
 }
@@ -2044,9 +2044,9 @@ fn pc_op_with_push_offset() {
 
 //     let caller_ops = vec![
 //         Operation::Push((32, U256::from(32))),      // ret_size
-//         Operation::Push((32, U256::from(0))),       // ret_offset
-//         Operation::Push((32, U256::from(0))),       // args_size
-//         Operation::Push((32, U256::from(0))),       // args_offset
+//         Operation::Push((32, U256::zero())),       // ret_offset
+//         Operation::Push((32, U256::zero())),       // args_size
+//         Operation::Push((32, U256::zero())),       // args_offset
 //         Operation::Push((32, callee_address_u256)), // code address
 //         Operation::Push((32, U256::from(100_000))), // gas
 //         Operation::DelegateCall,
@@ -2107,9 +2107,9 @@ fn pc_op_with_push_offset() {
 
 //     let caller_ops = vec![
 //         Operation::Push((32, U256::from(32))),      // ret_size
-//         Operation::Push((32, U256::from(0))),       // ret_offset
-//         Operation::Push((32, U256::from(0))),       // args_size
-//         Operation::Push((32, U256::from(0))),       // args_offset
+//         Operation::Push((32, U256::zero())),       // ret_offset
+//         Operation::Push((32, U256::zero())),       // args_size
+//         Operation::Push((32, U256::zero())),       // args_offset
 //         Operation::Push((32, U256::zero())),        // value
 //         Operation::Push((32, callee_address_u256)), // address
 //         Operation::Push((32, U256::from(100_000))), // gas
@@ -2170,9 +2170,9 @@ fn pc_op_with_push_offset() {
 
 //     let caller_ops = vec![
 //         Operation::Push((32, U256::from(32))),      // ret_size
-//         Operation::Push((32, U256::from(0))),       // ret_offset
-//         Operation::Push((32, U256::from(0))),       // args_size
-//         Operation::Push((32, U256::from(0))),       // args_offset
+//         Operation::Push((32, U256::zero())),       // ret_offset
+//         Operation::Push((32, U256::zero())),       // args_size
+//         Operation::Push((32, U256::zero())),       // args_offset
 //         Operation::Push((32, callee_address_u256)), // code address
 //         Operation::Push((32, U256::from(100_000))), // gas
 //         Operation::DelegateCall,
@@ -2205,7 +2205,7 @@ fn pc_op_with_push_offset() {
 //         current_call_frame.msg_sender,
 //         Address::from_low_u64_be(U256::from(1).low_u64())
 //     );
-//     assert_eq!(current_call_frame.msg_value, U256::from(0));
+//     assert_eq!(current_call_frame.msg_value, U256::zero());
 
 //     // --- CALLCODE ---
 
@@ -2229,10 +2229,10 @@ fn pc_op_with_push_offset() {
 //         .with_bytecode(callee_bytecode);
 
 //     let caller_ops = vec![
-//         Operation::Push((32, U256::from(0))),       // ret_size
-//         Operation::Push((32, U256::from(0))),       // ret_offset
-//         Operation::Push((32, U256::from(0))),       // args_size
-//         Operation::Push((32, U256::from(0))),       // args_offset
+//         Operation::Push((32, U256::zero())),       // ret_size
+//         Operation::Push((32, U256::zero())),       // ret_offset
+//         Operation::Push((32, U256::zero())),       // args_size
+//         Operation::Push((32, U256::zero())),       // args_offset
 //         Operation::Push((32, U256::from(100))),     // value
 //         Operation::Push((32, callee_address_u256)), // address
 //         Operation::Push((32, U256::from(100_000))), // gas
@@ -2426,7 +2426,7 @@ fn calldataload_being_set_by_parent() {
     let ops = vec![
         Operation::Push((32, U256::zero())), // offset
         Operation::CallDataLoad,
-        Operation::Push((32, U256::from(0))), // offset
+        Operation::Push((32, U256::zero())), // offset
         Operation::Mstore,
         Operation::Push((32, U256::from(32))), // size
         Operation::Push((32, U256::zero())),   // offset
@@ -2449,12 +2449,12 @@ fn calldataload_being_set_by_parent() {
 
     let caller_ops = vec![
         Operation::Push((32, U256::from_big_endian(&calldata[..32]))), // value
-        Operation::Push((32, U256::from(0))),                          // offset
+        Operation::Push((32, U256::zero())),                          // offset
         Operation::Mstore,
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::from(0))),       // ret_offset
+        Operation::Push((32, U256::zero())),       // ret_offset
         Operation::Push((32, U256::from(32))),      // args_size
-        Operation::Push((32, U256::from(0))),       // args_offset
+        Operation::Push((32, U256::zero())),       // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -2523,7 +2523,7 @@ fn calldatacopy() {
     let ops = vec![
         Operation::Push((32, U256::from(2))), // size
         Operation::Push((32, U256::from(1))), // calldata_offset
-        Operation::Push((32, U256::from(0))), // dest_offset
+        Operation::Push((32, U256::zero())), // dest_offset
         Operation::CallDataCopy,
         Operation::Stop,
     ];
@@ -2563,7 +2563,7 @@ fn returndatacopy() {
     let ops = vec![
         Operation::Push((32, U256::from(2))), // size
         Operation::Push((32, U256::from(1))), // returndata_offset
-        Operation::Push((32, U256::from(0))), // dest_offset
+        Operation::Push((32, U256::zero())), // dest_offset
         Operation::ReturnDataCopy,
         Operation::Stop,
     ];
@@ -2590,17 +2590,17 @@ fn returndatacopy_being_set_by_parent() {
         .with_bytecode(callee_bytecode);
 
     let caller_ops = vec![
-        Operation::Push((32, U256::from(0))),       // ret_offset
+        Operation::Push((32, U256::zero())),       // ret_offset
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::from(0))),       // args_size
-        Operation::Push((32, U256::from(0))),       // args_offset
+        Operation::Push((32, U256::zero())),       // args_size
+        Operation::Push((32, U256::zero())),       // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, U256::from(2))),       // callee address
         Operation::Push((32, U256::from(100_000))), // gas
         Operation::Call,
         Operation::Push((32, U256::from(32))), // size
-        Operation::Push((32, U256::from(0))),  // returndata offset
-        Operation::Push((32, U256::from(0))),  // dest offset
+        Operation::Push((32, U256::zero())),  // returndata offset
+        Operation::Push((32, U256::zero())),  // dest offset
         Operation::ReturnDataCopy,
         Operation::Stop,
     ];
@@ -3435,9 +3435,9 @@ fn logs_from_multiple_callers() {
 
     let mut caller_ops = vec![
         Operation::Push((32, U256::from(32))),      // ret_size
-        Operation::Push((32, U256::from(0))),       // ret_offset
-        Operation::Push((32, U256::from(0))),       // args_size
-        Operation::Push((32, U256::from(0))),       // args_offset
+        Operation::Push((32, U256::zero())),       // ret_offset
+        Operation::Push((32, U256::zero())),       // args_size
+        Operation::Push((32, U256::zero())),       // args_offset
         Operation::Push((32, U256::zero())),        // value
         Operation::Push((32, callee_address_u256)), // address
         Operation::Push((32, U256::from(100_000))), // gas
@@ -3488,9 +3488,9 @@ fn logs_from_multiple_callers() {
 
 //     let caller_ops = vec![
 //         Operation::Push((32,U256::from(32))),      // ret_size
-//         Operation::Push((32,U256::from(0))),       // ret_offset
-//         Operation::Push((32,U256::from(0))),       // args_size
-//         Operation::Push((32,U256::from(0))),       // args_offset
+//         Operation::Push((32,U256::zero())),       // ret_offset
+//         Operation::Push((32,U256::zero())),       // args_size
+//         Operation::Push((32,U256::zero())),       // args_offset
 //         Operation::Push((32,U256::zero())),        // value
 //         Operation::Push((32,callee_address_u256)), // address
 //         Operation::Push((32,U256::from(100_000))), // gas


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- remove unnecessary stuff and make things clearer

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Adds comments to `CallFrame`
- Changes `returndata` name for `output`, because it had that role and it was confusing when comparing with Exec specs.
- Remove `sub_return_data_offset` and `sub_return_data_size` because from `CallFrame` they were unnecessary

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

