### PR TITLE
refactor(levm): generalize the incrementation of the pc

### DIFF
--- a/cmd/ef_tests/levm/runner/revm_runner.rs
+++ b/cmd/ef_tests/levm/runner/revm_runner.rs
@@ -463,7 +463,6 @@ pub fn _ensure_post_state_revm(
                             logs: vec![],
                             output: Bytes::new(),
                             new_state: HashMap::new(),
-                            created_address: None,
                         },
                         //TODO: This is not a TransactionReport because it is REVM
                         error_reason,
@@ -489,7 +488,6 @@ pub fn _ensure_post_state_revm(
                                 logs: vec![],
                                 output: Bytes::new(),
                                 new_state: HashMap::new(),
-                                created_address: None,
                             },
                             //TODO: This is not a TransactionReport because it is REVM
                             error_reason,

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -144,8 +144,4 @@ impl CallFrame {
             .ok_or(VMError::Internal(InternalError::PCOverflowed))?;
         Ok(())
     }
-
-    pub fn pc(&self) -> usize {
-        self.pc
-    }
 }

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -145,10 +145,6 @@ impl CallFrame {
         Ok(())
     }
 
-    pub fn increment_pc(&mut self) -> Result<(), VMError> {
-        self.increment_pc_by(1)
-    }
-
     pub fn pc(&self) -> usize {
         self.pc
     }

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -221,14 +221,6 @@ pub enum OpcodeResult {
     Halt,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HaltReason {
-    Stop,
-    Revert,
-    Return,
-    SelfDestruct,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TxResult {
     Success,

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -217,7 +217,7 @@ pub enum PrecompileError {
 /// means that the execution stopped. It's not called "Stop" because
 /// "Stop" is an Opcode
 pub enum OpcodeResult {
-    Continue,
+    Continue { pc_increment: usize },
     Halt(HaltReason),
 }
 

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -235,9 +235,6 @@ pub struct TransactionReport {
     pub gas_refunded: u64,
     pub output: Bytes,
     pub logs: Vec<Log>,
-    // This only applies to create transactions. It's fundamentally ambiguous since
-    // a transaction could create multiple new contracts, but whatever.
-    pub created_address: Option<Address>,
 }
 
 impl TransactionReport {

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -218,7 +218,7 @@ pub enum PrecompileError {
 /// "Stop" is an Opcode
 pub enum OpcodeResult {
     Continue { pc_increment: usize },
-    Halt(HaltReason),
+    Halt,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -165,7 +165,6 @@ impl VM {
 
     pub fn handle_opcode_result(
         &mut self,
-        // _reason: HaltReason,
         current_call_frame: &mut CallFrame,
         backup: StateBackup,
     ) -> Result<TransactionReport, VMError> {

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -2,10 +2,7 @@ use crate::{
     call_frame::CallFrame,
     constants::*,
     db::CacheDB,
-    errors::{
-        HaltReason, InternalError, OpcodeResult, OutOfGasError, TransactionReport, TxResult,
-        VMError,
-    },
+    errors::{InternalError, OpcodeResult, OutOfGasError, TransactionReport, TxResult, VMError},
     gas_cost::CODE_DEPOSIT_COST,
     opcodes::Opcode,
     utils::*,

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -61,7 +61,7 @@ impl VM {
         opcode: Opcode,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
-        let op_result = match opcode {
+        match opcode {
             Opcode::STOP => Ok(OpcodeResult::Halt(HaltReason::Stop)),
             Opcode::ADD => self.op_add(current_call_frame),
             Opcode::MUL => self.op_mul(current_call_frame),
@@ -163,13 +163,7 @@ impl VM {
             Opcode::SELFDESTRUCT => self.op_selfdestruct(current_call_frame),
 
             _ => Err(VMError::OpcodeNotFound),
-        };
-
-        // if opcode != Opcode::JUMP && opcode != Opcode::JUMPI {
-        //     current_call_frame.increment_pc()?;
-        // }
-
-        op_result
+        }
     }
 
     pub fn handle_opcode_result(

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -165,9 +165,9 @@ impl VM {
             _ => Err(VMError::OpcodeNotFound),
         };
 
-        if opcode != Opcode::JUMP && opcode != Opcode::JUMPI {
-            current_call_frame.increment_pc()?;
-        }
+        // if opcode != Opcode::JUMP && opcode != Opcode::JUMPI {
+        //     current_call_frame.increment_pc()?;
+        // }
 
         op_result
     }

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -29,7 +29,6 @@ impl VM {
                     gas_refunded: 0,
                     output,
                     logs: std::mem::take(&mut current_call_frame.logs),
-                    created_address: None,
                 })
             }
             Err(error) => {
@@ -48,7 +47,6 @@ impl VM {
                     gas_refunded: 0,
                     output: Bytes::new(),
                     logs: std::mem::take(&mut current_call_frame.logs),
-                    created_address: None,
                 })
             }
         }
@@ -221,7 +219,6 @@ impl VM {
                         gas_refunded: self.env.refunded_gas,
                         output: std::mem::take(&mut current_call_frame.output),
                         logs: std::mem::take(&mut current_call_frame.logs),
-                        created_address: None,
                     });
                 }
             }
@@ -234,7 +231,6 @@ impl VM {
             gas_refunded: self.env.refunded_gas,
             output: std::mem::take(&mut current_call_frame.output),
             logs: std::mem::take(&mut current_call_frame.logs),
-            created_address: None,
         })
     }
 
@@ -267,7 +263,6 @@ impl VM {
             gas_refunded: self.env.refunded_gas,
             output: std::mem::take(&mut current_call_frame.output), // Bytes::new() if error is not RevertOpcode
             logs: std::mem::take(&mut current_call_frame.logs),
-            created_address: None,
         })
     }
 }

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -62,7 +62,7 @@ impl VM {
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
         match opcode {
-            Opcode::STOP => Ok(OpcodeResult::Halt(HaltReason::Stop)),
+            Opcode::STOP => Ok(OpcodeResult::Halt),
             Opcode::ADD => self.op_add(current_call_frame),
             Opcode::MUL => self.op_mul(current_call_frame),
             Opcode::SUB => self.op_sub(current_call_frame),
@@ -168,7 +168,7 @@ impl VM {
 
     pub fn handle_opcode_result(
         &mut self,
-        _reason: HaltReason,
+        // _reason: HaltReason,
         current_call_frame: &mut CallFrame,
         backup: StateBackup,
     ) -> Result<TransactionReport, VMError> {

--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -22,7 +22,7 @@ impl VM {
         let sum = augend.overflowing_add(addend).0;
         current_call_frame.stack.push(sum)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SUB operation
@@ -34,7 +34,7 @@ impl VM {
         let difference = minuend.overflowing_sub(subtrahend).0;
         current_call_frame.stack.push(difference)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MUL operation
@@ -46,7 +46,7 @@ impl VM {
         let product = multiplicand.overflowing_mul(multiplier).0;
         current_call_frame.stack.push(product)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // DIV operation
@@ -57,11 +57,11 @@ impl VM {
         let divisor = current_call_frame.stack.pop()?;
         let Some(quotient) = dividend.checked_div(divisor) else {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         };
         current_call_frame.stack.push(quotient)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SDIV operation
@@ -72,7 +72,7 @@ impl VM {
         let divisor = current_call_frame.stack.pop()?;
         if divisor.is_zero() || dividend.is_zero() {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let abs_dividend = abs(dividend);
@@ -92,7 +92,7 @@ impl VM {
 
         current_call_frame.stack.push(quotient)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MOD operation
@@ -106,7 +106,7 @@ impl VM {
 
         current_call_frame.stack.push(remainder)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SMOD operation
@@ -118,7 +118,7 @@ impl VM {
 
         if unchecked_divisor.is_zero() || unchecked_dividend.is_zero() {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let divisor = abs(unchecked_divisor);
@@ -128,7 +128,7 @@ impl VM {
             Some(remainder) => remainder,
             None => {
                 current_call_frame.stack.push(U256::zero())?;
-                return Ok(OpcodeResult::Continue);
+                return Ok(OpcodeResult::Continue { pc_increment: 1 });
             }
         };
 
@@ -140,7 +140,7 @@ impl VM {
 
         current_call_frame.stack.push(remainder)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // ADDMOD operation
@@ -156,7 +156,7 @@ impl VM {
 
         if modulus.is_zero() {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let new_augend: U512 = augend.into();
@@ -176,7 +176,7 @@ impl VM {
 
         current_call_frame.stack.push(sum_mod)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MULMOD operation
@@ -192,7 +192,7 @@ impl VM {
 
         if modulus.is_zero() || multiplicand.is_zero() || multiplier.is_zero() {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let multiplicand: U512 = multiplicand.into();
@@ -213,7 +213,7 @@ impl VM {
 
         current_call_frame.stack.push(product_mod)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // EXP operation
@@ -228,7 +228,7 @@ impl VM {
         let power = base.overflowing_pow(exponent).0;
         current_call_frame.stack.push(power)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SIGNEXTEND operation
@@ -243,7 +243,7 @@ impl VM {
 
         if byte_size_minus_one > U256::from(31) {
             current_call_frame.stack.push(value_to_extend)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let bits_per_byte = U256::from(8);
@@ -272,7 +272,7 @@ impl VM {
         };
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }
 

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -19,7 +19,7 @@ impl VM {
         let result = u256_from_bool(lho < rho);
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // GT operation
@@ -30,7 +30,7 @@ impl VM {
         let result = u256_from_bool(lho > rho);
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SLT operation (signed less than)
@@ -49,7 +49,7 @@ impl VM {
         };
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SGT operation (signed greater than)
@@ -68,7 +68,7 @@ impl VM {
         };
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // EQ operation (equality check)
@@ -80,7 +80,7 @@ impl VM {
 
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // ISZERO operation (check if zero)
@@ -95,7 +95,7 @@ impl VM {
 
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // AND operation
@@ -105,7 +105,7 @@ impl VM {
         let b = current_call_frame.stack.pop()?;
         current_call_frame.stack.push(a & b)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // OR operation
@@ -115,7 +115,7 @@ impl VM {
         let b = current_call_frame.stack.pop()?;
         current_call_frame.stack.push(a | b)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // XOR operation
@@ -125,7 +125,7 @@ impl VM {
         let b = current_call_frame.stack.pop()?;
         current_call_frame.stack.push(a ^ b)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // NOT operation
@@ -134,7 +134,7 @@ impl VM {
         let a = current_call_frame.stack.pop()?;
         current_call_frame.stack.push(!a)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // BYTE operation
@@ -147,7 +147,7 @@ impl VM {
             Err(_) => {
                 // Index is out of bounds, then push 0
                 current_call_frame.stack.push(U256::zero())?;
-                return Ok(OpcodeResult::Continue);
+                return Ok(OpcodeResult::Continue { pc_increment: 1 });
             }
         };
 
@@ -168,7 +168,7 @@ impl VM {
             current_call_frame.stack.push(U256::zero())?;
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SHL operation (shift left)
@@ -185,7 +185,7 @@ impl VM {
             current_call_frame.stack.push(U256::zero())?;
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SHR operation (shift right)
@@ -202,7 +202,7 @@ impl VM {
             current_call_frame.stack.push(U256::zero())?;
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SAR operation (arithmetic shift right)
@@ -219,7 +219,7 @@ impl VM {
         };
         current_call_frame.stack.push(res)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }
 

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -33,7 +33,7 @@ impl VM {
             || block_number >= self.env.block_number
         {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let block_number: u64 = block_number
@@ -48,7 +48,7 @@ impl VM {
             current_call_frame.stack.push(U256::zero())?;
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // COINBASE operation
@@ -62,7 +62,7 @@ impl VM {
             .stack
             .push(address_to_word(self.env.coinbase))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // TIMESTAMP operation
@@ -74,7 +74,7 @@ impl VM {
 
         current_call_frame.stack.push(self.env.timestamp)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // NUMBER operation
@@ -86,7 +86,7 @@ impl VM {
 
         current_call_frame.stack.push(self.env.block_number)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // PREVRANDAO operation
@@ -101,7 +101,7 @@ impl VM {
             .stack
             .push(U256::from_big_endian(randao.0.as_slice()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // GASLIMIT operation
@@ -115,7 +115,7 @@ impl VM {
             .stack
             .push(self.env.block_gas_limit.into())?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CHAINID operation
@@ -127,7 +127,7 @@ impl VM {
 
         current_call_frame.stack.push(self.env.chain_id)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SELFBALANCE operation
@@ -142,7 +142,7 @@ impl VM {
             .balance;
 
         current_call_frame.stack.push(balance)?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // BASEFEE operation
@@ -154,7 +154,7 @@ impl VM {
 
         current_call_frame.stack.push(self.env.base_fee_per_gas)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // BLOBHASH operation
@@ -175,7 +175,7 @@ impl VM {
         let blob_hashes = &self.env.tx_blob_hashes;
         if index >= blob_hashes.len().into() {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let index: usize = index
@@ -191,7 +191,7 @@ impl VM {
             .stack
             .push(U256::from_big_endian(blob_hash.as_bytes()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     fn get_blob_gasprice(&mut self) -> Result<U256, VMError> {
@@ -220,7 +220,7 @@ impl VM {
 
         current_call_frame.stack.push(blob_base_fee)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }
 

--- a/crates/vm/levm/src/opcode_handlers/dup.rs
+++ b/crates/vm/levm/src/opcode_handlers/dup.rs
@@ -35,6 +35,6 @@ impl VM {
         // Push the duplicated value onto the stack
         current_call_frame.stack.push(*value_at_depth)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -27,7 +27,7 @@ impl VM {
             .stack
             .push(U256::from_big_endian(addr.as_bytes()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // BALANCE operation
@@ -43,7 +43,7 @@ impl VM {
 
         current_call_frame.stack.push(account_info.balance)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // ORIGIN operation
@@ -58,7 +58,7 @@ impl VM {
             .stack
             .push(U256::from_big_endian(origin.as_bytes()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CALLER operation
@@ -73,7 +73,7 @@ impl VM {
             .stack
             .push(U256::from_big_endian(caller.as_bytes()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CALLVALUE operation
@@ -87,7 +87,7 @@ impl VM {
 
         current_call_frame.stack.push(callvalue)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CALLDATALOAD operation
@@ -105,7 +105,7 @@ impl VM {
         // have no data to return.
         if offset > calldata_size {
             current_call_frame.stack.push(U256::zero())?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         };
         let offset: usize = offset
             .try_into()
@@ -128,7 +128,7 @@ impl VM {
 
         current_call_frame.stack.push(result)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CALLDATASIZE operation
@@ -142,7 +142,7 @@ impl VM {
             .stack
             .push(U256::from(current_call_frame.calldata.len()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CALLDATACOPY operation
@@ -166,13 +166,13 @@ impl VM {
         )?;
 
         if size == 0 {
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let mut data = vec![0u8; size];
         if calldata_offset > current_call_frame.calldata.len().into() {
             memory::try_store_data(&mut current_call_frame.memory, dest_offset, &data)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let calldata_offset: usize = calldata_offset
@@ -193,7 +193,7 @@ impl VM {
 
         memory::try_store_data(&mut current_call_frame.memory, dest_offset, &data)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CODESIZE operation
@@ -207,7 +207,7 @@ impl VM {
             .stack
             .push(U256::from(current_call_frame.bytecode.len()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CODECOPY operation
@@ -233,7 +233,7 @@ impl VM {
         )?;
 
         if size == 0 {
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let mut data = vec![0u8; size];
@@ -257,7 +257,7 @@ impl VM {
 
         memory::try_store_data(&mut current_call_frame.memory, destination_offset, &data)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // GASPRICE operation
@@ -269,7 +269,7 @@ impl VM {
 
         current_call_frame.stack.push(self.env.gas_price)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // EXTCODESIZE operation
@@ -292,7 +292,7 @@ impl VM {
             account_info.bytecode.len().into()
         })?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // EXTCODECOPY operation
@@ -327,7 +327,7 @@ impl VM {
         )?;
 
         if size == 0 {
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let bytecode = if is_delegation {
@@ -350,7 +350,7 @@ impl VM {
 
         memory::try_store_data(&mut current_call_frame.memory, dest_offset, &data)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // RETURNDATASIZE operation
@@ -364,7 +364,7 @@ impl VM {
             .stack
             .push(U256::from(current_call_frame.sub_return_data.len()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // RETURNDATACOPY operation
@@ -392,7 +392,7 @@ impl VM {
         )?;
 
         if size == 0 && returndata_offset == 0 {
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let sub_return_data_len = current_call_frame.sub_return_data.len();
@@ -422,7 +422,7 @@ impl VM {
 
         memory::try_store_data(&mut current_call_frame.memory, dest_offset, &data)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // EXTCODEHASH operation
@@ -447,13 +447,13 @@ impl VM {
             // An account is considered empty when it has no code and zero nonce and zero balance. [EIP-161]
             if account_info.is_empty() {
                 current_call_frame.stack.push(U256::zero())?;
-                return Ok(OpcodeResult::Continue);
+                return Ok(OpcodeResult::Continue { pc_increment: 1 });
             }
 
             let hash = U256::from_big_endian(keccak(account_info.bytecode).as_fixed_bytes());
             current_call_frame.stack.push(hash)?;
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/opcode_handlers/exchange.rs
+++ b/crates/vm/levm/src/opcode_handlers/exchange.rs
@@ -33,6 +33,6 @@ impl VM {
             .stack
             .swap(stack_top_index, to_swap_index)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -40,6 +40,6 @@ impl VM {
             .stack
             .push(U256::from_big_endian(&hasher.finalize()))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/opcode_handlers/logging.rs
+++ b/crates/vm/levm/src/opcode_handlers/logging.rs
@@ -55,6 +55,6 @@ impl VM {
         };
         current_call_frame.logs.push(log);
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -26,9 +26,12 @@ impl VM {
             .stack
             .push(U256::from_big_endian(value_to_push.as_slice()))?;
 
-        current_call_frame.increment_pc_by(n_bytes)?;
+        // The n_bytes that you push to the stack + 1 for the next instruction
+        let increment_pc_by = n_bytes + 1;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue {
+            pc_increment: increment_pc_by,
+        })
     }
 
     // PUSH0
@@ -45,7 +48,7 @@ impl VM {
 
         current_call_frame.stack.push(U256::zero())?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }
 

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -27,7 +27,7 @@ impl VM {
             .push(U256::from_big_endian(value_to_push.as_slice()))?;
 
         // The n_bytes that you push to the stack + 1 for the next instruction
-        let increment_pc_by = n_bytes + 1;
+        let increment_pc_by = n_bytes.wrapping_add(1);
 
         Ok(OpcodeResult::Continue {
             pc_increment: increment_pc_by,

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -53,8 +53,8 @@ impl VM {
 }
 
 fn read_bytcode_slice(current_call_frame: &CallFrame, n_bytes: usize) -> Result<&[u8], VMError> {
-    let pc_offset = current_call_frame
-        .pc()
+    let current_pc = current_call_frame.pc;
+    let pc_offset = current_pc
         // Add 1 to the PC because we don't want to include the
         // Bytecode of the current instruction in the data we're about
         // to read. We only want to read the data _NEXT_ to that

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -305,7 +305,7 @@ impl VM {
         let jump_address = current_call_frame.stack.pop()?;
         Self::jump(current_call_frame, jump_address)?;
 
-        Ok(OpcodeResult::Continue { pc_increment: 1 })
+        Ok(OpcodeResult::Continue { pc_increment: 0 })
     }
 
     /// JUMP* family (`JUMP` and `JUMP` ATTOW [DEC 2024]) helper
@@ -350,7 +350,7 @@ impl VM {
         } else {
             current_call_frame.increment_pc()?;
         }
-        Ok(OpcodeResult::Continue { pc_increment: 1 })
+        Ok(OpcodeResult::Continue { pc_increment: 0 })
     }
 
     // JUMPDEST operation

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -345,12 +345,14 @@ impl VM {
 
         self.increase_consumed_gas(current_call_frame, gas_cost::JUMPI)?;
 
-        if !condition.is_zero() {
-            Self::jump(current_call_frame, jump_address)?
+        let pc_increment = if !condition.is_zero() {
+            // Move the PC but don't increment it afterwards
+            Self::jump(current_call_frame, jump_address)?;
+            0
         } else {
-            current_call_frame.increment_pc()?;
-        }
-        Ok(OpcodeResult::Continue { pc_increment: 0 })
+            1
+        };
+        Ok(OpcodeResult::Continue { pc_increment })
     }
 
     // JUMPDEST operation

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -16,7 +16,7 @@ impl VM {
     pub fn op_pop(&mut self, current_call_frame: &mut CallFrame) -> Result<OpcodeResult, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::POP)?;
         current_call_frame.stack.pop()?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // TLOAD operation
@@ -40,7 +40,7 @@ impl VM {
             .unwrap_or(U256::zero());
 
         current_call_frame.stack.push(value)?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // TSTORE operation
@@ -65,7 +65,7 @@ impl VM {
             .transient_storage
             .insert((current_call_frame.to, key), value);
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MLOAD operation
@@ -86,7 +86,7 @@ impl VM {
             .stack
             .push(memory::load_word(&mut current_call_frame.memory, offset)?)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MSTORE operation
@@ -111,7 +111,7 @@ impl VM {
             &value.to_big_endian(),
         )?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MSTORE8 operation
@@ -137,7 +137,7 @@ impl VM {
             &value.to_big_endian()[WORD_SIZE - 1..WORD_SIZE],
         )?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SLOAD operation
@@ -156,7 +156,7 @@ impl VM {
         self.increase_consumed_gas(current_call_frame, gas_cost::sload(storage_slot_was_cold)?)?;
 
         current_call_frame.stack.push(storage_slot.current_value)?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // SSTORE operation
@@ -228,7 +228,7 @@ impl VM {
         )?;
 
         self.update_account_storage(current_call_frame.to, key, new_storage_slot_value)?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MSIZE operation
@@ -240,7 +240,7 @@ impl VM {
         current_call_frame
             .stack
             .push(current_call_frame.memory.len().into())?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // GAS operation
@@ -254,7 +254,7 @@ impl VM {
         // Note: These are not consumed gas calculations, but are related, so I used this wrapping here
         current_call_frame.stack.push(remaining_gas.into())?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MCOPY operation
@@ -295,7 +295,7 @@ impl VM {
             size,
         )?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // JUMP operation
@@ -305,7 +305,7 @@ impl VM {
         let jump_address = current_call_frame.stack.pop()?;
         Self::jump(current_call_frame, jump_address)?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     /// JUMP* family (`JUMP` and `JUMP` ATTOW [DEC 2024]) helper
@@ -350,7 +350,7 @@ impl VM {
         } else {
             current_call_frame.increment_pc()?;
         }
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // JUMPDEST operation
@@ -359,7 +359,7 @@ impl VM {
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
         self.increase_consumed_gas(current_call_frame, gas_cost::JUMPDEST)?;
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // PC operation
@@ -370,6 +370,6 @@ impl VM {
             .stack
             .push(U256::from(current_call_frame.pc))?;
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -194,7 +194,7 @@ impl VM {
             .map_err(|_err| VMError::VeryLargeNumber)?;
 
         if size == 0 {
-            return Ok(OpcodeResult::Halt(HaltReason::Return));
+            return Ok(OpcodeResult::Halt);
         }
 
         let new_memory_size = calculate_memory_size(offset, size)?;
@@ -210,7 +210,7 @@ impl VM {
                 .to_vec()
                 .into();
 
-        Ok(OpcodeResult::Halt(HaltReason::Return))
+        Ok(OpcodeResult::Halt)
     }
 
     // DELEGATECALL operation
@@ -561,7 +561,7 @@ impl VM {
                 .insert(current_call_frame.to);
         }
 
-        Ok(OpcodeResult::Halt(HaltReason::SelfDestruct))
+        Ok(OpcodeResult::Halt)
     }
 
     /// Common behavior for CREATE and CREATE2 opcodes

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -2,7 +2,7 @@ use crate::{
     call_frame::CallFrame,
     constants::{CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, REVERT_FOR_CALL, SUCCESS_FOR_CALL},
     db::cache,
-    errors::{HaltReason, InternalError, OpcodeResult, OutOfGasError, TxResult, VMError},
+    errors::{InternalError, OpcodeResult, OutOfGasError, TxResult, VMError},
     gas_cost::{self, max_message_call_gas},
     memory::{self, calculate_memory_size},
     utils::*,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -630,7 +630,7 @@ impl VM {
                 .ok_or(VMError::Internal(InternalError::GasOverflow))?;
             // Push 0
             current_call_frame.stack.push(CREATE_DEPLOYMENT_FAIL)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         // THIRD: Validations that push 0 to the stack without returning reserved gas but incrementing deployer's nonce
@@ -638,7 +638,7 @@ impl VM {
         if new_account.has_code_or_nonce() {
             increment_account_nonce(&mut self.cache, &self.db, deployer_address)?;
             current_call_frame.stack.push(CREATE_DEPLOYMENT_FAIL)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         // FOURTH: Changes to the state
@@ -719,7 +719,7 @@ impl VM {
             }
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -757,7 +757,7 @@ impl VM {
                 .checked_sub(gas_limit)
                 .ok_or(InternalError::GasOverflow)?;
             current_call_frame.stack.push(REVERT_FOR_CALL)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         // 2. Validate max depth has not been reached yet.
@@ -772,7 +772,7 @@ impl VM {
                 .checked_sub(gas_limit)
                 .ok_or(InternalError::GasOverflow)?;
             current_call_frame.stack.push(REVERT_FOR_CALL)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         if bytecode.is_empty() && is_delegation {
@@ -781,7 +781,7 @@ impl VM {
                 .checked_sub(gas_limit)
                 .ok_or(InternalError::GasOverflow)?;
             current_call_frame.stack.push(SUCCESS_FOR_CALL)?;
-            return Ok(OpcodeResult::Continue);
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
         let mut new_call_frame = CallFrame::new(
@@ -842,6 +842,6 @@ impl VM {
             }
         }
 
-        Ok(OpcodeResult::Continue)
+        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -255,8 +255,8 @@ impl VM {
                 Ok(OpcodeResult::Continue { pc_increment }) => {
                     current_call_frame.increment_pc_by(pc_increment)?
                 }
-                Ok(OpcodeResult::Halt(reason)) => {
-                    return self.handle_opcode_result(reason, current_call_frame, backup)
+                Ok(OpcodeResult::Halt) => {
+                    return self.handle_opcode_result(current_call_frame, backup)
                 }
                 Err(error) => return self.handle_opcode_error(error, current_call_frame, backup),
             }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -860,7 +860,6 @@ impl VM {
             logs: vec![],
             new_state: HashMap::default(),
             output: Bytes::new(),
-            created_address: None,
         };
 
         self.post_execution_changes(initial_call_frame, &mut report)?;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -252,7 +252,9 @@ impl VM {
             let op_result = self.handle_current_opcode(opcode, current_call_frame);
 
             match op_result {
-                Ok(OpcodeResult::Continue) => {}
+                Ok(OpcodeResult::Continue { pc_increment }) => {
+                    current_call_frame.increment_pc_by(pc_increment)?
+                }
                 Ok(OpcodeResult::Halt(reason)) => {
                     return self.handle_opcode_result(reason, current_call_frame, backup)
                 }

--- a/crates/vm/levm/tests/edge_case_tests.rs
+++ b/crates/vm/levm/tests/edge_case_tests.rs
@@ -109,7 +109,7 @@ fn push_with_overflow() {
     let mut current_call_frame = vm.call_frames.pop().unwrap();
     vm.execute(&mut current_call_frame).unwrap();
 
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 33);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 33);
 }
 
 #[test]

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -75,7 +75,7 @@ fn add_op() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert!(vm.current_call_frame_mut().unwrap().stack.pop().unwrap() == U256::one());
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 67);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 67);
 }
 
 #[test]
@@ -1381,7 +1381,7 @@ fn keccak256_zero_offset_size_four() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from("0x29045a592007d0c246ef02c2223570da9522d0cf0f73282c79a1bc8f0bb2c238")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 39);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 39);
     assert_eq!(current_call_frame.gas_used, 52);
 }
 
@@ -1411,7 +1411,7 @@ fn keccak256_zero_offset_size_bigger_than_actual_memory() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap()
             == U256::from("0xae75624a7d0413029c1e0facdd38cc8e177d9225892e2490a69c2f1f89512061")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 39);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 39);
     assert_eq!(current_call_frame.gas_used, 61);
 }
 
@@ -1433,7 +1433,7 @@ fn keccak256_zero_offset_zero_size() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 3);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 3);
     assert_eq!(current_call_frame.gas_used, 34);
 }
 
@@ -1463,7 +1463,7 @@ fn keccak256_offset_four_size_four() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from("0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 40);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 40);
     assert_eq!(current_call_frame.gas_used, 53);
 }
 
@@ -1485,7 +1485,7 @@ fn mstore() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from(32)
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 68);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 68);
     assert_eq!(current_call_frame.gas_used, 14);
 }
 
@@ -2979,7 +2979,7 @@ fn jump_op() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from(10)
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 69);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 69);
     assert_eq!(current_call_frame.gas_used, 15);
 }
 
@@ -3530,7 +3530,7 @@ fn push0_ok() {
         vm.current_call_frame_mut().unwrap().stack.stack[0],
         U256::zero()
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 1);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 1);
 }
 
 #[test]
@@ -3543,7 +3543,7 @@ fn push1_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 2);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 2);
 }
 
 #[test]
@@ -3556,7 +3556,7 @@ fn push5_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 6);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 6);
 }
 
 #[test]
@@ -3569,7 +3569,7 @@ fn push31_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 32);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 32);
 }
 
 #[test]
@@ -3582,7 +3582,7 @@ fn push32_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 33);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 33);
 }
 
 #[test]
@@ -3601,7 +3601,7 @@ fn dup1_ok() {
     let stack_len = vm.current_call_frame_mut().unwrap().stack.len();
 
     assert_eq!(stack_len, 2);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 3);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 3);
     assert_eq!(
         vm.current_call_frame_mut().unwrap().stack.stack[stack_len - 1],
         value
@@ -3667,7 +3667,7 @@ fn swap1_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.len(), 2);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 5);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 5);
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], top);
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[1], bottom);
 }
@@ -3688,7 +3688,7 @@ fn swap16_ok() {
     let stack_len = vm.current_call_frame_mut().unwrap().stack.len();
 
     assert_eq!(stack_len, 17);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 20);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 20);
     assert_eq!(
         vm.current_call_frame_mut().unwrap().stack.stack[stack_len - 1],
         bottom

--- a/crates/vm/levm/tests/tests.rs
+++ b/crates/vm/levm/tests/tests.rs
@@ -75,7 +75,7 @@ fn add_op() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert!(vm.current_call_frame_mut().unwrap().stack.pop().unwrap() == U256::one());
-    assert!(vm.current_call_frame_mut().unwrap().pc() == 68);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 67);
 }
 
 #[test]
@@ -1381,7 +1381,7 @@ fn keccak256_zero_offset_size_four() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from("0x29045a592007d0c246ef02c2223570da9522d0cf0f73282c79a1bc8f0bb2c238")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 40);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 39);
     assert_eq!(current_call_frame.gas_used, 52);
 }
 
@@ -1411,7 +1411,7 @@ fn keccak256_zero_offset_size_bigger_than_actual_memory() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap()
             == U256::from("0xae75624a7d0413029c1e0facdd38cc8e177d9225892e2490a69c2f1f89512061")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 40);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 39);
     assert_eq!(current_call_frame.gas_used, 61);
 }
 
@@ -1433,7 +1433,7 @@ fn keccak256_zero_offset_zero_size() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 4);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 3);
     assert_eq!(current_call_frame.gas_used, 34);
 }
 
@@ -1463,7 +1463,7 @@ fn keccak256_offset_four_size_four() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from("0xe8e77626586f73b955364c7b4bbf0bb7f7685ebd40e852b164633a4acbd3244c")
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 41);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 40);
     assert_eq!(current_call_frame.gas_used, 53);
 }
 
@@ -1485,7 +1485,7 @@ fn mstore() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from(32)
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 69);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 68);
     assert_eq!(current_call_frame.gas_used, 14);
 }
 
@@ -2979,7 +2979,7 @@ fn jump_op() {
         vm.current_call_frame_mut().unwrap().stack.pop().unwrap(),
         U256::from(10)
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 70);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 69);
     assert_eq!(current_call_frame.gas_used, 15);
 }
 
@@ -3530,7 +3530,7 @@ fn push0_ok() {
         vm.current_call_frame_mut().unwrap().stack.stack[0],
         U256::zero()
     );
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 2);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 1);
 }
 
 #[test]
@@ -3543,7 +3543,7 @@ fn push1_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 3);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 2);
 }
 
 #[test]
@@ -3556,7 +3556,7 @@ fn push5_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 7);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 6);
 }
 
 #[test]
@@ -3569,7 +3569,7 @@ fn push31_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 33);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 32);
 }
 
 #[test]
@@ -3582,7 +3582,7 @@ fn push32_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], to_push);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 34);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 33);
 }
 
 #[test]
@@ -3601,7 +3601,7 @@ fn dup1_ok() {
     let stack_len = vm.current_call_frame_mut().unwrap().stack.len();
 
     assert_eq!(stack_len, 2);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 4);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 3);
     assert_eq!(
         vm.current_call_frame_mut().unwrap().stack.stack[stack_len - 1],
         value
@@ -3627,7 +3627,7 @@ fn dup16_ok() {
     let stack_len = vm.current_call_frame_mut().unwrap().stack.len();
 
     assert_eq!(stack_len, 17);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 19);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc, 18);
     assert_eq!(
         vm.current_call_frame_mut().unwrap().stack.stack[stack_len - 1],
         value
@@ -3667,7 +3667,7 @@ fn swap1_ok() {
     vm.execute(&mut current_call_frame).unwrap();
 
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.len(), 2);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 6);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 5);
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[0], top);
     assert_eq!(vm.current_call_frame_mut().unwrap().stack.stack[1], bottom);
 }
@@ -3688,7 +3688,7 @@ fn swap16_ok() {
     let stack_len = vm.current_call_frame_mut().unwrap().stack.len();
 
     assert_eq!(stack_len, 17);
-    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 21);
+    assert_eq!(vm.current_call_frame_mut().unwrap().pc(), 20);
     assert_eq!(
         vm.current_call_frame_mut().unwrap().stack.stack[stack_len - 1],
         bottom


### PR DESCRIPTION
**Motivation**

Make the increment of the PC "generalized". Right now, we increment the PC by 1 every time; which requires some additional logic for the cases where the PC should _not_ be increment (such as JUMP and JUMPI).

**Description**

Every OPCODE now returns how much they should increment the PC. This avoids issues where some Opcode increment the PC by different amount at different times; thus leaving the window open for state changes.

With this the increment of the PC is done in a single place. 

Also, remove the following:
- Method `increment_pc` from VM.
- `pc()` method from VM.
- Remove `HaltReason` enum. It was not being used.
- `created_address` member variable from `TransactionReport` since it was not being used. 

Closes #1833

