### PR TITLE
feat(levm): add support for eip3651_warm_coinbase test suite

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -650,7 +650,8 @@ fn address_access_cost(
 pub fn balance(address_was_cold: bool, fork: Fork) -> Result<u64, VMError> {
     match fork {
         f if f < Fork::Tangerine => Ok(BALANCE_PRE_TANGERINE),
-        f if f >= Fork::Tangerine && fork < Fork::Cancun => Ok(BALANCE_TANGERINE),
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2929.md#storage-read-changes
+        f if f >= Fork::Tangerine && fork < Fork::Berlin => Ok(BALANCE_TANGERINE),
         f => address_access_cost(
             address_was_cold,
             BALANCE_STATIC,
@@ -664,7 +665,8 @@ pub fn balance(address_was_cold: bool, fork: Fork) -> Result<u64, VMError> {
 pub fn extcodesize(address_was_cold: bool, fork: Fork) -> Result<u64, VMError> {
     match fork {
         f if f < Fork::Tangerine => Ok(EXTCODESIZE_PRE_TANGERINE),
-        f if f >= Fork::Tangerine && fork < Fork::Cancun => Ok(EXTCODESIZE_TANGERINE),
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2929.md#storage-read-changes
+        f if f >= Fork::Tangerine && fork < Fork::Berlin => Ok(EXTCODESIZE_TANGERINE),
         f => address_access_cost(
             address_was_cold,
             EXTCODESIZE_STATIC,

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -323,10 +323,21 @@ impl VM {
             return self.handle_precompile_result(precompile_result, current_call_frame, backup);
         }
 
+        dbg!(&current_call_frame.msg_sender);
+        dbg!(&current_call_frame.to);
+        dbg!(&current_call_frame.gas_used);
+        dbg!(&current_call_frame.gas_limit);
+
         loop {
             let opcode = current_call_frame.next_opcode();
 
+            dbg!(&opcode);
+
             let op_result = self.handle_current_opcode(opcode, current_call_frame);
+
+            dbg!(&current_call_frame.gas_used);
+            dbg!(&current_call_frame.stack);
+            dbg!(&op_result);
 
             match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -323,21 +323,10 @@ impl VM {
             return self.handle_precompile_result(precompile_result, current_call_frame, backup);
         }
 
-        dbg!(&current_call_frame.msg_sender);
-        dbg!(&current_call_frame.to);
-        dbg!(&current_call_frame.gas_used);
-        dbg!(&current_call_frame.gas_limit);
-
         loop {
             let opcode = current_call_frame.next_opcode();
 
-            dbg!(&opcode);
-
             let op_result = self.handle_current_opcode(opcode, current_call_frame);
-
-            dbg!(&current_call_frame.gas_used);
-            dbg!(&current_call_frame.stack);
-            dbg!(&op_result);
 
             match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

In this PR we add support for the `eip3651_warm_coinbase` test suite.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

Change the cold/warm cost for `balance` and `extcodesize` of the [eip-2929](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2929.md#storage-read-changes) to be on forks after Berlin and not after Cancun.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1916 

