### PR TITLE
fix(levm): created account in create type tx was not added to substate

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -231,7 +231,7 @@ impl VM {
                     selfdestrutct_set: HashSet::new(),
                     touched_accounts: default_touched_accounts,
                     touched_storage_slots: default_touched_storage_slots,
-                    created_accounts: HashSet::new(),
+                    created_accounts: HashSet::from([new_contract_address]),
                 };
 
                 Ok(Self {


### PR DESCRIPTION
**Motivation**
The account was not removed when calling selfdestruct in CREATE type transactions because the new account was not in the accrued_substate

**Description**
- Add the new address to the substate at vm creation time.

