### PR TITLE
feat(levm): add a warning when REVM fails an EF-test and ignore tests

### DIFF
--- a/cmd/ef_tests/state/parser.rs
+++ b/cmd/ef_tests/state/parser.rs
@@ -20,7 +20,7 @@ pub enum EFTestParseError {
     FailedToParseTestFile(String),
 }
 
-const IGNORED_TESTS: [&str; 7] = [
+const IGNORED_TESTS: [&str; 11] = [
     "ValueOverflowParis.json",                 // Skip because of errors
     "loopMul.json",                            // Skip because it takes too long to run
     "dynamicAccountOverwriteEmpty_Paris.json", // Skip because it fails on REVM
@@ -28,6 +28,10 @@ const IGNORED_TESTS: [&str; 7] = [
     "RevertInCreateInInit_Paris.json", // Skip because it fails on REVM. See https://github.com/lambdaclass/ethrex/issues/1555
     "create2collisionStorageParis.json", // Skip because it fails on REVM
     "InitCollisionParis.json",         // Skip because it fails on REVM
+    "InitCollision.json",              // Skip because it fails on REVM
+    "basefeeExample.json",             // Skip because it has access list before Berlin fork
+    "eip1559.json",                    // Skip because it has access list before Berlin fork
+    "mergeTest.json",                  // Skip because it has access list before Berlin fork
 ];
 
 pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestParseError> {

--- a/cmd/ef_tests/state/parser.rs
+++ b/cmd/ef_tests/state/parser.rs
@@ -20,7 +20,7 @@ pub enum EFTestParseError {
     FailedToParseTestFile(String),
 }
 
-const IGNORED_TESTS: [&str; 11] = [
+const IGNORED_TESTS: [&str; 8] = [
     "ValueOverflowParis.json",                 // Skip because of errors
     "loopMul.json",                            // Skip because it takes too long to run
     "dynamicAccountOverwriteEmpty_Paris.json", // Skip because it fails on REVM
@@ -29,9 +29,6 @@ const IGNORED_TESTS: [&str; 11] = [
     "create2collisionStorageParis.json", // Skip because it fails on REVM
     "InitCollisionParis.json",         // Skip because it fails on REVM
     "InitCollision.json",              // Skip because it fails on REVM
-    "basefeeExample.json",             // Skip because it has access list before Berlin fork
-    "eip1559.json",                    // Skip because it has access list before Berlin fork
-    "mergeTest.json",                  // Skip because it has access list before Berlin fork
 ];
 
 pub fn parse_ef_tests(opts: &EFTestRunnerOptions) -> Result<Vec<EFTest>, EFTestParseError> {

--- a/cmd/ef_tests/state/report.rs
+++ b/cmd/ef_tests/state/report.rs
@@ -569,6 +569,7 @@ impl EFTestReportForkResult {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ComparisonReport {
+    pub expected_post_state_root: H256,
     pub levm_post_state_root: H256,
     pub revm_post_state_root: H256,
     pub initial_accounts: HashMap<Address, Account>,
@@ -581,6 +582,12 @@ pub struct ComparisonReport {
 
 impl fmt::Display for ComparisonReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.revm_post_state_root != self.expected_post_state_root {
+            writeln!(
+                f,
+                " =============== WARNING: REVM *fails* this tests ================== "
+            )?
+        }
         if self.levm_post_state_root != self.revm_post_state_root {
             writeln!(
                 f,

--- a/cmd/ef_tests/state/report.rs
+++ b/cmd/ef_tests/state/report.rs
@@ -585,7 +585,7 @@ impl fmt::Display for ComparisonReport {
         if self.revm_post_state_root != self.expected_post_state_root {
             writeln!(
                 f,
-                " =============== WARNING: REVM *fails* this tests ================== "
+                "================ WARNING: REVM *fails* this tests ==================="
             )?
         }
         if self.levm_post_state_root != self.revm_post_state_root {

--- a/cmd/ef_tests/state/runner/mod.rs
+++ b/cmd/ef_tests/state/runner/mod.rs
@@ -19,7 +19,7 @@ pub enum EFTestRunnerError {
     VMInitializationFailed(String),
     #[error("Transaction execution failed when it was not expected to fail: {0}")]
     ExecutionFailedUnexpectedly(VMError),
-    #[error("Failed to ensure post-state: {0}")]
+    #[error("Failed to ensure pre-state: {0}")]
     FailedToEnsurePreState(String),
     #[error("Failed to ensure post-state: {1}")]
     FailedToEnsurePostState(ExecutionReport, String),

--- a/cmd/ef_tests/state/runner/revm_runner.rs
+++ b/cmd/ef_tests/state/runner/revm_runner.rs
@@ -396,6 +396,7 @@ pub fn compare_levm_revm_account_updates(
         levm_post_state_root,
         revm_post_state_root,
         initial_accounts,
+        expected_post_state_root: test.post.vector_post_value(vector, *fork).hash,
         levm_account_updates: levm_account_updates.to_vec(),
         revm_account_updates: revm_account_updates.to_vec(),
         levm_updated_accounts_only: levm_updated_accounts

--- a/cmd/ef_tests/state/runner/revm_runner.rs
+++ b/cmd/ef_tests/state/runner/revm_runner.rs
@@ -333,7 +333,9 @@ pub fn ensure_post_state(
             );
             let revm_account_updates = ethrex_vm::get_state_transitions(revm_state);
             let account_updates_report = compare_levm_revm_account_updates(
+                vector,
                 test,
+                fork,
                 &levm_account_updates,
                 &revm_account_updates,
             );
@@ -345,7 +347,9 @@ pub fn ensure_post_state(
 }
 
 pub fn compare_levm_revm_account_updates(
+    vector: &TestVector,
     test: &EFTest,
+    fork: &Fork,
     levm_account_updates: &[AccountUpdate],
     revm_account_updates: &[AccountUpdate],
 ) -> ComparisonReport {

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -203,7 +203,7 @@ impl VM {
                 _ => (4800, 19900, 2800),
             };
 
-        if self.env.config.fork < Fork::Istanbul && self.env.config.fork != Fork::Constantinople {
+        if self.env.config.fork <= Fork::Byzantium || self.env.config.fork == Fork::Petersburg {
             if !storage_slot.current_value.is_zero() && new_storage_slot_value.is_zero() {
                 gas_refunds = gas_refunds
                     .checked_add(15000)

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -203,7 +203,7 @@ impl VM {
                 _ => (4800, 19900, 2800),
             };
 
-        if self.env.config.fork <= Fork::Byzantium || self.env.config.fork == Fork::Petersburg {
+        if self.env.config.fork < Fork::Istanbul && self.env.config.fork != Fork::Constantinople {
             if !storage_slot.current_value.is_zero() && new_storage_slot_value.is_zero() {
                 gas_refunds = gas_refunds
                     .checked_add(15000)


### PR DESCRIPTION
**Motivation**

There is no clear warning when REVM fails an EF-Test, one has to check manually that there is a difference between REVM's post-state-root and the expected.

**Description**

This PR adds a warning in the report when REVM fails a test. This should also make it easier to check/parse how many tests REVM fails.

Also ignore some EF-tests that test wrong/impossible behavior.  