### PR TITLE
fix(l1): only active full sync after successful snap sync + fix max retries logic when fetching account range

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -327,6 +327,7 @@ async fn rebuild_state_trie(
     // We cannot keep an open trie here so we will track the root between lookups
     let mut current_state_root = *EMPTY_TRIE_HASH;
     // Fetch Account Ranges
+    // If we reached the maximum amount of retries then it means the state we are requesting is probably old and no longer available
     let mut retry_count = 0;
     while retry_count <= MAX_RETRIES {
         let peer = peers

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -79,8 +79,6 @@ impl SyncManager {
                     "Sync finished, time elapsed: {} secs",
                     start_time.elapsed().as_secs()
                 );
-                // Next sync will be full-sync
-                self.sync_mode = SyncMode::Full;
             }
             Err(error) => warn!(
                 "Sync failed due to {error}, time elapsed: {} secs ",
@@ -200,6 +198,8 @@ impl SyncManager {
                 }
                 store_receipts_handle.await??;
                 self.last_snap_pivot = pivot_header.number;
+                // Next sync will be full-sync
+                self.sync_mode = SyncMode::Full;
             }
             SyncMode::Full => {
                 // full-sync: Fetch all block bodies and execute them sequentially to build the state


### PR DESCRIPTION
**Motivation**
Two small fixes to snap sync logic:
- Fixes succesful queries being counted as retries and limiting the amount of account ranges fetched during snap sync
- Fixes full sync being enabled even when snap sync was not successfully completed
<!-- Why does this pull request exist? What are its goals? -->

**Description**
- Fix retry logic in `rebuild_state_trie` to use a separate resetting counter
- Activate full sync after snap sync was completed without aborting halfway
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

