### PR TITLE
feat(core): add `p2p.enabled` flag

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -50,6 +50,14 @@ pub fn cli() -> Command {
                 .action(ArgAction::Set),
         )
         .arg(
+            Arg::new("p2p.enabled")
+                .long("p2p.enabled")
+                .required(false)
+                .default_value(if cfg!(feature = "l2") { "false" } else { "true" })
+                .value_name("P2P_ENABLED")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("p2p.addr")
                 .long("p2p.addr")
                 .default_value("0.0.0.0")

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -81,18 +81,24 @@ async fn main() {
         } else {
             use ethrex::initializers::{init_network};
 
-            init_network(
-                &matches,
-                &network,
-                &data_dir,
-                local_p2p_node,
-                signer,
-                peer_table.clone(),
-                store.clone(),
-                tracker.clone(),
-                blockchain.clone(),
-            )
-            .await;
+            let p2p_enabled = matches.get_flag("p2p.enabled");
+
+            if p2p_enabled {
+                init_network(
+                    &matches,
+                    &network,
+                    &data_dir,
+                    local_p2p_node,
+                    signer,
+                    peer_table.clone(),
+                    store.clone(),
+                    tracker.clone(),
+                    blockchain.clone(),
+                )
+                .await;
+            } else {
+                info!("P2P is disabled");
+            }
         }
     }
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -183,13 +183,6 @@ pub async fn init_network(
     tracker: TaskTracker,
     blockchain: Arc<Blockchain>,
 ) {
-    let p2p_enabled = matches.get_flag("p2p.enabled");
-
-    if !p2p_enabled {
-        info!("P2P is disabled");
-        return;
-    }
-
     let dev_mode = *matches.get_one::<bool>("dev").unwrap_or(&false);
 
     if dev_mode {

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -183,6 +183,13 @@ pub async fn init_network(
     tracker: TaskTracker,
     blockchain: Arc<Blockchain>,
 ) {
+    let p2p_enabled = matches.get_flag("p2p.enabled");
+
+    if !p2p_enabled {
+        info!("P2P is disabled");
+        return;
+    }
+
     let dev_mode = *matches.get_one::<bool>("dev").unwrap_or(&false);
 
     if dev_mode {


### PR DESCRIPTION
**Motivation**

In most of the L2 use cases we want to disable de P2P network.

**Description**

Add a `p2p.enabled` flag for users to explicit whether they want to enable the P2P in their node.

It is enabled by default in the L1 and disabled by default for the L2.

