### PR TITLE
Changed L1 db index from u8 to String

### DIFF
--- a/crates/storage/utils.rs
+++ b/crates/storage/utils.rs
@@ -2,32 +2,26 @@
 //  Stores chain-specific data such as chain id and latest finalized/pending/safe block number
 #[derive(Debug, Copy, Clone)]
 pub enum ChainDataIndex {
-    ChainConfig = 0,
-    EarliestBlockNumber = 1,
-    FinalizedBlockNumber = 2,
-    SafeBlockNumber = 3,
-    LatestBlockNumber = 4,
-    PendingBlockNumber = 5,
-    IsSynced = 6,
+    ChainConfig,
+    EarliestBlockNumber,
+    FinalizedBlockNumber,
+    SafeBlockNumber,
+    LatestBlockNumber,
+    PendingBlockNumber,
+    IsSynced,
 }
 
-impl From<u8> for ChainDataIndex {
-    fn from(value: u8) -> Self {
-        match value {
-            x if x == ChainDataIndex::ChainConfig as u8 => ChainDataIndex::ChainConfig,
-            x if x == ChainDataIndex::EarliestBlockNumber as u8 => {
-                ChainDataIndex::EarliestBlockNumber
-            }
-            x if x == ChainDataIndex::FinalizedBlockNumber as u8 => {
-                ChainDataIndex::FinalizedBlockNumber
-            }
-            x if x == ChainDataIndex::SafeBlockNumber as u8 => ChainDataIndex::SafeBlockNumber,
-            x if x == ChainDataIndex::LatestBlockNumber as u8 => ChainDataIndex::LatestBlockNumber,
-            x if x == ChainDataIndex::PendingBlockNumber as u8 => {
-                ChainDataIndex::PendingBlockNumber
-            }
-            x if x == ChainDataIndex::IsSynced as u8 => ChainDataIndex::IsSynced,
-            _ => panic!("Invalid value when casting to ChainDataIndex: {}", value),
+impl From<&str> for ChainDataIndex {
+    fn from(s: &str) -> Self {
+        match s {
+            "chain_config" => ChainDataIndex::ChainConfig,
+            "earliest_block_number" => ChainDataIndex::EarliestBlockNumber,
+            "finalized_block_number" => ChainDataIndex::FinalizedBlockNumber,
+            "safe_block_number" => ChainDataIndex::SafeBlockNumber,
+            "latest_block_number" => ChainDataIndex::LatestBlockNumber,
+            "pending_block_number" => ChainDataIndex::PendingBlockNumber,
+            "is_synced" => ChainDataIndex::IsSynced,
+            _ => panic!("Invalid value when casting to ChainDataIndex: {}", s),
         }
     }
 }
@@ -38,29 +32,30 @@ impl From<u8> for ChainDataIndex {
 #[derive(Debug, Copy, Clone)]
 pub enum SnapStateIndex {
     // Hash of the last downloaded header in a previous sync cycle that was aborted
-    HeaderDownloadCheckpoint = 0,
+    HeaderDownloadCheckpoint,
     // Paths from the storage trie in need of healing, grouped by hashed account address
-    StorageHealPaths = 2,
+    StorageHealPaths,
     // Last key fetched from the state trie
-    StateTrieKeyCheckpoint = 3,
+    StateTrieKeyCheckpoint,
     // Paths from the state trie in need of healing
-    StateHealPaths = 4,
+    StateHealPaths,
     // Trie Rebuild Checkpoint (Current State Trie Root, Last Inserted Key Per Segment)
-    StateTrieRebuildCheckpoint = 5,
+    StateTrieRebuildCheckpoint,
     // Storage tries awaiting rebuild (AccountHash, ExpectedRoot)
-    StorageTrieRebuildPending = 6,
+    StorageTrieRebuildPending,
 }
 
-impl From<u8> for SnapStateIndex {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => SnapStateIndex::HeaderDownloadCheckpoint,
-            2 => SnapStateIndex::StorageHealPaths,
-            3 => SnapStateIndex::StateTrieKeyCheckpoint,
-            4 => SnapStateIndex::StateHealPaths,
-            5 => SnapStateIndex::StateTrieRebuildCheckpoint,
-            6 => SnapStateIndex::StorageTrieRebuildPending,
-            _ => panic!("Invalid value when casting to SnapDataIndex: {}", value),
+impl From<&str> for SnapStateIndex {
+    fn from(s: &str) -> Self {
+        match s {
+            "header_download_checkpoint" => Self::HeaderDownloadCheckpoint,
+            "storage_heal_paths" => Self::StorageHealPaths,
+            "state_trie_key_checkpoint" => Self::StateTrieKeyCheckpoint,
+            "state_heal_paths" => Self::StateHealPaths,
+            "state_trie_rebuild_checkpoint" => Self::StateTrieRebuildCheckpoint,
+            "storage_trie_rebuild_pending" => Self::StorageTrieRebuildPending,
+            _ => panic!("Invalid SnapStateIndex string: {}", s),
         }
     }
 }
+


### PR DESCRIPTION
**Motivation**

Changing the L1 DB index from u8 to String, in crates/storage/utils.rs

**Description**

Enums ChainDataIndex and SnapStateIndex are used as a set of keys to store general information in the database. Currently, those indexes are implemented as u8, but we want them to be strings instead.


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2078

