### PR TITLE
fix(levm): early return could consume more gas than gas_limit

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -279,9 +279,7 @@ pub fn modexp(
         .into();
 
     if b_size == U256::zero() && m_size == U256::zero() {
-        *consumed_gas = consumed_gas
-            .checked_add(MODEXP_STATIC_COST)
-            .ok_or(OutOfGasError::ConsumedGasOverflow)?;
+        increase_precompile_consumed_gas(gas_for_call, MODEXP_STATIC_COST, consumed_gas)?;
         return Ok(Bytes::new());
     }
 

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -25,7 +25,7 @@ use sha3::Digest;
 
 use crate::{
     call_frame::CallFrame,
-    errors::{InternalError, OutOfGasError, PrecompileError, VMError},
+    errors::{InternalError, PrecompileError, VMError},
     gas_cost::{self, ECADD_COST, ECMUL_COST, ECRECOVER_COST, MODEXP_STATIC_COST},
 };
 


### PR DESCRIPTION
**Motivation**

We were not using the `increase_precompile_consumed_gas` function for the early return in the `modexp` precompile so we were not checking the `gas_limit` when consuming `MODEXP_STATIC_COST`

**Description**
- Use the function `increase_precompile_consumed_gas` that includes all the necessary checks for gas consumption inside a precompile
