### PR TITLE
fix(ci): move hive setup to its own job so we only do it once

### DIFF
--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -101,17 +101,17 @@ jobs:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
 
-    setup-hive:
-      name: "Setup Hive"
-      runs-on: ubuntu-latest
-      steps:
-        - name: Setup Hive
-          run: make setup-hive
-        - name: Upload artifacts
-          uses: actions/upload-artifact@v4
-          with:
-            name: hive_executable
-            path: hive/hive
+  setup-hive:
+    name: "Setup Hive"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Hive
+        run: make setup-hive
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hive_executable
+          path: hive/hive
 
 
   run-assertoor:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -205,9 +205,7 @@ jobs:
       #     docker load --input /tmp/ethrex_image.tar
 
       - name: Run Hive Simulation
-        run: 
-          chmod +x hive
-          ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: chmod +x hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -204,13 +204,10 @@ jobs:
       #   run: |
       #     docker load --input /tmp/ethrex_image.tar
 
-      - name: Rustup toolchain install
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
       - name: Run Hive Simulation
-        run: ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: 
+          chmod +x hive
+          ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -192,7 +192,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: hive_executable
-          path: /
+          path: /tmp
 
       - name: Load image
         run: |
@@ -213,7 +213,7 @@ jobs:
         run: make setup-hive
 
       - name: Run Hive Simulation
-        run: ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -155,8 +155,7 @@ jobs:
   run-hive:
     name: Hive - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    # needs: [docker_build, setup-hive]
-    needs: [setup-hive]
+    needs: [docker_build, setup-hive]
     if: ${{ github.event_name != 'merge_group' }}
     strategy:
       matrix:
@@ -186,11 +185,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      # - name: Download ethrex image artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: ethrex_image
-      #     path: /tmp
+      - name: Download ethrex image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ethrex_image
+          path: /tmp
 
       - name: Download hive artifacts
         uses: actions/download-artifact@v4
@@ -200,9 +199,9 @@ jobs:
       - name: Debug
         run: ls
 
-      # - name: Load image
-      #   run: |
-      #     docker load --input /tmp/ethrex_image.tar
+      - name: Load image
+        run: |
+          docker load --input /tmp/ethrex_image.tar
 
       - name: Run Hive Simulation
         run: chmod +x hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -209,11 +209,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
 
-      - name: Setup Hive
-        run: make setup-hive
-
       - name: Run Hive Simulation
-        run: cd /tmp && chmod +x hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -196,9 +196,6 @@ jobs:
         with:
           name: hive
           path: /tmp
-      
-      - name: Debug
-        run: ls
 
       - name: Load image
         run: |
@@ -210,7 +207,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp/hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -207,7 +207,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run Hive Simulation
-        run: cd /tmp/hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -210,7 +210,7 @@ jobs:
         uses: actions/setup-go@v5
 
       - name: Run Hive Simulation
-        run: cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp && chmod +x hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -182,6 +182,9 @@ jobs:
             simulation: ethereum/engine
             test_pattern: "engine-api/RPC|Re-Org Back to Canonical Chain From Syncing Chain|Re-org to Previously Validated Sidechain Payload|Re-Org Back into Canonical Chain, Depth=5|Safe Re-Org|Transaction Re-Org|Inconsistent|Suggested Fee|PrevRandao|Fork ID|Unknown|Invalid PayloadAttributes|Bad Hash|Unique Payload ID|Re-Execute Payload|In-Order|Multiple New Payloads|Valid NewPayload|NewPayload with|Invalid NewPayload|Payload Build|Invalid NewPayload, Transaction|ParentHash equals|Build Payload|Invalid Missing Ancestor ReOrg"
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
       - name: Download ethrex image artifact
         uses: actions/download-artifact@v4
         with:
@@ -192,14 +195,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: hive_executable
-          path: /tmp
+          path: /hive
 
       - name: Load image
         run: |
           docker load --input /tmp/ethrex_image.tar
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
@@ -208,10 +208,7 @@ jobs:
 
       - name: Run Hive Simulation
         run: 
-          chmod +x /tmp/hive
-          ls
-          ls tmp
-          cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+          cd hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -213,6 +213,7 @@ jobs:
         run: make setup-hive
 
       - name: Run Hive Simulation
+        run: chmod +x /tmp/hive
         run: cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -201,9 +201,9 @@ jobs:
       - name: Debug
         run: ls
 
-      - name: Load image
-        run: |
-          docker load --input /tmp/ethrex_image.tar
+      # - name: Load image
+      #   run: |
+      #     docker load --input /tmp/ethrex_image.tar
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -196,6 +196,9 @@ jobs:
         with:
           name: hive
           path: /tmp
+      
+      - name: Debug
+        run: ls
 
       - name: Load image
         run: |

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -101,6 +101,19 @@ jobs:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
 
+    setup-hive:
+      name: "Setup Hive"
+      runs-on: ubuntu-latest
+      steps:
+        - name: Setup Hive
+          run: make setup-hive
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: hive_executable
+            path: hive/hive
+
+
   run-assertoor:
     name: Assertoor - ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -119,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download artifacts
+      - name: Download etherex image artifact
         uses: actions/download-artifact@v4
         with:
           name: ethrex_image
@@ -141,7 +154,7 @@ jobs:
   run-hive:
     name: Hive - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [docker_build]
+    needs: [docker_build, setup-hive]
     if: ${{ github.event_name != 'merge_group' }}
     strategy:
       matrix:
@@ -168,11 +181,17 @@ jobs:
             simulation: ethereum/engine
             test_pattern: "engine-api/RPC|Re-Org Back to Canonical Chain From Syncing Chain|Re-org to Previously Validated Sidechain Payload|Re-Org Back into Canonical Chain, Depth=5|Safe Re-Org|Transaction Re-Org|Inconsistent|Suggested Fee|PrevRandao|Fork ID|Unknown|Invalid PayloadAttributes|Bad Hash|Unique Payload ID|Re-Execute Payload|In-Order|Multiple New Payloads|Valid NewPayload|NewPayload with|Invalid NewPayload|Payload Build|Invalid NewPayload, Transaction|ParentHash equals|Build Payload|Invalid Missing Ancestor ReOrg"
     steps:
-      - name: Download artifacts
+      - name: Download ethrex image artifact
         uses: actions/download-artifact@v4
         with:
           name: ethrex_image
           path: /tmp
+
+      - name: Download hive artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: hive
+          path: /
 
       - name: Load image
         run: |
@@ -193,7 +212,7 @@ jobs:
         run: make setup-hive
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -213,7 +213,7 @@ jobs:
         run: make setup-hive
 
       - name: Run Hive Simulation
-        run: cd tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -206,11 +206,8 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-
       - name: Run Hive Simulation
-        run: cd /tmp && chmod +x hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp && chmod +x hive && ls && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -191,7 +191,7 @@ jobs:
       - name: Download hive artifact
         uses: actions/download-artifact@v4
         with:
-          name: hive
+          name: hive_executable
           path: /
 
       - name: Load image

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -186,17 +186,17 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ethrex_image
-          path: /tmp
-
-      # - name: Download hive artifacts
+      # - name: Download ethrex image artifact
       #   uses: actions/download-artifact@v4
       #   with:
-      #     name: hive
+      #     name: ethrex_image
       #     path: /tmp
+
+      - name: Download hive artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: hive
+          path: /tmp
 
       - name: Debug
         run: ls

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -210,7 +210,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run Hive Simulation
-        run: cd /tmp/hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -105,6 +105,7 @@ jobs:
     name: "Setup Hive"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Hive
         run: make setup-hive
       - name: Upload artifacts

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -213,8 +213,7 @@ jobs:
         run: make setup-hive
 
       - name: Run Hive Simulation
-        run: chmod +x /tmp/hive
-        run: cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp && chmod +x hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -108,10 +108,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Hive
         run: make setup-hive
-      - name: Upload artifacts
+      - name: Upload hive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: hive_executable
+          name: hive
           path: hive/hive
 
 
@@ -191,11 +191,11 @@ jobs:
           name: ethrex_image
           path: /tmp
 
-      - name: Download hive artifact
+      - name: Download hive artifacts
         uses: actions/download-artifact@v4
         with:
-          name: hive_executable
-          path: /hive
+          name: hive
+          path: /tmp
 
       - name: Load image
         run: |
@@ -207,8 +207,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run Hive Simulation
-        run: 
-          cd hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: cd /tmp/hive && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hive
-          path: hive/hive
+          path: hive
 
 
   run-assertoor:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -207,7 +207,11 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run Hive Simulation
-        run: cd /tmp && chmod +x hive && ls && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
+        run: 
+          chmod +x /tmp/hive
+          ls
+          ls tmp
+          cd /tmp && ./hive --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 4
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -192,11 +192,11 @@ jobs:
           name: ethrex_image
           path: /tmp
 
-      - name: Download hive artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: hive
-          path: /tmp
+      # - name: Download hive artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: hive
+      #     path: /tmp
 
       - name: Debug
         run: ls

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -196,9 +196,6 @@ jobs:
         with:
           name: hive
 
-      - name: Debug
-        run: ls
-
       - name: Load image
         run: |
           docker load --input /tmp/ethrex_image.tar

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -155,7 +155,8 @@ jobs:
   run-hive:
     name: Hive - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [docker_build, setup-hive]
+    # needs: [docker_build, setup-hive]
+    needs: [setup-hive]
     if: ${{ github.event_name != 'merge_group' }}
     strategy:
       matrix:
@@ -196,6 +197,9 @@ jobs:
         with:
           name: hive
           path: /tmp
+
+      - name: Debug
+        run: ls
 
       - name: Load image
         run: |

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -196,7 +196,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: hive
-          path: /tmp
 
       - name: Debug
         run: ls


### PR DESCRIPTION
**Motivation**
I ran into errors due to the frequency of docker pulls performed when adding more elements to the `run-hive` matrix strategy. I think we can solve it by only setting up hive once and then passing on the executable to the different hive test jobs.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Create a `setup-hive` job that creates the `hive` executable
* Retrieve the `hive` executable instead of creating it for each parallel run in `run-hive`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

