### PR TITLE
feat(levm): implement EIP-2929 cold/warm storage access tracking for Berlin and later specs

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1061,7 +1061,6 @@ impl VM {
         key: H256,
     ) -> Result<(StorageSlot, bool), VMError> {
         // [EIP-2929] - Introduced conditional tracking of accessed storage slots for Berlin and later specs.
-
         let mut storage_slot_was_cold = false;
         if self.env.spec_id >= SpecId::BERLIN {
             storage_slot_was_cold = self

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1060,12 +1060,17 @@ impl VM {
         address: Address,
         key: H256,
     ) -> Result<(StorageSlot, bool), VMError> {
-        let storage_slot_was_cold = self
-            .accrued_substate
-            .touched_storage_slots
-            .entry(address)
-            .or_default()
-            .insert(key);
+        // [EIP-2929] - Introduced conditional tracking of accessed storage slots for Berlin and later specs.
+
+        let mut storage_slot_was_cold = false;
+        if self.env.spec_id >= SpecId::BERLIN {
+            storage_slot_was_cold = self
+                .accrued_substate
+                .touched_storage_slots
+                .entry(address)
+                .or_default()
+                .insert(key);
+        }
         let storage_slot = match cache::get_account(&self.cache, &address) {
             Some(account) => match account.storage.get(&key) {
                 Some(storage_slot) => storage_slot.clone(),


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
This PR fixes issues with tests for older EVM specs. One test, "src/GeneralStateTestsFiller/Pyspecs/homestead/yul/test_yul_example.py::test_yul[fork_Constantinople-state_test]", fails due to a 2100 gas difference caused by storage_slot_was_cold being True. This is related to EIP-2929, which was introduced in Berlin. We want to handle this differently for specs before Berlin.
**Description**


<!-- A clear and concise general description of the changes this PR introduces -->
Added a check in access_storage_slot to handle the storage slot logic differently depending on the spec version. For Berlin and later, it keeps the current behavior with cold/warm storage slots. For earlier specs, it skips this logic to avoid test failures.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Related to #1637 

