### PR TITLE
fix(l1): fcu not triggering sync if snap is enabled + re-enable snap sync hive test

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -174,11 +174,10 @@ jobs:
             simulation: ethereum/sync
             test_pattern: ""
             ethrex_flags: "--syncmode full"
-          # Flaky test, reenable when fixed
-          # - name: "Sync snap"
-          #   simulation: ethereum/sync
-          #   test_pattern: ""
-          #   ethrex_flags: "--syncmode snap"
+          - name: "Sync snap"
+            simulation: ethereum/sync
+            test_pattern: ""
+            ethrex_flags: "--syncmode snap"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -74,11 +74,20 @@ impl SyncManager {
         }
     }
 
-    /// Sets the latest fcu head and starts the next sync cycle if the syncer is currenlty inactive
+    /// Sets the latest fcu head and starts the next sync cycle if the syncer is currently inactive
     pub fn sync_to_head(&self, fcu_head: H256) {
         self.set_head(fcu_head);
         if !self.is_active() {
             self.start_sync();
+        }
+    }
+
+    /// Returns the syncer's current syncmode (either snap or full)
+    pub fn sync_mode(&self) -> SyncMode {
+        if self.snap_enabled.load(Ordering::Relaxed) {
+            SyncMode::Snap
+        } else {
+            SyncMode::Full
         }
     }
 
@@ -99,7 +108,7 @@ impl SyncManager {
     /// Attempts to sync to the last received fcu head
     /// Will do nothing if the syncer is already involved in a sync process
     /// If the sync process would require multiple sync cycles (such as snap sync), starts all required sync cycles until the sync is complete
-    pub fn start_sync(&self) {
+    fn start_sync(&self) {
         let syncer = self.syncer.clone();
         let store = self.store.clone();
         let sync_head = self.last_fcu_head.clone();
@@ -145,14 +154,5 @@ impl SyncManager {
                 }
             }
         });
-    }
-
-    /// Returns the syncer's current syncmode (either snap or full)
-    pub fn sync_mode(&self) -> SyncMode {
-        if self.snap_enabled.load(Ordering::Relaxed) {
-            SyncMode::Snap
-        } else {
-            SyncMode::Full
-        }
     }
 }

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -250,7 +250,9 @@ async fn handle_forkchoice(
     }
 
     if context.syncer.sync_mode() == SyncMode::Snap {
-        context.syncer.set_head(fork_choice_state.head_block_hash);
+        context
+            .syncer
+            .sync_to_head(fork_choice_state.head_block_hash);
         return Ok((None, PayloadStatus::syncing().into()));
     }
 
@@ -312,8 +314,9 @@ async fn handle_forkchoice(
                         .update_sync_status(false)
                         .await
                         .map_err(|e| RpcErr::Internal(e.to_string()))?;
-                    context.syncer.set_head(fork_choice_state.head_block_hash);
-                    context.syncer.start_sync();
+                    context
+                        .syncer
+                        .sync_to_head(fork_choice_state.head_block_hash);
                     ForkChoiceResponse::from(PayloadStatus::syncing())
                 }
                 InvalidForkChoice::Disconnected(_, _) | InvalidForkChoice::ElementNotFound(_) => {

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -698,9 +698,7 @@ async fn try_execute_payload(
                 .update_sync_status(false)
                 .await
                 .map_err(|e| RpcErr::Internal(e.to_string()))?;
-            context.syncer.set_head(block_hash);
-            context.syncer.start_sync();
-
+            context.syncer.sync_to_head(block_hash);
             Ok(PayloadStatus::syncing())
         }
         // Under the current implementation this is not possible: we always calculate the state


### PR DESCRIPTION
**Motivation**
PR #2426 changed how fork choice & new payload interact with the syncer and also introduced a bug. If snap sync is enabled, then fork choice update will never attempt to trigger a sync, so the sync process never gets started.
This PR fixes the bug and also refactors the sync manager api to better suit the new use cases
<!-- Why does this pull request exist? What are its goals? -->
* Combine commonly used together `SyncManager` methods `set_head` & `start_sync` into `sync_to_head`
* Remove unused `SyncManager` method `status` and associated struct
* Make sure sync is triggered during fcu  when needed even if snap sync is enabled
* Re-enable snap sync hive test suite
**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2521 

