### PR TITLE
fix(l1): avoid overlapping peer requests

### DIFF
--- a/crates/networking/p2p/peer_channels.rs
+++ b/crates/networking/p2p/peer_channels.rs
@@ -80,8 +80,8 @@ impl PeerChannels {
             skip: 0,
             reverse: matches!(order, BlockRequestOrder::NewToOld),
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let block_headers = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -113,8 +113,8 @@ impl PeerChannels {
             id: request_id,
             block_hashes,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let block_bodies = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -147,8 +147,8 @@ impl PeerChannels {
             id: request_id,
             block_hashes,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let receipts = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -186,8 +186,8 @@ impl PeerChannels {
             limit_hash: HASH_MAX,
             response_bytes: MAX_RESPONSE_BYTES,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let (accounts, proof) = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -238,8 +238,8 @@ impl PeerChannels {
             hashes,
             bytes: MAX_RESPONSE_BYTES,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let codes = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -281,8 +281,8 @@ impl PeerChannels {
             limit_hash: HASH_MAX,
             response_bytes: MAX_RESPONSE_BYTES,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let (mut slots, proof) = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -387,8 +387,8 @@ impl PeerChannels {
                 .collect(),
             bytes: MAX_RESPONSE_BYTES,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let nodes = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {
@@ -446,8 +446,8 @@ impl PeerChannels {
                 .collect(),
             bytes: MAX_RESPONSE_BYTES,
         });
-        self.sender.send(request).await.ok()?;
         let mut receiver = self.receiver.lock().await;
+        self.sender.send(request).await.ok()?;
         let nodes = tokio::time::timeout(PEER_REPLY_TIMOUT, async move {
             loop {
                 match receiver.recv().await {


### PR DESCRIPTION
**Motivation**
In contexts with few peers we might encounter a case in which one peer is used to perform two simultaneous requests (such as block bodies & account ranges during a sync) and the responses might be received by the incorrect calling context. This PR aims to add a simple fix for this issue by acquiring the receiver channel's lock before sending the request, therefore no other requests may be sent while the actual context is awaiting a response from the peer
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Aguirre the receiver channel lock before sending a request to the peer in `PeerChannels` methods
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but came out as a result of #1500 
