### PR TITLE
fix(l1): prevents HelloMessage decode from failing if there are unknown capabilities

### DIFF
--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -167,7 +167,11 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                     )
                     .await;
             };
-            let capabilities = self.capabilities.iter().map(|(cap, _)| *cap).collect();
+            let capabilities = self
+                .capabilities
+                .iter()
+                .map(|(cap, _)| cap.clone())
+                .collect();
             table
                 .lock()
                 .await

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -15,7 +15,7 @@ use super::{
     utils::{pubkey2id, snappy_compress},
 };
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Capability {
     P2p,
     Eth,

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -20,6 +20,7 @@ pub enum Capability {
     P2p,
     Eth,
     Snap,
+    UnsupportedCapability(String),
 }
 
 impl RLPEncode for Capability {
@@ -28,6 +29,7 @@ impl RLPEncode for Capability {
             Self::P2p => "p2p".encode(buf),
             Self::Eth => "eth".encode(buf),
             Self::Snap => "snap".encode(buf),
+            Self::UnsupportedCapability(name) => name.encode(buf),
         }
     }
 }
@@ -39,7 +41,7 @@ impl RLPDecode for Capability {
             "p2p" => Ok((Capability::P2p, rest)),
             "eth" => Ok((Capability::Eth, rest)),
             "snap" => Ok((Capability::Snap, rest)),
-            _ => Err(RLPDecodeError::UnexpectedString),
+            other => Ok((Capability::UnsupportedCapability(other.to_string()), rest)),
         }
     }
 }


### PR DESCRIPTION
This was solved by adding an `UnsupportedCapability` in the Capability enum. The rationale behind this is:

- We can't just represent all possible capabilities because some nodes use off-spec capabilities and may add them whenever they want, which would prevent us from connecting with them.
- We may represent them as RlpxDecode errors, but as we decode a vector of them, the vector decoding function would need to be rewritten to not break in this very specific case.
- If we represent this as a type, we don't have ramifications, as we only use it to check if there's at least one of the other node capabilities that we support.

Closes #1656

