### PR TITLE
fix(l1): disable full sync for pow chains

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -110,7 +110,6 @@ pub fn cli() -> Command {
             Arg::new("syncmode")
                 .long("syncmode")
                 .required(false)
-                .default_value("full")
                 .value_name("SYNC_MODE"),
         )
         .arg(

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -62,7 +62,7 @@ lazy_static::lazy_static! {
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SyncMode {
     Full,
     Snap,


### PR DESCRIPTION
**Motivation**

The flag `--syncmode full` could be set for chains that used POW but we don't support it

**Description**

- Remove the default value from clap for syncmode, it is now set on the function `sync_mode` when the parser returns  `None`
- If the genesis has a `terminal_total_difficulty` different than 0 then the chain uses POW so we always set it to Snap
- If the genesis does not have a `terminal_total_difficulty` then we use  the field `terminal_total_difficulty_passed` if set to `false` then we asume the chain is POW then set sync_mode to snap
- We only show the warn message if clap returns a none and the user set the flag to full

Closes #issue_number

