### PR TITLE
feat(l1) Check withdrawals is not missing or null on v2 engine payloads.

### DIFF
--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -183,7 +183,7 @@ jobs:
             test_pattern: "engine-api/RPC|Re-Org Back to Canonical Chain From Syncing Chain|Re-org to Previously Validated Sidechain Payload|Re-Org Back into Canonical Chain, Depth=5|Safe Re-Org|Transaction Re-Org|Inconsistent|Suggested Fee|PrevRandao|Fork ID|Unknown|Invalid PayloadAttributes|Bad Hash|Unique Payload ID|Re-Execute Payload|In-Order|Multiple New Payloads|Valid NewPayload|NewPayload with|Invalid NewPayload|Payload Build|Invalid NewPayload, Transaction|ParentHash equals|Build Payload|Invalid Missing Ancestor ReOrg"
           - name: "Engine withdrawal tests"
             simulation: ethereum/engine
-            test_pattern: "engine-withdrawals/engine-withdrawals test loader|GetPayloadV2 Block Value|Sync after 2 blocks - Withdrawals on Genesis|Max Initcode Size|Pre-Merge Fork Number > 0|Empty Withdrawals|Corrupted Block Hash Payload (INVALID)"
+            test_pattern: "engine-withdrawals/engine-withdrawals test loader|GetPayloadV2 Block Value|Sync after 2 blocks - Withdrawals on Genesis|Max Initcode Size|Pre-Merge Fork Number > 0|Empty Withdrawals|Corrupted Block Hash Payload"
           - name: "Sync"
             simulation: ethereum/sync
             test_pattern: ""

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -183,7 +183,7 @@ jobs:
             test_pattern: "engine-api/RPC|Re-Org Back to Canonical Chain From Syncing Chain|Re-org to Previously Validated Sidechain Payload|Re-Org Back into Canonical Chain, Depth=5|Safe Re-Org|Transaction Re-Org|Inconsistent|Suggested Fee|PrevRandao|Fork ID|Unknown|Invalid PayloadAttributes|Bad Hash|Unique Payload ID|Re-Execute Payload|In-Order|Multiple New Payloads|Valid NewPayload|NewPayload with|Invalid NewPayload|Payload Build|Invalid NewPayload, Transaction|ParentHash equals|Build Payload|Invalid Missing Ancestor ReOrg"
           - name: "Engine withdrawal tests"
             simulation: ethereum/engine
-            test_pattern: "engine-withdrawals/engine-withdrawals test loader|GetPayloadV2 Block Value|Sync after 2 blocks - Withdrawals on Genesis|Max Initcode Size|Pre-Merge Fork Number > 0|Empty Withdrawals"
+            test_pattern: "engine-withdrawals/engine-withdrawals test loader|GetPayloadV2 Block Value|Sync after 2 blocks - Withdrawals on Genesis|Max Initcode Size|Pre-Merge Fork Number > 0|Empty Withdrawals|Corrupted Block Hash Payload (INVALID)"
           - name: "Sync"
             simulation: ethereum/sync
             test_pattern: ""

--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -183,7 +183,7 @@ jobs:
             test_pattern: "engine-api/RPC|Re-Org Back to Canonical Chain From Syncing Chain|Re-org to Previously Validated Sidechain Payload|Re-Org Back into Canonical Chain, Depth=5|Safe Re-Org|Transaction Re-Org|Inconsistent|Suggested Fee|PrevRandao|Fork ID|Unknown|Invalid PayloadAttributes|Bad Hash|Unique Payload ID|Re-Execute Payload|In-Order|Multiple New Payloads|Valid NewPayload|NewPayload with|Invalid NewPayload|Payload Build|Invalid NewPayload, Transaction|ParentHash equals|Build Payload|Invalid Missing Ancestor ReOrg"
           - name: "Engine withdrawal tests"
             simulation: ethereum/engine
-            test_pattern: "engine-withdrawals/engine-withdrawals test loader|GetPayloadV2 Block Value|Sync after 2 blocks - Withdrawals on Genesis|Max Initcode Size|Pre-Merge Fork Number > 0"
+            test_pattern: "engine-withdrawals/engine-withdrawals test loader|GetPayloadV2 Block Value|Sync after 2 blocks - Withdrawals on Genesis|Max Initcode Size|Pre-Merge Fork Number > 0|Empty Withdrawals"
           - name: "Sync"
             simulation: ethereum/sync
             test_pattern: ""

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -214,6 +214,11 @@ fn validate_v2(
     context: &RpcApiContext,
 ) -> Result<(), RpcErr> {
     let chain_config = context.storage.get_chain_config()?;
+    if attributes.withdrawals.is_none() {
+        return Err(RpcErr::WrongParam(
+            "forkChoiceV2 withdrawals is null".to_string(),
+        ));
+    }
     if attributes.parent_beacon_block_root.is_some() {
         return Err(RpcErr::InvalidPayloadAttributes(
             "forkChoiceV2 with Beacon Root".to_string(),

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -188,7 +188,10 @@ fn parse_execution_payload(params: &Option<Vec<Value>>) -> Result<ExecutionPaylo
         } => Err(RpcErr::WrongParam(
             "forkChoiceV2 withdrawals is null".to_string(),
         )),
-        ExecutionPayload { withdrawals: Some(_), .. } => Ok(payload),
+        ExecutionPayload {
+            withdrawals: Some(_),
+            ..
+        } => Ok(payload),
     }
 }
 

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -182,12 +182,13 @@ fn parse_execution_payload(params: &Option<Vec<Value>>) -> Result<ExecutionPaylo
     let payload: ExecutionPayload = serde_json::from_value(params[0].clone())
         .map_err(|_| RpcErr::WrongParam("payload".to_string()))?;
 
-    if payload.withdrawals.is_none() {
-        return Err(RpcErr::WrongParam(
+    match payload {
+        ExecutionPayload {
+            withdrawals: None, ..
+        } => Err(RpcErr::WrongParam(
             "forkChoiceV2 withdrawals is null".to_string(),
-        ));
-    } else {
-        return Ok(payload);
+        )),
+        ExecutionPayload { withdrawals: Some(_), .. } => Ok(payload),
     }
 }
 

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -179,7 +179,16 @@ fn parse_execution_payload(params: &Option<Vec<Value>>) -> Result<ExecutionPaylo
     if params.len() != 1 {
         return Err(RpcErr::BadParams("Expected 1 params".to_owned()));
     }
-    serde_json::from_value(params[0].clone()).map_err(|_| RpcErr::WrongParam("payload".to_string()))
+    let payload: ExecutionPayload = serde_json::from_value(params[0].clone())
+        .map_err(|_| RpcErr::WrongParam("payload".to_string()))?;
+
+    if payload.withdrawals.is_none() {
+        return Err(RpcErr::WrongParam(
+            "forkChoiceV2 withdrawals is null".to_string(),
+        ));
+    } else {
+        return Ok(payload);
+    }
 }
 
 fn handle_new_payload_v1_v2(

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -35,7 +35,7 @@ pub struct ExecutionPayload {
     pub block_hash: H256,
     transactions: Vec<EncodedTransaction>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    withdrawals: Option<Vec<Withdrawal>>,
+    pub withdrawals: Option<Vec<Withdrawal>>,
     // ExecutionPayloadV3 fields. Optional since we support V2 too
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -104,7 +104,6 @@ impl ExecutionPayload {
             ommers: vec![],
             withdrawals: self.withdrawals,
         };
-
         let header = BlockHeader {
             parent_hash: self.parent_hash,
             ommers_hash: *DEFAULT_OMMERS_HASH,


### PR DESCRIPTION
**Description**
The difference between a v1 vs a v2 engine payload is the fact that v2 has a withdrawal field, this PR adds
a check on V2 fork & engine endpoints to check this field is not missing.

Closes #1605 