### PR TITLE
refactor(l2): rename prover client config to a more descriptive name

### DIFF
--- a/crates/l2/configs/prover_client_config_example.toml
+++ b/crates/l2/configs/prover_client_config_example.toml
@@ -1,6 +1,6 @@
 [prover_client]
 prover_server_endpoint = "localhost:3900"
-interval_ms = 5000
+proving_time_ms = 5000
 # mock, cpu, cuda
 sp1_prover = "mock"
 # 1 for dev_mode

--- a/crates/l2/prover/src/prover_client.rs
+++ b/crates/l2/prover/src/prover_client.rs
@@ -24,14 +24,14 @@ struct ProverData {
 
 struct ProverClient {
     prover_server_endpoint: String,
-    interval_ms: u64,
+    proving_time_ms: u64,
 }
 
 impl ProverClient {
     pub fn new(config: ProverClientConfig) -> Self {
         Self {
             prover_server_endpoint: config.prover_server_endpoint,
-            interval_ms: config.interval_ms,
+            proving_time_ms: config.proving_time_ms,
         }
     }
 
@@ -56,11 +56,11 @@ impl ProverClient {
                     };
                 }
                 Err(e) => {
-                    sleep(Duration::from_millis(self.interval_ms)).await;
+                    sleep(Duration::from_millis(self.proving_time_ms)).await;
                     warn!("Failed to request new data: {e}");
                 }
             }
-            sleep(Duration::from_millis(self.interval_ms)).await;
+            sleep(Duration::from_millis(self.proving_time_ms)).await;
         }
     }
 

--- a/crates/l2/utils/config/prover_client.rs
+++ b/crates/l2/utils/config/prover_client.rs
@@ -5,7 +5,7 @@ use super::errors::ConfigError;
 #[derive(Deserialize, Debug)]
 pub struct ProverClientConfig {
     pub prover_server_endpoint: String,
-    pub interval_ms: u64,
+    pub proving_time_ms: u64,
 }
 
 impl ProverClientConfig {

--- a/crates/l2/utils/config/toml_parser.rs
+++ b/crates/l2/utils/config/toml_parser.rs
@@ -158,7 +158,7 @@ struct ProverClient {
     prover_server_endpoint: String,
     sp1_prover: String,
     risc0_dev_mode: u64,
-    interval_ms: u64,
+    proving_time_ms: u64,
 }
 
 impl ProverClient {
@@ -166,25 +166,12 @@ impl ProverClient {
         let prefix = "PROVER_CLIENT";
         format!(
             "{prefix}_PROVER_SERVER_ENDPOINT={}
-{prefix}_INTERVAL_MS={}
+{prefix}_PROVING_TIME_MS={}
 RISC0_DEV_MODE={}
 SP1_PROVER={}
 ",
-            self.prover_server_endpoint, self.interval_ms, self.risc0_dev_mode, self.sp1_prover
+            self.prover_server_endpoint, self.proving_time_ms, self.risc0_dev_mode, self.sp1_prover
         )
-    }
-}
-
-#[derive(Deserialize, Debug)]
-struct ProverClientConfig {
-    prover_client: ProverClient,
-}
-
-impl ProverClientConfig {
-    fn to_env(&self) -> String {
-        let mut env_representation = String::new();
-        env_representation.push_str(&self.prover_client.to_env());
-        env_representation
     }
 }
 
@@ -293,7 +280,7 @@ fn read_config(config_path: String, mode: ConfigMode) -> Result<(), ConfigError>
             write_to_env(config.to_env(), mode)?;
         }
         ConfigMode::ProverClient => {
-            let config: ProverClientConfig =
+            let config: ProverClient =
                 toml::from_str(&file).map_err(|_| TomlParserError::TomlFormat(toml_file_name))?;
             write_to_env(config.to_env(), mode)?;
         }


### PR DESCRIPTION
- Rename prover client `interval_ms` -> `proving_time_ms`.
- Remove needless `ProverClientConfig` struct in `toml_parser`.