### PR TITLE
ci(levm): added eftests job trigger on changes to runner

### DIFF
--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - "crates/vm/levm/**"
       - ".github/workflows/pr-main_levm.yaml"
+      - "cmd/ef_tests/state"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
**Motivation**

Properly test changes to runner don't break test execution.

**Description**

Currently we don't trigger a run of the ef tests when changes to the test runner are made. This PR changes the CI so it does.

Closes #2634

