### PR TITLE
ci(core): skip loc job on repository forks.

### DIFF
--- a/.github/workflows/ci_loc_pr.yaml
+++ b/.github/workflows/ci_loc_pr.yaml
@@ -8,6 +8,8 @@ jobs:
   report-loc-changes:
     name: Report PR Line Changes
     runs-on: ubuntu-latest
+    # Skip the job if the PR is from a fork since it doesn't have permissions to post comments
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.82.0


### PR DESCRIPTION
**Motivation**
External contributors don't have permissions to post comments programatically. So the LOC doesn't make sense in that case.
