### PR TITLE
fix(l1): bug in storage healer

### DIFF
--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -107,7 +107,7 @@ async fn heal_storage_batch(
             // Add children to batch
             let children = trie_nodes
                 .iter()
-                .zip(paths.drain(..paths.len().min(nodes.len())))
+                .zip(paths.drain(..trie_nodes.len()))
                 .map(|(node, path)| node_missing_children(node, &path, trie.state()))
                 .collect::<Result<Vec<_>, _>>()?;
             paths.extend(children.into_iter().flatten());

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -104,7 +104,7 @@ async fn heal_storage_batch(
             // Get the corresponding nodes
             let trie_nodes: Vec<ethrex_trie::Node> =
                 nodes.drain(..paths.len().min(nodes.len())).collect();
-            // Add children to batch
+            // Update batch: remove fetched paths & add children
             let children = trie_nodes
                 .iter()
                 .zip(paths.drain(..trie_nodes.len()))


### PR DESCRIPTION
**Motivation**
There is currently a bug in the storage healer causing fetched paths to not be properly updated. This makes storage healing virtually infinite as fetched paths are constantly being added back to the queue.
This fix should restore regular storage healing behaviour
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Fix logic error when updating pending paths for the next fetch during storage healing
<!-- A clear and concise general description of the changes this PR introduces -->

**Other info**
This bug was unknowingly introduced by #2288 
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

