### PR TITLE
refactor(levm): gas cost in return and revert

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -235,7 +235,7 @@ pub fn codecopy(
     )
 }
 
-pub fn returnn(new_memory_size: usize, current_memory_size: usize) -> Result<u64, VMError> {
+pub fn exit_opcode(new_memory_size: usize, current_memory_size: usize) -> Result<u64, VMError> {
     memory::expansion_cost(new_memory_size, current_memory_size)
 }
 

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -235,6 +235,7 @@ pub fn codecopy(
     )
 }
 
+// Used in return and revert opcodes
 pub fn exit_opcode(new_memory_size: usize, current_memory_size: usize) -> Result<u64, VMError> {
     memory::expansion_cost(new_memory_size, current_memory_size)
 }

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -235,6 +235,10 @@ pub fn codecopy(
     )
 }
 
+pub fn returnn(new_memory_size: usize, current_memory_size: usize) -> Result<u64, VMError> {
+    memory::expansion_cost(new_memory_size, current_memory_size)
+}
+
 pub fn returndatacopy(
     new_memory_size: usize,
     current_memory_size: usize,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -172,11 +172,12 @@ impl VM {
         }
 
         let new_memory_size = calculate_memory_size(offset, size)?;
+        let current_memory_size = current_call_frame.memory.len();
 
-        let memory_expansion_cost =
-            memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?;
-
-        self.increase_consumed_gas(current_call_frame, memory_expansion_cost)?;
+        self.increase_consumed_gas(
+            current_call_frame,
+            gas_cost::returnn(new_memory_size, current_memory_size)?,
+        )?;
 
         current_call_frame.output =
             memory::load_range(&mut current_call_frame.memory, offset, size)?

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -176,7 +176,7 @@ impl VM {
 
         self.increase_consumed_gas(
             current_call_frame,
-            gas_cost::returnn(new_memory_size, current_memory_size)?,
+            gas_cost::exit_opcode(new_memory_size, current_memory_size)?,
         )?;
 
         current_call_frame.output =
@@ -406,11 +406,12 @@ impl VM {
             .map_err(|_err| VMError::VeryLargeNumber)?;
 
         let new_memory_size = calculate_memory_size(offset, size)?;
+        let current_memory_size = current_call_frame.memory.len();
 
-        let memory_expansion_cost: u64 =
-            memory::expansion_cost(new_memory_size, current_call_frame.memory.len())?;
-
-        self.increase_consumed_gas(current_call_frame, memory_expansion_cost)?;
+        self.increase_consumed_gas(
+            current_call_frame,
+            gas_cost::exit_opcode(new_memory_size, current_memory_size)?,
+        )?;
 
         current_call_frame.output =
             memory::load_range(&mut current_call_frame.memory, offset, size)?


### PR DESCRIPTION
**Motivation**

The gas costs are calculated inside the opcode function, we should extract it to the `gas_costs` modules to keep consistency.

**Description**

- Create `gas_cost::exit_opcode()` function, to calculate the gas cost of `op_return` and `op_revert`.

Closes #1431 

