### PR TITLE
fix(levm): add comment in LEVM Makefile

### DIFF
--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -85,6 +85,6 @@ build-image-levm: ## 🐳 Build the Docker image with LEVM features
 	cd ../../../ && \
 	docker build -t ethrex --build-arg BUILD_FLAGS=$(FLAGS) .
 
-run-hive-debug-levm: build-image-levm 
+run-hive-debug-levm: build-image-levm ## 🐝 Run Hive with LEVM in debug mode
 	$(MAKE) -C ../../../ setup-hive
 	cd ../../../hive && ./hive --sim $(SIMULATION) --client ethrex --sim.limit "$(TEST_PATTERN)" --docker.output


### PR DESCRIPTION
**Motivation**

Add text to `run-hive-debug-levm` to be displayed in the `make help`

**Description**

When we did `make help`, `run-hive-debug-levm` was not being displayed. Added comment.

