### PR TITLE
ci(core): remove rust version since it's already specified in toolchain

### DIFF
--- a/.github/workflows/ci_l1.yaml
+++ b/.github/workflows/ci_l1.yaml
@@ -12,9 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  RUST_VERSION: 1.82.0
-
 jobs:
   lint:
     # "Lint" is a required check, don't change the name
@@ -27,7 +24,6 @@ jobs:
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
 
       - name: Add Rust Cache
@@ -58,8 +54,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci_l2.yaml
+++ b/.github/workflows/ci_l2.yaml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  RUST_VERSION: 1.82.0
-
 jobs:
   test:
     # "Integration Test" is a required check, don't change the name
@@ -25,8 +22,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.82.0
 
 jobs:
   ef-test:
@@ -27,8 +26,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2
@@ -80,8 +77,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2
@@ -150,7 +145,7 @@ jobs:
           name: pr-ef-test-data
           path: crates/vm/levm/
 
-     # NOTE: diff will exit with a non 0 exit code when there are differences
+      # NOTE: diff will exit with a non 0 exit code when there are differences
       - name: Compare files
         id: branch_diffs
         continue-on-error: true
@@ -294,8 +289,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2
@@ -314,8 +307,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
@@ -343,7 +334,6 @@ jobs:
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
 
       - name: Add Rust Cache

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -14,7 +14,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.82.0
 
 jobs:
   run-hive:
@@ -84,8 +83,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Download all results
         uses: actions/download-artifact@v4

--- a/.github/workflows/daily_loc.yaml
+++ b/.github/workflows/daily_loc.yaml
@@ -6,9 +6,6 @@ on:
     - cron: "0 0 * * 1,2,3,4,5"
   workflow_dispatch:
 
-env:
-  RUST_VERSION: 1.82.0
-
 jobs:
   loc:
     name: Count ethrex loc and generate report
@@ -19,8 +16,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -6,9 +6,6 @@ on:
     - cron: "0 0 * * 1,2,3,4,5"
   workflow_dispatch:
 
-env:
-  RUST_VERSION: 1.82.0
-
 jobs:
   hive-report-creation-levm:
     uses: ./.github/workflows/common_hive_reports.yaml
@@ -110,8 +107,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/flamegraph_reporter.yaml
+++ b/.github/workflows/flamegraph_reporter.yaml
@@ -15,7 +15,6 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_VERSION: 1.85.0
   RUST_RETH_VERSION: 1.85.0
 
 jobs:
@@ -41,7 +40,7 @@ jobs:
             ${{ env.HOME }}/.cargo/bin/flamegraph
             ${{ env.HOME }}/.cargo/bin/inferno-*
             ${{ env.HOME }}/ethrex/ethrex/cmd/ef_tests/state/vectors
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-extra-binaries
+          key: ${{ runner.os }}-extra-binaries
 
       - name: Change perf settings
         run: |
@@ -173,8 +172,6 @@ jobs:
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2
@@ -187,14 +184,14 @@ jobs:
             ${{ env.HOME }}/.cargo/bin/addr2line
             ${{ env.HOME }}/.cargo/bin/flamegraph
             ${{ env.HOME }}/.cargo/bin/inferno-*
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-extra-binaries
+          key: ${{ runner.os }}-extra-binaries
 
       - name: Cache ethrex_l2
         id: cache-ethrex-l2
         uses: actions/cache@v4
         with:
           path: ${{ env.HOME }}/.cargo/bin/ethrex_l2
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-ethrex-l2-${{ hashFiles('cmd/ethrex_l2/Cargo.lock') }}
+          key: ${{ runner.os }}-ethrex-l2-${{ hashFiles('cmd/ethrex_l2/Cargo.lock') }}
 
       - name: Change perf settings
         run: |
@@ -320,14 +317,14 @@ jobs:
             ${{ env.HOME }}/.cargo/bin/addr2line
             ${{ env.HOME }}/.cargo/bin/flamegraph
             ${{ env.HOME }}/.cargo/bin/inferno-*
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-extra-binaries
+          key: ${{ runner.os }}-extra-binaries
 
       - name: Cache ethrex_l2
         id: cache-ethrex-l2
         uses: actions/cache@v4
         with:
           path: ${{ env.HOME }}/.cargo/bin/ethrex_l2
-          key: ${{ runner.os }}-${{ env.RUST_VERSION }}-ethrex-l2-${{ hashFiles('cmd/ethrex_l2/Cargo.lock') }}
+          key: ${{ runner.os }}-ethrex-l2-${{ hashFiles('cmd/ethrex_l2/Cargo.lock') }}
 
       - name: Change perf settings
         run: |


### PR DESCRIPTION
**Motivation**
You can see this message in the CI:
`info: note that the toolchain '1.82.0-x86_64-unknown-linux-gnu' is currently in use (overridden by '/home/runner/work/ethrex/ethrex/rust-toolchain.toml')`

