### PR TITLE
perf(l1): add block snapshots with account states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "libmdbx",
+ "moka",
  "redb",
  "serde",
  "serde_json",
@@ -3882,6 +3883,19 @@ name = "gen_ops"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
+
+[[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
+]
 
 [[package]]
 name = "generic-array"
@@ -5251,6 +5265,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.19",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5424,6 +5451,25 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version 0.4.1",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -8574,6 +8620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9718,7 +9770,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -9741,6 +9793,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -10610,6 +10668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10930,6 +10997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10940,15 +11017,39 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
  "windows-link",
- "windows-result",
+ "windows-result 0.3.2",
  "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -10956,6 +11057,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10985,9 +11097,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result",
+ "windows-result 0.3.2",
  "windows-strings 0.3.1",
  "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10997,6 +11118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/cmd/ethrex_l2/src/commands/stack.rs
+++ b/cmd/ethrex_l2/src/commands/stack.rs
@@ -242,7 +242,11 @@ impl Command {
                     // Apply all account updates to trie
                     let account_updates = state_diff.to_account_updates(&new_trie)?;
                     new_trie = store
-                        .apply_account_updates_from_trie(new_trie, &account_updates)
+                        .apply_account_updates_from_trie(
+                            new_trie,
+                            &account_updates,
+                            genesis_block_hash,
+                        )
                         .await
                         .expect("Error applying account updates");
 

--- a/cmd/ethrex_l2/src/commands/stack.rs
+++ b/cmd/ethrex_l2/src/commands/stack.rs
@@ -242,11 +242,7 @@ impl Command {
                     // Apply all account updates to trie
                     let account_updates = state_diff.to_account_updates(&new_trie)?;
                     new_trie = store
-                        .apply_account_updates_from_trie(
-                            new_trie,
-                            &account_updates,
-                            genesis_block_hash,
-                        )
+                        .apply_account_updates_from_trie(new_trie, &account_updates)
                         .await
                         .expect("Error applying account updates");
 

--- a/cmd/load_test/Cargo.toml
+++ b/cmd/load_test/Cargo.toml
@@ -17,4 +17,3 @@ futures = "0.3"
 eyre = "0.6"
 keccak-hash.workspace = true
 tokio.workspace = true
-

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -144,7 +144,7 @@ impl Blockchain {
 
         self.storage
             .update_snapshot(block_hash, new_state_root)
-            .await;
+            .await?;
 
         Ok(())
     }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -115,6 +115,10 @@ impl Blockchain {
         Ok(execution_result)
     }
 
+    pub fn init_new_snapshot(&self, prev_hash: BlockHash, block_hash: BlockHash) {
+        self.storage.init_new_snapshot(prev_hash, block_hash);
+    }
+
     pub async fn store_block(
         &self,
         block: &Block,

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -289,7 +289,7 @@ pub trait Signable {
 }
 
 impl Transaction {
-    pub fn tx_type(&self) -> TxType {
+    pub const fn tx_type(&self) -> TxType {
         match self {
             Transaction::LegacyTransaction(_) => TxType::Legacy,
             Transaction::EIP2930Transaction(_) => TxType::EIP2930,
@@ -298,6 +298,11 @@ impl Transaction {
             Transaction::EIP7702Transaction(_) => TxType::EIP7702,
             Transaction::PrivilegedL2Transaction(_) => TxType::Privileged,
         }
+    }
+
+    #[inline]
+    pub fn is_blob_tx(&self) -> bool {
+        self.tx_type() == TxType::EIP4844
     }
 
     fn calc_effective_gas_price(&self, base_fee_per_gas: Option<u64>) -> Option<u64> {

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -720,6 +720,10 @@ async fn try_execute_payload(
             "Missing latest canonical block".to_owned(),
         ))?;
 
+    context
+        .blockchain
+        .init_new_snapshot(latest_valid_hash, block_hash);
+
     match context.blockchain.add_block(block).await {
         Err(ChainError::ParentNotFound) => {
             // Start sync

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -26,6 +26,8 @@ redb = { workspace = true, optional = true }
 # We only need the runtime for the blocking databases to spawn blocking tasks
 tokio = { version = "1.41.1", optional = true, default-features = false, features = ["rt"] }
 
+moka ={ version = "0.12.10", features = ["sync"]}
+
 [features]
 default = ["dep:tokio"]
 libmdbx = ["dep:libmdbx", "ethrex-trie/libmdbx", "dep:tokio"]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -27,7 +27,7 @@ redb = { workspace = true, optional = true }
 tokio = { version = "1.41.1", optional = true, default-features = false, features = ["rt"] }
 
 [features]
-default = []
+default = ["dep:tokio"]
 libmdbx = ["dep:libmdbx", "ethrex-trie/libmdbx", "dep:tokio"]
 redb = ["dep:redb", "dep:tokio"]
 

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -166,6 +166,7 @@ impl Hook for DefaultHook {
 
         // check for nonce mismatch
         if sender_account.info.nonce != vm.env.tx_nonce {
+            dbg!(sender_account.info.nonce, vm.env.tx_nonce);
             return Err(VMError::TxValidation(TxValidationError::NonceMismatch));
         }
 


### PR DESCRIPTION
Very work in progress and mostly just investigating aproaches right now.

```
CPU: AMD Ryzen 9 7900X3D (24 threads) @ 5.66 GHz (native march = AVX512)
RAM: 64gb @ 6000mt/s

cargo run --bin ethrex --release --features dev -- --network test_data/genesis-l1-dev.json --dev

make load-test-erc20

main (https://github.com/lambdaclass/ethrex/commit/33e34efcf5f339ff1d344b134d8f60e78d16e8c4):
433 seconds

PR ( 56ba606412b179b6af6ee1176bcdaf289736b7bf ): 422
```

**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

