### PR TITLE
docs(l2): fixed broken link in `state_diffs.md`

### DIFF
--- a/crates/l2/docs/state_diffs.md
+++ b/crates/l2/docs/state_diffs.md
@@ -1,6 +1,6 @@
 # State diffs
 
-This architecture was inspired by MatterLabs' ZKsync pubdata architecture (see [here](https://github.com/matter-labs/zksync-era/blob/main/docs/src/specs/data_availability/pubdata.md)).
+This architecture was inspired by MatterLabs' ZKsync pubdata architecture (see [here](https://github.com/matter-labs/zksync-era/blob/main/docs/src/specs/contracts/settlement_contracts/data_availability/pubdata.md)).
 
 To provide data availability for our network, we need to publish enough information on every commit transaction to be able to reconstruct the entire state of the L2 from the beginning by querying the L1.
 


### PR DESCRIPTION
**Motivation**

The old link to the ZKsync pubdata spec was outdated due to recent file restructuring in the MatterLabs repo.

**Description**

I fixed the link in `crates/l2/docs/state_diffs.md` to point to the new path:  
from  
 - `docs/src/specs/data_availability/pubdata.md`  
to  
 - `docs/src/specs/contracts/settlement_contracts/data_availability/pubdata.md`