### PR TITLE
fix(l2): sequencer config inconsistencies

### DIFF
--- a/crates/l2/configs/sequencer_config_example.toml
+++ b/crates/l2/configs/sequencer_config_example.toml
@@ -1,18 +1,17 @@
 [deployer]
-address = "0x3d1e15a1a55578f7c920884a9943b3b35d0d885b"
-private_key = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924"
-# If set to 0xAA skip proof verification.
-# Only use in dev mode.
+# Address of a funded account that will be used for L1 contract deployment
+l1_address = "0x3d1e15a1a55578f7c920884a9943b3b35d0d885b"
+# Private key corresponding to the above address.
+l1_private_key = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924"
+# If set to 0xAA skip proof verification -> Only use in dev mode.
 pico_contract_verifier = "0x00000000000000000000000000000000000000AA"
+# If set to true, it will deploy the contract and override the address above with the deployed one.
 pico_deploy_verifier = false
-# If set to 0xAA skip proof verification.
-# Only use in dev mode.
+# If set to 0xAA skip proof verification -> Only use in dev mode.
 risc0_contract_verifier = "0x00000000000000000000000000000000000000AA"
-# Risc0Groth16Verifier Address
-# risc0_contract_verifier = "0xAC292cF957Dd5BA174cdA13b05C16aFC71700327"
-# If set to 0xAA skip proof verification.
-# Only use in dev mode.
+# If set to 0xAA skip proof verification -> Only use in dev mode.
 sp1_contract_verifier = "0x00000000000000000000000000000000000000AA"
+# If set to true, it will deploy the contract and override the address above with the deployed one.
 sp1_deploy_verifier = false
 # If set to false, the salt will be randomized.
 salt_is_zero = true
@@ -35,21 +34,24 @@ block_time_ms = 5000
 coinbase_address = "0x0007a881CD95B1484fca47615B64803dad620C8d"
 
 [committer]
-on_chain_proposer_address = "0x52178cfc3db571f60016d43adf47d61c2009fa72"
+# Address of a funded account that the sequencer will use to send commit txs to the L1.
 l1_address = "0x3d1e15a1a55578f7c920884a9943b3b35d0d885b"
+# Private key corresponding to the above address.
 l1_private_key = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924"
-interval_ms = 5000
+on_chain_proposer_address = "0x52178cfc3db571f60016d43adf47d61c2009fa72"
+# How often does the sequencer commit new blocks to the L1.
+commit_time_ms = 5000
 # 1 Gwei
 arbitrary_base_blob_gas_price = 1000000000
 
 [prover_server]
-# set it to 0.0.0.0 to allow connections from other machines
+# Address of a funded account that the sequencer will use to send verify txs to the L1.
+# Has to be a different account than comitter.l1_address.
+l1_address = "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
+# Private key corresponding to the above address.
+l1_private_key = "0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d"
+# Set it to 0.0.0.0 to allow connections from other machines.
 listen_ip = "127.0.0.1"
 listen_port = 3900
-# Not the same account as the [committer] l1 Account
-# The proposer is in charge of blob commitments.
-# The prover_server is in charge of verifying the zkProofs.
-verifier_address = "0xE25583099BA105D9ec0A67f5Ae86D90e50036425"
-verifier_private_key = "0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d"
 dev_mode = true
 dev_interval_ms = 5000

--- a/crates/l2/contracts/deployer.rs
+++ b/crates/l2/contracts/deployer.rs
@@ -167,31 +167,31 @@ fn setup() -> Result<SetupResult, DeployError> {
 
     let eth_client = EthClient::new(&read_env_var("ETH_RPC_URL")?);
 
-    let deployer_address = parse_env_var("DEPLOYER_ADDRESS")?;
+    let deployer_address = parse_env_var("DEPLOYER_L1_ADDRESS")?;
     let deployer_private_key = SecretKey::from_slice(
         H256::from_str(
-            read_env_var("DEPLOYER_PRIVATE_KEY")?
+            read_env_var("DEPLOYER_L1_PRIVATE_KEY")?
                 .strip_prefix("0x")
                 .ok_or(DeployError::ParseError(
-                    "Malformed DEPLOYER PRIVATE KEY (strip_prefix(\"0x\"))".to_owned(),
+                    "Malformed DEPLOYER_L1_PRIVATE_KEY (strip_prefix(\"0x\"))".to_owned(),
                 ))?,
         )
         .map_err(|err| {
             DeployError::ParseError(format!(
-                "Malformed DEPLOYER PRIVATE KEY (H256::from_str): {err}"
+                "Malformed DEPLOYER_L1_PRIVATE_KEY (H256::from_str): {err}"
             ))
         })?
         .as_bytes(),
     )
     .map_err(|err| {
         DeployError::ParseError(format!(
-            "Malformed DEPLOYER_PRIVATE_KEY (SecretKey::parse): {err}"
+            "Malformed DEPLOYER_L1_PRIVATE_KEY (SecretKey::parse): {err}"
         ))
     })?;
 
     let committer_address = parse_env_var("COMMITTER_L1_ADDRESS")?;
 
-    let verifier_address = parse_env_var("PROVER_SERVER_VERIFIER_ADDRESS")?;
+    let verifier_address = parse_env_var("PROVER_SERVER_L1_ADDRESS")?;
 
     let contracts_path = Path::new(
         std::env::var("DEPLOYER_CONTRACTS_PATH")

--- a/crates/l2/docs/sequencer.md
+++ b/crates/l2/docs/sequencer.md
@@ -53,8 +53,8 @@ The following environment variables are available to configure the Proposer cons
 
 - Under the [deployer] section:
 
-  - `address`: L1 account which will deploy the common bridge contracts in L1.
-  - `private key`: Its private key.
+  - `l1_address`: L1 account which will deploy the common bridge contracts in L1.
+  - `l1_private key`: Its private key.
   - `risc0_contract_verifier`: Address which will verify the `risc0` proofs.
   - `sp1_contract_verifier`: Address which will verify the `sp1` proofs.
   - `sp1_deploy_verifier`: Whether to deploy the `sp1` verifier contract or not.
@@ -79,17 +79,25 @@ The following environment variables are available to configure the Proposer cons
   - `l2_proposer_private_key`: Private key of the L2 proposer.
 
 - Under the [proposer] section:
+
   - `interval_ms`: Interval in milliseconds to produce new blocks for the proposer.
   - `coinbase address`: Address which will receive the execution fees.
 
-Under the [committer] section: - `l1_address`: Address of the L1 committer. - `l1_private_key`: Private key of the L1 committer. - `on_chain_proposer_address`: Address of the on-chain committer.
+- Under the [committer] section:
+
+  - `l1_address`: Address of the L1 committer.
+  - `l1_private_key`: Its private key.
+  - `commit_time_ms`: Sleep time after sending the commit transaction.
+  - `on_chain_proposer_address`: Address of the on-chain committer.
 
 - Under the [prover_server] section:
+
+  - `l1_address`: Address of the account that sends verify transaction to L1.
+    - Must be different than the `committer.l1_address`, there might be conflicts with the transactions' nonce.
+  - `l1_private_key`: Its private key.
   - `listen_ip`: IP to listen for proof data requests.
   - `listen_port`: Port to listen for proof data requests.
-  - `verifier_address`: Address of the account that sends verify transaction to L1.
-  - `verifier_private_key`: Private key for the account that sends verify transaction to L1.
-  - `dev_mode`: whether `dev_mode` is activated.
+  - `dev_mode`: Whether `dev_mode` is activated or not.
 
 If you want to use a different configuration file, you can set the:
 

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -36,7 +36,7 @@ pub struct Committer {
     store: Store,
     l1_address: Address,
     l1_private_key: SecretKey,
-    interval_ms: u64,
+    commit_time_ms: u64,
     arbitrary_base_blob_gas_price: u64,
     execution_cache: Arc<ExecutionCache>,
 }
@@ -67,7 +67,7 @@ impl Committer {
             store,
             l1_address: committer_config.l1_address,
             l1_private_key: committer_config.l1_private_key,
-            interval_ms: committer_config.interval_ms,
+            commit_time_ms: committer_config.commit_time_ms,
             arbitrary_base_blob_gas_price: committer_config.arbitrary_base_blob_gas_price,
             execution_cache,
         }
@@ -79,7 +79,7 @@ impl Committer {
                 error!("L1 Committer Error: {}", err);
             }
 
-            sleep_random(self.interval_ms).await;
+            sleep_random(self.commit_time_ms).await;
         }
     }
 

--- a/crates/l2/sequencer/prover_server.rs
+++ b/crates/l2/sequencer/prover_server.rs
@@ -56,8 +56,8 @@ struct ProverServer {
     store: Store,
     eth_client: EthClient,
     on_chain_proposer_address: Address,
-    verifier_address: Address,
-    verifier_private_key: SecretKey,
+    l1_address: Address,
+    l1_private_key: SecretKey,
     dev_interval_ms: u64,
     needed_proof_types: Vec<ProverType>,
 }
@@ -177,8 +177,8 @@ impl ProverServer {
             store,
             eth_client,
             on_chain_proposer_address,
-            verifier_address: config.verifier_address,
-            verifier_private_key: config.verifier_private_key,
+            l1_address: config.l1_address,
+            l1_private_key: config.l1_private_key,
             needed_proof_types,
 
             dev_interval_ms: config.dev_interval_ms,
@@ -557,7 +557,7 @@ impl ProverServer {
             .eth_client
             .build_eip1559_transaction(
                 self.on_chain_proposer_address,
-                self.verifier_address,
+                self.l1_address,
                 calldata.into(),
                 Overrides {
                     max_fee_per_gas: Some(gas_price),
@@ -571,7 +571,7 @@ impl ProverServer {
 
         let verify_tx_hash = self
             .eth_client
-            .send_tx_bump_gas_exponential_backoff(&mut tx, &self.verifier_private_key)
+            .send_tx_bump_gas_exponential_backoff(&mut tx, &self.l1_private_key)
             .await?;
 
         info!("Sent proof for block {block_number}, with transaction hash {verify_tx_hash:#x}");
@@ -640,7 +640,7 @@ impl ProverServer {
                 .eth_client
                 .build_eip1559_transaction(
                     self.on_chain_proposer_address,
-                    self.verifier_address,
+                    self.l1_address,
                     calldata.into(),
                     Overrides {
                         max_fee_per_gas: Some(gas_price),
@@ -654,12 +654,12 @@ impl ProverServer {
 
             let mut tx = WrappedTransaction::EIP1559(verify_tx);
             self.eth_client
-                .set_gas_for_wrapped_tx(&mut tx, self.verifier_address)
+                .set_gas_for_wrapped_tx(&mut tx, self.l1_address)
                 .await?;
 
             let verify_tx_hash = self
                 .eth_client
-                .send_tx_bump_gas_exponential_backoff(&mut tx, &self.verifier_private_key)
+                .send_tx_bump_gas_exponential_backoff(&mut tx, &self.l1_private_key)
                 .await?;
 
             info!("Sent proof for block {last_verified_block}, with transaction hash {verify_tx_hash:#x}");

--- a/crates/l2/utils/config/block_producer.rs
+++ b/crates/l2/utils/config/block_producer.rs
@@ -11,8 +11,11 @@ pub struct BlockProducerConfig {
 
 impl BlockProducerConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
-        envy::prefixed("PROPOSER_")
-            .from_env::<Self>()
-            .map_err(ConfigError::from)
+        envy::prefixed("PROPOSER_").from_env::<Self>().map_err(|e| {
+            ConfigError::ConfigDeserializationError {
+                err: e,
+                from: "BlockProducerConfig".to_string(),
+            }
+        })
     }
 }

--- a/crates/l2/utils/config/committer.rs
+++ b/crates/l2/utils/config/committer.rs
@@ -11,7 +11,7 @@ pub struct CommitterConfig {
     pub l1_address: Address,
     #[serde(deserialize_with = "secret_key_deserializer")]
     pub l1_private_key: SecretKey,
-    pub interval_ms: u64,
+    pub commit_time_ms: u64,
     pub arbitrary_base_blob_gas_price: u64,
 }
 
@@ -19,6 +19,9 @@ impl CommitterConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
         envy::prefixed("COMMITTER_")
             .from_env::<Self>()
-            .map_err(ConfigError::from)
+            .map_err(|e| ConfigError::ConfigDeserializationError {
+                err: e,
+                from: "CommitterConfig".to_string(),
+            })
     }
 }

--- a/crates/l2/utils/config/errors.rs
+++ b/crates/l2/utils/config/errors.rs
@@ -3,8 +3,8 @@ use ethrex_rpc::clients::{auth, eth};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
-    #[error("Error deserializing config from env: {0}")]
-    ConfigDeserializationError(#[from] envy::Error),
+    #[error("Error deserializing config from env: {err}. From config: {from:?}")]
+    ConfigDeserializationError { err: envy::Error, from: String },
     #[error("Error reading env file: {0}")]
     EnvFileError(#[from] std::io::Error),
     #[error("Error building Proposer from config: {0}")]

--- a/crates/l2/utils/config/eth.rs
+++ b/crates/l2/utils/config/eth.rs
@@ -9,8 +9,11 @@ pub struct EthConfig {
 
 impl EthConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
-        envy::prefixed("ETH_")
-            .from_env::<Self>()
-            .map_err(ConfigError::from)
+        envy::prefixed("ETH_").from_env::<Self>().map_err(|e| {
+            ConfigError::ConfigDeserializationError {
+                err: e,
+                from: "EthConfig".to_string(),
+            }
+        })
     }
 }

--- a/crates/l2/utils/config/l1_watcher.rs
+++ b/crates/l2/utils/config/l1_watcher.rs
@@ -18,6 +18,9 @@ impl L1WatcherConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
         envy::prefixed("L1_WATCHER_")
             .from_env::<Self>()
-            .map_err(ConfigError::from)
+            .map_err(|e| ConfigError::ConfigDeserializationError {
+                err: e,
+                from: "L1WatcherConfig".to_string(),
+            })
     }
 }

--- a/crates/l2/utils/config/prover_client.rs
+++ b/crates/l2/utils/config/prover_client.rs
@@ -12,6 +12,9 @@ impl ProverClientConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
         envy::prefixed("PROVER_CLIENT_")
             .from_env::<Self>()
-            .map_err(ConfigError::from)
+            .map_err(|e| ConfigError::ConfigDeserializationError {
+                err: e,
+                from: "ProverClientConfig".to_string(),
+            })
     }
 }

--- a/crates/l2/utils/config/prover_server.rs
+++ b/crates/l2/utils/config/prover_server.rs
@@ -7,11 +7,11 @@ use std::net::IpAddr;
 
 #[derive(Clone, Deserialize)]
 pub struct ProverServerConfig {
+    pub l1_address: Address,
+    #[serde(deserialize_with = "secret_key_deserializer")]
+    pub l1_private_key: SecretKey,
     pub listen_ip: IpAddr,
     pub listen_port: u16,
-    pub verifier_address: Address,
-    #[serde(deserialize_with = "secret_key_deserializer")]
-    pub verifier_private_key: SecretKey,
     pub dev_mode: bool,
     pub dev_interval_ms: u64,
 }
@@ -20,6 +20,9 @@ impl ProverServerConfig {
     pub fn from_env() -> Result<Self, ConfigError> {
         envy::prefixed("PROVER_SERVER_")
             .from_env::<Self>()
-            .map_err(ConfigError::from)
+            .map_err(|e| ConfigError::ConfigDeserializationError {
+                err: e,
+                from: "ProverServerConfig".to_string(),
+            })
     }
 }

--- a/crates/l2/utils/config/toml_parser.rs
+++ b/crates/l2/utils/config/toml_parser.rs
@@ -8,8 +8,8 @@ use std::io::Write;
 
 #[derive(Deserialize, Debug)]
 struct Deployer {
-    address: String,
-    private_key: String,
+    l1_address: String,
+    l1_private_key: String,
     risc0_contract_verifier: String,
     sp1_contract_verifier: String,
     pico_contract_verifier: String,
@@ -22,8 +22,8 @@ impl Deployer {
     fn to_env(&self) -> String {
         let prefix = "DEPLOYER";
         format!(
-            "{prefix}_ADDRESS={}
-{prefix}_PRIVATE_KEY={}
+            "{prefix}_L1_ADDRESS={}
+{prefix}_L1_PRIVATE_KEY={}
 {prefix}_RISC0_CONTRACT_VERIFIER={}
 {prefix}_SP1_CONTRACT_VERIFIER={}
 {prefix}_PICO_CONTRACT_VERIFIER={}
@@ -31,8 +31,8 @@ impl Deployer {
 {prefix}_PICO_DEPLOY_VERIFIER={}
 {prefix}_SALT_IS_ZERO={}
 ",
-            self.address,
-            self.private_key,
+            self.l1_address,
+            self.l1_private_key,
             self.risc0_contract_verifier,
             self.sp1_contract_verifier,
             self.pico_contract_verifier,
@@ -129,7 +129,7 @@ struct Committer {
     on_chain_proposer_address: String,
     l1_address: String,
     l1_private_key: String,
-    interval_ms: u64,
+    commit_time_ms: u64,
     arbitrary_base_blob_gas_price: u64,
 }
 
@@ -141,13 +141,13 @@ impl Committer {
 {prefix}_ON_CHAIN_PROPOSER_ADDRESS={}
 {prefix}_L1_ADDRESS={}
 {prefix}_L1_PRIVATE_KEY={}
-{prefix}_INTERVAL_MS={}
+{prefix}_COMMIT_TIME_MS={}
 {prefix}_ARBITRARY_BASE_BLOB_GAS_PRICE={}
 ",
             self.on_chain_proposer_address,
             self.l1_address,
             self.l1_private_key,
-            self.interval_ms,
+            self.commit_time_ms,
             self.arbitrary_base_blob_gas_price,
         )
     }
@@ -177,10 +177,10 @@ SP1_PROVER={}
 
 #[derive(Deserialize, Debug)]
 struct ProverServer {
+    l1_address: String,
+    l1_private_key: String,
     listen_ip: String,
     listen_port: u64,
-    verifier_address: String,
-    verifier_private_key: String,
     dev_mode: bool,
     dev_interval_ms: u64,
 }
@@ -190,17 +190,17 @@ impl ProverServer {
         let prefix = "PROVER_SERVER";
         format!(
             "
+{prefix}_L1_ADDRESS={}
+{prefix}_L1_PRIVATE_KEY={}
 {prefix}_LISTEN_IP={}
 {prefix}_LISTEN_PORT={}
-{prefix}_VERIFIER_ADDRESS={}
-{prefix}_VERIFIER_PRIVATE_KEY={}
 {prefix}_DEV_MODE={}
 {prefix}_DEV_INTERVAL_MS={}
 ",
+            self.l1_address,
+            self.l1_private_key,
             self.listen_ip,
             self.listen_port,
-            self.verifier_address,
-            self.verifier_private_key,
             self.dev_mode,
             self.dev_interval_ms
         )


### PR DESCRIPTION
**Motivation**

We have some inconsistencies with the config variables. The idea is to unify the notation.

**Description**

- Apply the suggested changes in #2350
- Specify within the error message the config that couldn't be parsed. We now have variables with the same name in different configs, making it unclear if some variable wasn't found.
  - Now if the `.env` file doesn't have a expected value the error specifies the config:
   ```
   2025-03-28T17:51:07.923767Z ERROR ethrex_l2::sequencer: Error starting Proposer: Error deserializing config from env: missing value for field l1_private_key. From config: "ProverServerConfig"
   ```

Closes #2350

