### PR TITLE
feat(l1): periodically show peer stats

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -258,13 +258,15 @@ async fn main() {
                 tcp_socket_addr,
                 bootnodes,
                 signer,
-                peer_table,
+                peer_table.clone(),
                 store,
             )
             .into_future();
             tracker.spawn(networking);
         }
     }
+
+    tracker.spawn(ethrex_net::peridically_show_peer_stats(peer_table));
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -263,10 +263,9 @@ async fn main() {
             )
             .into_future();
             tracker.spawn(networking);
+            tracker.spawn(ethrex_net::periodically_show_peer_stats(peer_table));
         }
     }
-
-    tracker.spawn(ethrex_net::peridically_show_peer_stats(peer_table));
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -821,7 +821,7 @@ pub fn node_id_from_signing_key(signer: &SigningKey) -> H512 {
     H512::from_slice(&encoded.as_bytes()[1..])
 }
 
-
+/// Shows the amount of connected peers, active peers, and peers suitable for snap sync on a set interval
 pub async fn peridically_show_peer_stats(peer_table: Arc<Mutex<KademliaTable>>) {
     const INTERVAL_DURATION: tokio::time::Duration = tokio::time::Duration::from_secs(30);
     let mut interval = tokio::time::interval(INTERVAL_DURATION);

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -822,7 +822,7 @@ pub fn node_id_from_signing_key(signer: &SigningKey) -> H512 {
 }
 
 /// Shows the amount of connected peers, active peers, and peers suitable for snap sync on a set interval
-pub async fn peridically_show_peer_stats(peer_table: Arc<Mutex<KademliaTable>>) {
+pub async fn periodically_show_peer_stats(peer_table: Arc<Mutex<KademliaTable>>) {
     const INTERVAL_DURATION: tokio::time::Duration = tokio::time::Duration::from_secs(30);
     let mut interval = tokio::time::interval(INTERVAL_DURATION);
     loop {

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -821,6 +821,16 @@ pub fn node_id_from_signing_key(signer: &SigningKey) -> H512 {
     H512::from_slice(&encoded.as_bytes()[1..])
 }
 
+
+pub async fn peridically_show_peer_stats(peer_table: Arc<Mutex<KademliaTable>>) {
+    const INTERVAL_DURATION: tokio::time::Duration = tokio::time::Duration::from_secs(30);
+    let mut interval = tokio::time::interval(INTERVAL_DURATION);
+    loop {
+        peer_table.lock().await.show_peer_stats();
+        interval.tick().await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
**Motivation**
PR #1659 added a method to show the peer stats but left it as a debug tool. This PR aims to include it in the main execution loop by showing the peer stats periodically over a set interval
<!-- Why does this pull request exist? What are its goals? -->

**Description**
- Add method `periodically_show_peer_stats` which calls on `show_peer_stats` every 30 seconds and spawn it from the main function
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but completes #1659 
