### PR TITLE
fix(l2): download solc fixed version in Dockerfile

### DIFF
--- a/crates/l2/contracts/Dockerfile
+++ b/crates/l2/contracts/Dockerfile
@@ -28,9 +28,10 @@ RUN cargo build --release --manifest-path crates/l2/contracts/Cargo.toml
 FROM --platform=${BUILDPLATFORM} ubuntu:24.04
 WORKDIR /usr/local/bin
 
-RUN apt-get update && apt-get -y install git gnupg software-properties-common
+RUN apt-get update && apt-get -y install git gnupg software-properties-common curl
 RUN add-apt-repository ppa:ethereum/ethereum
-RUN apt-get update && apt-get -y install solc
+RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.8.29/solc-static-linux
+RUN chmod +x /usr/bin/solc
 
 COPY --from=builder ethrex/target/release/ethrex_l2_l1_deployer .
 


### PR DESCRIPTION
**Motivation**

A new version of solidity was released a few hours ago ([`0.8.30`](https://github.com/ethereum/solidity/releases/latest)) and the Dockerfile was written to always download the latest version while our contracts Solidity version is fixed to `0.8.29`.

**Description**

Updates the L1 contract deployer Dockerfile to download a fixed version of solc.

