### PR TITLE
fix(levm): sstore refund logic

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -367,7 +367,6 @@ pub fn sstore(
     storage_slot: &StorageSlot,
     new_value: U256,
     storage_slot_was_cold: bool,
-    current_call_frame: &CallFrame,
 ) -> Result<u64, VMError> {
     let static_gas = SSTORE_STATIC;
 

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -369,15 +369,6 @@ pub fn sstore(
     storage_slot_was_cold: bool,
     current_call_frame: &CallFrame,
 ) -> Result<u64, VMError> {
-    // EIP-2200
-    let gas_left = current_call_frame
-        .gas_limit
-        .checked_sub(current_call_frame.gas_used)
-        .ok_or(OutOfGasError::ConsumedGasOverflow)?;
-    if gas_left <= SSTORE_STIPEND {
-        return Err(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded));
-    }
-
     let static_gas = SSTORE_STATIC;
 
     let mut base_dynamic_gas = if new_value == storage_slot.current_value {

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -177,7 +177,10 @@ impl VM {
         let mut gas_refunds = self.env.refunded_gas;
 
         if new_storage_slot_value != storage_slot.current_value {
-            if !storage_slot.original_value.is_zero() && new_storage_slot_value.is_zero() {
+            if !storage_slot.original_value.is_zero()
+                && !storage_slot.current_value.is_zero()
+                && new_storage_slot_value.is_zero()
+            {
                 gas_refunds = gas_refunds
                     .checked_add(4800)
                     .ok_or(VMError::GasRefundsOverflow)?;
@@ -195,7 +198,6 @@ impl VM {
                         .checked_add(19900)
                         .ok_or(VMError::GasRefundsOverflow)?;
                 } else {
-                    // Slot originalmente no vacío y ahora lo estás actualizando nuevamente
                     gas_refunds = gas_refunds
                         .checked_add(2800)
                         .ok_or(VMError::GasRefundsOverflow)?;

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -218,12 +218,7 @@ impl VM {
 
         self.increase_consumed_gas(
             current_call_frame,
-            gas_cost::sstore(
-                &storage_slot,
-                new_storage_slot_value,
-                storage_slot_was_cold,
-                current_call_frame,
-            )?,
+            gas_cost::sstore(&storage_slot, new_storage_slot_value, storage_slot_was_cold)?,
         )?;
 
         self.update_account_storage(current_call_frame.to, key, new_storage_slot_value)?;


### PR DESCRIPTION
**Motivation**

There was a discrepancies in gas usage and refunds. The issue was related to an improper management of gas refunds in `sstore`.

**Description**

There was an error when calculating the gas refund. Adjust the conditional logic to subtract refunds when reverting storage changes and adding refunds appropriately. Also, reordered refund and cost logic.
