### PR TITLE
fix(core): fix criterion benchmark

### DIFF
--- a/.github/workflows/main_perf_benchmark.yml
+++ b/.github/workflows/main_perf_benchmark.yml
@@ -1,6 +1,7 @@
 name: Block Import Benchmark
 
 on:
+  workflow_call:
   push:
     branches: [main]
 

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -262,7 +262,7 @@ pub fn remove_db(datadir: &str, force: bool) {
     if path.exists() {
         if force {
             std::fs::remove_dir_all(path).expect("Failed to remove data directory");
-            println!("Database removed successfully.");
+            info!("Database removed successfully.");
         } else {
             print!("Are you sure you want to remove the database? (y/n): ");
             io::stdout().flush().unwrap();


### PR DESCRIPTION
**Motivation**

On #2419 the criterion benchmark was broken printing extra lines, which causes the parser to fai.

**Description**

Replaces `println!()` with `info!()` on the non-user-interactive path.
