### PR TITLE
chore(l1): remove --import and --import_dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,10 @@ QUIET ?= false
 
 hive:
 	if [ "$(QUIET)" = "true" ]; then \
-		git clone --quiet --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --quiet --single-branch --branch import_subcommand --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --quiet --detach $(HIVE_REVISION) && go build .; \
 	else \
-		git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --single-branch --branch import_subcommand --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --detach $(HIVE_REVISION) && go build .; \
 	fi
 
@@ -96,12 +96,12 @@ setup-hive: hive ## 🐝 Set up Hive testing framework
 	if [ "$$(cd hive && git rev-parse HEAD)" != "$(HIVE_REVISION)" ]; then \
 		if [ "$(QUIET)" = "true" ]; then \
 			cd hive && \
-			git checkout --quiet master && \
+			git checkout --quiet import_subcommand && \
 			git fetch --quiet --shallow-since=$(HIVE_SHALLOW_SINCE) && \
 			git checkout --quiet --detach $(HIVE_REVISION) && go build .;\
 		else \
 			cd hive && \
-			git checkout master && \
+			git checkout import_subcommand && \
 			git fetch --shallow-since=$(HIVE_SHALLOW_SINCE) && \
 			git checkout --detach $(HIVE_REVISION) && go build .;\
 		fi \

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := b21c217ba5f48949b6b64ef28f7fb11e40584652
+HIVE_REVISION := 4ca1936688f32eae23072ef7620b2223bd06e817
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := 4ca1936688f32eae23072ef7620b2223bd06e817
+HIVE_REVISION := d98bcfa37f501f4ea1869d0a79fde35ed472937f
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).
@@ -85,10 +85,10 @@ QUIET ?= false
 
 hive:
 	if [ "$(QUIET)" = "true" ]; then \
-		git clone --quiet --single-branch --branch import_subcommand --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --quiet --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --quiet --detach $(HIVE_REVISION) && go build .; \
 	else \
-		git clone --single-branch --branch import_subcommand --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --detach $(HIVE_REVISION) && go build .; \
 	fi
 
@@ -96,12 +96,12 @@ setup-hive: hive ## 🐝 Set up Hive testing framework
 	if [ "$$(cd hive && git rev-parse HEAD)" != "$(HIVE_REVISION)" ]; then \
 		if [ "$(QUIET)" = "true" ]; then \
 			cd hive && \
-			git checkout --quiet import_subcommand && \
+			git checkout --quiet master && \
 			git fetch --quiet --shallow-since=$(HIVE_SHALLOW_SINCE) && \
 			git checkout --quiet --detach $(HIVE_REVISION) && go build .;\
 		else \
 			cd hive && \
-			git checkout import_subcommand && \
+			git checkout master && \
 			git fetch --shallow-since=$(HIVE_SHALLOW_SINCE) && \
 			git checkout --detach $(HIVE_REVISION) && go build .;\
 		fi \

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -100,23 +100,11 @@ pub fn cli() -> Command {
                 .help("If the datadir is the word `memory`, ethrex will use the InMemory Engine"),
         )
         .arg(
-            Arg::new("import")
-                .long("import")
-                .required(false)
-                .value_name("CHAIN_RLP_PATH"),
-        )
-        .arg(
             Arg::new("syncmode")
                 .long("syncmode")
                 .required(false)
                 .default_value("full")
                 .value_name("SYNC_MODE"),
-        )
-        .arg(
-            Arg::new("import_dir")
-                .long("import_dir")
-                .required(false)
-                .value_name("BLOCKS_DIR_PATH"),
         )
         .arg(
             Arg::new("metrics.port")

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -51,7 +51,7 @@ async fn main() {
 
     let store = init_store(&data_dir, &network);
 
-    let blockchain = init_blockchain(&matches, evm_engine, store.clone());
+    let blockchain = init_blockchain(evm_engine, store.clone());
 
     let signer = get_signer(&data_dir);
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1,8 +1,7 @@
 use crate::{
     networks,
     utils::{
-        parse_socket_addr, read_block_file, read_chain_file, read_genesis_file,
-        read_jwtsecret_file, read_known_peers, sync_mode,
+        parse_socket_addr, read_genesis_file, read_jwtsecret_file, read_known_peers, sync_mode,
     },
 };
 use bytes::Bytes;
@@ -87,39 +86,8 @@ pub fn init_store(data_dir: &str, network: &str) -> Store {
     store
 }
 
-pub fn init_blockchain(
-    matches: &ArgMatches,
-    evm_engine: EvmEngine,
-    store: Store,
-) -> Arc<Blockchain> {
-    let blockchain = Blockchain::new(evm_engine, store);
-
-    if let Some(chain_rlp_path) = matches.get_one::<String>("import") {
-        info!("Importing blocks from chain file: {}", chain_rlp_path);
-        let blocks = read_chain_file(chain_rlp_path);
-        blockchain.import_blocks(&blocks);
-    }
-    //TODO: remove --import --import_dir when we update hive fork
-    if let Some(blocks_path) = matches.get_one::<String>("import_dir") {
-        info!(
-            "Importing blocks from individual block files in directory: {}",
-            blocks_path
-        );
-        let mut blocks = vec![];
-        let dir_reader = fs::read_dir(blocks_path).expect("Failed to read blocks directory");
-        for file_res in dir_reader {
-            let file = file_res.expect("Failed to open file in directory");
-            let path = file.path();
-            let s = path
-                .to_str()
-                .expect("Path could not be converted into string");
-            blocks.push(read_block_file(s));
-        }
-
-        blockchain.import_blocks(&blocks);
-    }
-
-    Arc::new(blockchain)
+pub fn init_blockchain(evm_engine: EvmEngine, store: Store) -> Arc<Blockchain> {
+    Blockchain::new(evm_engine, store).into()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/cmd/ethrex/subcommands/import.rs
+++ b/cmd/ethrex/subcommands/import.rs
@@ -1,12 +1,14 @@
 use std::fs::{self, metadata};
 
 use clap::ArgMatches;
-use ethrex_blockchain::Blockchain;
 
 use ethrex_vm::backends::EvmEngine;
 use tracing::info;
 
-use crate::{initializers::init_store, utils};
+use crate::{
+    initializers::{init_blockchain, init_store},
+    utils,
+};
 
 use super::removedb;
 
@@ -26,8 +28,7 @@ pub fn import_blocks_from_path(
 
     let store = init_store(&data_dir, network);
 
-    // Todo use initializers::init_blockchain when we remove --import from it
-    let blockchain = Blockchain::new(evm, store.clone());
+    let blockchain = init_blockchain(evm, store);
 
     let path_metadata = metadata(path).expect("Failed to read path");
     let blocks = if path_metadata.is_dir() {


### PR DESCRIPTION
**Motivation**

The arguments `--import` and `--import_dir` were left over because the hive fork was not updated 

**Description**

- Remove arguments `--import` and `--import_dir` from cli


Closes #2122 