### PR TITLE
fix(levm): disable opcodes in block.rs for old forks

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -123,6 +123,11 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
+        // Added in Istanbul fork
+        // https://eips.ethereum.org/EIPS/eip-1344
+        if self.env.config.fork < Fork::Istanbul {
+            return Err(VMError::InvalidOpcode);
+        }
         current_call_frame.increase_consumed_gas(gas_cost::CHAINID)?;
 
         current_call_frame.stack.push(self.env.chain_id)?;
@@ -135,6 +140,11 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
+        // Added in London fork
+        // https://eips.ethereum.org/EIPS/eip-1884
+        if self.env.config.fork < Fork::London {
+            return Err(VMError::InvalidOpcode);
+        }
         current_call_frame.increase_consumed_gas(gas_cost::SELFBALANCE)?;
 
         let balance = get_account(&mut self.cache, self.db.clone(), current_call_frame.to)
@@ -150,6 +160,11 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
+        // Added in London fork
+        // https://eips.ethereum.org/EIPS/eip-3198
+        if self.env.config.fork < Fork::London {
+            return Err(VMError::InvalidOpcode);
+        }
         current_call_frame.increase_consumed_gas(gas_cost::BASEFEE)?;
 
         current_call_frame.stack.push(self.env.base_fee_per_gas)?;

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -123,7 +123,6 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
-        // Added in Istanbul fork
         // https://eips.ethereum.org/EIPS/eip-1344
         if self.env.config.fork < Fork::Istanbul {
             return Err(VMError::InvalidOpcode);
@@ -140,7 +139,6 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
-        // Added in London fork
         // https://eips.ethereum.org/EIPS/eip-1884
         if self.env.config.fork < Fork::London {
             return Err(VMError::InvalidOpcode);
@@ -160,7 +158,6 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
-        // Added in London fork
         // https://eips.ethereum.org/EIPS/eip-3198
         if self.env.config.fork < Fork::London {
             return Err(VMError::InvalidOpcode);


### PR DESCRIPTION
**Motivation**

`CHAINID`, `SELFBALANCE` and `BASEFEE` should be disabled for old forks

**Description**

Return `VmError::InvalidOpcode` when the opcodes should be disabled

