### PR TITLE
ci(levm): add pipefail option to stop job execution if compilation fails

### DIFF
--- a/.github/workflows/ci_bench_levm_in_pr.yaml
+++ b/.github/workflows/ci_bench_levm_in_pr.yaml
@@ -181,6 +181,7 @@ jobs:
       - name: Run tests
         run: |
           cd crates/vm/levm
+          set -o pipefail
           make run-evm-ef-tests-ci | tee test_result.txt
 
       - name: Show test summary -- short

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Run tests
         run: |
           cd crates/vm/levm
+          set -o pipefail
           make run-evm-ef-tests-ci | tee test_result_pr.txt
 
       - name: Show test summary -- full
@@ -58,6 +59,13 @@ jobs:
         with:
           name: pr-ef-test-data
           path: crates/vm/levm/test_result_pr_short.txt
+
+        # This is only needed in the PR. As soon as this is merged, this should be deleted
+      - name: Upload comparison shell script
+        uses: actions/upload-artifact@v4
+        with:
+          name: ef-test-shell-script
+          path: .github/scripts/parse_test_result.sh
 
       - name: Check EF-TESTS status is 100%
         run: |
@@ -93,11 +101,19 @@ jobs:
       - name: Run tests
         run: |
           cd crates/vm/levm
+          set -o pipefail
           make run-evm-ef-tests-ci | tee test_result_main.txt
 
       - name: Show test summary -- full
         run: |
           cd crates/vm/levm && awk '/Summary: /,0' test_result_main.txt
+
+        # This is only needed in the PR. As soon as this is merged, this should be deleted
+      - name: Download shell script
+        uses: actions/download-artifact@v4
+        with:
+          name: ef-test-shell-script
+          path: .github/scripts/
 
       - name: Show test summary -- short
         run: |

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -60,13 +60,6 @@ jobs:
           name: pr-ef-test-data
           path: crates/vm/levm/test_result_pr_short.txt
 
-        # This is only needed in the PR. As soon as this is merged, this should be deleted
-      - name: Upload comparison shell script
-        uses: actions/upload-artifact@v4
-        with:
-          name: ef-test-shell-script
-          path: .github/scripts/parse_test_result.sh
-
       - name: Check EF-TESTS status is 100%
         run: |
           cd crates/vm/levm
@@ -107,13 +100,6 @@ jobs:
       - name: Show test summary -- full
         run: |
           cd crates/vm/levm && awk '/Summary: /,0' test_result_main.txt
-
-        # This is only needed in the PR. As soon as this is merged, this should be deleted
-      - name: Download shell script
-        uses: actions/download-artifact@v4
-        with:
-          name: ef-test-shell-script
-          path: .github/scripts/
 
       - name: Show test summary -- short
         run: |

--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -108,6 +108,7 @@ jobs:
       - name: Run tests
         run: |
           cd crates/vm/levm
+          set -o pipefail
           make generate-evm-ef-tests-report | tee test_result.txt
 
       - name: Post results in summary

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -1096,7 +1096,7 @@ fn calculate_cost_and_gas_limit_call(
     let gas: u64 = gas_from_stack
         .min(max_gas_for_call.into())
         .try_into()
-        .map_err(|_err| OutOfGasError::MaxGasLimitExceeded)?
+        .map_err(|_err| OutOfGasError::MaxGasLimitExceeded)?;
 
     Ok((
         gas.checked_add(call_gas_costs)

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -1096,7 +1096,7 @@ fn calculate_cost_and_gas_limit_call(
     let gas: u64 = gas_from_stack
         .min(max_gas_for_call.into())
         .try_into()
-        .map_err(|_err| OutOfGasError::MaxGasLimitExceeded)?;
+        .map_err(|_err| OutOfGasError::MaxGasLimitExceeded)?
 
     Ok((
         gas.checked_add(call_gas_costs)


### PR DESCRIPTION
**Motivation**

Currently, when the LEVM's CI compiles the project, the following command is run:

```
make run-evm-ef-tests-ci | tee test_result.txt
```
However, if the compilation fails, the job is _not_ stopped. 

This is because, by default, bash will return the last exit code in the pipeline. In this case, that is the `tee` command, which exits correctly.

**Description**
Setting the `pipefail` option, will make it so that job will fail if the `make` routine fails. 


Closes #1918

