### PR TITLE
fix(levm): change initial value of gas refund in sstore

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -179,7 +179,10 @@ impl VM {
 
         // Gas Refunds
         // TODO: Think about what to do in case of underflow of gas refunds (when we try to substract from it if the value is low)
-        let mut gas_refunds = U256::zero();
+        // dbg!(self.env.refunded_gas);
+        let mut gas_refunds = self.env.refunded_gas;
+        // dbg!(gas_refunds);
+        dbg!(&storage_slot);
         if new_storage_slot_value != storage_slot.current_value {
             if storage_slot.current_value == storage_slot.original_value {
                 if !storage_slot.original_value.is_zero() && new_storage_slot_value.is_zero() {
@@ -210,14 +213,11 @@ impl VM {
             }
         };
 
-        self.env.refunded_gas = self
-            .env
-            .refunded_gas
-            .checked_add(gas_refunds)
-            .ok_or(VMError::GasLimitPriceProductOverflow)?;
+        self.env.refunded_gas = gas_refunds;
 
+        // dbg!(self.get_account(current_call_frame.to));
         self.update_account_storage(current_call_frame.to, key, new_storage_slot_value)?;
-
+        // dbg!(self.get_account(current_call_frame.to));
         Ok(OpcodeSuccess::Continue)
     }
 

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -178,11 +178,8 @@ impl VM {
         )?;
 
         // Gas Refunds
-        // TODO: Think about what to do in case of underflow of gas refunds (when we try to substract from it if the value is low)
-        // dbg!(self.env.refunded_gas);
+        // Sync gas refund with global env, ensuring consistency accross contexts.
         let mut gas_refunds = self.env.refunded_gas;
-        // dbg!(gas_refunds);
-        dbg!(&storage_slot);
         if new_storage_slot_value != storage_slot.current_value {
             if storage_slot.current_value == storage_slot.original_value {
                 if !storage_slot.original_value.is_zero() && new_storage_slot_value.is_zero() {
@@ -215,9 +212,7 @@ impl VM {
 
         self.env.refunded_gas = gas_refunds;
 
-        // dbg!(self.get_account(current_call_frame.to));
         self.update_account_storage(current_call_frame.to, key, new_storage_slot_value)?;
-        // dbg!(self.get_account(current_call_frame.to));
         Ok(OpcodeSuccess::Continue)
     }
 


### PR DESCRIPTION
**Motivation**

There was a problem with the refunded gas. It was not aligned correctly in the subcontexts.

**Description**

- Use the gas refund that we have in the `env` as the value in `sstore`.
- Update `self.env.refunded_gas` with the new `gas_refunds` value.

With this change, we prevent losing track of gas refunds across different contexts.