### PR TITLE
chore(l1): change disconnect reason to an enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,6 +2559,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "local-ip-address",
+ "num_enum 0.7.3",
  "rand 0.8.5",
  "redb",
  "serde_json",
@@ -4835,7 +4836,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive 0.7.3",
 ]
 
 [[package]]
@@ -4848,6 +4858,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -6672,7 +6694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3372685893a9f67d18e98e792d690017287fd17379a83d798d958e517d380fa9"
 dependencies = [
  "downcast-rs",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
 ]
 

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -35,6 +35,7 @@ cfg-if = "1.0.0"
 
 ethrex-dev = { path = "../../crates/blockchain/dev", optional = true }
 ethrex-metrics = { path = "../../crates/blockchain/metrics" }
+num_enum = "0.7.3"
 
 [[bin]]
 name = "ethrex"

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -38,7 +38,7 @@ use tokio::{
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
-use super::utils::log_peer_warn;
+use super::{p2p::DisconnectReason, utils::log_peer_warn};
 
 const CAP_P2P_5: (Capability, u8) = (Capability::P2p, 5);
 const CAP_ETH_68: (Capability, u8) = (Capability::Eth, 68);
@@ -171,7 +171,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         // Discard peer from kademlia table
         match error {
             // already connected, don't discard it
-            RLPxError::DisconnectRequested(s) if s == "Already connected" => {
+            RLPxError::DisconnectRequested(r) if r == DisconnectReason::AlreadyConnected => {
                 log_peer_debug(&self.node, "Peer already connected don't replace it");
             }
             _ => {
@@ -187,9 +187,9 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         let _ = self.framed.close().await;
     }
 
-    fn match_disconnect_reason(&self, error: &RLPxError) -> Option<u8> {
+    fn match_disconnect_reason(&self, error: &RLPxError) -> Option<DisconnectReason> {
         match error {
-            RLPxError::RLPDecodeError(_) => Some(2_u8),
+            RLPxError::RLPDecodeError(_) => Some(DisconnectReason::NetworkError),
             // TODO build a proper matching between error types and disconnection reasons
             _ => None,
         }
@@ -198,10 +198,10 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
     async fn exchange_hello_messages(&mut self, peer_count: usize) -> Result<(), RLPxError> {
         if peer_count >= MAX_PEERS {
             let disconnect_msg = Message::Disconnect(DisconnectMessage {
-                reason: Some(0x04), // Too many peers
+                reason: Some(DisconnectReason::TooManyPeers), // Too many peers
             });
             self.send(disconnect_msg).await?;
-            return Err(RLPxError::DisconnectSent("Too many peers".to_string()));
+            return Err(RLPxError::DisconnectSent(DisconnectReason::TooManyPeers));
         }
 
         let hello_msg = Message::Hello(p2p::HelloMessage::new(
@@ -256,9 +256,9 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
 
                 Ok(())
             }
-            Message::Disconnect(disconnect) => Err(RLPxError::DisconnectRequested(
-                disconnect.reason().to_string(),
-            )),
+            Message::Disconnect(disconnect) => {
+                Err(RLPxError::DisconnectRequested(disconnect.reason()))
+            }
             _ => {
                 // Fail if it is not a hello message
                 Err(RLPxError::BadRequest("Expected Hello message".to_string()))
@@ -357,9 +357,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                     &format!("Received Disconnect: {}", msg_data.reason()),
                 );
                 // TODO handle the disconnection request
-                return Err(RLPxError::DisconnectRequested(
-                    msg_data.reason().to_string(),
-                ));
+                return Err(RLPxError::DisconnectRequested(msg_data.reason()));
             }
             Message::Ping(_) => {
                 log_peer_debug(&self.node, "Sending pong message");

--- a/crates/networking/p2p/rlpx/error.rs
+++ b/crates/networking/p2p/rlpx/error.rs
@@ -4,7 +4,7 @@ use ethrex_storage::error::StoreError;
 use thiserror::Error;
 use tokio::sync::broadcast::error::RecvError;
 
-use super::message::Message;
+use super::{message::Message, p2p::DisconnectReason};
 
 // TODO improve errors
 #[derive(Debug, Error)]
@@ -16,9 +16,9 @@ pub(crate) enum RLPxError {
     #[error("Peer disconnected")]
     Disconnected(),
     #[error("Diconnect sent: {0}")]
-    DisconnectSent(String),
+    DisconnectSent(DisconnectReason),
     #[error("Disconnect requested: {0}")]
-    DisconnectRequested(String),
+    DisconnectRequested(DisconnectReason),
     #[error("Not Found: {0}")]
     NotFound(String),
     #[error("Invalid peer id")]

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -102,39 +102,96 @@ impl RLPxMessage for HelloMessage {
     }
 }
 
+// Create disconnectreason enum
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DisconnectReason {
+    DisconnectRequested = 0x00,
+    NetworkError = 0x01,
+    ProtocolError = 0x02,
+    UselessPeer = 0x03,
+    TooManyPeers = 0x04,
+    AlreadyConnected = 0x05,
+    IncompatibleVersion = 0x06,
+    InvalidIdentity = 0x07,
+    ClientQuitting = 0x08,
+    UnexpectedIdentity = 0x09,
+    SelfIdentity = 0x0a,
+    PingTimeout = 0x0b,
+    SubprotocolError = 0x10,
+    InvalidReason = 0xff,
+}
+
+// impl display for disconnectreason
+impl std::fmt::Display for DisconnectReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DisconnectReason::DisconnectRequested => write!(f, "Disconnect Requested"),
+            DisconnectReason::NetworkError => write!(f, "TCP Subsystem Error"),
+            DisconnectReason::ProtocolError => write!(f, "Breach of Protocol"),
+            DisconnectReason::UselessPeer => write!(f, "Useless Peer"),
+            DisconnectReason::TooManyPeers => write!(f, "Too Many Peers"),
+            DisconnectReason::AlreadyConnected => write!(f, "Already Connected"),
+            DisconnectReason::IncompatibleVersion => {
+                write!(f, "Incompatible P2P Protocol Version")
+            }
+            DisconnectReason::InvalidIdentity => write!(f, "Null Node Identity Received"),
+            DisconnectReason::ClientQuitting => write!(f, "Client Quitting"),
+            DisconnectReason::UnexpectedIdentity => {
+                write!(f, "Unexpected Identity in Handshake")
+            }
+            DisconnectReason::SelfIdentity => {
+                write!(f, "Identity is the Same as This Node")
+            }
+            DisconnectReason::PingTimeout => write!(f, "Ping Timeout"),
+            DisconnectReason::SubprotocolError => {
+                write!(f, "Some Other Reason Specific to a Subprotocol")
+            }
+            DisconnectReason::InvalidReason => write!(f, "Invalid Disconnect Reason"),
+        }
+    }
+}
+
+impl From<u8> for DisconnectReason {
+    fn from(value: u8) -> Self {
+        match value {
+            0x00 => DisconnectReason::DisconnectRequested,
+            0x01 => DisconnectReason::NetworkError,
+            0x02 => DisconnectReason::ProtocolError,
+            0x03 => DisconnectReason::UselessPeer,
+            0x04 => DisconnectReason::TooManyPeers,
+            0x05 => DisconnectReason::AlreadyConnected,
+            0x06 => DisconnectReason::IncompatibleVersion,
+            0x07 => DisconnectReason::InvalidIdentity,
+            0x08 => DisconnectReason::ClientQuitting,
+            0x09 => DisconnectReason::UnexpectedIdentity,
+            0x0a => DisconnectReason::SelfIdentity,
+            0x0b => DisconnectReason::PingTimeout,
+            0x10 => DisconnectReason::SubprotocolError,
+            _ => DisconnectReason::InvalidReason,
+        }
+    }
+}
+
+impl Into<u8> for DisconnectReason {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct DisconnectMessage {
-    pub(crate) reason: Option<u8>,
+    pub(crate) reason: Option<DisconnectReason>,
 }
 
 impl DisconnectMessage {
-    pub fn new(reason: Option<u8>) -> Self {
+    pub fn new(reason: Option<DisconnectReason>) -> Self {
         Self { reason }
     }
 
     /// Returns the meaning of the disconnect reason's error code
     /// The meaning of each error code is defined by the spec: https://github.com/ethereum/devp2p/blob/master/rlpx.md#disconnect-0x01
-    pub fn reason(&self) -> &str {
-        if let Some(reason) = self.reason {
-            match reason {
-                0x00 => "Disconnect requested",
-                0x01 => "TCP sub-system error",
-                0x02 => "Breach of protocol, e.g. a malformed message, bad RLP, ...",
-                0x03 => "Useless peer",
-                0x04 => "Too many peers",
-                0x05 => "Already connected",
-                0x06 => "Incompatible P2P protocol version",
-                0x07 => "Null node identity received - this is automatically invalid",
-                0x08 => "Client quitting",
-                0x09 => "Unexpected identity in handshake",
-                0x0a => "Identity is the same as this node (i.e. connected to itself)",
-                0x0b => "Ping timeout",
-                0x10 => "Some other reason specific to a subprotocol",
-                _ => "Unknown Reason",
-            }
-        } else {
-            "Reason Not Provided"
-        }
+    pub fn reason(&self) -> DisconnectReason {
+        self.reason.unwrap_or(DisconnectReason::InvalidReason)
     }
 }
 
@@ -142,7 +199,7 @@ impl RLPxMessage for DisconnectMessage {
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Disconnect msg_data is reason or none
-        match self.reason {
+        match self.reason.map(|r| Into::<u8>::into(r)) {
             Some(value) => Encoder::new(&mut encoded_data)
                 .encode_field(&value)
                 .finish(),
@@ -174,7 +231,7 @@ impl RLPxMessage for DisconnectMessage {
             }
         };
 
-        Ok(Self::new(reason))
+        Ok(Self::new(reason.map(|r| r.into())))
     }
 }
 

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -199,7 +199,7 @@ impl RLPxMessage for DisconnectMessage {
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Disconnect msg_data is reason or none
-        match self.reason.map(|r| Into::<u8>::into(r)) {
+        match self.reason.map(Into::<u8>::into) {
             Some(value) => Encoder::new(&mut encoded_data)
                 .encode_field(&value)
                 .finish(),


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- Change DisconnectReason from `u8` to an `enum`.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

