### PR TITLE
fix(levm): resize memory in `generic_call` before any validation

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -6,7 +6,7 @@ use crate::{
     gas_cost::{
         self, max_message_call_gas, CALLCODE_POSITIVE_VALUE_STIPEND, CALL_POSITIVE_VALUE_STIPEND,
     },
-    memory::{self, calculate_memory_size},
+    memory::{self, calculate_memory_size, try_resize},
     vm::{address_to_word, word_to_address, VM},
     Account,
 };
@@ -134,6 +134,8 @@ impl VM {
                 value_to_transfer,
             )?,
         )?;
+
+        try_resize(&mut current_call_frame.memory, new_memory_size)?;
 
         // Sender and recipient are the same in this case. But the code executed is from another account.
         let msg_sender = current_call_frame.to;

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -6,7 +6,7 @@ use crate::{
     gas_cost::{
         self, max_message_call_gas, CALLCODE_POSITIVE_VALUE_STIPEND, CALL_POSITIVE_VALUE_STIPEND,
     },
-    memory::{self, calculate_memory_size, try_resize},
+    memory::{self, calculate_memory_size},
     vm::{address_to_word, word_to_address, VM},
     Account,
 };
@@ -134,8 +134,6 @@ impl VM {
                 value_to_transfer,
             )?,
         )?;
-
-        try_resize(&mut current_call_frame.memory, new_memory_size)?;
 
         // Sender and recipient are the same in this case. But the code executed is from another account.
         let msg_sender = current_call_frame.to;

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -643,6 +643,9 @@ impl VM {
         // Clear callframe subreturn data
         current_call_frame.sub_return_data = Bytes::new();
 
+        let calldata =
+            memory::load_range(&mut current_call_frame.memory, args_offset, args_size)?.to_vec();
+
         // 1. Validate sender has enough value
         let sender_account_info = self.access_account(msg_sender).0;
         if should_transfer_value && sender_account_info.balance < value {
@@ -662,8 +665,6 @@ impl VM {
         }
 
         let recipient_bytecode = self.access_account(code_address).0.bytecode;
-        let calldata =
-            memory::load_range(&mut current_call_frame.memory, args_offset, args_size)?.to_vec();
         // Gas Limit for the child context is capped.
         let gas_cap = max_message_call_gas(current_call_frame)?;
         let gas_limit = std::cmp::min(gas_limit, gas_cap.into());


### PR DESCRIPTION
**Motivation**

The `CALLCODE` operand was not resizing the memory with its new size; it was only using the new size to calculate the gas cost. This turned out to be a problem common to all the `CALL*` family of operands. 

**Description**

Right at the beginning of `generic_call`, we now resize the memory of the current call frame. This is because, the memory should be expanded even if the caller does not have enough funds to proceed with the transaction.

This comes from the test `stRandom/randomStatetest248.json`.  In this test, the caller is trying to transfer `U256::MAX` to a different address.  In our code, we only expand the memory IF the user has enough funds; but we should expand the memory regardless of funds.

