### PR TITLE
fix(chore): fix build l1 client in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 help: ## 📚 Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build: ## 🔨 Build the client
-	cargo build --workspace
+build: ## 🔨 Build the l1 client
+	cargo build
 
 lint: ## 🧹 Linter check
 	cargo clippy --all-targets --all-features --workspace --exclude ethrex-prover --exclude zkvm_interface -- -D warnings


### PR DESCRIPTION
**Motivation**

fix build l1 client in Makefile

**Description**

change `cargo build --workspace` to `cargo build` in Makefile  to build l1 client without l1 prover

Closes #issue_number

