### PR TITLE
ci(core): restrict github job permissions by default.

### DIFF
--- a/.github/workflows/ci_bench_block_execution.yaml
+++ b/.github/workflows/ci_bench_block_execution.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  pull-requests: write
+
 jobs:
   build-binaries:
     if: contains(github.event.pull_request.labels.*.name, 'performance')

--- a/.github/workflows/ci_bench_levm_in_pr.yaml
+++ b/.github/workflows/ci_bench_levm_in_pr.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - "crates/vm/levm/**"
 
+permissions:
+  pull-requests: write
+
 jobs:
   benchmark-pr:
     name: Benchmark for PR
@@ -159,4 +162,3 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: combined_result.md
           edit-mode: replace
-

--- a/.github/workflows/ci_levm.yaml
+++ b/.github/workflows/ci_levm.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci_loc_pr.yaml
+++ b/.github/workflows/ci_loc_pr.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  pull-requests: write
+
 jobs:
   report-loc-changes:
     name: Report PR Line Changes


### PR DESCRIPTION
**Motivation**
Use the principle of least privilege and don't grand write permissions that are then forwarded to potentially malicious actions.


