### PR TITLE
fix(l1): correctly account for completed segments when showing state sync progress

### DIFF
--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -242,7 +242,8 @@ impl StateSyncProgress {
         progress.data.lock().await.current_keys[segment_number] = current_key
     }
     async fn end_segment(progress: StateSyncProgress, segment_number: usize) {
-        progress.data.lock().await.ended[segment_number] = true
+        progress.data.lock().await.ended[segment_number] = true;
+        progress.data.lock().await.current_keys[segment_number] = STATE_TRIE_SEGMENTS_END[segment_number]
     }
 
     // Returns true if the state sync ended

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -243,7 +243,7 @@ impl StateSyncProgress {
     }
     async fn end_segment(progress: StateSyncProgress, segment_number: usize) {
         progress.data.lock().await.ended[segment_number] = true;
-        progress.data.lock().await.current_keys[segment_number] = 
+        progress.data.lock().await.current_keys[segment_number] =
             STATE_TRIE_SEGMENTS_END[segment_number]
     }
 

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -244,7 +244,7 @@ impl StateSyncProgress {
         progress.data.lock().await.current_keys[segment_number] = current_key
     }
     async fn end_segment(progress: StateSyncProgress, segment_number: usize, last_key: H256) {
-        let data = progress.data.lock().await;
+        let mut data = progress.data.lock().await;
         data.ended[segment_number] = true;
         data.current_keys[segment_number] = last_key;
     }

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -243,7 +243,8 @@ impl StateSyncProgress {
     }
     async fn end_segment(progress: StateSyncProgress, segment_number: usize) {
         progress.data.lock().await.ended[segment_number] = true;
-        progress.data.lock().await.current_keys[segment_number] = STATE_TRIE_SEGMENTS_END[segment_number]
+        progress.data.lock().await.current_keys[segment_number] = 
+            STATE_TRIE_SEGMENTS_END[segment_number]
     }
 
     // Returns true if the state sync ended

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -244,8 +244,9 @@ impl StateSyncProgress {
         progress.data.lock().await.current_keys[segment_number] = current_key
     }
     async fn end_segment(progress: StateSyncProgress, segment_number: usize, last_key: H256) {
-        progress.data.lock().await.ended[segment_number] = true;
-        progress.data.lock().await.current_keys[segment_number] = last_key;
+        let data = progress.data.lock().await;
+        data.ended[segment_number] = true;
+        data.current_keys[segment_number] = last_key;
     }
 
     // Returns true if the state sync ended

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -101,7 +101,12 @@ async fn state_sync_segment(
     ));
     // Skip state sync if we are already on healing
     if start_account_hash == STATE_TRIE_SEGMENTS_END[segment_number] {
-        // Update sync progress (this task is not vital so we can detach it)
+        // Update sync progress (these tasks are not vital so we can detach it)
+        tokio::task::spawn(StateSyncProgress::update_key(
+            state_sync_progress.clone(),
+            segment_number,
+            start_account_hash,
+        ));
         tokio::task::spawn(StateSyncProgress::end_segment(
             state_sync_progress.clone(),
             segment_number,
@@ -242,9 +247,7 @@ impl StateSyncProgress {
         progress.data.lock().await.current_keys[segment_number] = current_key
     }
     async fn end_segment(progress: StateSyncProgress, segment_number: usize) {
-        progress.data.lock().await.ended[segment_number] = true;
-        progress.data.lock().await.current_keys[segment_number] =
-            STATE_TRIE_SEGMENTS_END[segment_number]
+        progress.data.lock().await.ended[segment_number] = true
     }
 
     // Returns true if the state sync ended


### PR DESCRIPTION
**Motivation**
Currenlty, completed segments show as 0% complete when showing state sync progress. This is due to the last_key value used to calculate progress not being updated before marking the segment as finished. This PR fixes this issue
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Set last key when marking segment state sync finalization in the state sync progress tracker
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

