### PR TITLE
perf: log gas-per-second every 30 seconds

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -345,9 +345,9 @@ async fn main() {
         loop {
             let instant = interval.tick().await;
             let counter = ethrex_blockchain::get_gas_counter();
-            let duration = instant.duration_since(since);
+            let duration = instant.duration_since(since).as_secs();
 
-            if duration.as_secs() <= 0 {
+            if duration <= 0 {
                 continue;
             }
 
@@ -357,9 +357,9 @@ async fn main() {
             // Note the counter itself also wraps on overflow.
             let gas_used = counter.wrapping_sub(old_counter);
 
-            let gps = gas_used / duration.as_secs();
+            let gps = gas_used / duration;
 
-            info!("[METRIC] GPS: {gps}");
+            info!("[METRIC] GPS: {gps} INTERVAL: {duration}");
 
             old_counter = counter;
             since = instant;

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -5,6 +5,12 @@ pub mod mempool;
 pub mod payload;
 mod smoke_test;
 
+use std::{
+    time::Instant,
+    sync::atomic::{AtomicU64, Ordering},
+};
+use tracing::info;
+
 use error::{ChainError, InvalidBlockError};
 use ethrex_common::constants::GAS_PER_BLOB;
 use ethrex_common::types::requests::Requests;
@@ -21,8 +27,6 @@ use ethrex_storage::Store;
 use ethrex_vm::db::evm_state;
 use ethrex_vm::{backends::BlockExecutionResult, get_evm_backend_or_default};
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 //TODO: Implement a struct Chain or BlockChain to encapsulate
 //functionality and canonical chain state and config
 
@@ -38,6 +42,8 @@ pub fn get_gas_counter() -> u64 {
 ///
 /// Performs pre and post execution validation, and updates the database with the post state.
 pub fn add_block(block: &Block, storage: &Store) -> Result<(), ChainError> {
+    let since = Instant::now();
+
     let block_hash = block.header.compute_block_hash();
 
     // Validate if it can be the new head and find the parent
@@ -78,7 +84,19 @@ pub fn add_block(block: &Block, storage: &Store) -> Result<(), ChainError> {
     store_block(storage, block.clone())?;
     store_receipts(storage, receipts, block_hash)?;
 
-    _ = GAS_COUNTER.fetch_add(block.header.gas_used, Ordering::Relaxed);
+    let old_counter = GAS_COUNTER.fetch_add(block.header.gas_used, Ordering::Relaxed);
+    // Detect overflow, if this happens two or more times between reads they will be
+    // underestimated by (N-1) * u64::MAX, where N is the number of overflows in that
+    // period.
+    if old_counter.checked_add(block.header.gas_used).is_none() {
+        info!("GAS_COUNTER overflowed");
+    }
+
+    let interval = Instant::now().duration_since(since).as_millis();
+    if interval != 0 {
+        let throughput = (block.header.gas_used as u128 / interval) * 1000;
+        info!("[METRIC] BLOCK THROUGHPUT: {throughput} Gas/s TIME SPENT: {interval} msecs");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
**Motivation**

We need to optimize the L1 and L2. This means we need to know what we're optimizing.
A basic metric for computation in Ethereum is gas spent, so measuring gas-per-second gives us a rough indication of performance.

**Description**

Quick and dirty implementation:
- One atomic, updated after every block;
- One getter;
- One Tokio task fired by the main function in `ethrex` that queries the
  value every 30 seconds and logs as `info`.
