### PR TITLE
chore(levm): remove harcoded spec-id in REVM

### DIFF
--- a/cmd/ef_tests/levm/runner/revm_runner.rs
+++ b/cmd/ef_tests/levm/runner/revm_runner.rs
@@ -14,7 +14,7 @@ use ethrex_levm::{
     Account, StorageSlot,
 };
 use ethrex_storage::{error::StoreError, AccountUpdate};
-use ethrex_vm::{db::StoreWrapper, EvmState, RevmAddress, RevmU256, SpecId};
+use ethrex_vm::{db::StoreWrapper, EvmState, RevmAddress, RevmU256};
 use revm::{
     db::State,
     inspectors::TracerEip3155 as RevmTracerEip3155,
@@ -167,7 +167,7 @@ pub fn prepare_revm_for_tx<'state>(
         .with_block_env(block_env)
         .with_tx_env(tx_env)
         .modify_cfg_env(|cfg| cfg.chain_id = chain_spec.chain_id)
-        .with_spec_id(SpecId::CANCUN) //TODO: In the future replace cancun for the actual spec id
+        .with_spec_id(test.fork()) //TODO: In the future replace cancun for the actual spec id
         .with_external_context(
             RevmTracerEip3155::new(Box::new(std::io::stderr())).without_summary(),
         );

--- a/cmd/ef_tests/levm/runner/revm_runner.rs
+++ b/cmd/ef_tests/levm/runner/revm_runner.rs
@@ -167,7 +167,7 @@ pub fn prepare_revm_for_tx<'state>(
         .with_block_env(block_env)
         .with_tx_env(tx_env)
         .modify_cfg_env(|cfg| cfg.chain_id = chain_spec.chain_id)
-        .with_spec_id(test.fork()) //TODO: In the future replace cancun for the actual spec id
+        .with_spec_id(test.fork())
         .with_external_context(
             RevmTracerEip3155::new(Box::new(std::io::stderr())).without_summary(),
         );


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
REVM was not using the right spec because it was harcoded to use `SpecId::CANCUN`

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
change the harcode value from `SpecId::CANCUN` to `test.fork()`
<!-- Link to issues: Resolves #111, Resolves #222 -->