### PR TITLE
fix(l1,l2): fix lint

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -2,6 +2,7 @@ name: L1
 on:
   push:
     branches: ["main"]
+  merge_group:
   pull_request:
     branches: ["**"]
     paths-ignore:


### PR DESCRIPTION
**Motivation**

In #2360, a commit that failed lint was added. It makes the authentication code dead if l2 or based is enabled, which causes the linter to fail.

**Description**

Instead of using cfg-if, we use cfg! which removes the code later in the pipeline.
