### PR TITLE
feat(l1): add connection state to kademlia table

### DIFF
--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -191,24 +191,6 @@ impl KademliaTable {
         peer.revalidation = Some(false);
     }
 
-    /// Marks a node as connected. Should be called when the TCP connection starts.
-    pub fn node_connected(&mut self, node_id: H512) {
-        let Some(peer) = self.get_by_node_id_mut(node_id) else {
-            return;
-        };
-
-        peer.set_is_connected(true);
-    }
-
-    /// Marks a node as diconnected. Should be called when the TCP connection stops.
-    pub fn node_disconnected(&mut self, node_id: H512) {
-        let Some(peer) = self.get_by_node_id_mut(node_id) else {
-            return;
-        };
-
-        peer.set_is_connected(false);
-    }
-
     /// ## Returns
     /// The a vector of length of the provided `limit` of the peers who have the highest `last_ping` timestamp,
     /// that is, those peers that were pinged least recently. Careful with the `limit` param, as a
@@ -328,6 +310,7 @@ impl KademliaTable {
         }) {
             peer.channels = Some(channels);
             peer.supported_capabilities = capabilities;
+            peer.is_connected = true;
         } else {
             debug!(
                 "[PEERS] Peer with node_id {:?} not found in the kademlia table when trying to init backend communication",
@@ -389,8 +372,8 @@ pub struct PeerData {
     pub revalidation: Option<bool>,
     /// communication channels between the peer data and its active connection
     pub channels: Option<PeerChannels>,
-    /// Starts as false when a node is added. True when a connection is active. False when the
-    /// connection finishes or breaks. Useful to avoid connecting multiple times to a single peer.
+    /// Starts as false when a node is added. Set to true when a connection si active. When a
+    /// connection fails, the peer record is removed, so no need to set it to false.
     pub is_connected: bool,
 }
 
@@ -434,10 +417,6 @@ impl PeerData {
 
     pub fn decrement_liveness(&mut self) {
         self.liveness /= 3;
-    }
-
-    pub fn set_is_connected(&mut self, is_connected: bool) {
-        self.is_connected = is_connected;
     }
 }
 

--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -191,6 +191,24 @@ impl KademliaTable {
         peer.revalidation = Some(false);
     }
 
+    /// Marks a node as connected. Should be called when the TCP connection starts.
+    pub fn node_connected(&mut self, node_id: H512) {
+        let Some(peer) = self.get_by_node_id_mut(node_id) else {
+            return;
+        };
+
+        peer.set_is_connected(true);
+    }
+
+    /// Marks a node as diconnected. Should be called when the TCP connection stops.
+    pub fn node_disconnected(&mut self, node_id: H512) {
+        let Some(peer) = self.get_by_node_id_mut(node_id) else {
+            return;
+        };
+
+        peer.set_is_connected(false);
+    }
+
     /// ## Returns
     /// The a vector of length of the provided `limit` of the peers who have the highest `last_ping` timestamp,
     /// that is, those peers that were pinged least recently. Careful with the `limit` param, as a
@@ -371,6 +389,9 @@ pub struct PeerData {
     pub revalidation: Option<bool>,
     /// communication channels between the peer data and its active connection
     pub channels: Option<PeerChannels>,
+    /// Starts as false when a node is added. True when a connection is active. False when the
+    /// connection finishes or breaks. Useful to avoid connecting multiple times to a single peer.
+    pub is_connected: bool,
 }
 
 impl PeerData {
@@ -394,6 +415,7 @@ impl PeerData {
             revalidation: None,
             channels: None,
             supported_capabilities: vec![],
+            is_connected: false,
         }
     }
 
@@ -412,6 +434,10 @@ impl PeerData {
 
     pub fn decrement_liveness(&mut self) {
         self.liveness /= 3;
+    }
+
+    pub fn set_is_connected(&mut self, is_connected: bool) {
+        self.is_connected = is_connected;
     }
 }
 

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -29,7 +29,7 @@ use tokio::{
         broadcast::{self, Sender},
         Mutex,
     },
-    task::{self, Id, JoinHandle},
+    task::Id,
 };
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info};

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -946,12 +946,6 @@ fn listener(tcp_addr: SocketAddr) -> Result<TcpListener, io::Error> {
 }
 
 async fn handle_peer_as_receiver(context: P2PContext, peer_addr: SocketAddr, stream: TcpStream) {
-    context
-        .table
-        .lock()
-        .await
-        .node_connected(context.local_node.node_id);
-
     let mut conn =
         RLPxConnection::receiver(context.signer, stream, context.storage, context.broadcast);
     conn.start_peer(peer_addr, context.table).await;
@@ -979,7 +973,6 @@ async fn handle_peer_as_initiator(
 
     match RLPxConnection::initiator(signer, msg, stream, storage, connection_broadcast) {
         Ok(mut conn) => {
-            table.lock().await.node_connected(node.node_id);
             conn.start_peer(SocketAddr::new(node.ip, node.udp_port), table)
                 .await
         }

--- a/crates/networking/p2p/net.rs
+++ b/crates/networking/p2p/net.rs
@@ -232,6 +232,7 @@ async fn discover_peers_server(context: P2PContext, udp_socket: Arc<UdpSocket>) 
                                 debug!("Discarding pong as the node did not send a previous ping");
                                 continue;
                             }
+
                             if peer
                                 .last_ping_hash
                                 .is_some_and(|hash| hash == msg.ping_hash)
@@ -250,6 +251,12 @@ async fn discover_peers_server(context: P2PContext, udp_socket: Arc<UdpSocket>) 
                                             req_hash,
                                         );
                                     }
+                                }
+
+                                // We won't initiate a connection if we are already connected.
+                                // This will typically be the case when revalidating a node.
+                                if peer.is_connected {
+                                    continue;
                                 }
 
                                 let mut msg_buf = vec![0; read - 32];


### PR DESCRIPTION
**Description**

Changes:

- Adds a connection bool to the peer data in the kademlia table, that starts as false.
- Sets `is_connected` to true when the handshake completes.
- No need to ever set it as false as the record is deleted when the connection fails.
- Check `is_connected` directly from the kademlia table before starting a connection in Pong.

Closes #1684 

