### PR TITLE
fix(levm): fix ef tests deserialize

### DIFF
--- a/cmd/ef_tests/state/deserialize.rs
+++ b/cmd/ef_tests/state/deserialize.rs
@@ -293,7 +293,8 @@ where
         let fork = match fork_str.as_str() {
             "Frontier" => Fork::Frontier,
             "Homestead" => Fork::Homestead,
-            "Constantinople" | "ConstantinopleFix" | "Petersburg" => Fork::Constantinople,
+            "Constantinople" => Fork::Constantinople,
+            "ConstantinopleFix" | "Petersburg" => Fork::Petersburg,
             "Istanbul" => Fork::Istanbul,
             "Berlin" => Fork::Berlin,
             "London" => Fork::London,

--- a/cmd/ef_tests/state/report.rs
+++ b/cmd/ef_tests/state/report.rs
@@ -127,7 +127,7 @@ pub fn summary_for_slack(reports: &[EFTestReport]) -> String {
             "type": "section",
             "text": {{
                 "type": "mrkdwn",
-                "text": "*Summary*: {total_passed}/{total_run} ({success_percentage:.2}%)\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n"
+                "text": "*Summary*: {total_passed}/{total_run} ({success_percentage:.2}%)\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n"
             }}             
         }}
     ]
@@ -138,6 +138,7 @@ pub fn summary_for_slack(reports: &[EFTestReport]) -> String {
         fork_summary_for_slack(reports, Fork::Byzantium),
         fork_summary_for_slack(reports, Fork::Berlin),
         fork_summary_for_slack(reports, Fork::Constantinople),
+        fork_summary_for_slack(reports, Fork::Petersburg),
         fork_summary_for_slack(reports, Fork::Paris),
         fork_summary_for_slack(reports, Fork::Homestead),
         fork_summary_for_slack(reports, Fork::Istanbul),
@@ -171,13 +172,14 @@ pub fn summary_for_github(reports: &[EFTestReport]) -> String {
     let total_run = total_fork_test_run(reports);
     let success_percentage = (total_passed as f64 / total_run as f64) * 100.0;
     format!(
-        r#"Summary: {total_passed}/{total_run} ({success_percentage:.2}%)\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n"#,
+        r#"Summary: {total_passed}/{total_run} ({success_percentage:.2}%)\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n"#,
         fork_summary_for_github(reports, Fork::Prague),
         fork_summary_for_github(reports, Fork::Cancun),
         fork_summary_for_github(reports, Fork::Shanghai),
         fork_summary_for_github(reports, Fork::Byzantium),
         fork_summary_for_github(reports, Fork::Berlin),
         fork_summary_for_github(reports, Fork::Constantinople),
+        fork_summary_for_github(reports, Fork::Petersburg),
         fork_summary_for_github(reports, Fork::Paris),
         fork_summary_for_github(reports, Fork::Homestead),
         fork_summary_for_github(reports, Fork::Istanbul),
@@ -211,7 +213,7 @@ pub fn summary_for_shell(reports: &[EFTestReport]) -> String {
     let total_run = total_fork_test_run(reports);
     let success_percentage = (total_passed as f64 / total_run as f64) * 100.0;
     format!(
-        "{} {}/{total_run} ({success_percentage:.2}%)\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n\n\n{}\n",
+        "{} {}/{total_run} ({success_percentage:.2}%)\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n\n\n{}\n",
         "Summary:".bold(),
         if total_passed == total_run {
             format!("{}", total_passed).green()
@@ -228,6 +230,7 @@ pub fn summary_for_shell(reports: &[EFTestReport]) -> String {
         fork_summary_shell(reports, Fork::Berlin),
         fork_summary_shell(reports, Fork::Istanbul),
         fork_summary_shell(reports, Fork::Constantinople),
+        fork_summary_shell(reports, Fork::Petersburg),
         fork_summary_shell(reports, Fork::Byzantium),
         fork_summary_shell(reports, Fork::Homestead),
         fork_summary_shell(reports, Fork::Frontier),
@@ -349,6 +352,7 @@ impl Display for EFTestsReport {
         writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Byzantium))?;
         writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Berlin))?;
         writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Constantinople))?;
+        writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Petersburg))?;
         writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Paris))?;
         writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Homestead))?;
         writeln!(f, "{}", fork_summary_shell(&self.0, Fork::Istanbul))?;


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

In this PR we solved the wrong ef tests summaries due to incorrect fork parsing

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

We change the `"ConstantinopleFix"` to be parsed as the `Petersburg` fork, instead of the `Constantinople`

<!-- Link to issues: Resolves #111, Resolves #222 -->


