### PR TITLE
ci(l1): skip test job on merge queue.

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -48,6 +48,7 @@ jobs:
   test:
     # "Test" is a required check, don't change the name
     name: Test
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
**Motivation**
Running all spec tests seems overkill for the merge queue, where we mostly care about build/lint, since it's the more likely thing to break.

