### PR TITLE
feat(l1): use a config file for sync parameters (Early Draft)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "toml 0.7.8",
  "tracing",
 ]
 
@@ -9677,6 +9678,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
@@ -9703,6 +9716,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.8.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ethrex-p2p"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -38,6 +39,10 @@ rand = "0.8.5"
 
 [dev-dependencies]
 hex-literal = "0.4.1"
+
+[build-dependencies]
+serde_json = "1.0.117"
+serde.workspace = true
 
 [lib]
 path = "./p2p.rs"

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -41,8 +41,8 @@ rand = "0.8.5"
 hex-literal = "0.4.1"
 
 [build-dependencies]
-serde_json = "1.0.117"
 serde.workspace = true
+toml = "0.7"
 
 [lib]
 path = "./p2p.rs"

--- a/crates/networking/p2p/build.rs
+++ b/crates/networking/p2p/build.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+const CONFIG_PATH: &str = "config.json";
+const CONSTANTS_PATH: &str = "constants.rs";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+struct P2PConfig {
+    sync_config: SyncConfig,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+struct SyncConfig {
+    max_parallel_fetches: usize,
+    batch_size: usize,
+    node_batch_size: usize,
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=config.json");
+
+    let config_data: P2PConfig = serde_json::from_reader(
+        std::fs::File::open(CONFIG_PATH).expect("Failed to open p2p config file"),
+    )
+    .expect("Failed to read p2p config file");
+    let out_dir = std::env::var_os("OUT_DIR").unwrap();
+    let destination_path = std::path::Path::new(&out_dir).join(CONSTANTS_PATH);
+    config_data.write_to_destination(destination_path);
+    // std::fs::write(&path, "pub fn test() { todo!() }").unwrap();
+}
+
+impl P2PConfig {
+    fn write_to_destination(&self, destination_path: PathBuf) {
+        std::fs::write(
+            destination_path,
+            format!(
+                "pub const MAX_PARALLEL_FETCHES: usize = {};
+            pub const BATCH_SIZE: usize = {};
+            pub const NODE_BATCH_SIZE: usize = {};",
+                self.sync_config.max_parallel_fetches,
+                self.sync_config.batch_size,
+                self.sync_config.node_batch_size
+            ),
+        )
+        .unwrap()
+    }
+}

--- a/crates/networking/p2p/build.rs
+++ b/crates/networking/p2p/build.rs
@@ -1,12 +1,12 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-const CONFIG_PATH: &str = "config.json";
+const CONFIG_PATH: &str = "config.toml";
 const CONSTANTS_PATH: &str = "constants.rs";
 
 #[derive(Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
+#[serde(rename_all = "kebab-case")]
 struct P2PConfig {
     sync_config: SyncConfig,
 }
@@ -14,23 +14,24 @@ struct P2PConfig {
 #[derive(Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 struct SyncConfig {
-    max_parallel_fetches: usize,
     batch_size: usize,
     node_batch_size: usize,
+    max_parallel_fetches: usize,
+    max_channel_messages: usize,
+    max_channel_reads: usize,
 }
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=config.json");
+    println!("cargo:rerun-if-changed=config.toml");
 
-    let config_data: P2PConfig = serde_json::from_reader(
-        std::fs::File::open(CONFIG_PATH).expect("Failed to open p2p config file"),
+    let config_data: P2PConfig = toml::from_str(
+        &std::fs::read_to_string(Path::new(CONFIG_PATH)).expect("Failed to open p2p config file"),
     )
     .expect("Failed to read p2p config file");
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
     let destination_path = std::path::Path::new(&out_dir).join(CONSTANTS_PATH);
     config_data.write_to_destination(destination_path);
-    // std::fs::write(&path, "pub fn test() { todo!() }").unwrap();
 }
 
 impl P2PConfig {
@@ -38,12 +39,17 @@ impl P2PConfig {
         std::fs::write(
             destination_path,
             format!(
-                "pub const MAX_PARALLEL_FETCHES: usize = {};
-            pub const BATCH_SIZE: usize = {};
-            pub const NODE_BATCH_SIZE: usize = {};",
-                self.sync_config.max_parallel_fetches,
+                "// Sync constants
+                pub(crate) const BATCH_SIZE: usize = {};
+                pub(crate)const NODE_BATCH_SIZE: usize = {};
+                pub(crate)const MAX_PARALLEL_FETCHES: usize = {};
+                pub(crate)const MAX_CHANNEL_MESSAGES: usize = {};
+                pub(crate)const MAX_CHANNEL_READS: usize = {};",
                 self.sync_config.batch_size,
-                self.sync_config.node_batch_size
+                self.sync_config.node_batch_size,
+                self.sync_config.max_parallel_fetches,
+                self.sync_config.max_channel_messages,
+                self.sync_config.max_channel_reads,
             ),
         )
         .unwrap()

--- a/crates/networking/p2p/config.json
+++ b/crates/networking/p2p/config.json
@@ -1,7 +1,0 @@
-{
-    "SYNC_CONFIG": {
-        "MAX_PARALLEL_FETCHES": 2,
-        "BATCH_SIZE": 300,
-        "NODE_BATCH_SIZE": 900
-    }
-}

--- a/crates/networking/p2p/config.json
+++ b/crates/networking/p2p/config.json
@@ -1,0 +1,7 @@
+{
+    "SYNC_CONFIG": {
+        "MAX_PARALLEL_FETCHES": 2,
+        "BATCH_SIZE": 300,
+        "NODE_BATCH_SIZE": 900
+    }
+}

--- a/crates/networking/p2p/config.toml
+++ b/crates/networking/p2p/config.toml
@@ -1,0 +1,12 @@
+# Sync-related constants
+[sync-config]
+# Max size of a bach to start a fetch request in queues
+BATCH_SIZE = 300
+# Max size of a bach to start a fetch request in queues for nodes
+NODE_BATCH_SIZE = 900
+# Maximum amount of concurrent paralell fetches for a queue
+MAX_PARALLEL_FETCHES = 10
+# Maximum amount of messages in a channel
+MAX_CHANNEL_MESSAGES = 500
+# Maximum amount of messages to read from a channel at once
+MAX_CHANNEL_READS = 200

--- a/crates/networking/p2p/p2p.rs
+++ b/crates/networking/p2p/p2p.rs
@@ -9,3 +9,7 @@ pub mod types;
 
 pub use network::periodically_show_peer_stats;
 pub use network::start_network;
+
+pub mod constants {
+    include!(concat!(env!("OUT_DIR"), "/constants.rs"));
+}

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -37,22 +37,13 @@ use crate::{
     },
 };
 
-// Constants defined in the crate's config file `config.json`
-use crate::constants::{BATCH_SIZE, MAX_PARALLEL_FETCHES, NODE_BATCH_SIZE};
+// Constants defined in the crate's config file `config.toml`
+use crate::constants::{
+    BATCH_SIZE, MAX_CHANNEL_MESSAGES, MAX_CHANNEL_READS, MAX_PARALLEL_FETCHES, NODE_BATCH_SIZE,
+};
 
 /// The minimum amount of blocks from the head that we want to full sync during a snap sync
 const MIN_FULL_BLOCKS: usize = 64;
-/// Max size of a bach to start a fetch request in queues
-//const BATCH_SIZE: usize = 300;
-/// Max size of a bach to start a fetch request in queues for nodes
-//const NODE_BATCH_SIZE: usize = 900;
-// / Maximum amount of concurrent paralell fetches for a queue
-// const MAX_PARALLEL_FETCHES: usize = 10;
-/// Maximum amount of messages in a channel
-const MAX_CHANNEL_MESSAGES: usize = 500;
-/// Maximum amount of messages to read from a channel at once
-const MAX_CHANNEL_READS: usize = 200;
-/// Pace at which progress is shown via info tracing
 const SHOW_PROGRESS_INTERVAL_DURATION: Duration = Duration::from_secs(30);
 
 lazy_static::lazy_static! {

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -35,15 +35,17 @@ use crate::{
         BlockRequestOrder, PeerHandler, HASH_MAX, MAX_BLOCK_BODIES_TO_REQUEST,
         MAX_BLOCK_HEADERS_TO_REQUEST,
     },
-    constants::MAX_PARALLEL_FETCHES
 };
+
+// Constants defined in the crate's config file `config.json`
+use crate::constants::{BATCH_SIZE, MAX_PARALLEL_FETCHES, NODE_BATCH_SIZE};
 
 /// The minimum amount of blocks from the head that we want to full sync during a snap sync
 const MIN_FULL_BLOCKS: usize = 64;
 /// Max size of a bach to start a fetch request in queues
-const BATCH_SIZE: usize = 300;
+//const BATCH_SIZE: usize = 300;
 /// Max size of a bach to start a fetch request in queues for nodes
-const NODE_BATCH_SIZE: usize = 900;
+//const NODE_BATCH_SIZE: usize = 900;
 // / Maximum amount of concurrent paralell fetches for a queue
 // const MAX_PARALLEL_FETCHES: usize = 10;
 /// Maximum amount of messages in a channel

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -35,16 +35,17 @@ use crate::{
         BlockRequestOrder, PeerHandler, HASH_MAX, MAX_BLOCK_BODIES_TO_REQUEST,
         MAX_BLOCK_HEADERS_TO_REQUEST,
     },
+    constants::MAX_PARALLEL_FETCHES
 };
 
 /// The minimum amount of blocks from the head that we want to full sync during a snap sync
 const MIN_FULL_BLOCKS: usize = 64;
-/// Max size of a bach to stat a fetch request in queues
+/// Max size of a bach to start a fetch request in queues
 const BATCH_SIZE: usize = 300;
-/// Max size of a bach to stat a fetch request in queues for nodes
+/// Max size of a bach to start a fetch request in queues for nodes
 const NODE_BATCH_SIZE: usize = 900;
-/// Maximum amount of concurrent paralell fetches for a queue
-const MAX_PARALLEL_FETCHES: usize = 10;
+// / Maximum amount of concurrent paralell fetches for a queue
+// const MAX_PARALLEL_FETCHES: usize = 10;
 /// Maximum amount of messages in a channel
 const MAX_CHANNEL_MESSAGES: usize = 500;
 /// Maximum amount of messages to read from a channel at once


### PR DESCRIPTION
**Motivation**
This PR adds the possibility to rearrange the parameters of the sync process via a config file by using compile time constants defined by a build script.
This first draft only sets some of the sync parameters but can be extended to other p2p constants such as maximum amount of peers, peer request timeouts, etc.
The toml file format was chosen as json files don't allow comments to document what each config parameter defines.
<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

