### PR TITLE
fix(l1): catch potential panic when decoding `NodeHash`

### DIFF
--- a/crates/common/trie/node_hash.rs
+++ b/crates/common/trie/node_hash.rs
@@ -1,5 +1,5 @@
 use ethereum_types::H256;
-use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, structs::Encoder};
+use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, error::RLPDecodeError, structs::Encoder};
 #[cfg(feature = "libmdbx")]
 use libmdbx::orm::{Decodable, Encodable};
 use sha3::{Digest, Keccak256};
@@ -36,7 +36,7 @@ impl NodeHash {
     }
 
     /// Converts a slice of an already hashed data (in case it's not inlineable) to a NodeHash.
-    ///
+    /// Panics if the slice is over 32 bits
     /// If you need to hash it in case its len >= 32 see `from_encoded_raw`
     pub(crate) fn from_slice(slice: &[u8]) -> NodeHash {
         match slice.len() {
@@ -103,12 +103,6 @@ impl NodeHash {
     }
 }
 
-impl From<Vec<u8>> for NodeHash {
-    fn from(value: Vec<u8>) -> Self {
-        NodeHash::from_slice(&value)
-    }
-}
-
 impl From<H256> for NodeHash {
     fn from(value: H256) -> Self {
         NodeHash::Hashed(value)
@@ -160,7 +154,10 @@ impl RLPDecode for NodeHash {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), ethrex_rlp::error::RLPDecodeError> {
         let (hash, rest): (Vec<u8>, &[u8]);
         (hash, rest) = RLPDecode::decode_unfinished(rlp)?;
-        let hash = NodeHash::from(hash);
+        if hash.len() > 32 {
+            return Err(RLPDecodeError::InvalidLength);
+        }
+        let hash = NodeHash::from_slice(&hash);
         Ok((hash, rest))
     }
 }

--- a/crates/common/trie/node_hash.rs
+++ b/crates/common/trie/node_hash.rs
@@ -36,7 +36,7 @@ impl NodeHash {
     }
 
     /// Converts a slice of an already hashed data (in case it's not inlineable) to a NodeHash.
-    /// Panics if the slice is over 32 bits
+    /// Panics if the slice is over 32 bytes
     /// If you need to hash it in case its len >= 32 see `from_encoded_raw`
     pub(crate) fn from_slice(slice: &[u8]) -> NodeHash {
         match slice.len() {


### PR DESCRIPTION
**Motivation**
The method `NodeHash::from_slice` can panic if the slice is over 32 bytes. This could cause panics when decoding nodes as it is used without checking the length beforehand. This PR adds a check and returns an invalid length error before calling `from_slice`. It also mentions the potential panic on the method's documentation & removes a misleading `From<Vec<u8>>` implementation that would also panic under the same condition.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Remove `From<Vec<u8>> for NodeHash` impl as it could cause panics
* Mention potential panic on `NodeHash::from_slice` doc
* Check rlp decoded data len to avoid panics when decoding `NodeHash`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2649
