### PR TITLE
fix(l2): disable system calls for prover in L2 mode

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -47,12 +47,17 @@ path = "./lib.rs"
 [features]
 default = ["libmdbx", "c-kzg", "blst"]
 dev = ["dep:ethrex-dev"]
-c-kzg = ["ethrex-vm/c-kzg", "ethrex-common/c-kzg", "ethrex-blockchain/c-kzg", "ethrex-p2p/c-kzg"]
+c-kzg = [
+  "ethrex-vm/c-kzg",
+  "ethrex-common/c-kzg",
+  "ethrex-blockchain/c-kzg",
+  "ethrex-p2p/c-kzg",
+]
 metrics = ["ethrex-blockchain/metrics"]
 libmdbx = ["ethrex-storage/libmdbx"]
 redb = ["dep:redb", "ethrex-storage/redb"]
 blst = ["ethrex-vm/blst"]
-l2 = ["dep:ethrex-l2", "ethrex-vm/l2"]
+l2 = ["dep:ethrex-l2", "ethrex-vm/l2", "ethrex-blockchain/l2"]
 based = ["l2", "ethrex-rpc/based"]
 
 

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -30,5 +30,6 @@ path = "./blockchain.rs"
 
 [features]
 default = []
+l2 = []
 c-kzg = ["ethrex-common/c-kzg", "ethrex-vm/c-kzg"]
 metrics = ["ethrex-metrics/transactions"]

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -262,6 +262,7 @@ impl Blockchain {
         debug!("Building payload");
         let mut context = PayloadBuildContext::new(payload, self.evm_engine, &self.storage)?;
 
+        #[cfg(not(feature = "l2"))]
         self.apply_system_operations(&mut context)?;
         self.apply_withdrawals(&mut context)?;
         self.fill_transactions(&mut context)?;

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -16,9 +16,9 @@ ethereum-types.workspace = true
 ethrex-common.workspace = true
 ethrex-rlp.workspace = true
 ethrex-rpc.workspace = true
-ethrex-blockchain.workspace = true
+ethrex-blockchain = { workspace = true, features = ["l2"] }
 ethrex-storage.workspace = true
-ethrex-vm.workspace = true
+ethrex-vm = { workspace = true, features = ["l2"] }
 ethrex-dev = { path = "../../crates/blockchain/dev", default-features = false }
 hex.workspace = true
 bytes.workspace = true
@@ -30,7 +30,7 @@ thiserror.workspace = true
 directories = "5.0.1"
 toml = { version = "0.8.19", features = ["parse"] }
 
-zkvm_interface = { path = "./prover/zkvm/interface/", default-features = false }
+zkvm_interface = { path = "./prover/zkvm/interface/", features = ["l2"] }
 
 # risc0
 risc0-zkvm = { version = "1.2.2" }

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -148,7 +148,7 @@ init-prover: ## 🚀 Initializes the Prover
 	else \
 		GPU=",gpu"; \
 	fi; \
-	cargo run --release --features "build_$$T$$GPU" --manifest-path ./prover/Cargo.toml --bin ethrex_prover -- $$T
+	cargo run --release --features "build_$$T$$GPU,l2" --manifest-path ./prover/Cargo.toml --bin ethrex_prover -- $$T
 
 rm-db-l2: ## 🛑 Removes the DB used by the L2
 	cargo run --release --manifest-path ../../Cargo.toml --bin ethrex -- removedb --datadir ${ethrex_L2_DEV_LIBMDBX}

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -51,6 +51,7 @@ build_sp1 = ["zkvm_interface/build_sp1"]
 l2 = [
   "ethrex-vm/l2",
   "zkvm_interface/l2",
+  "ethrex-blockchain/l2",
 ] # the prover can work with both l1 or l2 blocks
 gpu = ["risc0-zkvm/cuda", "sp1-sdk/cuda"]
 

--- a/crates/l2/prover/zkvm/interface/risc0/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/risc0/Cargo.toml
@@ -22,4 +22,4 @@ secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "p
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 
 [features]
-l2 = ["ethrex-vm/l2", "zkvm_interface/l2"]
+l2 = ["ethrex-vm/l2", "zkvm_interface/l2", "ethrex-blockchain/l2"]

--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
@@ -23,4 +23,4 @@ ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecd
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
 
 [features]
-l2 = ["ethrex-vm/l2", "zkvm_interface/l2"]
+l2 = ["ethrex-vm/l2", "zkvm_interface/l2", "ethrex-blockchain/l2"]


### PR DESCRIPTION
**Motivation**

Currently ethrex-prover fails to prove blocks created from the proposer because both the proposer and the prover are executing system calls that are exclusive for L1 mode.

