### PR TITLE
fix(core): block producer in dev mode

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -125,9 +125,12 @@ pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block,
             ),
         ),
         parent_beacon_block_root: args.beacon_root,
-        requests_hash: chain_config
-            .is_prague_activated(args.timestamp)
-            .then_some(H256::zero()), // TODO: set the value properly
+        // TODO: set the value properly
+        requests_hash: if chain_config.is_prague_activated(args.timestamp) {
+            None
+        } else {
+            Some(H256::zero())
+        },
     };
 
     let body = BlockBody {

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -126,11 +126,7 @@ pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block,
         ),
         parent_beacon_block_root: args.beacon_root,
         // TODO: set the value properly
-        requests_hash: if chain_config.is_prague_activated(args.timestamp) {
-            None
-        } else {
-            Some(H256::zero())
-        },
+        requests_hash: None,
     };
 
     let body = BlockBody {

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -548,7 +548,7 @@ pub fn validate_block_header(
 /// Validates that excess_blob_gas and blob_gas_used are present in the header and
 /// validates that excess_blob_gas value is correct on the block header
 /// according to the values in the parent header.
-pub fn validate_cancun_header_fields(
+pub fn validate_post_cancun_header_fields(
     header: &BlockHeader,
     parent_header: &BlockHeader,
 ) -> Result<(), InvalidBlockHeaderError> {
@@ -569,7 +569,7 @@ pub fn validate_cancun_header_fields(
 
 /// Validates that the excess blob gas value is correct on the block header
 /// according to the values in the parent header.
-pub fn validate_no_cancun_header_fields(
+pub fn validate_pre_cancun_header_fields(
     header: &BlockHeader,
 ) -> Result<(), InvalidBlockHeaderError> {
     if header.excess_blob_gas.is_some() {

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -272,10 +272,12 @@ impl Genesis {
                 .config
                 .is_cancun_activated(self.timestamp)
                 .then_some(H256::zero()),
-            requests_hash: self
-                .config
-                .is_prague_activated(self.timestamp)
-                .then_some(H256::zero()), // TODO: set the value properly
+            // TODO: set the value properly
+            requests_hash: if self.config.is_prague_activated(self.timestamp) {
+                None
+            } else {
+                Some(H256::zero())
+            },
         }
     }
 

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -273,11 +273,10 @@ impl Genesis {
                 .is_cancun_activated(self.timestamp)
                 .then_some(H256::zero()),
             // TODO: set the value properly
-            requests_hash: if self.config.is_prague_activated(self.timestamp) {
-                None
-            } else {
-                Some(H256::zero())
-            },
+            requests_hash: self
+                .config
+                .is_prague_activated(self.timestamp)
+                .then_some(H256::zero()),
         }
     }
 

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -99,11 +99,7 @@ impl RpcHandler for NewPayloadV3Request {
 
     fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let block = get_block_from_payload(&self.payload, Some(self.parent_beacon_block_root))?;
-        let fork = context
-            .storage
-            .get_chain_config()?
-            .get_fork(block.header.timestamp);
-        validate_fork(&block, fork, &context)?;
+        validate_fork(&block, Fork::Cancun, &context)?;
         validate_execution_payload_v3(&self.payload)?;
         let payload_status = {
             if let Err(RpcErr::Internal(error_msg)) = validate_block_hash(&self.payload, &block) {
@@ -192,11 +188,7 @@ impl RpcHandler for GetPayloadV3Request {
 
     fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let payload = get_payload(self.payload_id, &context)?;
-        let fork = context
-            .storage
-            .get_chain_config()?
-            .fork(payload.0.header.timestamp);
-        validate_fork(&payload.0, fork, &context)?;
+        validate_fork(&payload.0, Fork::Cancun, &context)?;
         let execution_payload_response =
             build_execution_payload_response(self.payload_id, payload, Some(false), context)?;
 
@@ -476,7 +468,8 @@ fn validate_fork(block: &Block, fork: Fork, context: &RpcApiContext) -> Result<(
     // Check timestamp matches valid fork
     let chain_config = &context.storage.get_chain_config()?;
     let current_fork = chain_config.get_fork(block.header.timestamp);
-    if current_fork != fork {
+    // If current_fork is less than Fork::Cancun, return an error.
+    if current_fork < fork {
         return Err(RpcErr::UnsuportedFork(format!("{current_fork:?}")));
     }
     Ok(())

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -99,7 +99,11 @@ impl RpcHandler for NewPayloadV3Request {
 
     fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let block = get_block_from_payload(&self.payload, Some(self.parent_beacon_block_root))?;
-        validate_fork(&block, Fork::Cancun, &context)?;
+        let fork = context
+            .storage
+            .get_chain_config()?
+            .get_fork(block.header.timestamp);
+        validate_fork(&block, fork, &context)?;
         validate_execution_payload_v3(&self.payload)?;
         let payload_status = {
             if let Err(RpcErr::Internal(error_msg)) = validate_block_hash(&self.payload, &block) {
@@ -188,7 +192,11 @@ impl RpcHandler for GetPayloadV3Request {
 
     fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let payload = get_payload(self.payload_id, &context)?;
-        validate_fork(&payload.0, Fork::Cancun, &context)?;
+        let fork = context
+            .storage
+            .get_chain_config()?
+            .fork(payload.0.header.timestamp);
+        validate_fork(&payload.0, fork, &context)?;
         let execution_payload_response =
             build_execution_payload_response(self.payload_id, payload, Some(false), context)?;
 

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -49,6 +49,7 @@ pub struct ExecutionPayload {
         default
     )]
     pub excess_blob_gas: Option<u64>,
+    pub requests_hash: Option<H256>,
 }
 
 #[derive(Clone, Debug)]
@@ -159,6 +160,7 @@ impl ExecutionPayload {
             withdrawals: block.body.withdrawals,
             blob_gas_used: block.header.blob_gas_used,
             excess_blob_gas: block.header.excess_blob_gas,
+            requests_hash: block.header.requests_hash,
         }
     }
 }


### PR DESCRIPTION
**Motivation**

We were having some issues when Prague was activated, while we implement Prague properly a fix for the block producer is needed.

**Description**

- Set `requests_hash` to `None` &rarr; we have to set this variable accordingly.
- `validate_fork`depending on the block's timestamp &rarr; essentially retrieving the fork in the same way it's done inside `validate_fork` (Maybe we can pass the `Fork` inside the `RpcApiContext`)

