### PR TITLE
fix(levm): bug when collecting storage updates affecting batch execute

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -192,8 +192,7 @@ impl LEVM {
             // 2. Storage has been updated if the current value is different from the one before execution.
             let mut added_storage = HashMap::new();
             for (key, storage_slot) in &new_state_account.storage {
-                let storage_before_block = db.store.get_storage_slot(address, *key)?;
-                if storage_slot.current_value != storage_before_block {
+                if storage_slot.current_value != storage_slot.original_value{
                     added_storage.insert(*key, storage_slot.current_value);
                     storage_updated = true;
                 }


### PR DESCRIPTION
**Motivation**
After executing a block, levm collects account updates resulting from the executed transactions. The criteria for a storage slot to be considered updated and added to the storage updates is that the value on the cache is different than the value stored in the DB (Store). This works well when we execute a single block, collect the updates and immediately apply them to the Store, but doesn't work with batch execution.
In batch execution changes from various block executions are collected and merged together and then applied to the store. So we could get the following case:

-  Store currenlty has the key-value pair 17: 0 for a given account
- We execute a batch containing blocks 5 and 6
- Block 5 changes the value of key 17 to 19 -> This is collected as an update as 19 != 0
- Block 6 changes the value of key 17 back to 0 -> This is not considered an update as 0 == 0
- We apply all updates for the batch of blocks and now key 17 has value 19, and the world state root doesn't match, invalidating this and following batch's execution.
The solution proposed in this PR is not to check if the cached value differs from the stored value but if the current value of the storage slot differs from the original value in the cache. This both fixes the issue and removed the need for DB reads

<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Change inclusion criteria for storage updates in levm from checking current cached value vs db stored value to current value vs original value in cache
<!-- A clear and concise general description of the changes this PR introduces -->
**Other Information**
* This bug was detected when executing blocks 1557 and 1558 of holesky testnet in the same batch during full sync using execute_block_batch
* This bug could also be fixed by implementing #2504 but also addresses #2505 
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

