### PR TITLE
fix(levm): code_deposit_cost was not deducted in CREATE type tx

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,14 +1,10 @@
 use crate::{
     call_frame::CallFrame,
-    constants::{
-        CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, INVALID_CONTRACT_PREFIX, REVERT_FOR_CALL,
-        SUCCESS_FOR_CALL,
-    },
+    constants::{CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, REVERT_FOR_CALL, SUCCESS_FOR_CALL},
     db::cache,
     errors::{InternalError, OpcodeSuccess, OutOfGasError, ResultReason, TxResult, VMError},
     gas_cost::{
         self, max_message_call_gas, CALLCODE_POSITIVE_VALUE_STIPEND, CALL_POSITIVE_VALUE_STIPEND,
-        CODE_DEPOSIT_COST,
     },
     memory::{self, calculate_memory_size},
     vm::{address_to_word, word_to_address, VM},
@@ -193,12 +189,6 @@ impl VM {
             memory::load_range(&mut current_call_frame.memory, offset, size)?
                 .to_vec()
                 .into();
-        if current_call_frame.create_op_called {
-            let code_deposit_cost = U256::from(current_call_frame.output.len())
-                .checked_mul(CODE_DEPOSIT_COST)
-                .ok_or(InternalError::ArithmeticOperationOverflow)?;
-            self.increase_consumed_gas(current_call_frame, code_deposit_cost)?;
-        }
 
         Ok(OpcodeSuccess::Result(ResultReason::Return))
     }
@@ -582,15 +572,6 @@ impl VM {
 
         match tx_report.result {
             TxResult::Success => {
-                let deployed_code = tx_report.output;
-
-                if !deployed_code.is_empty() {
-                    if let Some(&INVALID_CONTRACT_PREFIX) = deployed_code.first() {
-                        return Err(VMError::InvalidContractPrefix);
-                    }
-                }
-                // New account's bytecode is going to be the output of initcode exec.
-                self.update_account_bytecode(new_address, deployed_code)?;
                 current_call_frame
                     .stack
                     .push(address_to_word(new_address))?;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     gas_cost::{
         self, fake_exponential, ACCESS_LIST_ADDRESS_COST, ACCESS_LIST_STORAGE_KEY_COST,
-        BLOB_GAS_PER_BLOB, CREATE_BASE_COST,
+        BLOB_GAS_PER_BLOB, CODE_DEPOSIT_COST, CREATE_BASE_COST,
     },
     opcodes::Opcode,
     precompiles::{execute_precompile, is_precompile},
@@ -414,6 +414,58 @@ impl VM {
                 Ok(OpcodeSuccess::Continue) => {}
                 Ok(OpcodeSuccess::Result(_)) => {
                     self.call_frames.push(current_call_frame.clone());
+                    // On successful create check output validity
+                    if (self.is_create() && current_call_frame.depth == 0)
+                        || current_call_frame.create_op_called
+                    {
+                        let contract_code = current_call_frame.output.clone();
+                        let code_length = contract_code.len();
+                        let code_deposit_cost = U256::from(code_length)
+                            .checked_mul(CODE_DEPOSIT_COST)
+                            .ok_or(VMError::Internal(
+                                InternalError::ArithmeticOperationOverflow,
+                            ))?;
+
+                        // Revert
+                        // If the first byte of code is 0xef
+                        // If the code_length > MAX_CODE_SIZE
+                        // If current_consumed_gas + code_deposit_cost > gas_limit
+                        let validate_create = if code_length > MAX_CODE_SIZE {
+                            Err(VMError::ContractOutputTooBig)
+                        } else if contract_code.first().unwrap_or(&0) == &INVALID_CONTRACT_PREFIX {
+                            Err(VMError::InvalidContractPrefix)
+                        } else if self
+                            .increase_consumed_gas(current_call_frame, code_deposit_cost)
+                            .is_err()
+                        {
+                            Err(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))
+                        } else {
+                            Ok(current_call_frame.to)
+                        };
+
+                        match validate_create {
+                            Ok(new_address) => {
+                                // Set bytecode to new account if success
+                                self.update_account_bytecode(new_address, contract_code)?;
+                            }
+                            Err(error) => {
+                                // Revert if error
+                                current_call_frame.gas_used = current_call_frame.gas_limit;
+                                self.restore_state(backup_db, backup_substate, backup_refunded_gas);
+
+                                return Ok(TransactionReport {
+                                    result: TxResult::Revert(error),
+                                    new_state: self.cache.clone(),
+                                    gas_used: current_call_frame.gas_used.low_u64(),
+                                    gas_refunded: self.env.refunded_gas.low_u64(),
+                                    output: current_call_frame.output.clone(), // Bytes::new() if error is not RevertOpcode
+                                    logs: current_call_frame.logs.clone(),
+                                    created_address: None,
+                                });
+                            }
+                        }
+                    }
+
                     return Ok(TransactionReport {
                         result: TxResult::Success,
                         new_state: self.cache.clone(),
@@ -829,22 +881,8 @@ impl VM {
         self.prepare_execution(&mut initial_call_frame)?;
 
         let mut report = self.execute(&mut initial_call_frame)?;
-
-        if self.is_create() {
-            match self.create_post_execution(&mut initial_call_frame, &mut report) {
-                Ok(_) => {}
-                Err(error) => {
-                    if error.is_internal() {
-                        return Err(error);
-                    } else {
-                        report.result = TxResult::Revert(error);
-                        if report.result != TxResult::Revert(VMError::RevertOpcode) {
-                            report.gas_used = self.env.gas_limit.low_u64(); // Consume all gas unless the error cause is revert opcode
-                        }
-                        remove_account(&mut self.cache, &initial_call_frame.to);
-                    }
-                }
-            };
+        if self.is_create() && !report.is_success() {
+            remove_account(&mut self.cache, &initial_call_frame.to);
         }
 
         self.post_execution_changes(&initial_call_frame, &mut report)?;
@@ -859,48 +897,6 @@ impl VM {
         self.call_frames.last_mut().ok_or(VMError::Internal(
             InternalError::CouldNotAccessLastCallframe,
         ))
-    }
-
-    fn create_post_execution(
-        &mut self,
-        initial_call_frame: &mut CallFrame,
-        report: &mut TransactionReport,
-    ) -> Result<(), VMError> {
-        if let TxResult::Revert(error) = &report.result {
-            return Err(error.clone());
-        }
-
-        let contract_code = report.clone().output;
-
-        if contract_code.len() > MAX_CODE_SIZE {
-            return Err(VMError::ContractOutputTooBig);
-        }
-
-        // If contract code is not empty then the first byte should not be 0xef
-        if let Some(&INVALID_CONTRACT_PREFIX) = contract_code.first() {
-            return Err(VMError::InvalidContractPrefix);
-        }
-
-        let max_gas = self.env.gas_limit.low_u64();
-
-        // If initialization code is successful, code-deposit cost is paid.
-        let code_length: u64 = contract_code
-            .len()
-            .try_into()
-            .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
-        let code_deposit_cost = code_length.checked_mul(200).ok_or(VMError::Internal(
-            InternalError::ArithmeticOperationOverflow,
-        ))?;
-
-        report.add_gas_with_max(code_deposit_cost, max_gas)?;
-        // Charge 22100 gas for each storage variable set (???)
-
-        // Assign bytecode to the new contract
-        let contract_address = initial_call_frame.to;
-
-        self.update_account_bytecode(contract_address, contract_code)?;
-
-        Ok(())
     }
 
     /// Calculates the address of a new conctract using the CREATE opcode as follow

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -458,7 +458,7 @@ impl VM {
                                     new_state: self.cache.clone(),
                                     gas_used: current_call_frame.gas_used.low_u64(),
                                     gas_refunded: self.env.refunded_gas.low_u64(),
-                                    output: current_call_frame.output.clone(), // Bytes::new() if error is not RevertOpcode
+                                    output: current_call_frame.output.clone(),
                                     logs: current_call_frame.logs.clone(),
                                     created_address: None,
                                 });


### PR DESCRIPTION
**Motivation**

- The `code_deposit_cost` was deducted outside of the callframe that does the contract creation for CREATE type transactions, this was incorrect because subtracting `code_deposit_cost` could make the callfreme revert because of OOG

**Description**
- Unify the contract creation behaviour between the opcodes CREATE/CREATE2 and transactions of type CREATE.
    - After the callframe that does contract creation succeeds do the following checks:
       - Check if the output of this callframe is valid contract (verify length && first byte != 0xef")
       - Check if the `current_callframe.gas_used + code_deposit_cost < current_call_frame.gas_limit`
       
       If any of this checks fail revert the callframe
       If the checks pass add the bytecode to the new account address
- Remove the `create_post_execution` function as the functionality is now done at return in callframe execution