### PR TITLE
fix(levm): move code deposit cost of CREATE

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -87,6 +87,8 @@ pub struct CallFrame {
     pub depth: usize,
     /// Set of valid jump destinations (where a JUMP or JUMPI can jump to)
     pub valid_jump_destinations: HashSet<usize>,
+    /// This is set to true if the function that created this callframe is CREATE or CREATE2
+    pub create_op_called: bool,
 }
 
 impl CallFrame {
@@ -118,6 +120,7 @@ impl CallFrame {
         gas_limit: U256,
         gas_used: U256,
         depth: usize,
+        create_op_called: bool,
     ) -> Self {
         let valid_jump_destinations = get_valid_jump_destinations(&bytecode).unwrap_or_default();
         Self {
@@ -132,6 +135,7 @@ impl CallFrame {
             depth,
             gas_used,
             valid_jump_destinations,
+            create_op_called,
             ..Default::default()
         }
     }

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -20,6 +20,8 @@ pub enum VMError {
     OpcodeNotFound,
     #[error("Invalid Bytecode")]
     InvalidBytecode,
+    #[error("Invalid Contract Prefix")]
+    InvalidContractPrefix,
     #[error("Very Large Number")]
     VeryLargeNumber,
     #[error("Fatal Error")]

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -46,8 +46,6 @@ pub enum VMError {
     AddressAlreadyOccupied,
     #[error("Contract Output Too Big")]
     ContractOutputTooBig,
-    #[error("Invalid Initial Byte")]
-    InvalidInitialByte,
     #[error("Gas limit price product overflow")]
     GasLimitPriceProductOverflow,
     #[error("Balance Overflow")]

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -427,10 +427,6 @@ fn compute_gas_create(
         .checked_mul(INIT_CODE_WORD_COST.as_usize()) // will not panic since it's 2
         .ok_or(OutOfGasError::GasCostOverflow)?;
 
-    let code_deposit_cost = code_size_in_memory
-        .checked_mul(CODE_DEPOSIT_COST.as_usize()) // will not panic since it's 200
-        .ok_or(OutOfGasError::GasCostOverflow)?;
-
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
 
     let hash_cost = if is_create_2 {
@@ -443,8 +439,6 @@ fn compute_gas_create(
 
     Ok(U256::from(memory_expansion_cost)
         .checked_add(init_code_cost.into())
-        .ok_or(OutOfGasError::CreationCostIsTooHigh)?
-        .checked_add(code_deposit_cost.into())
         .ok_or(OutOfGasError::CreationCostIsTooHigh)?
         .checked_add(CREATE_BASE_COST)
         .ok_or(OutOfGasError::CreationCostIsTooHigh)?

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -193,6 +193,12 @@ impl VM {
             memory::load_range(&mut current_call_frame.memory, offset, size)?
                 .to_vec()
                 .into();
+        if current_call_frame.create_op_called {
+            let code_deposit_cost = U256::from(current_call_frame.output.len())
+                .checked_mul(CODE_DEPOSIT_COST)
+                .ok_or(InternalError::ArithmeticOperationOverflow)?;
+            self.increase_consumed_gas(current_call_frame, code_deposit_cost)?;
+        }
 
         Ok(OpcodeSuccess::Result(ResultReason::Return))
     }
@@ -560,6 +566,7 @@ impl VM {
             U256::from(max_message_call_gas),
             U256::zero(),
             new_depth,
+            true,
         );
 
         self.accrued_substate.created_accounts.insert(new_address); // Mostly for SELFDESTRUCT during initcode.
@@ -581,13 +588,7 @@ impl VM {
                     if let Some(&INVALID_CONTRACT_PREFIX) = deployed_code.first() {
                         return Err(VMError::InvalidContractPrefix);
                     }
-
-                    let code_deposit_cost = U256::from(deployed_code.len())
-                        .checked_mul(CODE_DEPOSIT_COST)
-                        .ok_or(InternalError::ArithmeticOperationOverflow)?;
-                    self.increase_consumed_gas(current_call_frame, code_deposit_cost)?;
                 }
-
                 // New account's bytecode is going to be the output of initcode exec.
                 self.update_account_bytecode(new_address, deployed_code)?;
                 current_call_frame
@@ -662,6 +663,7 @@ impl VM {
             gas_limit,
             U256::zero(),
             new_depth,
+            false,
         );
 
         // Transfer value from caller to callee.

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,6 +1,9 @@
 use crate::{
     call_frame::CallFrame,
-    constants::{CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, REVERT_FOR_CALL, SUCCESS_FOR_CALL},
+    constants::{
+        CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, INVALID_CONTRACT_PREFIX, REVERT_FOR_CALL,
+        SUCCESS_FOR_CALL,
+    },
     db::cache,
     errors::{InternalError, OpcodeSuccess, OutOfGasError, ResultReason, TxResult, VMError},
     gas_cost::{
@@ -575,8 +578,7 @@ impl VM {
                 let deployed_code = tx_report.output;
 
                 if !deployed_code.is_empty() {
-                    let get_contract_prefix = deployed_code.first().ok_or(VMError::OutOfBounds)?;
-                    if *get_contract_prefix == 0xEF {
+                    if let Some(&INVALID_CONTRACT_PREFIX) = deployed_code.first() {
                         return Err(VMError::InvalidContractPrefix);
                     }
 

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -334,7 +334,7 @@ impl VM {
             )?,
         )?;
 
-        self.create(
+        self.generic_create(
             value_in_wei_to_send,
             code_offset_in_memory,
             code_size_in_memory,
@@ -369,7 +369,7 @@ impl VM {
             )?,
         )?;
 
-        self.create(
+        self.generic_create(
             value_in_wei_to_send,
             code_offset_in_memory,
             code_size_in_memory,
@@ -469,7 +469,7 @@ impl VM {
     }
 
     /// Common behavior for CREATE and CREATE2 opcodes
-    pub fn create(
+    pub fn generic_create(
         &mut self,
         value_in_wei_to_send: U256,
         code_offset_in_memory: U256,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -572,8 +572,8 @@ impl VM {
 
         match tx_report.result {
             TxResult::Success => {
-                let final_code = tx_report.output;
-                let code_deposit_cost = U256::from(final_code.len())
+                let deployed_code = tx_report.output;
+                let code_deposit_cost = U256::from(deployed_code.len())
                     .checked_mul(CODE_DEPOSIT_COST)
                     .ok_or(InternalError::ArithmeticOperationOverflow)?;
 

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -536,7 +536,7 @@ impl VM {
 
         // THIRD: Changes to the state
         // 1. Creating contract.
-        let new_account = Account::new(value_in_wei_to_send, code.clone(), 1, Default::default());
+        let new_account = Account::new(value_in_wei_to_send, Bytes::new(), 1, Default::default());
         cache::insert_account(&mut self.cache, new_address, new_account);
 
         // 2. Increment sender's nonce.

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -580,7 +580,7 @@ impl VM {
                 self.increase_consumed_gas(current_call_frame, code_deposit_cost)?;
 
                 // New account's bytecode is going to be the output of initcode exec.
-                self.update_account_bytecode(new_address, final_code)?;
+                self.update_account_bytecode(new_address, deployed_code)?;
                 current_call_frame
                     .stack
                     .push(address_to_word(new_address))?;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -178,6 +178,7 @@ impl VM {
                     env.gas_limit,
                     U256::zero(),
                     0,
+                    false,
                 );
 
                 let substate = Substate {
@@ -223,6 +224,7 @@ impl VM {
                     env.gas_limit,
                     U256::zero(),
                     0,
+                    false,
                 );
 
                 let substate = Substate {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -874,8 +874,8 @@ impl VM {
         }
 
         // If contract code is not empty then the first byte should not be 0xef
-        if *contract_code.first().unwrap_or(&0) == INVALID_CONTRACT_PREFIX {
-            return Err(VMError::InvalidInitialByte);
+        if let Some(&INVALID_CONTRACT_PREFIX) = contract_code.first() {
+            return Err(VMError::InvalidContractPrefix);
         }
 
         let max_gas = self.env.gas_limit.low_u64();

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -208,7 +208,8 @@ impl VM {
 
                 default_touched_accounts.insert(new_contract_address);
 
-                let created_contract = Account::new(value, calldata.clone(), 1, HashMap::new());
+                let created_contract = Account::new(value, Bytes::new(), 1, HashMap::new());
+
                 cache::insert_account(&mut cache, new_contract_address, created_contract);
 
                 let initial_call_frame = CallFrame::new(


### PR DESCRIPTION
**Motivation**

We were miscalculating the `gas` of the `create()` because we always added the `code_deposit_cost` to the `gas`. We should do that only when the contract is successfully created.

**Description**

- Change name from `create()` to `generic_create()`
- Remove the `code_deposit_cost` from`compute_gas_create()`, that is responsible for calculating the base gas of the create. This is now done in case that `TxResult::Success` in `create()`.
- Check the prefix of the deployed code. If it's `0xEF`, we return an error.
- We were assigning the bytecode of the new account as soon as it was created. I removed that step and now create it with empty bytecode. Now it is assigned only when it completes successfully.