### PR TITLE
fix(l2): fix zkVM programs

### DIFF
--- a/.github/workflows/ci_l2_prover.yaml
+++ b/.github/workflows/ci_l2_prover.yaml
@@ -4,8 +4,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
-    paths:
-      - "crates/l2/prover/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7122,7 +7122,7 @@ dependencies = [
  "bytes",
  "elf",
  "enum-map",
- "getrandom 0.2.15",
+ "getrandom",
  "hex",
  "keccak",
  "lazy-regex",
@@ -7159,7 +7159,7 @@ checksum = "a6b5ac61f6d36b02655a415a8a2afd021aa260402d45deff5524c80dbc521f29"
 dependencies = [
  "bytemuck",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "libm",
  "stability",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce58205497760ded0e4c743bc7a7aee28da5ca29b4adb7a635bf3bee2d118ebc"
+checksum = "32a6c42e9ac4df9f62aade6f4a7fab56db33d4518d1cac37434f040f610f6d40"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "jobserver",
  "libc",
@@ -4863,6 +4863,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6845,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fb75d62d70320adc7adae2abad354a3b7565603115dfb3134465227846475"
+checksum = "fac7b3a4d7f6e86b2be2daf0ec53b9b8740895ff8279011cee24e4bae72cd77e"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6860,9 +6871,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99fb40aeeaf59dddd6b6c3a177c95e8b3c7f0fb6de7d25a0687d12398323292"
+checksum = "4481ff9a05c3d96c0df2278a4681172fb40291253049a3ab57ffa2c46c24a0ba"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6879,9 +6890,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4442d03cc80f55629df6eb79dbb406d0e637ea2b683a430404dd25b46eadcd33"
+checksum = "23f29e33a7c90e9c326e2af642030ff155f88338ebbf09d64ac5faacabd423e1"
 dependencies = [
  "cc",
  "directories",
@@ -6890,14 +6901,51 @@ dependencies = [
  "rayon",
  "sha2 0.10.8",
  "tempfile",
- "which 6.0.3",
+]
+
+[[package]]
+name = "risc0-circuit-keccak"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25beb2e593a72e4baa3ed9a18a2ee4148f629bfa9dcdac5cbe84faa12d2590d1"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "cfg-if",
+ "keccak",
+ "paste",
+ "rayon",
+ "risc0-binfmt",
+ "risc0-circuit-keccak-sys",
+ "risc0-circuit-recursion",
+ "risc0-core",
+ "risc0-sys",
+ "risc0-zkp",
+ "tracing",
+ "xz2",
+]
+
+[[package]]
+name = "risc0-circuit-keccak-sys"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a910fc9d6c0b57628326b38358c5bd2bfb44d4588e6308a08072e7a4dd31378"
+dependencies = [
+ "cc",
+ "cust",
+ "derive_more 1.0.0",
+ "glob",
+ "risc0-build-kernel",
+ "risc0-core",
+ "risc0-sys",
+ "sppark",
 ]
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b0736401dd72a60a775e675bd0adba2e0e0e2ce2b73b63fda2899d9d7889b0"
+checksum = "e02357d6333355b2f9f3903149757fec59c59ef7cefd7494738446f33148cd00"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -6921,9 +6969,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cdee375eb66d84b1f2e78e756071734e9a8271018b4351a7f158ea806838afa"
+checksum = "d2ef7b40cbafb07ec994c4d317096e72cf22998f6c0e7873db31bbb2f6377478"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -6934,9 +6982,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6d7eb9ae600c2df004bf8849db2df870fd56bd5911a2ad756fb8701350b3c6"
+checksum = "d062e3ee0a8a788cfeff90777e95792d58520fb71b40c28a04000277a3f0054d"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -6947,6 +6995,7 @@ dependencies = [
  "crypto-bigint",
  "cust",
  "derive_more 1.0.0",
+ "enum-map",
  "lazy-regex",
  "metal",
  "num-bigint 0.4.6",
@@ -6967,9 +7016,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964920cf4c65ed1a5bb211debb31ef6147160a858d55ec12975a2da3062064b3"
+checksum = "28a380438dbfcc4e1780f455bb63d3aac7c821e06e188f18652467915209d4f9"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -6980,9 +7029,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733491635d50b742d1f30a923aa3b83d62f35cef724bbf402dfc02e6f10f587a"
+checksum = "da950fcd306644dc5c2c0a09ad288901450eb5f41c42f4f2120be2949f63cd2e"
 dependencies = [
  "bytemuck",
  "nvtx",
@@ -6992,9 +7041,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5babc69b0db6906a6ff4011641109ca2ba06636096356b32208b0dfb26b3809"
+checksum = "414481d8f3f8c666a7f45b03dd9c5e32cc6dadb2abd0f55b9460386f731eeb4a"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -7017,12 +7066,11 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93d549191707c61dfb45b61ccc6b1de11fe054ae24cf73efedd6ea850dc0690"
+checksum = "048046fedafcab0084477b31a8ba3b9e25c6dc9d0fa5fafa7ed16de03f46e459"
 dependencies = [
  "anyhow",
- "cc",
  "cust",
  "risc0-build-kernel",
  "sppark",
@@ -7030,9 +7078,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eadc5099bf0d8ecaed718810dc5deaf237ae39a2fcb66e542e8f9660132617"
+checksum = "ddf3776370f26ea04e50f7e6f9d2468807aa1049063ca1b9000e1974d092ddc5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -7061,9 +7109,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b619085d02d57dcafc41eb74714682797ed666621ced1814c55bbe7ae7762ba"
+checksum = "6700c4875b90726b7bf9e981fccbde4ea11b3593d3b2ac6fa09c96f6de166152"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -7073,8 +7121,10 @@ dependencies = [
  "bytemuck",
  "bytes",
  "elf",
- "getrandom",
+ "enum-map",
+ "getrandom 0.2.15",
  "hex",
+ "keccak",
  "lazy-regex",
  "num-bigint 0.4.6",
  "num-traits",
@@ -7083,6 +7133,7 @@ dependencies = [
  "rayon",
  "risc0-binfmt",
  "risc0-build",
+ "risc0-circuit-keccak",
  "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
@@ -7094,7 +7145,6 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "sha2 0.10.8",
- "sha3",
  "stability",
  "tempfile",
  "tracing",
@@ -7103,12 +7153,13 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bbcc486222a0086d36244ae1f388cac1318270bca2dd23d77af2005d679edf"
+checksum = "a6b5ac61f6d36b02655a415a8a2afd021aa260402d45deff5524c80dbc521f29"
 dependencies = [
  "bytemuck",
- "getrandom",
+ "cfg-if",
+ "getrandom 0.2.15",
  "libm",
  "stability",
 ]
@@ -8305,7 +8356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5090642d9ae844edd9a5c23cb1fce6724ca88d50c55178ee8d1f656df5826b"
 dependencies = [
  "cc",
- "which 4.4.2",
+ "which",
 ]
 
 [[package]]
@@ -9460,18 +9511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix",
- "winsafe",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9728,12 +9767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9771,6 +9804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethrex-levm = { path = "../vm/levm" }
+ethrex-levm = { path = "../vm/levm", default-features = false }
 thiserror.workspace = true
 sha3.workspace = true
 tracing.workspace = true
@@ -32,5 +32,5 @@ path = "./blockchain.rs"
 [features]
 default = ["c-kzg"]
 libmdbx = ["ethrex-core/libmdbx", "ethrex-storage/default", "ethrex-vm/libmdbx"]
-c-kzg = ["ethrex-core/c-kzg"]
+c-kzg = ["ethrex-core/c-kzg", "ethrex-levm/c-kzg"]
 metrics = ["ethrex-metrics/transactions"]

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -32,7 +32,7 @@ directories = "5.0.1"
 zkvm_interface = { path = "./prover/zkvm/interface/", default-features = false }
 
 # risc0
-risc0-zkvm = { version = "1.2.0" }
+risc0-zkvm = { version = "1.2.2" }
 # sp1
 sp1-sdk = { version = "3.4.0" }
 ethrex-sdk = { path = "./sdk" }

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -26,7 +26,7 @@ ethrex-l2.workspace = true
 zkvm_interface = { path = "./zkvm/interface", default-features = false }
 
 # risc0
-risc0-zkvm = { version = "1.2.0" }
+risc0-zkvm = { version = "1.2.2" }
 
 # sp1
 sp1-sdk = "3.4.0"

--- a/crates/l2/prover/zkvm/interface/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/Cargo.toml
@@ -26,6 +26,5 @@ default = []
 build_risc0 = []
 build_sp1 = []
 
-
 [lib]
 path = "./src/lib.rs"

--- a/crates/l2/prover/zkvm/interface/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/Cargo.toml
@@ -15,7 +15,7 @@ ethrex-storage = { path = "../../../../storage/store", default-features = false 
 ethrex-trie = { path = "../../../../storage/trie", default-features = false }
 
 [build-dependencies]
-risc0-build = { version = "1.2.0" }
+risc0-build = { version = "1.2.2" }
 sp1-build = "3.4.0"
 
 [package.metadata.risc0]

--- a/crates/l2/prover/zkvm/interface/risc0/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/risc0/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.2.0", default-features = false, features = ["std"] }
+risc0-zkvm = { version = "1.2.2", default-features = false, features = ["std"] }
 zkvm_interface = { path = "../" }
 
 ethrex-core = { path = "../../../../../common", default-features = false }

--- a/crates/l2/prover/zkvm/interface/risc0/src/main.rs
+++ b/crates/l2/prover/zkvm/interface/risc0/src/main.rs
@@ -1,7 +1,7 @@
 use risc0_zkvm::guest::env;
 
 use ethrex_blockchain::{validate_block, validate_gas_used};
-use ethrex_vm::{execute_block, get_state_transitions, EvmState};
+use ethrex_vm::{backends::revm::execute_block, get_state_transitions, db::EvmState};
 use zkvm_interface::{
     io::{ProgramInput, ProgramOutput},
     trie::{update_tries, verify_db},

--- a/crates/l2/prover/zkvm/interface/sp1/src/main.rs
+++ b/crates/l2/prover/zkvm/interface/sp1/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use ethrex_blockchain::{validate_block, validate_gas_used};
-use ethrex_vm::{execute_block, get_state_transitions, EvmState};
+use ethrex_vm::{backends::revm::execute_block, db::EvmState, get_state_transitions};
 use zkvm_interface::{
     io::{ProgramInput, ProgramOutput},
     trie::{update_tries, verify_db},

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 ethrex-core = { path = "../common", default-features = false }
 ethrex-storage = { path = "../storage/store", default-features = false }
-ethrex-levm = { path = "./levm" }
+ethrex-levm = { path = "./levm", default-features = false }
 ethrex-trie = { path = "../storage/trie", default-features = false }
 ethrex-rlp = { path = "../common/rlp", default-features = false }
 revm = { version = "18.0.0", features = [
@@ -40,7 +40,7 @@ path = "./vm.rs"
 [features]
 default = ["c-kzg", "blst"]
 l2 = []
-c-kzg = ["revm/c-kzg"]
+c-kzg = ["revm/c-kzg", "ethrex-levm/c-kzg", "ethrex-core/c-kzg"]
 blst = ["revm/blst"]
 libmdbx = ["ethrex-storage/default", "ethrex-core/libmdbx"]
 

--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-ethrex-core.workspace = true
+ethrex-core = { path = "../../common", default-features = false }
 ethrex-rlp.workspace = true
 revm-primitives = { version = "14.0.0", features = [
   "std",
@@ -26,17 +26,23 @@ num-bigint = "0.4.5"
 lambdaworks-math = "0.11.0"
 k256 = { version = "0.13.3", features = ["ecdh"] }
 kzg-rs = "0.2.3"
-bls12_381 = { git = "https://github.com/lambdaclass/bls12_381", branch = "expose-fp-struct", features = ["groups", "bits", "pairings", "alloc", "experimental"] }
+bls12_381 = { git = "https://github.com/lambdaclass/bls12_381", branch = "expose-fp-struct", features = [
+  "groups",
+  "bits",
+  "pairings",
+  "alloc",
+  "experimental",
+] }
 
 [dev-dependencies]
 hex.workspace = true
 colored = "2.1.0"
 spinoff = "0.8.0"
 
-
 [features]
+default = ["c-kzg"]
+c-kzg = ["ethrex-core/c-kzg"]
 ethereum_foundation_tests = []
-
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

zkVM programs fail to compile after #1861 was merged to main. This PR fixes the problem and bumps provers' versions.

L2 breaking changes keep being merged because the prover compilation job isn't run in pushes that don't modify the L2 code, but the L2 is strongly dependent on L1 code. This PR enables the job for all pushes. The job takes ~13 minutes to complete, which is comparable to other jobs which run on all pushes.

<!-- A clear and concise general description of the changes this PR introduces -->

- fixes `ethrex-levm` adding c-kzg into the zkVMs programs dependency tree
- bumps SP1 and Risc0 versions
- enables prover CI job for all pushes

