### PR TITLE
refactor(ci): optimize prover build on `integration-test` job (`pr-main_l2`)

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -73,6 +73,30 @@ jobs:
         run: |
           cargo fmt --all -- --check
 
+  build-prover:
+    name: Build Prover
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build prover
+        run: |
+          cd crates/l2
+          make build-prover
+
+      - name: Upload Prover Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ethrex_prover
+          path: target/release/ethrex_prover
+
   integration-test:
     name: Integration Test - ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -83,7 +107,7 @@ jobs:
             validium: true
           - name: "Vanilla"
             validium: false
-    needs: [docker-bake]
+    needs: [docker-bake, build-prover]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -114,10 +138,11 @@ jobs:
             ethrex_l2.cache-from=type=local,src=/tmp/buildx-cache/ethrex_l2
             contract_deployer.cache-from=type=local,src=/tmp/buildx-cache/contract_deployer
 
-      - name: Build prover
-        run: |
-          cd crates/l2
-          make build-prover
+      - name: Download Prover Binary
+        uses: actions/download-artifact@v3
+        with:
+          name: ethrex_prover
+          path: target/release/ethrex_prover
 
       - name: Build test
         run: |


### PR DESCRIPTION
**Motivation**

With the introduction of Validium (09e7db7745d819c253b85bb01b107f9b37e3fd00), the `integration test` is being run twice: once for Validium ethrex L2 and another for Vanilla ethrex L2. Each run builds the Prover independently, and those builds take too long.

**Description**

- Add a separate job `build-prover` to build the Prover binary and upload it as artifact.
- Constraint the `integration-test` job to require `build-prover` job to run, and replace the Prover building step with a Prover artifact download step.

