### PR TITLE
feat(core): add metrics address config flag

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -60,6 +60,13 @@ pub struct Options {
     #[arg(long = "syncmode", default_value = "full", value_name = "SYNC_MODE", value_parser = utils::parse_sync_mode, help = "The way in which the node will sync its state.", long_help = "Can be either \"full\" or \"snap\" with \"full\" as default value.", help_heading = "P2P options")]
     pub syncmode: SyncMode,
     #[arg(
+        long = "metrics.addr",
+        value_name = "ADDRESS",
+        default_value = "0.0.0.0",
+        help_heading = "Node options"
+    )]
+    pub metrics_addr: String,
+    #[arg(
         long = "metrics.port",
         value_name = "PROMETHEUS_METRICS_PORT",
         default_value = "9090", // Default Prometheus port (https://prometheus.io/docs/tutorials/getting_started/#show-me-how-it-is-done).
@@ -177,6 +184,7 @@ impl Default for Options {
             bootnodes: Default::default(),
             datadir: Default::default(),
             syncmode: Default::default(),
+            metrics_addr: "0.0.0.0".to_owned(),
             metrics_port: Default::default(),
             dev: Default::default(),
             evm: Default::default(),

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -62,9 +62,10 @@ pub struct Options {
     #[arg(
         long = "metrics.port",
         value_name = "PROMETHEUS_METRICS_PORT",
+        default_value = "9090", // Default Prometheus port (https://prometheus.io/docs/tutorials/getting_started/#show-me-how-it-is-done).
         help_heading = "Node options"
     )]
-    pub metrics_port: Option<String>,
+    pub metrics_port: String,
     #[arg(
         long = "dev",
         action = ArgAction::SetTrue,

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -56,10 +56,8 @@ pub fn init_tracing(opts: &Options) {
 }
 
 pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
-    if let Some(port) = &opts.metrics_port {
-        let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(port.clone());
-        tracker.spawn(metrics_api);
-    }
+    let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(opts.metrics_port.clone());
+    tracker.spawn(metrics_api);
 }
 
 pub fn init_store(data_dir: &str, network: &str) -> Store {

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -56,7 +56,10 @@ pub fn init_tracing(opts: &Options) {
 }
 
 pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
-    let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(opts.metrics_port.clone());
+    let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(
+        opts.metrics_addr.clone(),
+        opts.metrics_port.clone(),
+    );
     tracker.spawn(metrics_api);
 }
 

--- a/crates/blockchain/metrics/api.rs
+++ b/crates/blockchain/metrics/api.rs
@@ -5,13 +5,16 @@ use crate::metrics_l2::METRICS_L2;
 
 use crate::{metrics_transactions::METRICS_TX, MetricsApiError};
 
-pub async fn start_prometheus_metrics_api(port: String) -> Result<(), MetricsApiError> {
+pub async fn start_prometheus_metrics_api(
+    address: String,
+    port: String,
+) -> Result<(), MetricsApiError> {
     let app = Router::new()
         .route("/metrics", get(get_metrics))
         .route("/health", get("Service Up"));
 
     // Start the axum app
-    let listener = tokio::net::TcpListener::bind(&format!("0.0.0.0:{port}")).await?;
+    let listener = tokio::net::TcpListener::bind(&format!("{address}:{port}")).await?;
     axum::serve(listener, app).await?;
 
     Ok(())


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Nowadays, the metrics API address is hardcoded to `0.0.0.0`. This PR aims to parameterize this. 

**Description**

- Adds a `--metrics.addr` flag to the CLI with `0.0.0.0` as the default value.
- Implement the wiring necessary to pass the flag value to the metrics API initialization. 
