### PR TITLE
refactor(l2): contracts

### DIFF
--- a/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
+++ b/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
@@ -58,10 +58,10 @@ interface ICommonBridge {
         bytes data;
     }
 
-    /// @notice Method to retrieve all the deposit logs hashes.
-    /// @dev This method is used by the L2 L1_Watcher to get the remaining
-    /// deposit logs to be processed.
-    function getDepositLogs() external view returns (bytes32[] memory);
+    /// @notice Method to retrieve all the pending deposit logs hashes.
+    /// @dev This method is used by the L2 L1_Watcher to get the pending deposit
+    /// logs to be processed.
+    function getPendingDepositLogs() external view returns (bytes32[] memory);
 
     /// @notice Initializes the contract.
     /// @dev This method is called only once after the contract is deployed.
@@ -76,19 +76,20 @@ interface ICommonBridge {
     /// @param depositValues the values needed to create the deposit.
     function deposit(DepositValues calldata depositValues) external payable;
 
-    /// @notice Method to retrieve the versioned hash of the first `number` deposit logs.
-    /// @param number of deposit logs to retrieve the versioned hash.
-    function getDepositLogsVersionedHash(
+    /// @notice Method to retrieve the versioned hash of the first `number`
+    /// pending deposit logs.
+    /// @param number of pending deposit logs to retrieve the versioned hash.
+    function getPendingDepositLogsVersionedHash(
         uint16 number
     ) external view returns (bytes32);
 
-    /// @notice Remove deposit from depositLogs queue.
-    /// @dev This method is used by the L2 OnChainOperator to remove the deposit
-    /// logs from the queue after the deposit is verified.
-    /// @param number of deposit logs to remove.
+    /// @notice Remove pending deposit from the pendingDepositLogs queue.
+    /// @dev This method is used by the L2 OnChainOperator to remove the pending
+    /// deposit logs from the queue after the deposit is verified.
+    /// @param number of pending deposit logs to remove.
     /// As deposits are processed in order, we don't need to specify
-    /// the deposit logs to remove, only the number of them.
-    function removeDepositLogs(uint16 number) external;
+    /// the pending deposit logs to remove, only the number of them.
+    function removePendingDepositLogs(uint16 number) external;
 
     /// @notice Publishes the L2 withdrawals on L1.
     /// @dev This method is used by the L2 OnChainOperator to publish the L2

--- a/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
@@ -48,12 +48,13 @@ interface IOnChainProposer {
     /// @param stateDiffKZGVersionedHash of the block to be committed.
     /// @param withdrawalsLogsMerkleRoot the merkle root of the withdrawal logs
     /// of the block to be committed.
-    /// @param depositLogs the deposit logs of the block to be committed.
+    /// @param processedDepositLogs the processed deposits logs of the block to
+    /// be committed.
     function commit(
         uint256 blockNumber,
         bytes32 stateDiffKZGVersionedHash,
         bytes32 withdrawalsLogsMerkleRoot,
-        bytes32 depositLogs
+        bytes32 processedDepositLogs
     ) external;
 
     /// @notice Method used to verify an L2 block proof.

--- a/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
@@ -14,9 +14,14 @@ interface IOnChainProposer {
     /// @return The latest verified block number as a uint256.
     function lastVerifiedBlock() external view returns (uint256);
 
+    // TODO: We are using the state diff KZG versioned hash to figure out
+    // whether a block was committed or not. Ideally, we should use the new
+    // state root hash instead.
     /// @notice A block has been committed.
     /// @dev Event emitted when a block is committed.
-    event BlockCommitted(bytes32 indexed currentBlockCommitment);
+    /// @param stateDiffKZGVersionedHash the KZG versioned hash of the committed
+    /// block's state diff.
+    event BlockCommitted(bytes32 indexed stateDiffKZGVersionedHash);
 
     /// @notice A block has been verified.
     /// @dev Event emitted when a block is verified.
@@ -40,13 +45,13 @@ interface IOnChainProposer {
     /// @dev Committing to an L2 block means to store the block's commitment
     /// and to publish withdrawals if any.
     /// @param blockNumber the number of the block to be committed.
-    /// @param commitment of the block to be committed.
+    /// @param stateDiffKZGVersionedHash of the block to be committed.
     /// @param withdrawalsLogsMerkleRoot the merkle root of the withdrawal logs
     /// of the block to be committed.
     /// @param depositLogs the deposit logs of the block to be committed.
     function commit(
         uint256 blockNumber,
-        bytes32 commitment,
+        bytes32 stateDiffKZGVersionedHash,
         bytes32 withdrawalsLogsMerkleRoot,
         bytes32 depositLogs
     ) external;

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -337,17 +337,16 @@ impl Committer {
         info!("Sending commitment for block {block_number}");
 
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
+
+        let state_diff_kzg_versioned_hash = blob_versioned_hashes
+            .first()
+            .ok_or(BlobsBundleError::BlobBundleEmptyError)
+            .map_err(CommitterError::from)?
+            .as_fixed_bytes();
+
         let calldata_values = vec![
             Value::Uint(U256::from(block_number)),
-            Value::FixedBytes(
-                blob_versioned_hashes
-                    .first()
-                    .ok_or(BlobsBundleError::BlobBundleEmptyError)
-                    .map_err(CommitterError::from)?
-                    .as_fixed_bytes()
-                    .to_vec()
-                    .into(),
-            ),
+            Value::FixedBytes(state_diff_kzg_versioned_hash.to_vec().into()),
             Value::FixedBytes(withdrawal_logs_merkle_root.0.to_vec().into()),
             Value::FixedBytes(deposit_logs_hash.0.to_vec().into()),
         ];


### PR DESCRIPTION
**Motivation**

Some variable names are misleading and can confuse the reader.

**Description**

- Renamed deposit logs related variables in `OnChainProposer` and `CommonBridge` and their interfaces with clearer names.
- Improved some documentation on the above.
- Renamed some misleading naming in variables such as `commitment` in `OnChainProposer` and its interface.

