### PR TITLE
fix(l2): add missing requirements to run the L2

### DIFF
--- a/crates/l2/docs/README.md
+++ b/crates/l2/docs/README.md
@@ -13,7 +13,12 @@ For more detailed documentation on each part of the system:
 - [Prover](./prover.md)
 - [State Diffs](./state_diffs.md)
 - [Withdrawals](./withdrawals.md)
+  
+## Prerequisites
 
+- [Rust](https://www.rust-lang.org/tools/install)
+- [Solc 0.29](https://docs.soliditylang.org/en/latest/installing-solidity.html)
+  
 ## Quick HandsOn
 
 1. `cd crates/l2`

--- a/crates/l2/docs/README.md
+++ b/crates/l2/docs/README.md
@@ -18,8 +18,11 @@ For more detailed documentation on each part of the system:
 
 - [Rust](https://www.rust-lang.org/tools/install)
 - [Solc 0.29](https://docs.soliditylang.org/en/latest/installing-solidity.html)
+- [Docker](https://docs.docker.com/engine/install/)
   
 ## Quick HandsOn
+
+Make sure docker is running!
 
 1. `cd crates/l2`
 2. `make rm-db-l2 && make down`


### PR DESCRIPTION
**Motivation**

Build fails if requirements are not met. In particular, solc versions need to be the requirements

**Description**

This adds a short description of the requirements

