### PR TITLE
fix(l1, l2): fix load tests

### DIFF
--- a/cmd/ethrex_l2/src/commands/test.rs
+++ b/cmd/ethrex_l2/src/commands/test.rs
@@ -153,7 +153,7 @@ async fn transfer_from(
                         None
                     },
                     gas_limit: Some(TX_GAS_COST * 100),
-                    nonce: Some(nonce + i),
+                    nonce: Some(i),
                     ..Default::default()
                 },
             )

--- a/cmd/ethrex_l2/src/commands/test.rs
+++ b/cmd/ethrex_l2/src/commands/test.rs
@@ -152,9 +152,8 @@ async fn transfer_from(
                     } else {
                         None
                     },
-                    max_fee_per_gas: Some(3121115334),
-                    max_priority_fee_per_gas: Some(3000000000),
                     gas_limit: Some(TX_GAS_COST * 100),
+                    nonce: Some(nonce + i),
                     ..Default::default()
                 },
             )

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -39,7 +39,7 @@ use crate::{
     Blockchain,
 };
 
-use tracing::debug;
+use tracing::{debug, error};
 
 pub struct BuildPayloadArgs {
     pub parent: BlockHash,
@@ -425,7 +425,7 @@ impl Blockchain {
                 }
                 // Ignore following txs from sender
                 Err(e) => {
-                    debug!("Failed to execute transaction: {}, {e}", tx_hash);
+                    error!("Failed to execute transaction: {tx_hash:x}, {e}");
                     metrics!(METRICS_TX.inc_tx_with_status_and_type(
                         MetricsTxStatus::Failed,
                         MetricsTxType(head_tx.tx_type())


### PR DESCRIPTION
**Motivation**

Load tests were broken for two reasons:

- We were not correctly passing the nonce as an override and thus were relying on the RPC endpoint to get it, which was not correct (since we want to pre-send transactions with higher nonces). We now pass `Some(i)` as the nonce, because that `i` has the nonce value in a given iteration.
- We were hardcoding gas fees; this is because when we first wrote the load tests, the gas price endpoint on ethrex did not work properly. Now that it does, we can remove the hardcoded values and just rely on the endpoint (the default behaviour if you do not pass an `Override` to the `build_eip1559_transaction` function).

I also changed the `debug!` log when a mempool transaction failed to be executed while building a block to be an `error!`, because I noticed it's quite a common occurrence when we run load tests due to some nonce issue, and I think it's worth investigating (it's the reason why sometimes we get empty blocks when running load tests).

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

