### PR TITLE
fix(levm): fix remaining hive tests execution with LEVM

### DIFF
--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -104,3 +104,15 @@ impl From<RevmError<ExecutionDBError>> for EvmError {
         }
     }
 }
+
+impl From<ethrex_levm::errors::VMError> for EvmError {
+    fn from(value: ethrex_levm::errors::VMError) -> Self {
+        if value.is_internal() {
+            // We don't categorize our internal errors yet, so we label them as "Custom"
+            EvmError::Custom(value.to_string())
+        } else {
+            // If an error is not internal it means it is a transaction validation error.
+            EvmError::Transaction(value.to_string())
+        }
+    }
+}

--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -1,5 +1,6 @@
 use ethereum_types::{H160, H256};
 use ethrex_core::types::BlockHash;
+use ethrex_levm::errors::VMError;
 use ethrex_storage::error::StoreError;
 use ethrex_trie::TrieError;
 use revm::primitives::{
@@ -105,8 +106,8 @@ impl From<RevmError<ExecutionDBError>> for EvmError {
     }
 }
 
-impl From<ethrex_levm::errors::VMError> for EvmError {
-    fn from(value: ethrex_levm::errors::VMError) -> Self {
+impl From<VMError> for EvmError {
+    fn from(value: VMError) -> Self {
         if value.is_internal() {
             // We don't categorize our internal errors yet, so we label them as "Custom"
             EvmError::Custom(value.to_string())

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -174,7 +174,7 @@ cfg_if::cfg_if! {
             let mut block_cache: CacheDB = HashMap::new();
 
             for tx in block.body.transactions.iter() {
-                let report = execute_tx_levm(tx, block_header, store_wrapper.clone(), block_cache.clone(), spec_id).unwrap();
+                let report = execute_tx_levm(tx, block_header, store_wrapper.clone(), block_cache.clone(), spec_id).map_err(EvmError::from)?;
 
                 let mut new_state = report.new_state.clone();
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Everything looked fine but some engine tests were failing.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- It seems that the tests that were failing were doing so because of error handling when interacting with our VM. We had to map the VM error to the error type that we use in L1 for representing errors in VM execution.

