### PR TITLE
chore(core): add `rust-toolchain.toml`

### DIFF
--- a/.github/workflows/ci_l2_prover_nightly.yaml
+++ b/.github/workflows/ci_l2_prover_nightly.yaml
@@ -35,10 +35,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       # https://pico-docs.brevis.network/getting-started/installation
       - name: Install pico-cli
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: pico-cli
-          git: https://github.com/brevis-network/pico
+        run: cargo +nightly install --git https://github.com/brevis-network/pico pico-cli
       - name: ${{ matrix.action.command }} Command
         run: cargo +nightly-2024-11-27 ${{ matrix.action.command }} ${{ matrix.action.args }}
 
@@ -56,10 +53,7 @@ jobs:
           components: rust-src
       # https://pico-docs.brevis.network/getting-started/installation
       - name: Install pico-cli
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: pico-cli
-          git: https://github.com/brevis-network/pico
+        run: cargo +nightly install --git https://github.com/brevis-network/pico pico-cli
       - name: Build
         run: |
           cd crates/l2/prover

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.82.0"
+profile = "default"


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We have a pinned version of Rust in the CI and also in `.tool-versions` (for `asdf`) but not for `rustup`. We encountered ourselves running different versions of Rust, with different results, specially when running tools like Clippy

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Added a `rust-toolchain.toml` file with the pinned version of Rust so it's evaluated by default when using `rustup`. As a side effect, needed to change the way Pico CLI is installed in the CI.
