### PR TITLE
fix: removed redundant `to_owned()` call

### DIFF
--- a/cmd/ef_tests/state/deserialize.rs
+++ b/cmd/ef_tests/state/deserialize.rs
@@ -382,7 +382,7 @@ impl<'de> Deserialize<'de> for EFTests {
             }
 
             let ef_test = EFTest {
-                name: test_name.to_owned().to_owned(),
+                name: test_name.to_owned(),
                 dir: String::default(),
                 _info: serde_json::from_value(
                     test_data


### PR DESCRIPTION
**Motivation**  
While reviewing the code, I noticed a redundant `to_owned()` call that could be simplified to improve efficiency and clarity.

**Description**  
The same `to_owned()` method was being called twice on the same value.
Removed the extra call to avoid unnecessary allocation.