### PR TITLE
fix(levm): fix returndatacopy

### DIFF
--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -71,7 +71,7 @@ pub enum VMError {
     #[error("Transaction validation error: {0}")]
     TxValidation(#[from] TxValidationError),
     #[error("Offset out of bounds")]
-    OutOfOffset,
+    OutOfBounds,
 }
 
 impl VMError {

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -385,11 +385,11 @@ impl VM {
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
 
-        let limit_to_copy = returndata_offset
+        let copy_limit = returndata_offset
             .checked_add(size)
             .ok_or(VMError::VeryLargeNumber)?;
 
-        if limit_to_copy > sub_return_data_len {
+        if copy_limit > sub_return_data_len {
             return Err(VMError::OutOfBounds);
         }
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -1,7 +1,7 @@
 use crate::{
     call_frame::CallFrame,
     errors::{InternalError, OpcodeSuccess, VMError},
-    gas_cost::{self, RETURNDATASIZE},
+    gas_cost::{self},
     memory::{self, calculate_memory_size},
     vm::{word_to_address, VM},
 };

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -154,7 +154,7 @@ fn test_non_compliance_returndatacopy() {
         new_vm_with_bytecode(Bytes::copy_from_slice(&[56, 56, 56, 56, 56, 56, 62, 56])).unwrap();
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     let txreport = vm.execute(&mut current_call_frame).unwrap();
-    assert_eq!(txreport.result, TxResult::Revert(VMError::VeryLargeNumber));
+    assert_eq!(txreport.result, TxResult::Revert(VMError::OutOfBounds));
 }
 
 #[test]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Fix returndatacopy: If offset + size is larger than returndatasize then we have to revert execution, and we weren't doing that. [EVM Codes](https://www.evm.codes/?fork=cancun#3e)
- Changes name of `OutOfOffset` error for `OutOfBounds` because I consider it more appropriate.


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

