### PR TITLE
chore(l1): add conditional imports for `ReceiptRLP` type alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "cfg-if",
  "ethereum-types",
  "ethrex-common",
  "ethrex-rlp",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -22,6 +22,8 @@ serde_json = "1.0.117"
 libmdbx = { workspace = true, optional = true }
 redb = { workspace = true, optional = true }
 
+cfg-if = "1.0.0"
+
 [features]
 default = []
 libmdbx = ["dep:libmdbx", "ethrex-trie/libmdbx"]

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -2,19 +2,25 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use bytes::Bytes;
-#[cfg(feature = "redb")]
-use ethrex_common::types::Receipt;
+
 use ethrex_common::{
     types::{payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader},
     H256,
 };
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
+
 #[cfg(feature = "libmdbx")]
 use libmdbx::orm::{Decodable, Encodable};
-#[cfg(feature = "redb")]
-use redb::TypeName;
-#[cfg(feature = "redb")]
-use std::any::type_name;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "redb")] {
+    use ethrex_common::types::Receipt;
+    use redb::TypeName;
+    use std::any::type_name;
+    // Receipt types
+    pub type ReceiptRLP = Rlp<Receipt>;
+    }
+}
 
 // Account types
 pub type AccountCodeHashRLP = Rlp<H256>;
@@ -27,11 +33,6 @@ pub type BlockHashRLP = Rlp<BlockHash>;
 pub type BlockHeaderRLP = Rlp<BlockHeader>;
 pub type BlockBodyRLP = Rlp<BlockBody>;
 pub type BlockRLP = Rlp<Block>;
-
-/// NOTE: Only used with redb
-// Receipt types
-#[cfg(feature = "redb")]
-pub type ReceiptRLP = Rlp<Receipt>;
 
 // Transaction types
 pub type TransactionHashRLP = Rlp<H256>;

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -3,7 +3,9 @@ use std::marker::PhantomData;
 
 use bytes::Bytes;
 use ethrex_common::{
-    types::{payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader},
+    types::{
+        payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader, Receipt,
+    },
     H256,
 };
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
@@ -25,6 +27,9 @@ pub type BlockHashRLP = Rlp<BlockHash>;
 pub type BlockHeaderRLP = Rlp<BlockHeader>;
 pub type BlockBodyRLP = Rlp<BlockBody>;
 pub type BlockRLP = Rlp<Block>;
+
+// Receipt types
+pub type ReceiptRLP = Rlp<Receipt>;
 
 // Transaction types
 pub type TransactionHashRLP = Rlp<H256>;

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -3,9 +3,7 @@ use std::marker::PhantomData;
 
 use bytes::Bytes;
 use ethrex_common::{
-    types::{
-        payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader, Receipt,
-    },
+    types::{payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader},
     H256,
 };
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
@@ -27,9 +25,6 @@ pub type BlockHashRLP = Rlp<BlockHash>;
 pub type BlockHeaderRLP = Rlp<BlockHeader>;
 pub type BlockBodyRLP = Rlp<BlockBody>;
 pub type BlockRLP = Rlp<Block>;
-
-// Receipt types
-pub type ReceiptRLP = Rlp<Receipt>;
 
 // Transaction types
 pub type TransactionHashRLP = Rlp<H256>;

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -2,10 +2,10 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use bytes::Bytes;
+#[cfg(feature = "redb")]
+use ethrex_common::types::Receipt;
 use ethrex_common::{
-    types::{
-        payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader, Receipt,
-    },
+    types::{payload::PayloadBundle, AccountState, Block, BlockBody, BlockHash, BlockHeader},
     H256,
 };
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
@@ -28,7 +28,9 @@ pub type BlockHeaderRLP = Rlp<BlockHeader>;
 pub type BlockBodyRLP = Rlp<BlockBody>;
 pub type BlockRLP = Rlp<Block>;
 
+/// NOTE: Only used with redb
 // Receipt types
+#[cfg(feature = "redb")]
 pub type ReceiptRLP = Rlp<Receipt>;
 
 // Transaction types


### PR DESCRIPTION
**Motivation**

When you compile the project, you get a warning stating:
```
warning: type alias `ReceiptRLP` is never used
  --> crates/storage/rlp.rs:32:10
   |
32 | pub type ReceiptRLP = Rlp<Receipt>;
   |          ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

This is only used when you compile the project with `redb` support.

**Description**

Add conditional importing for `ReceiptRLP` type alias. 
