### PR TITLE
feat(levm): implement precompile ripemd160

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,7 @@ dependencies = [
  "hex",
  "keccak-hash 0.11.0",
  "libsecp256k1",
+ "ripemd",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -17,6 +17,7 @@ keccak-hash = "0.11.0"
 thiserror = "2.0.3"
 libsecp256k1 = "0.7.1"
 sha2 = "0.10.8"
+ripemd = "0.1.3"
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
**Motivation**

The goal is to implement ripemd160 precompile.

**Description**

The implementation is quite similar to the sha2-256. There is one test named `static_Call50000_rip160` that fails, but I think that fails due to other reasons.


