### PR TITLE
fix(l1): block gas limit

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::{min, Ordering},
+    cmp::{max, Ordering},
     collections::HashMap,
 };
 
@@ -125,7 +125,7 @@ pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block,
 fn calc_gas_limit(parent_gas_limit: u64, desired_limit: u64) -> u64 {
     let delta = parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1;
     let mut limit = parent_gas_limit;
-    let desired_limit = min(desired_limit, MIN_GAS_LIMIT);
+    let desired_limit = max(desired_limit, MIN_GAS_LIMIT);
     if limit < desired_limit {
         limit = parent_gas_limit + delta;
         if limit > desired_limit {


### PR DESCRIPTION
**Motivation**

The `block_gas_limit` is around 30M gas per block. The calculations automatically adjust the gas limit if it changes. When using the `min` function, the gas limit is consistently decremented. Consequently, if the node runs for an extended period, it may eventually reach a point where no transactions are accepted.

**Description**

Change `min` with `max`. With this change, the gas reaches 30M and stays around it.