### PR TITLE
chore(l1): change `clientId` to `Ethrex` in p2p.

### DIFF
--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -65,7 +65,7 @@ impl RLPxMessage for HelloMessage {
     fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         Encoder::new(&mut buf)
             .encode_field(&5_u8) // protocolVersion
-            .encode_field(&"Ethereum(++)/1.0.0") // clientId
+            .encode_field(&"Ethrex/0.1.0") // clientId
             .encode_field(&self.capabilities) // capabilities
             .encode_field(&0u8) // listenPort (ignored)
             .encode_field(&pubkey2id(&self.node_id)) // nodeKey


### PR DESCRIPTION
**Motivation**
So that when communicating with other nodes, they know we're Ethrex and not this generic name.
