### PR TITLE
feat(l1): write multiple account's storage batches in the same db txn

### DIFF
--- a/crates/networking/p2p/sync/storage_fetcher.rs
+++ b/crates/networking/p2p/sync/storage_fetcher.rs
@@ -151,9 +151,9 @@ async fn fetch_storage_batch(
             // The incomplete range is not the first, we cannot asume it is a large trie, so lets add it back to the queue
         }
         // Store the storage ranges & rebuild the storage trie for each account
-        complete_storages.extend(batch[..values.len()].iter());
-        let account_hashes: Vec<H256> = batch[..values.len()].iter().map(|(hash, _)| *hash).collect();
-        let batch = batch[values.len()..].to_vec();
+        let filled_storages: Vec<(H256, H256)> = batch.drain(..values.len()).collect();
+        let account_hashes: Vec<H256> = filled_storages.iter().map(|(hash, _)| *hash).collect();
+        complete_storages.extend(filled_storages);
         store.write_snapshot_storage_batches(account_hashes, keys, values)?;
         // Send complete storages to the rebuilder
         storage_trie_rebuilder_sender

--- a/crates/storage/api.rs
+++ b/crates/storage/api.rs
@@ -271,6 +271,14 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
         storage_values: Vec<U256>,
     ) -> Result<(), StoreError>;
 
+    /// Write multiple storage batches belonging to different accounts into the current storage snapshot
+    fn write_snapshot_storage_batches(
+        &self,
+        account_hashes: Vec<H256>,
+        storage_keys: Vec<Vec<H256>>,
+        storage_values: Vec<Vec<U256>>,
+    ) -> Result<(), StoreError>;
+
     /// Set the latest root of the rebuilt state trie and the last downloaded hashes from each segment
     fn set_state_trie_rebuild_checkpoint(
         &self,

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -957,6 +957,16 @@ impl Store {
             .write_snapshot_storage_batch(account_hash, storage_keys, storage_values)
     }
 
+    /// Write multiple storage batches belonging to different accounts into the current storage snapshot
+    pub fn write_snapshot_storage_batches(
+        &self,
+        account_hashes: Vec<H256>,
+        storage_keys: Vec<Vec<H256>>,
+        storage_values: Vec<Vec<U256>>,
+    ) -> Result<(), StoreError> {
+        self.engine.write_snapshot_storage_batches(account_hashes, storage_keys, storage_values)
+    }
+
     /// Clears all checkpoint data created during the last snap sync
     pub fn clear_snap_state(&self) -> Result<(), StoreError> {
         self.engine.clear_snap_state()

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -964,7 +964,8 @@ impl Store {
         storage_keys: Vec<Vec<H256>>,
         storage_values: Vec<Vec<U256>>,
     ) -> Result<(), StoreError> {
-        self.engine.write_snapshot_storage_batches(account_hashes, storage_keys, storage_values)
+        self.engine
+            .write_snapshot_storage_batches(account_hashes, storage_keys, storage_values)
     }
 
     /// Clears all checkpoint data created during the last snap sync

--- a/crates/storage/store_db/in_memory.rs
+++ b/crates/storage/store_db/in_memory.rs
@@ -480,6 +480,24 @@ impl StoreEngine for Store {
             .extend(storage_keys.into_iter().zip(storage_values));
         Ok(())
     }
+    fn write_snapshot_storage_batches(
+        &self,
+        account_hashes: Vec<H256>,
+        storage_keys: Vec<Vec<H256>>,
+        storage_values: Vec<Vec<U256>>,
+    ) -> Result<(), StoreError> {
+        for (account_hash, (storage_keys, storage_values)) in account_hashes
+            .into_iter()
+            .zip(storage_keys.into_iter().zip(storage_values.into_iter()))
+        {
+            self.inner()
+                .storage_snapshot
+                .entry(account_hash)
+                .or_default()
+                .extend(storage_keys.into_iter().zip(storage_values));
+        }
+        Ok(())
+    }
 
     fn set_state_trie_rebuild_checkpoint(
         &self,


### PR DESCRIPTION
**Motivation**
When measuring time taken by each task during snap sync I noticed that a lot of time was spent writing the storage ranges obtained from peers to the DB snapshot. It would take anywhere from 3 to over 10 seconds to write all the ranges to the DB (around 300 storage ranges per request). This PR modifies the insertion logic to write all 300 ranges in the same DB transaction, reducing the time taken to write all the ranges to the DB to 10 milliseconds or less
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `write_storage_snapshot_batches` method to `Store`, which can write multiple batches from different accounts on the same txn
* Write all storage ranges received from peers in a single DB txn using the method above on the storage fetcher (snap sync)
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes: None, but helps speed up snap sync

