### PR TITLE
feat(l2): add utils to the cli

### DIFF
--- a/cmd/ethrex_l2/src/cli.rs
+++ b/cmd/ethrex_l2/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands::{autocomplete, config, info, prove, stack, test, wallet},
+    commands::{autocomplete, config, info, prove, stack, test, utils, wallet},
     config::load_selected_config,
 };
 use clap::{Parser, Subcommand};
@@ -33,6 +33,8 @@ enum EthrexL2Command {
     Info(info::Command),
     #[clap(about = "Read a test chain from disk and prove a block.")]
     Prove(prove::Command),
+    #[clap(subcommand, about = "Utils commands.")]
+    Utils(utils::Command),
 }
 
 pub async fn start() -> eyre::Result<()> {
@@ -53,6 +55,7 @@ pub async fn start() -> eyre::Result<()> {
         EthrexL2Command::Test(cmd) => cmd.run(cfg).await?,
         EthrexL2Command::Info(cmd) => cmd.run(cfg).await?,
         EthrexL2Command::Prove(_) => unreachable!(),
+        EthrexL2Command::Utils(cmd) => cmd.run()?,
     };
     Ok(())
 }

--- a/cmd/ethrex_l2/src/commands/mod.rs
+++ b/cmd/ethrex_l2/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod info;
 pub(crate) mod prove;
 pub(crate) mod stack;
 pub(crate) mod test;
+pub(crate) mod utils;
 pub(crate) mod wallet;

--- a/cmd/ethrex_l2/src/commands/utils.rs
+++ b/cmd/ethrex_l2/src/commands/utils.rs
@@ -10,7 +10,7 @@ pub(crate) enum Command {
         about = "Convert private key to address."
     )]
     PrivateKeyToAddress {
-        #[arg(long = "pk", help = "Private key in hex format.", required = true)]
+        #[arg(help = "Private key in hex format.", required = true)]
         private_key: String,
     },
 }

--- a/cmd/ethrex_l2/src/commands/utils.rs
+++ b/cmd/ethrex_l2/src/commands/utils.rs
@@ -20,7 +20,7 @@ impl Command {
                 let pk_bytes = pk_h256.as_bytes();
                 let secret_key = SecretKey::from_slice(pk_bytes)?;
                 let address = ethrex_l2_sdk::get_address_from_secret_key(&secret_key)?;
-                println!("Address: {address:#x}");
+                println!("{address:#x}");
             }
         }
         Ok(())

--- a/cmd/ethrex_l2/src/commands/utils.rs
+++ b/cmd/ethrex_l2/src/commands/utils.rs
@@ -1,0 +1,28 @@
+use clap::Subcommand;
+use keccak_hash::H256;
+use secp256k1::SecretKey;
+
+#[derive(Subcommand)]
+pub(crate) enum Command {
+    #[clap(about = "Convert private key to address.")]
+    PrivateKeyToAddress {
+        #[arg(long = "pk", help = "Private key in hex format.", required = true)]
+        private_key: String,
+    },
+}
+
+impl Command {
+    pub fn run(self) -> eyre::Result<()> {
+        match self {
+            Command::PrivateKeyToAddress { private_key } => {
+                let pk_str = private_key.strip_prefix("0x").unwrap_or(&private_key);
+                let pk_h256 = pk_str.parse::<H256>()?;
+                let pk_bytes = pk_h256.as_bytes();
+                let secret_key = SecretKey::from_slice(pk_bytes)?;
+                let address = ethrex_l2_sdk::get_address_from_secret_key(&secret_key)?;
+                println!("Address: {:#x}", address);
+            }
+        }
+        Ok(())
+    }
+}

--- a/cmd/ethrex_l2/src/commands/utils.rs
+++ b/cmd/ethrex_l2/src/commands/utils.rs
@@ -4,7 +4,11 @@ use secp256k1::SecretKey;
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
-    #[clap(about = "Convert private key to address.")]
+    #[clap(
+        name = "address",
+        visible_aliases = ["a"],
+        about = "Convert private key to address."
+    )]
     PrivateKeyToAddress {
         #[arg(long = "pk", help = "Private key in hex format.", required = true)]
         private_key: String,

--- a/cmd/ethrex_l2/src/commands/utils.rs
+++ b/cmd/ethrex_l2/src/commands/utils.rs
@@ -20,7 +20,7 @@ impl Command {
                 let pk_bytes = pk_h256.as_bytes();
                 let secret_key = SecretKey::from_slice(pk_bytes)?;
                 let address = ethrex_l2_sdk::get_address_from_secret_key(&secret_key)?;
-                println!("Address: {:#x}", address);
+                println!("Address: {address:#x}");
             }
         }
         Ok(())

--- a/cmd/ethrex_l2/src/commands/utils.rs
+++ b/cmd/ethrex_l2/src/commands/utils.rs
@@ -1,5 +1,4 @@
 use clap::Subcommand;
-use keccak_hash::H256;
 use secp256k1::SecretKey;
 
 #[derive(Subcommand)]
@@ -19,10 +18,10 @@ impl Command {
     pub fn run(self) -> eyre::Result<()> {
         match self {
             Command::PrivateKeyToAddress { private_key } => {
-                let pk_str = private_key.strip_prefix("0x").unwrap_or(&private_key);
-                let pk_h256 = pk_str.parse::<H256>()?;
-                let pk_bytes = pk_h256.as_bytes();
-                let secret_key = SecretKey::from_slice(pk_bytes)?;
+                let secret_key = private_key
+                    .strip_prefix("0x")
+                    .unwrap_or(&private_key)
+                    .parse::<SecretKey>()?;
                 let address = ethrex_l2_sdk::get_address_from_secret_key(&secret_key)?;
                 println!("{address:#x}");
             }


### PR DESCRIPTION
**Motivation**

In this PR we add the `utils` subcommand to the cli with the `private-key-to-address` option

**Description**

* Added the `utils.rs` file
* Using the function `get_address_from_secret_key` from the sdk we compute the address

Links to: #2034 

