### PR TITLE
fix(levm): remove logs from transaction revert

### DIFF
--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -45,7 +45,7 @@ impl<'a> VM<'a> {
                     gas_used: current_call_frame.gas_limit,
                     gas_refunded: self.env.refunded_gas,
                     output: Bytes::new(),
-                    logs: std::mem::take(&mut current_call_frame.logs),
+                    logs: vec![],
                 })
             }
         }
@@ -217,7 +217,7 @@ impl<'a> VM<'a> {
                         gas_used: current_call_frame.gas_used,
                         gas_refunded: self.env.refunded_gas,
                         output: std::mem::take(&mut current_call_frame.output),
-                        logs: std::mem::take(&mut current_call_frame.logs),
+                        logs: vec![],
                     });
                 }
             }


### PR DESCRIPTION
**Description**

This PR removes logs from the `ExecutionReport` when a transaction reverts.
With this fix, LEVM no longer breaks at block 80k while syncing on Holesky testnet.
