### PR TITLE
fix(levm): clear sub_return_data in generic_call()

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -630,6 +630,9 @@ impl VM {
         ret_offset: U256,
         ret_size: usize,
     ) -> Result<OpcodeSuccess, VMError> {
+        // Clear callframe subreturn data
+        current_call_frame.sub_return_data = Bytes::new();
+
         // 1. Validate sender has enough value
         let sender_account_info = self.access_account(msg_sender).0;
         if should_transfer_value && sender_account_info.balance < value {


### PR DESCRIPTION
**Motivation**

Ensure the `sub_return_data` is cleared at the start of every `generic_call()`

**Description**

Added a step to clear the `sub_return_data` with empty bytes. This change prevents residual data from previous calls.
