### PR TITLE
ci(l1,l2):  fix comparison of HEAD with main branch for the block bench CI

### DIFF
--- a/.github/workflows/ci_bench_block_execution.yaml
+++ b/.github/workflows/ci_bench_block_execution.yaml
@@ -43,7 +43,7 @@ jobs:
 
   run-hyperfine:
     if: contains(github.event.pull_request.labels.*.name, 'performance')
-    name: Run benchmark against base branch
+    name: Run benchmark against main branch
     needs: [build-binaries]
     runs-on: ubuntu-22.04
     steps:
@@ -61,11 +61,11 @@ jobs:
         with:
           tool: hyperfine@1.16
 
-      - name: Fetch base binary
+      - name: Fetch main binary
         uses: actions/cache/restore@v3
         with:
-          path: bin/ethrex-base
-          key: binary-${{ github.event.pull_request.base.sha }}
+          path: bin/ethrex-main
+          key: binary-${{ github.event.pull_request.main.sha }}
 
       - name: Fetch HEAD binary
         uses: actions/cache/restore@v3
@@ -77,8 +77,8 @@ jobs:
         id: run-benchmarks
         run: |
           sudo swapoff -a
-          BINS="base,head"
-          hyperfine --setup "./bin/ethrex-base removedb" -w 5 -N -r 10 --show-output --export-markdown "bench_pr_comparison.md" \
+          BINS="main,head"
+          hyperfine --setup "./bin/ethrex-head removedb" -w 5 -N -r 10 --show-output --export-markdown "bench_pr_comparison.md" \
           -L bin "$BINS" -n "{bin}" \
           "./bin/ethrex-{bin} --network test_data/genesis-l2-ci.json import ./test_data/l2-1k-erc20.rlp --removedb"
           echo -e "## Benchmark Block Execution Results Comparison Against Main\n\n$(cat bench_pr_comparison.md)" > bench_pr_comparison.md


### PR DESCRIPTION
**Motivation**

Some needed changes to compare a feature branch against main were 
left out with the initial PR that introduced this change (#2253).

This PR addresses this issue.

