### PR TITLE
fix(levm): mcopy should resize to the biggest offset

### DIFF
--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -139,7 +139,10 @@ pub fn try_copy_within(
         .map_err(|_err| VMError::VeryLargeNumber)?;
     try_resize(
         memory,
-        to_offset.checked_add(size).ok_or(VMError::OutOfBounds)?,
+        to_offset
+            .max(from_offset)
+            .checked_add(size)
+            .ok_or(VMError::OutOfBounds)?,
     )?;
 
     let mut temporary_buffer = vec![0u8; size];


### PR DESCRIPTION
**Motivation**

There is a bug in the `MCOPY` opcode, memory is not being resized to the correct value.

**Description**

The `memory::try_copy_within` function has two parameters `from_offset` and `to_offset`, when resizing the memory we now use the biggest of the two values.