### PR TITLE
feat(l1): show the disconnect reason in the HandshakeError when a peer disconnects mid-handshake

### DIFF
--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -238,24 +238,33 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         self.send(hello_msg).await?;
 
         // Receive Hello message
-        if let Message::Hello(hello_message) = self.receive().await? {
-            self.capabilities = hello_message.capabilities;
+        match self.receive().await? {
+            Message::Hello(hello_message) => {
+                self.capabilities = hello_message.capabilities;
 
-            // Check if we have any capability in common
-            for cap in self.capabilities.clone() {
-                if SUPPORTED_CAPABILITIES.contains(&cap) {
-                    return Ok(());
+                // Check if we have any capability in common
+                for cap in self.capabilities.clone() {
+                    if SUPPORTED_CAPABILITIES.contains(&cap) {
+                        return Ok(());
+                    }
                 }
+                // Return error if not
+                Err(RLPxError::HandshakeError(
+                    "No matching capabilities".to_string(),
+                ))
             }
-            // Return error if not
-            Err(RLPxError::HandshakeError(
-                "No matching capabilities".to_string(),
-            ))
-        } else {
-            // Fail if it is not a hello message
-            Err(RLPxError::HandshakeError(
-                "Expected Hello message".to_string(),
-            ))
+            Message::Disconnect(disconnect) => {
+                return Err(RLPxError::HandshakeError(format!(
+                    "Peer disconnected due to: {}",
+                    disconnect.reason()
+                )))
+            }
+            _ => {
+                // Fail if it is not a hello message
+                Err(RLPxError::HandshakeError(
+                    "Expected Hello message".to_string(),
+                ))
+            }
         }
     }
 
@@ -479,7 +488,13 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                     debug!("Received Status");
                     backend::validate_status(msg_data, &self.storage)?
                 }
-                _msg => {
+                Message::Disconnect(disconnect) => {
+                    return Err(RLPxError::HandshakeError(format!(
+                        "Peer disconnected due to: {}",
+                        disconnect.reason()
+                    )))
+                }
+                _ => {
                     return Err(RLPxError::HandshakeError(
                         "Expected a Status message".to_string(),
                     ))

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -254,7 +254,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                 ))
             }
             Message::Disconnect(disconnect) => {
-                return Err(RLPxError::HandshakeError(format!(
+                Err(RLPxError::HandshakeError(format!(
                     "Peer disconnected due to: {}",
                     disconnect.reason()
                 )))

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -253,12 +253,10 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                     "No matching capabilities".to_string(),
                 ))
             }
-            Message::Disconnect(disconnect) => {
-                Err(RLPxError::HandshakeError(format!(
-                    "Peer disconnected due to: {}",
-                    disconnect.reason()
-                )))
-            }
+            Message::Disconnect(disconnect) => Err(RLPxError::HandshakeError(format!(
+                "Peer disconnected due to: {}",
+                disconnect.reason()
+            ))),
             _ => {
                 // Fail if it is not a hello message
                 Err(RLPxError::HandshakeError(


### PR DESCRIPTION
**Motivation**
When connecting to the sepolia testnet I encountered a lot of handshake errors but all of them said "Expected Hello" or "Expected Status" with no other information. Most of these handshake failures are due to the peer sending a disconnect message instead. This PR aims to improve observability & debugging experience by showing the disconnect reason in the `HandshakeError`.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Show the disconnect reason in the `HandshakeError` message when a `Disconnect` message is received during the handshake process (p2p)
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

