### PR TITLE
feat(l1): write state nodes in batches during state healing

### DIFF
--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -112,35 +112,36 @@ async fn heal_state_batch(
         // - Add its children to the queue (if we don't have them already)
         // - If it is a leaf, request its bytecode & storage
         // - If it is a leaf, add its path & value to the trie
-        for node in nodes {
-            // We cannot keep the trie state open
+        {
             let mut trie = store.open_state_trie(*EMPTY_TRIE_HASH);
-            let path = batch.remove(0);
-            batch.extend(node_missing_children(&node, &path, trie.state())?);
-            if let Node::Leaf(node) = &node {
-                // Fetch bytecode & storage
-                let account = AccountState::decode(&node.value)?;
-                // By now we should have the full path = account hash
-                let path = &path.concat(node.partial.clone()).to_bytes();
-                if path.len() != 32 {
-                    // Something went wrong
-                    return Err(SyncError::CorruptPath);
-                }
-                let account_hash = H256::from_slice(path);
-                if account.storage_root != *EMPTY_TRIE_HASH
-                    && !store.contains_storage_node(account_hash, account.storage_root)?
-                {
-                    hashed_addresses.push(account_hash);
-                }
-                if account.code_hash != *EMPTY_KECCACK_HASH
-                    && store.get_account_code(account.code_hash)?.is_none()
-                {
-                    code_hashes.push(account.code_hash);
+            for node in nodes.iter() {
+                let path = batch.remove(0);
+                batch.extend(node_missing_children(node, &path, trie.state())?);
+                if let Node::Leaf(node) = &node {
+                    // Fetch bytecode & storage
+                    let account = AccountState::decode(&node.value)?;
+                    // By now we should have the full path = account hash
+                    let path = &path.concat(node.partial.clone()).to_bytes();
+                    if path.len() != 32 {
+                        // Something went wrong
+                        return Err(SyncError::CorruptPath);
+                    }
+                    let account_hash = H256::from_slice(path);
+                    if account.storage_root != *EMPTY_TRIE_HASH
+                        && !store.contains_storage_node(account_hash, account.storage_root)?
+                    {
+                        hashed_addresses.push(account_hash);
+                    }
+                    if account.code_hash != *EMPTY_KECCACK_HASH
+                        && store.get_account_code(account.code_hash)?.is_none()
+                    {
+                        code_hashes.push(account.code_hash);
+                    }
                 }
             }
-            // Add node to trie
-            let hash = node.compute_hash();
-            trie.state_mut().write_node(node, hash)?;
+            // Write nodes to trie
+            let node_hashes = nodes.iter().map(|node| node.compute_hash()).collect();
+            trie.state_mut().write_node_batch(nodes, node_hashes)?;
         }
         // Send storage & bytecode requests
         if !hashed_addresses.is_empty() {


### PR DESCRIPTION
**Motivation**
In a similar fashion to #2288, this PR aims to reduce the time spent writing data to the DB by writing data in batches. In this case the nodes received during storage healing are written all at once using the `write_node_batch` method introduced in #2288
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Refactor state healer code to write all nodes for a trie in a single operation
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

