### PR TITLE
feat(levm): change gas type from U256 to u64 pt. 2

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -267,9 +267,6 @@ fn copy_behavior(
         .map_err(|_| VMError::VeryLargeNumber)?;
 
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let minimum_word_size_cost = dynamic_base
         .checked_mul(minimum_word_size)
@@ -311,10 +308,6 @@ pub fn log(
     let bytes_cost = LOGN_DYNAMIC_BYTE_BASE
         .checked_mul(size)
         .ok_or(OutOfGasError::GasCostOverflow)?;
-
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     Ok(topics_cost
         .checked_add(LOGN_STATIC)
@@ -408,9 +401,6 @@ pub fn mcopy(
         / WORD_SIZE;
 
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let words_copied: u64 = words_copied
         .try_into()
@@ -474,9 +464,6 @@ fn compute_gas_create(
         .ok_or(OutOfGasError::GasCostOverflow)?; // will not panic since it's 2
 
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let hash_cost = if is_create_2 {
         minimum_word_size
@@ -635,9 +622,6 @@ pub fn call(
     gas_left: u64,
 ) -> Result<(u64, u64), VMError> {
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let address_access_cost = address_access_cost(
         address_was_cold,
@@ -681,9 +665,6 @@ pub fn callcode(
     gas_left: u64,
 ) -> Result<(u64, u64), VMError> {
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let address_access_cost = address_access_cost(
         address_was_cold,
@@ -719,9 +700,6 @@ pub fn delegatecall(
     gas_left: u64,
 ) -> Result<(u64, u64), VMError> {
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let address_access_cost = address_access_cost(
         address_was_cold,
@@ -744,9 +722,6 @@ pub fn staticcall(
     gas_left: u64,
 ) -> Result<(u64, u64), VMError> {
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::VeryLargeNumber)?;
 
     let address_access_cost = address_access_cost(
         address_was_cold,

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -336,9 +336,6 @@ fn mem_expansion_behavior(
     static_cost: u64,
 ) -> Result<u64, VMError> {
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
-    let memory_expansion_cost: u64 = memory_expansion_cost
-        .try_into()
-        .map_err(|_| VMError::RevertOpcode)?;
 
     Ok(static_cost
         .checked_add(memory_expansion_cost)

--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -201,9 +201,7 @@ fn cost(memory_size: usize) -> Result<u64, VMError> {
         )
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?;
 
-    gas_cost
-        .try_into()
-        .map_err(|_| VMError::Internal(InternalError::ConversionError))
+    gas_cost.try_into().map_err(|_| VMError::VeryLargeNumber)
 }
 
 pub fn calculate_memory_size(offset: U256, size: usize) -> Result<usize, VMError> {

--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -189,7 +189,7 @@ fn cost(memory_size: usize) -> Result<u64, VMError> {
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?
         / WORD_SIZE_IN_BYTES_USIZE;
 
-    let a = memory_size_word
+    let gas_cost = memory_size_word
         .checked_pow(2)
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?
         .checked_div(MEMORY_EXPANSION_QUOTIENT)
@@ -201,8 +201,9 @@ fn cost(memory_size: usize) -> Result<u64, VMError> {
         )
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?;
 
-    Ok(a.try_into()
-        .map_err(|_| VMError::Internal(InternalError::ConversionError))?)
+    gas_cost
+        .try_into()
+        .map_err(|_| VMError::Internal(InternalError::ConversionError))
 }
 
 pub fn calculate_memory_size(offset: U256, size: usize) -> Result<usize, VMError> {

--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -167,10 +167,7 @@ pub fn try_copy_within(
 
 /// When a memory expansion is triggered, only the additional bytes of memory
 /// must be paid for.
-pub fn expansion_cost(
-    new_memory_size: usize,
-    current_memory_size: usize,
-) -> Result<usize, VMError> {
+pub fn expansion_cost(new_memory_size: usize, current_memory_size: usize) -> Result<u64, VMError> {
     let cost = if new_memory_size <= current_memory_size {
         0
     } else {
@@ -182,7 +179,7 @@ pub fn expansion_cost(
 }
 
 /// The total cost for a given memory size.
-fn cost(memory_size: usize) -> Result<usize, VMError> {
+fn cost(memory_size: usize) -> Result<u64, VMError> {
     let memory_size_word = memory_size
         .checked_add(
             WORD_SIZE_IN_BYTES_USIZE
@@ -192,7 +189,7 @@ fn cost(memory_size: usize) -> Result<usize, VMError> {
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?
         / WORD_SIZE_IN_BYTES_USIZE;
 
-    Ok(memory_size_word
+    let a = memory_size_word
         .checked_pow(2)
         .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?
         .checked_div(MEMORY_EXPANSION_QUOTIENT)
@@ -202,7 +199,10 @@ fn cost(memory_size: usize) -> Result<usize, VMError> {
                 .checked_mul(memory_size_word)
                 .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?,
         )
-        .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?)
+        .ok_or(OutOfGasError::MemoryExpansionCostOverflow)?;
+
+    Ok(a.try_into()
+        .map_err(|_| VMError::Internal(InternalError::ConversionError))?)
 }
 
 pub fn calculate_memory_size(offset: U256, size: usize) -> Result<usize, VMError> {

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -173,10 +173,8 @@ impl VM {
 
         let new_memory_size = calculate_memory_size(offset, size)?;
 
-        let memory_expansion_cost: u64 =
-            memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?
-                .try_into()
-                .map_err(|_err| VMError::Internal(InternalError::ConversionError))?;
+        let memory_expansion_cost =
+            memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?;
 
         self.increase_consumed_gas(current_call_frame, memory_expansion_cost)?;
 
@@ -409,9 +407,7 @@ impl VM {
         let new_memory_size = calculate_memory_size(offset, size)?;
 
         let memory_expansion_cost: u64 =
-            memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?
-                .try_into()
-                .map_err(|_err| VMError::Internal(InternalError::ConversionError))?;
+            memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?;
 
         self.increase_consumed_gas(current_call_frame, memory_expansion_cost)?;
 


### PR DESCRIPTION
**Motivation**

After 2bb8fa9b455c8f0ca51e8a4e26af63e2b915ce4d , the gas cost type changed from U256 to u64. However, _some_ functions did not update their return values to u64; this patch makes them return u64. 
 

**Description**

Make the following functions return u64:
- expansion_cost
- cost


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1547

