### PR TITLE
fix(l1): fix decoding of `Disconnect` RLPx messages with non-compressed reason 

### DIFF
--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -128,9 +128,13 @@ impl RLPxMessage for DisconnectMessage {
 
     fn decode(msg_data: &[u8]) -> Result<Self, RLPDecodeError> {
         // decode disconnect message: [reason (optional)]
-        let decompressed_data = snappy_decompress(msg_data)?;
+        // The msg data may be compressed or not
+        let msg_data = if let Ok(decompressed) = snappy_decompress(msg_data) {
+            decompressed
+        } else {
+            msg_data.to_vec()
+        };
         // It seems that disconnect reason can be encoded in different ways:
-        // TODO: it may be not compressed at all. We should check that case
         let reason = match decompressed_data.len() {
             0 => None,
             // As a single u8

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -135,13 +135,13 @@ impl RLPxMessage for DisconnectMessage {
             msg_data.to_vec()
         };
         // It seems that disconnect reason can be encoded in different ways:
-        let reason = match decompressed_data.len() {
+        let reason = match msg_data.len() {
             0 => None,
             // As a single u8
-            1 => Some(decompressed_data[0]),
+            1 => Some(msg_data[0]),
             // As an RLP encoded Vec<u8>
             _ => {
-                let decoder = Decoder::new(&decompressed_data)?;
+                let decoder = Decoder::new(&msg_data)?;
                 let (reason, _): (Option<u8>, _) = decoder.decode_optional_field();
                 reason
             }


### PR DESCRIPTION
**Motivation**
I get errors when trying to connect to peers on holesky testnet due to failure to decompress Disconnect messages. There is also a TODO in the Disconnect decode that mentions that the reason might not be compressed
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* When decoding an rlpx Disconnect message, use the original message if decompression fails (aka allow both compressed and decompressed disconnect reasons
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but removes a TODO from the codebase

