### PR TITLE
chore(l1): update hive revision to point to our latest commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := df7d5103d4ddc772307f9947be4ad1f20ce03ed0
+HIVE_REVISION := 37bde6deee7044b86fff88a39a52b33be460ae9c
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).


### PR DESCRIPTION
**Motivation**

The Makefile had an outdated version of hive.

**Description**

Updates hive revision to point to our latest commit of the `main` branch of our hive fork

Closes None
