### PR TITLE
feat(l1,l2): make write path APIs async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+#### 2025-04-01
+
+- Asyncify DB write APIs, as well as its users [#2336](https://github.com/lambdaclass/ethrex/pull/2336)
+
 #### 2025-03-30
 
 - Faster block import, use a slice instead of copy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,6 +2742,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2766,6 +2767,7 @@ dependencies = [
  "serde_json",
  "spinoff",
  "thiserror 2.0.12",
+ "tokio",
 ]
 
 [[package]]
@@ -3052,6 +3054,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
 ]
 
@@ -3323,6 +3326,7 @@ name = "ethrex-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "ethereum-types",
  "ethrex-common",
@@ -3337,6 +3341,7 @@ dependencies = [
  "sha3",
  "tempdir",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ethrex-prover = { path = "./crates/l2/prover" }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 
+async-trait = "0.1.88"
 ethereum-types = { version = "0.15.1", features = ["serialize"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -15,19 +15,19 @@ use tracing_subscriber::{filter::Directive, EnvFilter, FmtSubscriber};
 fn block_import() {
     let data_dir = DEFAULT_DATADIR;
     set_datadir(data_dir);
-
     remove_db(data_dir);
 
     let evm_engine = "revm".to_owned().try_into().unwrap();
 
     let network = "../../test_data/genesis-l2-ci.json";
 
-    import_blocks(
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(import_blocks(
         "../../test_data/l2-1k-erc20.rlp",
         data_dir,
         network,
         evm_engine,
-    );
+    ));
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/cmd/ef_tests/blockchain/Cargo.toml
+++ b/cmd/ef_tests/blockchain/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 bytes.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 datatest-stable = "0.2.9"

--- a/cmd/ef_tests/blockchain/tests/cancun.rs
+++ b/cmd/ef_tests/blockchain/tests/cancun.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 // test or set of tests
 
 fn parse_and_execute_until_cancun(path: &Path) -> datatest_stable::Result<()> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
@@ -22,7 +23,7 @@ fn parse_and_execute_until_cancun(path: &Path) -> datatest_stable::Result<()> {
             // them. This produces false positives
             continue;
         }
-        run_ef_test(&test_key, &test);
+        rt.block_on(run_ef_test(&test_key, &test));
     }
 
     Ok(())
@@ -30,6 +31,7 @@ fn parse_and_execute_until_cancun(path: &Path) -> datatest_stable::Result<()> {
 
 #[allow(dead_code)]
 fn parse_and_execute_all(path: &Path) -> datatest_stable::Result<()> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
@@ -37,7 +39,7 @@ fn parse_and_execute_all(path: &Path) -> datatest_stable::Result<()> {
             // These tests fall into the not supported forks. This produces false positives
             continue;
         }
-        run_ef_test(&test_key, &test);
+        rt.block_on(run_ef_test(&test_key, &test));
     }
 
     Ok(())

--- a/cmd/ef_tests/blockchain/tests/prague.rs
+++ b/cmd/ef_tests/blockchain/tests/prague.rs
@@ -13,6 +13,7 @@ const SKIPPED_TEST: [&str; 2] = [
 
 #[allow(dead_code)]
 fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
@@ -21,7 +22,7 @@ fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
             continue;
         }
 
-        run_ef_test(&test_key, &test);
+        rt.block_on(run_ef_test(&test_key, &test));
     }
     Ok(())
 }

--- a/cmd/ef_tests/blockchain/tests/shanghai.rs
+++ b/cmd/ef_tests/blockchain/tests/shanghai.rs
@@ -6,6 +6,7 @@ use ef_tests_blockchain::{
 };
 
 fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let tests = parse_test_file(path);
 
     for (test_key, test) in tests {
@@ -14,7 +15,7 @@ fn parse_and_execute(path: &Path) -> datatest_stable::Result<()> {
             continue;
         }
 
-        run_ef_test(&test_key, &test);
+        rt.block_on(run_ef_test(&test_key, &test));
     }
     Ok(())
 }

--- a/cmd/ef_tests/state/Cargo.toml
+++ b/cmd/ef_tests/state/Cargo.toml
@@ -29,6 +29,7 @@ revm = { version = "19.0.0", features = [
     "optional_no_base_fee",
     "optional_block_gas_limit",
 ], default-features = false }
+tokio.workspace = true
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/cmd/ef_tests/state/runner/mod.rs
+++ b/cmd/ef_tests/state/runner/mod.rs
@@ -70,27 +70,27 @@ pub struct EFTestRunnerOptions {
     pub revm: bool,
 }
 
-pub fn run_ef_tests(
+pub async fn run_ef_tests(
     ef_tests: Vec<EFTest>,
     opts: &EFTestRunnerOptions,
 ) -> Result<(), EFTestRunnerError> {
     let mut reports = report::load()?;
     if reports.is_empty() {
         if opts.revm {
-            run_with_revm(&mut reports, &ef_tests, opts)?;
+            run_with_revm(&mut reports, &ef_tests, opts).await?;
             return Ok(());
         } else {
-            run_with_levm(&mut reports, &ef_tests, opts)?;
+            run_with_levm(&mut reports, &ef_tests, opts).await?;
         }
     }
     if opts.summary {
         return Ok(());
     }
-    re_run_with_revm(&mut reports, &ef_tests, opts)?;
+    re_run_with_revm(&mut reports, &ef_tests, opts).await?;
     write_report(&reports)
 }
 
-fn run_with_levm(
+async fn run_with_levm(
     reports: &mut Vec<EFTestReport>,
     ef_tests: &[EFTest],
     opts: &EFTestRunnerOptions,
@@ -113,7 +113,7 @@ fn run_with_levm(
         if !opts.spinner && opts.verbose {
             println!("Running test: {:?}", test.name);
         }
-        let ef_test_report = match levm_runner::run_ef_test(test) {
+        let ef_test_report = match levm_runner::run_ef_test(test).await {
             Ok(ef_test_report) => ef_test_report,
             Err(EFTestRunnerError::Internal(err)) => return Err(EFTestRunnerError::Internal(err)),
             non_internal_errors => {
@@ -154,7 +154,7 @@ fn run_with_levm(
 }
 
 /// ### Runs all tests with REVM
-fn run_with_revm(
+async fn run_with_revm(
     reports: &mut Vec<EFTestReport>,
     ef_tests: &[EFTest],
     opts: &EFTestRunnerOptions,
@@ -183,7 +183,7 @@ fn run_with_revm(
             ),
             opts.spinner,
         );
-        let ef_test_report = match revm_runner::_run_ef_test_revm(test) {
+        let ef_test_report = match revm_runner::_run_ef_test_revm(test).await {
             Ok(ef_test_report) => ef_test_report,
             Err(EFTestRunnerError::Internal(err)) => return Err(EFTestRunnerError::Internal(err)),
             non_internal_errors => {
@@ -210,7 +210,7 @@ fn run_with_revm(
     Ok(())
 }
 
-fn re_run_with_revm(
+async fn re_run_with_revm(
     reports: &mut [EFTestReport],
     ef_tests: &[EFTest],
     opts: &EFTestRunnerOptions,
@@ -262,7 +262,7 @@ fn re_run_with_revm(
                 })
                 .unwrap(),
             failed_test_report,
-        ) {
+        ).await {
             Ok(re_run_report) => {
                 failed_test_report.register_re_run_report(re_run_report.clone());
             }

--- a/cmd/ef_tests/state/runner/revm_runner.rs
+++ b/cmd/ef_tests/state/runner/revm_runner.rs
@@ -32,7 +32,7 @@ use revm::{
 };
 use std::collections::{HashMap, HashSet};
 
-pub fn re_run_failed_ef_test(
+pub async fn re_run_failed_ef_test(
     test: &EFTest,
     failed_test_report: &EFTestReport,
 ) -> Result<TestReRunReport, EFTestRunnerError> {
@@ -43,7 +43,7 @@ pub fn re_run_failed_ef_test(
             match vector_failure {
                 // We only want to re-run tests that failed in the post-state validation.
                 EFTestRunnerError::FailedToEnsurePostState(transaction_report, _, levm_cache) => {
-                    match re_run_failed_ef_test_tx(levm_cache.clone(), vector, test, transaction_report, &mut re_run_report, fork) {
+                    match re_run_failed_ef_test_tx(levm_cache.clone(), vector, test, transaction_report, &mut re_run_report, fork).await {
                         Ok(_) => continue,
                         Err(EFTestRunnerError::VMInitializationFailed(reason)) => {
                             return Err(EFTestRunnerError::Internal(InternalError::ReRunInternal(
@@ -75,7 +75,7 @@ pub fn re_run_failed_ef_test(
     Ok(re_run_report)
 }
 
-pub fn re_run_failed_ef_test_tx(
+pub async fn re_run_failed_ef_test_tx(
     levm_cache: HashMap<Address, Account>,
     vector: &TestVector,
     test: &EFTest,
@@ -83,7 +83,7 @@ pub fn re_run_failed_ef_test_tx(
     re_run_report: &mut TestReRunReport,
     fork: &Fork,
 ) -> Result<(), EFTestRunnerError> {
-    let (mut state, _block_hash) = load_initial_state(test);
+    let (mut state, _block_hash) = load_initial_state(test).await;
     let mut revm = prepare_revm_for_tx(&mut state, vector, test, fork)?;
     if !test.post.has_vector_for_fork(vector, *fork) {
         return Ok(());
@@ -97,7 +97,7 @@ pub fn re_run_failed_ef_test_tx(
         re_run_report,
         fork,
     )?;
-    ensure_post_state(levm_cache, vector, &mut state, test, re_run_report, fork)?;
+    ensure_post_state(levm_cache, vector, &mut state, test, re_run_report, fork).await?;
     Ok(())
 }
 
@@ -310,7 +310,7 @@ pub fn compare_levm_revm_execution_results(
     Ok(())
 }
 
-pub fn ensure_post_state(
+pub async fn ensure_post_state(
     levm_cache: HashMap<Address, Account>,
     vector: &TestVector,
     revm_state: &mut EvmState,
@@ -322,7 +322,7 @@ pub fn ensure_post_state(
         Some(_expected_exception) => {}
         // We only want to compare account updates when no exception is expected.
         None => {
-            let mut db = load_initial_state_levm(test);
+            let mut db = load_initial_state_levm(test).await;
             db.cache = levm_cache;
             let levm_account_updates = backends::levm::LEVM::get_state_transitions(&mut db, *fork)
                 .map_err(|_| {
@@ -335,7 +335,8 @@ pub fn ensure_post_state(
                 fork,
                 &levm_account_updates,
                 &revm_account_updates,
-            );
+            )
+            .await;
             re_run_report.register_account_updates_report(*vector, account_updates_report, *fork);
         }
     }
@@ -343,15 +344,15 @@ pub fn ensure_post_state(
     Ok(())
 }
 
-pub fn compare_levm_revm_account_updates(
+pub async fn compare_levm_revm_account_updates(
     vector: &TestVector,
     test: &EFTest,
     fork: &Fork,
     levm_account_updates: &[AccountUpdate],
     revm_account_updates: &[AccountUpdate],
 ) -> ComparisonReport {
-    let levm_post_state_root = post_state_root(levm_account_updates, test);
-    let revm_post_state_root = post_state_root(revm_account_updates, test);
+    let levm_post_state_root = post_state_root(levm_account_updates, test).await;
+    let revm_post_state_root = post_state_root(revm_account_updates, test).await;
     let mut initial_accounts: HashMap<Address, Account> = test
         .pre
         .0
@@ -411,7 +412,7 @@ pub fn compare_levm_revm_account_updates(
     }
 }
 
-pub fn _run_ef_test_revm(test: &EFTest) -> Result<EFTestReport, EFTestRunnerError> {
+pub async fn _run_ef_test_revm(test: &EFTest) -> Result<EFTestReport, EFTestRunnerError> {
     let hash = test
         ._info
         .generated_test_hash
@@ -426,7 +427,7 @@ pub fn _run_ef_test_revm(test: &EFTest) -> Result<EFTestReport, EFTestRunnerErro
             if !test.post.has_vector_for_fork(vector, *fork) {
                 continue;
             }
-            match _run_ef_test_tx_revm(vector, test, fork) {
+            match _run_ef_test_tx_revm(vector, test, fork).await {
                 Ok(_) => continue,
                 Err(EFTestRunnerError::VMInitializationFailed(reason)) => {
                     ef_test_report_fork.register_vm_initialization_failure(reason, *vector);
@@ -471,22 +472,22 @@ pub fn _run_ef_test_revm(test: &EFTest) -> Result<EFTestReport, EFTestRunnerErro
     Ok(ef_test_report)
 }
 
-pub fn _run_ef_test_tx_revm(
+pub async fn _run_ef_test_tx_revm(
     vector: &TestVector,
     test: &EFTest,
     fork: &Fork,
 ) -> Result<(), EFTestRunnerError> {
-    let (mut state, _block_hash) = load_initial_state(test);
+    let (mut state, _block_hash) = load_initial_state(test).await;
     let mut revm = prepare_revm_for_tx(&mut state, vector, test, fork)?;
     let revm_execution_result = revm.transact_commit();
     drop(revm); // Need to drop the state mutable reference.
 
-    _ensure_post_state_revm(revm_execution_result, vector, test, &mut state, fork)?;
+    _ensure_post_state_revm(revm_execution_result, vector, test, &mut state, fork).await?;
 
     Ok(())
 }
 
-pub fn _ensure_post_state_revm(
+pub async fn _ensure_post_state_revm(
     revm_execution_result: Result<RevmExecutionResult, REVMError<StoreError>>,
     vector: &TestVector,
     test: &EFTest,
@@ -516,7 +517,7 @@ pub fn _ensure_post_state_revm(
                 None => {
                     let revm_account_updates =
                         backends::revm::REVM::get_state_transitions(revm_state);
-                    let pos_state_root = post_state_root(&revm_account_updates, test);
+                    let pos_state_root = post_state_root(&revm_account_updates, test).await;
                     let expected_post_state_root_hash =
                         test.post.vector_post_value(vector, *fork).hash;
                     if expected_post_state_root_hash != pos_state_root {

--- a/cmd/ef_tests/state/tests/all.rs
+++ b/cmd/ef_tests/state/tests/all.rs
@@ -5,9 +5,10 @@ use ef_tests_state::{
 };
 use std::error::Error;
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     let opts = EFTestRunnerOptions::parse();
     let ef_tests = parser::parse_ef_tests(&opts)?;
-    runner::run_ef_tests(ef_tests, &opts)?;
+    runner::run_ef_tests(ef_tests, &opts).await?;
     Ok(())
 }

--- a/cmd/ef_tests/state/utils.rs
+++ b/cmd/ef_tests/state/utils.rs
@@ -14,11 +14,11 @@ use ethrex_vm::{
 use spinoff::Spinner;
 
 /// Loads initial state, used for REVM as it contains EvmState.
-pub fn load_initial_state(test: &EFTest) -> (EvmState, H256) {
+pub async fn load_initial_state(test: &EFTest) -> (EvmState, H256) {
     let genesis = Genesis::from(test);
 
     let storage = Store::new("./temp", EngineType::InMemory).expect("Failed to create Store");
-    storage.add_initial_state(genesis.clone()).unwrap();
+    storage.add_initial_state(genesis.clone()).await.unwrap();
 
     (
         evm_state(
@@ -30,11 +30,11 @@ pub fn load_initial_state(test: &EFTest) -> (EvmState, H256) {
 }
 
 /// Loads initial state, function for LEVM as it does not require EvmState
-pub fn load_initial_state_levm(test: &EFTest) -> GeneralizedDatabase {
+pub async fn load_initial_state_levm(test: &EFTest) -> GeneralizedDatabase {
     let genesis = Genesis::from(test);
 
     let storage = Store::new("./temp", EngineType::InMemory).expect("Failed to create Store");
-    storage.add_initial_state(genesis.clone()).unwrap();
+    storage.add_initial_state(genesis.clone()).await.unwrap();
 
     let block_hash = genesis.get_block().header.compute_block_hash();
 

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -233,7 +233,7 @@ impl Subcommand {
                     .as_ref()
                     .expect("--network is required and it was not provided");
 
-                import_blocks(&path, &opts.datadir, network, opts.evm);
+                import_blocks(&path, &opts.datadir, network, opts.evm).await;
             }
             #[cfg(any(feature = "l2", feature = "based"))]
             Subcommand::L2(command) => command.run().await?,
@@ -255,10 +255,10 @@ pub fn remove_db(datadir: &str) {
     }
 }
 
-pub fn import_blocks(path: &str, data_dir: &str, network: &str, evm: EvmEngine) {
+pub async fn import_blocks(path: &str, data_dir: &str, network: &str, evm: EvmEngine) {
     let data_dir = set_datadir(data_dir);
 
-    let store = init_store(&data_dir, network);
+    let store = init_store(&data_dir, network).await;
 
     let blockchain = init_blockchain(evm, store);
 
@@ -279,5 +279,5 @@ pub fn import_blocks(path: &str, data_dir: &str, network: &str, evm: EvmEngine) 
         info!("Importing blocks from chain file: {path}");
         utils::read_chain_file(path)
     };
-    blockchain.import_blocks(&blocks);
+    blockchain.import_blocks(&blocks).await;
 }

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -29,7 +29,7 @@ async fn main() -> eyre::Result<()> {
 
     let network = get_network(&opts);
 
-    let store = init_store(&data_dir, &network);
+    let store = init_store(&data_dir, &network).await;
 
     let blockchain = init_blockchain(opts.evm, store.clone());
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -63,7 +63,7 @@ pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
     tracker.spawn(metrics_api);
 }
 
-pub fn init_store(data_dir: &str, network: &str) -> Store {
+pub async fn init_store(data_dir: &str, network: &str) -> Store {
     let path = PathBuf::from(data_dir);
     let store = if path.ends_with("memory") {
         Store::new(data_dir, EngineType::InMemory).expect("Failed to create Store")
@@ -84,6 +84,7 @@ pub fn init_store(data_dir: &str, network: &str) -> Store {
     let genesis = read_genesis_file(network);
     store
         .add_initial_state(genesis.clone())
+        .await
         .expect("Failed to create genesis block");
     store
 }

--- a/cmd/ethrex/l2.rs
+++ b/cmd/ethrex/l2.rs
@@ -99,7 +99,7 @@ impl Command {
 
                 let network = get_network(&opts.node_opts);
 
-                let store = init_store(&data_dir, &network);
+                let store = init_store(&data_dir, &network).await;
 
                 let blockchain = init_blockchain(opts.node_opts.evm, store.clone());
 

--- a/cmd/ethrex_l2/src/commands/stack.rs
+++ b/cmd/ethrex_l2/src/commands/stack.rs
@@ -303,7 +303,8 @@ impl Command {
                     store_path.to_str().expect("Invalid store path"),
                     EngineType::Libmdbx,
                     genesis.to_str().expect("Invalid genesis path"),
-                )?;
+                )
+                .await?;
 
                 let genesis_header = store.get_block_header(0)?.expect("Genesis block not found");
                 let genesis_block_hash = genesis_header.compute_block_hash();
@@ -328,6 +329,7 @@ impl Command {
 
                     new_trie = store
                         .apply_account_updates_from_trie(new_trie, &account_updates)
+                        .await
                         .expect("Error applying account updates");
 
                     let new_block = BlockHeader {
@@ -339,15 +341,19 @@ impl Command {
                     };
                     let new_block_hash = new_block.compute_block_hash();
 
-                    store.add_block_header(new_block_hash, new_block)?;
-                    store.add_block_number(new_block_hash, last_number + 1)?;
-                    store.set_canonical_block(last_number + 1, new_block_hash)?;
+                    store.add_block_header(new_block_hash, new_block).await?;
+                    store
+                        .add_block_number(new_block_hash, last_number + 1)
+                        .await?;
+                    store
+                        .set_canonical_block(last_number + 1, new_block_hash)
+                        .await?;
 
                     last_number += 1;
                     last_hash = new_block_hash;
                 }
 
-                store.update_latest_block_number(last_number)?;
+                store.update_latest_block_number(last_number).await?;
             }
         }
         Ok(())

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -24,6 +24,7 @@ ethrex-metrics = { path = "./metrics", default-features = false }
 [dev-dependencies]
 serde_json.workspace = true
 hex = "0.4.3"
+tokio.workspace = true
 
 [lib]
 path = "./blockchain.rs"

--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -18,7 +18,7 @@ use crate::{
 /// and itself are made canonical.
 ///
 /// If the fork choice state is applied correctly, the head block header is returned.
-pub fn apply_fork_choice(
+pub async fn apply_fork_choice(
     store: &Store,
     head_hash: H256,
     safe_hash: H256,
@@ -104,24 +104,26 @@ pub fn apply_fork_choice(
 
     // Make all ancestors to head canonical.
     for (number, hash) in new_canonical_blocks {
-        store.set_canonical_block(number, hash)?;
+        store.set_canonical_block(number, hash).await?;
     }
 
     // Remove anything after the head from the canonical chain.
     for number in (head.number + 1)..(latest + 1) {
-        store.unset_canonical_block(number)?;
+        store.unset_canonical_block(number).await?;
     }
 
     // Make head canonical and label all special blocks correctly.
-    store.set_canonical_block(head.number, head_hash)?;
+    store.set_canonical_block(head.number, head_hash).await?;
     if let Some(finalized) = finalized_res {
-        store.update_finalized_block_number(finalized.number)?;
+        store
+            .update_finalized_block_number(finalized.number)
+            .await?;
     }
     if let Some(safe) = safe_res {
-        store.update_safe_block_number(safe.number)?;
+        store.update_safe_block_number(safe.number).await?;
     }
-    store.update_latest_block_number(head.number)?;
-    store.update_sync_status(true)?;
+    store.update_latest_block_number(head.number).await?;
+    store.update_sync_status(true).await?;
 
     Ok(head)
 }

--- a/crates/common/trie/db.rs
+++ b/crates/common/trie/db.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-pub trait TrieDB {
+pub trait TrieDB: Send + Sync {
     fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, TrieError>;
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), TrieError>;
     // fn put_batch(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), TrieError>;

--- a/crates/l2/prover/tests/perf_zkvm.rs
+++ b/crates/l2/prover/tests/perf_zkvm.rs
@@ -44,7 +44,7 @@ async fn setup() -> (ProgramInput, Block) {
 
     let genesis =
         ethrex_l2::utils::test_data_io::read_genesis_file(genesis_file_path.to_str().unwrap());
-    store.add_initial_state(genesis.clone()).unwrap();
+    store.add_initial_state(genesis.clone()).await.unwrap();
 
     let blocks = ethrex_l2::utils::test_data_io::read_chain_file(chain_file_path.to_str().unwrap());
     info!("Number of blocks to insert: {}", blocks.len());
@@ -56,7 +56,7 @@ async fn setup() -> (ProgramInput, Block) {
             block.body.transactions.len(),
             block.header.number
         );
-        blockchain.add_block(block).unwrap();
+        blockchain.add_block(block).await.unwrap();
     }
     let block_to_prove = blocks.get(3).unwrap();
 

--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.lock
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.lock
@@ -539,6 +539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "aurora-engine-modexp"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1309,7 @@ name = "ethrex-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "ethereum-types",
  "ethrex-common",

--- a/crates/l2/utils/prover/save_state.rs
+++ b/crates/l2/utils/prover/save_state.rs
@@ -394,8 +394,8 @@ mod tests {
     use test_casing::test_casing;
 
     #[test_casing(2, [EvmEngine::LEVM, EvmEngine::REVM])]
-    #[test]
-    fn test_state_file_integration(
+    #[tokio::test]
+    async fn test_state_file_integration(
         _evm_engine: EvmEngine,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if let Err(e) = fs::remove_dir_all(default_datadir()?) {
@@ -413,13 +413,13 @@ mod tests {
         let store = Store::new("memory", EngineType::InMemory).expect("Failed to create Store");
 
         let genesis = test_data_io::read_genesis_file(genesis_file_path.to_str().unwrap());
-        store.add_initial_state(genesis.clone()).unwrap();
+        store.add_initial_state(genesis.clone()).await.unwrap();
 
         let blocks = test_data_io::read_chain_file(chain_file_path.to_str().unwrap());
         // create blockchain
         let blockchain = Blockchain::default_with_store(store.clone());
         for block in &blocks {
-            blockchain.add_block(block).unwrap();
+            blockchain.add_block(block).await.unwrap();
         }
 
         let mut account_updates_vec: Vec<Vec<AccountUpdate>> = Vec::new();

--- a/crates/l2/utils/test_data_io.rs
+++ b/crates/l2/utils/test_data_io.rs
@@ -63,6 +63,8 @@ pub fn generate_program_input(
     chain: Vec<Block>,
     block_number: usize,
 ) -> Result<ProgramInput, ProverInputError> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
     let block = chain
         .get(block_number)
         .ok_or(ProverInputError::InvalidBlockNumber(block_number))?
@@ -70,11 +72,11 @@ pub fn generate_program_input(
 
     // create store
     let store = Store::new("memory", EngineType::InMemory)?;
-    store.add_initial_state(genesis)?;
+    rt.block_on(store.add_initial_state(genesis))?;
     // create blockchain
     let blockchain = Blockchain::default_with_store(store.clone());
     for block in chain {
-        blockchain.add_block(&block)?;
+        rt.block_on(blockchain.add_block(&block))?;
     }
 
     let parent_hash = block.header.parent_hash;

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -505,7 +505,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
             }
             Message::PooledTransactions(msg) if peer_supports_eth => {
                 if is_synced {
-                    msg.handle(&self.node, &self.blockchain)?;
+                    msg.handle(&self.node, &self.blockchain).await?;
                 }
             }
             Message::GetStorageRanges(req) => {

--- a/crates/networking/p2p/rlpx/eth/backend.rs
+++ b/crates/networking/p2p/rlpx/eth/backend.rs
@@ -103,9 +103,9 @@ mod tests {
     use ethrex_storage::{EngineType, Store};
     use std::{fs::File, io::BufReader};
 
-    #[test]
+    #[tokio::test]
     // TODO add tests for failing validations
-    fn test_validate_status() {
+    async fn test_validate_status() {
         // Setup
         // TODO we should have this setup exported to some test_utils module and use from there
         let storage =
@@ -117,6 +117,7 @@ mod tests {
             serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
         storage
             .add_initial_state(genesis.clone())
+            .await
             .expect("Failed to add genesis block to DB");
         let config = genesis.config;
         let total_difficulty = U256::from(config.terminal_total_difficulty.unwrap_or_default());

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -272,7 +272,7 @@ impl PooledTransactions {
 
     /// Saves every incoming pooled transaction to the mempool.
 
-    pub fn handle(self, node: &Node, blockchain: &Blockchain) -> Result<(), MempoolError> {
+    pub async fn handle(self, node: &Node, blockchain: &Blockchain) -> Result<(), MempoolError> {
         for tx in self.pooled_transactions {
             if let P2PTransaction::EIP4844TransactionWithBlobs(itx) = tx {
                 if let Err(e) = blockchain.add_blob_transaction_to_pool(itx.tx, itx.blobs_bundle) {

--- a/crates/networking/p2p/sync/bytecode_fetcher.rs
+++ b/crates/networking/p2p/sync/bytecode_fetcher.rs
@@ -56,7 +56,7 @@ async fn fetch_bytecode_batch(
         debug!("Received {} bytecodes", bytecodes.len());
         // Store the bytecodes
         for code in bytecodes.into_iter() {
-            store.add_account_code(batch.remove(0), code)?;
+            store.add_account_code(batch.remove(0), code).await?;
         }
     }
     // Return remaining code hashes in the batch if we couldn't fetch all of them

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -82,7 +82,7 @@ pub(crate) async fn heal_state_trie(
     // Save paths for the next cycle
     if !paths.is_empty() {
         debug!("Caching {} paths for the next cycle", paths.len());
-        store.set_state_heal_paths(paths.clone())?;
+        store.set_state_heal_paths(paths.clone()).await?;
     }
     // Send empty batch to signal that no more batches are incoming
     bytecode_sender.send(vec![]).await?;

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -71,7 +71,9 @@ pub(crate) async fn state_sync(
         state_trie_checkpoint[index] = last_key;
     }
     // Update state trie checkpoint
-    store.set_state_trie_key_checkpoint(state_trie_checkpoint)?;
+    store
+        .set_state_trie_key_checkpoint(state_trie_checkpoint)
+        .await?;
     Ok(stale_pivot)
 }
 
@@ -180,7 +182,9 @@ async fn state_sync_segment(
                     .await?;
             }
             // Update Snapshot
-            store.write_snapshot_account_batch(account_hashes, accounts)?;
+            store
+                .write_snapshot_account_batch(account_hashes, accounts)
+                .await?;
             // As we are downloading the state trie in segments the `should_continue` flag will mean that there
             // are more accounts to be fetched but these accounts may belong to the next segment
             if !should_continue || start_account_hash >= STATE_TRIE_SEGMENTS_END[segment_number] {

--- a/crates/networking/p2p/sync/storage_fetcher.rs
+++ b/crates/networking/p2p/sync/storage_fetcher.rs
@@ -158,7 +158,9 @@ async fn fetch_storage_batch(
                 let (account_hash, storage_root) = batch.remove(0);
                 let last_key = *last_keys.last().unwrap();
                 // Store downloaded range
-                store.write_snapshot_storage_batch(account_hash, last_keys, last_values)?;
+                store
+                    .write_snapshot_storage_batch(account_hash, last_keys, last_values)
+                    .await?;
                 // Delegate the rest of the trie to the large trie fetcher
                 large_storage_sender
                     .send(vec![LargeStorageRequest {
@@ -174,7 +176,9 @@ async fn fetch_storage_batch(
         // Store the storage ranges & rebuild the storage trie for each account
         let filled_storages: Vec<(H256, H256)> = batch.drain(..values.len()).collect();
         let account_hashes: Vec<H256> = filled_storages.iter().map(|(hash, _)| *hash).collect();
-        store.write_snapshot_storage_batches(account_hashes, keys, values)?;
+        store
+            .write_snapshot_storage_batches(account_hashes, keys, values)
+            .await?;
         // Send complete storages to the rebuilder
         storage_trie_rebuilder_sender.send(filled_storages).await?;
         // Return remaining code hashes in the batch if we couldn't fetch all of them
@@ -295,7 +299,9 @@ async fn fetch_large_storage(
         // Update next batch's start
         request.last_key = *keys.last().unwrap();
         // Write storage range to snapshot
-        store.write_snapshot_storage_batch(request.account_hash, keys, values)?;
+        store
+            .write_snapshot_storage_batch(request.account_hash, keys, values)
+            .await?;
         if incomplete {
             Ok((Some(request), false))
         } else {

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -92,7 +92,9 @@ pub(crate) async fn storage_healer(
     }
     let healing_complete = pending_paths.is_empty();
     // Store pending paths
-    store.set_storage_heal_paths(pending_paths.into_iter().collect())?;
+    store
+        .set_storage_heal_paths(pending_paths.into_iter().collect())
+        .await?;
     Ok(healing_complete)
 }
 

--- a/crates/networking/p2p/sync/trie_rebuild.rs
+++ b/crates/networking/p2p/sync/trie_rebuild.rs
@@ -138,7 +138,7 @@ async fn rebuild_state_trie_in_backgound(
         }
         // Update DB checkpoint
         let checkpoint = (root, rebuild_status.clone().map(|st| st.current));
-        store.set_state_trie_rebuild_checkpoint(checkpoint)?;
+        store.set_state_trie_rebuild_checkpoint(checkpoint).await?;
         // Move on to the next segment
         current_segment = (current_segment + 1) % STATE_TRIE_SEGMENTS
     }
@@ -235,7 +235,9 @@ async fn rebuild_storage_trie_in_background(
             res?;
         }
     }
-    store.set_storage_trie_rebuild_pending(pending_storages)?;
+    store
+        .set_storage_trie_rebuild_pending(pending_storages)
+        .await?;
     Ok(())
 }
 

--- a/crates/networking/rpc/engine/exchange_transition_config.rs
+++ b/crates/networking/rpc/engine/exchange_transition_config.rs
@@ -47,7 +47,7 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
         Ok(ExchangeTransitionConfigV1Req { payload })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!("Received new engine request: {self}");
         let payload = &self.payload;
 

--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -53,7 +53,7 @@ impl RpcHandler for ExchangeCapabilitiesRequest {
             })
     }
 
-    fn handle(&self, _context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, _context: RpcApiContext) -> Result<Value, RpcErr> {
         Ok(json!(CAPABILITIES))
     }
 }

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -32,9 +32,9 @@ impl RpcHandler for NewPayloadV1Request {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         validate_execution_payload_v1(&self.payload)?;
-        handle_new_payload_v1_v2(&self.payload, context)
+        handle_new_payload_v1_v2(&self.payload, context).await
     }
 }
 
@@ -49,7 +49,7 @@ impl RpcHandler for NewPayloadV2Request {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let chain_config = &context.storage.get_chain_config()?;
         if chain_config.is_shanghai_activated(self.payload.timestamp) {
             validate_execution_payload_v2(&self.payload)?;
@@ -58,7 +58,7 @@ impl RpcHandler for NewPayloadV2Request {
             validate_execution_payload_v1(&self.payload)?;
         }
 
-        handle_new_payload_v1_v2(&self.payload, context)
+        handle_new_payload_v1_v2(&self.payload, context).await
     }
 }
 
@@ -117,7 +117,7 @@ impl RpcHandler for NewPayloadV3Request {
             request.parent_beacon_block_root,
         );
 
-        let client_response = Self::call(req, context);
+        let client_response = Self::call(req, context).await;
 
         let gateway_response = gateway_request
             .await
@@ -139,7 +139,7 @@ impl RpcHandler for NewPayloadV3Request {
         gateway_response.or(client_response)
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let block =
             get_block_from_payload(&self.payload, Some(self.parent_beacon_block_root), None)?;
         validate_fork(&block, Fork::Cancun, &context)?;
@@ -149,7 +149,8 @@ impl RpcHandler for NewPayloadV3Request {
             context,
             block,
             self.expected_blob_versioned_hashes.clone(),
-        )?;
+        )
+        .await?;
         serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
@@ -180,7 +181,7 @@ impl RpcHandler for NewPayloadV4Request {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         // validate the received requests
         validate_execution_requests(&self.execution_requests)?;
 
@@ -206,7 +207,8 @@ impl RpcHandler for NewPayloadV4Request {
             context,
             block,
             self.expected_blob_versioned_hashes.clone(),
-        )?;
+        )
+        .await?;
         serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
@@ -222,12 +224,12 @@ impl RpcHandler for GetPayloadV1Request {
         Ok(Self { payload_id })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let payload = get_payload(self.payload_id, &context)?;
         // NOTE: This validation is actually not required to run Hive tests. Not sure if it's
         // necessary
         validate_payload_v1_v2(&payload.block, &context)?;
-        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context)?;
+        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context).await?;
 
         let response = ExecutionPayload::from_block(payload_bundle.block);
 
@@ -245,10 +247,10 @@ impl RpcHandler for GetPayloadV2Request {
         Ok(Self { payload_id })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let payload = get_payload(self.payload_id, &context)?;
         validate_payload_v1_v2(&payload.block, &context)?;
-        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context)?;
+        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context).await?;
 
         let response = ExecutionPayloadResponse {
             execution_payload: ExecutionPayload::from_block(payload_bundle.block),
@@ -295,7 +297,7 @@ impl RpcHandler for GetPayloadV3Request {
 
         let gateway_request = gateway_auth_client.engine_get_payload_v3(request.payload_id);
 
-        let client_response = Self::call(req, context);
+        let client_response = Self::call(req, context).await;
 
         let gateway_response = gateway_request
             .await
@@ -317,10 +319,10 @@ impl RpcHandler for GetPayloadV3Request {
         gateway_response.or(client_response)
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let payload = get_payload(self.payload_id, &context)?;
         validate_fork(&payload.block, Fork::Cancun, &context)?;
-        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context)?;
+        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context).await?;
 
         let response = ExecutionPayloadResponse {
             execution_payload: ExecutionPayload::from_block(payload_bundle.block),
@@ -354,7 +356,7 @@ impl RpcHandler for GetPayloadV4Request {
         Ok(Self { payload_id })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let payload = get_payload(self.payload_id, &context)?;
         let chain_config = &context.storage.get_chain_config()?;
 
@@ -365,7 +367,7 @@ impl RpcHandler for GetPayloadV4Request {
             )));
         }
 
-        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context)?;
+        let payload_bundle = build_payload_if_necessary(self.payload_id, payload, context).await?;
 
         let response = ExecutionPayloadResponse {
             execution_payload: ExecutionPayload::from_block(payload_bundle.block),
@@ -403,7 +405,7 @@ impl RpcHandler for GetPayloadBodiesByHashV1Request {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         if self.hashes.len() >= GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
@@ -440,7 +442,7 @@ impl RpcHandler for GetPayloadBodiesByRangeV1Request {
         Ok(GetPayloadBodiesByRangeV1Request { start, count })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         if self.count as usize >= GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
@@ -556,7 +558,7 @@ fn validate_ancestors(
 }
 
 // TODO: We need to check why we return a Result<Value, RpcErr> here instead of a Result<PayloadStatus, RpcErr> as in v3.
-fn handle_new_payload_v1_v2(
+async fn handle_new_payload_v1_v2(
     payload: &ExecutionPayload,
     context: RpcApiContext,
 ) -> Result<Value, RpcErr> {
@@ -583,11 +585,11 @@ fn handle_new_payload_v1_v2(
     }
 
     // All checks passed, execute payload
-    let payload_status = execute_payload(&block, &context)?;
+    let payload_status = execute_payload(&block, &context).await?;
     serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
 }
 
-fn handle_new_payload_v3(
+async fn handle_new_payload_v3(
     payload: &ExecutionPayload,
     context: RpcApiContext,
     block: Block,
@@ -625,7 +627,7 @@ fn handle_new_payload_v3(
     }
 
     // All checks passed, execute payload
-    execute_payload(&block, &context)
+    execute_payload(&block, &context).await
 }
 
 // Elements of the list MUST be ordered by request_type in ascending order.
@@ -671,7 +673,7 @@ fn validate_block_hash(payload: &ExecutionPayload, block: &Block) -> Result<(), 
     Ok(())
 }
 
-fn execute_payload(block: &Block, context: &RpcApiContext) -> Result<PayloadStatus, RpcErr> {
+async fn execute_payload(block: &Block, context: &RpcApiContext) -> Result<PayloadStatus, RpcErr> {
     let block_hash = block.hash();
     let storage = &context.storage;
     // Return the valid message directly if we have it.
@@ -699,7 +701,7 @@ fn execute_payload(block: &Block, context: &RpcApiContext) -> Result<PayloadStat
         }
     };
 
-    match context.blockchain.add_block(block) {
+    match context.blockchain.add_block(block).await {
         Err(ChainError::ParentNotFound) => Ok(PayloadStatus::syncing()),
         // Under the current implementation this is not possible: we always calculate the state
         // transition of any new payload as long as the parent is present. If we received the
@@ -786,7 +788,7 @@ fn validate_fork(block: &Block, fork: Fork, context: &RpcApiContext) -> Result<(
     Ok(())
 }
 
-fn build_payload_if_necessary(
+async fn build_payload_if_necessary(
     payload_id: u64,
     mut payload: PayloadBundle,
     context: RpcApiContext,
@@ -803,6 +805,7 @@ fn build_payload_if_necessary(
             } = context
                 .blockchain
                 .build_payload(&mut payload.block)
+                .await
                 .map_err(|err| RpcErr::Internal(err.to_string()))?;
             (blobs_bundle, requests, block_value)
         };
@@ -817,7 +820,8 @@ fn build_payload_if_necessary(
 
         context
             .storage
-            .update_payload(payload_id, new_payload.clone())?;
+            .update_payload(payload_id, new_payload.clone())
+            .await?;
 
         Ok(new_payload)
     }

--- a/crates/networking/rpc/eth/account.rs
+++ b/crates/networking/rpc/eth/account.rs
@@ -47,7 +47,7 @@ impl RpcHandler for GetBalanceRequest {
             block: BlockIdentifierOrHash::parse(params[1].clone(), 1)?,
         })
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!(
             "Requested balance of account {} at block {}",
             self.address, self.block
@@ -82,7 +82,7 @@ impl RpcHandler for GetCodeRequest {
             block: BlockIdentifierOrHash::parse(params[1].clone(), 1)?,
         })
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!(
             "Requested code of account {} at block {}",
             self.address, self.block
@@ -118,7 +118,7 @@ impl RpcHandler for GetStorageAtRequest {
             block: BlockIdentifierOrHash::parse(params[2].clone(), 2)?,
         })
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!(
             "Requested storage sot {} of account {} at block {}",
             self.storage_slot, self.address, self.block
@@ -153,7 +153,7 @@ impl RpcHandler for GetTransactionCountRequest {
             block: BlockIdentifierOrHash::parse(params[1].clone(), 1)?,
         })
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!(
             "Requested nonce of account {} at block {}",
             self.address, self.block
@@ -203,7 +203,7 @@ impl RpcHandler for GetProofRequest {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         info!(
             "Requested proof for account {} at block {} with storage keys: {:?}",

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -64,7 +64,7 @@ impl RpcHandler for GetBlockByNumberRequest {
             hydrated: serde_json::from_value(params[1].clone())?,
         })
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         info!("Requested block with number: {}", self.block);
         let block_number = match self.block.resolve_block_number(storage)? {
@@ -98,7 +98,7 @@ impl RpcHandler for GetBlockByHashRequest {
             hydrated: serde_json::from_value(params[1].clone())?,
         })
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         info!("Requested block with hash: {:#x}", self.block);
         let block_number = match storage.get_block_number(self.block)? {
@@ -131,7 +131,7 @@ impl RpcHandler for GetBlockTransactionCountRequest {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!(
             "Requested transaction count for block with number: {}",
             self.block
@@ -164,7 +164,7 @@ impl RpcHandler for GetBlockReceiptsRequest {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         info!("Requested receipts for block with number: {}", self.block);
         let block_number = match self.block.resolve_block_number(storage)? {
@@ -197,7 +197,7 @@ impl RpcHandler for GetRawHeaderRequest {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!(
             "Requested raw header for block with identifier: {}",
             self.block
@@ -230,7 +230,7 @@ impl RpcHandler for GetRawBlockRequest {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!("Requested raw block: {}", self.block);
         let block_number = match self.block.resolve_block_number(&context.storage)? {
             Some(block_number) => block_number,
@@ -263,7 +263,7 @@ impl RpcHandler for GetRawReceipts {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         let block_number = match self.block.resolve_block_number(storage)? {
             Some(block_number) => block_number,
@@ -288,7 +288,7 @@ impl RpcHandler for BlockNumberRequest {
         Ok(Self {})
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!("Requested latest block number");
         serde_json::to_value(format!("{:#x}", context.storage.get_latest_block_number()?))
             .map_err(|error| RpcErr::Internal(error.to_string()))
@@ -300,7 +300,7 @@ impl RpcHandler for GetBlobBaseFee {
         Ok(Self {})
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!("Requested blob gas price");
         let block_number = context.storage.get_latest_block_number()?;
         let header = match context.storage.get_block_header(block_number)? {

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -12,7 +12,7 @@ impl RpcHandler for ChainId {
         Ok(Self {})
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         info!("Requested chain id");
         let chain_spec = context
             .storage
@@ -29,7 +29,7 @@ impl RpcHandler for Syncing {
         Ok(Self {})
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let is_synced = context.storage.is_synced()?;
         Ok(Value::Bool(!is_synced))
     }

--- a/crates/networking/rpc/eth/fee_calculator.rs
+++ b/crates/networking/rpc/eth/fee_calculator.rs
@@ -87,33 +87,33 @@ mod tests {
         BASE_PRICE_IN_WEI,
     };
 
-    #[test]
-    fn test_for_legacy_txs() {
-        let storage = setup_store();
-        add_legacy_tx_blocks(&storage, 20, 10);
+    #[tokio::test]
+    async fn test_for_legacy_txs() {
+        let storage = setup_store().await;
+        add_legacy_tx_blocks(&storage, 20, 10).await;
         let gas_tip = estimate_gas_tip(&storage).unwrap().unwrap();
         assert_eq!(gas_tip, BASE_PRICE_IN_WEI);
     }
 
-    #[test]
-    fn test_for_eip1559_txs() {
-        let storage = setup_store();
-        add_eip1559_tx_blocks(&storage, 20, 10);
+    #[tokio::test]
+    async fn test_for_eip1559_txs() {
+        let storage = setup_store().await;
+        add_eip1559_tx_blocks(&storage, 20, 10).await;
         let gas_tip = estimate_gas_tip(&storage).unwrap().unwrap();
         assert_eq!(gas_tip, BASE_PRICE_IN_WEI);
     }
 
-    #[test]
-    fn test_for_mixed_txs() {
-        let storage = setup_store();
-        add_mixed_tx_blocks(&storage, 20, 10);
+    #[tokio::test]
+    async fn test_for_mixed_txs() {
+        let storage = setup_store().await;
+        add_mixed_tx_blocks(&storage, 20, 10).await;
         let gas_tip = estimate_gas_tip(&storage).unwrap().unwrap();
         assert_eq!(gas_tip, BASE_PRICE_IN_WEI);
     }
 
-    #[test]
-    fn test_for_empty_blocks() {
-        let storage = setup_store();
+    #[tokio::test]
+    async fn test_for_empty_blocks() {
+        let storage = setup_store().await;
         let gas_tip = estimate_gas_tip(&storage).unwrap();
         assert_eq!(gas_tip, None);
     }

--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -84,7 +84,7 @@ impl RpcHandler for FeeHistoryRequest {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         let config = storage.get_chain_config()?;
         info!(

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -465,6 +465,7 @@ mod tests {
         context
             .storage
             .add_initial_state(genesis_config)
+            .await
             .expect("Fatal: could not add test genesis in test");
         let response = map_http_requests(&request, context)
             .await

--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -17,7 +17,7 @@ impl RpcHandler for GasPrice {
         Ok(GasPrice {})
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let latest_block_number = context.storage.get_latest_block_number()?;
 
         let estimated_gas_tip = estimate_gas_tip(&context.storage)?;
@@ -71,8 +71,8 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
 
-    fn default_context() -> RpcApiContext {
-        let storage = setup_store();
+    async fn default_context() -> RpcApiContext {
+        let storage = setup_store().await;
         let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         RpcApiContext {
             storage,
@@ -95,58 +95,58 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_for_legacy_txs() {
-        let context = default_context();
+    #[tokio::test]
+    async fn test_for_legacy_txs() {
+        let context = default_context().await;
 
-        add_legacy_tx_blocks(&context.storage, 100, 10);
+        add_legacy_tx_blocks(&context.storage, 100, 10).await;
 
         let gas_price = GasPrice {};
-        let response = gas_price.handle(context).unwrap();
+        let response = gas_price.handle(context).await.unwrap();
         let parsed_result = parse_json_hex(&response).unwrap();
         assert_eq!(parsed_result, 2 * BASE_PRICE_IN_WEI);
     }
 
-    #[test]
-    fn test_for_eip_1559_txs() {
-        let context = default_context();
+    #[tokio::test]
+    async fn test_for_eip_1559_txs() {
+        let context = default_context().await;
 
-        add_eip1559_tx_blocks(&context.storage, 100, 10);
+        add_eip1559_tx_blocks(&context.storage, 100, 10).await;
 
         let gas_price = GasPrice {};
-        let response = gas_price.handle(context).unwrap();
+        let response = gas_price.handle(context).await.unwrap();
         let parsed_result = parse_json_hex(&response).unwrap();
         assert_eq!(parsed_result, 2 * BASE_PRICE_IN_WEI);
     }
-    #[test]
-    fn test_with_mixed_transactions() {
-        let context = default_context();
+    #[tokio::test]
+    async fn test_with_mixed_transactions() {
+        let context = default_context().await;
 
-        add_mixed_tx_blocks(&context.storage, 100, 10);
+        add_mixed_tx_blocks(&context.storage, 100, 10).await;
 
         let gas_price = GasPrice {};
-        let response = gas_price.handle(context).unwrap();
+        let response = gas_price.handle(context).await.unwrap();
         let parsed_result = parse_json_hex(&response).unwrap();
         assert_eq!(parsed_result, 2 * BASE_PRICE_IN_WEI);
     }
-    #[test]
-    fn test_with_not_enough_blocks_or_transactions() {
-        let context = default_context();
+    #[tokio::test]
+    async fn test_with_not_enough_blocks_or_transactions() {
+        let context = default_context().await;
 
-        add_mixed_tx_blocks(&context.storage, 100, 0);
+        add_mixed_tx_blocks(&context.storage, 100, 0).await;
 
         let gas_price = GasPrice {};
-        let response = gas_price.handle(context).unwrap();
+        let response = gas_price.handle(context).await.unwrap();
         let parsed_result = parse_json_hex(&response).unwrap();
         assert_eq!(parsed_result, BASE_PRICE_IN_WEI);
     }
-    #[test]
-    fn test_with_no_blocks_but_genesis() {
-        let context = default_context();
+    #[tokio::test]
+    async fn test_with_no_blocks_but_genesis() {
+        let context = default_context().await;
         let gas_price = GasPrice {};
         // genesis base fee is = BASE_PRICE_IN_WEI
         let expected_gas_price = BASE_PRICE_IN_WEI;
-        let response = gas_price.handle(context).unwrap();
+        let response = gas_price.handle(context).await.unwrap();
         let parsed_result = parse_json_hex(&response).unwrap();
         assert_eq!(parsed_result, expected_gas_price);
     }
@@ -160,10 +160,10 @@ mod tests {
         });
         let expected_response = json!("0x3b9aca00");
         let request: RpcRequest = serde_json::from_value(raw_json).expect("Test json is not valid");
-        let mut context = default_context();
+        let mut context = default_context().await;
         context.local_p2p_node = example_p2p_node();
 
-        add_legacy_tx_blocks(&context.storage, 100, 1);
+        add_legacy_tx_blocks(&context.storage, 100, 1).await;
 
         let response = map_http_requests(&request, context).await.unwrap();
         assert_eq!(response, expected_response)

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -85,7 +85,7 @@ impl RpcHandler for LogsFilter {
             )),
         }
     }
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let filtered_logs = fetch_logs_with_filter(self, context.storage)?;
         serde_json::to_value(filtered_logs).map_err(|error| {
             tracing::error!("Log filtering request failed with: {error}");

--- a/crates/networking/rpc/eth/mod.rs
+++ b/crates/networking/rpc/eth/mod.rs
@@ -73,7 +73,7 @@ pub mod test_utils {
         }
     }
 
-    fn add_blocks_with_transactions(
+    async fn add_blocks_with_transactions(
         storage: &Store,
         block_count: u64,
         txs_per_block: Vec<Transaction>,
@@ -86,11 +86,12 @@ pub mod test_utils {
             };
             let block_header = test_header(block_num);
             let block = Block::new(block_header.clone(), block_body);
-            storage.add_block(block).unwrap();
+            storage.add_block(block).await.unwrap();
             storage
                 .set_canonical_block(block_num, block_header.compute_block_hash())
+                .await
                 .unwrap();
-            storage.update_latest_block_number(block_num).unwrap();
+            storage.update_latest_block_number(block_num).await.unwrap();
         }
     }
 
@@ -131,37 +132,37 @@ pub mod test_utils {
         })
     }
 
-    pub fn setup_store() -> Store {
+    pub async fn setup_store() -> Store {
         let genesis: &str = include_str!("../../../../test_data/genesis-l1.json");
         let genesis: Genesis =
             serde_json::from_str(genesis).expect("Fatal: test config is invalid");
         let store = Store::new("test-store", EngineType::InMemory)
             .expect("Fail to create in-memory db test");
-        store.add_initial_state(genesis).unwrap();
+        store.add_initial_state(genesis).await.unwrap();
         store
     }
 
-    pub fn add_legacy_tx_blocks(storage: &Store, block_count: u64, tx_count: u64) {
+    pub async fn add_legacy_tx_blocks(storage: &Store, block_count: u64, tx_count: u64) {
         for block_num in 1..=block_count {
             let mut txs = vec![];
             for nonce in 1..=tx_count {
                 txs.push(legacy_tx_for_test(nonce));
             }
-            add_blocks_with_transactions(storage, block_num, txs);
+            add_blocks_with_transactions(storage, block_num, txs).await;
         }
     }
 
-    pub fn add_eip1559_tx_blocks(storage: &Store, block_count: u64, tx_count: u64) {
+    pub async fn add_eip1559_tx_blocks(storage: &Store, block_count: u64, tx_count: u64) {
         for block_num in 1..=block_count {
             let mut txs = vec![];
             for nonce in 1..=tx_count {
                 txs.push(eip1559_tx_for_test(nonce));
             }
-            add_blocks_with_transactions(storage, block_num, txs);
+            add_blocks_with_transactions(storage, block_num, txs).await;
         }
     }
 
-    pub fn add_mixed_tx_blocks(storage: &Store, block_count: u64, tx_count: u64) {
+    pub async fn add_mixed_tx_blocks(storage: &Store, block_count: u64, tx_count: u64) {
         for block_num in 1..=block_count {
             let mut txs = vec![];
             for nonce in 1..=tx_count {
@@ -171,7 +172,7 @@ pub mod test_utils {
                     txs.push(eip1559_tx_for_test(nonce));
                 }
             }
-            add_blocks_with_transactions(storage, block_num, txs);
+            add_blocks_with_transactions(storage, block_num, txs).await;
         }
     }
 }

--- a/crates/networking/rpc/l2/transaction.rs
+++ b/crates/networking/rpc/l2/transaction.rs
@@ -61,7 +61,7 @@ impl RpcHandler for SponsoredTx {
         })
     }
 
-    fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         // Dont allow create txs
         if self.to.is_zero() {
             return Err(RpcErr::InvalidEthrexL2Message(
@@ -132,7 +132,7 @@ impl RpcHandler for SponsoredTx {
         let max_priority_fee_per_gas = estimate_gas_tip(&context.storage)
             .map_err(RpcErr::from)?
             .unwrap_or_default();
-        let gas_price_request = GasPrice {}.handle(context.clone())?;
+        let gas_price_request = GasPrice {}.handle(context.clone()).await?;
         let max_fee_per_gas = u64::from_str_radix(
             gas_price_request
                 .as_str()
@@ -185,7 +185,8 @@ impl RpcHandler for SponsoredTx {
             transaction: generic,
             block: None,
         }
-        .handle(context.clone())?;
+        .handle(context.clone())
+        .await?;
         let gas_limit = u64::from_str_radix(
             estimate_gas_request
                 .as_str()
@@ -222,6 +223,6 @@ impl RpcHandler for SponsoredTx {
             }
         }
 
-        tx.handle(context)
+        tx.handle(context).await
     }
 }

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -342,6 +342,7 @@ pub mod test_utils {
             Store::new("", EngineType::InMemory).expect("Failed to create in-memory storage");
         storage
             .add_initial_state(serde_json::from_str(TEST_GENESIS).unwrap())
+            .await
             .expect("Failed to build test genesis");
         let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
         let jwt_secret = Default::default();

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,6 +10,7 @@ ethrex-rlp.workspace = true
 ethrex-common.workspace = true
 ethrex-trie.workspace = true
 
+async-trait.workspace = true
 ethereum-types.workspace = true
 anyhow = "1.0.86"
 bytes.workspace = true
@@ -21,11 +22,14 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 libmdbx = { workspace = true, optional = true }
 redb = { workspace = true, optional = true }
+# NOTE: intentionally avoiding the workspace dep as it brings "full" features, breaking the provers
+# We only need the runtime for the blocking databases to spawn blocking tasks
+tokio = { version = "1.41.1", optional = true, default-features = false, features = ["rt"] }
 
 [features]
 default = []
-libmdbx = ["dep:libmdbx", "ethrex-trie/libmdbx"]
-redb = ["dep:redb"]
+libmdbx = ["dep:libmdbx", "ethrex-trie/libmdbx", "dep:tokio"]
+redb = ["dep:redb", "dep:tokio"]
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/storage/api.rs
+++ b/crates/storage/api.rs
@@ -9,23 +9,26 @@ use std::{collections::HashMap, fmt::Debug, panic::RefUnwindSafe};
 use crate::{error::StoreError, store::STATE_TRIE_SEGMENTS};
 use ethrex_trie::{Nibbles, Trie};
 
+// We need async_trait because the stabilized feature lacks support for object safety
+// (i.e. dyn StoreEngine)
+#[async_trait::async_trait]
 pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     /// Add a batch of blocks in a single transaction.
     /// This will store -> BlockHeader, BlockBody, BlockTransactions, BlockNumber.
-    fn add_blocks(&self, blocks: &[Block]) -> Result<(), StoreError>;
+    async fn add_blocks(&self, blocks: Vec<Block>) -> Result<(), StoreError>;
 
     /// Sets the blocks as part of the canonical chain
-    fn mark_chain_as_canonical(&self, blocks: &[Block]) -> Result<(), StoreError>;
+    async fn mark_chain_as_canonical(&self, blocks: &[Block]) -> Result<(), StoreError>;
 
     /// Add block header
-    fn add_block_header(
+    async fn add_block_header(
         &self,
         block_hash: BlockHash,
         block_header: BlockHeader,
     ) -> Result<(), StoreError>;
 
     /// Add a batch of block headers
-    fn add_block_headers(
+    async fn add_block_headers(
         &self,
         block_hashes: Vec<BlockHash>,
         block_headers: Vec<BlockHeader>,
@@ -38,7 +41,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<Option<BlockHeader>, StoreError>;
 
     /// Add block body
-    fn add_block_body(
+    async fn add_block_body(
         &self,
         block_hash: BlockHash,
         block_body: BlockBody,
@@ -58,11 +61,11 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
         block_hash: BlockHash,
     ) -> Result<Option<BlockHeader>, StoreError>;
 
-    fn add_pending_block(&self, block: Block) -> Result<(), StoreError>;
+    async fn add_pending_block(&self, block: Block) -> Result<(), StoreError>;
     fn get_pending_block(&self, block_hash: BlockHash) -> Result<Option<Block>, StoreError>;
 
     /// Add block number for a given hash
-    fn add_block_number(
+    async fn add_block_number(
         &self,
         block_hash: BlockHash,
         block_number: BlockNumber,
@@ -72,7 +75,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     fn get_block_number(&self, block_hash: BlockHash) -> Result<Option<BlockNumber>, StoreError>;
 
     /// Store transaction location (block number and index of the transaction within the block)
-    fn add_transaction_location(
+    async fn add_transaction_location(
         &self,
         transaction_hash: H256,
         block_number: BlockNumber,
@@ -81,7 +84,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<(), StoreError>;
 
     /// Store transaction locations in batch (one db transaction for all)
-    fn add_transaction_locations(
+    async fn add_transaction_locations(
         &self,
         locations: Vec<(H256, BlockNumber, BlockHash, Index)>,
     ) -> Result<(), StoreError>;
@@ -93,7 +96,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<Option<(BlockNumber, BlockHash, Index)>, StoreError>;
 
     /// Add receipt
-    fn add_receipt(
+    async fn add_receipt(
         &self,
         block_hash: BlockHash,
         index: Index,
@@ -101,11 +104,14 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<(), StoreError>;
 
     /// Add receipts
-    fn add_receipts(&self, block_hash: BlockHash, receipts: Vec<Receipt>)
-        -> Result<(), StoreError>;
+    async fn add_receipts(
+        &self,
+        block_hash: BlockHash,
+        receipts: Vec<Receipt>,
+    ) -> Result<(), StoreError>;
 
     /// Adds receipts for a batch of blocks
-    fn add_receipts_for_blocks(
+    async fn add_receipts_for_blocks(
         &self,
         receipts: HashMap<BlockHash, Vec<Receipt>>,
     ) -> Result<(), StoreError>;
@@ -118,7 +124,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<Option<Receipt>, StoreError>;
 
     /// Add account code
-    fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError>;
+    async fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError>;
 
     /// Obtain account code via code hash
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, StoreError>;
@@ -170,37 +176,47 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
 
     /// Stores the chain configuration values, should only be called once after reading the genesis file
     /// Ignores previously stored values if present
-    fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError>;
+    async fn set_chain_config(&self, chain_config: &ChainConfig) -> Result<(), StoreError>;
 
     /// Returns the stored chain configuration
     fn get_chain_config(&self) -> Result<ChainConfig, StoreError>;
 
     /// Update earliest block number
-    fn update_earliest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
+    async fn update_earliest_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError>;
 
     /// Obtain earliest block number
     fn get_earliest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     /// Update finalized block number
-    fn update_finalized_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
+    async fn update_finalized_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError>;
 
     /// Obtain finalized block number
     fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     /// Update safe block number
-    fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
+    async fn update_safe_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
 
     /// Obtain safe block number
     fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     /// Update latest block number
-    fn update_latest_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
+    async fn update_latest_block_number(&self, block_number: BlockNumber)
+        -> Result<(), StoreError>;
 
     /// Obtain latest block number
     fn get_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
 
     /// Update pending block number
-    fn update_pending_block_number(&self, block_number: BlockNumber) -> Result<(), StoreError>;
+    async fn update_pending_block_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<(), StoreError>;
 
     /// Obtain pending block number
     fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError>;
@@ -216,29 +232,38 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     fn open_state_trie(&self, state_root: H256) -> Trie;
 
     /// Set the canonical block hash for a given block number.
-    fn set_canonical_block(&self, number: BlockNumber, hash: BlockHash) -> Result<(), StoreError>;
+    async fn set_canonical_block(
+        &self,
+        number: BlockNumber,
+        hash: BlockHash,
+    ) -> Result<(), StoreError>;
 
     /// Unsets canonical block for a block number.
-    fn unset_canonical_block(&self, number: BlockNumber) -> Result<(), StoreError>;
+    async fn unset_canonical_block(&self, number: BlockNumber) -> Result<(), StoreError>;
 
-    fn add_payload(&self, payload_id: u64, block: Block) -> Result<(), StoreError>;
+    async fn add_payload(&self, payload_id: u64, block: Block) -> Result<(), StoreError>;
 
     fn get_payload(&self, payload_id: u64) -> Result<Option<PayloadBundle>, StoreError>;
 
-    fn update_payload(&self, payload_id: u64, payload: PayloadBundle) -> Result<(), StoreError>;
+    async fn update_payload(
+        &self,
+        payload_id: u64,
+        payload: PayloadBundle,
+    ) -> Result<(), StoreError>;
 
     fn get_receipts_for_block(&self, block_hash: &BlockHash) -> Result<Vec<Receipt>, StoreError>;
 
     // Snap State methods
 
     /// Sets the hash of the last header downloaded during a snap sync
-    fn set_header_download_checkpoint(&self, block_hash: BlockHash) -> Result<(), StoreError>;
+    async fn set_header_download_checkpoint(&self, block_hash: BlockHash)
+        -> Result<(), StoreError>;
 
     /// Gets the hash of the last header downloaded during a snap sync
     fn get_header_download_checkpoint(&self) -> Result<Option<BlockHash>, StoreError>;
 
     /// Sets the last key fetched from the state trie being fetched during snap sync
-    fn set_state_trie_key_checkpoint(
+    async fn set_state_trie_key_checkpoint(
         &self,
         last_keys: [H256; STATE_TRIE_SEGMENTS],
     ) -> Result<(), StoreError>;
@@ -249,35 +274,37 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<Option<[H256; STATE_TRIE_SEGMENTS]>, StoreError>;
 
     /// Sets the storage trie paths in need of healing, grouped by hashed address
-    fn set_storage_heal_paths(&self, accounts: Vec<(H256, Vec<Nibbles>)>)
-        -> Result<(), StoreError>;
+    async fn set_storage_heal_paths(
+        &self,
+        accounts: Vec<(H256, Vec<Nibbles>)>,
+    ) -> Result<(), StoreError>;
 
     /// Gets the storage trie paths in need of healing, grouped by hashed address
     #[allow(clippy::type_complexity)]
     fn get_storage_heal_paths(&self) -> Result<Option<Vec<(H256, Vec<Nibbles>)>>, StoreError>;
 
     /// Sets the state trie paths in need of healing
-    fn set_state_heal_paths(&self, paths: Vec<Nibbles>) -> Result<(), StoreError>;
+    async fn set_state_heal_paths(&self, paths: Vec<Nibbles>) -> Result<(), StoreError>;
 
     /// Gets the state trie paths in need of healing
     fn get_state_heal_paths(&self) -> Result<Option<Vec<Nibbles>>, StoreError>;
 
     /// Clears all checkpoint data created during the last snap sync
-    fn clear_snap_state(&self) -> Result<(), StoreError>;
+    async fn clear_snap_state(&self) -> Result<(), StoreError>;
 
     fn is_synced(&self) -> Result<bool, StoreError>;
 
-    fn update_sync_status(&self, status: bool) -> Result<(), StoreError>;
+    async fn update_sync_status(&self, status: bool) -> Result<(), StoreError>;
 
     /// Write an account batch into the current state snapshot
-    fn write_snapshot_account_batch(
+    async fn write_snapshot_account_batch(
         &self,
         account_hashes: Vec<H256>,
         account_states: Vec<AccountState>,
     ) -> Result<(), StoreError>;
 
     /// Write a storage batch into the current storage snapshot
-    fn write_snapshot_storage_batch(
+    async fn write_snapshot_storage_batch(
         &self,
         account_hash: H256,
         storage_keys: Vec<H256>,
@@ -285,7 +312,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<(), StoreError>;
 
     /// Write multiple storage batches belonging to different accounts into the current storage snapshot
-    fn write_snapshot_storage_batches(
+    async fn write_snapshot_storage_batches(
         &self,
         account_hashes: Vec<H256>,
         storage_keys: Vec<Vec<H256>>,
@@ -293,7 +320,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<(), StoreError>;
 
     /// Set the latest root of the rebuilt state trie and the last downloaded hashes from each segment
-    fn set_state_trie_rebuild_checkpoint(
+    async fn set_state_trie_rebuild_checkpoint(
         &self,
         checkpoint: (H256, [H256; STATE_TRIE_SEGMENTS]),
     ) -> Result<(), StoreError>;
@@ -304,7 +331,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     ) -> Result<Option<(H256, [H256; STATE_TRIE_SEGMENTS])>, StoreError>;
 
     /// Get the accont hashes and roots of the storage tries awaiting rebuild
-    fn set_storage_trie_rebuild_pending(
+    async fn set_storage_trie_rebuild_pending(
         &self,
         pending: Vec<(H256, H256)>,
     ) -> Result<(), StoreError>;
@@ -313,7 +340,7 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     fn get_storage_trie_rebuild_pending(&self) -> Result<Option<Vec<(H256, H256)>>, StoreError>;
 
     /// Clears the state and storage snapshots
-    fn clear_snapshot(&self) -> Result<(), StoreError>;
+    async fn clear_snapshot(&self) -> Result<(), StoreError>;
 
     /// Reads the next `MAX_SNAPSHOT_READS` accounts from the state snapshot as from the `start` hash
     fn read_account_snapshot(&self, start: H256) -> Result<Vec<(H256, AccountState)>, StoreError>;

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -10,7 +10,7 @@ pub mod cache;
 pub use cache::CacheDB;
 pub mod error;
 
-pub trait Database {
+pub trait Database: Send + Sync {
     fn get_account_info(&self, address: Address) -> Result<AccountInfo, DatabaseError>;
     fn get_storage_slot(&self, address: Address, key: H256) -> Result<U256, DatabaseError>;
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>, DatabaseError>;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -183,7 +183,7 @@ pub struct GeneralizedDatabase {
 }
 
 impl GeneralizedDatabase {
-    pub fn new(store: Arc<dyn Database>, cache: CacheDB) -> Self {
+    pub fn new(store: Arc<dyn Database + Send + Sync>, cache: CacheDB) -> Self {
         Self { store, cache }
     }
 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -183,7 +183,7 @@ pub struct GeneralizedDatabase {
 }
 
 impl GeneralizedDatabase {
-    pub fn new(store: Arc<dyn Database + Send + Sync>, cache: CacheDB) -> Self {
+    pub fn new(store: Arc<dyn Database>, cache: CacheDB) -> Self {
         Self { store, cache }
     }
 }


### PR DESCRIPTION
**Motivation**

Some of our sync APIs can produce starving when running on Tokio due to taking a long time to reach the next `await`-point.
Specifically, writing to the DB tends to take a long time, which blocks other tasks, sometimes the whole runtime due to how the scheduler in Tokio works.
Thus, we need a way to inform the runtime we're going to be working for a while, and give it control while we wait for stuff.

**Description**

Take the mutable APIs for the DB and mark them `async`. Then bubble that up to their users. Then make the functions non-blocking by using `spawn_blocking` to run on the blocking thread, releasing the runtime to handle more work.
The DB writing APIs had to change to pass-by-value to satisfy the borrow-checker in the blocking task context. I think I can use proper lifetime bounds with a helper crate, if that's preferred. The values were already being discarded after passing to the DB, so passing by value should not be a problem either way.

Special considerations:
- For some work performed before benchmarks and EF tests which are inherently synchronous I opted for calling with an ad-hoc runtime instance and `block_on`, as that might reduce the changes needed by localizing the async work. If desired, that can be changed up to making a `tokio::main`. The same is true for some setup functions for tests.
- For the DBs I had to separate the Tokio import. This is because they need to compile with L2, which means provers' custom compilers, and those don't support the networking functions in the stdlib, which Tokio with full features (as the workspace dep declares) brings them in.
- The InMemoryDB was left untouched other than updating the interfaces, given hashmap access should be quick enough.
- I need to comment on [this hack](https://github.com/lambdaclass/ethrex/pull/2336/files#diff-264636d3ee6ee67bd6e136b8c98f74152de6a8e2a07f597cfb5f622d4e0d815aR143-R146): `and_then` can't be used on futures and everything became a mess without that little helper.
- I'm unsure about whether or not we also want to cover the read APIs, at least for consistency I would think so, but for now I left them out.

closes #2402 
