### PR TITLE
fix(core): make metrics port flag not optional

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -62,9 +62,10 @@ pub struct Options {
     #[arg(
         long = "metrics.port",
         value_name = "PROMETHEUS_METRICS_PORT",
+        default_value = "9090", // Default Prometheus port (https://prometheus.io/docs/tutorials/getting_started/#show-me-how-it-is-done).
         help_heading = "Node options"
     )]
-    pub metrics_port: Option<String>,
+    pub metrics_port: String,
     #[arg(
         long = "dev",
         action = ArgAction::SetTrue,

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -56,10 +56,8 @@ pub fn init_tracing(opts: &Options) {
 }
 
 pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
-    if let Some(port) = &opts.metrics_port {
-        let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(port.clone());
-        tracker.spawn(metrics_api);
-    }
+    let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(opts.metrics_port.clone());
+    tracker.spawn(metrics_api);
 }
 
 pub fn init_store(data_dir: &str, network: &str) -> Store {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Currently, the metrics are initiated iif the `--metrics-port` flag is passed. This is wrong because the flag is used both to configure the listening port and as a metrics enabler flag.

If needed, a flag `--metrics.enabled` could be introduced in another PR if metrics are unwanted for some reason. IMHO initializing metrics as default is ok.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

- Always initialize metrics
- The `--metrics.port` flag is now not optional and defaults to 9090 as the default value.

