### PR TITLE
fix(l2): sigint to kill prover in integration test

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -208,7 +208,6 @@ integration-test: rm-db-l2 rm-db-l1
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} up --detach --build
 	RUST_LOG=info,ethrex_prover_lib=debug make init-prover & cargo test l2 --release -- --nocapture --test-threads=1
 	killall ethrex_prover -s SIGINT
-	$(MAKE) down
 
 integration-test-gpu: rm-db-l2 rm-db-l1
 	# We create an empty .env file simply because if the file
@@ -218,7 +217,6 @@ integration-test-gpu: rm-db-l2 rm-db-l1
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} up --detach --build
 	RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover & cargo test l2 --release -- --nocapture --test-threads=1
 	killall ethrex_prover -s SIGINT
-	$(MAKE) down
 
 # State reconstruction tests
 state-diff-test:

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -207,7 +207,8 @@ integration-test: rm-db-l2 rm-db-l1
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} down
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} up --detach --build
 	RUST_LOG=info,ethrex_prover_lib=debug make init-prover & cargo test l2 --release -- --nocapture --test-threads=1
-	killall ethrex_prover
+	killall ethrex_prover -s SIGINT
+	$(MAKE) down
 
 integration-test-gpu: rm-db-l2 rm-db-l1
 	# We create an empty .env file simply because if the file
@@ -216,7 +217,8 @@ integration-test-gpu: rm-db-l2 rm-db-l1
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} down
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} up --detach --build
 	RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover & cargo test l2 --release -- --nocapture --test-threads=1
-	killall ethrex_prover
+	killall ethrex_prover -s SIGINT
+	$(MAKE) down
 
 # State reconstruction tests
 state-diff-test:


### PR DESCRIPTION
**Motivation**

SP1 deploys a container for GPU proving. If the prover is killed with `SIGTERM`, the program does not remove the container and a next run may get stuck. If the prover is killed with `SIGINT`, then the container gets deleted.