### PR TITLE
chore(l1): bump EF tests version to v4.0.0

### DIFF
--- a/cmd/ef_tests/blockchain/.fixtures_url
+++ b/cmd/ef_tests/blockchain/.fixtures_url
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz
+https://github.com/ethereum/execution-spec-tests/releases/download/v4.0.0/fixtures_develop.tar.gz


### PR DESCRIPTION
**Description**

Bumps EF tests suite to [version 4.0.0](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.0.0).
Develop asset was selected due to the new format specified [here](https://github.com/ethereum/execution-spec-tests/pull/788)

