### PR TITLE
chore(l1): create a `L1_CLIENT` environment variable for hive tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,18 +112,20 @@ SIM_LOG_LEVEL ?= 4
 EVM_BACKEND := revm
 SIM_PARALLELISM := 16
 
+L1_CLIENT       ?= ethrex
+
 # Runs a hive testing suite
 # The endpoints tested may be limited by supplying a test pattern in the form "/endpoint_1|enpoint_2|..|enpoint_n"
 # For example, to run the rpc-compat suites for eth_chainId & eth_blockNumber you should run:
 # `make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_blockNumber"`
 run-hive: build-image setup-hive ## 🧪 Run Hive testing suite
-	cd hive && ./hive --client ethrex --ethrex.flags "--evm $(EVM_BACKEND)" --sim $(SIMULATION) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)"
+	cd hive && ./hive --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim $(SIMULATION) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)"
 
 run-hive-all: build-image setup-hive ## 🧪 Run all Hive testing suites
-	cd hive && ./hive --client ethrex --ethrex.flags "--evm $(EVM_BACKEND)" --sim ".*" --sim.parallelism "$(SIM_PARALLELISM)"
+	cd hive && ./hive --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim ".*" --sim.parallelism "$(SIM_PARALLELISM)"
 
 run-hive-debug: build-image setup-hive ## 🐞 Run Hive testing suite in debug mode
-	cd hive && ./hive --sim $(SIMULATION) --client ethrex --ethrex.flags "--evm $(EVM_BACKEND)" --sim.loglevel $(SIM_LOG_LEVEL) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)" --docker.output
+	cd hive &&  HIVE_LOGLEVEL=1 ./hive --sim $(SIMULATION) --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim.loglevel $(SIM_LOG_LEVEL) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)" --docker.output
 
 clean-hive-logs: ## 🧹 Clean Hive logs
 	rm -rf ./hive/workspace/logs

--- a/Makefile
+++ b/Makefile
@@ -118,13 +118,13 @@ L1_CLIENT       ?= ethrex
 # The endpoints tested may be limited by supplying a test pattern in the form "/endpoint_1|enpoint_2|..|enpoint_n"
 # For example, to run the rpc-compat suites for eth_chainId & eth_blockNumber you should run:
 # `make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_blockNumber"`
-run-hive: build-image setup-hive ## 🧪 Run Hive testing suite
+run-hive: $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🧪 Run Hive testing suite
 	cd hive && ./hive --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim $(SIMULATION) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)"
 
-run-hive-all: build-image setup-hive ## 🧪 Run all Hive testing suites
+run-hive-all: $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🧪 Run all Hive testing suites
 	cd hive && ./hive --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim ".*" --sim.parallelism "$(SIM_PARALLELISM)"
 
-run-hive-debug: build-image setup-hive ## 🐞 Run Hive testing suite in debug mode
+run-hive-debug: $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🐞 Run Hive testing suite in debug mode
 	cd hive &&  HIVE_LOGLEVEL=1 ./hive --sim $(SIMULATION) --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim.loglevel $(SIM_LOG_LEVEL) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)" --docker.output
 
 clean-hive-logs: ## 🧹 Clean Hive logs

--- a/Makefile
+++ b/Makefile
@@ -114,17 +114,25 @@ SIM_PARALLELISM := 16
 
 L1_CLIENT       ?= ethrex
 
+display-hive-alternatives:
+	@echo ""
+	@echo "Running L1 with ${L1_CLIENT} as client. Other clients are available in order to compare tests results."
+	@echo "In order to use a different client, use the environment variable 'L1_CLIENT' with one of the follwoing values:"
+	@echo "   - ethrex: https://github.com/lambdaclass/ethrex"
+	@echo "   - go-ethereum: https://github.com/ethereum/go-ethereum"
+	@echo ""
+
 # Runs a hive testing suite
 # The endpoints tested may be limited by supplying a test pattern in the form "/endpoint_1|enpoint_2|..|enpoint_n"
 # For example, to run the rpc-compat suites for eth_chainId & eth_blockNumber you should run:
 # `make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_blockNumber"`
-run-hive: $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🧪 Run Hive testing suite
+run-hive: display-hive-alternatives $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🧪 Run Hive testing suite
 	cd hive && ./hive --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim $(SIMULATION) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)"
 
-run-hive-all: $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🧪 Run all Hive testing suites
+run-hive-all: display-hive-alternatives $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🧪 Run all Hive testing suites
 	cd hive && ./hive --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim ".*" --sim.parallelism "$(SIM_PARALLELISM)"
 
-run-hive-debug: $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🐞 Run Hive testing suite in debug mode
+run-hive-debug: display-hive-alternatives $(if $(filter $(L1_CLIENT),ethrex), build-image) setup-hive ## 🐞 Run Hive testing suite in debug mode
 	cd hive &&  HIVE_LOGLEVEL=1 ./hive --sim $(SIMULATION) --client $(L1_CLIENT) --ethrex.flags "--evm $(EVM_BACKEND)" --sim.loglevel $(SIM_LOG_LEVEL) --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)" --docker.output
 
 clean-hive-logs: ## 🧹 Clean Hive logs


### PR DESCRIPTION
**Motivation**

Currently, if you want to run the hive test suite with a different client different than ethrex, you have to change the Makefile manually. 

**Description**

This PR introduces a new environment variable `L1_CLIENT` that allows you to select a different L1 to run the Hive tests with; without needing to modify the Makefile manually. 

