### PR TITLE
fix(l2): use absolute path for `.env` file

### DIFF
--- a/crates/l2/contracts/deployer.rs
+++ b/crates/l2/contracts/deployer.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use ethereum_types::{Address, H160, H256};
 use ethrex_common::U256;
 use ethrex_l2::utils::config::errors;
-use ethrex_l2::utils::config::{read_env_as_lines, read_env_file, write_env};
+use ethrex_l2::utils::config::{read_env_as_lines, read_env_file, write_env_file};
 use ethrex_l2::utils::test_data_io::read_genesis_file;
 use ethrex_l2_sdk::calldata::{encode_calldata, Value};
 use ethrex_l2_sdk::get_address_from_secret_key;
@@ -166,7 +166,7 @@ If running locally, a reasonable value would be CONFIG_FILE=config.toml",
         }
         wr_lines.push(line);
     }
-    write_env(wr_lines).map_err(DeployError::EnvFileError)?;
+    write_env_file(wr_lines).map_err(DeployError::EnvFileError)?;
     Ok(())
 }
 

--- a/crates/l2/parse_toml.rs
+++ b/crates/l2/parse_toml.rs
@@ -1,4 +1,4 @@
-use crate::errors::*;
+use crate::{errors::*, utils};
 use serde::Deserialize;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -243,12 +243,12 @@ impl L2Config {
 }
 
 pub fn write_to_env(config: String) -> Result<(), ConfigError> {
-    let env_file_name = std::env::var("ENV_FILE").unwrap_or(".env".to_string());
+    let env_file_path = utils::config::get_env_file_path();
     let env_file = OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
-        .open(env_file_name);
+        .open(env_file_path);
     match env_file {
         Ok(mut file) => {
             file.write_all(&config.into_bytes()).map_err(|_| {

--- a/crates/l2/utils/config/mod.rs
+++ b/crates/l2/utils/config/mod.rs
@@ -16,11 +16,7 @@ pub mod errors;
 pub const CARGO_MANIFEST_DIR: &str = std::env!("CARGO_MANIFEST_DIR");
 
 pub fn read_env_file() -> Result<(), errors::ConfigError> {
-    let env_file_path = match std::env::var("ENV_FILE") {
-        Ok(env_file_path) => PathBuf::from(env_file_path),
-        Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env"),
-    };
-    let env_file = open_readable(env_file_path)?;
+    let env_file = open_readable()?;
     let reader = std::io::BufReader::new(env_file);
 
     for line in reader.lines() {
@@ -49,14 +45,14 @@ pub fn read_env_file() -> Result<(), errors::ConfigError> {
 
 pub fn read_env_as_lines(
 ) -> Result<std::io::Lines<std::io::BufReader<std::fs::File>>, errors::ConfigError> {
-    let env_file_path = std::env::var("ENV_FILE").unwrap_or(".env".to_owned());
-    let env_file = open_readable(env_file_path)?;
+    let env_file = open_readable()?;
     let reader = std::io::BufReader::new(env_file);
 
     Ok(reader.lines())
 }
 
-fn open_readable(path: PathBuf) -> std::io::Result<std::fs::File> {
+fn open_readable() -> std::io::Result<std::fs::File> {
+    let path = get_env_file_path();
     match std::fs::File::open(path) {
         Ok(file) => Ok(file),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -64,6 +60,13 @@ fn open_readable(path: PathBuf) -> std::io::Result<std::fs::File> {
             Err(err)
         }
         Err(err) => Err(err),
+    }
+}
+
+pub fn get_env_file_path() -> PathBuf {
+    match std::env::var("ENV_FILE") {
+        Ok(env_file_path) => PathBuf::from(env_file_path),
+        Err(_) => PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env"),
     }
 }
 

--- a/crates/l2/utils/config/mod.rs
+++ b/crates/l2/utils/config/mod.rs
@@ -13,8 +13,6 @@ pub mod prover_server;
 
 pub mod errors;
 
-pub const CARGO_MANIFEST_DIR: &str = std::env!("CARGO_MANIFEST_DIR");
-
 pub fn read_env_file() -> Result<(), errors::ConfigError> {
     let env_file = open_readable()?;
     let reader = std::io::BufReader::new(env_file);

--- a/crates/l2/utils/config/mod.rs
+++ b/crates/l2/utils/config/mod.rs
@@ -14,7 +14,7 @@ pub mod prover_server;
 pub mod errors;
 
 pub fn read_env_file() -> Result<(), errors::ConfigError> {
-    let env_file = open_readable()?;
+    let env_file = open_env_file()?;
     let reader = std::io::BufReader::new(env_file);
 
     for line in reader.lines() {
@@ -43,13 +43,13 @@ pub fn read_env_file() -> Result<(), errors::ConfigError> {
 
 pub fn read_env_as_lines(
 ) -> Result<std::io::Lines<std::io::BufReader<std::fs::File>>, errors::ConfigError> {
-    let env_file = open_readable()?;
+    let env_file = open_env_file()?;
     let reader = std::io::BufReader::new(env_file);
 
     Ok(reader.lines())
 }
 
-fn open_readable() -> std::io::Result<std::fs::File> {
+fn open_env_file() -> std::io::Result<std::fs::File> {
     let path = get_env_file_path();
     match std::fs::File::open(path) {
         Ok(file) => Ok(file),
@@ -68,7 +68,7 @@ pub fn get_env_file_path() -> PathBuf {
     }
 }
 
-pub fn write_env(lines: Vec<String>) -> Result<(), errors::ConfigError> {
+pub fn write_env_file(lines: Vec<String>) -> Result<(), errors::ConfigError> {
     let path = get_env_file_path();
     let env_file = match std::fs::OpenOptions::new()
         .write(true)

--- a/crates/l2/utils/config/mod.rs
+++ b/crates/l2/utils/config/mod.rs
@@ -10,8 +10,11 @@ pub mod prover_server;
 
 pub mod errors;
 
+pub const CARGO_MANIFEST_DIR: &str = std::env!("CARGO_MANIFEST_DIR");
+
 pub fn read_env_file() -> Result<(), errors::ConfigError> {
-    let env_file_name = std::env::var("ENV_FILE").unwrap_or(".env".to_string());
+    let env_file_name =
+        std::env::var("ENV_FILE").unwrap_or(CARGO_MANIFEST_DIR.to_string() + "/.env");
     let env_file_path = open_readable(env_file_name)?;
     let reader = std::io::BufReader::new(env_file_path);
 

--- a/crates/l2/utils/config/mod.rs
+++ b/crates/l2/utils/config/mod.rs
@@ -69,11 +69,11 @@ pub fn get_env_file_path() -> PathBuf {
 }
 
 pub fn write_env(lines: Vec<String>) -> Result<(), errors::ConfigError> {
-    let env_file_name = std::env::var("ENV_FILE").unwrap_or(".env".to_string());
+    let path = get_env_file_path();
     let env_file = match std::fs::OpenOptions::new()
         .write(true)
         .truncate(true)
-        .open(&env_file_name)
+        .open(path)
     {
         Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {


### PR DESCRIPTION
**Motivation**

Running the stack outside of `crates/l2` fails because the `.env` file path is set to its relative form. 

**Description**

Use the `.env` file absolute path.

