### PR TITLE
fix(levm): remove unstable tests

### DIFF
--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -30,12 +30,10 @@ STATETEST_URL := https://github.com/ethereum/execution-spec-tests/releases/downl
 download-evm-ef-tests: ## 📥 Download EF Tests
 	mkdir -p $(TMP_DIR)
 	mkdir -p $(VECTORS_DIR)/GeneralStateTests
-	mkdir -p $(VECTORS_DIR)/stEIP2537
 	mkdir -p $(VECTORS_DIR)/state_tests
 	curl -L -o $(SPECTEST_ARTIFACT) $(SPECTEST_URL)
 	tar -xzf $(SPECTEST_ARTIFACT) -C $(TMP_DIR)
 	mv $(TMP_DIR)/tests-14.1/GeneralStateTests/* $(VECTORS_DIR)/GeneralStateTests/
-	mv $(TMP_DIR)/tests-14.1/EIPTests/StateTests/stEIP2537/* $(VECTORS_DIR)/stEIP2537/
 	curl -L -o $(STATETEST_ARTIFACT) $(STATETEST_URL)
 	tar -xzf $(STATETEST_ARTIFACT) -C $(TMP_DIR)
 	mv $(TMP_DIR)/fixtures/state_tests/* $(VECTORS_DIR)/state_tests/


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

This PR removes a folder of tests for the EIP-2537. This tests hasn't been updated for 9 months.
400 tests were successfully passing with the existing implementation, no modifications were required to address the issues.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

A [folder](https://github.com/ethereum/tests/tree/develop/EIPTests/StateTests/stEIP2537) containing 1403 tests for the precompiles added for Prague fork was removed.
Removes the line from download and create a directory for this tests in the Makefile.

<!-- Link to issues: Resolves #111, Resolves #222 -->


