### PR TITLE
fix(l2): remove uses of blocking sleeps from async code

### DIFF
--- a/cmd/ethrex_l2/src/commands/stack.rs
+++ b/cmd/ethrex_l2/src/commands/stack.rs
@@ -18,7 +18,6 @@ use secp256k1::SecretKey;
 use std::{
     fs::{create_dir_all, read_dir},
     path::{Path, PathBuf},
-    thread::sleep,
     time::Duration,
 };
 
@@ -224,7 +223,7 @@ impl Command {
                 let mut current_block = U256::zero();
                 while current_block < U256::from(64) {
                     current_block = eth_client.get_block_number().await?;
-                    sleep(Duration::from_secs(12));
+                    tokio::time::sleep(Duration::from_secs(12)).await;
                 }
                 current_block = current_block
                     .checked_sub(U256::from(64))
@@ -234,7 +233,7 @@ impl Command {
 
                 loop {
                     // Wait for a block
-                    sleep(Duration::from_secs(12));
+                    tokio::time::sleep(Duration::from_secs(12)).await;
 
                     let logs = eth_client
                         .get_logs(

--- a/cmd/ethrex_l2/src/commands/test.rs
+++ b/cmd/ethrex_l2/src/commands/test.rs
@@ -22,10 +22,7 @@ use std::{
     path::Path,
     time::{Duration, Instant},
 };
-use tokio::{
-    task::JoinSet,
-    time::sleep,
-};
+use tokio::{task::JoinSet, time::sleep};
 
 // ERC20 compiled artifact generated from this tutorial:
 // https://medium.com/@kaishinaw/erc20-using-hardhat-a-comprehensive-guide-3211efba98d4

--- a/cmd/ethrex_l2/src/commands/test.rs
+++ b/cmd/ethrex_l2/src/commands/test.rs
@@ -20,10 +20,12 @@ use std::{
     fs::File,
     io::{self, BufRead},
     path::Path,
-    thread::sleep,
     time::{Duration, Instant},
 };
-use tokio::task::JoinSet;
+use tokio::{
+    task::JoinSet,
+    time::sleep,
+};
 
 // ERC20 compiled artifact generated from this tutorial:
 // https://medium.com/@kaishinaw/erc20-using-hardhat-a-comprehensive-guide-3211efba98d4

--- a/cmd/ethrex_l2/src/commands/test.rs
+++ b/cmd/ethrex_l2/src/commands/test.rs
@@ -168,9 +168,9 @@ async fn transfer_from(
         while let Err(e) = client.send_eip1559_transaction(&tx, &private_key).await {
             println!("Transaction failed (PK: {pk} - Nonce: {}): {e}", tx.nonce);
             retries += 1;
-            sleep(std::time::Duration::from_secs(2));
+            sleep(std::time::Duration::from_secs(2)).await;
         }
-        sleep(Duration::from_millis(3));
+        sleep(Duration::from_millis(3)).await;
     }
 
     retries
@@ -191,7 +191,7 @@ async fn test_connection(cfg: EthrexL2Config) -> Result<(), EthClientError> {
             }
             Err(err) => {
                 println!("Couldn't establish connection to L2: {err}, retrying {retry}/{RETRIES}");
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                sleep(Duration::from_secs(1)).await;
                 retry += 1
             }
         }
@@ -207,7 +207,7 @@ async fn wait_receipt(
     for _ in 0..retries {
         match client.get_transaction_receipt(tx_hash).await {
             Err(_) | Ok(None) => {
-                let _ = tokio::time::sleep(Duration::from_secs(1)).await;
+                let _ = sleep(Duration::from_secs(1)).await;
             }
             Ok(Some(receipt)) => return Ok(receipt),
         };
@@ -331,7 +331,7 @@ async fn erc20_load_test(
                 )
                 .await?;
             let client = client.clone();
-            tokio::time::sleep(Duration::from_micros(800)).await;
+            sleep(Duration::from_micros(800)).await;
             tasks.spawn(async move {
                 let _sent = client
                     .send_eip1559_transaction(&send_tx, &sk)

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -57,7 +57,7 @@ async fn l2_integration_test() -> Result<(), Box<dyn std::error::Error>> {
     println!("Waiting for L2 to update for initial deposit");
     let mut retries = 0;
     while retries < 30 && l2_initial_balance.is_zero() {
-        std::thread::sleep(std::time::Duration::from_secs(2));
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         println!("[{retries}/30] Waiting for L2 balance to update");
         l2_initial_balance = proposer_client.get_balance(l1_rich_wallet_address).await?;
         retries += 1;
@@ -112,7 +112,7 @@ async fn l2_integration_test() -> Result<(), Box<dyn std::error::Error>> {
     // tx hash for the user to wait for the receipt.
     let mut retries = 0;
     while retries < 30 && l2_after_deposit_balance < l2_initial_balance + deposit_value {
-        std::thread::sleep(std::time::Duration::from_secs(2));
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         println!("[{retries}/30] Waiting for L2 balance to update after deposit");
         l2_after_deposit_balance = proposer_client.get_balance(l1_rich_wallet_address).await?;
         retries += 1;
@@ -260,7 +260,7 @@ async fn l2_integration_test() -> Result<(), Box<dyn std::error::Error>> {
         < withdraw_tx_receipt.block_info.block_number
     {
         println!("Withdrawal is not verified on L1 yet");
-        std::thread::sleep(Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_secs(2)).await;
     }
 
     let claim_tx = ethrex_l2_sdk::claim_withdraw(


### PR DESCRIPTION
There were still some sleeps blocking the runtime. Found mostly in the load test, but in other places as well. Changed them by tokio::sleep calls.
