### PR TITLE
feat (l1): write nodes in batches during storage healing

### DIFF
--- a/crates/common/trie/state.rs
+++ b/crates/common/trie/state.rs
@@ -102,10 +102,18 @@ impl TrieState {
     }
 
     /// Writes a node batch directly to the DB bypassing the cache
-    pub fn write_node_batch(&mut self, nodes: Vec<Node>, node_hashes: Vec<NodeHash>) -> Result<(), TrieError> {
+    pub fn write_node_batch(
+        &mut self,
+        nodes: Vec<Node>,
+        node_hashes: Vec<NodeHash>,
+    ) -> Result<(), TrieError> {
         // Don't insert the node if it is already inlined on the parent
-        let key_values = node_hashes.into_iter().zip(nodes).filter(|(hash, _)| matches!(hash, NodeHash::Hashed(_)))
-        .map(|(hash, node)| (hash.into(), node.encode_to_vec())).collect();
+        let key_values = node_hashes
+            .into_iter()
+            .zip(nodes)
+            .filter(|(hash, _)| matches!(hash, NodeHash::Hashed(_)))
+            .map(|(hash, node)| (hash.into(), node.encode_to_vec()))
+            .collect();
         self.db.put_batch(key_values)?;
         Ok(())
     }

--- a/crates/common/trie/state.rs
+++ b/crates/common/trie/state.rs
@@ -100,4 +100,13 @@ impl TrieState {
         }
         Ok(())
     }
+
+    /// Writes a node batch directly to the DB bypassing the cache
+    pub fn write_node_batch(&mut self, nodes: Vec<Node>, node_hashes: Vec<NodeHash>) -> Result<(), TrieError> {
+        // Don't insert the node if it is already inlined on the parent
+        let key_values = node_hashes.into_iter().zip(nodes).filter(|(hash, _)| matches!(hash, NodeHash::Hashed(_)))
+        .map(|(hash, node)| (hash.into(), node.encode_to_vec())).collect();
+        self.db.put_batch(key_values)?;
+        Ok(())
+    }
 }

--- a/crates/common/trie/state.rs
+++ b/crates/common/trie/state.rs
@@ -111,8 +111,10 @@ impl TrieState {
         let key_values = node_hashes
             .into_iter()
             .zip(nodes)
-            .filter(|(hash, _)| matches!(hash, NodeHash::Hashed(_)))
-            .map(|(hash, node)| (hash.into(), node.encode_to_vec()))
+            .filter_map(|(hash, node)| {
+                matches!(hash, NodeHash::Hashed(_))
+                    .then(|| (hash.into(), node.encode_to_vec()))
+            })
             .collect();
         self.db.put_batch(key_values)?;
         Ok(())

--- a/crates/common/trie/state.rs
+++ b/crates/common/trie/state.rs
@@ -105,7 +105,7 @@ impl TrieState {
     pub fn write_node_batch(&mut self, nodes: &[Node]) -> Result<(), TrieError> {
         // Don't insert the node if it is already inlined on the parent
         let key_values = nodes
-            .into_iter()
+            .iter()
             .filter_map(|node| {
                 let hash = node.compute_hash();
                 matches!(hash, NodeHash::Hashed(_)).then(|| (hash.into(), node.encode_to_vec()))

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -114,9 +114,14 @@ async fn heal_storage_batch(
         for (acc_path, paths) in batch.iter_mut() {
             let mut trie = store.open_storage_trie(*acc_path, *EMPTY_TRIE_HASH);
             // Get the corresponding nodes
-            let trie_nodes: Vec<ethrex_trie::Node> = nodes.drain(..paths.len().min(nodes.len())).collect();
+            let trie_nodes: Vec<ethrex_trie::Node> =
+                nodes.drain(..paths.len().min(nodes.len())).collect();
             // Add children to batch
-            let children = trie_nodes.iter().zip(paths.drain(..paths.len().min(nodes.len()))).map(|(node, path)| node_missing_children(&node, &path, trie.state())).collect::<Result<Vec<_>,_>>()?;
+            let children = trie_nodes
+                .iter()
+                .zip(paths.drain(..paths.len().min(nodes.len())))
+                .map(|(node, path)| node_missing_children(node, &path, trie.state()))
+                .collect::<Result<Vec<_>, _>>()?;
             paths.extend(children.into_iter().flatten());
             // Write nodes to trie
             let node_hashes = trie_nodes.iter().map(|node| node.compute_hash()).collect();

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -114,15 +114,13 @@ async fn heal_storage_batch(
         for (acc_path, paths) in batch.iter_mut() {
             let mut trie = store.open_storage_trie(*acc_path, *EMPTY_TRIE_HASH);
             // Get the corresponding nodes
-            for node in nodes.drain(..paths.len().min(nodes.len())) {
-                let path = paths.remove(0);
-                // Add children to batch
-                let children = node_missing_children(&node, &path, trie.state())?;
-                paths.extend(children);
-                let hash = node.compute_hash();
-                trie.state_mut().write_node(node, hash)?;
-            }
-            // Cut the loop if we ran out of nodes
+            let trie_nodes: Vec<ethrex_trie::Node> = nodes.drain(..paths.len().min(nodes.len())).collect();
+            // Add children to batch
+            let children = trie_nodes.iter().zip(paths.drain(..paths.len().min(nodes.len()))).map(|(node, path)| node_missing_children(&node, &path, trie.state())).collect::<Result<Vec<_>,_>>()?;
+            paths.extend(children.into_iter().flatten());
+            // Write nodes to trie
+            let node_hashes = trie_nodes.iter().map(|node| node.compute_hash()).collect();
+            trie.state_mut().write_node_batch(trie_nodes, node_hashes)?;
             if nodes.is_empty() {
                 break;
             }

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -124,8 +124,7 @@ async fn heal_storage_batch(
                 .collect::<Result<Vec<_>, _>>()?;
             paths.extend(children.into_iter().flatten());
             // Write nodes to trie
-            let node_hashes = trie_nodes.iter().map(|node| node.compute_hash()).collect();
-            trie.state_mut().write_node_batch(trie_nodes, node_hashes)?;
+            trie.state_mut().write_node_batch(&nodes)?;
             if nodes.is_empty() {
                 break;
             }


### PR DESCRIPTION
**Motivation**
In a similar fashion to #2270, this PR aims to reduce the time spent writing data to the DB by writing data in batches. In this case the nodes received during storage healing are written all at once using the already existing `put_batch` method of the TrieDB trait.
This could only be done for nodes belonging to the same trie, as it would otherwise involve leaking and constraining the internal representation of TrieDB.
This has shown to reduce the time spent writing storage nodes in the DB from around 4 seconds to less than 20 milliseconds
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `write_node_batch` method for `TrieState` relying on `TrieDB::put_batch`
* Refactor storage healer code to write all nodes for a trie in a single operation
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

