### PR TITLE
feat(l2): add support for web3signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3142,6 +3142,7 @@ dependencies = [
  "lazy_static",
  "once_cell",
  "rayon",
+ "reqwest",
  "secp256k1",
  "serde",
  "serde_json",

--- a/cmd/ethrex_l2/src/commands/wallet.rs
+++ b/cmd/ethrex_l2/src/commands/wallet.rs
@@ -2,6 +2,7 @@ use crate::config::EthrexL2Config;
 use bytes::Bytes;
 use clap::Subcommand;
 use ethereum_types::{Address, H256, U256};
+use ethrex_common::types::signer::LocalSigner;
 use ethrex_l2_sdk::calldata::{encode_calldata, Value};
 use ethrex_l2_sdk::{COMMON_BRIDGE_L2_ADDRESS, L2_WITHDRAW_SIGNATURE};
 use ethrex_rpc::clients::eth::BlockByNumber;
@@ -337,8 +338,9 @@ impl Command {
                     )
                     .await?;
 
+                let signer = LocalSigner::new(cfg.wallet.private_key).into();
                 let tx_hash = client
-                    .send_eip1559_transaction(&transfer_tx, &cfg.wallet.private_key)
+                    .send_eip1559_transaction(&transfer_tx, &signer)
                     .await?;
 
                 println!(
@@ -444,9 +446,8 @@ impl Command {
                         },
                     )
                     .await?;
-                let tx_hash = client
-                    .send_eip1559_transaction(&tx, &cfg.wallet.private_key)
-                    .await?;
+                let signer = LocalSigner::new(cfg.wallet.private_key).into();
+                let tx_hash = client.send_eip1559_transaction(&tx, &signer).await?;
 
                 println!(
                     "[{}] Transaction sent: {tx_hash:#x}",
@@ -503,10 +504,10 @@ impl Command {
                     false => rollup_client,
                 };
 
+                let signer = LocalSigner::new(cfg.wallet.private_key).into();
                 let (deployment_tx_hash, deployed_contract_address) = client
                     .deploy(
-                        from,
-                        cfg.wallet.private_key,
+                        &signer,
                         bytecode,
                         Overrides {
                             value: value.into(),

--- a/cmd/load_test/src/main.rs
+++ b/cmd/load_test/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, ValueEnum};
 use ethereum_types::{Address, H160, H256, U256};
 use ethrex_blockchain::constants::TX_GAS_COST;
+use ethrex_common::types::signer::{LocalSigner, Signer};
 use ethrex_l2_sdk::calldata::{self, Value};
 use ethrex_rpc::clients::eth::BlockByNumber;
 use ethrex_rpc::clients::{EthClient, EthClientError, Overrides};
@@ -8,8 +9,7 @@ use ethrex_rpc::types::receipt::RpcReceipt;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hex::ToHex;
-use keccak_hash::keccak;
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::SecretKey;
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
@@ -29,8 +29,6 @@ const FIBO_CODE: &str = "6080604052348015600e575f5ffd5b506103198061001c5f395ff3f
 // Contract with a function that touches 100 storage slots on every transaction.
 // See `test_data/IOHeavyContract.sol` for the code.
 const IO_HEAVY_CODE: &str = "6080604052348015600e575f5ffd5b505f5f90505b6064811015603e57805f8260648110602d57602c6043565b5b018190555080806001019150506014565b506070565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b6102728061007d5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c8063431aabc21461004357806358faa02f1461007357806362f8e72a1461007d575b5f5ffd5b61005d6004803603810190610058919061015c565b61009b565b60405161006a9190610196565b60405180910390f35b61007b6100b3565b005b61008561010a565b6040516100929190610196565b60405180910390f35b5f81606481106100a9575f80fd5b015f915090505481565b5f5f90505b60648110156101075760015f82606481106100d6576100d56101af565b5b01546100e29190610209565b5f82606481106100f5576100f46101af565b5b018190555080806001019150506100b8565b50565b5f5f5f6064811061011e5761011d6101af565b5b0154905090565b5f5ffd5b5f819050919050565b61013b81610129565b8114610145575f5ffd5b50565b5f8135905061015681610132565b92915050565b5f6020828403121561017157610170610125565b5b5f61017e84828501610148565b91505092915050565b61019081610129565b82525050565b5f6020820190506101a95f830184610187565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61021382610129565b915061021e83610129565b9250828201905080821115610236576102356101dc565b5b9291505056fea264697066735822122055f6d7149afdb56c745a203d432710eaa25a8ccdb030503fb970bf1c964ac03264736f6c634300081b0033";
-
-type Account = (PublicKey, SecretKey);
 
 #[derive(Parser)]
 #[command(name = "load_test")]
@@ -82,43 +80,29 @@ const ETH_TRANSFER_VALUE: u64 = 1000;
 // Private key for the rich account present in the gesesis_l2.json file.
 const RICH_ACCOUNT: &str = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924";
 
-// TODO: this should be in common utils.
-fn address_from_pub_key(public_key: PublicKey) -> H160 {
-    let bytes = public_key.serialize_uncompressed();
-    let hash = keccak(&bytes[1..]);
-    let address_bytes: [u8; 20] = hash.as_ref().get(12..32).unwrap().try_into().unwrap();
-
-    Address::from(address_bytes)
-}
-
 async fn deploy_contract(
     client: EthClient,
-    deployer: (PublicKey, SecretKey),
+    deployer: &Signer,
     contract: Vec<u8>,
 ) -> eyre::Result<Address> {
     let (_, contract_address) = client
-        .deploy(
-            address_from_pub_key(deployer.0),
-            deployer.1,
-            contract.into(),
-            Overrides::default(),
-        )
+        .deploy(deployer, contract.into(), Overrides::default())
         .await?;
 
     eyre::Ok(contract_address)
 }
 
-async fn erc20_deploy(client: EthClient, deployer: Account) -> eyre::Result<Address> {
+async fn erc20_deploy(client: EthClient, deployer: &Signer) -> eyre::Result<Address> {
     let erc20_bytecode = hex::decode(ERC20).expect("Failed to decode ERC20 bytecode");
     deploy_contract(client, deployer, erc20_bytecode).await
 }
 
-async fn deploy_fibo(client: EthClient, deployer: Account) -> eyre::Result<Address> {
+async fn deploy_fibo(client: EthClient, deployer: &Signer) -> eyre::Result<Address> {
     let fibo_bytecode = hex::decode(FIBO_CODE).expect("Failed to decode Fibo bytecode");
     deploy_contract(client, deployer, fibo_bytecode).await
 }
 
-async fn deploy_io_heavy(client: EthClient, deployer: Account) -> eyre::Result<Address> {
+async fn deploy_io_heavy(client: EthClient, deployer: &Signer) -> eyre::Result<Address> {
     let io_heavy_bytecode = hex::decode(IO_HEAVY_CODE).expect("Failed to decode IO Heavy bytecode");
     deploy_contract(client, deployer, io_heavy_bytecode).await
 }
@@ -127,29 +111,27 @@ async fn deploy_io_heavy(client: EthClient, deployer: Account) -> eyre::Result<A
 async fn claim_erc20_balances(
     contract_address: Address,
     client: EthClient,
-    accounts: &[Account],
+    accounts: Vec<Signer>,
 ) -> eyre::Result<()> {
     let mut tasks = JoinSet::new();
 
-    for (pk, sk) in accounts {
+    for account in accounts {
         let contract = contract_address;
         let client = client.clone();
-        let pk = *pk;
-        let sk = *sk;
 
         tasks.spawn(async move {
             let claim_balance_calldata = calldata::encode_calldata("freeMint()", &[]).unwrap();
             let claim_tx = client
                 .build_eip1559_transaction(
                     contract,
-                    address_from_pub_key(pk),
+                    account.address(),
                     claim_balance_calldata.into(),
                     Default::default(),
                 )
                 .await
                 .unwrap();
             let tx_hash = client
-                .send_eip1559_transaction(&claim_tx, &sk)
+                .send_eip1559_transaction(&claim_tx, &account)
                 .await
                 .unwrap();
             client.wait_for_transaction_receipt(tx_hash, RETRIES).await
@@ -216,23 +198,21 @@ impl TxBuilder {
 
 async fn load_test(
     tx_amount: u64,
-    accounts: &[Account],
+    accounts: Vec<Signer>,
     client: EthClient,
     chain_id: u64,
     tx_builder: TxBuilder,
 ) -> eyre::Result<()> {
     let mut tasks = FuturesUnordered::new();
-    for (pk, sk) in accounts {
-        let pk = *pk;
-        let sk = *sk;
+    for account in accounts {
         let client = client.clone();
         let tx_builder = tx_builder.clone();
         tasks.push(async move {
             let nonce = client
-                .get_nonce(address_from_pub_key(pk), BlockByNumber::Latest)
+                .get_nonce(account.address(), BlockByNumber::Latest)
                 .await
                 .unwrap();
-            let src = address_from_pub_key(pk);
+            let src = account.address();
             let encoded_src: String = src.encode_hex();
 
             for i in 0..tx_amount {
@@ -255,7 +235,7 @@ async fn load_test(
                     .await?;
                 let client = client.clone();
                 sleep(Duration::from_micros(800)).await;
-                let _sent = client.send_eip1559_transaction(&tx, &sk).await?;
+                let _sent = client.send_eip1559_transaction(&tx, &account).await?;
                 println!(
                     "Tx number {} sent! From: {}. To: {}",
                     nonce + i + 1,
@@ -277,15 +257,14 @@ async fn load_test(
 async fn wait_until_all_included(
     client: EthClient,
     wait: Option<Duration>,
-    accounts: &[Account],
+    accounts: Vec<Signer>,
     tx_amount: u64,
 ) -> Result<(), String> {
     let start_time = tokio::time::Instant::now();
 
-    for (pk, _) in accounts {
-        let pk = *pk;
+    for account in accounts {
         let client = client.clone();
-        let src = address_from_pub_key(pk);
+        let src = account.address();
         let encoded_src: String = src.encode_hex();
         loop {
             let elapsed = start_time.elapsed();
@@ -316,24 +295,23 @@ async fn wait_until_all_included(
     Ok(())
 }
 
-fn parse_pk_file(path: &Path) -> eyre::Result<Vec<Account>> {
+fn parse_pk_file(path: &Path) -> eyre::Result<Vec<Signer>> {
     let pkeys_content = fs::read_to_string(path).expect("Unable to read private keys file");
-    let accounts: Vec<Account> = pkeys_content
+    let accounts: Vec<Signer> = pkeys_content
         .lines()
-        .map(parse_private_key_into_account)
+        .map(parse_private_key_into_local_signer)
         .collect();
 
     Ok(accounts)
 }
 
-fn parse_private_key_into_account(pkey: &str) -> Account {
+fn parse_private_key_into_local_signer(pkey: &str) -> Signer {
     let key = pkey
         .parse::<H256>()
         .unwrap_or_else(|_| panic!("Private key is not a valid hex representation {}", pkey));
     let secret_key = SecretKey::from_slice(key.as_bytes())
         .unwrap_or_else(|_| panic!("Invalid private key {}", pkey));
-    let public_key = secret_key.public_key(secp256k1::SECP256K1);
-    (public_key, secret_key)
+    LocalSigner::new(secret_key).into()
 }
 
 #[tokio::main]
@@ -351,16 +329,16 @@ async fn main() {
         .expect("Failed to get chain id")
         .as_u64();
 
-    let deployer = parse_private_key_into_account(RICH_ACCOUNT);
+    let deployer = parse_private_key_into_local_signer(RICH_ACCOUNT);
 
     let tx_builder = match cli.test_type {
         TestType::Erc20 => {
             println!("ERC20 Load test starting");
             println!("Deploying ERC20 contract...");
-            let contract_address = erc20_deploy(client.clone(), deployer)
+            let contract_address = erc20_deploy(client.clone(), &deployer)
                 .await
                 .expect("Failed to deploy ERC20 contract");
-            claim_erc20_balances(contract_address, client.clone(), &accounts)
+            claim_erc20_balances(contract_address, client.clone(), accounts.clone())
                 .await
                 .expect("Failed to claim ERC20 balances");
             TxBuilder::Erc20(contract_address)
@@ -372,7 +350,7 @@ async fn main() {
         TestType::Fibonacci => {
             println!("Fibonacci load test starting");
             println!("Deploying Fibonacci contract...");
-            let contract_address = deploy_fibo(client.clone(), deployer)
+            let contract_address = deploy_fibo(client.clone(), &deployer)
                 .await
                 .expect("Failed to deploy Fibonacci contract");
             TxBuilder::Fibonacci(contract_address)
@@ -380,7 +358,7 @@ async fn main() {
         TestType::IOHeavy => {
             println!("IO Heavy load test starting");
             println!("Deploying IO Heavy contract...");
-            let contract_address = deploy_io_heavy(client.clone(), deployer)
+            let contract_address = deploy_io_heavy(client.clone(), &deployer)
                 .await
                 .expect("Failed to deploy IO Heavy contract");
             TxBuilder::IOHeavy(contract_address)
@@ -395,7 +373,7 @@ async fn main() {
 
     load_test(
         cli.tx_amount,
-        &accounts,
+        accounts.clone(),
         client.clone(),
         chain_id,
         tx_builder,
@@ -410,7 +388,7 @@ async fn main() {
     };
 
     println!("Waiting for all transactions to be included in blocks...");
-    wait_until_all_included(client, wait_time, &accounts, cli.tx_amount)
+    wait_until_all_included(client, wait_time, accounts, cli.tx_amount)
         .await
         .unwrap();
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -27,6 +27,7 @@ bytes.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
 rayon = "1.5"
+reqwest.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/crates/common/types/mod.rs
+++ b/crates/common/types/mod.rs
@@ -7,6 +7,7 @@ mod genesis;
 pub mod payload;
 mod receipt;
 pub mod requests;
+pub mod signer;
 pub mod transaction;
 pub mod tx_fields;
 

--- a/crates/common/types/signer.rs
+++ b/crates/common/types/signer.rs
@@ -1,0 +1,111 @@
+use bytes::Bytes;
+use ethereum_types::{Address, Signature};
+use keccak_hash::keccak;
+use reqwest::{Client, Url};
+use secp256k1::{Message, PublicKey, SecretKey, SECP256K1};
+
+pub enum Signer {
+    Local(LocalSigner),
+    Remote(RemoteSigner),
+}
+
+impl Signer {
+    pub async fn sign(&self, data: Bytes) -> Result<Signature, SignerError> {
+        match self {
+            Self::Local(signer) => Ok(signer.sign(data)),
+            Self::Remote(signer) => signer.sign(data).await,
+        }
+    }
+
+    pub fn address(&self) -> Address {
+        match self {
+            Self::Local(signer) => signer.address,
+            Self::Remote(signer) => {
+                Address::from(keccak(&signer.public_key.serialize_uncompressed()[1..]))
+            }
+        }
+    }
+}
+
+impl From<LocalSigner> for Signer {
+    fn from(value: LocalSigner) -> Self {
+        Self::Local(value)
+    }
+}
+
+impl From<RemoteSigner> for Signer {
+    fn from(value: RemoteSigner) -> Self {
+        Self::Remote(value)
+    }
+}
+
+pub struct LocalSigner {
+    pub private_key: SecretKey,
+    pub address: Address,
+}
+
+impl LocalSigner {
+    pub fn new(private_key: SecretKey) -> Self {
+        let address = Address::from(keccak(
+            &private_key.public_key(SECP256K1).serialize_uncompressed()[1..],
+        ));
+        return Self {
+            private_key,
+            address,
+        };
+    }
+
+    pub fn sign(&self, data: Bytes) -> Signature {
+        let hash = keccak(data);
+        let msg = Message::from_digest(hash.0);
+        let signature = SECP256K1
+            .sign_ecdsa_recoverable(&msg, &self.private_key)
+            .serialize_compact();
+
+        Signature::from_slice(&[&[signature.0.to_i32() as u8], signature.1.as_slice()].concat())
+    }
+}
+
+pub struct RemoteSigner {
+    pub url: Url,
+    pub public_key: PublicKey,
+    pub client: Client,
+}
+
+impl RemoteSigner {
+    pub fn new(url: Url, public_key: PublicKey) -> Self {
+        Self {
+            url,
+            public_key,
+            client: Client::new(),
+        }
+    }
+
+    pub async fn sign(&self, data: Bytes) -> Result<Signature, SignerError> {
+        let url = format!(
+            "{}api/v1/eth1/sign/{}",
+            self.url,
+            hex::encode(&self.public_key.serialize_uncompressed()[1..])
+        );
+        let body = format!("{{\"data\": \"0x{}\"}}", hex::encode(data.clone()));
+
+        self.client
+            .post(url)
+            .body(body)
+            .header("content-type", "application/json")
+            .send()
+            .await?
+            .text()
+            .await?
+            .parse::<Signature>()
+            .map_err(|e| SignerError::ParseError(e.to_string()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SignerError {
+    #[error("Failed with a reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Failed to parse value: {0}")]
+    ParseError(String),
+}

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use calldata::{encode_calldata, Value};
 use ethereum_types::{Address, H160, H256, U256};
+use ethrex_common::types::signer::LocalSigner;
 use ethrex_common::types::GenericTransaction;
 use ethrex_rpc::clients::eth::{
     errors::EthClientError, eth_sender::Overrides, EthClient, WithdrawalProof,
@@ -105,7 +106,8 @@ pub async fn transfer(
     tx_generic.from = from;
     let gas_limit = client.estimate_gas(tx_generic).await?;
     tx.gas_limit = gas_limit;
-    client.send_eip1559_transaction(&tx, &private_key).await
+    let signer = LocalSigner::new(private_key).into();
+    client.send_eip1559_transaction(&tx, &signer).await
 }
 
 pub async fn deposit(
@@ -152,8 +154,9 @@ pub async fn withdraw(
         )
         .await?;
 
+    let signer = LocalSigner::new(from_pk).into();
     proposer_client
-        .send_eip1559_transaction(&withdraw_transaction, &from_pk)
+        .send_eip1559_transaction(&withdraw_transaction, &signer)
         .await
 }
 
@@ -205,8 +208,9 @@ pub async fn claim_withdraw(
         )
         .await?;
 
+    let signer = LocalSigner::new(from_pk).into();
     eth_client
-        .send_eip1559_transaction(&claim_tx, &from_pk)
+        .send_eip1559_transaction(&claim_tx, &signer)
         .await
 }
 

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -4,6 +4,7 @@ use crate::utils::prover::errors::SaveStateError;
 use crate::utils::prover::proving_systems::ProverType;
 use ethereum_types::FromStrRadixErr;
 use ethrex_blockchain::error::{ChainError, InvalidForkChoice};
+use ethrex_common::types::signer::SignerError;
 use ethrex_common::types::{BlobsBundleError, FakeExponentialError};
 use ethrex_l2_sdk::merkle_tree::MerkleError;
 use ethrex_rpc::clients::eth::errors::{CalldataEncodeError, EthClientError};
@@ -149,6 +150,8 @@ pub enum CommitterError {
     InternalError(String),
     #[error("Failed to get withdrawals: {0}")]
     FailedToGetWithdrawals(#[from] UtilsError),
+    #[error("Failed to sign error: {0}")]
+    FailedToSignError(#[from] SignerError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -11,9 +11,11 @@ use crate::{
 
 use ethrex_common::{
     types::{
-        blobs_bundle, fake_exponential_checked, BlobsBundle, BlobsBundleError, Block, BlockHeader,
-        BlockNumber, PrivilegedL2Transaction, Receipt, Transaction, TxKind, TxType,
-        BLOB_BASE_FEE_UPDATE_FRACTION, MIN_BASE_FEE_PER_BLOB_GAS,
+        blobs_bundle, fake_exponential_checked,
+        signer::{LocalSigner, RemoteSigner, Signer},
+        BlobsBundle, BlobsBundleError, Block, BlockHeader, BlockNumber, PrivilegedL2Transaction,
+        Receipt, Transaction, TxKind, TxType, BLOB_BASE_FEE_UPDATE_FRACTION,
+        MIN_BASE_FEE_PER_BLOB_GAS,
     },
     Address, H256, U256,
 };
@@ -44,13 +46,11 @@ pub struct Committer {
     on_chain_proposer_address: Address,
     store: Store,
     rollup_store: StoreRollup,
-    l1_address: Address,
-    l1_private_key: SecretKey,
     commit_time_ms: u64,
     arbitrary_base_blob_gas_price: u64,
     execution_cache: Arc<ExecutionCache>,
     validium: bool,
-    remote_signer_url: Option<Url>,
+    signer: Signer,
 }
 
 pub async fn start_l1_committer(
@@ -80,6 +80,18 @@ impl Committer {
         rollup_store: StoreRollup,
         execution_cache: Arc<ExecutionCache>,
     ) -> Self {
+        let signer = if let Some(remote_signer_url) = eth_config.remote_signer_url {
+            RemoteSigner::new(
+                remote_signer_url,
+                committer_config
+                    .l1_private_key
+                    .public_key(secp256k1::SECP256K1),
+            )
+            .into()
+        } else {
+            LocalSigner::new(committer_config.l1_private_key).into()
+        };
+
         Self {
             eth_client: EthClient::new_with_maximum_fees(
                 &eth_config.rpc_url,
@@ -89,13 +101,11 @@ impl Committer {
             on_chain_proposer_address: committer_config.on_chain_proposer_address,
             store,
             rollup_store,
-            l1_address: committer_config.l1_address,
-            l1_private_key: committer_config.l1_private_key,
             commit_time_ms: committer_config.commit_time_ms,
             arbitrary_base_blob_gas_price: committer_config.arbitrary_base_blob_gas_price,
             execution_cache,
             validium: committer_config.validium,
-            remote_signer_url: eth_config.remote_signer_url,
+            signer,
         }
     }
 
@@ -509,10 +519,10 @@ impl Committer {
                 .eth_client
                 .build_eip4844_transaction(
                     self.on_chain_proposer_address,
-                    self.l1_address,
+                    self.signer.address(),
                     calldata.into(),
                     Overrides {
-                        from: Some(self.l1_address),
+                        from: Some(self.signer.address()),
                         gas_price_per_blob: Some(gas_price_per_blob),
                         max_fee_per_gas: Some(gas_price),
                         max_priority_fee_per_gas: Some(gas_price),
@@ -529,10 +539,10 @@ impl Committer {
                 .eth_client
                 .build_eip1559_transaction(
                     self.on_chain_proposer_address,
-                    self.l1_address,
+                    self.signer.address(),
                     calldata.into(),
                     Overrides {
-                        from: Some(self.l1_address),
+                        from: Some(self.signer.address()),
                         max_fee_per_gas: Some(gas_price),
                         max_priority_fee_per_gas: Some(gas_price),
                         ..Default::default()
@@ -545,56 +555,37 @@ impl Committer {
         };
 
         self.eth_client
-            .set_gas_for_wrapped_tx(&mut tx, self.l1_address)
+            .set_gas_for_wrapped_tx(&mut tx, self.signer.address())
             .await?;
 
-        let commit_tx_hash = if let Some(remote_signer_url) = &self.remote_signer_url {
-            let client = Client::new();
-            let pubkey = self
-                .l1_private_key
-                .public_key(secp256k1::SECP256K1)
-                .serialize_uncompressed();
-            let url = format!(
-                "{remote_signer_url}api/v1/eth1/sign/{}",
-                hex::encode(&pubkey[1..])
-            );
-            let body = format!(
-                "{{\"data\": \"0x03{}\"}}",
-                hex::encode(tx.encode_payload_to_vec().map_err(|_| {
-                    CommitterError::InternalError("Unexpected error".to_string())
-                })?)
-            );
-            let signature = client
-                .post(url)
-                .body(body)
-                .header("content-type", "application/json")
-                .send()
-                .await
-                .map_err(|e| CommitterError::InternalError(format!("{e}")))?
-                .text()
-                .await
-                .map_err(|e| CommitterError::InternalError(format!("{e}")))?
-                .parse()
-                .map_err(|e| CommitterError::InternalError(format!("{e}")))?;
-            tx.add_signature(signature)?;
-            let data = match tx {
-                WrappedTransaction::EIP1559(tx) => {
-                    [vec![TxType::EIP1559.into()], tx.encode_to_vec()].concat()
-                }
-                WrappedTransaction::EIP4844(tx_wrapper) => {
-                    [vec![TxType::EIP4844.into()], tx_wrapper.encode_to_vec()].concat()
-                }
-                WrappedTransaction::L2(_) => {
-                    return Err(CommitterError::InternalError(
-                        "Unsupported tx type".to_string(),
-                    ))
-                }
-            };
-            self.eth_client.send_raw_transaction(&data).await?
-        } else {
-            self.eth_client
-                .send_tx_bump_gas_exponential_backoff(&mut tx, &self.l1_private_key)
-                .await?
+        let commit_tx_hash = match &self.signer {
+            Signer::Local(signer) => {
+                self.eth_client
+                    .send_tx_bump_gas_exponential_backoff(&mut tx, &signer.private_key)
+                    .await?
+            }
+            Signer::Remote(signer) => {
+                let signature = signer
+                    .sign([vec![TxType::EIP4844.into()], tx.encode_payload_to_vec().map_err(|_| {
+                        CommitterError::InternalError("Unexpected error".to_string())
+                    })?].concat().into())
+                    .await?;
+                tx.add_signature(signature)?;
+                let data = match tx {
+                    WrappedTransaction::EIP1559(tx) => {
+                        [vec![TxType::EIP1559.into()], tx.encode_to_vec()].concat()
+                    }
+                    WrappedTransaction::EIP4844(tx_wrapper) => {
+                        [vec![TxType::EIP4844.into()], tx_wrapper.encode_to_vec()].concat()
+                    }
+                    WrappedTransaction::L2(_) => {
+                        return Err(CommitterError::InternalError(
+                            "Unsupported tx type".to_string(),
+                        ))
+                    }
+                };
+                self.eth_client.send_raw_transaction(&data).await?
+            }
         };
 
         info!("Commitment sent: {commit_tx_hash:#x}");

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, str::FromStr};
 
-use ethrex_common::{Address, H160, H256, U256};
+use ethrex_common::{types::signer::LocalSigner, Address, H160, H256, U256};
 use ethrex_l2_sdk::calldata::{encode_calldata, Value};
 use ethrex_rpc::{
     clients::{eth::WrappedTransaction, Overrides},
@@ -189,9 +189,10 @@ impl L1ProofSender {
 
         let mut tx = WrappedTransaction::EIP1559(verify_tx);
 
+        let signer = LocalSigner::new(self.l1_private_key).into();
         let verify_tx_hash = self
             .eth_client
-            .send_tx_bump_gas_exponential_backoff(&mut tx, &self.l1_private_key)
+            .send_tx_bump_gas_exponential_backoff(&mut tx, &signer)
             .await?;
 
         info!("Sent proof for batch {batch_number}, with transaction hash {verify_tx_hash:#x}");

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::expect_used)]
 use bytes::Bytes;
 use ethereum_types::{Address, H160, U256};
+use ethrex_common::types::signer::LocalSigner;
 use ethrex_common::types::BlockNumber;
 use ethrex_l2::utils::config::{read_env_file_by_config, ConfigMode};
 use ethrex_l2_sdk::calldata::{self, Value};
@@ -449,13 +450,10 @@ async fn l2_deposit_with_contract_call() -> Result<(), Box<dyn std::error::Error
 
     let init_code = hex::decode("6080604052348015600e575f5ffd5b506101008061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c8063f15d140b14602a575b5f5ffd5b60406004803603810190603c919060a4565b6042565b005b807f9ec8254969d1974eac8c74afb0c03595b4ffe0a1d7ad8a7f82ed31b9c854259160405160405180910390a250565b5f5ffd5b5f819050919050565b6086816076565b8114608f575f5ffd5b50565b5f81359050609e81607f565b92915050565b5f6020828403121560b65760b56072565b5b5f60c1848285016092565b9150509291505056fea26469706673582212206f6d360696127c56e2d2a456f3db4a61e30eae0ea9b3af3c900c81ea062e8fe464736f6c634300081c0033")?;
 
+    let signer = LocalSigner::new(l1_rich_wallet_private_key()).into();
+
     let (_, contract_address) = proposer_client
-        .deploy(
-            l1_rich_wallet_address,
-            l1_rich_wallet_private_key(),
-            init_code.into(),
-            Overrides::default(),
-        )
+        .deploy(signer, init_code.into(), Overrides::default())
         .await?;
 
     println!("Contract deployed on L2: {contract_address:?}");
@@ -645,13 +643,10 @@ async fn l2_deposit_with_contract_call_revert() -> Result<(), Box<dyn std::error
     //     }
     // }
     let init_code = hex::decode("6080604052348015600e575f5ffd5b506101138061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c806311ebce9114602a575b5f5ffd5b60306032565b005b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040160629060c1565b60405180910390fd5b5f82825260208201905092915050565b7f52657665727465640000000000000000000000000000000000000000000000005f82015250565b5f60ad600883606b565b915060b682607b565b602082019050919050565b5f6020820190508181035f83015260d68160a3565b905091905056fea2646970667358221220903f571921ce472f979989f9135b8637314b68e080fd70d0da6ede87ad8b5bd564736f6c634300081c0033")?;
+
+    let signer = LocalSigner::new(l1_rich_wallet_private_key()).into();
     let (_, contract_address) = proposer_client
-        .deploy(
-            l1_rich_wallet_address,
-            l1_rich_wallet_private_key(),
-            init_code.into(),
-            Overrides::default(),
-        )
+        .deploy(signer, init_code.into(), Overrides::default())
         .await?;
 
     println!("Contract deployed on L2: {contract_address:?}");
@@ -757,13 +752,10 @@ async fn l2_sdk_deploy() -> Result<(), Box<dyn std::error::Error>> {
     //}
     let init_code = hex::decode("6080604052348015600e575f5ffd5b5060ac80601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80638381f58a14602a575b5f5ffd5b60306044565b604051603b9190605f565b60405180910390f35b602581565b5f819050919050565b6059816049565b82525050565b5f60208201905060705f8301846052565b9291505056fea2646970667358221220a6516c1bfca94ad11d1315b32cd08f115c050e098a0631d58ee55923e70bc36364736f6c634300081c0033")?;
 
+    let signer = LocalSigner::new(l1_rich_wallet_private_key()).into();
+
     let (_, contract_address) = eth_client
-        .deploy(
-            l1_rich_wallet_address(),
-            l1_rich_wallet_private_key(),
-            init_code.into(),
-            Overrides::default(),
-        )
+        .deploy(signer, init_code.into(), Overrides::default())
         .await?;
 
     println!("Contract deployed on L1: {contract_address:?}");

--- a/crates/l2/utils/config/eth.rs
+++ b/crates/l2/utils/config/eth.rs
@@ -1,10 +1,14 @@
+use reqwest::Url;
 use serde::Deserialize;
 
+use super::super::parse::deserialize_optional_url;
 use super::errors::ConfigError;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct EthConfig {
     pub rpc_url: String,
+    #[serde(deserialize_with = "deserialize_optional_url")]
+    pub remote_signer_url: Option<Url>,
     pub maximum_allowed_max_fee_per_gas: u64,
     pub maximum_allowed_max_fee_per_blob_gas: u64,
 }

--- a/crates/l2/utils/config/toml_parser.rs
+++ b/crates/l2/utils/config/toml_parser.rs
@@ -1,7 +1,9 @@
+use super::super::parse::deserialize_url;
 use crate::utils::config::{
     errors::{ConfigError, TomlParserError},
     ConfigMode,
 };
+use reqwest::Url;
 use serde::Deserialize;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -48,6 +50,8 @@ struct Eth {
     rpc_url: String,
     maximum_allowed_max_fee_per_gas: u64,
     maximum_allowed_max_fee_per_blob_gas: u64,
+    #[serde(deserialize_with = "deserialize_url")]
+    remote_signer_url: Url,
 }
 
 impl Eth {
@@ -58,10 +62,12 @@ impl Eth {
 {prefix}_RPC_URL={}
 {prefix}_MAXIMUM_ALLOWED_MAX_FEE_PER_GAS={}
 {prefix}_MAXIMUM_ALLOWED_MAX_FEE_PER_BLOB_GAS={}
+{prefix}_REMOTE_SIGNER_URL={}
 ",
             self.rpc_url,
             self.maximum_allowed_max_fee_per_gas,
-            self.maximum_allowed_max_fee_per_blob_gas
+            self.maximum_allowed_max_fee_per_blob_gas,
+            self.remote_signer_url
         )
     }
 }

--- a/crates/l2/utils/parse.rs
+++ b/crates/l2/utils/parse.rs
@@ -1,5 +1,23 @@
+use std::str::FromStr;
+
 use ethereum_types::{Address, H256};
+use reqwest::Url;
 
 pub fn hash_to_address(hash: H256) -> Address {
     Address::from_slice(&hash.as_fixed_bytes()[12..])
+}
+
+pub fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let url_str: String = serde::Deserialize::deserialize(deserializer)?;
+    Url::from_str(&url_str).map_err(|e| serde::de::Error::custom(e))
+}
+
+pub fn deserialize_optional_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(deserialize_url(deserializer).ok())
 }

--- a/crates/l2/utils/parse.rs
+++ b/crates/l2/utils/parse.rs
@@ -12,7 +12,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let url_str: String = serde::Deserialize::deserialize(deserializer)?;
-    Url::from_str(&url_str).map_err(|e| serde::de::Error::custom(e))
+    Url::from_str(&url_str).map_err(serde::de::Error::custom)
 }
 
 pub fn deserialize_optional_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>

--- a/crates/networking/rpc/clients/eth/errors.rs
+++ b/crates/networking/rpc/clients/eth/errors.rs
@@ -1,3 +1,5 @@
+use ethrex_common::types::signer::SignerError;
+
 use crate::utils::RpcRequest;
 
 #[derive(Debug, thiserror::Error)]
@@ -46,6 +48,8 @@ pub enum EthClientError {
     TimeoutError,
     #[error("Internal Error. This is most likely a bug: {0}")]
     InternalError(String),
+    #[error("Failed to sign transaction: {0}")]
+    SignerError(#[from] SignerError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -56,10 +56,10 @@ pub enum WrappedTransaction {
 }
 
 impl WrappedTransaction {
-    pub fn encode_payload_to_vec(&self) -> Result<Bytes, EthClientError> {
+    pub fn encode_payload_to_vec(&self) -> Result<Vec<u8>, EthClientError> {
         match self {
-            Self::EIP1559(tx) => Ok(tx.encode_payload_to_vec().into()),
-            Self::EIP4844(tx_wrapper) => Ok(tx_wrapper.tx.encode_payload_to_vec().into()),
+            Self::EIP1559(tx) => Ok(tx.encode_payload_to_vec()),
+            Self::EIP4844(tx_wrapper) => Ok(tx_wrapper.tx.encode_payload_to_vec()),
             Self::L2(_) => {
                 return Err(EthClientError::InternalError(
                     "L2 Privileged transaction not supported".to_string(),

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -33,6 +33,8 @@ pub enum RpcErr {
     InvalidBasedMessage(String),
     #[cfg(feature = "l2")]
     InvalidEthrexL2Message(String),
+    #[cfg(feature = "l2")]
+    SignerError,
 }
 
 impl From<RpcErr> for RpcErrorMetadata {
@@ -143,6 +145,12 @@ impl From<RpcErr> for RpcErrorMetadata {
                 code: -39000,
                 data: None,
                 message: format!("Invalid Ethex L2 message: {reason}",),
+            },
+            #[cfg(feature = "l2")]
+            RpcErr::SignerError => RpcErrorMetadata {
+                code: -39001,
+                data: None,
+                message: format!("Failed to sign data"),
             },
         }
     }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Many operators will want to use a remote signer instead of having the private keys on the same server as the sequencer.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Replace all uses of a private key with a new `Signer` enum. This signer can be either `Local` or `Remote` and can be lately extended. This aims to standardise the way all kind of messages are signed across the L2 and facilitate the setup via flags or environment

<!-- Link to issues: Resolves #111, Resolves #222 -->


