### PR TITLE
docs(l2): update documentation with the new `config.toml` format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ TODO: Expand on tasks about proper interoperability between chains (seamlessly b
 >
 > 1. Make sure you are inside the `crates/l2` directory.
 > 2. Make sure the Docker daemon is running.
-> 3. Make sure you have created a `.env` file following the `.env.example` file.
+> 3. Make sure you have created a `config.toml` file following the `config_example.toml` file.
 
 ```
 make init

--- a/crates/l2/docs/README.md
+++ b/crates/l2/docs/README.md
@@ -16,7 +16,7 @@ For more detailed documentation on each part of the system:
 1. `cd crates/l2`
 2. `make rm-db-l2 && make down`
    - It will remove any old database, if present, stored in your computer. The absolute path of libmdbx is defined by [data_dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html).
-3. `cp .env.example .env` &rarr; check if you want to change any config.
+3. `cp config_example.toml config.toml` &rarr; check if you want to change any config.
 4. `make init`
    - Init the L1 in a docker container on port `8545`.
    - Deploy the needed contracts for the L2 on the L1.

--- a/crates/l2/docs/proposer.md
+++ b/crates/l2/docs/proposer.md
@@ -38,10 +38,24 @@ For more information about the Prover Server, the [Prover Docs](./prover.md) pro
 
 Configuration is done through environment variables. The easiest way to configure the Proposer is by creating a `config.toml` file and setting the variables there. Then, at start, it will read the file and set the variables.
 
-The following environment variables are available to configure the Proposer:
+The following environment variables are available to configure the Proposer (consider looking at the provided [config_example.toml](../config_example.toml):
+
+<!-- NOTE: Mantain the titles in the same order as present in [config_example.toml](../config_example.toml). -->
+
+- Under the [deployer] title:
+    - `address`: L1 account which will deploy the common bridge contracts in L1.
+    - `private key`: Its private key.
+    - `risc0_contract_verifier`: Address which will verify the `risc0` proofs.
+    - `sp1_contract_verifier`: Address which will verify the `sp1` proofs.
+    - `sp1_deploy_verifier`: Whether to deploy the sp1 verifier
+    - `salt_is_zero`: Whether a 0 value salt will be used. Keep as true for deterministic `create2` operations.
 
 - Under the [eth] title:
     - `rpc_url`: URL of the L1 RPC.
+
+- Under the [engine] title:
+    - `rpc_url`: URL of the EngineAPI.
+    - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
 
 - Under the [watcher] title:
     - `bridge_address`: Address of the bridge contract on L1.
@@ -49,9 +63,14 @@ The following environment variables are available to configure the Proposer:
     - `max_block_step`: Maximum number of blocks to look for when checking for new events.
     - `l2_proposer_private_key`: Private key of the L2 proposer.
 
-- Under the [engine] title:
-    - `rpc_url`: URL of the EngineAPI.
-    - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
+- Under the [proposer] title:
+    - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
+    - `coinbase address`: Address which will receive the execution fees.
+
+Under the [committer] title:
+    - `l1_address`: Address of the L1 committer.
+    - `l1_private_key`: Private key of the L1 committer.
+    - `on_chain_proposer_address`: Address of the on-chain committer.
 
 - Under the [prover] title:
     - `sp1_prover`: Configure how the `sp1_prover` computes its proofs, `"local"` for real proofs and `"mock"` for fake proofs.
@@ -64,14 +83,9 @@ The following environment variables are available to configure the Proposer:
 - Under the [prover.server] title:
     - `listen_ip`: IP to listen for proof data requests.
     - `listen_port`: Port to listen for proof data requests.
+    - `verifier_address`: Address in charge of verifying zkProofs.
+    - `verifier_private_key`: zkProof verifier's private key.
+    - `dev_mode`: whether `dev_mode` is activated.
 
-Under the [committer] title:
-- `l1_address`: Address of the L1 committer.
-- `l1_private_key`: Private key of the L1 committer.
-- `on_chain_proposer_address`: Address of the on-chain committer.
-
-- Under the [proposer] title:
-    - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
-    - `coinbase address`: Address which will receive the execution fees.
 
 If you want to use a different configuration file, you can set the `CONFIG_FILE` environment variable to the path of the file.

--- a/crates/l2/docs/proposer.md
+++ b/crates/l2/docs/proposer.md
@@ -40,9 +40,9 @@ Configuration is done through environment variables. The easiest way to configur
 
 The following environment variables are available to configure the Proposer (consider looking at the provided [config_example.toml](../config_example.toml):
 
-<!-- NOTE: Mantain the titles in the same order as present in [config_example.toml](../config_example.toml). -->
+<!-- NOTE: Mantain the sections in the same order as present in [config_example.toml](../config_example.toml). -->
 
-- Under the [deployer] title:
+- Under the [deployer] section:
     - `address`: L1 account which will deploy the common bridge contracts in L1.
     - `private key`: Its private key.
     - `risc0_contract_verifier`: Address which will verify the `risc0` proofs.
@@ -50,37 +50,37 @@ The following environment variables are available to configure the Proposer (con
     - `sp1_deploy_verifier`: Whether to deploy the sp1 verifier
     - `salt_is_zero`: Whether a 0 value salt will be used. Keep as true for deterministic `create2` operations.
 
-- Under the [eth] title:
+- Under the [eth] section:
     - `rpc_url`: URL of the L1 RPC.
 
-- Under the [engine] title:
+- Under the [engine] section:
     - `rpc_url`: URL of the EngineAPI.
     - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
 
-- Under the [watcher] title:
+- Under the [watcher] section:
     - `bridge_address`: Address of the bridge contract on L1.
     - `check_interval_ms`: Interval in milliseconds to check for new events.
     - `max_block_step`: Maximum number of blocks to look for when checking for new events.
     - `l2_proposer_private_key`: Private key of the L2 proposer.
 
-- Under the [proposer] title:
+- Under the [proposer] section:
     - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
     - `coinbase address`: Address which will receive the execution fees.
 
-Under the [committer] title:
+Under the [committer] section:
     - `l1_address`: Address of the L1 committer.
     - `l1_private_key`: Private key of the L1 committer.
     - `on_chain_proposer_address`: Address of the on-chain committer.
 
-- Under the [prover] title:
+- Under the [prover] section:
     - `sp1_prover`: Configure how the `sp1_prover` computes its proofs, `"local"` for real proofs and `"mock"` for fake proofs.
     - `risc0_dev_mode`: Whether `risc0`'s dev mode is on.
 
-- Under the [prover.client] title:
+- Under the [prover.client] section:
     - `prover_server_endpoint`: Endpoint for the prover server.
     - `interval_ms`: Interval in milliseconds to prove new blocks (Currently unused).
 
-- Under the [prover.server] title:
+- Under the [prover.server] section:
     - `listen_ip`: IP to listen for proof data requests.
     - `listen_port`: Port to listen for proof data requests.
     - `verifier_address`: Address in charge of verifying zkProofs.

--- a/crates/l2/docs/proposer.md
+++ b/crates/l2/docs/proposer.md
@@ -48,25 +48,30 @@ The following environment variables are available to configure the Proposer:
     - `check_interval_ms`: Interval in milliseconds to check for new events.
     - `max_block_step`: Maximum number of blocks to look for when checking for new events.
     - `l2_proposer_private_key`: Private key of the L2 proposer.
+
 - Under the [engine] title:
     - `rpc_url`: URL of the EngineAPI.
     - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
+
 - Under the [prover] title:
     - `sp1_prover`: Configure how the `sp1_prover` computes its proofs, `"local"` for real proofs and `"mock"` for fake proofs.
     - `risc0_dev_mode`: Whether `risc0`'s dev mode is on.
+
 - Under the [prover.client] title:
     - `prover_server_endpoint`: Endpoint for the prover server.
-- `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
-- `PROVER_SERVER_LISTEN_IP`: IP to listen for proof data requests.
-- `PROVER_SERVER_LISTEN_PORT`: Port to listen for proof data requests.
-- `PROVER_ELF_PATH`: Path to the ELF file for the prover.
+    - `interval_ms`: Interval in milliseconds to prove new blocks (Currently unused).
+
+- Under the [prover.server] title:
+    - `listen_ip`: IP to listen for proof data requests.
+    - `listen_port`: Port to listen for proof data requests.
+
 Under the [committer] title:
 - `l1_address`: Address of the L1 committer.
 - `l1_private_key`: Private key of the L1 committer.
 - `on_chain_proposer_address`: Address of the on-chain committer.
 
-Under the [proposer] title:
-- `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
-- `coinbase address`: Address which will receive the execution fees.
+- Under the [proposer] title:
+    - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
+    - `coinbase address`: Address which will receive the execution fees.
 
 If you want to use a different configuration file, you can set the `CONFIG_FILE` environment variable to the path of the file.

--- a/crates/l2/docs/proposer.md
+++ b/crates/l2/docs/proposer.md
@@ -36,25 +36,37 @@ For more information about the Prover Server, the [Prover Docs](./prover.md) pro
 
 ## Configuration
 
-Configuration is done through environment variables. The easiest way to configure the Proposer is by creating a `.env` file and setting the variables there. Then, at start, it will read the file and set the variables.
+Configuration is done through environment variables. The easiest way to configure the Proposer is by creating a `config.toml` file and setting the variables there. Then, at start, it will read the file and set the variables.
 
 The following environment variables are available to configure the Proposer:
 
-- `ETH_RPC_URL`: URL of the L1 RPC.
-- `L1_WATCHER_BRIDGE_ADDRESS`: Address of the bridge contract on L1.
-- `L1_WATCHER_TOPICS`: Topics to filter the L1 events.
-- `L1_WATCHER_CHECK_INTERVAL_MS`: Interval in milliseconds to check for new events.
-- `L1_WATCHER_MAX_BLOCK_STEP`: Maximum number of blocks to look for when checking for new events.
-- `L1_WATCHER_L2_PROPOSER_PRIVATE_KEY`: Private key of the L2 proposer.
-- `ENGINE_API_RPC_URL`: URL of the EngineAPI.
-- `ENGINE_API_JWT_PATH`: Path to the JWT authentication file, required to connect to the EngineAPI.
+- Under the [eth] title:
+    - `rpc_url`: URL of the L1 RPC.
+
+- Under the [watcher] title:
+    - `bridge_address`: Address of the bridge contract on L1.
+    - `check_interval_ms`: Interval in milliseconds to check for new events.
+    - `max_block_step`: Maximum number of blocks to look for when checking for new events.
+    - `l2_proposer_private_key`: Private key of the L2 proposer.
+- Under the [engine] title:
+    - `rpc_url`: URL of the EngineAPI.
+    - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
+- Under the [prover] title:
+    - `sp1_prover`: Configure how the `sp1_prover` computes its proofs, `"local"` for real proofs and `"mock"` for fake proofs.
+    - `risc0_dev_mode`: Whether `risc0`'s dev mode is on.
+- Under the [prover.client] title:
+    - `prover_server_endpoint`: Endpoint for the prover server.
+- `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
 - `PROVER_SERVER_LISTEN_IP`: IP to listen for proof data requests.
 - `PROVER_SERVER_LISTEN_PORT`: Port to listen for proof data requests.
-- `PROVER_PROVER_SERVER_ENDPOINT`: Endpoint for the prover server.
 - `PROVER_ELF_PATH`: Path to the ELF file for the prover.
-- `PROPOSER_ON_CHAIN_PROPOSER_ADDRESS`: Address of the on-chain proposer.
-- `PROPOSER_L1_ADDRESS`: Address of the L1 proposer.
-- `PROPOSER_L1_PRIVATE_KEY`: Private key of the L1 proposer.
-- `PROPOSER_INTERVAL_MS`: Interval in milliseconds to produce new blocks for the proposer.
+Under the [committer] title:
+- `l1_address`: Address of the L1 committer.
+- `l1_private_key`: Private key of the L1 committer.
+- `on_chain_proposer_address`: Address of the on-chain committer.
 
-If you want to use a different configuration file, you can set the `ENV_FILE` environment variable to the path of the file.
+Under the [proposer] title:
+- `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
+- `coinbase address`: Address which will receive the execution fees.
+
+If you want to use a different configuration file, you can set the `CONFIG_FILE` environment variable to the path of the file.

--- a/crates/l2/docs/proposer.md
+++ b/crates/l2/docs/proposer.md
@@ -83,8 +83,8 @@ Under the [committer] section:
 - Under the [prover.server] section:
     - `listen_ip`: IP to listen for proof data requests.
     - `listen_port`: Port to listen for proof data requests.
-    - `verifier_address`: Address in charge of verifying zkProofs.
-    - `verifier_private_key`: zkProof verifier's private key.
+    - `verifier_address`: Address of the account that sends verify transaction to L1.
+    - `verifier_private_key`: Private key for the account that sends verify transaction to L1.
     - `dev_mode`: whether `dev_mode` is activated.
 
 

--- a/crates/l2/docs/prover.md
+++ b/crates/l2/docs/prover.md
@@ -69,7 +69,7 @@ Then run any of the targets:
 
 ### Dev Mode
 
-To run the blockchain (`proposer`) and prover in conjunction in a development environment, set the following environment variables in the `.env` file:
+To run the blockchain (`proposer`) and prover in conjunction in a development environment, set the following environment variables in the `config.toml` file:
 - `PROVER_SERVER_DEV_MODE=false`
 - Depending on the Proving System:
   - RISC0: `RISC0_DEV_MODE=1` [(docs)](https://dev.risczero.com/api/generating-proofs/dev-mode)

--- a/crates/l2/docs/prover.md
+++ b/crates/l2/docs/prover.md
@@ -88,7 +88,7 @@ If neither `risc0` nor `sp1` is installed on the system, the prover can be built
 1. `cd crates/l2`
 2. `make rm-db-l2 && make down`
    - It will remove any old database, if present, stored in your computer. The absolute path of libmdbx is defined by [data_dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html).
-3. `cp .env.example .env` &rarr; check if you want to change any config.
+3. `cp config_example.toml config.toml` &rarr; check if you want to change any config.
 4. `make init`
    - Make sure you have the `solc` compiler installed in your system.
    - Init the L1 in a docker container on port `8545`.
@@ -136,14 +136,17 @@ Two servers are required: one for the `prover` and another for the `proposer`. I
 
 1. `prover_client`/`zkvm` &rarr; prover with gpu, make sure to have all the required dependencies described at the beginning of [Gpu Mode](#gpu-mode) section.
     1. `cd ethrex/crates/l2`
-    2. `cp .example.env` and change the `PROVER_CLIENT_PROVER_SERVER_ENDPOINT` with the ip of the other server.
+    2. `cp config_example.toml config.toml` and change the `prover_server_endpoint` entry under the [prover.client] section with the ip of the other server.
 
 The important variables are:
 
 ```sh
-PROVER_CLIENT_PROVER_SERVER_ENDPOINT=<ip-address>:3000
-RISC0_DEV_MODE=0
-SP1_PROVER=local
+[prover.client]
+prover_server_endpoint=<ip-address>:3000
+
+[prover]
+risc0_dev_mode=0
+sp1_prover=local
 ```
 
 - `Finally`, to start the `prover_client`/`zkvm`, run:
@@ -151,13 +154,15 @@ SP1_PROVER=local
 
 2. `prover_server`/`proposer` &rarr; this server just needs rust installed.
     1. `cd ethrex/crates/l2`
-    2. `cp .example.env` and change the addresses and the following fields:
-       - `PROVER_SERVER_LISTEN_IP=0.0.0.0` &rarr; used to handle the tcp communication with the other server.
+    2. `cp config_example.toml config.toml` and change the addresses and the following fields:
+       - [prover.server]
+       `listen_ip=0.0.0.0` &rarr; used to handle the tcp communication with the other server.
        - The `COMMITTER` and `PROVER_SERVER_VERIFIER` must be different accounts, the `DEPLOYER_ADDRESS` as well as the `L1_WATCHER` may be the same account used by the `COMMITTER`.
-       - `DEPLOYER_SALT_IS_ZERO=false` &rarr; set to false to randomize the salt.
-       - `DEPLOYER_SP1_DEPLOY_VERIFIER=true` overwrites `DEPLOYER_SP1_CONTRACT_VERIFIER`. Check if the contract is deployed in your preferred network or set to `true` to deploy it.
-       - `DEPLOYER_CONTRACT_VERIFIER=0xd9b0d07CeCd808a8172F21fA7C97992168f045CA` &rarr; risc0’s verifier contract deployed on Sepolia. (Check the if the contract is deployed in your preferred network).
-       - Set the `ETH_RPC_URL` to any L1 endpoint.
+       - [deployer]
+            - `salt_is_zero=false` &rarr; set to false to randomize the salt.
+       - `sp1_deploy_verifier = true` overwrites `sp1_contract_verifier`. Check if the contract is deployed in your preferred network or set to `true` to deploy it.
+       - `risc0_contract_verifier = 0xd9b0d07CeCd808a8172F21fA7C97992168f045CA` &rarr; risc0’s verifier contract deployed on Sepolia. (Check the if the contract is deployed in your preferred network). An analog variable called `sp1_contract_verifier` exists for SP1.
+       - Set the [eth] `rpc_url` to any L1 endpoint.
 
 >[!NOTE]
 > Make sure to have funds, if you want to perform a quick test `0.2[ether]` on each account should be enough.


### PR DESCRIPTION
**Motivation**

Some of the documentation present in L2 still used the pre #2100 style of configuration via the `.env` file. With the introduction of the `config.toml`, this is now outdated. 

**Description**

Update the L2 documentation, using the `config.toml` file.

