### PR TITLE
fix(levm): read chain_id from chain config, not from transaction

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -712,7 +712,7 @@ fn env_from_generic(
         coinbase: header.coinbase,
         timestamp: header.timestamp.into(),
         prev_randao: Some(header.prev_randao),
-        chain_id: tx.chain_id.unwrap_or(chain_config.chain_id).into(),
+        chain_id: chain_config.chain_id.into(),
         base_fee_per_gas: header.base_fee_per_gas.unwrap_or_default().into(),
         gas_price,
         block_excess_blob_gas: header.excess_blob_gas.map(U256::from),


### PR DESCRIPTION
**Motivation**

At block 576991 the sync with holesky would fail due to an incorrect state calculation.

**Description**

As per [EIP-1344](https://eips.ethereum.org/EIPS/eip-1344) the chain ID should be read from the chain configuration and not the transaction. This is because transactions may not have replay protection configured.
