### PR TITLE
fix(levm): internal error on precompiles

### DIFF
--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -1,6 +1,6 @@
 use crate::account::Account;
 use bytes::Bytes;
-use ethrex_core::{types::Log, Address};
+use ethrex_core::{types::Log, Address, H160};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror;
@@ -176,6 +176,8 @@ pub enum InternalError {
     UndefinedState(i32), // This error is temporarily for things that cause an undefined state.
     #[error("Invalid precompile address. Tried to execute a precompile that does not exist.")]
     InvalidPrecompileAddress,
+    #[error("Precompile not implemented: {0}")]
+    PrecompileNotImplemented(u64),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -7,6 +7,7 @@ use crate::{
         self, max_message_call_gas, CALLCODE_POSITIVE_VALUE_STIPEND, CALL_POSITIVE_VALUE_STIPEND,
     },
     memory::{self, calculate_memory_size},
+    precompiles::is_precompile,
     vm::{address_to_word, word_to_address, VM},
     Account,
 };

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -256,6 +256,11 @@ impl VM {
         );
 
         if is_precompile(&current_call_frame.code_address) {
+            //TODO: Remove this when implementing precompiles
+            return Err(VMError::Internal(InternalError::PrecompileNotImplemented(
+                current_call_frame.code_address.to_low_u64_be(),
+            )));
+
             let precompile_result = execute_precompile(current_call_frame);
 
             match precompile_result {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

- THIS IS NOT FOR MERGING
- The idea is to return an internal error when a precompile is found so that we don't debug tests that involve precompiles for now.
- Feel free to modify this branch however you like

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

