### PR TITLE
fix(l2): fix gas estimation for deployments in load tests

### DIFF
--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -333,14 +333,9 @@ impl EthClient {
         &self,
         transaction: GenericTransaction,
     ) -> Result<u64, EthClientError> {
-        // If the transaction.to field matches TxKind::Create, we use an empty string.
-        // In this way, when the blockchain receives the request, it deserializes the json into a GenericTransaction,
-        // with the 'to' field set to TxKind::Create.
-        // The TxKind has TxKind::Create as #[default]
-        // https://github.com/lambdaclass/ethrex/blob/41b124c39030ad5d0b2674d7369be3599c7a3008/crates/common/types/transaction.rs#L267
         let to = match transaction.to {
-            TxKind::Call(addr) => format!("{addr:#x}"),
-            TxKind::Create => String::new(),
+            TxKind::Call(addr) => Some(format!("{addr:#x}")),
+            TxKind::Create => None,
         };
         let mut data = json!({
             "to": to,


### PR DESCRIPTION
**Motivation**

While ethrex accepts transactions with empty strings as deploy transactions, most other nodes do not, instead expecting a null value in the `to` field.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

