### PR TITLE
fix(l2): make TCP connection async

### DIFF
--- a/crates/l2/prover/src/prover_client.rs
+++ b/crates/l2/prover/src/prover_client.rs
@@ -3,12 +3,12 @@ use ethrex_l2::{
     sequencer::prover_server::ProofData,
     utils::{config::prover_client::ProverClientConfig, prover::proving_systems::ProofCalldata},
 };
-use std::{
-    io::{BufReader, BufWriter},
-    time::Duration,
+use std::time::Duration;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    time::sleep,
 };
-use tokio::{io::AsyncReadExt, net::TcpStream};
-use tokio::{io::AsyncWriteExt, time::sleep};
 use tracing::{debug, error, info, warn};
 use zkvm_interface::io::ProgramInput;
 

--- a/crates/l2/prover/src/prover_client.rs
+++ b/crates/l2/prover/src/prover_client.rs
@@ -5,10 +5,10 @@ use ethrex_l2::{
 };
 use std::{
     io::{BufReader, BufWriter},
-    net::TcpStream,
     time::Duration,
 };
-use tokio::time::sleep;
+use tokio::{io::AsyncReadExt, net::TcpStream};
+use tokio::{io::AsyncWriteExt, time::sleep};
 use tracing::{debug, error, info, warn};
 use zkvm_interface::io::ProgramInput;
 
@@ -38,14 +38,15 @@ impl ProverClient {
     pub async fn start(&self) {
         // Build the prover depending on the prover_type passed as argument.
         loop {
-            match self.request_new_input() {
+            match self.request_new_input().await {
                 // If we get the input
                 Ok(prover_data) => {
                     // Generate the Proof
                     match prove(prover_data.input).and_then(to_calldata) {
                         Ok(proving_output) => {
-                            if let Err(e) =
-                                self.submit_proof(prover_data.block_number, proving_output)
+                            if let Err(e) = self
+                                .submit_proof(prover_data.block_number, proving_output)
+                                .await
                             {
                                 // TODO: Retry?
                                 warn!("Failed to submit proof: {e}");
@@ -63,10 +64,11 @@ impl ProverClient {
         }
     }
 
-    fn request_new_input(&self) -> Result<ProverData, String> {
+    async fn request_new_input(&self) -> Result<ProverData, String> {
         // Request the input with the correct block_number
         let request = ProofData::request();
         let response = connect_to_prover_server_wr(&self.prover_server_endpoint, &request)
+            .await
             .map_err(|e| format!("Failed to get Response: {e}"))?;
 
         match response {
@@ -95,10 +97,15 @@ impl ProverClient {
         }
     }
 
-    fn submit_proof(&self, block_number: u64, proving_output: ProofCalldata) -> Result<(), String> {
+    async fn submit_proof(
+        &self,
+        block_number: u64,
+        proving_output: ProofCalldata,
+    ) -> Result<(), String> {
         let submit = ProofData::submit(block_number, proving_output);
 
         let submit_ack = connect_to_prover_server_wr(&self.prover_server_endpoint, &submit)
+            .await
             .map_err(|e| format!("Failed to get SubmitAck: {e}"))?;
 
         match submit_ack {
@@ -111,17 +118,19 @@ impl ProverClient {
     }
 }
 
-fn connect_to_prover_server_wr(
+async fn connect_to_prover_server_wr(
     addr: &str,
     write: &ProofData,
 ) -> Result<ProofData, Box<dyn std::error::Error>> {
-    let stream = TcpStream::connect(addr)?;
-    let buf_writer = BufWriter::new(&stream);
+    let mut stream = TcpStream::connect(addr).await?;
     debug!("Connection established!");
-    serde_json::ser::to_writer(buf_writer, write)?;
-    stream.shutdown(std::net::Shutdown::Write)?;
 
-    let buf_reader = BufReader::new(&stream);
-    let response: ProofData = serde_json::de::from_reader(buf_reader)?;
-    Ok(response)
+    stream.write(&serde_json::to_vec(&write)?).await?;
+    stream.shutdown().await?;
+
+    let mut buffer = Vec::new();
+    stream.read_to_end(&mut buffer).await?;
+
+    let response: Result<ProofData, _> = serde_json::from_slice(&buffer);
+    Ok(response?)
 }

--- a/crates/l2/prover/src/prover_client.rs
+++ b/crates/l2/prover/src/prover_client.rs
@@ -125,7 +125,7 @@ async fn connect_to_prover_server_wr(
     let mut stream = TcpStream::connect(addr).await?;
     debug!("Connection established!");
 
-    stream.write(&serde_json::to_vec(&write)?).await?;
+    stream.write_all(&serde_json::to_vec(&write)?).await?;
     stream.shutdown().await?;
 
     let mut buffer = Vec::new();

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -56,6 +56,8 @@ pub enum ProverServerError {
     SaveStateError(#[from] SaveStateError),
     #[error("Failed to encode calldata: {0}")]
     CalldataEncodeError(#[from] CalldataEncodeError),
+    #[error("ProverServer failed when (de)serializing JSON: {0}")]
+    JsonError(#[from] serde_json::Error),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/l2/sequencer/prover_server.rs
+++ b/crates/l2/sequencer/prover_server.rs
@@ -384,7 +384,7 @@ impl ProverServer {
 
         let buffer = serde_json::to_vec(&response)?;
         stream
-            .write(&buffer)
+            .write_all(&buffer)
             .await
             .map_err(ProverServerError::ConnectionError)?;
         Ok(())

--- a/crates/l2/sequencer/prover_server.rs
+++ b/crates/l2/sequencer/prover_server.rs
@@ -367,7 +367,7 @@ impl ProverServer {
 
         let buffer = serde_json::to_vec(&response)?;
         stream
-            .write(&buffer)
+            .write_all(&buffer)
             .await
             .map_err(ProverServerError::ConnectionError)?;
         Ok(())

--- a/crates/l2/sequencer/prover_server.rs
+++ b/crates/l2/sequencer/prover_server.rs
@@ -26,11 +26,12 @@ use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::Debug,
-    io::{BufReader, BufWriter, Write},
-    net::{IpAddr, Shutdown, TcpListener, TcpStream},
+    net::IpAddr,
     sync::mpsc::{self, Receiver},
     time::Duration,
 };
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 use tokio::{
     signal::unix::{signal, SignalKind},
     time::sleep,
@@ -207,21 +208,23 @@ impl ProverServer {
         let mut sigint = signal(SignalKind::interrupt())?;
         sigint.recv().await.ok_or(SigIntError::Recv)?;
         tx.send(()).map_err(SigIntError::Send)?;
-        TcpStream::connect(format!("{}:{}", config.listen_ip, config.listen_port))?
-            .shutdown(Shutdown::Both)
+        TcpStream::connect(format!("{}:{}", config.listen_ip, config.listen_port))
+            .await?
+            .shutdown()
+            .await
             .map_err(SigIntError::Shutdown)?;
 
         Ok(())
     }
 
     pub async fn start(&mut self, rx: Receiver<()>) -> Result<(), ProverServerError> {
-        let listener = TcpListener::bind(format!("{}:{}", self.ip, self.port))?;
+        let listener = TcpListener::bind(format!("{}:{}", self.ip, self.port)).await?;
 
         info!("Starting TCP server at {}:{}", self.ip, self.port);
 
-        for stream in listener.incoming() {
-            match stream {
-                Ok(stream) => {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
                     debug!("Connection established!");
 
                     if let Ok(()) = rx.try_recv() {
@@ -242,7 +245,8 @@ impl ProverServer {
     }
 
     async fn handle_connection(&mut self, mut stream: TcpStream) -> Result<(), ProverServerError> {
-        let buf_reader = BufReader::new(&stream);
+        let mut buffer = Vec::new();
+        stream.read_to_end(&mut buffer).await?;
 
         let last_verified_block =
             EthClient::get_last_verified_block(&self.eth_client, self.on_chain_proposer_address)
@@ -274,11 +278,11 @@ impl ProverServer {
             tx_submitted = true;
         }
 
-        let data: Result<ProofData, _> = serde_json::de::from_reader(buf_reader);
+        let data: Result<ProofData, _> = serde_json::from_slice(&buffer);
         match data {
             Ok(ProofData::Request) => {
                 if let Err(e) = self
-                    .handle_request(&stream, block_to_verify, tx_submitted)
+                    .handle_request(&mut stream, block_to_verify, tx_submitted)
                     .await
                 {
                     warn!("Failed to handle request: {e}");
@@ -288,7 +292,7 @@ impl ProverServer {
                 block_number,
                 calldata,
             }) => {
-                self.handle_submit(&mut stream, block_number)?;
+                self.handle_submit(&mut stream, block_number).await?;
 
                 // Avoid storing a proof of a future block_number
                 // CHECK: maybe we would like to store all the proofs given the case in which
@@ -338,7 +342,7 @@ impl ProverServer {
 
     async fn handle_request(
         &self,
-        stream: &TcpStream,
+        stream: &mut TcpStream,
         block_number: u64,
         tx_submitted: bool,
     ) -> Result<(), ProverServerError> {
@@ -361,12 +365,15 @@ impl ProverServer {
             response
         };
 
-        let writer = BufWriter::new(stream);
-        serde_json::to_writer(writer, &response)
-            .map_err(|e| ProverServerError::ConnectionError(e.into()))
+        let buffer = serde_json::to_vec(&response)?;
+        stream
+            .write(&buffer)
+            .await
+            .map_err(ProverServerError::ConnectionError)?;
+        Ok(())
     }
 
-    fn handle_submit(
+    async fn handle_submit(
         &self,
         stream: &mut TcpStream,
         block_number: u64,
@@ -374,12 +381,12 @@ impl ProverServer {
         debug!("Submit received for BlockNumber: {block_number}");
 
         let response = ProofData::submit_ack(block_number);
-        let json_string = serde_json::to_string(&response)
-            .map_err(|e| ProverServerError::Custom(format!("serde_json::to_string(): {e}")))?;
-        stream
-            .write_all(json_string.as_bytes())
-            .map_err(ProverServerError::ConnectionError)?;
 
+        let buffer = serde_json::to_vec(&response)?;
+        stream
+            .write(&buffer)
+            .await
+            .map_err(ProverServerError::ConnectionError)?;
         Ok(())
     }
 


### PR DESCRIPTION
**Motivation**

The prover server-client TCP connection uses blocking primitive from the standard library, so whenever one of the processes is expecting a connection they don't yield control to the runtime and all other processes get blocked (because tokio's scheduler is cooperative).

This PR replaces these primitives with tokio's async ones.

Closes #1983
Closes #2019