### PR TITLE
fix(l2): prover_client_config parser

### DIFF
--- a/crates/l2/configs/prover_client_config_example.toml
+++ b/crates/l2/configs/prover_client_config_example.toml
@@ -1,4 +1,3 @@
-[prover_client]
 prover_server_endpoint = "localhost:3900"
 proving_time_ms = 5000
 # mock, cpu, cuda


### PR DESCRIPTION
**Motivation**

The previous PR removed the `ProverClientConfig` leaving just the `ProverClient` structure. To successfully parse the file, we should remove the `prover_client` table header.

**Description**

- Remove header from `prover_client_config_example.toml`

