### PR TITLE
fix: discarding already connected peers

### DIFF
--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -153,12 +153,21 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         });
 
         // Discard peer from kademlia table
-        let remote_node_id = self.node.node_id;
-        log_peer_error(
-            &self.node,
-            &format!("{error_text}: ({error}), discarding peer {remote_node_id}"),
-        );
-        table.lock().await.replace_peer(remote_node_id);
+        match error {
+            // already connected, don't discard it
+            RLPxError::DisconnectRequested(s) if s == "Already connected" => {
+                log_peer_debug(&self.node, "Peer already connected don't replace it");
+            }
+            _ => {
+                // Discard peer from kademlia table
+                let remote_node_id = self.node.node_id;
+                log_peer_error(
+                    &self.node,
+                    &format!("{error_text}: ({error}), discarding peer {remote_node_id}"),
+                );
+                table.lock().await.replace_peer(remote_node_id);
+            }
+        }
     }
 
     fn match_disconnect_reason(&self, error: &RLPxError) -> Option<u8> {


### PR DESCRIPTION
**Motivation**
When running `make localnet`, we noticed the following error: 
```shell
Hello messages exchange failed: (Disconnect requested: Already connected)
```

**Description**
The problem is that the node starts a connection with us as receivers, and we also try to start one as initiators. Whichever happens first will provoke the second one and cause a disconnection because the other node will detect it as already connected. This pr is a quick fix that simply matches the `error` type, and if it detects `Already Connected` then it does not discard the peer from the table (as there is still a `tcp` conn open). A more proper fix would be to introduce a mutex when starting connections.

Closes None

