### PR TITLE
fix(levm): add support for yul and stSStoreTest

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -423,7 +423,7 @@ pub fn sstore(
     fork: Fork,
 ) -> Result<u64, VMError> {
     // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1087.md
-    if fork <= Fork::Berlin {
+    if fork < Fork::Berlin {
         if storage_slot.current_value.is_zero() && !new_value.is_zero() {
             Ok(SSTORE_PRE_BERLIN_NON_ZERO)
         } else {

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -269,6 +269,7 @@ pub fn get_intrinsic_gas(
             .checked_add(CREATE_BASE_COST)
             .ok_or(OutOfGasError::ConsumedGasOverflow)?;
 
+        // https://eips.ethereum.org/EIPS/eip-3860
         if fork >= Fork::Shanghai {
             let number_of_words = initial_call_frame.calldata.len().div_ceil(WORD_SIZE);
             let double_number_of_words: u64 = number_of_words

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -253,7 +253,6 @@ pub fn get_intrinsic_gas(
     // 4 gas for each zero byte in the transaction data 16 gas for each non-zero byte in the transaction.
     let calldata_cost =
         gas_cost::tx_calldata(&initial_call_frame.calldata, fork).map_err(VMError::OutOfGas)?;
-    dbg!(calldata_cost);
 
     intrinsic_gas = intrinsic_gas
         .checked_add(calldata_cost)
@@ -265,19 +264,18 @@ pub fn get_intrinsic_gas(
         .ok_or(OutOfGasError::ConsumedGasOverflow)?;
 
     // Create Cost
-    if dbg!(is_create) {
+    if is_create {
         intrinsic_gas = intrinsic_gas
             .checked_add(CREATE_BASE_COST)
             .ok_or(OutOfGasError::ConsumedGasOverflow)?;
 
-        if fork >= Fork::Cancun {
+        if fork >= Fork::Shanghai {
             let number_of_words = initial_call_frame.calldata.len().div_ceil(WORD_SIZE);
             let double_number_of_words: u64 = number_of_words
                 .checked_mul(2)
                 .ok_or(OutOfGasError::ConsumedGasOverflow)?
                 .try_into()
                 .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
-            dbg!(double_number_of_words);
 
             intrinsic_gas = intrinsic_gas
                 .checked_add(double_number_of_words)
@@ -297,7 +295,6 @@ pub fn get_intrinsic_gas(
                 .ok_or(OutOfGasError::ConsumedGasOverflow)?;
         }
     }
-    dbg!(access_lists_cost);
 
     intrinsic_gas = intrinsic_gas
         .checked_add(access_lists_cost)
@@ -315,7 +312,6 @@ pub fn get_intrinsic_gas(
     let authorization_list_cost = PER_EMPTY_ACCOUNT_COST
         .checked_mul(amount_of_auth_tuples)
         .ok_or(VMError::Internal(InternalError::GasOverflow))?;
-    dbg!(authorization_list_cost);
 
     intrinsic_gas = intrinsic_gas
         .checked_add(authorization_list_cost)

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -253,6 +253,7 @@ pub fn get_intrinsic_gas(
     // 4 gas for each zero byte in the transaction data 16 gas for each non-zero byte in the transaction.
     let calldata_cost =
         gas_cost::tx_calldata(&initial_call_frame.calldata, fork).map_err(VMError::OutOfGas)?;
+    dbg!(calldata_cost);
 
     intrinsic_gas = intrinsic_gas
         .checked_add(calldata_cost)
@@ -264,21 +265,24 @@ pub fn get_intrinsic_gas(
         .ok_or(OutOfGasError::ConsumedGasOverflow)?;
 
     // Create Cost
-    if is_create {
+    if dbg!(is_create) {
         intrinsic_gas = intrinsic_gas
             .checked_add(CREATE_BASE_COST)
             .ok_or(OutOfGasError::ConsumedGasOverflow)?;
 
-        let number_of_words = initial_call_frame.calldata.len().div_ceil(WORD_SIZE);
-        let double_number_of_words: u64 = number_of_words
-            .checked_mul(2)
-            .ok_or(OutOfGasError::ConsumedGasOverflow)?
-            .try_into()
-            .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
+        if fork >= Fork::Cancun {
+            let number_of_words = initial_call_frame.calldata.len().div_ceil(WORD_SIZE);
+            let double_number_of_words: u64 = number_of_words
+                .checked_mul(2)
+                .ok_or(OutOfGasError::ConsumedGasOverflow)?
+                .try_into()
+                .map_err(|_| VMError::Internal(InternalError::ConversionError))?;
+            dbg!(double_number_of_words);
 
-        intrinsic_gas = intrinsic_gas
-            .checked_add(double_number_of_words)
-            .ok_or(OutOfGasError::ConsumedGasOverflow)?;
+            intrinsic_gas = intrinsic_gas
+                .checked_add(double_number_of_words)
+                .ok_or(OutOfGasError::ConsumedGasOverflow)?;
+        }
     }
 
     // Access List Cost
@@ -293,6 +297,7 @@ pub fn get_intrinsic_gas(
                 .ok_or(OutOfGasError::ConsumedGasOverflow)?;
         }
     }
+    dbg!(access_lists_cost);
 
     intrinsic_gas = intrinsic_gas
         .checked_add(access_lists_cost)
@@ -310,6 +315,7 @@ pub fn get_intrinsic_gas(
     let authorization_list_cost = PER_EMPTY_ACCOUNT_COST
         .checked_mul(amount_of_auth_tuples)
         .ok_or(VMError::Internal(InternalError::GasOverflow))?;
+    dbg!(authorization_list_cost);
 
     intrinsic_gas = intrinsic_gas
         .checked_add(authorization_list_cost)

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -323,21 +323,10 @@ impl VM {
             return self.handle_precompile_result(precompile_result, current_call_frame, backup);
         }
 
-        // dbg!(&current_call_frame.to);
-        // dbg!(&current_call_frame.msg_sender);
-        // dbg!(&current_call_frame.gas_used);
-        // dbg!(&current_call_frame.gas_limit);
-
         loop {
             let opcode = current_call_frame.next_opcode();
-            // dbg!(&opcode);
 
             let op_result = self.handle_current_opcode(opcode, current_call_frame);
-
-            // dbg!(&op_result);
-            // dbg!(&current_call_frame.gas_used);
-            // dbg!(&current_call_frame.stack);
-            // dbg!(&self.env.refunded_gas);
 
             match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -323,10 +323,19 @@ impl VM {
             return self.handle_precompile_result(precompile_result, current_call_frame, backup);
         }
 
+        dbg!(&current_call_frame.to);
+        dbg!(&current_call_frame.msg_sender);
+        dbg!(&current_call_frame.gas_limit);
+
         loop {
             let opcode = current_call_frame.next_opcode();
+            dbg!(&opcode);
 
             let op_result = self.handle_current_opcode(opcode, current_call_frame);
+
+            dbg!(&op_result);
+            dbg!(&current_call_frame.gas_used);
+            dbg!(&current_call_frame.stack);
 
             match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -323,19 +323,21 @@ impl VM {
             return self.handle_precompile_result(precompile_result, current_call_frame, backup);
         }
 
-        dbg!(&current_call_frame.to);
-        dbg!(&current_call_frame.msg_sender);
-        dbg!(&current_call_frame.gas_limit);
+        // dbg!(&current_call_frame.to);
+        // dbg!(&current_call_frame.msg_sender);
+        // dbg!(&current_call_frame.gas_used);
+        // dbg!(&current_call_frame.gas_limit);
 
         loop {
             let opcode = current_call_frame.next_opcode();
-            dbg!(&opcode);
+            // dbg!(&opcode);
 
             let op_result = self.handle_current_opcode(opcode, current_call_frame);
 
-            dbg!(&op_result);
-            dbg!(&current_call_frame.gas_used);
-            dbg!(&current_call_frame.stack);
+            // dbg!(&op_result);
+            // dbg!(&current_call_frame.gas_used);
+            // dbg!(&current_call_frame.stack);
+            // dbg!(&self.env.refunded_gas);
 
             match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

In this PR we add support for the `yul` and `stSStoreTest` test suite.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

* We change and incorrect check of the fork Berlin. Previously it was inclusive when it should be exclusive.
* We make a correct gas charge in the `get_intrinsic_gas` function. In a Create type transaction, 2 gas per 32-byte words must be charged in order to follow [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) but only in Shanghai or later forks 

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1938 

