### PR TITLE
fix(core): flamegraphs width

### DIFF
--- a/.github/workflows/main_flamegraph_report.yaml
+++ b/.github/workflows/main_flamegraph_report.yaml
@@ -429,6 +429,9 @@ jobs:
           cp -r flamegraph_ethrex.svg flamegraphs/
           cp -r flamegraph_reth.svg flamegraphs/
 
+          # Fix flamegraphs width
+          sed -i 's|frames.attributes.width.value = |// |' flamegraphs/flamegraph_*.svg
+
           # ETHREX HTML
           sed -i "s/{{LAST_UPDATE}}/$(TZ='Etc/GMT+3' date +'%Y-%m-%dT%H:%M:%S')/g" templates/index.html
           sed -i "s/{{ETHREX_TIME}}/${{ needs.flamegraph-ethrex.outputs.time }}/g" templates/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ ethereum-package/
 **/.DS_Store
 **/.vscode
 **/.idea
+**/.zed
 
 
 # EVM Mlir stuff


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
The flamegraphs are displayed half-sized on GH Pages.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
In the CI, remove the line that cause the problem. Added Zed editor config directory to `.gitignore` btw.

<!-- Link to issues: Resolves #111, Resolves #222 -->

