### PR TITLE
fix(l1): resume sync upon node restart

### DIFF
--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -124,7 +124,7 @@ impl SyncManager {
                 // Edge case: If we are resuming a sync process after a node restart, wait until the next fcu to start
                 if sync_head.is_zero() {
                     info!("Resuming sync after node restart, waiting for next FCU");
-                    sleep(Duration::new(5, 0)).await;
+                    sleep(Duration::from_secs(5)).await;
                     continue;
                 }
                 // Start the sync cycle

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -56,7 +56,7 @@ impl SyncManager {
             store: store.clone(),
         };
         // If the node was in the middle of a sync and then re-started we must resume syncing
-        // Otherwise we will incorreclty asume the node is already synced and work on invalid state
+        // Otherwise we will incorreclty assume the node is already synced and work on invalid state
         if store
             .get_header_download_checkpoint()
             .is_ok_and(|res| res.is_some())

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -6,9 +6,12 @@ use std::sync::{
 use ethrex_blockchain::Blockchain;
 use ethrex_common::H256;
 use ethrex_storage::{error::StoreError, Store};
-use tokio::sync::Mutex;
+use tokio::{
+    sync::Mutex,
+    time::{sleep, Duration},
+};
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{
     kademlia::KademliaTable,
@@ -46,12 +49,21 @@ impl SyncManager {
             cancel_token,
             blockchain,
         )));
-        Self {
+        let sync_manager = Self {
             snap_enabled,
             syncer,
             last_fcu_head: Arc::new(Mutex::new(H256::zero())),
-            store,
+            store: store.clone(),
+        };
+        // If the node was in the middle of a sync and then re-started we must resume syncing
+        // Otherwise we will incorreclty asume the node is already synced and work on invalid state
+        if store
+            .get_header_download_checkpoint()
+            .is_ok_and(|res| res.is_some())
+        {
+            sync_manager.start_sync();
         }
+        sync_manager
     }
 
     /// Creates a dummy SyncManager for tests where syncing is not needed
@@ -109,6 +121,12 @@ impl SyncManager {
                     };
                     *sync_head
                 };
+                // Edge case: If we are resuming a sync process after a node restart, wait until the next fcu to start
+                if sync_head.is_zero() {
+                    info!("Resuming sync after node restart, waiting for next FCU");
+                    sleep(Duration::new(5, 0)).await;
+                    continue;
+                }
                 // Start the sync cycle
                 syncer
                     .start_sync(current_head, sync_head, store.clone())


### PR DESCRIPTION
**Motivation**
After PR #2303 sync cycles are restarted automatically by the same process that started the sync, removing the notion of "pending syncs". This works fine until the node is restarted during the sync.
If the node is restarted, no one is checking whether there was an active sync progress before, and the node continues unknowingly operating on the invalid state left from the unfinished sync.
This PR aims to fix this by resuming the sync process as soon as the sync manager is created
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* When creating the SyncManager, check if there are checkpoints from an active sync process leftover and start the next sync cycle if needed
* in `SyncManager::start_sync` check that the latest fcu head is not the default before starting a cycle and wait around fro the next fcu update if needed
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

