### PR TITLE
fix(levm): copy return data if callframe reverts in generic_create

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -595,7 +595,7 @@ impl VM {
                     .stack
                     .push(address_to_word(new_address))?;
             }
-            TxResult::Revert(_) => {
+            TxResult::Revert(err) => {
                 // Return value to sender
                 self.increase_account_balance(deployer_address, value_in_wei_to_send)?;
 
@@ -604,6 +604,10 @@ impl VM {
                 self.accrued_substate.created_accounts.remove(&new_address);
                 self.accrued_substate.touched_accounts.remove(&new_address);
 
+                // If revert we have to copy the return_data
+                if err == VMError::RevertOpcode {
+                    current_call_frame.sub_return_data = tx_report.output;
+                }
                 current_call_frame.stack.push(CREATE_DEPLOYMENT_FAIL)?;
             }
         }


### PR DESCRIPTION
**Motivation**

If the callframe that performs contract creation ends with an opcode revert, we should copy the output to the sub_return_data of the current callframe.

**Description**

- Add a check if the result is revert because of VMError::RevertOpcode, we copy the output of the txreport to the current callframe sub_return_data
