### PR TITLE
fix(levm): warm new precompile prague addresses

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -134,6 +134,10 @@ pub const PRECOMPILES_POST_CANCUN: [H160; 7] = [
 
 pub const BLAKE2F_ELEMENT_SIZE: usize = 8;
 
+pub const SIZE_PRECOMPILES: u64 = 9;
+pub const SIZE_PRECOMPILES_CANCUN: u64 = 10;
+pub const SIZE_PRECOMPILES_PRAGUE: u64 = 17;
+
 pub fn is_precompile(callee_address: &Address, spec_id: SpecId) -> bool {
     // Cancun specs is the only one that allows point evaluation precompile
     if *callee_address == POINT_EVALUATION_ADDRESS && spec_id < SpecId::CANCUN {
@@ -145,7 +149,7 @@ pub fn is_precompile(callee_address: &Address, spec_id: SpecId) -> bool {
         return false;
     }
 
-    PRECOMPILES.contains(callee_address)
+    PRECOMPILES.contains(callee_address) || PRECOMPILES_POST_CANCUN.contains(callee_address)
 }
 
 pub fn execute_precompile(

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -17,7 +17,10 @@ use crate::{
         TOTAL_COST_FLOOR_PER_TOKEN,
     },
     opcodes::Opcode,
-    precompiles::{execute_precompile, is_precompile},
+    precompiles::{
+        execute_precompile, is_precompile, SIZE_PRECOMPILES, SIZE_PRECOMPILES_CANCUN,
+        SIZE_PRECOMPILES_PRAGUE,
+    },
     AccountInfo, TransientStorage,
 };
 use bytes::Bytes;
@@ -155,7 +158,11 @@ impl VM {
 
         // Add precompiled contracts addresses to cache.
         // TODO: Use the addresses from precompiles.rs in a future
-        let max_precompile_address = if env.spec_id >= SpecId::CANCUN { 10 } else { 9 };
+        let max_precompile_address = match env.spec_id {
+            spec if spec >= SpecId::PRAGUE => SIZE_PRECOMPILES_PRAGUE,
+            spec if spec >= SpecId::CANCUN => SIZE_PRECOMPILES_CANCUN,
+            _ => SIZE_PRECOMPILES,
+        };
         for i in 1..=max_precompile_address {
             default_touched_accounts.insert(Address::from_low_u64_be(i));
         }


### PR DESCRIPTION
**Motivation**

All precompiled contracts must be initialized as warm addresses. Following the Prague fork, newly added precompiles must also be included.

**Description**

When initialized the VM, all addresses from 1 to 17 are added to the `default_touched_accounts`


