### PR TITLE
fix(l1,l2): fix storage tests build

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -35,6 +35,7 @@ redb = ["dep:redb", "dep:tokio"]
 hex.workspace = true
 hex-literal.workspace = true
 tempdir = "0.3.7"
+tokio = { version = "1.41.1", default-features = false, features = ["rt", "macros", "test-util", "rt-multi-thread"] }
 
 [lib]
 path = "./lib.rs"


### PR DESCRIPTION
**Motivation**

When trying to run the storage tests from the crate itself (that is, using `cargo test`)
I found out they were not building. This PR fixes it.

**Description**
- Add tokio as a dev-dependency to make tests build.


