### PR TITLE
refactor(levm): removed call frame as parameter from certain functions

### DIFF
--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -152,7 +152,6 @@ impl<'a> VM<'a> {
             .backups
             .pop()
             .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-        let refunded_gas = self.env.refunded_gas;
         let mut transaction_result = TxResult::Success;
         {
             // Check for the case where the transaction is a contract creation one
@@ -218,6 +217,7 @@ impl<'a> VM<'a> {
                 self.restore_state(backup, self.current_call_frame()?.cache_backup.clone())?;
             }
         }
+        let refunded_gas = self.env.refunded_gas;
         let current_call_frame = self.current_call_frame_mut()?;
 
         Ok(ExecutionReport {

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -242,9 +242,6 @@ impl<'a> VM<'a> {
 
         {
             let current_call_frame = self.current_call_frame_mut()?;
-            let refunded = backup.refunded_gas;
-            let output = std::mem::take(&mut current_call_frame.output); // Bytes::new() if error is not RevertOpcode
-            let gas_used = current_call_frame.gas_used;
             // Unless error is from Revert opcode, all gas is consumed
             if error != VMError::RevertOpcode {
                 let left_gas = current_call_frame
@@ -252,7 +249,9 @@ impl<'a> VM<'a> {
                     .saturating_sub(current_call_frame.gas_used);
                 current_call_frame.gas_used = current_call_frame.gas_used.saturating_add(left_gas);
             }
-            
+            let refunded = backup.refunded_gas;
+            let output = std::mem::take(&mut current_call_frame.output); // Bytes::new() if error is not RevertOpcode
+            let gas_used = current_call_frame.gas_used;
             execution_report = Ok(ExecutionReport {
                 result: TxResult::Revert(error),
                 gas_used,

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -19,16 +19,16 @@ impl<'a> VM<'a> {
         backup: StateBackup,
     ) -> Result<ExecutionReport, VMError> {
         match precompile_result {
-                Ok(output) => { 
-                    let current_call_frame = self.current_call_frame()?;
-                    Ok(ExecutionReport {
+            Ok(output) => {
+                let current_call_frame = self.current_call_frame()?;
+                Ok(ExecutionReport {
                     result: TxResult::Success,
                     gas_used: current_call_frame.gas_used,
                     gas_refunded: self.env.refunded_gas,
                     output,
                     logs: std::mem::take(&mut self.current_call_frame_mut()?.logs),
                 })
-            },
+            }
             Err(error) => {
                 if error.is_internal() {
                     return Err(error);
@@ -226,10 +226,7 @@ impl<'a> VM<'a> {
         })
     }
 
-    pub fn handle_opcode_error(
-        &mut self,
-        error: VMError,
-    ) -> Result<ExecutionReport, VMError> {
+    pub fn handle_opcode_error(&mut self, error: VMError) -> Result<ExecutionReport, VMError> {
         let backup = self
             .backups
             .pop()

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -16,15 +16,13 @@ impl<'a> VM<'a> {
         backup: StateBackup,
     ) -> Result<ExecutionReport, VMError> {
         match precompile_result {
-            Ok(output) => {
-                Ok(ExecutionReport {
-                    result: TxResult::Success,
-                    gas_used: self.current_call_frame()?.gas_used,
-                    gas_refunded: self.env.refunded_gas,
-                    output,
-                    logs: std::mem::take(&mut self.current_call_frame_mut()?.logs),
-                })
-            }
+            Ok(output) => Ok(ExecutionReport {
+                result: TxResult::Success,
+                gas_used: self.current_call_frame()?.gas_used,
+                gas_refunded: self.env.refunded_gas,
+                output,
+                logs: std::mem::take(&mut self.current_call_frame_mut()?.logs),
+            }),
             Err(error) => {
                 if error.is_internal() {
                     return Err(error);

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -1,5 +1,4 @@
 use crate::{
-    call_frame::{self, CallFrame},
     constants::*,
     errors::{ExecutionReport, InternalError, OpcodeResult, OutOfGasError, TxResult, VMError},
     gas_cost::CODE_DEPOSIT_COST,
@@ -7,8 +6,6 @@ use crate::{
     utils::*,
     vm::{StateBackup, VM},
 };
-
-use ethrex_common::types::Fork;
 
 use bytes::Bytes;
 

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,5 +1,5 @@
 use crate::{
-    call_frame::{self, CallFrame},
+    call_frame::CallFrame,
     constants::{CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, REVERT_FOR_CALL, SUCCESS_FOR_CALL},
     db::cache,
     errors::{ExecutionReport, InternalError, OpcodeResult, OutOfGasError, TxResult, VMError},

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1,5 +1,5 @@
 use crate::{
-    call_frame::CallFrame,
+    call_frame::{self, CallFrame},
     constants::{CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, REVERT_FOR_CALL, SUCCESS_FOR_CALL},
     db::cache,
     errors::{ExecutionReport, InternalError, OpcodeResult, OutOfGasError, TxResult, VMError},

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -908,10 +908,7 @@ impl<'a> VM<'a> {
         Ok(OpcodeResult::Continue { pc_increment: 0 })
     }
 
-    pub fn handle_return(
-        &mut self,
-        tx_report: &ExecutionReport,
-    ) -> Result<bool, VMError> {
+    pub fn handle_return(&mut self, tx_report: &ExecutionReport) -> Result<bool, VMError> {
         if self.current_call_frame()?.depth == 0 {
             return Ok(false);
         }
@@ -919,7 +916,10 @@ impl<'a> VM<'a> {
             .return_data
             .pop()
             .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-        let call_frame = self.call_frames.pop().ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
+        let call_frame = self
+            .call_frames
+            .pop()
+            .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
         if retdata.is_create {
             self.handle_return_create(&call_frame, tx_report, retdata)?;
         } else {

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -910,21 +910,20 @@ impl<'a> VM<'a> {
 
     pub fn handle_return(
         &mut self,
-        call_frame: &CallFrame,
         tx_report: &ExecutionReport,
     ) -> Result<bool, VMError> {
-        if call_frame.depth == 0 {
-            self.call_frames.push(call_frame.clone());
+        if self.current_call_frame()?.depth == 0 {
             return Ok(false);
         }
         let retdata = self
             .return_data
             .pop()
             .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
+        let call_frame = self.call_frames.pop().ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
         if retdata.is_create {
-            self.handle_return_create(call_frame, tx_report, retdata)?;
+            self.handle_return_create(&call_frame, tx_report, retdata)?;
         } else {
-            self.handle_return_call(call_frame, tx_report, retdata)?;
+            self.handle_return_call(&call_frame, tx_report, retdata)?;
         }
         Ok(true)
     }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -299,17 +299,13 @@ impl<'a> VM<'a> {
         let fork = self.env.config.fork;
 
         if is_precompile(&self.current_call_frame()?.code_address, fork) {
-            let mut current_call_frame = self
-                .call_frames
-                .pop()
-                .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-            let precompile_result = execute_precompile(&mut current_call_frame, fork);
+            let precompile_result = execute_precompile(self.current_call_frame_mut()?,fork);
             let backup = self
                 .backups
                 .pop()
                 .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
             let report =
-                self.handle_precompile_result(precompile_result, backup, &mut current_call_frame)?;
+                self.handle_precompile_result(precompile_result, backup)?;
             self.handle_return(&current_call_frame, &report)?;
             self.current_call_frame_mut()?.increment_pc_by(1)?;
             return Ok(report);
@@ -325,24 +321,16 @@ impl<'a> VM<'a> {
                     .current_call_frame_mut()?
                     .increment_pc_by(pc_increment)?,
                 Ok(OpcodeResult::Halt) => {
-                    let mut current_call_frame = self
-                        .call_frames
-                        .pop()
-                        .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-                    let report = self.handle_opcode_result(&mut current_call_frame)?;
-                    if self.handle_return(&current_call_frame, &report)? {
+                    let report = self.handle_opcode_result(self.current_call_frame_mut()?)?;
+                    if self.handle_return(&report)? {
                         self.current_call_frame_mut()?.increment_pc_by(1)?;
                     } else {
                         return Ok(report);
                     }
                 }
                 Err(error) => {
-                    let mut current_call_frame = self
-                        .call_frames
-                        .pop()
-                        .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-                    let report = self.handle_opcode_error(error, &mut current_call_frame)?;
-                    if self.handle_return(&current_call_frame, &report)? {
+                    let report = self.handle_opcode_error(error)?;
+                    if self.handle_return(&report)? {
                         self.current_call_frame_mut()?.increment_pc_by(1)?;
                     } else {
                         return Ok(report);

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -299,13 +299,12 @@ impl<'a> VM<'a> {
         let fork = self.env.config.fork;
 
         if is_precompile(&self.current_call_frame()?.code_address, fork) {
-            let precompile_result = execute_precompile(self.current_call_frame_mut()?,fork);
+            let precompile_result = execute_precompile(self.current_call_frame_mut()?, fork);
             let backup = self
                 .backups
                 .pop()
                 .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-            let report =
-                self.handle_precompile_result(precompile_result, backup)?;
+            let report = self.handle_precompile_result(precompile_result, backup)?;
             self.handle_return(&current_call_frame, &report)?;
             self.current_call_frame_mut()?.increment_pc_by(1)?;
             return Ok(report);

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -305,7 +305,7 @@ impl<'a> VM<'a> {
                 .pop()
                 .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
             let report = self.handle_precompile_result(precompile_result, backup)?;
-            self.handle_return(&current_call_frame, &report)?;
+            self.handle_return(&report)?;
             self.current_call_frame_mut()?.increment_pc_by(1)?;
             return Ok(report);
         }
@@ -320,7 +320,7 @@ impl<'a> VM<'a> {
                     .current_call_frame_mut()?
                     .increment_pc_by(pc_increment)?,
                 Ok(OpcodeResult::Halt) => {
-                    let report = self.handle_opcode_result(self.current_call_frame_mut()?)?;
+                    let report = self.handle_opcode_result()?;
                     if self.handle_return(&report)? {
                         self.current_call_frame_mut()?.increment_pc_by(1)?;
                     } else {


### PR DESCRIPTION
**Motivation**

Simplify some function calls by removing unnecessary parameters and make the code of the handlers a bit more readable.

**Description**

The current call frame was being passed as a parameter to certain function calls in the VM. This removes it in favor of using the VM method. Some variables are also renamed for further clarity, and the responsability of popping the current call frame from the stack is delegated to the handle_return_call and handle_return_create methods (where both the call frame that has just been executed, and the one to be returned to, are needed).

Resolves[ #2542 ](https://github.com/lambdaclass/ethrex/issues/2542) and [#2569](https://github.com/lambdaclass/ethrex/issues/2569) 
