### PR TITLE
fix(core): Made engine_forkchoiceUpdatedV3 second parameter optional

### DIFF
--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -174,7 +174,7 @@ fn parse(
     let params = params
         .as_ref()
         .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
-    
+
     if params.len() != 2 || params.len() != 1 {
         return Err(RpcErr::BadParams("Expected 2 or 1 params".to_owned()));
     }
@@ -184,13 +184,13 @@ fn parse(
     if params.len() == 2 {
         // if there is an error when parsing (or the parameter is missing), set to None
         payload_attributes =
-        match serde_json::from_value::<Option<PayloadAttributesV3>>(params[1].clone()) {
-            Ok(attributes) => attributes,
-            Err(error) => {
-                info!("Could not parse params {}", error);
-                None
-            }
-        };
+            match serde_json::from_value::<Option<PayloadAttributesV3>>(params[1].clone()) {
+                Ok(attributes) => attributes,
+                Err(error) => {
+                    info!("Could not parse params {}", error);
+                    None
+                }
+            };
     }
     if let Some(attr) = &payload_attributes {
         if !is_v3 && attr.parent_beacon_block_root.is_some() {

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -175,7 +175,7 @@ fn parse(
         .as_ref()
         .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
 
-    if params.len() != 2 || params.len() != 1 {
+    if params.len() != 2 && params.len() != 1 {
         return Err(RpcErr::BadParams("Expected 2 or 1 params".to_owned()));
     }
 

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -174,13 +174,16 @@ fn parse(
     let params = params
         .as_ref()
         .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
-    if params.len() != 2 {
-        return Err(RpcErr::BadParams("Expected 2 params".to_owned()));
+    
+    if params.len() != 2 || params.len() != 1 {
+        return Err(RpcErr::BadParams("Expected 2 or 1 params".to_owned()));
     }
 
     let forkchoice_state: ForkChoiceState = serde_json::from_value(params[0].clone())?;
-    // if there is an error when parsing, set to None
-    let payload_attributes: Option<PayloadAttributesV3> =
+    let mut payload_attributes: Option<PayloadAttributesV3> = None;
+    if params.len() == 2 {
+        // if there is an error when parsing (or the parameter is missing), set to None
+        payload_attributes =
         match serde_json::from_value::<Option<PayloadAttributesV3>>(params[1].clone()) {
             Ok(attributes) => attributes,
             Err(error) => {
@@ -188,6 +191,7 @@ fn parse(
                 None
             }
         };
+    }
     if let Some(attr) = &payload_attributes {
         if !is_v3 && attr.parent_beacon_block_root.is_some() {
             return Err(RpcErr::InvalidPayloadAttributes(


### PR DESCRIPTION
**Motivation**

This PR makes it so that when parsing engine_forkchoiceUpdatedV3 the second parameter isn't required. This came to light while testing odometer #2507, which sent the updates without the second parameter. This change makes it more conforming with the spec.

**Description**

Made it so that the second optional parameter in engine_forkchoiceUpdatedV3 ( Payload attributes) isn't required to be sent in the post request.

Note: this was already working if the second parameter was sent as a null or had problems.

