### PR TITLE
feat(levm): add precompile bls12_map_fp_to_g1

### DIFF
--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -26,7 +26,7 @@ num-bigint = "0.4.5"
 lambdaworks-math = "0.11.0"
 k256 = { version = "0.13.3", features = ["ecdh"] }
 kzg-rs = "0.2.3"
-bls12_381 = {version = "0.8.0", features = ["groups", "bits", "pairings", "alloc", "experimental"]}
+bls12_381 = { git = "https://github.com/lambdaclass/bls12_381", branch = "expose-fp-struct", features = ["groups", "bits", "pairings", "alloc", "experimental"] }
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -26,7 +26,7 @@ num-bigint = "0.4.5"
 lambdaworks-math = "0.11.0"
 k256 = { version = "0.13.3", features = ["ecdh"] }
 kzg-rs = "0.2.3"
-bls12_381 = "0.8.0"
+bls12_381 = {version = "0.8.0", features = ["groups", "bits", "pairings", "alloc", "experimental"]}
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -173,6 +173,7 @@ pub const ACCESS_LIST_ADDRESS_COST: u64 = 2400;
 pub const ECRECOVER_COST: u64 = 3000;
 pub const BLS12_381_G1ADD_COST: u64 = 375;
 pub const BLS12_381_G2ADD_COST: u64 = 600;
+pub const BLS12_381_MAP_FP_TO_G1_COST: u64 = 5500;
 
 // Floor cost per token, specified in https://eips.ethereum.org/EIPS/eip-7623
 pub const TOTAL_COST_FLOOR_PER_TOKEN: u64 = 10;

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -1368,6 +1368,7 @@ pub fn bls12_map_fp_to_g1(
     increase_precompile_consumed_gas(gas_for_call, BLS12_381_MAP_FP_TO_G1_COST, consumed_gas)?;
 
     let _coordinate_bytes = parse_coordinate(calldata.get(0..64))?;
+
     Ok(Bytes::new())
 }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
In this PR we implement the sixth precompile contract stated in [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) for the Prague fork, the BLS12_MAP_FP_TO_G1

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
For the address 0x10, the function `bls12_map_fp_to_g1` si called.
The following specifications are implemented:

- Input format: One field element of 64 bytes with the first 16 bytes being zero.
- Output: One G1 point, consisting of 128 bytes with two field elements 64 bytes each.
- Gas cost: A constant value of `5500`.

state of the tests: bls12_map_fp_to_g1: 24/24 (100.00%)

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1699 

