### PR TITLE
fix(l2): bench crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "again"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05802a5ad4d172eaf796f7047b42d0af9db513585d16d4169660a21613d34b93"
+dependencies = [
+ "log",
+ "rand 0.7.3",
+ "wasm-timer",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stdin"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ff8b5d9b5ec29e0f49583ba71847b8c8888b67a8510133048a380903aa6822"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1084,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "async-throttle"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c99532de164435a0b91279e715bff4fa0d164643b409a67761907ffc210ee8f"
+dependencies = [
+ "backoff",
+ "dashmap 5.5.3",
+ "tokio",
 ]
 
 [[package]]
@@ -2330,6 +2361,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -3235,6 +3279,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethrex-prover-bench"
+version = "0.1.0"
+dependencies = [
+ "again",
+ "bincode",
+ "bytes",
+ "clap 4.5.36",
+ "derive_more 1.0.0",
+ "ethrex-common",
+ "ethrex-levm",
+ "ethrex-prover",
+ "ethrex-rlp",
+ "ethrex-storage",
+ "ethrex-trie",
+ "ethrex-vm",
+ "futures-util",
+ "hex",
+ "lazy_static",
+ "reqwest",
+ "revm 19.7.0",
+ "revm-inspectors",
+ "revm-primitives 15.2.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-utils",
+ "zkvm_interface",
+]
+
+[[package]]
 name = "ethrex-rlp"
 version = "0.1.0"
 dependencies = [
@@ -3775,6 +3849,17 @@ checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
 dependencies = [
  "serde",
  "typenum",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -7278,6 +7363,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -7297,6 +7395,16 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7336,6 +7444,15 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -7350,6 +7467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -8718,6 +8844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shutdown-async"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2799e69bde7e68bedd86c6d94bffa783219114f1f31435ddda61f4aeba348ff"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9885,6 +10020,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de75f75f464153a50fe48b9675360e3cf2ae1d7d81f9751363bd2ee4888f5ce8"
+dependencies = [
+ "async-stdin",
+ "async-throttle",
+ "shutdown-async",
+ "tub",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10169,6 +10316,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tub"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bca43faba247bc76eb1d6c1b8b561e4a1c5bdd427cc3d7a007faabea75c683a"
+dependencies = [
+ "crossbeam-queue",
+ "tokio",
+]
 
 [[package]]
 name = "twirp-rs"
@@ -10481,6 +10638,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -10573,6 +10736,21 @@ checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -16,10 +16,10 @@ ethereum-types.workspace = true
 ethrex-common.workspace = true
 ethrex-rlp.workspace = true
 ethrex-rpc.workspace = true
-ethrex-blockchain = { workspace = true, features = ["l2"] }
+ethrex-blockchain.workspace = true
 ethrex-storage.workspace = true
 ethrex-trie.workspace = true
-ethrex-vm = { workspace = true, features = ["l2"] }
+ethrex-vm.workspace = true
 ethrex-levm.workspace = true
 ethrex-dev = { path = "../../crates/blockchain/dev", default-features = false }
 ethrex-metrics = { path = "../blockchain/metrics", default-features = false }
@@ -36,7 +36,7 @@ directories = "5.0.1"
 toml = { version = "0.8.19", features = ["parse"] }
 bincode = "1.3.3"
 
-zkvm_interface = { path = "./prover/zkvm/interface/", features = ["l2"] }
+zkvm_interface = { path = "./prover/zkvm/interface/" }
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -53,5 +53,6 @@ unnecessary_cast = "warn"
 panic = "deny"
 
 [features]
-default = []
+default = ["l2"]
 metrics = ["ethrex-metrics/l2"]
+l2 = ["ethrex-blockchain/l2", "ethrex-vm/l2", "zkvm_interface/l2"]

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -22,7 +22,7 @@ ethrex-rlp.workspace = true
 ethrex-blockchain.workspace = true
 
 # l2
-ethrex-l2.workspace = true
+ethrex-l2 = { path = "../", default-features = false }
 ethrex-sdk.workspace = true
 
 zkvm_interface = { path = "./zkvm/interface", default-features = false }
@@ -60,6 +60,7 @@ l2 = [
   "ethrex-vm/l2",
   "zkvm_interface/l2",
   "ethrex-blockchain/l2",
+  "ethrex-l2/l2",
 ] # the prover can work with either l1 or l2 blocks
 
 [lints.clippy]

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -55,7 +55,7 @@ risc0 = [
 ]
 sp1 = ["zkvm_interface/sp1", "dep:sp1-sdk"]
 
-gpu = ["risc0-zkvm/cuda", "sp1-sdk/cuda"]
+gpu = ["risc0-zkvm?/cuda", "sp1-sdk?/cuda"]
 l2 = [
   "ethrex-vm/l2",
   "zkvm_interface/l2",

--- a/crates/l2/prover/bench/Cargo.toml
+++ b/crates/l2/prover/bench/Cargo.toml
@@ -9,7 +9,6 @@ ethrex-vm.workspace = true
 ethrex-storage.workspace = true
 ethrex-rlp.workspace = true
 ethrex-prover.workspace = true
-ethrex-l2.workspace = true
 ethrex-trie.workspace = true
 ethrex-levm.workspace = true
 

--- a/crates/l2/prover/bench/src/main.rs
+++ b/crates/l2/prover/bench/src/main.rs
@@ -1,7 +1,6 @@
 use std::{fs::File, io::Write};
 
 use clap::Parser;
-use ethrex_l2::utils::prover::proving_systems::ProverType;
 use ethrex_prover_bench::{
     cache::{load_cache, write_cache, Cache},
     rpc::{db::RpcDB, get_block, get_latest_block_number},

--- a/crates/l2/prover/bench/src/rpc/db.rs
+++ b/crates/l2/prover/bench/src/rpc/db.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 
 use crate::constants::{CANCUN_CONFIG, RPC_RATE_LIMIT};
@@ -9,8 +8,8 @@ use ethrex_common::{
     types::{AccountInfo, AccountState, Block, Fork, TxKind},
     Address, H256, U256,
 };
+use ethrex_levm::db::gen_db::GeneralizedDatabase;
 use ethrex_levm::db::Database as LevmDatabase;
-use ethrex_levm::vm::GeneralizedDatabase;
 use ethrex_storage::{hash_address, hash_key};
 use ethrex_trie::{Node, PathRLP, Trie};
 use ethrex_vm::backends::levm::{CacheDB, LEVM};

--- a/crates/l2/prover/bench/src/rpc/db.rs
+++ b/crates/l2/prover/bench/src/rpc/db.rs
@@ -540,7 +540,10 @@ fn get_potential_child_nodes(proof: &[NodeRLP], key: &PathRLP) -> Option<Vec<Nod
                 let mut variants = Vec::with_capacity(node.partial.len());
                 while {
                     variants.push(Node::from(node.clone()));
-                    node.partial.next().is_some()
+                    node.partial.next();
+                    !node.partial.is_empty() // skip the last nibble, which is the leaf flag.
+                                             // if we encode a leaf with its flag missing, it’s going to be encoded as an
+                                             // extension.
                 } {}
                 Some(variants)
             }


### PR DESCRIPTION
The pipeline was failing because of:
1. some breaking changes (renamed imports) 
2. a previously existing bug that we didn't catch until #2516 (we were encoding a leaf node without its leaf flag, so it would be decoded into an extension leaf and produce a panic)
3. we were executing the prover in L2 mode because we depended on ethrex-l2 (and in ethrex-prover, which depends on ethrex-l2), and that crate enables the L2 feature of ethrex-vm by default.
    - The solution was to make an `l2` feature for ethrex-l2, which isn't ideal. A better (but bigger) solution is proposed in #2662 