### PR TITLE
fix(levm): improve get state transitions LEVM

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -185,9 +185,12 @@ impl LEVM {
             }
 
             let new_state_code_hash = code_hash(&new_state_account.info.bytecode);
-            if initial_state_account.bytecode_hash() != new_state_code_hash {
+            let code = if initial_state_account.bytecode_hash() != new_state_code_hash {
                 acc_info_updated = true;
-            }
+                Some(new_state_account.info.bytecode.clone())
+            } else {
+                None
+            };
 
             // 2. Storage has been updated if the current value is different from the one before execution.
             let mut added_storage = HashMap::new();
@@ -199,17 +202,14 @@ impl LEVM {
                 }
             }
 
-            let (info, code) = if acc_info_updated {
-                (
-                    Some(AccountInfo {
-                        code_hash: new_state_code_hash,
-                        balance: new_state_account.info.balance,
-                        nonce: new_state_account.info.nonce,
-                    }),
-                    Some(new_state_account.info.bytecode.clone()),
-                )
+            let info = if acc_info_updated {
+                Some(AccountInfo {
+                    code_hash: new_state_code_hash,
+                    balance: new_state_account.info.balance,
+                    nonce: new_state_account.info.nonce,
+                })
             } else {
-                (None, None)
+                None
             };
 
             let mut removed = !initial_state_account.is_empty() && new_state_account.is_empty();


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- Make `get_state_transitions` we use un LEVM return the same as the one in REVM.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- I made changes in the past to make `get_state_transitions` for both LEVM and REVM the same for comparison but I missed one aspect. We only want to show the code in an `AccountUpdate` if the code itself has been modified, not just the `AccountInfo`. Before we were returning the code in the `AccountUpdate` even if only the nonce of the contract changed for example.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

