### PR TITLE
fix(l2): replace `ExecutionDB` `from_exec()` with `IndexDB`

### DIFF
--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -15,6 +15,7 @@ revm = { version = "14.0.3", features = [
   "serde-json",
   "optional_no_base_fee",
   "optional_block_gas_limit",
+  "optional_balance_check",
 ], default-features = false }
 
 # These dependencies must be kept up to date with the corresponding revm version, otherwise errors may pop up because of trait implementation mismatches


### PR DESCRIPTION
**Motivation**

A `ExecutionDB` is created from a block's pre-execution but the current implementation is incorrect and not all needed data gets stored. The goal is to replace this with another approach, using an auxiliary "indexing" database that will store all account addresses, storage keys, block numbers and code hashes touched during the pre-execution of a block, then the values can be retrieved from a `Store` or downloaded from an RPC endpoint (like in #1705).

**Description**

- adds `IndexDB`

