### PR TITLE
fix(l1): changing to keep transaction in mempool after get_payload

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -418,8 +418,6 @@ impl Blockchain {
             let receipt = match self.apply_transaction(&head_tx, context) {
                 Ok(receipt) => {
                     txs.shift()?;
-                    // Pull transaction from the mempool
-                    self.remove_transaction_from_pool(&head_tx.tx.compute_hash())?;
 
                     metrics!(METRICS_TX.inc_tx_with_status_and_type(
                         MetricsTxStatus::Succeeded,


### PR DESCRIPTION
**Motivation**

One of the tests for hive failed due to a transaction not being included in two different blocks with the same parent. The expected behaviour is to not remove the transaction from the mempool when a block is produced, only when the transaction is invalidated.

Possible problem: the mempool filling up because transactions aren't cleared somewhere else. 

**Description**

Just removes the line that removed the transaction from the mempool and the comment explanation.

Fixes "Sidechain Reorg" test in #1285

