### PR TITLE
fix(l1): don't cancel storage healer if state healing ends earlier

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -599,11 +599,14 @@ impl Syncer {
         // Spawn storage healer earlier so we can start healing stale storages
         // Create a cancellation token so we can end the storage healer when finished, make it a child so that it also ends upon shutdown
         let storage_healer_cancell_token = self.cancel_token.child_token();
+        // Create an AtomicBool to signal to the storage healer whether state healing has ended
+        let state_healing_ended = Arc::new(AtomicBool::new(false));
         let storage_healer_handler = tokio::spawn(storage_healer(
             state_root,
             self.peers.clone(),
             store.clone(),
             storage_healer_cancell_token.clone(),
+            state_healing_ended.clone()
         ));
         // Perform state sync if it was not already completed on a previous cycle
         // Retrieve storage data to check which snap sync phase we are in
@@ -650,7 +653,11 @@ impl Syncer {
         let state_heal_complete =
             heal_state_trie(state_root, store.clone(), self.peers.clone()).await?;
         // Wait for storage healer to end
-        storage_healer_cancell_token.cancel();
+        if state_heal_complete {
+            state_healing_ended.store(true, Ordering::Relaxed);
+        } else {
+            storage_healer_cancell_token.cancel();
+        }
         let storage_heal_complete = storage_healer_handler.await??;
         if !(state_heal_complete && storage_heal_complete) {
             warn!("Stale pivot, aborting healing");

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -606,7 +606,7 @@ impl Syncer {
             self.peers.clone(),
             store.clone(),
             storage_healer_cancell_token.clone(),
-            state_healing_ended.clone()
+            state_healing_ended.clone(),
         ));
         // Perform state sync if it was not already completed on a previous cycle
         // Retrieve storage data to check which snap sync phase we are in

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -5,7 +5,7 @@
 //! For each storage received, the process will first queue their root nodes and then queue all the missing children from each node fetched in the same way as state healing
 //! Even if the pivot becomes stale, the healer will remain active and listening until a termination signal (an empty batch) is received
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::{atomic::{AtomicBool, Ordering}, Arc}};
 
 use ethrex_common::H256;
 use ethrex_storage::Store;
@@ -30,11 +30,10 @@ pub(crate) async fn storage_healer(
     peers: PeerHandler,
     store: Store,
     cancel_token: CancellationToken,
+    state_healing_ended: Arc<AtomicBool>,
 ) -> Result<bool, SyncError> {
     // List of paths in need of healing, grouped by hashed address
     let mut pending_paths = BTreeMap::<H256, Vec<Nibbles>>::new();
-    // The pivot may become stale while the fetcher is active, we will still keep the process
-    // alive until the end signal so we don't lose queued messages
     let mut stale = false;
     while !(stale || cancel_token.is_cancelled()) {
         // If we have few storages in queue, fetch more from the store
@@ -46,6 +45,10 @@ pub(crate) async fn storage_healer(
                     .await?
                     .into_iter(),
             );
+        }
+        // If we have no more pending paths even after reading from the store, and state healing has finished, cut the loop
+        if pending_paths.is_empty() && state_healing_ended.load(Ordering::Relaxed) {
+            break;
         }
         // If we have enough pending storages to fill a batch
         // or if we have no more incoming batches, spawn a fetch process

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -5,7 +5,13 @@
 //! For each storage received, the process will first queue their root nodes and then queue all the missing children from each node fetched in the same way as state healing
 //! Even if the pivot becomes stale, the healer will remain active and listening until a termination signal (an empty batch) is received
 
-use std::{collections::BTreeMap, sync::{atomic::{AtomicBool, Ordering}, Arc}};
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use ethrex_common::H256;
 use ethrex_storage::Store;

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -61,7 +61,6 @@ impl SyncManager {
             .get_header_download_checkpoint()
             .is_ok_and(|res| res.is_some())
         {
-            info!("Header download checkpoint found, restarting sync");
             sync_manager.start_sync();
         }
         sync_manager

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -61,6 +61,7 @@ impl SyncManager {
             .get_header_download_checkpoint()
             .is_ok_and(|res| res.is_some())
         {
+            info!("Header download checkpoint found, restarting sync");
             sync_manager.start_sync();
         }
         sync_manager


### PR DESCRIPTION
**Motivation**
Currenlty, when state healing finishes, the storage healer is cancelled, even if there are still storages to be fetched and the tries are not stale yet, which slows down storage healing due to the frequent restarts if state healing ends before storage healing. This PR aims to fix this by changing the behaviour to not cancel storage healing if state healing is complete, but to instead give this information to the storage healer via an AtomicBoo, so that it can decide whether to stop based on if the state has become stale, or if no more paths are left to heal and mo more will be added by the state healer.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add AtomicBool param to `storage_healer` to signal whether state healing has ended
* Don't cancel storage healing if state healer ended due to state healing being complete
* End storage healer if there are no more pending storages left & state healing has ended
* (Misc) Remove outdated comment
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

