### PR TITLE
fix(l1): gate blob tests behind `c-kzg` feature

### DIFF
--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -255,6 +255,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "c-kzg")]
     fn transaction_with_valid_blobs_should_pass() {
         let blobs = vec!["Hello, world!".as_bytes(), "Goodbye, world!".as_bytes()]
             .into_iter()
@@ -282,7 +283,9 @@ mod tests {
 
         assert!(matches!(blobs_bundle.validate(&tx), Ok(())));
     }
+
     #[test]
+    #[cfg(feature = "c-kzg")]
     fn transaction_with_invalid_proofs_should_fail() {
         // blob data taken from: https://etherscan.io/tx/0x02a623925c05c540a7633ffa4eb78474df826497faa81035c4168695656801a2#blobs, but with 0 size blobs
         let blobs_bundle = BlobsBundle {
@@ -333,6 +336,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "c-kzg")]
     fn transaction_with_incorrect_blobs_should_fail() {
         // blob data taken from: https://etherscan.io/tx/0x02a623925c05c540a7633ffa4eb78474df826497faa81035c4168695656801a2#blobs
         let blobs_bundle = BlobsBundle {


### PR DESCRIPTION
**Motivation**
Currently, attempting to run any test on the common crate fails unless we explicitly add `--features c-kzg` due to the tests on the blobs_bundle module using code gated behind `c-kzg` feature. This PR solves this issue by feature-gating tests that use these feature-gated code.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `c-kzg` feature gate to tests on blobs_bundle module
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

