### PR TITLE
docs(l2): update dependencies

### DIFF
--- a/cmd/ef_tests/state/runner/revm_runner.rs
+++ b/cmd/ef_tests/state/runner/revm_runner.rs
@@ -118,6 +118,14 @@ pub fn prepare_revm_for_tx<'state>(
         .chain_config()
         .map_err(|err| EFTestRunnerError::VMInitializationFailed(err.to_string()))?;
 
+    let blob_excess_gas_and_price = if test.env.current_excess_blob_gas.is_none() {
+        None
+    } else {
+        Some(BlobExcessGasAndPrice {
+            blob_gasprice: 0,
+            excess_blob_gas: test.env.current_excess_blob_gas.unwrap().as_u64(),
+        })
+    };
     let block_env = RevmBlockEnv {
         number: RevmU256::from_limbs(test.env.current_number.0),
         coinbase: RevmAddress(test.env.current_coinbase.0.into()),
@@ -126,10 +134,7 @@ pub fn prepare_revm_for_tx<'state>(
         basefee: RevmU256::from_limbs(test.env.current_base_fee.unwrap_or_default().0),
         difficulty: RevmU256::from_limbs(test.env.current_difficulty.0),
         prevrandao: test.env.current_random.map(|v| v.0.into()),
-        blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-            blob_gasprice: 0,
-            excess_blob_gas: test.env.current_excess_blob_gas.unwrap().as_u64(),
-        }),
+        blob_excess_gas_and_price,
     };
     let tx = &test
         .transactions

--- a/crates/l2/docs/prover.md
+++ b/crates/l2/docs/prover.md
@@ -51,6 +51,7 @@ sequenceDiagram
 - [SP1](https://docs.succinct.xyz/docs/sp1/introduction)
    1. `curl -L https://sp1up.succinct.xyz | bash`
    2. `sp1up --version 3.4.0`
+- [SOLC](https://docs.soliditylang.org/en/latest/installing-solidity.html)
 
 After installing the toolchains, a quick test can be performed to check if we have everything installed correctly.
 
@@ -89,6 +90,7 @@ If neither `risc0` nor `sp1` is installed on the system, the prover can be built
    - It will remove any old database, if present, stored in your computer. The absolute path of libmdbx is defined by [data_dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html).
 3. `cp .env.example .env` &rarr; check if you want to change any config.
 4. `make init`
+   - Make sure you have the `solc` compiler installed in your system.
    - Init the L1 in a docker container on port `8545`.
    - Deploy the needed contracts for the L2 on the L1.
    - Start the L2 locally on port `1729`.

--- a/crates/l2/docs/prover.md
+++ b/crates/l2/docs/prover.md
@@ -50,7 +50,7 @@ sequenceDiagram
    2. `rzup install cargo-risczero 1.2.0`
 - [SP1](https://docs.succinct.xyz/docs/sp1/introduction)
    1. `curl -L https://sp1up.succinct.xyz | bash`
-   2. `sp1up --version 3.4.0`
+   2. `sp1up --version 4.0.0`
 - [SOLC](https://docs.soliditylang.org/en/latest/installing-solidity.html)
 
 After installing the toolchains, a quick test can be performed to check if we have everything installed correctly.


### PR DESCRIPTION
**Motivation**

If you run l2's makefile's `init` subroutine _without_ the solc compiler, you get an error message stating:
`Error: CompilationError(CompilationError("Failed to spawn solc: No such file or directory (os error 2)`

**Description**

This PR:
- adds the solc compiler as a dependency in the project's dependencies.
- bumps sp1 version