### PR TITLE
perf(levm): remove unnecessary double copying in op_push

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -15,9 +15,6 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::PUSHN)?;
 
-        if n_bytes > 32 {
-            return Err(VMError::InvalidOpcode);
-        }
         let read_n_bytes = read_bytcode_slice(current_call_frame, n_bytes)?;
 
         current_call_frame


### PR DESCRIPTION
**Motivation**

Removes a call to the `bytes_to_word` function (and the function itself), as it was unnecessary and implied copying the same slice twice.

I noticed while syncing in Holesky that (somewhat expectedly) a lot of time was spent on `op_push`, and while looking deeper realized that there was unnecessary work being done.

Flamegraph on `op_push` on main:
<img width="1504" alt="Screenshot 2025-05-08 at 11 32 37" src="https://github.com/user-attachments/assets/e990fa05-9a7b-4ba5-8a5b-7b177eeb25d4" />

Flamegraph on `op_push` on this branch:
<img width="1502" alt="Screenshot 2025-05-08 at 11 33 01" src="https://github.com/user-attachments/assets/ed0fc3d8-8c6b-4a11-9ca2-16d8f7afd1e1" />

My impression is that there's still work to be done on `op_push` however.

The bench comparison against `revm` in the comments shows around a ~5-6% improvement.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

