### PR TITLE
feat(levm): add precompile bls12_g2msm

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -213,6 +213,16 @@ pub const BLS12_381_G1_K_DISCOUNT: [u64; 128] = [
     528, 528, 527, 526, 525, 525, 524, 523, 522, 522, 521, 520, 520, 519,
 ];
 pub const G1_MUL_COST: u64 = 12000;
+pub const BLS12_381_G2_K_DISCOUNT: [u64; 128] = [
+    1000, 1000, 923, 884, 855, 832, 812, 796, 782, 770, 759, 749, 740, 732, 724, 717, 711, 704,
+    699, 693, 688, 683, 679, 674, 670, 666, 663, 659, 655, 652, 649, 646, 643, 640, 637, 634, 632,
+    629, 627, 624, 622, 620, 618, 615, 613, 611, 609, 607, 606, 604, 602, 600, 598, 597, 595, 593,
+    592, 590, 589, 587, 586, 584, 583, 582, 580, 579, 578, 576, 575, 574, 573, 571, 570, 569, 568,
+    567, 566, 565, 563, 562, 561, 560, 559, 558, 557, 556, 555, 554, 553, 552, 552, 551, 550, 549,
+    548, 547, 546, 545, 545, 544, 543, 542, 541, 541, 540, 539, 538, 537, 537, 536, 535, 535, 534,
+    533, 532, 532, 531, 530, 530, 529, 528, 528, 527, 526, 526, 525, 524, 524,
+];
+pub const G2_MUL_COST: u64 = 22500;
 
 pub fn exp(exponent: U256) -> Result<u64, VMError> {
     let exponent_byte_size = (exponent
@@ -1069,6 +1079,36 @@ pub fn bls12_g1msm(k: usize) -> Result<u64, VMError> {
     let gas_cost = u64::try_from(k)
         .map_err(|_| VMError::VeryLargeNumber)?
         .checked_mul(G1_MUL_COST)
+        .ok_or(VMError::VeryLargeNumber)?
+        .checked_mul(discount)
+        .ok_or(VMError::VeryLargeNumber)?
+        .checked_div(BLS12_381_MSM_MULTIPLIER)
+        .ok_or(VMError::VeryLargeNumber)?;
+    Ok(gas_cost)
+}
+
+pub fn bls12_g2msm(k: usize) -> Result<u64, VMError> {
+    if k == 0 {
+        return Ok(0);
+    }
+
+    let discount = if k < BLS12_381_G2_K_DISCOUNT.len() {
+        BLS12_381_G2_K_DISCOUNT
+            .get(k.checked_sub(1).ok_or(VMError::Internal(
+                InternalError::ArithmeticOperationUnderflow,
+            ))?)
+            .copied()
+            .ok_or(VMError::Internal(InternalError::SlicingError))?
+    } else {
+        BLS12_381_G2_K_DISCOUNT
+            .last()
+            .copied()
+            .ok_or(VMError::Internal(InternalError::SlicingError))?
+    };
+
+    let gas_cost = u64::try_from(k)
+        .map_err(|_| VMError::VeryLargeNumber)?
+        .checked_mul(G2_MUL_COST)
         .ok_or(VMError::VeryLargeNumber)?
         .checked_mul(discount)
         .ok_or(VMError::VeryLargeNumber)?

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -1355,11 +1355,11 @@ pub fn bls12_g2msm(
         let x_1 = parse_coordinate(calldata.get(x_1_offset..y_0_offset))?;
         let y_0 = parse_coordinate(calldata.get(y_0_offset..y_1_offset))?;
         let y_1 = parse_coordinate(calldata.get(y_1_offset..scalar_offset))?;
-        let g2 = parse_g2_point(x_0, x_1, y_0, y_1, false)?;
+        let point = parse_g2_point(x_0, x_1, y_0, y_1, false)?;
 
         let scalar = parse_scalar(calldata.get(scalar_offset..pair_end))?;
 
-        let scaled_point = G2Projective::mul(g2, scalar);
+        let scaled_point = G2Projective::mul(point, scalar);
         result = result.add(&scaled_point);
     }
 

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -1490,7 +1490,7 @@ fn parse_g2_point(
                     PrecompileError::BLS12381G2PointNotInCurve,
                 ));
             }
-          
+
             G2Projective::from(g2_affine)
         } else {
             let g2_affine = G2Affine::from_uncompressed(&g2_bytes)
@@ -1498,6 +1498,7 @@ fn parse_g2_point(
                 .ok_or(VMError::PrecompileError(PrecompileError::ParsingInputError))?;
 
             G2Projective::from(g2_affine)
+        }
     };
     Ok(g2_point)
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
In this PR we implement the fourth precompile contract stated in [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) for the Prague fork, the `BLS12_G2MSM`

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

For the address ox0e, the function `bls12_g2msm` is called.
The following specifications are implemented:

- Input format: `288*k` bytes (where k > 0) consisting of k pairs of:
  - G2 point (256 bytes): Four field elements of 64 bytes each, with the first 16 bytes being zero
  - Scalar value (32 bytes): Big-endian encoded integer
- Output: Single G2 point (256 bytes) representing the sum of all scalar multiplications
- Gas cost: Calculated based on the number of pairs as specified [here](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2537.md?plain=1#L291-L306)

<!-- Link to issues: Resolves #111, Resolves #222 -->

State of the tests: bls12_g2msm: 35/35 (100.00%)

Closes #1697 

