### PR TITLE
feat(levm): add in-memory database for storing database accounts in memory

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -255,6 +255,7 @@ impl LEVM {
 
             account_updates.push(account_update);
         }
+        db.memory_db = HashMap::new(); // Because changes ideally are commited to the database. Only pair with cache.drain()
         Ok(account_updates)
     }
 

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -20,11 +20,16 @@ use super::Database;
 pub struct GeneralizedDatabase {
     pub store: Arc<dyn Database>,
     pub cache: CacheDB,
+    pub memory_db: HashMap<Address, Account>,
 }
 
 impl GeneralizedDatabase {
     pub fn new(store: Arc<dyn Database>, cache: CacheDB) -> Self {
-        Self { store, cache }
+        Self {
+            store,
+            cache,
+            memory_db: HashMap::new(),
+        }
     }
 
     // ================== Account related functions =====================


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- When we get an account from the database we want to store it in memory (it's initial state) so that if we need that information again we have it available and we don't have to hit the db again because that would be slow.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->


Note: This PR supposes #2417 is merged.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Paused for now

