### PR TITLE
fix(l1): preventing `GetPayloadBodies Parallel` test to get blocked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := f220e0c55fb222aaaffdf17d66aa0537cd16a67a
+HIVE_REVISION := df7d5103d4ddc772307f9947be4ad1f20ce03ed0
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).


### PR DESCRIPTION
**Motivation**
On `engine-withdrawals/GetPayloadBodies Parallel` hive test: 
When all the parallel requests fail the parallel workers are killed and the channel where the requests are pushed gets blocked, causing the entire test to block.

**Description**

Using the [hive update](https://github.com/lambdaclass/hive/pull/15) that fixes that problem