### PR TITLE
fix(l1): move on to the next retry if request fails to send on peer handler requests

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     snap::encodable_to_proof,
 };
-use tracing::info;
+use tracing::{debug, info};
 pub const PEER_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 pub const PEER_SELECT_RETRY_ATTEMPTS: usize = 3;
 pub const REQUEST_RETRY_ATTEMPTS: usize = 5;
@@ -96,7 +96,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Eth).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some(block_headers) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -136,7 +139,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Eth).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some(block_bodies) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -178,7 +184,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Eth).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some(receipts) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -229,7 +238,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some((accounts, proof)) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -287,7 +299,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some(codes) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -339,7 +354,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some((mut slots, proof)) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -435,7 +453,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some(nodes) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -504,7 +525,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some(nodes) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {
@@ -566,7 +590,10 @@ impl PeerHandler {
             });
             let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
             let mut receiver = peer.receiver.lock().await;
-            peer.sender.send(request).await.ok()?;
+            if let Err(err) = peer.sender.send(request).await {
+                debug!("Failed to send message to peer: {err}");
+                continue;
+            }
             if let Some((mut slots, proof)) = tokio::time::timeout(PEER_REPLY_TIMEOUT, async move {
                 loop {
                     match receiver.recv().await {


### PR DESCRIPTION
**Motivation**
The PeerHandler contains methods to request all sorts of data from peers and ins used both in snap and full sync. It uses a retry system to ensure that we don't misinterpret a malicious/unsynced peer as the data not being available. If one peer doesn't return the requested data we would try with other peers first before assuming that the data is too old or doesn't exist.
When we sent the requests to the peer, we were not respecting the retry policy and returning a None response upon first failure. This led the synced to believe that data had become stale when it was not the case. This, on multiple occasions, caused the storage fetcher to cease fetching while the state sync was still alive and fetching accounts, leaving a huge backlog of storages to heal after the state sync.
This PR solves this by moving on to the next retry upon a send error instead of aborting the request and returning an empty response
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Continue to the next retry instead of returning None upon a failed `send` in  all `PeerHandler` request methods
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

