### PR TITLE
ci(l1, l2, levm): add PR <> `main` lines of code comparison comment in PRs

### DIFF
--- a/.github/workflows/ci_loc_pr.yaml
+++ b/.github/workflows/ci_loc_pr.yaml
@@ -1,0 +1,99 @@
+name: Benchmark LEVM vs REVM in PR
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  detailed-loc-pr:
+    name: Detailed Lines of Code Count for PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.81.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Lines of Code Counter for PR
+        run: make loc
+
+      - name: Upload PR Detailed Lines of Code Count Data
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-loc-data
+          path: current_detailed_loc_report.json
+
+  detailed-loc-main:
+    name: Detailed Lines of Code Count for main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.81.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Lines of Code Counter for main
+        run: |
+          make loc
+          mv current_detailed_loc_report.json previous_detailed_loc_report.json
+
+      - name: Upload main Detailed Lines of Code Count Data
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-loc-data
+          path: previous_detailed_loc_report.json
+
+  detailed-loc-comparison:
+    name: Compare Detailed Lines of Code Count
+    runs-on: ubuntu-latest
+    needs: [detailed-loc-pr, detailed-loc-main]
+    steps:
+      - name: Download PR Detailed Lines of Code Count Data
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-loc-data
+          path: .
+
+      - name: Download main Detailed Lines of Code Count Data
+        uses: actions/download-artifact@v4
+        with:
+          name: main-loc-data
+          path: .
+
+      - name: Compare Detailed Lines of Code Count
+        run: make loc-pr
+
+      - name: Find comment
+        continue-on-error: true
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Total lines changed"
+
+      - name: Create Comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: detailed_loc_report.txt
+          edit-mode: replace

--- a/.github/workflows/ci_loc_pr.yaml
+++ b/.github/workflows/ci_loc_pr.yaml
@@ -1,4 +1,4 @@
-name: Benchmark LEVM vs REVM in PR
+name: PR Lines of Code
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run Lines of Code Counter for PR
-        run: make loc
+        run: make loc-detailed
 
       - name: Upload PR Detailed Lines of Code Count Data
         uses: actions/upload-artifact@v4
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Lines of Code Counter for main
         run: |
-          make loc
+          make loc-detailed
           mv current_detailed_loc_report.json previous_detailed_loc_report.json
 
       - name: Upload main Detailed Lines of Code Count Data
@@ -79,7 +79,7 @@ jobs:
           path: .
 
       - name: Compare Detailed Lines of Code Count
-        run: make loc-pr
+        run: make loc-compare-detailed
 
       - name: Find comment
         continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width 0.1.14",
@@ -1759,6 +1759,27 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.7",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2106,6 +2127,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2157,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2278,6 +2320,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3744,6 +3792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4335,6 +4389,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4689,6 +4754,7 @@ dependencies = [
  "clap 4.5.21",
  "clap_complete",
  "colored",
+ "prettytable",
  "serde",
  "serde_json",
  "spinoff",
@@ -5925,6 +5991,20 @@ checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "prettytable"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46480520d1b77c9a3482d39939fcf96831537a250ec62d4fd8fbdf8e0302e781"
+dependencies = [
+ "csv",
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -8416,6 +8496,17 @@ dependencies = [
  "serde_json",
  "slug",
  "unic-segment",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build lint test clean run-image build-image download-test-vectors clean-vectors \
-	setup-hive test-pattern-default run-hive run-hive-debug clean-hive-logs detailed-loc
+	setup-hive test-pattern-default run-hive run-hive-debug clean-hive-logs loc-detailed \
+	loc-compare-detailed
 
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -140,6 +141,11 @@ loc-stats:
 		cargo run -p loc -- --summary;\
 	fi
 
+loc-detailed:
+	cargo run --release --bin loc -- --detailed
+
+loc-compare-detailed:
+	cargo run --release --bin loc -- --compare-detailed
 
 hive-stats:
 	make hive QUIET=true
@@ -156,6 +162,3 @@ stats:
 	cd crates/vm/levm && make run-evm-ef-tests QUIET=true && echo
 	make hive-stats
 	cargo run --quiet --release -p hive_report
-
-loc-pr:
-	cargo run --release --bin loc -- --pr

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build lint test clean run-image build-image download-test-vectors clean-vectors \
-	setup-hive test-pattern-default run-hive run-hive-debug clean-hive-logs
+	setup-hive test-pattern-default run-hive run-hive-debug clean-hive-logs detailed-loc
 
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -156,3 +156,6 @@ stats:
 	cd crates/vm/levm && make run-evm-ef-tests QUIET=true && echo
 	make hive-stats
 	cargo run --quiet --release -p hive_report
+
+loc-pr:
+	cargo run --release --bin loc -- --pr

--- a/cmd/loc/Cargo.toml
+++ b/cmd/loc/Cargo.toml
@@ -11,3 +11,4 @@ clap = { version = "4.3", features = ["derive"] }
 clap_complete = "4.5.17"
 colored = "2.1.0"
 spinoff = "0.8.0"
+prettytable = "0.10.0"

--- a/cmd/loc/src/main.rs
+++ b/cmd/loc/src/main.rs
@@ -1,35 +1,32 @@
 use clap::Parser;
 use report::{shell_summary, LinesOfCodeReport, LinesOfCodeReporterOptions};
 use spinoff::{spinners::Dots, Color, Spinner};
-use std::path::PathBuf;
-use tokei::{Config, LanguageType, Languages};
+use std::{collections::HashMap, env::current_dir, path::PathBuf};
+use tokei::{Config, Language, LanguageType, Languages};
 
 mod report;
 
-const CARGO_MANIFEST_DIR: &str = std::env!("CARGO_MANIFEST_DIR");
+fn count_loc(path: PathBuf, config: &Config) -> Language {
+    let mut languages = Languages::new();
+    languages.get_statistics(&[path], &["tests"], config);
+    languages.get(&LanguageType::Rust).unwrap().clone()
+}
 
 fn main() {
     let opts = LinesOfCodeReporterOptions::parse();
 
     let mut spinner = Spinner::new(Dots, "Counting lines of code...", Color::Cyan);
 
-    let ethrex = PathBuf::from(CARGO_MANIFEST_DIR).join("../../");
-    let levm = PathBuf::from(CARGO_MANIFEST_DIR).join("../../crates/vm");
-    let ethrex_l2 = PathBuf::from(CARGO_MANIFEST_DIR).join("../../crates/l2");
+    let ethrex = current_dir().unwrap();
+    let ethrex_crates = ethrex.join("crates");
+    let levm = ethrex_crates.join("vm");
+    let ethrex_l2 = ethrex_crates.join("l2");
 
     let config = Config::default();
 
-    let mut languages = Languages::new();
-    languages.get_statistics(&[ethrex.clone()], &["tests"], &config);
-    let ethrex_loc = &languages.get(&LanguageType::Rust).unwrap();
-
-    let mut languages = Languages::new();
-    languages.get_statistics(&[levm], &["tests"], &config);
-    let levm_loc = &languages.get(&LanguageType::Rust).unwrap();
-
-    let mut languages = Languages::new();
-    languages.get_statistics(&[ethrex_l2], &["tests"], &config);
-    let ethrex_l2_loc = &languages.get(&LanguageType::Rust).unwrap();
+    let ethrex_loc = count_loc(ethrex, &config);
+    let levm_loc = count_loc(levm, &config);
+    let ethrex_l2_loc = count_loc(ethrex_l2, &config);
 
     spinner.success("Lines of code calculated!");
 
@@ -42,7 +39,36 @@ fn main() {
         levm: levm_loc.code,
     };
 
-    if opts.summary {
+    let mut current_detailed_loc_report = HashMap::new();
+    for report in ethrex_loc.reports {
+        let file_path = report.name;
+        // let file_name = file_path.file_name().unwrap().to_str().unwrap();
+        // let dir_path = file_path.parent().unwrap();
+
+        current_detailed_loc_report
+            .entry(file_path.as_os_str().to_str().unwrap().to_owned())
+            .and_modify(|e: &mut usize| *e += report.stats.code)
+            .or_insert_with(|| report.stats.code);
+    }
+
+    std::fs::write(
+        "current_detailed_loc_report.json",
+        serde_json::to_string(&current_detailed_loc_report).unwrap(),
+    )
+    .expect("current_detailed_loc_report.json could not be written");
+
+    if opts.pr {
+        let previous_detailed_loc_report: HashMap<String, usize> =
+            std::fs::read_to_string("previous_detailed_loc_report.json")
+                .map(|s| serde_json::from_str(&s).unwrap())
+                .unwrap_or(current_detailed_loc_report.clone());
+
+        std::fs::write(
+            "detailed_loc_report.txt",
+            report::pr_message(previous_detailed_loc_report, current_detailed_loc_report),
+        )
+        .unwrap();
+    } else if opts.summary {
         spinner.success("Report generated!");
         println!("{}", shell_summary(new_report));
     } else {

--- a/cmd/loc/src/main.rs
+++ b/cmd/loc/src/main.rs
@@ -39,25 +39,30 @@ fn main() {
         levm: levm_loc.code,
     };
 
-    let mut current_detailed_loc_report = HashMap::new();
-    for report in ethrex_loc.reports {
-        let file_path = report.name;
-        // let file_name = file_path.file_name().unwrap().to_str().unwrap();
-        // let dir_path = file_path.parent().unwrap();
+    if opts.detailed {
+        let mut current_detailed_loc_report = HashMap::new();
+        for report in ethrex_loc.reports {
+            let file_path = report.name;
+            // let file_name = file_path.file_name().unwrap().to_str().unwrap();
+            // let dir_path = file_path.parent().unwrap();
 
-        current_detailed_loc_report
-            .entry(file_path.as_os_str().to_str().unwrap().to_owned())
-            .and_modify(|e: &mut usize| *e += report.stats.code)
-            .or_insert_with(|| report.stats.code);
-    }
+            current_detailed_loc_report
+                .entry(file_path.as_os_str().to_str().unwrap().to_owned())
+                .and_modify(|e: &mut usize| *e += report.stats.code)
+                .or_insert_with(|| report.stats.code);
+        }
 
-    std::fs::write(
-        "current_detailed_loc_report.json",
-        serde_json::to_string(&current_detailed_loc_report).unwrap(),
-    )
-    .expect("current_detailed_loc_report.json could not be written");
+        std::fs::write(
+            "current_detailed_loc_report.json",
+            serde_json::to_string(&current_detailed_loc_report).unwrap(),
+        )
+        .expect("current_detailed_loc_report.json could not be written");
+    } else if opts.compare_detailed {
+        let current_detailed_loc_report: HashMap<String, usize> =
+            std::fs::read_to_string("current_detailed_loc_report.json")
+                .map(|s| serde_json::from_str(&s).unwrap())
+                .expect("current_detailed_loc_report.json could not be read");
 
-    if opts.pr {
         let previous_detailed_loc_report: HashMap<String, usize> =
             std::fs::read_to_string("previous_detailed_loc_report.json")
                 .map(|s| serde_json::from_str(&s).unwrap())

--- a/cmd/loc/src/report.rs
+++ b/cmd/loc/src/report.rs
@@ -8,8 +8,10 @@ use std::collections::HashMap;
 pub struct LinesOfCodeReporterOptions {
     #[arg(short, long, value_name = "SUMMARY", default_value = "false")]
     pub summary: bool,
+    #[arg(short, long, value_name = "DETAILED", default_value = "false")]
+    pub detailed: bool,
     #[arg(short, long, value_name = "PR_SUMMARY", default_value = "false")]
-    pub pr: bool,
+    pub compare_detailed: bool,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Copy)]

--- a/cmd/loc/src/report.rs
+++ b/cmd/loc/src/report.rs
@@ -1,11 +1,15 @@
 use clap::Parser;
 use colored::Colorize;
+use prettytable::{row, Table};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Parser)]
 pub struct LinesOfCodeReporterOptions {
     #[arg(short, long, value_name = "SUMMARY", default_value = "false")]
     pub summary: bool,
+    #[arg(short, long, value_name = "PR_SUMMARY", default_value = "false")]
+    pub pr: bool,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Copy)]
@@ -14,6 +18,62 @@ pub struct LinesOfCodeReport {
     pub ethrex_l1: usize,
     pub ethrex_l2: usize,
     pub levm: usize,
+}
+
+pub fn pr_message(
+    old_report: HashMap<String, usize>,
+    new_report: HashMap<String, usize>,
+) -> String {
+    let sorted_file_paths = {
+        let mut keys: Vec<_> = new_report.keys().collect();
+        keys.sort();
+        keys
+    };
+
+    let mut table = Table::new();
+
+    table.add_row(row!["File", "Lines", "Diff"]);
+
+    let mut total_lines_changed: i64 = 0;
+
+    for file_path in sorted_file_paths {
+        let current_loc = *new_report.get(file_path).unwrap() as i64;
+        let previous_loc = *old_report.get(file_path).unwrap_or(&0) as i64;
+        let loc_diff = current_loc - previous_loc;
+
+        if loc_diff == 0 {
+            continue;
+        }
+
+        total_lines_changed = if current_loc > previous_loc {
+            total_lines_changed + loc_diff
+        } else {
+            total_lines_changed - loc_diff
+        };
+
+        table.add_row(row![
+            file_path,
+            current_loc,
+            match current_loc.cmp(&previous_loc) {
+                std::cmp::Ordering::Greater => format!("+{loc_diff}"),
+                std::cmp::Ordering::Less => format!("{loc_diff}"),
+                std::cmp::Ordering::Equal => "-".to_owned(),
+            }
+        ]);
+    }
+
+    if total_lines_changed != 0 {
+        format!(
+            "{table}\nTotal lines changed: {}",
+            match total_lines_changed.cmp(&0) {
+                std::cmp::Ordering::Greater => format!("+{total_lines_changed}"),
+                std::cmp::Ordering::Less => format!("{total_lines_changed}"),
+                std::cmp::Ordering::Equal => "-".to_owned(),
+            }
+        )
+    } else {
+        "The amount of lines of code in the project has not changed.".to_owned()
+    }
 }
 
 pub fn slack_message(old_report: LinesOfCodeReport, new_report: LinesOfCodeReport) -> String {


### PR DESCRIPTION
Add a CI job that counts the lines of code in main vs the PR -> main and compares them sending a diff in a comment in the PR