### PR TITLE
feat(levm): add debug build directive for run-evm-ef-tests

### DIFF
--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -44,6 +44,9 @@ run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	if [ "$(QUIET)" = "true" ]; then \
 		cd ../../../ && \
 		time cargo test --quiet -p ef_tests-levm --test ef_tests_levm --release -- $(flags) --summary;\
+	elif [ "$(DEBUG)" = "true" ]; then \
+		cd ../../../ && \
+		time cargo test -p ef_tests-levm --test ef_tests_levm -- $(flags);\
 	else \
 		cd ../../../ && \
 		time cargo test -p ef_tests-levm --test ef_tests_levm --release -- $(flags);\


### PR DESCRIPTION
**Motivation**

If one needs to run LEVM with debug symbols (in order to use a debugger, such as lldb), the `--release` flag in the makefile has to be removed manually every time. 

This PR adds a new if branch that checks if the "DEBUG" environment variable was passed  

**Description**

With this PR, running:
```
make DEBUG=true run-evm-ef-tests 
```
will compile the project with debug symbols. 


Closes #1779
