### PR TITLE
feat(l1): add `new_from_genesis` method to `Store`

### DIFF
--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -106,13 +106,19 @@ impl Store {
         Ok(store)
     }
 
-    pub fn init_genesis(&self, genesis_path: &str) -> Result<(), StoreError> {
+    pub fn new_from_genesis(
+        store_path: &str,
+        engine_type: EngineType,
+        genesis_path: &str,
+    ) -> Result<Self, StoreError> {
         let file = std::fs::File::open(genesis_path)
             .map_err(|error| StoreError::Custom(format!("Failed to open genesis file: {error}")))?;
         let reader = std::io::BufReader::new(file);
         let genesis: Genesis =
             serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
-        self.add_initial_state(genesis)
+        let store = Self::new(store_path, engine_type)?;
+        store.add_initial_state(genesis)?;
+        Ok(store)
     }
 
     pub fn get_account_info(

--- a/crates/storage/store/storage.rs
+++ b/crates/storage/store/storage.rs
@@ -106,6 +106,15 @@ impl Store {
         Ok(store)
     }
 
+    pub fn init_genesis(&self, genesis_path: &str) -> Result<(), StoreError> {
+        let file = std::fs::File::open(genesis_path)
+            .map_err(|error| StoreError::Custom(format!("Failed to open genesis file: {error}")))?;
+        let reader = std::io::BufReader::new(file);
+        let genesis: Genesis =
+            serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+        self.add_initial_state(genesis)
+    }
+
     pub fn get_account_info(
         &self,
         block_number: BlockNumber,


### PR DESCRIPTION
**Motivation**

Without this method, users must do the genesis file decoding manually, sometimes needing to unnecessarily add the `serde_json` crate to their `Cargo.toml`. 

Having a method that initializes the genesis state in the `Store` allows the user to start a new `Store` from the genesis file, which only has the genesis path.

**Description**

Adds a new `new_from_genesis` method to `Store` that initializes a new `Store` instance with the genesis (provided as a path to the genesis file). 
