### PR TITLE
docs(l1): latest valid ancestor store methods

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1074,6 +1074,8 @@ impl Store {
         self.engine.read_storage_snapshot(account_hash, start).await
     }
 
+    /// Fetches the latest valid ancestor for a block that was previously marked as invalid
+    /// Returns None if the block was never marked as invalid
     pub async fn get_latest_valid_ancestor(
         &self,
         block: BlockHash,
@@ -1081,6 +1083,7 @@ impl Store {
         self.engine.get_latest_valid_ancestor(block).await
     }
 
+    /// Marks a block as invalid and sets its latest valid ancestor
     pub async fn set_latest_valid_ancestor(
         &self,
         bad_block: BlockHash,


### PR DESCRIPTION
**Motivation**
The `Store` methods `set_latest_valid_ancestor` & `get_latest_valid_ancestor` can be confusing without proper documentation. These methods were properly documented on the `StoreEngine` trait, but they were not documented in the `Store` structure where they will be most often called from. This PR adds documentation for these methods on the `Store` implementation while also simplifying it, as the internal trait documentation provides more information on the context and design choices/requirements for the implementation which are not necessary for the top-level methods.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add doc comments for `Store` methods `set_latest_valid_ancestor` & `get_latest_valid_ancestor` 
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

