### PR TITLE
feat(l1): remove `Option` from `Store` methods `get_latest_block_number` & `get_earliest_block_number`

### DIFF
--- a/cmd/ef_tests/ethrex/test_runner.rs
+++ b/cmd/ef_tests/ethrex/test_runner.rs
@@ -112,7 +112,7 @@ fn check_prestate_against_db(test_key: &str, test: &TestUnit, db: &Store) {
 /// Panics if any comparison fails
 /// Tests that previously failed the validation stage shouldn't be executed with this function.
 fn check_poststate_against_db(test_key: &str, test: &TestUnit, db: &Store) {
-    let latest_block_number = db.get_latest_block_number().unwrap().unwrap();
+    let latest_block_number = db.get_latest_block_number().unwrap();
     for (addr, account) in &test.post_state {
         let expected_account: CoreAccount = account.clone().into();
         // Check info
@@ -153,7 +153,7 @@ fn check_poststate_against_db(test_key: &str, test: &TestUnit, db: &Store) {
         }
     }
     // Check lastblockhash is in store
-    let last_block_number = db.get_latest_block_number().unwrap().unwrap();
+    let last_block_number = db.get_latest_block_number().unwrap();
     let last_block_hash = db
         .get_block_header(last_block_number)
         .unwrap()

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -218,7 +218,7 @@ async fn main() {
 
             let authrpc_jwtsecret = std::fs::read(authrpc_jwtsecret).expect("Failed to read JWT secret");
             let head_block_hash = {
-                let current_block_number = store.get_latest_block_number().unwrap().unwrap();
+                let current_block_number = store.get_latest_block_number().unwrap();
                 store.get_canonical_block_hash(current_block_number).unwrap().unwrap()
             };
             let max_tries = 3;

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -161,11 +161,10 @@ pub fn validate_receipts_root(
 
 // Returns the hash of the head of the canonical chain (the latest valid hash).
 pub fn latest_canonical_block_hash(storage: &Store) -> Result<H256, ChainError> {
-    if let Some(latest_block_number) = storage.get_latest_block_number()? {
-        if let Some(latest_valid_header) = storage.get_block_header(latest_block_number)? {
-            let latest_valid_hash = latest_valid_header.compute_block_hash();
-            return Ok(latest_valid_hash);
-        }
+    let latest_block_number = storage.get_latest_block_number()?;
+    if let Some(latest_valid_header) = storage.get_block_header(latest_block_number)? {
+        let latest_valid_hash = latest_valid_header.compute_block_hash();
+        return Ok(latest_valid_hash);
     }
     Err(ChainError::StoreError(StoreError::Custom(
         "Could not find latest valid hash".to_string(),

--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -65,10 +65,7 @@ pub fn apply_fork_choice(
 
     total_difficulty_check(&head_hash, &head, store)?;
 
-    // TODO(#791): should we panic here? We should never not have a latest block number.
-    let Some(latest) = store.get_latest_block_number()? else {
-        return Err(StoreError::Custom("Latest block number not found".to_string()).into());
-    };
+    let latest = store.get_latest_block_number()?;
 
     // If the head block is an already present head ancestor, skip the update.
     if is_canonical(store, head.number, head_hash)? && head.number < latest {
@@ -192,11 +189,7 @@ fn find_link_with_canonical_chain(
         return Ok(Some(branch));
     }
 
-    let Some(genesis_number) = store.get_earliest_block_number()? else {
-        return Err(StoreError::Custom(
-            "Earliest block number not found. Node setup must have been faulty.".to_string(),
-        ));
-    };
+    let genesis_number = store.get_earliest_block_number()?;
 
     while block_number > genesis_number {
         block_number -= 1;

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -173,9 +173,7 @@ fn validate_transaction(
 ) -> Result<(), MempoolError> {
     // TODO: Add validations here
 
-    let header_no = store
-        .get_latest_block_number()?
-        .ok_or(MempoolError::NoBlockHeaderError)?;
+    let header_no = store.get_latest_block_number()?;
     let header = store
         .get_block_header(header_no)?
         .ok_or(MempoolError::NoBlockHeaderError)?;

--- a/crates/blockchain/smoke_test.rs
+++ b/crates/blockchain/smoke_test.rs
@@ -186,7 +186,7 @@ mod blockchain_integration_test {
         // Important blocks should still be the same as before.
         assert!(store.get_finalized_block_number().unwrap() == Some(0));
         assert!(store.get_safe_block_number().unwrap() == Some(0));
-        assert!(store.get_latest_block_number().unwrap() == Some(2));
+        assert!(store.get_latest_block_number().unwrap() == 2);
     }
 
     #[test]

--- a/crates/l2/proposer/mod.rs
+++ b/crates/l2/proposer/mod.rs
@@ -90,9 +90,7 @@ impl Proposer {
 
     pub async fn main_logic(&self, store: Store) -> Result<(), ProposerError> {
         let head_block_hash = {
-            let current_block_number = store
-                .get_latest_block_number()?
-                .ok_or(ProposerError::StorageDataIsNone)?;
+            let current_block_number = store.get_latest_block_number()?;
             store
                 .get_canonical_block_hash(current_block_number)?
                 .ok_or(ProposerError::StorageDataIsNone)?

--- a/crates/l2/proposer/prover_server.rs
+++ b/crates/l2/proposer/prover_server.rs
@@ -282,10 +282,7 @@ impl ProverServer {
     ) -> Result<(), ProverServerError> {
         debug!("Request received");
 
-        let latest_block_number = self
-            .store
-            .get_latest_block_number()?
-            .ok_or(ProverServerError::StorageDataIsNone)?;
+        let latest_block_number = self.store.get_latest_block_number()?;
 
         let response = if block_number > latest_block_number {
             let response = ProofData::response(None, None);

--- a/crates/networking/p2p/rlpx/eth/backend.rs
+++ b/crates/networking/p2p/rlpx/eth/backend.rs
@@ -16,9 +16,7 @@ pub fn get_status(storage: &Store) -> Result<StatusMessage, RLPxError> {
     let genesis_header = storage
         .get_block_header(0)?
         .ok_or(RLPxError::NotFound("Genesis Block".to_string()))?;
-    let block_number = storage
-        .get_latest_block_number()?
-        .ok_or(RLPxError::NotFound("Latest Block Number".to_string()))?;
+    let block_number = storage.get_latest_block_number()?;
     let block_header = storage
         .get_block_header(block_number)?
         .ok_or(RLPxError::NotFound(format!("Block {block_number}")))?;
@@ -43,9 +41,7 @@ pub fn validate_status(msg_data: StatusMessage, storage: &Store) -> Result<(), R
     let genesis_header = storage
         .get_block_header(0)?
         .ok_or(RLPxError::NotFound("Genesis Block".to_string()))?;
-    let block_number = storage
-        .get_latest_block_number()?
-        .ok_or(RLPxError::NotFound("Latest Block Number".to_string()))?;
+    let block_number = storage.get_latest_block_number()?;
     let block_header = storage
         .get_block_header(block_number)?
         .ok_or(RLPxError::NotFound(format!("Block {block_number}")))?;

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -175,7 +175,7 @@ fn handle_forkchoice(
                 }
                 InvalidForkChoice::Syncing => {
                     // Start sync
-                    let current_number = context.storage.get_latest_block_number()?.unwrap();
+                    let current_number = context.storage.get_latest_block_number()?;
                     let Some(current_head) =
                         context.storage.get_canonical_block_hash(current_number)?
                     else {

--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -157,16 +157,10 @@ impl FeeHistoryRequest {
         // TODO: We should probably restrict how many blocks we are fetching to a certain limit
 
         // Get earliest block
-        let earliest_block_num = storage
-            .get_earliest_block_number()?
-            .ok_or(RpcErr::Internal(
-                "Could not get earliest block number".to_owned(),
-            ))?;
+        let earliest_block_num = storage.get_earliest_block_number()?;
 
         // Get latest block
-        let latest_block_num = storage.get_latest_block_number()?.ok_or(RpcErr::Internal(
-            "Could not get latest block number".to_owned(),
-        ))?;
+        let latest_block_num = storage.get_latest_block_number()?;
 
         // Get finish_block number
         let finish_block = finish_block

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -85,10 +85,7 @@ impl NewFilterRequest {
             return Err(RpcErr::BadParams("Invalid block range".to_string()));
         }
 
-        let Some(last_block_number) = storage.get_latest_block_number()? else {
-            error!("Latest block number was requested but it does not exist");
-            return Err(RpcErr::Internal("Failed to create filter".to_string()));
-        };
+        let last_block_number = storage.get_latest_block_number()?;
         let id: u64 = random();
         let timestamp = Instant::now();
         let mut active_filters_guard = filters.lock().unwrap_or_else(|mut poisoned_guard| {
@@ -188,10 +185,7 @@ impl FilterChangesRequest {
         storage: ethrex_storage::Store,
         filters: ActiveFilters,
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
-        let Some(latest_block_num) = storage.get_latest_block_number()? else {
-            error!("Latest block number was requested but it does not exist");
-            return Err(RpcErr::Internal("Failed to create filter".to_string()));
-        };
+        let latest_block_num = storage.get_latest_block_number()?;
         let mut active_filters_guard = filters.lock().unwrap_or_else(|mut poisoned_guard| {
             error!("THREAD CRASHED WITH MUTEX TAKEN; SYSTEM MIGHT BE UNSTABLE");
             **poisoned_guard.get_mut() = HashMap::new();

--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -41,10 +41,7 @@ impl RpcHandler for GasPrice {
     /// Estimate Gas Price based on already accepted transactions,
     /// as per the spec, this will be returned in wei.
     fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        let Some(latest_block_number) = context.storage.get_latest_block_number()? else {
-            error!("FATAL: LATEST BLOCK NUMBER IS MISSING");
-            return Err(RpcErr::Internal("Error calculating gas price".to_string()));
-        };
+        let latest_block_number = context.storage.get_latest_block_number()?;
         let block_range_lower_bound =
             latest_block_number.saturating_sub(BLOCK_RANGE_LOWER_BOUND_DEC);
         // These are the blocks we'll use to estimate the price.

--- a/crates/networking/rpc/types/block_identifier.rs
+++ b/crates/networking/rpc/types/block_identifier.rs
@@ -35,10 +35,10 @@ impl BlockIdentifier {
         match self {
             BlockIdentifier::Number(num) => Ok(Some(*num)),
             BlockIdentifier::Tag(tag) => match tag {
-                BlockTag::Earliest => storage.get_earliest_block_number(),
+                BlockTag::Earliest => Ok(Some(storage.get_earliest_block_number()?)),
                 BlockTag::Finalized => storage.get_finalized_block_number(),
                 BlockTag::Safe => storage.get_safe_block_number(),
-                BlockTag::Latest => storage.get_latest_block_number(),
+                BlockTag::Latest => Ok(Some(storage.get_latest_block_number()?)),
                 BlockTag::Pending => {
                     // TODO(#1112): We need to check individual intrincacies of the pending tag for
                     // each RPC method that uses it.
@@ -47,7 +47,7 @@ impl BlockIdentifier {
                         // If there are no pending blocks, we return the latest block number
                         .and_then(|pending_block_number| match pending_block_number {
                             Some(block_number) => Ok(Some(block_number)),
-                            None => storage.get_latest_block_number(),
+                            None => Ok(Some(storage.get_latest_block_number()?)),
                         })
                 }
             },
@@ -114,10 +114,8 @@ impl BlockIdentifierOrHash {
 
         let result = self.resolve_block_number(storage)?;
         let latest = storage.get_latest_block_number()?;
-        match (result, latest) {
-            (Some(result), Some(latest)) => Ok(result == latest),
-            _ => Ok(false),
-        }
+
+        Ok(result.is_some_and(|res| res == latest))
     }
 }
 

--- a/crates/storage/store/error.rs
+++ b/crates/storage/store/error.rs
@@ -38,4 +38,8 @@ pub enum StoreError {
     Trie(#[from] TrieError),
     #[error("missing store: is an execution DB being used instead?")]
     MissingStore,
+    #[error("Missing latest block number")]
+    MissingLatestBlockNumber,
+    #[error("Missing earliest block number")]
+    MissingEarliestBlockNumber,
 }

--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -635,9 +635,10 @@ impl Store {
         self.engine.update_earliest_block_number(block_number)
     }
 
-    // TODO(#790): This should not return an option.
-    pub fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.get_earliest_block_number()
+    pub fn get_earliest_block_number(&self) -> Result<BlockNumber, StoreError> {
+        self.engine
+            .get_earliest_block_number()?
+            .ok_or(StoreError::MissingEarliestBlockNumber)
     }
 
     pub fn update_finalized_block_number(
@@ -663,9 +664,10 @@ impl Store {
         self.engine.update_latest_block_number(block_number)
     }
 
-    // TODO(#790): This should not return an option.
-    pub fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        self.engine.get_latest_block_number()
+    pub fn get_latest_block_number(&self) -> Result<BlockNumber, StoreError> {
+        self.engine
+            .get_latest_block_number()?
+            .ok_or(StoreError::MissingLatestBlockNumber)
     }
 
     pub fn update_latest_total_difficulty(&self, block_difficulty: U256) -> Result<(), StoreError> {
@@ -1239,10 +1241,10 @@ mod tests {
             .update_pending_block_number(pending_block_number)
             .unwrap();
 
-        let stored_earliest_block_number = store.get_earliest_block_number().unwrap().unwrap();
+        let stored_earliest_block_number = store.get_earliest_block_number().unwrap();
         let stored_finalized_block_number = store.get_finalized_block_number().unwrap().unwrap();
         let stored_safe_block_number = store.get_safe_block_number().unwrap().unwrap();
-        let stored_latest_block_number = store.get_latest_block_number().unwrap().unwrap();
+        let stored_latest_block_number = store.get_latest_block_number().unwrap();
         let stored_pending_block_number = store.get_pending_block_number().unwrap().unwrap();
 
         assert_eq!(earliest_block_number, stored_earliest_block_number);


### PR DESCRIPTION
**Motivation**
Both values are written since genesis and never deleted so them missing should be treated as a Core Storage error (either the genesis was not loaded or the db is corrupted) instead of as a regular missing value.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Remove the `Option` from the return types of the `Store` methods `get_latest_block_number` & `get_earliest_block_number`

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #791

