### PR TITLE
perf(core): transform the inline variant of NodeHash to a const sized array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2025-04-22
+
+- Transform the inlined variant of NodeHash to a constant sized array [2516](https://github.com/lambdaclass/ethrex/pull/2516)
+
 ### 2025-04-11
 
 - Removed some unnecessary clones and made some functions const: [2438](https://github.com/lambdaclass/ethrex/pull/2438)

--- a/crates/common/trie/node.rs
+++ b/crates/common/trie/node.rs
@@ -5,7 +5,6 @@ mod leaf;
 use std::array;
 
 pub use branch::BranchNode;
-use ethereum_types::H256;
 use ethrex_rlp::{decode::decode_bytes, error::RLPDecodeError, structs::Decoder};
 pub use extension::ExtensionNode;
 pub use leaf::LeafNode;
@@ -178,8 +177,8 @@ impl Node {
 
 fn decode_child(rlp: &[u8]) -> NodeHash {
     match decode_bytes(rlp) {
-        Ok((hash, &[])) if hash.len() == 32 => NodeHash::Hashed(H256::from_slice(hash)),
-        Ok((&[], &[])) => NodeHash::Inline(vec![]),
-        _ => NodeHash::Inline(rlp.to_vec()),
+        Ok((hash, &[])) if hash.len() == 32 => NodeHash::from_slice(hash),
+        Ok((&[], &[])) => NodeHash::default(),
+        _ => NodeHash::from_slice(rlp),
     }
 }

--- a/crates/common/trie/node/extension.rs
+++ b/crates/common/trie/node/extension.rs
@@ -28,7 +28,7 @@ impl ExtensionNode {
         // Otherwise, no value is present.
         if path.skip_prefix(&self.prefix) {
             let child_node = state
-                .get_node(self.child.clone())?
+                .get_node(self.child)?
                 .ok_or(TrieError::InconsistentTree)?;
 
             child_node.get(state, path)
@@ -144,21 +144,14 @@ impl ExtensionNode {
 
     /// Computes the node's hash
     pub fn compute_hash(&self) -> NodeHash {
-        NodeHash::from_encoded_raw(self.encode_raw())
+        NodeHash::from_encoded_raw(&self.encode_raw())
     }
 
     /// Encodes the node
     pub fn encode_raw(&self) -> Vec<u8> {
         let mut buf = vec![];
         let mut encoder = Encoder::new(&mut buf).encode_bytes(&self.prefix.encode_compact());
-        match &self.child {
-            NodeHash::Inline(x) => {
-                encoder = encoder.encode_raw(x);
-            }
-            NodeHash::Hashed(x) => {
-                encoder = encoder.encode_bytes(&x.0);
-            }
-        }
+        encoder = self.child.encode(encoder);
         encoder.finish();
         buf
     }
@@ -166,7 +159,7 @@ impl ExtensionNode {
     /// Inserts the node into the state and returns its hash
     pub fn insert_self(self, state: &mut TrieState) -> Result<NodeHash, TrieError> {
         let hash = self.compute_hash();
-        state.insert_node(self.into(), hash.clone());
+        state.insert_node(self.into(), hash);
         Ok(hash)
     }
 
@@ -187,7 +180,7 @@ impl ExtensionNode {
         // Continue to child
         if path.skip_prefix(&self.prefix) {
             let child_node = state
-                .get_node(self.child.clone())?
+                .get_node(self.child)?
                 .ok_or(TrieError::InconsistentTree)?;
             child_node.get_path(state, path, node_path)?;
         }

--- a/crates/common/trie/node/leaf.rs
+++ b/crates/common/trie/node/leaf.rs
@@ -101,7 +101,7 @@ impl LeafNode {
 
     /// Computes the node's hash
     pub fn compute_hash(&self) -> NodeHash {
-        NodeHash::from_encoded_raw(self.encode_raw())
+        NodeHash::from_encoded_raw(&self.encode_raw())
     }
 
     /// Encodes the node
@@ -118,7 +118,7 @@ impl LeafNode {
     /// Receives the offset that needs to be traversed to reach the leaf node from the canonical root, used to compute the node hash
     pub fn insert_self(self, state: &mut TrieState) -> Result<NodeHash, TrieError> {
         let hash = self.compute_hash();
-        state.insert_node(self.into(), hash.clone());
+        state.insert_node(self.into(), hash);
         Ok(hash)
     }
 

--- a/crates/common/trie/state.rs
+++ b/crates/common/trie/state.rs
@@ -26,8 +26,8 @@ impl TrieState {
     /// Retrieves a node based on its hash
     pub fn get_node(&self, hash: NodeHash) -> Result<Option<Node>, TrieError> {
         // Decode the node if it is inlined
-        if let NodeHash::Inline(encoded) = hash {
-            return Ok(Some(Node::decode_raw(&encoded)?));
+        if let NodeHash::Inline(_) = hash {
+            return Ok(Some(Node::decode_raw(hash.as_ref())?));
         }
         if let Some(node) = self.cache.get(&hash) {
             return Ok(Some(node.clone()));

--- a/crates/common/trie/trie.rs
+++ b/crates/common/trie/trie.rs
@@ -73,7 +73,7 @@ impl Trie {
         if let Some(root) = &self.root {
             let root_node = self
                 .state
-                .get_node(root.clone())?
+                .get_node(*root)?
                 .ok_or(TrieError::InconsistentTree)?;
             root_node.get(&self.state, Nibbles::from_bytes(path))
         } else {
@@ -128,7 +128,7 @@ impl Trie {
         Ok(self
             .root
             .as_ref()
-            .map(|root| root.clone().finalize())
+            .map(|root| root.finalize())
             .unwrap_or(*EMPTY_TRIE_HASH))
     }
 
@@ -137,7 +137,7 @@ impl Trie {
     pub fn hash_no_commit(&self) -> H256 {
         self.root
             .as_ref()
-            .map(|root| root.clone().finalize())
+            .map(|root| root.finalize())
             .unwrap_or(*EMPTY_TRIE_HASH)
     }
 
@@ -158,10 +158,10 @@ impl Trie {
             return Ok(node_path);
         };
         // If the root is inlined, add it to the node_path
-        if let NodeHash::Inline(node) = root {
-            node_path.push(node.to_vec());
+        if let NodeHash::Inline(_) = root {
+            node_path.push(root.as_ref().to_vec());
         }
-        if let Some(root_node) = self.state.get_node(root.clone())? {
+        if let Some(root_node) = self.state.get_node(*root)? {
             root_node.get_path(&self.state, Nibbles::from_bytes(path), &mut node_path)?;
         }
         Ok(node_path)
@@ -177,7 +177,7 @@ impl Trie {
         let Some(root_node) = self
             .root
             .as_ref()
-            .map(|root| self.state.get_node(root.clone()))
+            .map(|root| self.state.get_node(*root))
             .transpose()?
             .flatten()
         else {
@@ -230,7 +230,7 @@ impl Trie {
         }
         trie.root
             .as_ref()
-            .map(|root| root.clone().finalize())
+            .map(|root| root.finalize())
             .unwrap_or(*EMPTY_TRIE_HASH)
     }
 
@@ -274,7 +274,7 @@ impl Trie {
         let Some(root_node) = self
             .root
             .as_ref()
-            .map(|root| self.state.get_node(root.clone()))
+            .map(|root| self.state.get_node(*root))
             .transpose()?
             .flatten()
         else {
@@ -295,7 +295,7 @@ impl Trie {
                     if child_hash.is_valid() {
                         let child_node = self
                             .state
-                            .get_node(child_hash.clone())?
+                            .get_node(*child_hash)?
                             .ok_or(TrieError::InconsistentTree)?;
                         self.get_node_inner(child_node, partial_path)
                     } else {
@@ -310,7 +310,7 @@ impl Trie {
                 {
                     let child_node = self
                         .state
-                        .get_node(extension_node.child.clone())?
+                        .get_node(extension_node.child)?
                         .ok_or(TrieError::InconsistentTree)?;
                     self.get_node_inner(child_node, partial_path)
                 } else {

--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -9,7 +9,7 @@ pub struct TrieIterator {
 impl TrieIterator {
     pub(crate) fn new(trie: Trie) -> Self {
         let stack = if let Some(root) = &trie.root {
-            vec![(Nibbles::default(), root.clone())]
+            vec![(Nibbles::default(), *root)]
         } else {
             vec![]
         };
@@ -34,7 +34,7 @@ impl Iterator for TrieIterator {
                     if child.is_valid() {
                         let mut child_path = path.clone();
                         child_path.append(choice as u8);
-                        self.stack.push((child_path, child.clone()))
+                        self.stack.push((child_path, *child))
                     }
                 }
             }
@@ -42,8 +42,7 @@ impl Iterator for TrieIterator {
                 // Update path
                 path.extend(&extension_node.prefix);
                 // Add child to the stack
-                self.stack
-                    .push((path.clone(), extension_node.child.clone()));
+                self.stack.push((path.clone(), extension_node.child));
             }
             Node::Leaf(leaf) => {
                 path.extend(&leaf.partial);

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -677,13 +677,13 @@ fn node_missing_children(
     match &node {
         Node::Branch(node) => {
             for (index, child) in node.choices.iter().enumerate() {
-                if child.is_valid() && trie_state.get_node(child.clone())?.is_none() {
+                if child.is_valid() && trie_state.get_node(*child)?.is_none() {
                     paths.push(parent_path.append_new(index as u8));
                 }
             }
         }
         Node::Extension(node) => {
-            if node.child.is_valid() && trie_state.get_node(node.child.clone())?.is_none() {
+            if node.child.is_valid() && trie_state.get_node(node.child)?.is_none() {
                 paths.push(parent_path.concat(node.prefix.clone()));
             }
         }


### PR DESCRIPTION
**Motivation**

Transforms the inline variant of NodeHash to a fixed size array, allowing it to be copy and avoiding expensive Vec clones.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes [#2444](https://github.com/lambdaclass/ethrex/issues/2444)

