### PR TITLE
fix(levm): fix hive tests regression levm

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -377,14 +377,14 @@ impl LEVM {
 
         let mut vm = vm_from_generic(&tx, env.clone(), db)?;
 
-        vm.execute()?;
+        vm.stateless_execute()?;
         let access_list = build_access_list(&vm.accrued_substate);
 
         // Execute the tx again, now with the created access list.
         tx.access_list = access_list.iter().map(|item| item.into()).collect();
         let mut vm = vm_from_generic(&tx, env.clone(), db)?;
 
-        let report = vm.execute()?;
+        let report = vm.stateless_execute()?;
 
         Ok((report.into(), access_list))
     }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -230,6 +230,14 @@ impl<'a> VM<'a> {
 
         let default_hook: Arc<dyn Hook> = Arc::new(DefaultHook);
         let hooks = vec![default_hook];
+
+        // When instantiating a new vm the current value of the storage slots are actually the original values because it is a new transaction
+        for account in db.cache.values_mut() {
+            for storage_slot in account.storage.values_mut() {
+                storage_slot.original_value = storage_slot.current_value;
+            }
+        }
+
         match to {
             TxKind::Call(address_to) => {
                 default_touched_accounts.insert(address_to);

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -393,6 +393,16 @@ impl<'a> VM<'a> {
         Ok(floor_gas_price)
     }
 
+    /// Executes without making changes to the cache.
+    pub fn stateless_execute(&mut self) -> Result<ExecutionReport, VMError> {
+        let cache_backup = self.db.cache.clone();
+        let report = self.execute()?;
+        // Restore the cache to its original state
+        self.db.cache = cache_backup;
+        Ok(report)
+    }
+
+    /// Main function for executing an external transaction
     pub fn execute(&mut self) -> Result<ExecutionReport, VMError> {
         let mut initial_call_frame = self
             .call_frames


### PR DESCRIPTION
**Motivation**
- Fix hive tests that were failing (tested all RPC tests and they pass)
<!-- Why does this pull request exist? What are its goals? -->

**Description**
- Created `stateless_execute()`, a wrapper of execute() that doesn't alter the state. It actually backs up the cache before executing and then restores it. I know cloning the cache is not ideal but optimizations to that can be performed later. We use this method when creating access list.
- Clear the cache when instantiating a new VM: our storage slots have "original value" and "current value", this is for gas costs, but when executing a new transaction it should happen that all the original values and current values have to be the same. Before the database refactor we were doing this outside of LEVM, now it's embedded in the code!

Update: I'm currently trying to fix the failing test from `ethereum/engine` suite. It is the test with name "Replace Blob Transactions (Cancun) (ethrex)"

Closes #issue_number

