### PR TITLE
refactor(l2): fix typo: `start_l1_commiter` -> `start_l1_committer`

### DIFF
--- a/crates/l2/proposer/l1_committer.rs
+++ b/crates/l2/proposer/l1_committer.rs
@@ -41,7 +41,7 @@ pub struct Committer {
     arbitrary_base_blob_gas_price: u64,
 }
 
-pub async fn start_l1_commiter(store: Store) -> Result<(), ConfigError> {
+pub async fn start_l1_committer(store: Store) -> Result<(), ConfigError> {
     let eth_config = EthConfig::from_env()?;
     let committer_config = CommitterConfig::from_env()?;
     let committer = Committer::new_from_config(&committer_config, eth_config, store);

--- a/crates/l2/proposer/mod.rs
+++ b/crates/l2/proposer/mod.rs
@@ -35,7 +35,7 @@ pub async fn start_proposer(store: Store) {
 
     let mut task_set = JoinSet::new();
     task_set.spawn(l1_watcher::start_l1_watcher(store.clone()));
-    task_set.spawn(l1_committer::start_l1_commiter(store.clone()));
+    task_set.spawn(l1_committer::start_l1_committer(store.clone()));
     task_set.spawn(prover_server::start_prover_server(store.clone()));
     task_set.spawn(start_proposer_server(store.clone()));
     #[cfg(feature = "metrics")]


### PR DESCRIPTION
**Motivation**

`start_l1_commiter` has a typo. 

**Description**

Change the name of the function `start_l1_commiter` to `start_l1_committer`
