### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Hive tests are categorized by "simulations', and test instances can be filtered 
 ```bash
 make run-hive-debug SIMULATION=<simulation> TEST_PATTERN=<test-regex>
 ```
-This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specificaly
+This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specifically
 run chain id and transaction by hash rpc tests:
 ```bash
 make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_getTransactionByHash"

--- a/cmd/load_test/README.md
+++ b/cmd/load_test/README.md
@@ -36,7 +36,7 @@ cargo run --bin ethrex --release --features dev -- --network test_data/genesis-l
 
 Genesis-l2-ci has many rich accounts and does not include the prague fork, which is important for dev mode until it's fixed.
 
-After the node is runing, still in the repo root folder, execute the script with `make`. For example:
+After the node is running, still in the repo root folder, execute the script with `make`. For example:
 
 ```bash
 # Eth transfer load test

--- a/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
+++ b/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
@@ -130,7 +130,7 @@ interface ICommonBridge {
     /// @param withdrawalProof the merkle path to the withdrawal log.
     /// @param withdrawalLogIndex the index of the withdrawal log in the block.
     /// This is the index of the withdraw transaction relative to the block's
-    /// withdrawal transctions.
+    /// withdrawal transactions.
     /// A pseudocode would be [tx if tx is withdrawx for tx in block.txs()].index(leaf_tx).
     /// @param l2WithdrawalBlockNumber the block number where the withdrawal log
     /// was emitted.


### PR DESCRIPTION


**Description:**
This PR includes minor text corrections:

- Fixed spelling of "specifically" in README.md
- Corrected capitalization of "running" in cmd/load_test/README.md
- Fixed plural form of "transactions" in ICommonBridge.sol interface comments

These changes improve code documentation readability without affecting any functionality.

