### PR TITLE
docs: add descriptions for Verifier and L1MessageSender contracts

### DIFF
--- a/crates/l2/docs/contracts.md
+++ b/crates/l2/docs/contracts.md
@@ -23,10 +23,10 @@ Ensures the advancement of the L2. It is used by the operator to commit blocks a
 
 ### `Verifier`
 
-TODO
+A cryptographic proof verification contract that ensures the validity of L2 state transitions. It implements multiple verification schemes (Risc0, SP1, Pico) to validate zero-knowledge proofs submitted by the operator, guaranteeing that the L2 execution was performed correctly.
 
 ## L2 side
 
 ### `L1MessageSender`
 
-TODO
+Facilitates sending messages from L2 to L1. It allows users to initiate withdrawals by burning funds on L2 and sending a corresponding message to L1 that can be used to claim those funds. The contract works in conjunction with CommonBridgeL2 to enable secure cross-chain communication.


### PR DESCRIPTION
**Motivation**

Documentation was missing for two key contracts in the L2 system. Added clear descriptions to improve developer understanding of the contract architecture.

**Description**

- Added description for the Verifier contract explaining its role in cryptographic proof verification
- Added description for the L1MessageSender contract detailing its cross-chain communication functionality


