### PR TITLE
fix(levm): also use config chain_id

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -124,7 +124,7 @@ impl LEVM {
             coinbase: block_header.coinbase,
             timestamp: block_header.timestamp.into(),
             prev_randao: Some(block_header.prev_randao),
-            chain_id: tx.chain_id().unwrap_or_default().into(),
+            chain_id: chain_config.chain_id.into(),
             base_fee_per_gas: block_header.base_fee_per_gas.unwrap_or_default().into(),
             gas_price,
             block_excess_blob_gas: block_header.excess_blob_gas.map(U256::from),


### PR DESCRIPTION
**Motivation**

In #2531 only one of the creation methods was fixed to use chain_id from the config

**Description**

This PR changes it in the other constructor
