### PR TITLE
ci(levm): remove additional steps for #1894

### DIFF
--- a/.github/scripts/compare_ef_tests.sh
+++ b/.github/scripts/compare_ef_tests.sh
@@ -27,9 +27,9 @@ do
 
    emoji=""
    if (( $(echo "$result_main > $result_pr" |bc -l) )); then
-       emoji="🔴️️"
+       emoji="⬇️️"
    elif (( $(echo "$result_main < $result_pr" |bc -l) )); then
-       emoji="️🟢"
+       emoji="⬆️"
    else
        emoji="➖️"
    fi

--- a/.github/scripts/compare_ef_tests.sh
+++ b/.github/scripts/compare_ef_tests.sh
@@ -27,9 +27,9 @@ do
 
    emoji=""
    if (( $(echo "$result_main > $result_pr" |bc -l) )); then
-       emoji="⬇️️"
+       emoji="🔴️️"
    elif (( $(echo "$result_main < $result_pr" |bc -l) )); then
-       emoji="⬆️"
+       emoji="️🟢"
    else
        emoji="➖️"
    fi

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -59,13 +59,6 @@ jobs:
           name: pr-ef-test-data
           path: crates/vm/levm/test_result_pr_short.txt
 
-        # This is only needed in the PR. As soon as this is merged, this should be deleted
-      - name: Upload comparison shell script
-        uses: actions/upload-artifact@v4
-        with:
-          name: ef-test-shell-script
-          path: .github/scripts/parse_test_result.sh
-
       - name: Check EF-TESTS status is 100%
         run: |
           cd crates/vm/levm
@@ -105,13 +98,6 @@ jobs:
       - name: Show test summary -- full
         run: |
           cd crates/vm/levm && awk '/Summary: /,0' test_result_main.txt
-
-        # This is only needed in the PR. As soon as this is merged, this should be deleted
-      - name: Download shell script
-        uses: actions/download-artifact@v4
-        with:
-          name: ef-test-shell-script
-          path: .github/scripts/
 
       - name: Show test summary -- short
         run: |


### PR DESCRIPTION
**Motivation**

Remove the additional steps used in #1894 to make the CI pass. These simply downloaded the shell script in the main branch.

**Description**
- Remove said steps.
- Change the emojis in the shell script to make it clearer.
