### PR TITLE
Add `removedb` flag to CI block import benchmark

### DIFF
--- a/.github/workflows/ci_bench_block_execution.yaml
+++ b/.github/workflows/ci_bench_block_execution.yaml
@@ -78,7 +78,7 @@ jobs:
           BINS="base,head"
           hyperfine --setup "./bin/ethrex-base removedb" -w 5 -N -r 10 --show-output --export-markdown "bench_pr_comparison.md" \
           -L bin "$BINS" -n "{bin}" \
-          "./bin/ethrex-{bin} --network test_data/genesis-l2.json import ./test_data/2000-blocks.rlp"
+          "./bin/ethrex-{bin} --network test_data/genesis-l2.json import ./test_data/2000-blocks.rlp --removedb"
           echo -e "## Benchmark Block Execution Results Comparison Against Main\n\n$(cat bench_pr_comparison.md)" > bench_pr_comparison.md  
       - name: Upload PR results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
**Motivation**

The `removedb` flag was not being passed, meaning after the first import the rest already had the db populated

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

