### PR TITLE
refactor(l1): abstracted lock for sync manager

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -35,7 +35,7 @@ use tracing::{error, info, warn};
 #[derive(Debug)]
 pub struct Blockchain {
     pub evm_engine: EvmEngine,
-    storage: Store,
+    pub storage: Store,
     pub mempool: Mempool,
 }
 

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -251,7 +251,6 @@ mod tests {
         sync::{Arc, Mutex},
         time::{Duration, Instant},
     };
-    use tokio::sync::Mutex as TokioMutex;
 
     use super::ActiveFilters;
     use crate::{
@@ -448,7 +447,7 @@ mod tests {
             local_p2p_node: example_p2p_node(),
             local_node_record: example_local_node_record(),
             active_filters: filters_pointer.clone(),
-            syncer: Arc::new(TokioMutex::new(SyncManager::dummy())),
+            syncer: Arc::new(SyncManager::dummy()),
             #[cfg(feature = "based")]
             gateway_eth_client: EthClient::new(""),
             #[cfg(feature = "based")]
@@ -520,7 +519,7 @@ mod tests {
             local_node_record: example_local_node_record(),
             jwt_secret: Default::default(),
             active_filters: active_filters.clone(),
-            syncer: Arc::new(TokioMutex::new(SyncManager::dummy())),
+            syncer: Arc::new(SyncManager::dummy()),
             #[cfg(feature = "based")]
             gateway_eth_client: EthClient::new(""),
             #[cfg(feature = "based")]
@@ -557,7 +556,7 @@ mod tests {
             local_node_record: example_local_node_record(),
             active_filters: active_filters.clone(),
             jwt_secret: Default::default(),
-            syncer: Arc::new(TokioMutex::new(SyncManager::dummy())),
+            syncer: Arc::new(SyncManager::dummy()),
             #[cfg(feature = "based")]
             gateway_eth_client: EthClient::new(""),
             #[cfg(feature = "based")]

--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -71,7 +71,6 @@ mod tests {
     use secp256k1::{rand, SecretKey};
     use serde_json::json;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
 
     fn default_context() -> RpcApiContext {
         let storage = setup_store();
@@ -83,7 +82,7 @@ mod tests {
             local_p2p_node: example_p2p_node(),
             local_node_record: example_local_node_record(),
             active_filters: Default::default(),
-            syncer: Arc::new(Mutex::new(SyncManager::dummy())),
+            syncer: Arc::new(SyncManager::dummy()),
             #[cfg(feature = "based")]
             gateway_eth_client: EthClient::new(""),
             #[cfg(feature = "based")]

--- a/crates/networking/rpc/eth/max_priority_fee.rs
+++ b/crates/networking/rpc/eth/max_priority_fee.rs
@@ -54,7 +54,6 @@ mod tests {
     use secp256k1::{rand, SecretKey};
     use serde_json::{json, Value};
     use std::sync::Arc;
-    use tokio::sync::Mutex;
 
     fn default_context() -> RpcApiContext {
         let storage = setup_store();
@@ -66,7 +65,7 @@ mod tests {
             local_p2p_node: example_p2p_node(),
             local_node_record: example_local_node_record(),
             active_filters: Default::default(),
-            syncer: Arc::new(Mutex::new(SyncManager::dummy())),
+            syncer: Arc::new(SyncManager::dummy()),
             #[cfg(feature = "based")]
             gateway_eth_client: EthClient::new(""),
             #[cfg(feature = "based")]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Renamed the current `SyncManger` to `InnerSyncManger` and so that we can hide mutex.
* made storage public for blockchain so the `sync_status()` can be moved from `RpcApiContext` to `SyncManager`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Towards #2282 

