### PR TITLE
chore(core): delete duplicated file.

### DIFF
--- a/crates/l2/Clippy.toml
+++ b/crates/l2/Clippy.toml
@@ -1,1 +1,0 @@
-allow-unwrap-in-tests = true


### PR DESCRIPTION
**Motivation**
This file appears twice, once as Clippy.toml and once as clippy.toml

> warning: the following paths have collided (e.g. case-sensitive paths
> on a case-insensitive filesystem) and only one from the same
> colliding group is in the working tree:
> 
>   'crates/l2/Clippy.toml'
>   'crates/l2/clippy.toml'