### PR TITLE
feat(levm): fix gas refund on precompiles on success

### DIFF
--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -26,7 +26,7 @@ impl<'a> VM<'a> {
                 Ok(ExecutionReport {
                     result: TxResult::Success,
                     gas_used: current_call_frame.gas_used,
-                    gas_refunded: 0,
+                    gas_refunded: self.env.refunded_gas,
                     output,
                     logs: std::mem::take(&mut current_call_frame.logs),
                 })


### PR DESCRIPTION
**Motivation**

In this PR we fix the missing gas refunded while giving the execution report on a precompile

**Description**

Return the gas refunded in the environment instead of zero value

