### PR TITLE
fix(l1): solve network mismatch when adding preset boot nodes

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -276,7 +276,7 @@ pub fn get_bootnodes(matches: &ArgMatches, network: &str, data_dir: &str) -> Vec
 
     if network == networks::HOLESKY_GENESIS_PATH {
         info!("Adding holesky preset bootnodes");
-        bootnodes.extend(dbg!(networks::HOLESKY_BOOTNODES.iter()));
+        bootnodes.extend(networks::HOLESKY_BOOTNODES.iter());
     }
 
     if network == networks::SEPOLIA_GENESIS_PATH {

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -249,27 +249,17 @@ pub fn get_network(matches: &ArgMatches) -> String {
         .expect("network is required")
         .clone();
 
+    // Set preset genesis from known networks
     if network == "holesky" {
-        info!("Adding holesky preset bootnodes");
-        // Set holesky presets
         network = String::from(networks::HOLESKY_GENESIS_PATH);
     }
-
     if network == "sepolia" {
-        info!("Adding sepolia preset bootnodes");
-        // Set sepolia presets
         network = String::from(networks::SEPOLIA_GENESIS_PATH);
     }
-
     if network == "mekong" {
-        info!("Adding mekong preset bootnodes");
-        // Set mekong presets
         network = String::from(networks::MEKONG_GENESIS_PATH);
     }
-
     if network == "ephemery" {
-        info!("Adding ephemery preset bootnodes");
-        // Set ephemery presets
         network = String::from(networks::EPHEMERY_GENESIS_PATH);
     }
 
@@ -284,27 +274,23 @@ pub fn get_bootnodes(matches: &ArgMatches, network: &str, data_dir: &str) -> Vec
         .map(Iterator::collect)
         .unwrap_or_default();
 
-    if network == "holesky" {
+    if network == networks::HOLESKY_GENESIS_PATH {
         info!("Adding holesky preset bootnodes");
-        // Set holesky presets
-        bootnodes.extend(networks::HOLESKY_BOOTNODES.iter());
+        bootnodes.extend(dbg!(networks::HOLESKY_BOOTNODES.iter()));
     }
 
-    if network == "sepolia" {
+    if network == networks::SEPOLIA_GENESIS_PATH {
         info!("Adding sepolia preset bootnodes");
-        // Set sepolia presets
         bootnodes.extend(networks::SEPOLIA_BOOTNODES.iter());
     }
 
-    if network == "mekong" {
+    if network == networks::MEKONG_GENESIS_PATH {
         info!("Adding mekong preset bootnodes");
-        // Set mekong presets
         bootnodes.extend(networks::MEKONG_BOOTNODES.iter());
     }
 
-    if network == "ephemery" {
+    if network == networks::EPHEMERY_GENESIS_PATH {
         info!("Adding ephemery preset bootnodes");
-        // Set ephemery presets
         bootnodes.extend(networks::EPHEMERY_BOOTNODES.iter());
     }
 


### PR DESCRIPTION
**Motivation**
After a recent refactor the node was failing to add the preset boot nodes for known networks, rendering the node unable to connect to the network when using a known network without extra boot nodes.
This was due to the code first changing the value of the network flag to the full path to the preset network's genesis file before adding the preset boot nodes, so while the `get_bootnodes` function expected `holesky` as network value it was instead receiving the full genesis path, causing a mismatch. This PR solves this issue by matching against the full genesis paths, and also removes misleading info tracing (there was an adding preset bootnodes message when the network flag was being changed to the full  genesis path)
<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

