### PR TITLE
fix(levm): create address should remain touched even in fails

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -602,7 +602,6 @@ impl VM {
                 // Deployment failed so account shouldn't exist
                 cache::remove_account(&mut self.cache, &new_address);
                 self.accrued_substate.created_accounts.remove(&new_address);
-                self.accrued_substate.touched_accounts.remove(&new_address);
 
                 current_call_frame.stack.push(CREATE_DEPLOYMENT_FAIL)?;
             }


### PR DESCRIPTION
**Motivation**

The new address should remain in the touched adresses even in fails

**Description**
- Remove the line that removed the address from the touched addresses.

**Resources**
"Clarification: If a CREATE/CREATE2 operation fails later on, e.g during the execution of initcode or has insufficient gas to store the code in the state, the address of the contract itself remains in access_addresses (but any additions made within the inner scope are reverted)."

From https://eips.ethereum.org/EIPS/eip-2929
