### PR TITLE
fix(l1,levm): use last known block as base for withdrawls

### DIFF
--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -105,8 +105,8 @@ impl LevmDatabase for DatabaseLogger {
         self.store.get_account_code(code_hash)
     }
 
-    fn get_block(&self) -> CoreH256 {
-        self.store.get_block()
+    fn get_parent_hash(&self) -> CoreH256 {
+        self.store.get_parent_hash()
     }
 }
 
@@ -183,7 +183,7 @@ impl LevmDatabase for StoreWrapper {
             .map_err(|e| DatabaseError::Custom(e.to_string()))
     }
 
-    fn get_block(&self) -> CoreH256 {
+    fn get_parent_hash(&self) -> CoreH256 {
         self.block_hash
     }
 }
@@ -250,7 +250,7 @@ impl LevmDatabase for ExecutionDB {
         Ok(self.code.get(&code_hash).cloned())
     }
 
-    fn get_block(&self) -> CoreH256 {
+    fn get_parent_hash(&self) -> CoreH256 {
         *self.block_hashes.iter().max_by_key(|(k, _v)| *k).unwrap().1
     }
 }

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -79,7 +79,9 @@ impl LEVM {
         }
 
         if let Some(withdrawals) = &block.body.withdrawals {
-            Self::process_withdrawals(db, withdrawals, db.store.get_block())?;
+            if true {
+                Self::process_withdrawals(db, withdrawals, db.store.get_parent_hash())?;
+            }
         }
 
         cfg_if::cfg_if! {

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -22,5 +22,5 @@ pub trait Database: Send + Sync {
         address: Address,
     ) -> Result<Option<ethrex_common::types::AccountInfo>, DatabaseError>;
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, DatabaseError>;
-    fn get_block(&self) -> H256;
+    fn get_parent_hash(&self) -> H256;
 }


### PR DESCRIPTION
**Motivation**

Currently batch syncing isn't working with LEVM because withdrawls used the current block's parent as a source of state. In batch execution this state might not be available.

**Description**

This uses the first block of the batch as the fallback reference point for account state, just like for other VM operations.

This is correct because any updated accounts are in the cache (which, despite it's name, contains _all_ updated accounts).
