### PR TITLE
feat(l1): adjust byte code batch size (snap sync parameter)

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -36,7 +36,9 @@ use crate::{
 
 /// The minimum amount of blocks from the head that we want to full sync during a snap sync
 const MIN_FULL_BLOCKS: usize = 64;
-/// Max size of a bach to stat a fetch request in queues
+/// Max size of a bytecode bach to start a fetch request in queues
+const BYTECODE_BATCH_SIZE: usize = 70;
+/// Max size of a bach to start a fetch request in queues
 const BATCH_SIZE: usize = 300;
 /// Max size of a bach to stat a fetch request in queues for nodes
 const NODE_BATCH_SIZE: usize = 900;

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -36,11 +36,11 @@ use crate::{
 
 /// The minimum amount of blocks from the head that we want to full sync during a snap sync
 const MIN_FULL_BLOCKS: usize = 64;
-/// Max size of a bytecode bach to start a fetch request in queues
+/// Max size of bach to start a bytecode fetch request in queues
 const BYTECODE_BATCH_SIZE: usize = 70;
-/// Max size of a bach to start a fetch request in queues
-const BATCH_SIZE: usize = 300;
-/// Max size of a bach to stat a fetch request in queues for nodes
+/// Max size of a bach to start a storage fetch request in queues
+const STORAGE_BATCH_SIZE: usize = 300;
+/// Max size of a bach to start a node fetch request in queues
 const NODE_BATCH_SIZE: usize = 900;
 /// Maximum amount of concurrent paralell fetches for a queue
 const MAX_PARALLEL_FETCHES: usize = 10;

--- a/crates/networking/p2p/sync/bytecode_fetcher.rs
+++ b/crates/networking/p2p/sync/bytecode_fetcher.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 
 use crate::peer_handler::PeerHandler;
 
-use super::{SyncError, BATCH_SIZE};
+use super::{SyncError, BATCH_SIZE, BYTECODE_BATCH_SIZE};
 
 /// Waits for incoming code hashes from the receiver channel endpoint, queues them, and fetches and stores their bytecodes in batches
 pub(crate) async fn bytecode_fetcher(
@@ -32,9 +32,9 @@ pub(crate) async fn bytecode_fetcher(
         }
         // If we have enough pending bytecodes to fill a batch
         // or if we have no more incoming batches, spawn a fetch process
-        while pending_bytecodes.len() >= BATCH_SIZE || !incoming && !pending_bytecodes.is_empty() {
+        while pending_bytecodes.len() >= BYTECODE_BATCH_SIZE || !incoming && !pending_bytecodes.is_empty() {
             let next_batch = pending_bytecodes
-                .drain(..BATCH_SIZE.min(pending_bytecodes.len()))
+                .drain(..BYTECODE_BATCH_SIZE.min(pending_bytecodes.len()))
                 .collect::<Vec<_>>();
             let remaining = fetch_bytecode_batch(next_batch, peers.clone(), store.clone()).await?;
             // Add unfeched bytecodes back to the queue

--- a/crates/networking/p2p/sync/bytecode_fetcher.rs
+++ b/crates/networking/p2p/sync/bytecode_fetcher.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 
 use crate::peer_handler::PeerHandler;
 
-use super::{SyncError, BATCH_SIZE, BYTECODE_BATCH_SIZE};
+use super::{SyncError, BYTECODE_BATCH_SIZE};
 
 /// Waits for incoming code hashes from the receiver channel endpoint, queues them, and fetches and stores their bytecodes in batches
 pub(crate) async fn bytecode_fetcher(
@@ -32,7 +32,9 @@ pub(crate) async fn bytecode_fetcher(
         }
         // If we have enough pending bytecodes to fill a batch
         // or if we have no more incoming batches, spawn a fetch process
-        while pending_bytecodes.len() >= BYTECODE_BATCH_SIZE || !incoming && !pending_bytecodes.is_empty() {
+        while pending_bytecodes.len() >= BYTECODE_BATCH_SIZE
+            || !incoming && !pending_bytecodes.is_empty()
+        {
             let next_batch = pending_bytecodes
                 .drain(..BYTECODE_BATCH_SIZE.min(pending_bytecodes.len()))
                 .collect::<Vec<_>>();


### PR DESCRIPTION
**Motivation**
Previous changes have sped up other components of the snap sync process, making faults in the byte code fetcher more evident. The byte code fetcher used the same batch size as storage requests, 300, which is far more than the byte codes normally returned by a peer request, causing the byte code fetcher to keep on fetching the last batches when all other fetchers have already finished.
This PR reduces the batch size down to 70 so that it coincides with the amount of byte codes regularly returned by peers
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Rename constant `BATCH_SIZE` -> `STORAGE_BATCH_SIZE`
* Add constant `BYTECODE_BATCH_SIZE`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

