### PR TITLE
fix(l2): bashism in l2 Makefile

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -122,7 +122,7 @@ update-system-contracts:
 
 # L2
 init-l2: init-metrics ## 🚀 Initializes an L2 Lambda ethrex Client
-	if [[ -z "$$BASED" ]]; then \
+	if [ -z "$$BASED" ]; then \
 		FEATURES="l2,metrics"; \
 		echo "Running ethrex L2 vanilla"; \
 	else \


### PR DESCRIPTION
The `[[` builtin is not POSIX, which causes issues in some servers that
default their shell to `sh` (POSIX-compat mode). Specifically, because
the builtin does not exist, the L2 always runs in based mode due to the
error.

**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

