### PR TITLE
fix(levm): benches show output for levm in benchs

### DIFF
--- a/crates/vm/levm/bench/revm_comparison/src/lib.rs
+++ b/crates/vm/levm/bench/revm_comparison/src/lib.rs
@@ -34,7 +34,7 @@ pub fn run_with_levm(program: &str, runs: usize, number_of_iterations: u32) {
 
     match tx_report.result {
         TxResult::Success => {
-            println!("\t\t0x{}", hex::encode(current_call_frame.output));
+            println!("\t\t0x{}", hex::encode(tx_report.output));
         }
         TxResult::Revert(error) => panic!("Execution failed: {:?}", error),
     }


### PR DESCRIPTION
**Motivation**

we were not showing the output for `levm` when running `make revm-comparison`

**Description**

Use `tx_report.output` instead of `current_call_frame.output` since that was empty.