### PR TITLE
fix(l1): extend fetch head timeout for hive sync test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := d98bcfa37f501f4ea1869d0a79fde35ed472937f
+HIVE_REVISION := f9004c7e85de003bbdeb4fbcc4a9dbf8c3c4c9c2
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).


### PR DESCRIPTION
**Motivation**
Snap sync hive test has been flaky lately, after running with debug output on the CI the problem seems to be a timeout when fetching the latest block. A [PR](https://github.com/lambdaclass/hive/pull/22) was added to our hive fork to extend this timeout so the test doesn't fail. The timeout for the whole sync process has been left unchanged
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Extends the timeout for fetching the latest block on the sync hive test suite
* Update Hive ref
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

