### PR TITLE
fix(l1): fix unending storage healer process in snap sync

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -529,6 +529,8 @@ impl SyncManager {
             .await?;
             if stale_pivot {
                 warn!("Stale Pivot, aborting state sync");
+                storage_healer_sender.send(vec![]).await?;
+                storage_healer_handler.await??;
                 return Ok(false);
             }
         }

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -36,7 +36,7 @@ pub(crate) async fn storage_healer(
     // alive until the end signal so we don't lose queued messages
     let mut stale = false;
     let mut incoming = true;
-    while incoming || !pending_paths.is_empty() {
+    while incoming {
         // If we have enough pending storages to fill a batch
         // or if we have no more incoming batches, spawn a fetch process
         // If the pivot became stale don't process anything and just save incoming requests


### PR DESCRIPTION
**Motivation**
There is currently a bug in snap sync. When a state sync becomes stale, the snap sync cycle is aborted but the storage healer process is left hanging instead if signaling it to end and waiting for it to finish. The loop condition of the storage healer is also not properly set, keeping it alive even after the end signal if it still has paths to heal. This PR fixes both of this problems
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Fix loop condition in storage healer
* End storage healer if state sync aborts due to stale pivot
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

