### PR TITLE
fix(l1): return invalid payload for invalid transactions in new payload endpoint

### DIFF
--- a/.github/workflows/pr-main_l2_prover_nightly.yaml.disabled
+++ b/.github/workflows/pr-main_l2_prover_nightly.yaml.disabled
@@ -1,3 +1,5 @@
+# DISABLED: Temporarily disabled due to Pico dependency issues
+
 # The reason this exists is because the Pico zkVM compiles in nightly only.
 name: L2 Prover (nightly)
 on:

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -80,7 +80,6 @@ impl RpcHandler for NewPayloadV2Request {
     }
 }
 
-#[derive(Debug)]
 pub struct NewPayloadV3Request {
     pub payload: ExecutionPayload,
     pub expected_blob_versioned_hashes: Vec<H256>,
@@ -103,21 +102,20 @@ impl From<NewPayloadV3Request> for RpcRequest {
 
 impl RpcHandler for NewPayloadV3Request {
     fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
-        dbg!(&params);
         let params = params
             .as_ref()
             .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
         if params.len() != 3 {
             return Err(RpcErr::BadParams("Expected 3 params".to_owned()));
         }
-        Ok(dbg!(NewPayloadV3Request {
+        Ok(NewPayloadV3Request {
             payload: serde_json::from_value(params[0].clone())
                 .map_err(|_| RpcErr::WrongParam("payload".to_string()))?,
             expected_blob_versioned_hashes: serde_json::from_value(params[1].clone())
                 .map_err(|_| RpcErr::WrongParam("expected_blob_versioned_hashes".to_string()))?,
             parent_beacon_block_root: serde_json::from_value(params[2].clone())
                 .map_err(|_| RpcErr::WrongParam("parent_beacon_block_root".to_string()))?,
-        }))
+        })
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
@@ -135,7 +133,6 @@ impl RpcHandler for NewPayloadV3Request {
         };
         validate_fork(&block, Fork::Cancun, &context)?;
         validate_execution_payload_v3(&self.payload)?;
-        dbg!("Payload validated, proceed to exec");
         let payload_status = handle_new_payload_v3(
             &self.payload,
             context,

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -5,6 +5,7 @@ use ethrex_common::types::requests::{compute_requests_hash, EncodedRequests};
 use ethrex_common::types::{Block, BlockBody, BlockHash, BlockNumber, Fork};
 use ethrex_common::{H256, U256};
 use ethrex_p2p::sync::SyncMode;
+use ethrex_rlp::error::RLPDecodeError;
 use serde_json::Value;
 use tracing::{error, info, warn};
 

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -37,7 +37,11 @@ impl RpcHandler for NewPayloadV1Request {
         validate_execution_payload_v1(&self.payload)?;
         let block = match get_block_from_payload(&self.payload, None, None) {
             Ok(block) => block,
-            Err(err) => return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(&err.to_string()))?)
+            Err(err) => {
+                return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                    &err.to_string(),
+                ))?)
+            }
         };
         let payload_status = handle_new_payload_v1_v2(&self.payload, block, context).await?;
         serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
@@ -65,7 +69,11 @@ impl RpcHandler for NewPayloadV2Request {
         }
         let block = match get_block_from_payload(&self.payload, None, None) {
             Ok(block) => block,
-            Err(err) => return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(&err.to_string()))?)
+            Err(err) => {
+                return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                    &err.to_string(),
+                ))?)
+            }
         };
         let payload_status = handle_new_payload_v1_v2(&self.payload, block, context).await?;
         serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
@@ -113,9 +121,17 @@ impl RpcHandler for NewPayloadV3Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        let block = match get_block_from_payload(&self.payload, Some(self.parent_beacon_block_root), None) {
+        let block = match get_block_from_payload(
+            &self.payload,
+            Some(self.parent_beacon_block_root),
+            None,
+        ) {
             Ok(block) => block,
-            Err(err) => return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(&err.to_string()))?)
+            Err(err) => {
+                return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                    &err.to_string(),
+                ))?)
+            }
         };
         validate_fork(&block, Fork::Cancun, &context)?;
         validate_execution_payload_v3(&self.payload)?;
@@ -216,9 +232,17 @@ impl RpcHandler for NewPayloadV4Request {
         validate_execution_requests(&self.execution_requests)?;
 
         let requests_hash = compute_requests_hash(&self.execution_requests);
-        let block = match get_block_from_payload(&self.payload, Some(self.parent_beacon_block_root), Some(requests_hash)) {
+        let block = match get_block_from_payload(
+            &self.payload,
+            Some(self.parent_beacon_block_root),
+            Some(requests_hash),
+        ) {
             Ok(block) => block,
-            Err(err) => return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(&err.to_string()))?)
+            Err(err) => {
+                return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                    &err.to_string(),
+                ))?)
+            }
         };
 
         let chain_config = context.storage.get_chain_config()?;


### PR DESCRIPTION
**Motivation**
This fixes the failing consume-engine hive tests on Prague and Cancun
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Return `INVALID` payload status when we fail to decode transactions as per spec ([Step 6 item 1](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_newpayloadv1))
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

