### PR TITLE
fix(levm): subreturn data was not cleared in create

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -490,6 +490,9 @@ impl VM {
         let max_message_call_gas = max_message_call_gas(current_call_frame)?;
         self.increase_consumed_gas(current_call_frame, max_message_call_gas.into())?;
 
+        // Clear callframe subreturn data
+        current_call_frame.sub_return_data = Bytes::new();
+
         let deployer_address = current_call_frame.to;
 
         let deployer_account_info = self.access_account(deployer_address).0;


### PR DESCRIPTION
**Motivation**
The sub_return_data should be clearead when calling generic_create according to the spec

**Description**
- After doing all the OOG calculations, we asign Bytes::new() to the current_call_frame sub_return_data
