### PR TITLE
chore(levm): remove unused levm import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,19 +229,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
-dependencies = [
- "alloy-primitives 0.8.23",
- "alloy-rlp",
- "derive_more 1.0.0",
- "k256",
- "serde",
-]
-
-[[package]]
-name = "alloy-eip7702"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
@@ -261,7 +248,7 @@ checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
- "alloy-eip7702 0.5.1",
+ "alloy-eip7702",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde",
@@ -3157,7 +3144,6 @@ dependencies = [
  "libsecp256k1",
  "num-bigint 0.4.6",
  "p256",
- "revm-primitives 14.0.0",
  "ripemd",
  "serde",
  "serde_json",
@@ -7559,31 +7545,12 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3702f132bb484f4f0d0ca4f6fbde3c82cfd745041abbedd6eda67730e1868ef0"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702 0.4.2",
- "alloy-primitives 0.8.23",
- "auto_impl",
- "bitflags 2.9.0",
- "bitvec",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hex",
- "serde",
-]
-
-[[package]]
-name = "revm-primitives"
 version = "15.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702 0.5.1",
+ "alloy-eip7702",
  "alloy-primitives 0.8.23",
  "auto_impl",
  "bitflags 2.9.0",

--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -8,9 +8,6 @@ lazy_static.workspace = true
 ethrex-common.workspace = true
 ethrex-rlp.workspace = true
 derive_more = { version = "1.0.0", features = ["full"] }
-revm-primitives = { version = "14.0.0", features = [
-  "std",
-], default-features = false }
 
 bytes.workspace = true
 keccak-hash.workspace = true

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -1,5 +1,4 @@
 use ethrex_common::{Address, H256, U256};
-pub use revm_primitives::SpecId;
 
 use crate::vm::EVMConfig;
 


### PR DESCRIPTION
**Motivation**

This was the last remnant of revm on the levm codebase and gluecode for ethrex

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

