### PR TITLE
refactor(l1): make Blockchain an Arc<Blockchain>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,7 +2919,6 @@ dependencies = [
 name = "ethrex-vm"
 version = "0.1.0"
 dependencies = [
- "alloy-rpc-types-eth",
  "bincode",
  "bytes",
  "cfg-if",

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -177,7 +177,7 @@ async fn main() {
         }
         Store::new(&data_dir, engine_type).expect("Failed to create Store")
     };
-    let blockchain = Blockchain::new(evm.clone(), store.clone());
+    let blockchain = Arc::new(Blockchain::new(evm.clone(), store.clone()));
 
     let genesis = read_genesis_file(&network);
     store

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -33,10 +33,10 @@ use tracing::{error, info, warn};
 //TODO: Implement a struct Chain or BlockChain to encapsulate
 //functionality and canonical chain state and config
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Blockchain {
     pub vm: EVM,
-    pub storage: Store,
+    storage: Store,
     pub mempool: Mempool,
 }
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex, RwLock},
+    sync::{Mutex, RwLock},
 };
 
 use crate::{
@@ -17,10 +17,10 @@ use ethrex_common::{
 };
 use ethrex_storage::error::StoreError;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct Mempool {
-    transaction_pool: Arc<RwLock<HashMap<H256, MempoolTransaction>>>,
-    blobs_bundle_pool: Arc<Mutex<HashMap<H256, BlobsBundle>>>,
+    transaction_pool: RwLock<HashMap<H256, MempoolTransaction>>,
+    blobs_bundle_pool: Mutex<HashMap<H256, BlobsBundle>>,
 }
 impl Mempool {
     pub fn new() -> Self {

--- a/crates/l2/proposer/l1_watcher.rs
+++ b/crates/l2/proposer/l1_watcher.rs
@@ -11,11 +11,14 @@ use ethrex_rpc::types::receipt::RpcLog;
 use ethrex_storage::Store;
 use keccak_hash::keccak;
 use secp256k1::SecretKey;
-use std::{cmp::min, ops::Mul, time::Duration};
+use std::{cmp::min, ops::Mul, sync::Arc, time::Duration};
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
-pub async fn start_l1_watcher(store: Store, blockchain: Blockchain) -> Result<(), ConfigError> {
+pub async fn start_l1_watcher(
+    store: Store,
+    blockchain: Arc<Blockchain>,
+) -> Result<(), ConfigError> {
     let eth_config = EthConfig::from_env()?;
     let watcher_config = L1WatcherConfig::from_env()?;
     let mut l1_watcher = L1Watcher::new_from_config(watcher_config, eth_config).await?;

--- a/crates/l2/proposer/mod.rs
+++ b/crates/l2/proposer/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use crate::utils::config::{errors::ConfigError, proposer::ProposerConfig, read_env_file};
 use errors::ProposerError;
@@ -26,7 +26,7 @@ pub struct Proposer {
     jwt_secret: Vec<u8>,
 }
 
-pub async fn start_proposer(store: Store, blockchain: Blockchain) {
+pub async fn start_proposer(store: Store, blockchain: Arc<Blockchain>) {
     info!("Starting Proposer");
 
     if let Err(e) = read_env_file() {
@@ -35,10 +35,7 @@ pub async fn start_proposer(store: Store, blockchain: Blockchain) {
     }
 
     let mut task_set = JoinSet::new();
-    task_set.spawn(l1_watcher::start_l1_watcher(
-        store.clone(),
-        blockchain.clone(),
-    ));
+    task_set.spawn(l1_watcher::start_l1_watcher(store.clone(), blockchain));
     task_set.spawn(l1_committer::start_l1_committer(store.clone()));
     task_set.spawn(prover_server::start_prover_server(store.clone()));
     task_set.spawn(start_proposer_server(store.clone()));

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -678,7 +678,7 @@ pub(super) mod tests {
 
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let table = Arc::new(Mutex::new(KademliaTable::new(node_id)));
         let (broadcast, _) = tokio::sync::broadcast::channel::<(tokio::task::Id, Arc<RLPxMessage>)>(
             MAX_MESSAGES_TO_BROADCAST,

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -48,7 +48,7 @@ pub struct P2PContext {
     pub signer: SigningKey,
     pub table: Arc<Mutex<KademliaTable>>,
     pub storage: Store,
-    pub blockchain: Blockchain,
+    pub blockchain: Arc<Blockchain>,
     pub(crate) broadcast: RLPxConnBroadcastSender,
     pub local_node: Node,
     pub enr_seq: u64,
@@ -61,7 +61,7 @@ pub async fn start_network(
     signer: SigningKey,
     peer_table: Arc<Mutex<KademliaTable>>,
     storage: Store,
-    blockchain: Blockchain,
+    blockchain: Arc<Blockchain>,
 ) -> Result<(), NetworkError> {
     let (channel_broadcast_send_end, _) = tokio::sync::broadcast::channel::<(
         tokio::task::Id,

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -75,7 +75,7 @@ pub(crate) struct RLPxConnection<S> {
     node: Node,
     framed: Framed<S, RLPxCodec>,
     storage: Store,
-    blockchain: Blockchain,
+    blockchain: Arc<Blockchain>,
     capabilities: Vec<(Capability, u8)>,
     negotiated_eth_version: u8,
     negotiated_snap_version: u8,
@@ -100,7 +100,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         stream: S,
         codec: RLPxCodec,
         storage: Store,
-        blockchain: Blockchain,
+        blockchain: Arc<Blockchain>,
         connection_broadcast: RLPxConnBroadcastSender,
     ) -> Self {
         Self {

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -89,7 +89,7 @@ pub struct SyncManager {
     trie_rebuilder: Option<TrieRebuilder>,
     // Used for cancelling long-living tasks upon shutdown
     cancel_token: CancellationToken,
-    pub blockchain: Blockchain,
+    pub blockchain: Arc<Blockchain>,
 }
 
 impl SyncManager {
@@ -97,7 +97,7 @@ impl SyncManager {
         peer_table: Arc<Mutex<KademliaTable>>,
         sync_mode: SyncMode,
         cancel_token: CancellationToken,
-        blockchain: Blockchain,
+        blockchain: Arc<Blockchain>,
     ) -> Self {
         Self {
             sync_mode,
@@ -122,9 +122,9 @@ impl SyncManager {
             trie_rebuilder: None,
             // This won't be used
             cancel_token: CancellationToken::new(),
-            blockchain: Blockchain::default_with_store(
+            blockchain: Arc::new(Blockchain::default_with_store(
                 Store::new("", EngineType::InMemory).unwrap(),
-            ),
+            )),
         }
     }
 

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -439,7 +439,7 @@ mod tests {
     ) -> u64 {
         let storage = Store::new("in-mem", EngineType::InMemory)
             .expect("Fatal: could not create in memory test db");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let context = RpcApiContext {
             storage,
             blockchain,
@@ -505,7 +505,7 @@ mod tests {
 
         let storage = Store::new("in-mem", EngineType::InMemory)
             .expect("Fatal: could not create in memory test db");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let context = RpcApiContext {
             storage,
             blockchain,
@@ -536,7 +536,7 @@ mod tests {
 
         let storage = Store::new("in-mem", EngineType::InMemory)
             .expect("Fatal: could not create in memory test db");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let context = RpcApiContext {
             storage,
             blockchain,

--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -73,7 +73,7 @@ mod tests {
 
     fn default_context() -> RpcApiContext {
         let storage = setup_store();
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         RpcApiContext {
             storage,
             blockchain,

--- a/crates/networking/rpc/eth/max_priority_fee.rs
+++ b/crates/networking/rpc/eth/max_priority_fee.rs
@@ -56,7 +56,7 @@ mod tests {
 
     fn default_context() -> RpcApiContext {
         let storage = setup_store();
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         RpcApiContext {
             storage,
             blockchain,

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -80,7 +80,7 @@ enum RpcRequestWrapper {
 #[derive(Debug, Clone)]
 pub struct RpcApiContext {
     storage: Store,
-    blockchain: Blockchain,
+    blockchain: Arc<Blockchain>,
     jwt_secret: Bytes,
     local_p2p_node: Node,
     local_node_record: NodeRecord,
@@ -155,7 +155,7 @@ pub async fn start_api(
     http_addr: SocketAddr,
     authrpc_addr: SocketAddr,
     storage: Store,
-    blockchain: Blockchain,
+    blockchain: Arc<Blockchain>,
     jwt_secret: Bytes,
     local_p2p_node: Node,
     local_node_record: NodeRecord,
@@ -486,7 +486,7 @@ mod tests {
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
         storage.set_chain_config(&example_chain_config()).unwrap();
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let context = RpcApiContext {
             local_p2p_node,
             local_node_record: example_local_node_record(),
@@ -572,7 +572,7 @@ mod tests {
         // Setup initial storage
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let genesis = read_execution_api_genesis_file();
         storage
             .add_initial_state(genesis)
@@ -609,7 +609,7 @@ mod tests {
         // Setup initial storage
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let genesis = read_execution_api_genesis_file();
         storage
             .add_initial_state(genesis)
@@ -677,7 +677,7 @@ mod tests {
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
         storage.set_chain_config(&example_chain_config()).unwrap();
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let chain_id = storage
             .get_chain_config()
             .expect("failed to get chain_id")

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -252,7 +252,7 @@ pub fn parse_json_hex(hex: &serde_json::Value) -> Result<u64, String> {
 
 #[cfg(test)]
 pub mod test_utils {
-    use std::{net::SocketAddr, str::FromStr};
+    use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
     use ethrex_blockchain::Blockchain;
     use ethrex_common::H512;
@@ -312,7 +312,7 @@ pub mod test_utils {
         storage
             .add_initial_state(serde_json::from_str(TEST_GENESIS).unwrap())
             .expect("Failed to build test genesis");
-        let blockchain = Blockchain::default_with_store(storage.clone());
+        let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let jwt_secret = Default::default();
         let local_p2p_node = example_p2p_node();
         #[cfg(feature = "based")]


### PR DESCRIPTION
**Motivation**

This is a follow up to #2089 
Blockchain struct is supposed to be a singleton, we shouldn't be cloning it, only passing references.

**Description**

- Remove `derive(Clone)` from Blockchain. Make arguments to functions/structs `Arc<Blockchain>`, the only initialization of blockchain is done in `ethrex.rs` inside an Arc.
- Remove `derive(Clone)` from mempool as the mempool shouldn't be cloned outside of Blockchain, remove Arc from Mempool members as they should always be inside the blockchain which already is Arc.
- Remove `pub` from storage inside of blockchain as it should only be used by functions of `Blockchain`.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2105 

