### PR TITLE
feat(l1): update EF tests to use Prague pre-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ jwt.hex
 # Used by the make test target
 /tmp
 
-tests_v3.0.0.tar.gz
+tests*.tar.gz
 
 .env
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ lint: ## 🧹 Linter check
 	cargo clippy --all-targets --all-features --workspace --exclude ethrex-prover -- -D warnings
 
 SPECTEST_VERSION := v3.0.0
-SPECTEST_ARTIFACT := tests_$(SPECTEST_VERSION).tar.gz
+SPECTEST_LINK := https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-5%40v1.3.0/fixtures_pectra-devnet-5.tar.gz
+SPECTEST_ARTIFACT := tests.tar.gz
 SPECTEST_VECTORS_DIR := cmd/ef_tests/ethrex/vectors
 
 CRATE ?= *
@@ -34,12 +35,13 @@ run-image: build-image ## 🏃 Run the Docker image
 	docker run --rm -p 127.0.0.1:8545:8545 ethrex --http.addr 0.0.0.0
 
 $(SPECTEST_ARTIFACT):
-	rm -f tests_*.tar.gz # Delete older versions
-	curl -L -o $(SPECTEST_ARTIFACT) "https://github.com/ethereum/execution-spec-tests/releases/download/$(SPECTEST_VERSION)/fixtures_stable.tar.gz"
+	rm -f tests.tar.gz # Delete older versions
+	curl -L -o $(SPECTEST_ARTIFACT) $(SPECTEST_LINK)
 
 $(SPECTEST_VECTORS_DIR): $(SPECTEST_ARTIFACT)
 	mkdir -p $(SPECTEST_VECTORS_DIR) tmp
 	tar -xzf $(SPECTEST_ARTIFACT) -C tmp
+	rm -rf $(SPECTEST_VECTORS_DIR)/*
 	mv tmp/fixtures/blockchain_tests/* $(SPECTEST_VECTORS_DIR)
 
 download-test-vectors: $(SPECTEST_VECTORS_DIR) ## 📥 Download test vectors

--- a/cmd/ef_tests/ethrex/Cargo.toml
+++ b/cmd/ef_tests/ethrex/Cargo.toml
@@ -27,3 +27,7 @@ harness = false
 [[test]]
 name = "shanghai"
 harness = false
+
+[[test]]
+name = "prague"
+harness = false

--- a/cmd/ef_tests/ethrex/network.rs
+++ b/cmd/ef_tests/ethrex/network.rs
@@ -41,27 +41,44 @@ lazy_static! {
         cancun_time: Some(0),
         ..*SHANGHAI_CONFIG
     };
+    pub static ref CANCUN_TO_PRAGUE_AT_15K_CONFIG: ChainConfig = ChainConfig {
+        prague_time: Some(0x3a98),
+        ..*CANCUN_CONFIG
+    };
+    pub static ref PRAGUE_CONFIG: ChainConfig = ChainConfig {
+        prague_time: Some(0),
+        ..*CANCUN_CONFIG
+    };
 }
 
-#[derive(Debug, Deserialize)]
+// NOTE: We implement some dummy forks which won't be implemented, just so we can parse the tests
+#[derive(Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Network {
+    London = 0, // Dummy fork
+    Berlin = 1, // Dummy fork
     #[serde(alias = "Paris")]
-    Merge,
+    Merge = 2,
     #[serde(alias = "ParisToShanghaiAtTime15k")]
-    MergeToShanghaiAtTime15k,
-    Shanghai,
-    ShanghaiToCancunAtTime15k,
-    Cancun,
+    MergeToShanghaiAtTime15k = 3,
+    Shanghai = 4,
+    ShanghaiToCancunAtTime15k = 5,
+    Cancun = 6,
+    CancunToPragueAtTime15k = 7,
+    Prague = 8,
 }
 
 impl Network {
     pub fn chain_config(&self) -> &ChainConfig {
         match self {
+            Network::London => &MERGE_CONFIG, // Dummy fork
+            Network::Berlin => &MERGE_CONFIG, // Dummy fork
             Network::Merge => &MERGE_CONFIG,
             Network::MergeToShanghaiAtTime15k => &MERGE_TO_SHANGHAI_AT_15K_CONFIG,
             Network::Shanghai => &SHANGHAI_CONFIG,
             Network::ShanghaiToCancunAtTime15k => &SHANGHAI_TO_CANCUN_AT_15K_CONFIG,
             Network::Cancun => &CANCUN_CONFIG,
+            Network::CancunToPragueAtTime15k => &CANCUN_TO_PRAGUE_AT_15K_CONFIG,
+            Network::Prague => &PRAGUE_CONFIG,
         }
     }
 }

--- a/cmd/ef_tests/ethrex/tests/cancun.rs
+++ b/cmd/ef_tests/ethrex/tests/cancun.rs
@@ -1,33 +1,65 @@
+use ef_tests_ethrex::{
+    network::Network,
+    test_runner::{parse_test_file, run_ef_test},
+};
 use std::path::Path;
 
-use ef_tests_ethrex::test_runner::{parse_test_file, run_ef_test};
+// NOTE: There are many tests which are failing due to the usage of Prague fork.
+// These tests are distributed in almost all json test files.
+// The `parse_and_execute_only_cancun` function will filter those tests after parsing them
+// this will mark said tests as passed, so they will become a false positive.
+// The idea is to move those tests to be executed with the `parse_and_execute_all` function once
+// Prague development starts.
+// This modification should be made on the harness down below, matching the regex with the desired
+// test or set of tests
 
-fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
+fn parse_and_execute_until_cancun(path: &Path) -> datatest_stable::Result<()> {
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
+        if test.network < Network::Merge || test.network >= Network::CancunToPragueAtTime15k {
+            // These tests fall into the not developed or not-yet-developed forks, so we filter
+            // them. This produces false positives
+            continue;
+        }
         run_ef_test(&test_key, &test);
     }
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn parse_and_execute_all(path: &Path) -> datatest_stable::Result<()> {
+    let tests = parse_test_file(path);
+
+    for (test_key, test) in tests {
+        if test.network < Network::Merge {
+            // These tests fall into the not supported forks. This produces false positives
+            continue;
+        }
+        run_ef_test(&test_key, &test);
+    }
+
     Ok(())
 }
 
 datatest_stable::harness!(
-    parse_and_execute,
+    parse_and_execute_until_cancun,
     "vectors/cancun/",
     r"eip1153_tstore/.*/.*\.json",
-    parse_and_execute,
+    parse_and_execute_until_cancun,
     "vectors/cancun/",
     r"eip4788_beacon_root/.*/.*\.json",
-    parse_and_execute,
+    parse_and_execute_until_cancun,
     "vectors/cancun/",
     r"eip5656_mcopy/.*/.*\.json",
-    parse_and_execute,
+    parse_and_execute_until_cancun,
     "vectors/cancun/",
     r"eip7516_blobgasfee/.*/.*\.json",
-    parse_and_execute,
+    parse_and_execute_until_cancun,
     "vectors/cancun/",
     r"eip6780_selfdestruct/.*/.*\.json",
-    parse_and_execute,
+    parse_and_execute_until_cancun,
     "vectors/cancun/",
     r"eip4844_blobs/.*/.*\.json",
 );

--- a/cmd/ef_tests/ethrex/tests/prague.rs
+++ b/cmd/ef_tests/ethrex/tests/prague.rs
@@ -5,11 +5,12 @@ use ef_tests_ethrex::{
     test_runner::{parse_test_file, run_ef_test},
 };
 
+#[allow(dead_code)]
 fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
-        if test.network < Network::Merge || test.network >= Network::Prague {
+        if test.network < Network::Merge {
             // Discard this test
             continue;
         }
@@ -19,4 +20,10 @@ fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(parse_and_execute, "vectors/shanghai/", r".*/.*/.*\.json");
+// TODO: Delete main function and uncomment the following line to allow prague tests to be parsed
+
+// datatest_stable::harness!(parse_and_execute, "vectors/prague/", r".*/.*/.*\.json");
+
+fn main() {
+    //Do nothing
+}

--- a/cmd/ef_tests/ethrex/types.rs
+++ b/cmd/ef_tests/ethrex/types.rs
@@ -25,6 +25,31 @@ pub struct TestUnit {
     pub post_state: HashMap<Address, Account>,
     pub pre: HashMap<Address, Account>,
     pub seal_engine: serde_json::Value,
+    pub config: FixtureConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureConfig {
+    pub blob_schedule: Option<BlobSchedule>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkBlobSchedule {
+    #[serde(default, with = "ethrex_core::serde_utils::u64::hex_str")]
+    pub target: u64,
+    #[serde(default, with = "ethrex_core::serde_utils::u64::hex_str")]
+    pub max: u64,
+    #[serde(default, with = "ethrex_core::serde_utils::u64::hex_str")]
+    pub base_fee_update_fraction: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BlobSchedule {
+    pub cancun: Option<ForkBlobSchedule>,
+    pub prague: Option<ForkBlobSchedule>,
 }
 
 impl TestUnit {
@@ -63,6 +88,7 @@ impl TestUnit {
                 .genesis_block_header
                 .excess_blob_gas
                 .map(|v| v.as_u64()),
+            requests_hash: self.genesis_block_header.requests_hash,
         }
     }
 }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -159,6 +159,7 @@ pub fn validate_block(
     // Verify initial header validity against parent
     validate_block_header(&block.header, parent_header).map_err(InvalidBlockError::from)?;
 
+    // TODO: Properly handle these validations for Cancun and Prague
     match spec {
         spec if spec >= SpecId::CANCUN => {
             validate_post_cancun_header_fields(&block.header, parent_header)

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -8,7 +8,7 @@ use ethrex_core::{
         calculate_base_fee_per_blob_gas, calculate_base_fee_per_gas, compute_receipts_root,
         compute_transactions_root, compute_withdrawals_root, BlobsBundle, Block, BlockBody,
         BlockHash, BlockHeader, BlockNumber, ChainConfig, MempoolTransaction, Receipt, Transaction,
-        Withdrawal, DEFAULT_OMMERS_HASH,
+        Withdrawal, DEFAULT_OMMERS_HASH, DEFAULT_REQUESTS_HASH,
     },
     Address, Bloom, Bytes, H256, U256,
 };
@@ -125,8 +125,9 @@ pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block,
             ),
         ),
         parent_beacon_block_root: args.beacon_root,
-        // TODO: set the value properly
-        requests_hash: None,
+        requests_hash: chain_config
+            .is_prague_activated(args.timestamp)
+            .then_some(*DEFAULT_REQUESTS_HASH),
     };
 
     let body = BlockBody {

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -28,6 +28,7 @@ use once_cell::sync::OnceCell;
 
 lazy_static! {
     pub static ref DEFAULT_OMMERS_HASH: H256 = H256::from_slice(&hex::decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347").unwrap()); // = Keccak256(RLP([])) as of EIP-3675
+    pub static ref DEFAULT_REQUESTS_HASH: H256 = H256::from_slice(&hex::decode("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").unwrap()); // = Sha256([])) as of EIP-7685
 }
 #[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Block {

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 
 use super::{
     compute_receipts_root, compute_transactions_root, compute_withdrawals_root, AccountState,
-    Block, BlockBody, BlockHeader, BlockNumber, DEFAULT_OMMERS_HASH, INITIAL_BASE_FEE,
+    Block, BlockBody, BlockHeader, BlockNumber, DEFAULT_OMMERS_HASH, DEFAULT_REQUESTS_HASH,
+    INITIAL_BASE_FEE,
 };
 
 #[allow(unused)]
@@ -38,6 +39,7 @@ pub struct Genesis {
     pub blob_gas_used: Option<u64>,
     #[serde(default, with = "crate::serde_utils::u64::hex_str_opt")]
     pub excess_blob_gas: Option<u64>,
+    pub requests_hash: Option<H256>,
 }
 
 /// Blockchain settings defined per block
@@ -272,11 +274,10 @@ impl Genesis {
                 .config
                 .is_cancun_activated(self.timestamp)
                 .then_some(H256::zero()),
-            // TODO: set the value properly
             requests_hash: self
                 .config
                 .is_prague_activated(self.timestamp)
-                .then_some(H256::zero()),
+                .then_some(self.requests_hash.unwrap_or(*DEFAULT_REQUESTS_HASH)),
         }
     }
 


### PR DESCRIPTION
**Motivation**

We need a suite of tests to check our Prague implementation.

**Description**

This PR updates the EF tests to the latest [pre-release version](https://github.com/ethereum/execution-spec-tests/releases/tag/pectra-devnet-5%40v1.3.0), which includes Prague tests.

> [!IMPORTANT]
> Changes were introduced on how tests are parsed, so many tests will be shown as passing. These are false positives.
> Read below

The EF tests are organized in different directories. There is one directory per fork, each containing subdirectories for their implemented EIPs. For each of said EIPs there are many json files, which contain the information to run the tests. Those json files not only test the corresponding EIP fork, but also the remaining ones. For example, under `cancun` directory we may find some json files which not only test the EIPs on a `cancun` fork, but also on `Prague`. This is also true for the remaining forks.
Because of this, a filter was included in this PR so not-supported or not-yet-implemented forks tests are ignored. The idea is to loose this filter restriction while implementing Prague functionality. The crate that it's being used for parsing these tests is `datatest_stable`, and it does not provide a way of indicating that a test has been ignored, so all ignored tests will be marked as passing, producing false positives.


