### PR TITLE
refactor(l1): remove execute_block_without_clearing_state function

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -101,7 +101,7 @@ impl Blockchain {
         // Validate the block pre-execution
         validate_block(block, parent_header, chain_config)?;
 
-        let execution_result = vm.execute_block_without_clearing_state(block)?;
+        let execution_result = vm.execute_block(block)?;
 
         // Validate execution went alright
         validate_gas_used(&execution_result.receipts, &block.header)?;

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -87,27 +87,6 @@ impl Evm {
 
     pub fn execute_block(&mut self, block: &Block) -> Result<BlockExecutionResult, EvmError> {
         match self {
-            Evm::REVM { state } => {
-                let mut state = evm_state(
-                    state
-                        .database()
-                        .ok_or(EvmError::Custom(
-                            "Failed to fetch database from EVM State".to_owned(),
-                        ))?
-                        .clone(),
-                    block.header.parent_hash,
-                );
-                REVM::execute_block(block, &mut state)
-            }
-            Evm::LEVM { db } => LEVM::execute_block(block, db),
-        }
-    }
-
-    pub fn execute_block_without_clearing_state(
-        &mut self,
-        block: &Block,
-    ) -> Result<BlockExecutionResult, EvmError> {
-        match self {
             Evm::REVM { state } => REVM::execute_block(block, state),
             Evm::LEVM { db } => LEVM::execute_block(block, db),
         }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- I deleted `execute_block_without_clearing_state` and changed `execute_block` so that it doesn't create a new state when executing.
- We need to define what should happen to the state in execute_block. For LEVM we have to define what happens to our `db.cache`, if we should clear it or not. 

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

