### PR TITLE
feat(levm): replace ambiguous error with proper validation error when obtaining effective gas price

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -18,6 +18,7 @@ use ethrex_common::{
     Address, H256, U256,
 };
 use ethrex_levm::db::gen_db::GeneralizedDatabase;
+use ethrex_levm::errors::TxValidationError;
 use ethrex_levm::{
     errors::{ExecutionReport, TxResult, VMError},
     vm::{EVMConfig, Substate, VM},
@@ -106,7 +107,9 @@ impl LEVM {
         let chain_config = db.store.get_chain_config();
         let gas_price: U256 = tx
             .effective_gas_price(block_header.base_fee_per_gas)
-            .ok_or(VMError::InvalidTransaction)?
+            .ok_or(VMError::TxValidation(
+                TxValidationError::InsufficientMaxFeePerGas,
+            ))?
             .into();
 
         let config = EVMConfig::new_from_chain_config(&chain_config, block_header);


### PR DESCRIPTION
**Motivation**
While implementing a mapper for our ethrex & levm error types for the consume-engine hive test I ran into a test that was returning the error `Invalid Transaction: Invalid Transaction` which doesn't look useful at all. The error comes up when we fail to compute the effective gas for a transaction (aka the block's base_fee is higher than the transaction's max fee), so I replaced it with the appropriate error (TxValidationError::InsufficientMaxFeePerGas) which is also the one expected by the test suite.

**Description**
* Replace ambiguous error used when calculating effective gas price before tx execution with proper validation error.

Closes: None, but is needed to cleanly implement the error mapper needed for #2474 