### PR TITLE
fix(levm): change chainid from 1729 to 1, add 1 ignored test

### DIFF
--- a/cmd/ef_tests/levm/parser.rs
+++ b/cmd/ef_tests/levm/parser.rs
@@ -20,13 +20,14 @@ pub enum EFTestParseError {
     FailedToParseTestFile(String),
 }
 
-const IGNORED_TESTS: [&str; 6] = [
+const IGNORED_TESTS: [&str; 7] = [
     "ValueOverflowParis.json",                 // Skip because of errors
     "loopMul.json",                            // Skip because it takes too long to run
     "dynamicAccountOverwriteEmpty_Paris.json", // Skip because it fails on REVM
-    "RevertInCreateInInitCreate2Paris.json",   // Skip because it fails on REVM
-    "create2collisionStorageParis.json",       // Skip because it fails on REVM
-    "InitCollisionParis.json",                 // Skip because it fails on REVM
+    "RevertInCreateInInitCreate2Paris.json", // Skip because it fails on REVM. See https://github.com/lambdaclass/ethrex/issues/1555
+    "RevertInCreateInInit_Paris.json", // Skip because it fails on REVM. See https://github.com/lambdaclass/ethrex/issues/1555
+    "create2collisionStorageParis.json", // Skip because it fails on REVM
+    "InitCollisionParis.json",         // Skip because it fails on REVM
 ];
 
 pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestParseError> {

--- a/cmd/ef_tests/levm/runner/levm_runner.rs
+++ b/cmd/ef_tests/levm/runner/levm_runner.rs
@@ -100,7 +100,7 @@ pub fn prepare_vm_for_tx(vector: &TestVector, test: &EFTest) -> Result<VM, EFTes
             coinbase: test.env.current_coinbase,
             timestamp: test.env.current_timestamp,
             prev_randao: test.env.current_random,
-            chain_id: U256::from(1729),
+            chain_id: U256::from(1),
             base_fee_per_gas: test.env.current_base_fee.unwrap_or_default(),
             gas_price: effective_gas_price(test, &tx)?,
             block_excess_blob_gas: test.env.current_excess_blob_gas,


### PR DESCRIPTION
**Motivation**

Chain_id tests expect the chain_id to be 1
There is 1 test we want to ignore but wasn't added to the array of ignored tests

**Description**

- Change chain_id from 1729 to 1 in `levm_runner.rs`
- Add `RevertInCreateInInit_Paris.json` to the ignored tests array in `parser.rs`
