### PR TITLE
fix: gas test json

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -298,7 +298,7 @@ impl Transaction {
             TxType::EIP4844 => {
                 let priority_fee_per_gas = min(
                     self.max_priority_fee()?,
-                    self.max_fee_per_gas()? - base_fee_per_gas?,
+                    self.max_fee_per_gas()?.saturating_sub(base_fee_per_gas?)
                 );
                 Some(priority_fee_per_gas + base_fee_per_gas?)
             }


### PR DESCRIPTION
**Motivation**

We still need to fix some tests to use the levm feature by default
**Description**

Pending tests to fix:

- [x]     parse_and_execute::eip4844_blobs/blob_txs/invalid_normal_gas.json
- [ ]     parse_and_execute::eip4844_blobs/blobhash_opcode/blobhash_invalid_blob_index.json
- [ ]     parse_and_execute::eip4844_blobs/blobhash_opcode/blobhash_gas_cost.json
- [ ]     parse_and_execute::eip4844_blobs/blobhash_opcode/blobhash_multiple_txs_in_block.json
- [ ]     parse_and_execute::eip4844_blobs/excess_blob_gas/correct_decreasing_blob_gas_costs.json
- [ ]     parse_and_execute::eip4844_blobs/excess_blob_gas/correct_increasing_blob_gas_costs.json
- [ ]     parse_and_execute::eip4844_blobs/blobhash_opcode_contexts/blobhash_opcode_contexts.json
- [ ]     parse_and_execute::eip4844_blobs/blobhash_opcode/blobhash_scenarios.json

You can double check with:
```sh
cargo test  -p ef_tests-levm --workspace --features levm  --exclude ethrex-prover --exclude ethrex-levm --exclude ef_tests-levm --exclude ethrex-l2 -- --nocapture --skip test_contract_compilation
```
