### PR TITLE
fix(levm): add last precompile to touched accounts in vm new

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -150,7 +150,7 @@ impl VM {
 
         // Add precompiled contracts addresses to cache.
         // TODO: Use the addresses from precompiles.rs in a future
-        for i in 1..10 {
+        for i in 1..=10 {
             default_touched_accounts.insert(Address::from_low_u64_be(i));
         }
 


### PR DESCRIPTION
We should touch precompiles from 1 to 10, including the last one. Changes the exclusive range for an inclusive one.

