### PR TITLE
fix(l1): change the fork check for greater or equal rather than equal on beacon call

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -237,7 +237,7 @@ pub fn build_payload(
 pub fn apply_withdrawals(context: &mut PayloadBuildContext) -> Result<(), EvmError> {
     // Apply withdrawals & call beacon root contract, and obtain the new state root
     let spec_id = spec_id(&context.chain_config()?, context.payload.header.timestamp);
-    if context.payload.header.parent_beacon_block_root.is_some() && spec_id == SpecId::CANCUN {
+    if context.payload.header.parent_beacon_block_root.is_some() && spec_id >= SpecId::CANCUN {
         beacon_root_contract_call(context.evm_state, &context.payload.header, spec_id)?;
     }
     let withdrawals = context.payload.body.withdrawals.clone().unwrap_or_default();

--- a/crates/vm/vm.rs
+++ b/crates/vm/vm.rs
@@ -224,7 +224,7 @@ cfg_if::cfg_if! {
             //eip 4788: execute beacon_root_contract_call before block transactions
             cfg_if::cfg_if! {
                 if #[cfg(not(feature = "l2"))] {
-                    if block_header.parent_beacon_block_root.is_some() && fork == Fork::Cancun {
+                    if block_header.parent_beacon_block_root.is_some() && fork >= Fork::Cancun {
                         let report = beacon_root_contract_call_levm(store_wrapper.clone(), block_header, fork)?;
                         block_cache.extend(report.new_state);
                     }
@@ -342,7 +342,7 @@ cfg_if::cfg_if! {
             cfg_if::cfg_if! {
                 if #[cfg(not(feature = "l2"))] {
                     //eip 4788: execute beacon_root_contract_call before block transactions
-                    if block_header.parent_beacon_block_root.is_some() && spec_id == SpecId::CANCUN {
+                    if block_header.parent_beacon_block_root.is_some() && spec_id >= SpecId::CANCUN {
                         beacon_root_contract_call(state, block_header, spec_id)?;
                     }
                 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

In this PR we change the check for doing the beacon root call to make it work for future forks begging in Cancun

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

Change the equal assertion of the fork to a greater or equal assertion

<!-- Link to issues: Resolves #111, Resolves #222 -->


