### PR TITLE
refactor(l1): implement code method for RLPxMessage enum and use it for encoding/decoding

### DIFF
--- a/crates/networking/p2p/rlpx/eth/blocks.rs
+++ b/crates/networking/p2p/rlpx/eth/blocks.rs
@@ -75,6 +75,7 @@ pub struct GetBlockHeaders {
 pub const BLOCK_HEADER_LIMIT: u64 = 1024;
 
 impl GetBlockHeaders {
+    pub const CODE: u8 = 0x13;
     pub fn new(id: u64, startblock: HashOrNumber, limit: u64, skip: u64, reverse: bool) -> Self {
         Self {
             id,
@@ -174,6 +175,7 @@ pub struct BlockHeaders {
 }
 
 impl BlockHeaders {
+    pub const CODE: u8 = 0x14;
     pub fn new(id: u64, block_headers: Vec<BlockHeader>) -> Self {
         Self { block_headers, id }
     }
@@ -218,6 +220,7 @@ pub struct GetBlockBodies {
 pub const BLOCK_BODY_LIMIT: usize = 1024;
 
 impl GetBlockBodies {
+    pub const CODE: u8 = 0x15;
     pub fn new(id: u64, block_hashes: Vec<BlockHash>) -> Self {
         Self { block_hashes, id }
     }
@@ -279,6 +282,7 @@ pub struct BlockBodies {
 }
 
 impl BlockBodies {
+    pub const CODE: u8 = 0x16;
     pub fn new(id: u64, block_bodies: Vec<BlockBody>) -> Self {
         Self { block_bodies, id }
     }

--- a/crates/networking/p2p/rlpx/eth/blocks.rs
+++ b/crates/networking/p2p/rlpx/eth/blocks.rs
@@ -75,7 +75,6 @@ pub struct GetBlockHeaders {
 pub const BLOCK_HEADER_LIMIT: u64 = 1024;
 
 impl GetBlockHeaders {
-    pub const CODE: u8 = 0x13;
     pub fn new(id: u64, startblock: HashOrNumber, limit: u64, skip: u64, reverse: bool) -> Self {
         Self {
             id,
@@ -141,6 +140,7 @@ impl GetBlockHeaders {
 }
 
 impl RLPxMessage for GetBlockHeaders {
+    const CODE: u8 = 0x13;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         let limit = self.limit;
@@ -175,13 +175,13 @@ pub struct BlockHeaders {
 }
 
 impl BlockHeaders {
-    pub const CODE: u8 = 0x14;
     pub fn new(id: u64, block_headers: Vec<BlockHeader>) -> Self {
         Self { block_headers, id }
     }
 }
 
 impl RLPxMessage for BlockHeaders {
+    const CODE: u8 = 0x14;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Each message is encoded with its own
@@ -220,7 +220,6 @@ pub struct GetBlockBodies {
 pub const BLOCK_BODY_LIMIT: usize = 1024;
 
 impl GetBlockBodies {
-    pub const CODE: u8 = 0x15;
     pub fn new(id: u64, block_hashes: Vec<BlockHash>) -> Self {
         Self { block_hashes, id }
     }
@@ -250,6 +249,7 @@ impl GetBlockBodies {
 }
 
 impl RLPxMessage for GetBlockBodies {
+    const CODE: u8 = 0x15;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -282,13 +282,13 @@ pub struct BlockBodies {
 }
 
 impl BlockBodies {
-    pub const CODE: u8 = 0x16;
     pub fn new(id: u64, block_bodies: Vec<BlockBody>) -> Self {
         Self { block_bodies, id }
     }
 }
 
 impl RLPxMessage for BlockBodies {
+    const CODE: u8 = 0x16;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/eth/receipts.rs
+++ b/crates/networking/p2p/rlpx/eth/receipts.rs
@@ -19,13 +19,13 @@ pub(crate) struct GetReceipts {
 }
 
 impl GetReceipts {
-    pub const CODE: u8 = 0x1F;
     pub fn new(id: u64, block_hashes: Vec<BlockHash>) -> Self {
         Self { block_hashes, id }
     }
 }
 
 impl RLPxMessage for GetReceipts {
+    const CODE: u8 = 0x1F;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -58,13 +58,14 @@ pub(crate) struct Receipts {
 }
 
 impl Receipts {
-    pub const CODE: u8 = 0x20;
     pub fn new(id: u64, receipts: Vec<Vec<Receipt>>) -> Self {
         Self { receipts, id }
     }
 }
 
 impl RLPxMessage for Receipts {
+    const CODE: u8 = 0x20;
+
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/eth/receipts.rs
+++ b/crates/networking/p2p/rlpx/eth/receipts.rs
@@ -19,6 +19,7 @@ pub(crate) struct GetReceipts {
 }
 
 impl GetReceipts {
+    pub const CODE: u8 = 0x1F;
     pub fn new(id: u64, block_hashes: Vec<BlockHash>) -> Self {
         Self { block_hashes, id }
     }
@@ -57,6 +58,7 @@ pub(crate) struct Receipts {
 }
 
 impl Receipts {
+    pub const CODE: u8 = 0x20;
     pub fn new(id: u64, receipts: Vec<Vec<Receipt>>) -> Self {
         Self { receipts, id }
     }

--- a/crates/networking/p2p/rlpx/eth/status.rs
+++ b/crates/networking/p2p/rlpx/eth/status.rs
@@ -22,11 +22,8 @@ pub(crate) struct StatusMessage {
     pub(crate) fork_id: ForkId,
 }
 
-impl StatusMessage {
-    pub const CODE: u8 = 0x10;
-}
-
 impl RLPxMessage for StatusMessage {
+    const CODE: u8 = 0x10;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/eth/status.rs
+++ b/crates/networking/p2p/rlpx/eth/status.rs
@@ -22,6 +22,10 @@ pub(crate) struct StatusMessage {
     pub(crate) fork_id: ForkId,
 }
 
+impl StatusMessage {
+    pub const CODE: u8 = 0x10;
+}
+
 impl RLPxMessage for StatusMessage {
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -27,6 +27,7 @@ pub(crate) struct Transactions {
 }
 
 impl Transactions {
+    pub const CODE: u8 = 0x12;
     pub fn new(transactions: Vec<Transaction>) -> Self {
         Self { transactions }
     }
@@ -72,6 +73,7 @@ pub(crate) struct NewPooledTransactionHashes {
 }
 
 impl NewPooledTransactionHashes {
+    pub const CODE: u8 = 0x18;
     pub fn new(
         transactions: Vec<Transaction>,
         blockchain: &Blockchain,
@@ -168,6 +170,7 @@ pub(crate) struct GetPooledTransactions {
 }
 
 impl GetPooledTransactions {
+    pub const CODE: u8 = 0x19;
     pub fn new(id: u64, transaction_hashes: Vec<H256>) -> Self {
         Self {
             transaction_hashes,
@@ -263,6 +266,7 @@ pub(crate) struct PooledTransactions {
 }
 
 impl PooledTransactions {
+    pub const CODE: u8 = 0x1A;
     pub fn new(id: u64, pooled_transactions: Vec<P2PTransaction>) -> Self {
         Self {
             pooled_transactions,

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -27,13 +27,13 @@ pub(crate) struct Transactions {
 }
 
 impl Transactions {
-    pub const CODE: u8 = 0x12;
     pub fn new(transactions: Vec<Transaction>) -> Self {
         Self { transactions }
     }
 }
 
 impl RLPxMessage for Transactions {
+    const CODE: u8 = 0x12;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         let mut encoder = Encoder::new(&mut encoded_data);
@@ -73,7 +73,6 @@ pub(crate) struct NewPooledTransactionHashes {
 }
 
 impl NewPooledTransactionHashes {
-    pub const CODE: u8 = 0x18;
     pub fn new(
         transactions: Vec<Transaction>,
         blockchain: &Blockchain,
@@ -122,6 +121,7 @@ impl NewPooledTransactionHashes {
 }
 
 impl RLPxMessage for NewPooledTransactionHashes {
+    const CODE: u8 = 0x18;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -170,7 +170,6 @@ pub(crate) struct GetPooledTransactions {
 }
 
 impl GetPooledTransactions {
-    pub const CODE: u8 = 0x19;
     pub fn new(id: u64, transaction_hashes: Vec<H256>) -> Self {
         Self {
             transaction_hashes,
@@ -234,6 +233,7 @@ impl GetPooledTransactions {
 }
 
 impl RLPxMessage for GetPooledTransactions {
+    const CODE: u8 = 0x19;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -266,7 +266,6 @@ pub(crate) struct PooledTransactions {
 }
 
 impl PooledTransactions {
-    pub const CODE: u8 = 0x1A;
     pub fn new(id: u64, pooled_transactions: Vec<P2PTransaction>) -> Self {
         Self {
             pooled_transactions,
@@ -298,6 +297,7 @@ impl PooledTransactions {
 }
 
 impl RLPxMessage for PooledTransactions {
+    const CODE: u8 = 0x1A;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/message.rs
+++ b/crates/networking/p2p/rlpx/message.rs
@@ -17,6 +17,8 @@ use super::snap::{
 use ethrex_rlp::encode::RLPEncode;
 
 pub trait RLPxMessage: Sized {
+    const CODE: u8;
+
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError>;
 
     fn decode(msg_data: &[u8]) -> Result<Self, RLPDecodeError>;

--- a/crates/networking/p2p/rlpx/message.rs
+++ b/crates/networking/p2p/rlpx/message.rs
@@ -51,12 +51,39 @@ pub(crate) enum Message {
 }
 
 impl Message {
-    pub fn decode(msg_id: u8, msg_data: &[u8]) -> Result<Message, RLPDecodeError> {
+    pub const fn code(&self) -> u8 {
+        match self {
+            Message::Hello(_) => HelloMessage::CODE,
+            Message::Disconnect(_) => DisconnectMessage::CODE,
+            Message::Ping(_) => PingMessage::CODE,
+            Message::Pong(_) => PongMessage::CODE,
+            Message::Status(_) => StatusMessage::CODE,
+            Message::GetBlockHeaders(_) => GetBlockHeaders::CODE,
+            Message::BlockHeaders(_) => BlockHeaders::CODE,
+            Message::Transactions(_) => Transactions::CODE,
+            Message::GetBlockBodies(_) => GetBlockBodies::CODE,
+            Message::BlockBodies(_) => BlockBodies::CODE,
+            Message::GetReceipts(_) => GetReceipts::CODE,
+            Message::Receipts(_) => Receipts::CODE,
+            Message::NewPooledTransactionHashes(_) => NewPooledTransactionHashes::CODE,
+            Message::GetPooledTransactions(_) => GetPooledTransactions::CODE,
+            Message::PooledTransactions(_) => PooledTransactions::CODE,
+            Message::GetAccountRange(_) => GetAccountRange::CODE,
+            Message::AccountRange(_) => AccountRange::CODE,
+            Message::GetStorageRanges(_) => GetStorageRanges::CODE,
+            Message::StorageRanges(_) => StorageRanges::CODE,
+            Message::GetByteCodes(_) => GetByteCodes::CODE,
+            Message::ByteCodes(_) => ByteCodes::CODE,
+            Message::GetTrieNodes(_) => GetTrieNodes::CODE,
+            Message::TrieNodes(_) => TrieNodes::CODE,
+        }
+    }
+    pub fn decode(msg_id: u8, data: &[u8]) -> Result<Message, RLPDecodeError> {
         match msg_id {
-            0x00 => Ok(Message::Hello(HelloMessage::decode(msg_data)?)),
-            0x01 => Ok(Message::Disconnect(DisconnectMessage::decode(msg_data)?)),
-            0x02 => Ok(Message::Ping(PingMessage::decode(msg_data)?)),
-            0x03 => Ok(Message::Pong(PongMessage::decode(msg_data)?)),
+            HelloMessage::CODE => Ok(Message::Hello(HelloMessage::decode(data)?)),
+            DisconnectMessage::CODE => Ok(Message::Disconnect(DisconnectMessage::decode(data)?)),
+            PingMessage::CODE => Ok(Message::Ping(PingMessage::decode(data)?)),
+            PongMessage::CODE => Ok(Message::Pong(PongMessage::decode(data)?)),
             // Subprotocols like 'eth' use offsets to identify
             // themselves, the eth capability starts
             // at 0x10 (16), the status message
@@ -67,131 +94,63 @@ impl Message {
             // References:
             // - https://ethereum.stackexchange.com/questions/37051/ethereum-network-messaging
             // - https://github.com/ethereum/devp2p/blob/master/caps/eth.md#status-0x00
-            0x10 => Ok(Message::Status(StatusMessage::decode(msg_data)?)),
-            0x12 => Ok(Message::Transactions(Transactions::decode(msg_data)?)),
-            0x13 => Ok(Message::GetBlockHeaders(GetBlockHeaders::decode(msg_data)?)),
-            0x14 => Ok(Message::BlockHeaders(BlockHeaders::decode(msg_data)?)),
-            0x15 => Ok(Message::GetBlockBodies(GetBlockBodies::decode(msg_data)?)),
-            0x16 => Ok(Message::BlockBodies(BlockBodies::decode(msg_data)?)),
-            0x18 => Ok(Message::NewPooledTransactionHashes(
-                NewPooledTransactionHashes::decode(msg_data)?,
+            StatusMessage::CODE => Ok(Message::Status(StatusMessage::decode(data)?)),
+            Transactions::CODE => Ok(Message::Transactions(Transactions::decode(data)?)),
+            GetBlockHeaders::CODE => Ok(Message::GetBlockHeaders(GetBlockHeaders::decode(data)?)),
+            BlockHeaders::CODE => Ok(Message::BlockHeaders(BlockHeaders::decode(data)?)),
+            GetBlockBodies::CODE => Ok(Message::GetBlockBodies(GetBlockBodies::decode(data)?)),
+            BlockBodies::CODE => Ok(Message::BlockBodies(BlockBodies::decode(data)?)),
+            NewPooledTransactionHashes::CODE => Ok(Message::NewPooledTransactionHashes(
+                NewPooledTransactionHashes::decode(data)?,
             )),
-            0x19 => Ok(Message::GetPooledTransactions(
-                GetPooledTransactions::decode(msg_data)?,
+            GetPooledTransactions::CODE => Ok(Message::GetPooledTransactions(
+                GetPooledTransactions::decode(data)?,
             )),
-            0x1a => Ok(Message::PooledTransactions(PooledTransactions::decode(
-                msg_data,
-            )?)),
-            0x1F => Ok(Message::GetReceipts(GetReceipts::decode(msg_data)?)),
-            0x20 => Ok(Message::Receipts(Receipts::decode(msg_data)?)),
-            0x21 => Ok(Message::GetAccountRange(GetAccountRange::decode(msg_data)?)),
-            0x22 => Ok(Message::AccountRange(AccountRange::decode(msg_data)?)),
-            0x23 => Ok(Message::GetStorageRanges(GetStorageRanges::decode(
-                msg_data,
-            )?)),
-            0x24 => Ok(Message::StorageRanges(StorageRanges::decode(msg_data)?)),
-            0x25 => Ok(Message::GetByteCodes(GetByteCodes::decode(msg_data)?)),
-            0x26 => Ok(Message::ByteCodes(ByteCodes::decode(msg_data)?)),
-            0x27 => Ok(Message::GetTrieNodes(GetTrieNodes::decode(msg_data)?)),
-            0x28 => Ok(Message::TrieNodes(TrieNodes::decode(msg_data)?)),
+            PooledTransactions::CODE => Ok(Message::PooledTransactions(
+                PooledTransactions::decode(data)?,
+            )),
+            GetReceipts::CODE => Ok(Message::GetReceipts(GetReceipts::decode(data)?)),
+            Receipts::CODE => Ok(Message::Receipts(Receipts::decode(data)?)),
+            GetAccountRange::CODE => Ok(Message::GetAccountRange(GetAccountRange::decode(data)?)),
+            AccountRange::CODE => Ok(Message::AccountRange(AccountRange::decode(data)?)),
+            GetStorageRanges::CODE => {
+                Ok(Message::GetStorageRanges(GetStorageRanges::decode(data)?))
+            }
+            StorageRanges::CODE => Ok(Message::StorageRanges(StorageRanges::decode(data)?)),
+            GetByteCodes::CODE => Ok(Message::GetByteCodes(GetByteCodes::decode(data)?)),
+            ByteCodes::CODE => Ok(Message::ByteCodes(ByteCodes::decode(data)?)),
+            GetTrieNodes::CODE => Ok(Message::GetTrieNodes(GetTrieNodes::decode(data)?)),
+            TrieNodes::CODE => Ok(Message::TrieNodes(TrieNodes::decode(data)?)),
             _ => Err(RLPDecodeError::MalformedData),
         }
     }
 
     pub fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
+        self.code().encode(buf);
         match self {
-            Message::Hello(msg) => {
-                0x00_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::Disconnect(msg) => {
-                0x01_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::Ping(msg) => {
-                0x02_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::Pong(msg) => {
-                0x03_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::Status(msg) => {
-                0x10_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::Transactions(msg) => {
-                0x12_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetBlockHeaders(msg) => {
-                0x13_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::BlockHeaders(msg) => {
-                0x14_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetBlockBodies(msg) => {
-                0x15_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::BlockBodies(msg) => {
-                0x16_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::NewPooledTransactionHashes(msg) => {
-                0x18_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetPooledTransactions(msg) => {
-                0x19_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::PooledTransactions(msg) => {
-                0x1a_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetReceipts(msg) => {
-                0x1F_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::Receipts(msg) => {
-                0x20_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetAccountRange(msg) => {
-                0x21_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::AccountRange(msg) => {
-                0x22_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetStorageRanges(msg) => {
-                0x23_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::StorageRanges(msg) => {
-                0x24_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetByteCodes(msg) => {
-                0x25_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::ByteCodes(msg) => {
-                0x26_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::GetTrieNodes(msg) => {
-                0x27_u8.encode(buf);
-                msg.encode(buf)
-            }
-            Message::TrieNodes(msg) => {
-                0x28_u8.encode(buf);
-                msg.encode(buf)
-            }
+            Message::Hello(msg) => msg.encode(buf),
+            Message::Disconnect(msg) => msg.encode(buf),
+            Message::Ping(msg) => msg.encode(buf),
+            Message::Pong(msg) => msg.encode(buf),
+            Message::Status(msg) => msg.encode(buf),
+            Message::Transactions(msg) => msg.encode(buf),
+            Message::GetBlockHeaders(msg) => msg.encode(buf),
+            Message::BlockHeaders(msg) => msg.encode(buf),
+            Message::GetBlockBodies(msg) => msg.encode(buf),
+            Message::BlockBodies(msg) => msg.encode(buf),
+            Message::NewPooledTransactionHashes(msg) => msg.encode(buf),
+            Message::GetPooledTransactions(msg) => msg.encode(buf),
+            Message::PooledTransactions(msg) => msg.encode(buf),
+            Message::GetReceipts(msg) => msg.encode(buf),
+            Message::Receipts(msg) => msg.encode(buf),
+            Message::GetAccountRange(msg) => msg.encode(buf),
+            Message::AccountRange(msg) => msg.encode(buf),
+            Message::GetStorageRanges(msg) => msg.encode(buf),
+            Message::StorageRanges(msg) => msg.encode(buf),
+            Message::GetByteCodes(msg) => msg.encode(buf),
+            Message::ByteCodes(msg) => msg.encode(buf),
+            Message::GetTrieNodes(msg) => msg.encode(buf),
+            Message::TrieNodes(msg) => msg.encode(buf),
         }
     }
 }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -53,6 +53,7 @@ pub(crate) struct HelloMessage {
 }
 
 impl HelloMessage {
+    pub const CODE: u8 = 0x00;
     pub fn new(capabilities: Vec<(Capability, u8)>, node_id: PublicKey) -> Self {
         Self {
             capabilities,
@@ -183,6 +184,7 @@ pub(crate) struct DisconnectMessage {
 }
 
 impl DisconnectMessage {
+    pub const CODE: u8 = 0x01;
     pub fn new(reason: Option<DisconnectReason>) -> Self {
         Self { reason }
     }
@@ -238,6 +240,7 @@ impl RLPxMessage for DisconnectMessage {
 pub(crate) struct PingMessage {}
 
 impl PingMessage {
+    pub const CODE: u8 = 0x02;
     pub fn new() -> Self {
         Self {}
     }
@@ -268,6 +271,7 @@ impl RLPxMessage for PingMessage {
 pub(crate) struct PongMessage {}
 
 impl PongMessage {
+    pub const CODE: u8 = 0x03;
     pub fn new() -> Self {
         Self {}
     }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -53,7 +53,6 @@ pub(crate) struct HelloMessage {
 }
 
 impl HelloMessage {
-    pub const CODE: u8 = 0x00;
     pub fn new(capabilities: Vec<(Capability, u8)>, node_id: PublicKey) -> Self {
         Self {
             capabilities,
@@ -63,6 +62,7 @@ impl HelloMessage {
 }
 
 impl RLPxMessage for HelloMessage {
+    const CODE: u8 = 0x00;
     fn encode(&self, mut buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         Encoder::new(&mut buf)
             .encode_field(&5_u8) // protocolVersion
@@ -184,7 +184,6 @@ pub(crate) struct DisconnectMessage {
 }
 
 impl DisconnectMessage {
-    pub const CODE: u8 = 0x01;
     pub fn new(reason: Option<DisconnectReason>) -> Self {
         Self { reason }
     }
@@ -197,6 +196,7 @@ impl DisconnectMessage {
 }
 
 impl RLPxMessage for DisconnectMessage {
+    const CODE: u8 = 0x01;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Disconnect msg_data is reason or none
@@ -239,14 +239,8 @@ impl RLPxMessage for DisconnectMessage {
 #[derive(Debug)]
 pub(crate) struct PingMessage {}
 
-impl PingMessage {
-    pub const CODE: u8 = 0x02;
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
 impl RLPxMessage for PingMessage {
+    const CODE: u8 = 0x02;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Ping msg_data is only []
@@ -263,21 +257,15 @@ impl RLPxMessage for PingMessage {
         let result = decoder.finish_unchecked();
         let empty: &[u8] = &[];
         assert_eq!(result, empty, "Ping msg_data should be &[]");
-        Ok(Self::new())
+        Ok(Self {})
     }
 }
 
 #[derive(Debug)]
 pub(crate) struct PongMessage {}
 
-impl PongMessage {
-    pub const CODE: u8 = 0x03;
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
 impl RLPxMessage for PongMessage {
+    const CODE: u8 = 0x03;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Pong msg_data is only []
@@ -294,6 +282,6 @@ impl RLPxMessage for PongMessage {
         let result = decoder.finish_unchecked();
         let empty: &[u8] = &[];
         assert_eq!(result, empty, "Pong msg_data should be &[]");
-        Ok(Self::new())
+        Ok(Self {})
     }
 }

--- a/crates/networking/p2p/rlpx/snap.rs
+++ b/crates/networking/p2p/rlpx/snap.rs
@@ -26,20 +26,12 @@ pub(crate) struct GetAccountRange {
     pub response_bytes: u64,
 }
 
-impl GetAccountRange {
-    pub const CODE: u8 = 0x21;
-}
-
 #[derive(Debug)]
 pub(crate) struct AccountRange {
     // id is a u64 chosen by the requesting peer, the responding peer must mirror the value for the response
     pub id: u64,
     pub accounts: Vec<AccountRangeUnit>,
     pub proof: Vec<Bytes>,
-}
-
-impl AccountRange {
-    pub const CODE: u8 = 0x22;
 }
 
 #[derive(Debug)]
@@ -52,19 +44,11 @@ pub(crate) struct GetStorageRanges {
     pub response_bytes: u64,
 }
 
-impl GetStorageRanges {
-    pub const CODE: u8 = 0x23;
-}
-
 #[derive(Debug)]
 pub(crate) struct StorageRanges {
     pub id: u64,
     pub slots: Vec<Vec<StorageSlot>>,
     pub proof: Vec<Bytes>,
-}
-
-impl StorageRanges {
-    pub const CODE: u8 = 0x24;
 }
 
 #[derive(Debug)]
@@ -74,18 +58,10 @@ pub(crate) struct GetByteCodes {
     pub bytes: u64,
 }
 
-impl GetByteCodes {
-    pub const CODE: u8 = 0x25;
-}
-
 #[derive(Debug)]
 pub(crate) struct ByteCodes {
     pub id: u64,
     pub codes: Vec<Bytes>,
-}
-
-impl ByteCodes {
-    pub const CODE: u8 = 0x26;
 }
 
 #[derive(Debug)]
@@ -98,21 +74,14 @@ pub(crate) struct GetTrieNodes {
     pub bytes: u64,
 }
 
-impl GetTrieNodes {
-    pub const CODE: u8 = 0x27;
-}
-
 #[derive(Debug)]
 pub(crate) struct TrieNodes {
     pub id: u64,
     pub nodes: Vec<Bytes>,
 }
 
-impl TrieNodes {
-    pub const CODE: u8 = 0x28;
-}
-
 impl RLPxMessage for GetAccountRange {
+    const CODE: u8 = 0x21;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -149,6 +118,7 @@ impl RLPxMessage for GetAccountRange {
 }
 
 impl RLPxMessage for AccountRange {
+    const CODE: u8 = 0x22;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -179,6 +149,7 @@ impl RLPxMessage for AccountRange {
 }
 
 impl RLPxMessage for GetStorageRanges {
+    const CODE: u8 = 0x23;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -224,6 +195,7 @@ impl RLPxMessage for GetStorageRanges {
 }
 
 impl RLPxMessage for StorageRanges {
+    const CODE: u8 = 0x24;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -250,6 +222,7 @@ impl RLPxMessage for StorageRanges {
 }
 
 impl RLPxMessage for GetByteCodes {
+    const CODE: u8 = 0x25;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -276,6 +249,7 @@ impl RLPxMessage for GetByteCodes {
 }
 
 impl RLPxMessage for ByteCodes {
+    const CODE: u8 = 0x26;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -300,6 +274,7 @@ impl RLPxMessage for ByteCodes {
 }
 
 impl RLPxMessage for GetTrieNodes {
+    const CODE: u8 = 0x27;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -333,6 +308,7 @@ impl RLPxMessage for GetTrieNodes {
 }
 
 impl RLPxMessage for TrieNodes {
+    const CODE: u8 = 0x28;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/snap.rs
+++ b/crates/networking/p2p/rlpx/snap.rs
@@ -26,12 +26,20 @@ pub(crate) struct GetAccountRange {
     pub response_bytes: u64,
 }
 
+impl GetAccountRange {
+    pub const CODE: u8 = 0x21;
+}
+
 #[derive(Debug)]
 pub(crate) struct AccountRange {
     // id is a u64 chosen by the requesting peer, the responding peer must mirror the value for the response
     pub id: u64,
     pub accounts: Vec<AccountRangeUnit>,
     pub proof: Vec<Bytes>,
+}
+
+impl AccountRange {
+    pub const CODE: u8 = 0x22;
 }
 
 #[derive(Debug)]
@@ -44,11 +52,19 @@ pub(crate) struct GetStorageRanges {
     pub response_bytes: u64,
 }
 
+impl GetStorageRanges {
+    pub const CODE: u8 = 0x23;
+}
+
 #[derive(Debug)]
 pub(crate) struct StorageRanges {
     pub id: u64,
     pub slots: Vec<Vec<StorageSlot>>,
     pub proof: Vec<Bytes>,
+}
+
+impl StorageRanges {
+    pub const CODE: u8 = 0x24;
 }
 
 #[derive(Debug)]
@@ -58,10 +74,18 @@ pub(crate) struct GetByteCodes {
     pub bytes: u64,
 }
 
+impl GetByteCodes {
+    pub const CODE: u8 = 0x25;
+}
+
 #[derive(Debug)]
 pub(crate) struct ByteCodes {
     pub id: u64,
     pub codes: Vec<Bytes>,
+}
+
+impl ByteCodes {
+    pub const CODE: u8 = 0x26;
 }
 
 #[derive(Debug)]
@@ -74,10 +98,18 @@ pub(crate) struct GetTrieNodes {
     pub bytes: u64,
 }
 
+impl GetTrieNodes {
+    pub const CODE: u8 = 0x27;
+}
+
 #[derive(Debug)]
 pub(crate) struct TrieNodes {
     pub id: u64,
     pub nodes: Vec<Bytes>,
+}
+
+impl TrieNodes {
+    pub const CODE: u8 = 0x28;
 }
 
 impl RLPxMessage for GetAccountRange {


### PR DESCRIPTION
**Motivation**
Implements the refactor specified in the linked issues. Adding a single `code` method for the RLPxMessage enum was not enough for both encoding and decoding (as we would need to create the struct to call the method) so an associated constant was also added to support both needs.
This solution fulfills the purpose of the issue, to have only one instance of each message code that we can use for encoding/decoding of messages, but its implementation is more complex than what we would have liked. If the complexity is not acceptable, we should close both this PR and the originating issue.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Implement `code` method for `RLPxMessage`
* Add `CODE` associated constant to `RLPxEncode` trait
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1035  (Also #1034)

