### PR TITLE
fix(l1, l2): add "data" as an alias to the tx input field

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2194,7 +2194,7 @@ mod serde_impl {
         pub gas: Option<u64>,
         #[serde(default)]
         pub value: U256,
-        #[serde(default, with = "crate::serde_utils::bytes")]
+        #[serde(default, with = "crate::serde_utils::bytes", alias = "data")]
         pub input: Bytes,
         #[serde(default, with = "crate::serde_utils::u64::hex_str")]
         pub gas_price: u64,


### PR DESCRIPTION
**Motivation**

Our `GenericTransaction` struct calls the field where calldata goes `input`, but some (especially old) eth clients call it `data` instead. This was giving me problems when integrating with some of those clients.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

