### PR TITLE
fix(l1): `GetPooledTransactions` response were coming from db instead of mempool.

### DIFF
--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -58,6 +58,14 @@ pub fn add_transaction(transaction: Transaction, store: &Store) -> Result<H256, 
     Ok(hash)
 }
 
+/// Fetch a transaction from the mempool given its transaction hash
+pub fn get_transaction(
+    tx_hash: &H256,
+    store: Store,
+) -> Result<Option<MempoolTransaction>, MempoolError> {
+    Ok(store.get_transaction_from_pool(tx_hash)?)
+}
+
 /// Fetch a blobs bundle from the mempool given its blob transaction hash
 pub fn get_blobs_bundle(tx_hash: H256, store: Store) -> Result<Option<BlobsBundle>, MempoolError> {
     Ok(store.get_blobs_bundle_from_pool(tx_hash)?)

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2405,6 +2405,10 @@ mod mempool {
         pub fn sender(&self) -> Address {
             self.sender
         }
+
+        pub fn into_inner(self) -> Transaction {
+            self.inner
+        }
     }
 
     impl RLPEncode for MempoolTransaction {

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -181,10 +181,10 @@ impl GetPooledTransactions {
         hash: &H256,
         store: &Store,
     ) -> Result<Option<P2PTransaction>, StoreError> {
-        let Some(tx) = store.get_transaction_by_hash(*hash)? else {
+        let Some(tx) = store.get_transaction_from_pool(hash)? else {
             return Ok(None);
         };
-        let result = match tx {
+        let result = match tx.into_inner() {
             Transaction::LegacyTransaction(itx) => P2PTransaction::LegacyTransaction(itx),
             Transaction::EIP2930Transaction(itx) => P2PTransaction::EIP2930Transaction(itx),
             Transaction::EIP1559Transaction(itx) => P2PTransaction::EIP1559Transaction(itx),

--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -301,6 +301,19 @@ impl Store {
         Ok(())
     }
 
+    /// Get a transaction from the pool given its hash
+    pub fn get_transaction_from_pool(
+        &self,
+        hash: &H256,
+    ) -> Result<Option<MempoolTransaction>, StoreError> {
+        Ok(self
+            .mempool
+            .lock()
+            .map_err(|error| StoreError::Custom(error.to_string()))?
+            .get(hash)
+            .cloned())
+    }
+
     /// Get a blobs bundle to the pool given its blob transaction hash
     pub fn get_blobs_bundle_from_pool(
         &self,


### PR DESCRIPTION

**Motivation**
Found a bug where GetPooledTransactions were served from db instead of mempool.
<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1986

