### PR TITLE
stop popping callframe unnecessarily

### DIFF
--- a/crates/vm/levm/src/hooks/hook.rs
+++ b/crates/vm/levm/src/hooks/hook.rs
@@ -1,5 +1,4 @@
 use crate::{
-    call_frame::CallFrame,
     errors::{ExecutionReport, VMError},
     vm::VM,
 };
@@ -10,7 +9,6 @@ pub trait Hook {
     fn finalize_execution(
         &self,
         vm: &mut VM<'_>,
-        initial_call_frame: &CallFrame,
         report: &mut ExecutionReport,
     ) -> Result<(), VMError>;
 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -587,14 +587,9 @@ impl<'a> VM<'a> {
         // NOTE: ATTOW the default hook is created in VM::new(), so
         // (in theory) _at least_ the default finalize execution should
         // run
-        let call_frame = self
-            .call_frames
-            .pop()
-            .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
         for hook in self.hooks.clone() {
-            hook.finalize_execution(self, &call_frame, report)?;
+            hook.finalize_execution(self, report)?;
         }
-        self.call_frames.push(call_frame);
 
         Ok(())
     }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- stop popping callframe in finalize execution

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

