### PR TITLE
feat(l1): improve rebuild progress tracking

### DIFF
--- a/crates/networking/p2p/sync/trie_rebuild.rs
+++ b/crates/networking/p2p/sync/trie_rebuild.rs
@@ -366,16 +366,18 @@ async fn show_storage_tries_rebuild_progress(
     let rebuilt_storages_count = all_storages_in_queue.saturating_sub(current_storages_in_queue);
     let storage_rebuild_time = total_rebuild_time / (rebuilt_storages_count as u128 + 1);
     // Check if state sync has already finished before reporting estimated finish time
-    let state_sync_finished = if let Ok(Some(checkpoint)) = store.get_state_trie_key_checkpoint() {
-        checkpoint
-            .iter()
-            .enumerate()
-            .all(|(i, checkpoint)| checkpoint == &STATE_TRIE_SEGMENTS_END[i])
-    } else {
-        false
-    };
+    let state_sync_finished =
+        if let Ok(Some(checkpoint)) = store.get_state_trie_key_checkpoint().await {
+            checkpoint
+                .iter()
+                .enumerate()
+                .all(|(i, checkpoint)| checkpoint == &STATE_TRIE_SEGMENTS_END[i])
+        } else {
+            false
+        };
     // Show current speed only as debug data
-    debug!("Rebuilding Storage Tries, average speed: {} milliseconds per storage, currently in queue: {} storages",
+    debug!(
+        "Rebuilding Storage Tries, average speed: {} milliseconds per storage, currently in queue: {} storages",
         storage_rebuild_time, current_storages_in_queue,
     );
     if state_sync_finished {


### PR DESCRIPTION
**Motivation**
Previously, state and storage rebuilding took approximately the same time, so showing state trie rebuild progress was enough to keep the user updated. After some recent changes storage rebuilding is taking a bit longer, making its progress more relevant.
Also, the estimated finish time calculation takes into account all time since start, which means estimations at the start will be abnormally high as time is spent waiting for data to be downloaded instead of pure rebuilding time.
This PR tracks the average speed and remaining storages to rebuild and periodically shows them. It will only show the estimated finish time if the state sync is complete, and it will show the average rebuild speed as debug tracing.
It also counts the time spend rebuilding storages instead of the time that has passed since the rebuild started when performing time estimation
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Periodically show storage tries rebuild stats (speed/remaining for debug, estimated finish time if state sync is finished)
* Count time taken during rebuild instead of total time taken when estimating rebuild finish times
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

