### PR TITLE
fix(levm): return correct error on instrinsic gas too low

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -753,7 +753,7 @@ impl VM {
             let min_gas_limit = max(intrinsic_gas, floor_cost_by_tokens);
 
             if initial_call_frame.gas_limit < min_gas_limit {
-                return Err(VMError::TxValidation(TxValidationError::GasLimitTooLow));
+                return Err(VMError::TxValidation(TxValidationError::IntrinsicGasTooLow));
             }
         }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

When validating to prepare an execution, the minimum gas check was returning a bad Error type

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

Changed from `TxValidationError::GasLimitTooLow` to `TxValidationError::IntrinsicGasTooLow` error type if the gas limit was too low.

<!-- Link to issues: Resolves #111, Resolves #222 -->

