### PR TITLE
fix(l2): reject L2PrivilegedTx from RPC

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -583,6 +583,10 @@ impl RpcHandler for SendRawTransactionRequest {
         let transaction = SendRawTransactionRequest::decode_canonical(&data)
             .map_err(|error| RpcErr::BadParams(error.to_string()))?;
 
+        if matches!(transaction, SendRawTransactionRequest::PrivilegedL2(_)) {
+            return Err(RpcErr::BadParams("Invalid transaction type".to_string()));
+        }
+
         Ok(transaction)
     }
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We need to reject L2Privileged transactions from the RPC, as it will brake the chain.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


