### PR TITLE
fix(l1): potential panics in calculations done to show sync progress

### DIFF
--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -258,25 +258,26 @@ impl StateSyncProgress {
         // Copy the current data so we don't read while it is being written
         let data = self.data.lock().await.clone();
         // Calculate the total amount of accounts synced
-        let mut synced_accounts = U256::zero();
+        let mut synced_accounts = U512::zero();
         // Calculate the total amount of accounts synced this cycle
-        let mut synced_accounts_this_cycle = U256::one();
+        let mut synced_accounts_this_cycle = U512::one();
         for i in 0..STATE_TRIE_SEGMENTS {
-            let segment_synced_accounts = data.current_keys[i]
-                .into_uint()
-                .checked_sub(STATE_TRIE_SEGMENTS_START[i].into_uint())
-                .unwrap_or_default();
-            let segment_completion_rate = (U512::from(segment_synced_accounts + 1) * 100)
-                / U512::from(U256::MAX / STATE_TRIE_SEGMENTS);
+            let segment_synced_accounts = U512::from(
+                data.current_keys[i]
+                    .into_uint()
+                    .saturating_sub(STATE_TRIE_SEGMENTS_START[i].into_uint()),
+            );
+            let segment_completion_rate =
+                ((segment_synced_accounts + 1) * 100) / U512::from(U256::MAX / STATE_TRIE_SEGMENTS);
             debug!("Segment {i} completion rate: {segment_completion_rate}%");
-            synced_accounts += segment_synced_accounts;
+            synced_accounts += segment_synced_accounts.into();
             synced_accounts_this_cycle += data.current_keys[i]
                 .into_uint()
-                .checked_sub(data.initial_keys[i].into_uint())
-                .unwrap_or_default();
+                .saturating_sub(data.initial_keys[i].into_uint())
+                .into();
         }
         // Calculate current progress percentage
-        let completion_rate: U512 = (U512::from(synced_accounts) * 100) / U512::from(U256::MAX);
+        let completion_rate: U512 = (synced_accounts * 100) / U512::from(U256::MAX);
         // Make a simple time to finish estimation based on current progress
         // The estimation relies on account hashes being (close to) evenly distributed
         let remaining_accounts =

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -270,7 +270,7 @@ impl StateSyncProgress {
             let segment_completion_rate =
                 ((segment_synced_accounts + 1) * 100) / U512::from(U256::MAX / STATE_TRIE_SEGMENTS);
             debug!("Segment {i} completion rate: {segment_completion_rate}%");
-            synced_accounts += segment_synced_accounts.into();
+            synced_accounts += segment_synced_accounts;
             synced_accounts_this_cycle += data.current_keys[i]
                 .into_uint()
                 .saturating_sub(data.initial_keys[i].into_uint())
@@ -286,7 +286,7 @@ impl StateSyncProgress {
         let time_to_finish_secs =
             U512::from(Instant::now().duration_since(data.cycle_start).as_secs())
                 * remaining_accounts
-                / U512::from(synced_accounts_this_cycle);
+                / synced_accounts_this_cycle;
         info!(
             "Downloading state trie, completion rate: {}%, estimated time to finish: {}",
             completion_rate,

--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -280,7 +280,7 @@ impl StateSyncProgress {
         // Make a simple time to finish estimation based on current progress
         // The estimation relies on account hashes being (close to) evenly distributed
         let remaining_accounts =
-            (U512::from(U256::MAX) / 100) * (U512::from(100) - completion_rate);
+            (U512::from(U256::MAX) / 100) * (U512::from(100).saturating_sub(completion_rate));
         // Time to finish = Time since start / Accounts synced this cycle * Remaining accounts
         let time_to_finish_secs =
             U512::from(Instant::now().duration_since(data.cycle_start).as_secs())

--- a/crates/networking/p2p/sync/trie_rebuild.rs
+++ b/crates/networking/p2p/sync/trie_rebuild.rs
@@ -300,7 +300,7 @@ async fn show_trie_rebuild_progress(
     let completion_rate = (U512::from(accounts_processed + U256::one()) * U512::from(100))
         / U512::from(U256::max_value());
     // Time to finish = Time since start / Accounts processed this cycle * Remaining accounts
-    let remaining_accounts = U256::MAX - accounts_processed;
+    let remaining_accounts = U256::MAX.saturating_sub(accounts_processed);
     let time_to_finish = (U512::from(start_time.elapsed().as_secs())
         * U512::from(remaining_accounts))
         / (U512::from(accounts_processed_this_cycle));


### PR DESCRIPTION
**Motivation**
Some of the calculations done to show the sync progress can overflow under certain conditions. This PR solves them by using safer arithmetic functions and bigger type sizes
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Replace `-` with `saturating_sub` and use `U512` more often when computing state sync & trie rebuild progress'
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

