### PR TITLE
fix: Trimming newlines from jwt files

### DIFF
--- a/cmd/ethrex/decode.rs
+++ b/cmd/ethrex/decode.rs
@@ -13,6 +13,7 @@ pub fn jwtsecret_file(file: &mut File) -> Bytes {
     if contents[0..2] == *"0x" {
         contents = contents[2..contents.len()].to_string();
     }
+    contents = contents.trim_end_matches('\n').to_string();
     hex::decode(contents)
         .expect("Secret should be hex encoded")
         .into()


### PR DESCRIPTION
**Motivation**

jwt.hex files can end in newlines, in particular odometer's test jwt. This change aims to handle that case.

**Description**

This change executes `trim_end_matches` on the `contents` read from a jwt.hex file passed to ethrex.

