### PR TITLE
feat(l1,l2): faster block.rlp file import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Perf
 
+#### 2025-03-30
+* Faster block import, use a slice instead of copy
+[#2097](https://github.com/lambdaclass/ethrex/pull/2097)
+
+
 #### 2025-02-28
 
 * Don't recompute transaction senders when building blocks [#2097](https://github.com/lambdaclass/ethrex/pull/2097)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ default-members = ["cmd/ethrex"]
 version = "0.1.0"
 edition = "2021"
 
+[profile.release-with-debug]
+inherits = "release"
+debug = 2
+
 [workspace.dependencies]
 ethrex-blockchain = { path = "./crates/blockchain" }
 ethrex-common = { path = "./crates/common" }

--- a/cmd/ethrex/decode.rs
+++ b/cmd/ethrex/decode.rs
@@ -21,11 +21,12 @@ pub fn chain_file(file: File) -> Result<Vec<Block>, Error> {
     let mut chain_rlp_reader = BufReader::new(file);
     let mut buf = vec![];
     chain_rlp_reader.read_to_end(&mut buf)?;
+    let mut buf = buf.as_slice();
     let mut blocks = Vec::new();
     while !buf.is_empty() {
-        let (item, rest) = Block::decode_unfinished(&buf)?;
+        let (item, rest) = Block::decode_unfinished(buf)?;
         blocks.push(item);
-        buf = rest.to_vec();
+        buf = rest;
     }
     Ok(blocks)
 }


### PR DESCRIPTION
**Description**

- This is mostly a QOL of life improvement, running benchmarks the import step takes a couple of seconds,
this reduces it to an instant.

- Also add, a cargo profile to use with perf and/or samply.

