### PR TITLE
chore(core): run block benchmark with levm instead of revm

### DIFF
--- a/bench/criterion_benchmark.rs
+++ b/bench/criterion_benchmark.rs
@@ -17,7 +17,7 @@ fn block_import() {
     set_datadir(data_dir);
     remove_db(data_dir, true);
 
-    let evm_engine = "revm".to_owned().try_into().unwrap();
+    let evm_engine = "levm".to_owned().try_into().unwrap();
 
     let network = "../../test_data/genesis-l2-ci.json";
 


### PR DESCRIPTION
**Motivation**

This will almost surely show a downgrade on our webpage https://lambdaclass.github.io/ethrex/, but that is ok.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

