### PR TITLE
docs(l2, l1): fixed dead links

### DIFF
--- a/crates/l2/docs/state_diffs.md
+++ b/crates/l2/docs/state_diffs.md
@@ -1,6 +1,6 @@
 # State diffs
 
-This architecture was inspired by MatterLabs' ZKsync pubdata architecture (see [here](https://github.com/matter-labs/zksync-era/blob/main/docs/specs/data_availability/pubdata.md)).
+This architecture was inspired by MatterLabs' ZKsync pubdata architecture (see [here](https://github.com/matter-labs/zksync-era/blob/main/docs/src/specs/data_availability/pubdata.md)).
 
 To provide data availability for our network, we need to publish enough information on every commit transaction to be able to reconstruct the entire state of the L2 from the beginning by querying the L1.
 

--- a/crates/networking/docs/Network.md
+++ b/crates/networking/docs/Network.md
@@ -19,7 +19,7 @@ At startup, the discovery server launches three concurrent tokio tasks:
 
 Before starting these tasks, we run a [startup](#startup) process to connect to an array of initial nodes.
 
-Before diving into what each task does, first, we need to understand how we are storing our nodes. Nodes are stored in an in-memory matrix which we call a [Kademlia table](https://github.com/lambdaclass/ethrex/blob/main/crates/net/kademlia.rs#L20-L23), though it isn't really a Kademlia table as we don't thoroughly follow the spec but we take it as a reference, you can read more [here](https://en.wikipedia.org/wiki/Kademlia). This table holds:
+Before diving into what each task does, first, we need to understand how we are storing our nodes. Nodes are stored in an in-memory matrix which we call a [Kademlia table](https://github.com/lambdaclass/ethrex/blob/main/crates/networking/p2p/kademlia.rs#L25-L28), though it isn't really a Kademlia table as we don't thoroughly follow the spec but we take it as a reference, you can read more [here](https://en.wikipedia.org/wiki/Kademlia). This table holds:
 
 -   Our `node_id`: `node_id`s are derived from the public key. They are the 64 bytes starting from index 1 of the encoded pub key.
 -   A vector of 256 `bucket`s which holds:


### PR DESCRIPTION
**Motivation**

Dead links negatively impact developer experience and make it harder to understand architectural decisions.

**Description**

I updated two dead documentation links:

1. In `state_diffs.md`:
   - Updated zkSync pubdata architecture reference from:
     `docs/specs/data_availability/pubdata.md`
     to:
     `docs/src/specs/data_availability/pubdata.md`

2. In `Network.md` (ref #639 ):
   - Updated Kademlia table implementation reference from:
     `crates/net/kademlia.rs`
     to:
     `crates/networking/p2p/kademlia.rs`
