### PR TITLE
fix(l1): prevent amplification attack on `FindNode` request

### DIFF
--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -238,6 +238,10 @@ impl Discv4Server {
                 let Some(node) = node else {
                     return Err(DiscoveryError::InvalidMessage("not a known node".into()));
                 };
+                // Check that the received IP address matches the one we have stored to prevent aplification attacks
+                if from.ip() != node.node.ip {
+                    return Err(DiscoveryError::InvalidMessage("not a known node".into()));
+                }
                 if !node.is_proven {
                     return Err(DiscoveryError::InvalidMessage("node isn't proven".into()));
                 }

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -238,7 +238,10 @@ impl Discv4Server {
                 let Some(node) = node else {
                     return Err(DiscoveryError::InvalidMessage("not a known node".into()));
                 };
-                // Check that the received IP address matches the one we have stored to prevent aplification attacks
+                // Check that the IP address from which we receive the request matches the one we have stored to prevent amplification attacks
+                // This prevents an attack vector where the discovery protocol could be used to amplify traffic in a DDOS attack.
+                // A malicious actor would send a findnode request with the IP address and UDP port of the target as the source address.
+                // The recipient of the findnode packet would then send a neighbors packet (which is a much bigger packet than findnode) to the victim.
                 if from.ip() != node.node.ip {
                     return Err(DiscoveryError::InvalidMessage("not a known node".into()));
                 }


### PR DESCRIPTION
**Motivation**
Some hive devp2p tests have been failing as of lately. Particularly the `discv4/Amplification/WrongIP` test. Upon further investigation it looks like the test was previously passing but not for the right reasons. The test consists of sending Ping and Pong messages to the node from a given IP and then sending a `FindNode` request from the same node id but a different IP. The test fails if the node replies with a `Neighbours` message instead of noticing the IP mismatch that could represent an amplification attack.
Our test used to pass, but not due to the node catching the potential attack but due to a failure to deliver the neighbors message. On both failing and non-failing attempts the node constructs the neighbors message and attempts to send it which is not the correct behaviour.

This PR fixes this problem by checking that the IP from which we received the `FindNode` request matches the ip we stored when validating the node (via ping pong messages) as to prevent amplification attacks. It also adds some doc about the potential attack (taken from geth implementation)
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Check that the IP from which we receive a FindNode message matches the IP of the node
* Add doc about potential amplification attacks on FindNode requests
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

