### PR TITLE
fix(levm): add fork checks for returndatacopy, returndatasize & staticcall

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{access_account, has_delegation, word_to_address},
     vm::VM,
 };
-use ethrex_common::U256;
+use ethrex_common::{types::Fork, U256};
 use keccak_hash::keccak;
 
 // Environmental Information (16)
@@ -377,6 +377,10 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
+        // https://eips.ethereum.org/EIPS/eip-211
+        if self.env.config.fork < Fork::Byzantium {
+            return Err(VMError::InvalidOpcode);
+        };
         current_call_frame.increase_consumed_gas(gas_cost::RETURNDATASIZE)?;
 
         current_call_frame

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -395,6 +395,10 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
+        // https://eips.ethereum.org/EIPS/eip-211
+        if self.env.config.fork < Fork::Byzantium {
+            return Err(VMError::InvalidOpcode);
+        };
         let dest_offset = current_call_frame.stack.pop()?;
         let returndata_offset: usize = current_call_frame
             .stack

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -311,6 +311,10 @@ impl VM {
         &mut self,
         current_call_frame: &mut CallFrame,
     ) -> Result<OpcodeResult, VMError> {
+        // https://eips.ethereum.org/EIPS/eip-214
+        if self.env.config.fork < Fork::Byzantium {
+            return Err(VMError::InvalidOpcode);
+        };
         // STACK
         let gas = current_call_frame.stack.pop()?;
         let code_address = word_to_address(current_call_frame.stack.pop()?);


### PR DESCRIPTION
**Motivation**

The Byzantium fork introduced the following EIPS:
- [EIP-211](https://eips.ethereum.org/EIPS/eip-211)
- [EIP-214](https://eips.ethereum.org/EIPS/eip-214)

Which introduced the following opcodes:
- RETURNDATACOPY
- RETURNDATASIZE
- STATICCALL

Therefore, any call to those opcodes before Byzantium are an error.

**Description**

Add a fork check before calling those opcodes, if the fork is before Byzantium, return an Error


Closes #1951

