### PR TITLE
fix(l1): don't return an error if forkChoiceUpdate contains null PayloadAttributes

### DIFF
--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -130,8 +130,8 @@ fn parse(
     let forkchoice_state: ForkChoiceState = serde_json::from_value(params[0].clone())?;
     // if there is an error when parsing, set to None
     let payload_attributes: Option<PayloadAttributesV3> =
-        match serde_json::from_value::<PayloadAttributesV3>(params[1].clone()) {
-            Ok(attributes) => Some(attributes),
+        match serde_json::from_value::<Option<PayloadAttributesV3>>(params[1].clone()) {
+            Ok(attributes) => attributes,
             Err(error) => {
                 info!("Could not parse params {}", error);
                 None


### PR DESCRIPTION
**Motivation**
When we receive a payload with null payload attributes we return an error: `Could not parse params invalid type: null, expected struct PayloadAttributesV3`, when this is perfectly acceptable behaviour

**Description**
* Parse payload attributes as `Option<PayloadAttributes>` instead of just `PayloadAttributes`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

