### PR TITLE
refactor(l2): add flag for setting sponsor private key

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -48,7 +48,7 @@ name = "ethrex"
 path = "./lib.rs"
 
 [features]
-default = ["libmdbx", "c-kzg", "blst", "l2"]
+default = ["libmdbx", "c-kzg", "blst"]
 dev = ["dep:ethrex-dev"]
 c-kzg = [
     "ethrex-vm/c-kzg",

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -20,7 +20,7 @@ hex.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 k256.workspace = true
-clap = { version = "4.3", features = ["derive"] }
+clap = { version = "4.3", features = ["derive", "env"] }
 clap_complete = "4.5.17"
 eyre = "0.6.12"
 directories = "5.0.1"
@@ -48,7 +48,7 @@ name = "ethrex"
 path = "./lib.rs"
 
 [features]
-default = ["libmdbx", "c-kzg", "blst"]
+default = ["libmdbx", "c-kzg", "blst", "l2"]
 dev = ["dep:ethrex-dev"]
 c-kzg = [
     "ethrex-vm/c-kzg",

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -14,6 +14,9 @@ use crate::{
     DEFAULT_DATADIR,
 };
 
+#[cfg(feature = "l2")]
+use secp256k1::SecretKey;
+
 pub const VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
 
 #[allow(clippy::upper_case_acronyms)]
@@ -180,6 +183,7 @@ impl Default for Options {
     }
 }
 
+#[cfg(feature = "l2")]
 #[derive(ClapParser)]
 pub struct L2Options {
     #[arg(
@@ -189,6 +193,8 @@ pub struct L2Options {
         help_heading = "L2 options"
     )]
     pub sponsorable_addresses_file_path: Option<String>,
+    #[arg(long, value_parser = utils::parse_private_key, env = "SPONSOR_PRIVATE_KEY", help = "The private key of ethrex L2 transactions sponsor.", help_heading = "L2 options")]
+    pub sponsor_private_key: Option<SecretKey>,
 }
 
 #[cfg(feature = "based")]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -127,7 +127,7 @@ pub fn init_rpc_api(
         #[cfg(feature = "l2")]
         get_valid_delegation_addresses(l2_opts),
         #[cfg(feature = "l2")]
-        get_sponsor_pk(),
+        get_sponsor_pk(l2_opts),
     )
     .into_future();
 
@@ -360,7 +360,13 @@ pub fn get_valid_delegation_addresses(l2_opts: &L2Options) -> Vec<Address> {
 }
 
 #[cfg(feature = "l2")]
-pub fn get_sponsor_pk() -> SecretKey {
+pub fn get_sponsor_pk(opts: &L2Options) -> SecretKey {
+    if let Some(pk) = opts.sponsor_private_key {
+        return pk;
+    }
+
+    warn!("Sponsor private key not provided. Trying to read from the .env file.");
+
     if let Err(e) = read_env_file() {
         panic!("Failed to read .env file: {e}");
     }

--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -6,6 +6,7 @@ use ethrex_p2p::{kademlia::KademliaTable, sync::SyncMode, types::Node};
 use ethrex_rlp::decode::RLPDecode;
 use ethrex_vm::backends::EvmEngine;
 use hex::FromHexError;
+#[cfg(feature = "l2")]
 use secp256k1::SecretKey;
 use std::{
     fs::File,
@@ -121,6 +122,7 @@ pub fn read_known_peers(file_path: PathBuf) -> Result<Vec<Node>, serde_json::Err
     serde_json::from_reader(file)
 }
 
+#[cfg(feature = "l2")]
 pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
     Ok(SecretKey::from_slice(&parse_hex(s)?)?)
 }

--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -5,6 +5,8 @@ use ethrex_common::types::{Block, Genesis};
 use ethrex_p2p::{kademlia::KademliaTable, sync::SyncMode, types::Node};
 use ethrex_rlp::decode::RLPDecode;
 use ethrex_vm::backends::EvmEngine;
+use hex::FromHexError;
+use secp256k1::SecretKey;
 use std::{
     fs::File,
     io,
@@ -117,4 +119,15 @@ pub fn read_known_peers(file_path: PathBuf) -> Result<Vec<Node>, serde_json::Err
     };
 
     serde_json::from_reader(file)
+}
+
+pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
+    Ok(SecretKey::from_slice(&parse_hex(s)?)?)
+}
+
+pub fn parse_hex(s: &str) -> eyre::Result<Bytes, FromHexError> {
+    match s.strip_prefix("0x") {
+        Some(s) => hex::decode(s).map(Into::into),
+        None => hex::decode(s).map(Into::into),
+    }
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

The current implementation requires a `.env` file to exist and the execution panics if this file does not exist. Nevertheless, this has a purpose of being. As this feature should be used in `l2` it is assumed that there's a `.env` file and that is ok because it should. This PR intends to add a second path for setting the sponsor pk without needing a `.env`.

**Description**

Add a flag `--sponsor-private-key` as a second option for setting this value.

