### PR TITLE
chore(l2): temporarily disable pico job

### DIFF
--- a/.github/workflows/pr-main_l2_prover_nightly.yaml.disabled
+++ b/.github/workflows/pr-main_l2_prover_nightly.yaml.disabled
@@ -1,3 +1,5 @@
+# DISABLED: Temporarily disabled due to Pico dependency issues
+
 # The reason this exists is because the Pico zkVM compiles in nightly only.
 name: L2 Prover (nightly)
 on:


### PR DESCRIPTION
**Motivation**

In #2397, we are having issues with Pico dependencies. Since we are not using it at the moment, we prefer to temporarily disable the job until we focus on it later.

**Description**

- Disable pico job renaming `pr-main_l2_prover_nightly.yaml` to `.github/workflows/pr-main_l2_prover_nightly.yaml.disabled`.
- Create #2550.

Closes None

