### PR TITLE
chore(l1): set full sync as default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ ethrex supports the following command line arguments:
 - `--discovery.port <PORT>`: UDP port for P2P discovery. Default value: 30303.
 - `--bootnodes <BOOTNODE_LIST>`: Comma separated enode URLs for P2P discovery bootstrap.
 - `--log.level <LOG_LEVEL>`: The verbosity level used for logs. Default value: info. possible values: info, debug, trace, warn, error
-- `--syncmode <SYNC_MODE>`: The way in which the node will sync its state. Can be either "full" or "snap" with "snap" as default value.
+- `--syncmode <SYNC_MODE>`: The way in which the node will sync its state. Can be either "full" or "snap" with "full" as default value.
 - `--evm <EVM_BACKEND>`: Has to be `levm` or `revm`. Default value: `revm`.
 
 # ethrex L2

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -109,6 +109,7 @@ pub fn cli() -> Command {
             Arg::new("syncmode")
                 .long("syncmode")
                 .required(false)
+                .default_value("full")
                 .value_name("SYNC_MODE"),
         )
         .arg(

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -376,14 +376,10 @@ fn parse_socket_addr(addr: &str, port: &str) -> io::Result<SocketAddr> {
 
 fn sync_mode(matches: &clap::ArgMatches) -> SyncMode {
     let syncmode = matches.get_one::<String>("syncmode");
-    if let Some(syncmode) = syncmode {
-        match &**syncmode {
-            "full" => SyncMode::Full,
-            "snap" => SyncMode::Snap,
-            other => panic!("Invalid syncmode {other} expected either snap or full"),
-        }
-    } else {
-        SyncMode::Snap
+    match syncmode {
+        Some(mode) if mode == "full" => SyncMode::Full,
+        Some(mode) if mode == "snap" => SyncMode::Snap,
+        other => panic!("Invalid syncmode {:?} expected either snap or full", other),
     }
 }
 


### PR DESCRIPTION
**Motivation**
Before enabling snap sync as the default, we want to have everything working smoothly with full sync.

**Description**
- Changes the default sync mode to full.

