### PR TITLE
fix(levm): check fork before charging gas cost for create transaction

### DIFF
--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -265,7 +265,8 @@ pub fn get_intrinsic_gas(
 
     // Create Cost
     if is_create {
-        if fork > Fork::FrontierThawing {
+        // https://eips.ethereum.org/EIPS/eip-2#specification
+        if fork >= Fork::Homestead {
             intrinsic_gas = intrinsic_gas
                 .checked_add(CREATE_BASE_COST)
                 .ok_or(OutOfGasError::ConsumedGasOverflow)?;


### PR DESCRIPTION
**Motivation**

Before the Homestead fork, create transactions costed 21000. After Homestead, they started costing 53000.

The problem is that we were charging Homestead's prices even when the EVM was set in the Frontier fork. 

This change is decribed in [EIP-2](https://eips.ethereum.org/EIPS/eip-2#specification).

**Description**

Only charge the additional 32000 if the transaction is under a fork after Homestead.

