### PR TITLE
chore(l1): `blockchain` should not be accessed from inside the syncer.

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -92,7 +92,7 @@ pub struct SyncManager {
     trie_rebuilder: Option<TrieRebuilder>,
     // Used for cancelling long-living tasks upon shutdown
     cancel_token: CancellationToken,
-    pub blockchain: Arc<Blockchain>,
+    blockchain: Arc<Blockchain>,
 }
 
 impl SyncManager {


### PR DESCRIPTION
**Motivation**
The Sync Manager stores a reference to the `blockchain` object as a reference for convenience, but it is not meant to be exposed.

Closes #2063
