### PR TITLE
fix(core): exclude ethrex-prover-bench on make lint

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Run cargo clippy
         run: |
           cargo clippy --workspace --exclude ethrex-prover-bench -- -D warnings
-          cargo clippy --all-targets --all-features --workspace --exclude ethrex-prover --exclude ethrex-prover-bench --exclude zkvm_interface -- -D warnings
+          make lint
 
       - name: Run cargo fmt
         run: |

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -67,8 +67,7 @@ jobs:
       - name: Run cargo clippy
         run: |
           cargo clippy --workspace --exclude ethrex-prover-bench -- -D warnings
-          cargo clippy --all-targets --all-features --workspace --exclude ethrex-prover --exclude zkvm_interface --exclude ethrex-prover-bench -- -D warnings
-
+          make lint
       - name: Run cargo fmt
         run: |
           cargo fmt --all -- --check

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -68,6 +68,7 @@ jobs:
         run: |
           cargo clippy --workspace --exclude ethrex-prover-bench -- -D warnings
           make lint
+
       - name: Run cargo fmt
         run: |
           cargo fmt --all -- --check

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: ## 🔨 Build the client
 	cargo build --workspace
 
 lint: ## 🧹 Linter check
-	cargo clippy --all-targets --all-features --workspace --exclude ethrex-prover --exclude zkvm_interface -- -D warnings
+	cargo clippy --all-targets --all-features --workspace --exclude ethrex-prover --exclude zkvm_interface --exclude ethrex-prover-bench -- -D warnings
 
 CRATE ?= *
 test: ## 🧪 Run each crate's tests


### PR DESCRIPTION
**Motivation**

`make lint` throws an error in main:

```
error occurred in cc-rs: failed to find tool "nvcc": No such file or directory (os error 2)
```

**Description**

Exclude `ethrex-prover-bench` when running clippy.

Closes None

