### PR TITLE
chore(core): replace LEVM channel with L1 channel

### DIFF
--- a/.github/workflows/daily_loc.yaml
+++ b/.github/workflows/daily_loc.yaml
@@ -55,7 +55,7 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch'
               && secrets.TEST_CHANNEL_SLACK
               || format(
-                  '{0} {1} {2}',
+                  '{0} {1}',
                   secrets.ETHREX_L1_SLACK_WEBHOOK,
                   secrets.ETHREX_L2_SLACK_WEBHOOK
                 )

--- a/.github/workflows/daily_loc.yaml
+++ b/.github/workflows/daily_loc.yaml
@@ -57,8 +57,7 @@ jobs:
               || format(
                   '{0} {1} {2}',
                   secrets.ETHREX_L1_SLACK_WEBHOOK,
-                  secrets.ETHREX_L2_SLACK_WEBHOOK,
-                  secrets.LEVM_SLACK_WEBHOOK
+                  secrets.ETHREX_L2_SLACK_WEBHOOK
                 )
             }}
         run: |

--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -53,7 +53,7 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch'
               && secrets.TEST_CHANNEL_SLACK
               || format(
-                  '{0} {1} {2}',
+                  '{0} {1}',
                   secrets.ETHREX_L1_SLACK_WEBHOOK,
                   secrets.ETHREX_L2_SLACK_WEBHOOK
                 )

--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -55,8 +55,7 @@ jobs:
               || format(
                   '{0} {1} {2}',
                   secrets.ETHREX_L1_SLACK_WEBHOOK,
-                  secrets.ETHREX_L2_SLACK_WEBHOOK,
-                  secrets.LEVM_SLACK_WEBHOOK
+                  secrets.ETHREX_L2_SLACK_WEBHOOK
                 )
             }}
         run: |
@@ -72,8 +71,8 @@ jobs:
               && secrets.TEST_CHANNEL_SLACK
               || format(
                   '{0} {1}',
-                  secrets.ETHREX_L2_SLACK_WEBHOOK,
-                  secrets.LEVM_SLACK_WEBHOOK
+                  secrets.ETHREX_L1_SLACK_WEBHOOK,
+                  secrets.ETHREX_L2_SLACK_WEBHOOK
                 )
             }}
         run: |
@@ -87,7 +86,7 @@ jobs:
           SLACK_WEBHOOK: >
             ${{ github.event_name == 'workflow_dispatch'
               && secrets.TEST_CHANNEL_SLACK
-              || secrets.LEVM_SLACK_WEBHOOK
+              || secrets.ETHREX_L1_SLACK_WEBHOOK
             }}
         # Only send diff message if the diff has changed
         run: |
@@ -144,7 +143,7 @@ jobs:
           SLACK_WEBHOOK: >
             ${{ github.event_name == 'workflow_dispatch'
               && secrets.TEST_CHANNEL_SLACK
-              || secrets.LEVM_SLACK_WEBHOOK
+              || secrets.ETHREX_L1_SLACK_WEBHOOK
             }}
         run: sh .github/scripts/publish_levm_ef_tests.sh "$SLACK_WEBHOOK"
 
@@ -163,7 +162,7 @@ jobs:
               || format(
                   '{0} {1}',
                   secrets.ETHREX_L2_SLACK_WEBHOOK,
-                  secrets.LEVM_SLACK_WEBHOOK
+                  secrets.ETHREX_L1_SLACK_WEBHOOK
                 )
             }}
         run: |


### PR DESCRIPTION
**Motivation**

The L1 slack channel is now used for LEVM development

**Description**

This PR replaces the LEVM webhook with the L1 webhook.

