### PR TITLE
fix(l2): config error handling

### DIFF
--- a/.github/workflows/ci_l2.yaml
+++ b/.github/workflows/ci_l2.yaml
@@ -29,5 +29,5 @@ jobs:
       - name: Run L2 integration test
         run: |
           cd crates/l2
-          cp configs/config_example.toml configs/config.toml
+          cp configs/sequencer_config_example.toml configs/sequencer_config.toml
           make ci_test

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ At a high level, the following new parts are added to the node:
 >
 > 1. Make sure you are inside the `crates/l2` directory.
 > 2. Make sure the Docker daemon is running.
-> 3. Make sure you have created a `config.toml` file following the `config_example.toml` file.
+> 3. Make sure you have created a `sequencer_config.toml` file following the `sequencer_config_example.toml` file.
 
 ```
 make init

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -54,7 +54,7 @@ ethrex_METRICS_OVERRIDES_L2_DOCKER_COMPOSE_PATH=$(ethrex_PATH)/crates/blockchain
 CI_ETHREX_WORKDIR := /usr/local/bin
 
 ethrex_L2_CONFIGS_PATH=$(shell pwd)/configs
-ethrex_L2_SEQUENCER_CONFIG_FILE=config.toml
+ethrex_L2_SEQUENCER_CONFIG_FILE=sequencer_config.toml
 ethrex_L2_PROVER_CLIENT_CONFIG_FILE=prover_client_config.toml
 ethrex_L2_CONTRACTS_PATH=./contracts
 L1_RPC_URL=http://localhost:8545

--- a/crates/l2/configs/sequencer_config_example.toml
+++ b/crates/l2/configs/sequencer_config_example.toml
@@ -31,7 +31,7 @@ max_block_step = 5000
 l2_proposer_private_key = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924"
 
 [proposer]
-interval_ms = 5000
+block_time_ms = 5000
 coinbase_address = "0x0007a881CD95B1484fca47615B64803dad620C8d"
 
 [committer]

--- a/crates/l2/configs/sequencer_config_example.toml
+++ b/crates/l2/configs/sequencer_config_example.toml
@@ -31,7 +31,7 @@ max_block_step = 5000
 l2_proposer_private_key = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924"
 
 [proposer]
-block_time_ms = 5000
+interval_ms = 5000
 coinbase_address = "0x0007a881CD95B1484fca47615B64803dad620C8d"
 
 [committer]

--- a/crates/l2/docker-compose-l2.yaml
+++ b/crates/l2/docker-compose-l2.yaml
@@ -14,7 +14,7 @@ services:
     volumes:
       # NOTE: CI_ETHREX_WORKDIR is defined in crates/l2/Makefile
       - ./contracts:${CI_ETHREX_WORKDIR}/contracts
-      - ./configs/config.toml:${CI_ETHREX_WORKDIR}/configs/config.toml
+      - ./configs/sequencer_config.toml:${CI_ETHREX_WORKDIR}/configs/sequencer_config.toml
       - ./.env:${CI_ETHREX_WORKDIR}/.env
       - ../../test_data/genesis-l1-dev.json:${CI_ETHREX_WORKDIR}/test_data/genesis-l1-dev.json
       - ../../test_data/private_keys_l1.txt:${CI_ETHREX_WORKDIR}/test_data/private_keys_l1.txt
@@ -50,7 +50,7 @@ services:
     volumes:
       - ../../test_data/genesis-l2.json:/genesis-l2.json
       - ./.env:/.env:ro
-      - ./config.toml:/config.toml:ro
+      - ./sequencer_config.toml:/sequencer_config.toml:ro
     command: --network /genesis-l2.json --http.addr 0.0.0.0 --http.port 1729 --authrpc.port 8552
     depends_on:
       contract_deployer:

--- a/crates/l2/docs/README.md
+++ b/crates/l2/docs/README.md
@@ -16,7 +16,7 @@ For more detailed documentation on each part of the system:
 1. `cd crates/l2`
 2. `make rm-db-l2 && make down`
    - It will remove any old database, if present, stored in your computer. The absolute path of libmdbx is defined by [data_dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html).
-3. `cp configs/config_example.toml configs/config.toml` &rarr; check if you want to change any config.
+3. `cp configs/sequencer_config_example.toml configs/sequencer_config.toml` &rarr; check if you want to change any config.
    - The `salt_is_zero` can be set to:
      - `false` &rarr; randomizes the SALT to allow multiple deployments with random addresses.
      - `true` &rarr; uses SALT equal to `H256::zero()` to deploy to deterministic addresses.

--- a/crates/l2/docs/prover.md
+++ b/crates/l2/docs/prover.md
@@ -7,7 +7,7 @@
   - [What](#what)
   - [Workflow](#workflow)
   - [How](#how)
-      - [Quick Test](#quick-test)
+    - [Quick Test](#quick-test)
     - [Dev Mode](#dev-mode)
       - [Run the whole system with the prover - In one Machine](#run-the-whole-system-with-the-prover---in-one-machine)
     - [GPU mode](#gpu-mode)
@@ -92,7 +92,7 @@ select the "exec" backend whenever it's not desired to generate proofs, like in 
 1. `cd crates/l2`
 2. `make rm-db-l2 && make down`
    - It will remove any old database, if present, stored in your computer. The absolute path of libmdbx is defined by [data_dir](https://docs.rs/dirs/latest/dirs/fn.data_dir.html).
-3. `cp configs/config_example.toml configs/config.toml` &rarr; check if you want to change any config.
+3. `cp configs/sequencer_config_example.toml configs/sequencer_config.toml` &rarr; check if you want to change any config.
 4. `cp configs/prover_client_config_example.toml configs/prover_client_config.toml` &rarr; check if you want to change any config.
 5. `make init`
    - Make sure you have the `solc` compiler installed in your system.
@@ -160,7 +160,7 @@ prover_server_endpoint=<ip-address>:3900
 
 2. `prover_server`/`proposer` &rarr; this server just needs rust installed.
    1. `cd ethrex/crates/l2`
-   2. `cp configs/config_example.toml configs/config.toml` and change the addresses and the following fields:
+   2. `cp configs/sequencer_config_example.toml configs/sequencer_config.toml` and change the addresses and the following fields:
       - [prover_server]
         - `listen_ip=0.0.0.0` &rarr; Used to handle TCP communication with other servers from any network interface.
       - The `COMMITTER` and `PROVER_SERVER_VERIFIER` must be different accounts, the `DEPLOYER_ADDRESS` as well as the `L1_WATCHER` may be the same account used by the `COMMITTER`.

--- a/crates/l2/docs/sequencer.md
+++ b/crates/l2/docs/sequencer.md
@@ -41,7 +41,7 @@ For more information about the Prover Server, the [Prover Docs](./prover.md) pro
 
 ## Configuration
 
-Configuration is done through environment variables. The easiest way to configure the Sequencer is by creating a `config.toml` file and setting the variables there. Then, at start, it will read the file and set the variables.
+Configuration is done through environment variables. The easiest way to configure the Sequencer is by creating a `sequencer_config.toml` file and setting the variables there. Then, at start, it will read the file and set the variables.
 
 > [!NOTE]
 > The deployer.rs is in charge of parsing the `.toml` and creating/updating the `.env`
@@ -52,45 +52,46 @@ The following environment variables are available to configure the Proposer cons
 <!-- NOTE: Mantain the sections in the same order as present in [config_example.toml](../configs/config_example.toml). -->
 
 - Under the [deployer] section:
-    - `address`: L1 account which will deploy the common bridge contracts in L1.
-    - `private key`: Its private key.
-    - `risc0_contract_verifier`: Address which will verify the `risc0` proofs.
-    - `sp1_contract_verifier`: Address which will verify the `sp1` proofs.
-    - `sp1_deploy_verifier`: Whether to deploy the `sp1` verifier contract or not. 
-    - `pico_contract_verifier`: Address which will verify the `pico` proofs.
-    - `pico_deploy_verifier`: Whether to deploy the `pico` verifier contract or not.
-    - `salt_is_zero`: Whether a 0 value salt will be used. Keep as true for deterministic `create2` operations.
+
+  - `address`: L1 account which will deploy the common bridge contracts in L1.
+  - `private key`: Its private key.
+  - `risc0_contract_verifier`: Address which will verify the `risc0` proofs.
+  - `sp1_contract_verifier`: Address which will verify the `sp1` proofs.
+  - `sp1_deploy_verifier`: Whether to deploy the `sp1` verifier contract or not.
+  - `pico_contract_verifier`: Address which will verify the `pico` proofs.
+  - `pico_deploy_verifier`: Whether to deploy the `pico` verifier contract or not.
+  - `salt_is_zero`: Whether a 0 value salt will be used. Keep as true for deterministic `create2` operations.
 
 - Under the [eth] section:
-    - `rpc_url`: URL of the L1 RPC.
+
+  - `rpc_url`: URL of the L1 RPC.
 
 - Under the [engine] section:
-    - `rpc_url`: URL of the EngineAPI.
-    - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
+
+  - `rpc_url`: URL of the EngineAPI.
+  - `jwt_path`: Path to the JWT authentication file, required to connect to the EngineAPI.
 
 - Under the [watcher] section:
-    - `bridge_address`: Address of the bridge contract on L1.
-    - `check_interval_ms`: Interval in milliseconds to check for new events.
-    - `max_block_step`: Maximum number of blocks to look for when checking for new events.
-    - `l2_proposer_private_key`: Private key of the L2 proposer.
+
+  - `bridge_address`: Address of the bridge contract on L1.
+  - `check_interval_ms`: Interval in milliseconds to check for new events.
+  - `max_block_step`: Maximum number of blocks to look for when checking for new events.
+  - `l2_proposer_private_key`: Private key of the L2 proposer.
 
 - Under the [proposer] section:
-    - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
-    - `coinbase address`: Address which will receive the execution fees.
+  - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
+  - `coinbase address`: Address which will receive the execution fees.
 
-Under the [committer] section:
-    - `l1_address`: Address of the L1 committer.
-    - `l1_private_key`: Private key of the L1 committer.
-    - `on_chain_proposer_address`: Address of the on-chain committer.
+Under the [committer] section: - `l1_address`: Address of the L1 committer. - `l1_private_key`: Private key of the L1 committer. - `on_chain_proposer_address`: Address of the on-chain committer.
 
 - Under the [prover_server] section:
-    - `listen_ip`: IP to listen for proof data requests.
-    - `listen_port`: Port to listen for proof data requests.
-    - `verifier_address`: Address of the account that sends verify transaction to L1.
-    - `verifier_private_key`: Private key for the account that sends verify transaction to L1.
-    - `dev_mode`: whether `dev_mode` is activated.
-
+  - `listen_ip`: IP to listen for proof data requests.
+  - `listen_port`: Port to listen for proof data requests.
+  - `verifier_address`: Address of the account that sends verify transaction to L1.
+  - `verifier_private_key`: Private key for the account that sends verify transaction to L1.
+  - `dev_mode`: whether `dev_mode` is activated.
 
 If you want to use a different configuration file, you can set the:
+
 - `CONFIGS_PATH`: The path where the `SEQUENCER_CONFIG_FILE` is located at.
 - `SEQUENCER_CONFIG_FILE`: The `.toml` that contains the config for the `sequencer`.

--- a/crates/l2/utils/config/errors.rs
+++ b/crates/l2/utils/config/errors.rs
@@ -1,4 +1,4 @@
-use crate::sequencer::errors::BlockProducerError;
+use crate::{sequencer::errors::BlockProducerError, utils::config::ConfigMode};
 use ethrex_rpc::clients::{auth, eth};
 
 #[derive(Debug, thiserror::Error)]
@@ -24,25 +24,25 @@ pub enum TomlParserError {
     #[error(
         "Could not find crates/l2/configs/{0}
 Have you tried copying the provided example? Try:
-cp {manifest_dir}/configs/*_example.toml {manifest_dir}/configs/*.toml
+cp {manifest_dir}/configs/{1}_config_example.toml {manifest_dir}/configs/{1}_config.toml
 ",
         manifest_dir = env!("CARGO_MANIFEST_DIR")
 
     )]
-    TomlFileNotFound(String),
+    TomlFileNotFound(String, ConfigMode),
 
     #[error(
         "Could not parse crates/l2/configs/{0}
 Check the provided example to see if you have all the required fields.
 The example can be found at:
-crates/l2/configs/*_example.toml
+crates/l2/configs/{1}_config_example.toml
 You can also see the differences with:
-diff {manifest_dir}/configs/*_example.toml {manifest_dir}/configs/*.toml
+diff {manifest_dir}/configs/{1}_config_example.toml {manifest_dir}/configs/{1}_config.toml
 ",
         manifest_dir = env!("CARGO_MANIFEST_DIR")
 
     )]
-    TomlFormat(String),
+    TomlFormat(String, ConfigMode),
 
     #[error("\x1b[91mCould not write to .env file.\x1b[0m {0}")]
     EnvWriteError(String),

--- a/crates/l2/utils/config/mod.rs
+++ b/crates/l2/utils/config/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::{Debug, Display},
     io::{BufRead, Write},
     path::{Path, PathBuf},
 };
@@ -17,7 +18,7 @@ pub mod toml_parser;
 
 #[derive(Clone, Copy)]
 pub enum ConfigMode {
-    /// Parses the entire the config.toml
+    /// Parses the entire the sequencer_config.toml
     /// And generates the .env file.
     Sequencer,
     /// Parses the prover_config.toml
@@ -27,13 +28,13 @@ pub enum ConfigMode {
 
 impl ConfigMode {
     /// Gets the .*config.toml file from the environment, or sets a default value
-    /// config.toml         for the sequencer/L2 node
+    /// sequencer_config.toml         for the sequencer/L2 node
     /// prover_config.toml  for the the prover_client
     fn get_config_file_path(&self, config_path: &str) -> PathBuf {
         match self {
             ConfigMode::Sequencer => {
-                let sequencer_config_file_name =
-                    std::env::var("SEQUENCER_CONFIG_FILE").unwrap_or("config.toml".to_owned());
+                let sequencer_config_file_name = std::env::var("SEQUENCER_CONFIG_FILE")
+                    .unwrap_or("sequencer_config.toml".to_owned());
                 Path::new(&config_path).join(sequencer_config_file_name)
             }
             ConfigMode::ProverClient => {
@@ -57,6 +58,24 @@ impl ConfigMode {
             ConfigMode::ProverClient => std::env::var("PROVER_ENV_FILE")
                 .map(Into::into)
                 .unwrap_or(cargo_manifest_dir.join(".env.prover")),
+        }
+    }
+}
+
+impl Debug for ConfigMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sequencer => write!(f, "sequencer"),
+            Self::ProverClient => write!(f, "prover_client"),
+        }
+    }
+}
+
+impl Display for ConfigMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sequencer => write!(f, "sequencer"),
+            Self::ProverClient => write!(f, "prover_client"),
         }
     }
 }

--- a/crates/l2/utils/config/toml_parser.rs
+++ b/crates/l2/utils/config/toml_parser.rs
@@ -284,17 +284,20 @@ fn read_config(config_path: String, mode: ConfigMode) -> Result<(), ConfigError>
         .to_str()
         .ok_or(ConfigError::Custom("Couldn't convert to_str()".to_string()))?
         .to_owned();
-    let file = std::fs::read_to_string(toml_path)
-        .map_err(|_| TomlParserError::TomlFileNotFound(toml_file_name.clone()))?;
+    let file = std::fs::read_to_string(toml_path).map_err(|err| {
+        TomlParserError::TomlFileNotFound(format!("{err}: {}", toml_file_name.clone()), mode)
+    })?;
     match mode {
         ConfigMode::Sequencer => {
-            let config: L2Config = toml::from_str(&file)
-                .map_err(|_| TomlParserError::TomlFormat(toml_file_name.clone()))?;
+            let config: L2Config = toml::from_str(&file).map_err(|err| {
+                TomlParserError::TomlFormat(format!("{err}: {}", toml_file_name.clone()), mode)
+            })?;
             write_to_env(config.to_env(), mode)?;
         }
         ConfigMode::ProverClient => {
-            let config: ProverClientConfig =
-                toml::from_str(&file).map_err(|_| TomlParserError::TomlFormat(toml_file_name))?;
+            let config: ProverClientConfig = toml::from_str(&file).map_err(|err| {
+                TomlParserError::TomlFormat(format!("{err}: {}", toml_file_name.clone()), mode)
+            })?;
             write_to_env(config.to_env(), mode)?;
         }
     }

--- a/crates/l2/utils/config/toml_parser.rs
+++ b/crates/l2/utils/config/toml_parser.rs
@@ -282,7 +282,7 @@ fn read_config(config_path: String, mode: ConfigMode) -> Result<(), ConfigError>
             write_to_env(config.to_env(), mode)?;
         }
         ConfigMode::ProverClient => {
-            let config: ProverClientConfig = toml::from_str(&file).map_err(|err| {
+            let config: ProverClient = toml::from_str(&file).map_err(|err| {
                 TomlParserError::TomlFormat(format!("{err}: {}", toml_file_name.clone()), mode)
             })?;
             write_to_env(config.to_env(), mode)?;


### PR DESCRIPTION
**Motivation**

In a previous PR, the configuration file error handling was updated, and the help messages stopped being helpful. This PR aims to make these error messages useful again and improve their handling.

The current help message does not work:

```Shell
Error parsing the .toml configuration files: Could not find crates/l2/configs/config.toml
Have you tried copying the provided example? Try:
cp /Users/ivanlitteri/Repositories/lambdaclass/ethrex/crates/l2/configs/*_example.toml /Users/ivanlitteri/Repositories/lambdaclass/ethrex/crates/l2/configs/*.toml

Error: ConfigError(TomlParserError(TomlFileNotFound("config.toml")))
make: *** [deploy-l1] Error 1
➜  l2 git:(main) ✗ cp /Users/ivanlitteri/Repositories/lambdaclass/ethrex/crates/l2/configs/*_example.toml /Users/ivanlitteri/Repositories/lambdaclass/ethrex/crates/l2/configs/*.toml
cp: /Users/ivanlitteri/Repositories/lambdaclass/ethrex/crates/l2/configs/sequencer_config_example.toml is not a directory
```

**Description**

- Add a prefix `sequencer_` to the sequencer config file to be consistent with the prover client config file and update its references.
- Pass `ConfigMode` to the `toml` errors to make the help messages helpful again, and implement `Debug` and `Display` for this on it.
- Make the `toml` parsing error explicit.

