### PR TITLE
fix(core): add `token` to "Create or update comment" steps

### DIFF
--- a/.github/workflows/ci_bench_levm.yaml
+++ b/.github/workflows/ci_bench_levm.yaml
@@ -125,6 +125,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: combined_result.md
           edit-mode: replace

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -72,6 +72,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: test_summary.txt
           edit-mode: replace

--- a/.github/workflows/ci_loc_pr.yaml
+++ b/.github/workflows/ci_loc_pr.yaml
@@ -97,6 +97,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: detailed_loc_report.txt
           edit-mode: replace


### PR DESCRIPTION
External contributors' PRs cannot run some jobs successfully (see https://github.com/lambdaclass/ethrex/actions/runs/12951560002/job/36129604293?pr=1762)