### PR TITLE
feat(l1): show disconnect reason meaning when a peer disconnects

### DIFF
--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -340,7 +340,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         let peer_supports_eth = self.capabilities.contains(&CAP_ETH);
         match message {
             Message::Disconnect(msg_data) => {
-                debug!("Received Disconnect: {:?}", msg_data.reason);
+                debug!("Received Disconnect: {}", msg_data.reason());
                 // Returning a Disconnect error to be handled later at the call stack
                 return Err(RLPxError::Disconnect());
             }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -111,6 +111,7 @@ impl DisconnectMessage {
     }
 
     /// Returns the meaning of the disconnect reason's error code
+    /// The meaning of each error code is defined by the spec: https://github.com/ethereum/devp2p/blob/master/rlpx.md#disconnect-0x01
     pub fn reason(&self) -> &str {
         if let Some(reason) = self.reason {
             match reason {

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -109,6 +109,30 @@ impl DisconnectMessage {
     pub fn new(reason: Option<u8>) -> Self {
         Self { reason }
     }
+
+    /// Returns the meaning of the disconnect reason's error code
+    pub fn reason(&self) -> &str {
+        if let Some(reason) = self.reason {
+            match reason {
+                0x00 => "Disconnect requested",
+                0x01 => "TCP sub-system error",
+                0x02 => "Breach of protocol, e.g. a malformed message, bad RLP, ...",
+                0x03 => "Useless peer",
+                0x04 => "Too many peers",
+                0x05 => "Already connected",
+                0x06 => "Incompatible P2P protocol version",
+                0x07 => "Null node identity received - this is automatically invalid",
+                0x08 => "Client quitting",
+                0x09 => "Unexpected identity in handshake",
+                0x0a => "Identity is the same as this node (i.e. connected to itself)",
+                0x0b => "Ping timeout",
+                0x10 => "Some other reason specific to a subprotocol",
+                _ => "Unknown Reason",
+            }
+        } else {
+            "Reason Not Provided"
+        }
+    }
 }
 
 impl RLPxMessage for DisconnectMessage {


### PR DESCRIPTION
**Motivation**
When a peer disconnects there is an info! that shows the disconnect error code, but this is not very helpful. This PR replaces this error code with the corresponding error meaning according to the spec.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add method `reason` for rlpx Disconnect message which returns the meaning of the reason code as a str and uses it when tracing disconnects from peers in their listen loop.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, this is a minor improvement 

