### PR TITLE
fix(levm): fix hive tests execution with LEVM

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -49,6 +49,8 @@ pub fn add_block(block: &Block, storage: &Store) -> Result<(), ChainError> {
 
     let account_updates = get_state_transitions(&mut state);
 
+    dbg!(&account_updates);
+
     // Apply the account updates over the last block's state and compute the new state root
     let new_state_root = state
         .database()

--- a/crates/vm/db.rs
+++ b/crates/vm/db.rs
@@ -5,6 +5,7 @@ use revm::primitives::{
     Bytes as RevmBytes, B256 as RevmB256, U256 as RevmU256,
 };
 
+#[derive(Clone)]
 pub struct StoreWrapper {
     pub store: Store,
     pub block_hash: BlockHash,

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -94,7 +94,6 @@ cfg_if::cfg_if! {
             state: &mut EvmState,
             block_header: &BlockHeader,
         ) -> Result<TransactionReport, EvmError> {
-            // TODO: Change REVM for LEVM
             lazy_static! {
                 static ref SYSTEM_ADDRESS: Address =
                     Address::from_slice(&hex::decode("fffffffffffffffffffffffffffffffffffffffe").unwrap());
@@ -142,9 +141,9 @@ cfg_if::cfg_if! {
                         CacheDB::new(),
                         vec![],
                     )
-                    .unwrap(); //TODO: Replace this unwrap
+                    .map_err(|_| EvmError::Custom("Cannot instantiate vm".to_string()))?;
 
-                    let mut report = vm.transact().unwrap();
+                    let mut report = vm.transact().map_err(|e| EvmError::Custom("Transaction execution failed".to_string()))?;
 
                     report.new_state.remove(&*SYSTEM_ADDRESS);
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- This PR aims to fix hive tests with LEVM and to stop using anything related to REVM.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Fix withdrawal processing. We were not registering those into our AccountUpdates. We were instead updating the DB directly. With this fix we execute hive tests correctly
- We were using REVM for beacon root contract call, so I added a new function beacon_root_contract_call_levm that does the same but with LEVM.


WIP:
- Eliminate all REVM stuff from LEVM integration with L1. We are currently using REVM state for loads of functions, we don't want to.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

