### PR TITLE
fix(levm): don't show semantic differences as real differences in report

### DIFF
--- a/cmd/ef_tests/levm/report.rs
+++ b/cmd/ef_tests/levm/report.rs
@@ -1,6 +1,6 @@
 use crate::runner::{EFTestRunnerError, InternalError};
 use colored::Colorize;
-use ethrex_core::{Address, H256, U256};
+use ethrex_core::{Address, H256};
 use ethrex_levm::{
     errors::{TransactionReport, TxResult, VMError},
     Account, StorageSlot,
@@ -757,7 +757,7 @@ impl fmt::Display for ComparisonReport {
                         writeln!(f, "      Storage slot added {levm_key} -> value mismatch REVM: {revm_value} LEVM: {levm_value}")?;
                         diffs += 1;
                     }
-                } else if *levm_key != H256::zero() && *levm_value != U256::zero() {
+                } else {
                     writeln!(f, "      Storage slot added key is in LEVM but not in REVM {levm_key} -> {levm_value}")?;
                     diffs += 1;
                 }

--- a/cmd/ef_tests/levm/report.rs
+++ b/cmd/ef_tests/levm/report.rs
@@ -1,6 +1,6 @@
 use crate::runner::{EFTestRunnerError, InternalError};
 use colored::Colorize;
-use ethrex_core::{Address, H256};
+use ethrex_core::{Address, H256, U256};
 use ethrex_levm::{
     errors::{TransactionReport, TxResult, VMError},
     Account, StorageSlot,
@@ -757,7 +757,7 @@ impl fmt::Display for ComparisonReport {
                         writeln!(f, "      Storage slot added {levm_key} -> value mismatch REVM: {revm_value} LEVM: {levm_value}")?;
                         diffs += 1;
                     }
-                } else {
+                } else if *levm_key != H256::zero() && *levm_value != U256::zero() {
                     writeln!(f, "      Storage slot added key is in LEVM but not in REVM {levm_key} -> {levm_value}")?;
                     diffs += 1;
                 }

--- a/cmd/ef_tests/levm/report.rs
+++ b/cmd/ef_tests/levm/report.rs
@@ -695,13 +695,19 @@ impl fmt::Display for ComparisonReport {
             }
 
             match (&levm_updated_account.code, &revm_updated_account.code) {
-                (None, Some(_)) => {
-                    writeln!(f, "      Has code in REVM but not in LEVM")?;
-                    diffs += 1;
+                (None, Some(revm_account_code)) => {
+                    if **revm_account_code != *b"" {
+                        writeln!(f, "      Has code in REVM but not in LEVM")?;
+                        writeln!(f, "      REVM code: {}", hex::encode(revm_account_code))?;
+                        diffs += 1;
+                    }
                 }
-                (Some(_), None) => {
-                    writeln!(f, "      Has code in LEVM but not in REVM")?;
-                    diffs += 1;
+                (Some(levm_account_code), None) => {
+                    if **levm_account_code != *b"" {
+                        writeln!(f, "      Has code in LEVM but not in REVM")?;
+                        writeln!(f, "      LEVM code: {}", hex::encode(levm_account_code))?;
+                        diffs += 1;
+                    }
                 }
                 (Some(levm_account_code), Some(revm_account_code)) => {
                     if levm_account_code != revm_account_code {


### PR DESCRIPTION
**Motivation**

Currently, when a root mismatch occurs, the report shows claims that there are some differences between our results and REVM's. However, some of those differences are only semantic and do not affect the resulting merkle tree.

**Description**
The following difference should now be considered equivalent in reports:

- REVM puts an empty bytearray in the code field of an account that received a transaction, whilst LEVM leaves it empty.



