### PR TITLE
fix(l1): full-sync with both consensus and execution node

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -343,6 +343,7 @@ impl SyncManager {
         store: Store,
     ) -> Result<(), SyncError> {
         let mut last_valid_hash = H256::default();
+
         let mut current_chunk_idx = 0;
         let chunks: Vec<Vec<BlockHash>> = block_hashes
             .chunks(MAX_BLOCK_BODIES_TO_REQUEST)
@@ -384,13 +385,13 @@ impl SyncManager {
                         self.invalid_ancestors.insert(hash, last_valid_hash);
                         return Err(error.into());
                     }
+                    store.set_canonical_block(number, hash)?;
+                    store.update_latest_block_number(number)?;
+                    last_valid_hash = hash;
                     debug!(
                         "Executed and stored block number {} with hash {}",
                         number, hash
                     );
-                    store.set_canonical_block(number, hash)?;
-                    store.update_latest_block_number(number)?;
-                    last_valid_hash = hash;
                 }
                 debug!("Executed & stored {} blocks", block_bodies_len);
 

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -268,7 +268,15 @@ impl SyncManager {
             store.add_block_headers(block_hashes.clone(), block_headers)?;
 
             if self.sync_mode == SyncMode::Full {
-                self.download_and_run_blocks(&mut block_hashes, store.clone(), sync_head)
+                if sync_head_found {
+                    // Filter out everything after the sync_head
+                    block_hashes = block_hashes
+                        .iter()
+                        .take_while(|&hash| *hash != sync_head)
+                        .cloned()
+                        .collect();
+                }
+                self.download_and_run_blocks(&mut block_hashes, store.clone())
                     .await?;
             }
 
@@ -333,11 +341,8 @@ impl SyncManager {
         &mut self,
         block_hashes: &mut [BlockHash],
         store: Store,
-        sync_head: H256,
     ) -> Result<(), SyncError> {
         let mut last_valid_hash = H256::default();
-        let mut sync_head_reached = false;
-
         let mut current_chunk_idx = 0;
         let chunks: Vec<Vec<BlockHash>> = block_hashes
             .chunks(MAX_BLOCK_BODIES_TO_REQUEST)
@@ -383,14 +388,9 @@ impl SyncManager {
                         "Executed and stored block number {} with hash {}",
                         number, hash
                     );
-                    if !sync_head_reached {
-                        store.set_canonical_block(number, hash)?;
-                        store.update_latest_block_number(number)?;
-                        last_valid_hash = hash;
-                    }
-                    if hash == sync_head {
-                        sync_head_reached = true;
-                    }
+                    store.set_canonical_block(number, hash)?;
+                    store.update_latest_block_number(number)?;
+                    last_valid_hash = hash;
                 }
                 debug!("Executed & stored {} blocks", block_bodies_len);
 


### PR DESCRIPTION
**Motivation**

Currently, during full-sync, we download, execute and store blocks as canonical in chunks of `MAX_BLOCK_BODIES_TO_REQUEST=128`. However, we do not verify whether we are ahead of the consensus head, which results in invalid `forkChoice` responses.

**Description**

- Filters the downloaded headers to request only the needed bodies to peers.

Closes #2066

