### PR TITLE
fix(levm): correctly return outOfBounds in RETURNDATACOPY

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -379,7 +379,7 @@ impl VM {
             gas_cost::returndatacopy(new_memory_size, current_call_frame.memory.len(), size)?,
         )?;
 
-        if size == 0 {
+        if size == 0 && returndata_offset == 0 {
             return Ok(OpcodeSuccess::Continue);
         }
 


### PR DESCRIPTION
**Motivation**

Fix the remaining tests from the folder `stMemoryTest`

**Description**
- The opcode `RETURNDATACOPY` should fail if trying to read outside of the size of returndatabounds even if size is 0. Added a check for this case.

**Resources**
- Comment in line 238 and 238 from [this test](https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/stMemoryTest/bufferSrcOffsetFiller.yml#L238-L239)