### PR TITLE
Add --metrics flag to enable/disable metrics collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,12 @@ Node options:
       --network <GENESIS_FILE_PATH>
           Alternatively, the name of a known network can be provided instead to use its preset genesis file and include its preset bootnodes. The networks currently supported include holesky, sepolia, hoodi and mainnet.
 
+          [env: ETHREX_NETWORK=]
+
       --datadir <DATABASE_DIRECTORY>
           If the datadir is the word `memory`, ethrex will use the `InMemory Engine`.
 
+          [env: ETHREX_DATADIR=]
           [default: ethrex]
 
       --force
@@ -219,7 +222,11 @@ Node options:
           [default: 0.0.0.0]
 
       --metrics.port <PROMETHEUS_METRICS_PORT>
+          [env: ETHREX_METRICS_PORT=]
           [default: 9090]
+
+      --metrics
+          Enable metrics collection and exposition
 
       --dev
           If set it will be considered as `true`. The Binary has to be built with the `dev` feature enabled.
@@ -227,6 +234,7 @@ Node options:
       --evm <EVM_BACKEND>
           Has to be `levm` or `revm`
 
+          [env: ETHREX_EVM=]
           [default: revm]
 
       --log.level <LOG_LEVEL>
@@ -266,11 +274,13 @@ RPC options:
       --http.addr <ADDRESS>
           Listening address for the http rpc server.
 
+          [env: ETHREX_HTTP_ADDR=]
           [default: localhost]
 
       --http.port <PORT>
           Listening port for the http rpc server.
 
+          [env: ETHREX_HTTP_PORT=]
           [default: 8545]
 
       --authrpc.addr <ADDRESS>

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -80,6 +80,13 @@ pub struct Options {
     )]
     pub metrics_port: String,
     #[arg(
+        long = "metrics",
+        action = ArgAction::SetTrue,
+        help = "Enable metrics collection and exposition",
+        help_heading = "Node options"
+    )]
+    pub metrics_enabled: bool,
+    #[arg(
         long = "dev",
         action = ArgAction::SetTrue,
         help = "Used to create blocks without requiring a Consensus Client",
@@ -200,6 +207,7 @@ impl Default for Options {
             syncmode: Default::default(),
             metrics_addr: "0.0.0.0".to_owned(),
             metrics_port: Default::default(),
+            metrics_enabled: Default::default(),
             dev: Default::default(),
             evm: Default::default(),
             force: false,

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -58,7 +58,9 @@ async fn main() -> eyre::Result<()> {
     )
     .await;
 
-    init_metrics(&opts, tracker.clone());
+    if opts.metrics_enabled {
+        init_metrics(&opts, tracker.clone());
+    }
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "dev")] {

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -56,6 +56,11 @@ pub fn init_tracing(opts: &Options) {
 }
 
 pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
+    if !opts.metrics_enabled {
+        return;
+    }
+
+    tracing::info!("Starting metrics server on {}:{}", opts.metrics_addr, opts.metrics_port);
     let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(
         opts.metrics_addr.clone(),
         opts.metrics_port.clone(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -56,7 +56,11 @@ pub fn init_tracing(opts: &Options) {
 }
 
 pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
-    tracing::info!("Starting metrics server on {}:{}", opts.metrics_addr, opts.metrics_port);
+    tracing::info!(
+        "Starting metrics server on {}:{}",
+        opts.metrics_addr,
+        opts.metrics_port
+    );
     let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(
         opts.metrics_addr.clone(),
         opts.metrics_port.clone(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -56,10 +56,6 @@ pub fn init_tracing(opts: &Options) {
 }
 
 pub fn init_metrics(opts: &Options, tracker: TaskTracker) {
-    if !opts.metrics_enabled {
-        return;
-    }
-
     tracing::info!("Starting metrics server on {}:{}", opts.metrics_addr, opts.metrics_port);
     let metrics_api = ethrex_metrics::api::start_prometheus_metrics_api(
         opts.metrics_addr.clone(),

--- a/cmd/ethrex/l2.rs
+++ b/cmd/ethrex/l2.rs
@@ -152,8 +152,10 @@ impl Command {
                 )
                 .await;
 
-                // TODO: Add a --metrics flag to enable metrics.
-                init_metrics(&opts.node_opts, tracker.clone());
+                // Initialize metrics if enabled
+                if opts.node_opts.metrics_enabled {
+                    init_metrics(&opts.node_opts, tracker.clone());
+                }
 
                 if opts.node_opts.p2p_enabled {
                     init_network(

--- a/crates/blockchain/metrics/README.md
+++ b/crates/blockchain/metrics/README.md
@@ -5,8 +5,9 @@ If a new dashboard is designed just for the L1 or L2, it can be mounted only in 
 
 To run the node with metrics, the next steps should be followed:
 1. Build the `ethrex` binary with the `metrics` feature enabled.
-2. Set the `--metrics.port` cli arg of the ethrex binary to match the port defined in `metrics/provisioning/prometheus/prometheus*.yaml`
-3. Run the docker containers, example with the L2:
+2. Enable metrics by using the `--metrics` flag when starting the node.
+3. Set the `--metrics.port` cli arg of the ethrex binary to match the port defined in `metrics/provisioning/prometheus/prometheus*.yaml`
+4. Run the docker containers, example with the L2:
 
 ```sh
 docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l2.override.yaml up

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -148,6 +148,7 @@ init-l2-no-metrics: ## 🚀 Initializes an L2 Lambda ethrex Client
 	--network ${L2_GENESIS_FILE_PATH} \
 	--http.port ${L2_PORT} \
 	--http.addr 0.0.0.0 \
+	--metrics \
 	--metrics.port ${L2_PROMETHEUS_METRICS_PORT} \
 	--evm levm \
 	--datadir ${ethrex_L2_DEV_LIBMDBX}


### PR DESCRIPTION
**Motivation**

Currently, metrics are always initialized in the application, even if they're not needed. This can cause unnecessary resource usage and potential overhead. By making metrics optional through a command-line flag, users can have more control over their node's resource consumption and behavior.

**Description**

This PR adds a new --metrics command-line flag that allows users to explicitly enable or disable metrics collection and exposition. When metrics are disabled, the metrics server is not started, saving resources.

Key changes:
- Add a new metrics_enabled boolean flag to the Options struct
- Update the init_metrics function to check this flag before starting the metrics server
- Modify both the main ethrex command and the L2 command to conditionally initialize metrics
- Update the L2 Makefile to explicitly enable metrics
- Update documentation to include information about the new flag

