### PR TITLE
fix(levm): revert opcode is invalid before byzantium

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -474,6 +474,9 @@ impl VM {
         // Returns: VMError RevertOpcode if executed correctly.
         // Notes:
         //      The actual reversion of changes is made in the execute() function.
+        if self.env.config.fork < Fork::Byzantium {
+            return Err(VMError::InvalidOpcode);
+        }
 
         let offset = current_call_frame.stack.pop()?;
 


### PR DESCRIPTION
**Motivation**

The `REVERT` opcode was introduced in byzantium; therefore any use of `REVERT` before it is invalid. 

**Description**

Add a fork check in the `REVERT` opcode function.

