### PR TITLE
feat(l1): show healing in progress message at set intervals

### DIFF
--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -8,7 +8,7 @@
 //! This process will stop once it has fixed all trie inconsistencies or when the pivot becomes stale, in which case it can be resumed on the next cycle
 //! All healed accounts will also have their bytecodes and storages healed by the corresponding processes
 
-use std::cmp::min;
+use std::{cmp::min, time::Instant};
 
 use ethrex_common::{
     types::{AccountState, EMPTY_KECCACK_HASH},
@@ -24,7 +24,7 @@ use crate::{
     peer_handler::PeerHandler,
     sync::{
         bytecode_fetcher, node_missing_children, MAX_CHANNEL_MESSAGES, MAX_PARALLEL_FETCHES,
-        NODE_BATCH_SIZE,
+        NODE_BATCH_SIZE, SHOW_PROGRESS_INTERVAL_DURATION,
     },
 };
 
@@ -47,7 +47,12 @@ pub(crate) async fn heal_state_trie(
     ));
     // Add the current state trie root to the pending paths
     paths.push(Nibbles::default());
+    let mut last_update = Instant::now();
     while !paths.is_empty() {
+        if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
+            last_update = Instant::now();
+            info!("State Healing in Progress, pending paths: {}", paths.len());
+        }
         // Spawn multiple parallel requests
         let mut state_tasks = tokio::task::JoinSet::new();
         for _ in 0..MAX_PARALLEL_FETCHES {

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -18,7 +18,7 @@ use ethrex_rlp::decode::RLPDecode;
 use ethrex_storage::Store;
 use ethrex_trie::{Nibbles, Node, EMPTY_TRIE_HASH};
 use tokio::sync::mpsc::{channel, Sender};
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::{
     peer_handler::PeerHandler,

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -41,7 +41,10 @@ pub(crate) async fn storage_healer(
     while !(stale || cancel_token.is_cancelled()) {
         if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             last_update = Instant::now();
-            info!("Storage Healing in Progress, storages queued: {}", pending_paths.len());
+            info!(
+                "Storage Healing in Progress, storages queued: {}",
+                pending_paths.len()
+            );
         }
         // If we have few storages in queue, fetch more from the store
         // We won't be retrieving all of them as the read can become quite long and we may not end up using all of the paths in this cycle

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -10,8 +10,9 @@ use std::collections::BTreeMap;
 use ethrex_common::H256;
 use ethrex_storage::Store;
 use ethrex_trie::{Nibbles, EMPTY_TRIE_HASH};
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::{peer_handler::PeerHandler, sync::node_missing_children};
 
@@ -19,7 +20,7 @@ use crate::{peer_handler::PeerHandler, sync::node_missing_children};
 /// More paths will be read from the Store if the amount goes below this value
 const MINUMUM_STORAGES_IN_QUEUE: usize = 400;
 
-use super::{SyncError, MAX_PARALLEL_FETCHES, NODE_BATCH_SIZE};
+use super::{SyncError, MAX_PARALLEL_FETCHES, NODE_BATCH_SIZE, SHOW_PROGRESS_INTERVAL_DURATION};
 
 /// Waits for incoming hashed addresses from the receiver channel endpoint and queues the associated root nodes for state retrieval
 /// Also retrieves their children nodes until we have the full storage trie stored
@@ -36,7 +37,12 @@ pub(crate) async fn storage_healer(
     // The pivot may become stale while the fetcher is active, we will still keep the process
     // alive until the end signal so we don't lose queued messages
     let mut stale = false;
+    let mut last_update = Instant::now();
     while !(stale || cancel_token.is_cancelled()) {
+        if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
+            last_update = Instant::now();
+            info!("Storage Healing in Progress, storages queued: {}", pending_paths.len());
+        }
         // If we have few storages in queue, fetch more from the store
         // We won't be retrieving all of them as the read can become quite long and we may not end up using all of the paths in this cycle
         if pending_paths.len() < MINUMUM_STORAGES_IN_QUEUE {


### PR DESCRIPTION
**Motivation**
We are not able to perform estimations on when healing will end, but we should also not stay completely silent while healing takes place, as this is not very user-friendly.
This PR aims to add messages to inform wether state and storage healing are taking place, at the same pace as we show state sync and rebuild progress. For state sync, pending paths will be shown. These can give an insight on the progress, as the amount of paths will continuously increase as we progress through the trie, but will start gradually decreasing as we near the end of healing. For storages it is a slightly different story as we don't have the full number of pending storages available for showing so we only show the storages currently in the queue.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Periodically show amount of paths left during State Healing
* Periodically show storages in queue during Storage Healing
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


