### PR TITLE
fix(levm): don't read from parent block when processing withdrawals

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -294,7 +294,7 @@ impl Blockchain {
             .unwrap_or(&binding);
         context
             .vm
-            .process_withdrawals(withdrawals, &context.payload.header)
+            .process_withdrawals(withdrawals)
             .map_err(EvmError::from)
     }
 

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -77,11 +77,10 @@ impl LEVM {
 
             receipts.push(receipt);
         }
-        info!("Processing Withdrawals");
+
         if let Some(withdrawals) = &block.body.withdrawals {
             Self::process_withdrawals(db, withdrawals)?;
         }
-        info!("Processed Withdrawals");
 
         cfg_if::cfg_if! {
             if #[cfg(not(feature = "l2"))] {

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -201,16 +201,10 @@ impl Evm {
 
     /// Wraps the [REVM::process_withdrawals] and [LEVM::process_withdrawals].
     /// Applies the withdrawals to the state or the block_chache if using [LEVM].
-    pub fn process_withdrawals(
-        &mut self,
-        withdrawals: &[Withdrawal],
-        block_header: &BlockHeader,
-    ) -> Result<(), StoreError> {
+    pub fn process_withdrawals(&mut self, withdrawals: &[Withdrawal]) -> Result<(), StoreError> {
         match self {
             Evm::REVM { state } => REVM::process_withdrawals(state, withdrawals),
-            Evm::LEVM { db } => {
-                LEVM::process_withdrawals(db, withdrawals, block_header.parent_hash)
-            }
+            Evm::LEVM { db } => LEVM::process_withdrawals(db, withdrawals),
         }
     }
 

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -2,7 +2,7 @@ use crate::account::AccountInfo;
 use bytes::Bytes;
 use error::DatabaseError;
 use ethrex_common::{
-    types::{BlockHash, ChainConfig},
+    types::ChainConfig,
     Address, H256, U256,
 };
 
@@ -16,10 +16,5 @@ pub trait Database: Send + Sync {
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>, DatabaseError>;
     fn account_exists(&self, address: Address) -> bool;
     fn get_chain_config(&self) -> ChainConfig;
-    fn get_account_info_by_hash(
-        &self,
-        block_hash: BlockHash,
-        address: Address,
-    ) -> Result<Option<ethrex_common::types::AccountInfo>, DatabaseError>;
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, DatabaseError>;
 }

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -1,10 +1,7 @@
 use crate::account::AccountInfo;
 use bytes::Bytes;
 use error::DatabaseError;
-use ethrex_common::{
-    types::ChainConfig,
-    Address, H256, U256,
-};
+use ethrex_common::{types::ChainConfig, Address, H256, U256};
 
 pub mod cache;
 pub use cache::CacheDB;


### PR DESCRIPTION
**Motivation**
When processing withdrawals with levm, accounts that are not cached are fetched directly from the `Store` (aka our DB) using the block's parent hash instead of using the `StoreWrapper` api that already knows which block's state to read accounts from (as we do for all other DB reads). This works fine when executing one block at a time as the block that the StoreWrapper reads from is the block's parent. But when we execute blocks in batch, the StoreWrapper reads from the parent of the first block in the batch, as changes from the following blocks will be recorded in the cache, so when processing withdrawals we may not have the state of the current block's parent in the Store.
This PR fixes this issue by using the `StoreWrapper` to read uncached accounts from the batch's parent block instead of looking for an accounts in a parent state that may not exist. It also removes the method `get_account_info_by_hash` so we don't run into the same issue in the future
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Remove misleading method `get_account_info_by_hash` from levm Database trait (this can lead us to read state from a block that is not the designated parent block and which's state may not exist leading to Inconsistent Trie errors)
* Remove the argument `parent_block_hash` from `process_withdrawals`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

