### PR TITLE
ci(core): disable flamegraph report until it is fixed.

### DIFF
--- a/.github/workflows/flamegraph_reporter.yaml
+++ b/.github/workflows/flamegraph_reporter.yaml
@@ -5,13 +5,10 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 on:
-  push:
-    branches: ["main"]
+  # re-enable this when fixing the workflow
+  # push:
+  #   branches: ["main"]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
**Motivation**
This job is broken. Disabling it until it gets fixed.

