### PR TITLE
fix(l1): add network folder to docker image so bootnodes can be setup in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN cargo build --release $BUILD_FLAGS
 FROM ubuntu:24.04
 WORKDIR /usr/local/bin
 
+COPY cmd/ethrex/networks ./cmd/ethrex/networks
 COPY --from=builder ethrex/target/release/ethrex .
 EXPOSE 8545
 ENTRYPOINT [ "./ethrex" ]


### PR DESCRIPTION
Closes #1857 

