### PR TITLE
refactor(levm): use more descriptive names when popping call_frame 

### DIFF
--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -150,17 +150,17 @@ impl<'a> VM<'a> {
 
     pub fn handle_opcode_result(
         &mut self,
-        current_call_frame: &mut CallFrame,
+        executed_call_frame: &mut CallFrame,
     ) -> Result<ExecutionReport, VMError> {
         let backup = self
             .backups
             .pop()
             .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
         // On successful create check output validity
-        if (self.is_create() && current_call_frame.depth == 0)
-            || current_call_frame.create_op_called
+        if (self.is_create() && executed_call_frame.depth == 0)
+            || executed_call_frame.create_op_called
         {
-            let contract_code = std::mem::take(&mut current_call_frame.output);
+            let contract_code = std::mem::take(&mut executed_call_frame.output);
             let code_length = contract_code.len();
 
             let code_length_u64: u64 = code_length
@@ -185,13 +185,13 @@ impl<'a> VM<'a> {
                 .is_some_and(|val| val == &INVALID_CONTRACT_PREFIX)
             {
                 Err(VMError::InvalidContractPrefix)
-            } else if current_call_frame
+            } else if executed_call_frame
                 .increase_consumed_gas(code_deposit_cost)
                 .is_err()
             {
                 Err(VMError::OutOfGas(OutOfGasError::MaxGasLimitExceeded))
             } else {
-                Ok(current_call_frame.to)
+                Ok(executed_call_frame.to)
             };
 
             match validate_create {
@@ -201,14 +201,14 @@ impl<'a> VM<'a> {
                 }
                 Err(error) => {
                     // Revert if error
-                    current_call_frame.gas_used = current_call_frame.gas_limit;
-                    self.restore_state(backup, current_call_frame.call_frame_backup.clone())?;
+                    executed_call_frame.gas_used = executed_call_frame.gas_limit;
+                    self.restore_state(backup, executed_call_frame.call_frame_backup.clone())?;
 
                     return Ok(ExecutionReport {
                         result: TxResult::Revert(error),
-                        gas_used: current_call_frame.gas_used,
+                        gas_used: executed_call_frame.gas_used,
                         gas_refunded: self.env.refunded_gas,
-                        output: std::mem::take(&mut current_call_frame.output),
+                        output: std::mem::take(&mut executed_call_frame.output),
                         logs: vec![],
                     });
                 }
@@ -217,17 +217,17 @@ impl<'a> VM<'a> {
 
         Ok(ExecutionReport {
             result: TxResult::Success,
-            gas_used: current_call_frame.gas_used,
+            gas_used: executed_call_frame.gas_used,
             gas_refunded: self.env.refunded_gas,
-            output: std::mem::take(&mut current_call_frame.output),
-            logs: std::mem::take(&mut current_call_frame.logs),
+            output: std::mem::take(&mut executed_call_frame.output),
+            logs: std::mem::take(&mut executed_call_frame.logs),
         })
     }
 
     pub fn handle_opcode_error(
         &mut self,
         error: VMError,
-        current_call_frame: &mut CallFrame,
+        executed_call_frame: &mut CallFrame,
     ) -> Result<ExecutionReport, VMError> {
         let backup = self
             .backups
@@ -239,17 +239,17 @@ impl<'a> VM<'a> {
 
         // Unless error is from Revert opcode, all gas is consumed
         if error != VMError::RevertOpcode {
-            let left_gas = current_call_frame
+            let left_gas = executed_call_frame
                 .gas_limit
-                .saturating_sub(current_call_frame.gas_used);
-            current_call_frame.gas_used = current_call_frame.gas_used.saturating_add(left_gas);
+                .saturating_sub(executed_call_frame.gas_used);
+            executed_call_frame.gas_used = executed_call_frame.gas_used.saturating_add(left_gas);
         }
 
         let refunded = backup.refunded_gas;
-        let output = std::mem::take(&mut current_call_frame.output); // Bytes::new() if error is not RevertOpcode
-        let gas_used = current_call_frame.gas_used;
+        let output = std::mem::take(&mut executed_call_frame.output); // Bytes::new() if error is not RevertOpcode
+        let gas_used = executed_call_frame.gas_used;
 
-        self.restore_state(backup, current_call_frame.call_frame_backup.clone())?;
+        self.restore_state(backup, executed_call_frame.call_frame_backup.clone())?;
 
         Ok(ExecutionReport {
             result: TxResult::Revert(error),

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -330,24 +330,24 @@ impl<'a> VM<'a> {
                     .current_call_frame_mut()?
                     .increment_pc_by(pc_increment)?,
                 Ok(OpcodeResult::Halt) => {
-                    let mut current_call_frame = self
+                    let mut executed_call_frame = self
                         .call_frames
                         .pop()
                         .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-                    let report = self.handle_opcode_result(&mut current_call_frame)?;
-                    if self.handle_return(&current_call_frame, &report)? {
+                    let report = self.handle_opcode_result(&mut executed_call_frame)?;
+                    if self.handle_return(&executed_call_frame, &report)? {
                         self.current_call_frame_mut()?.increment_pc_by(1)?;
                     } else {
                         return Ok(report);
                     }
                 }
                 Err(error) => {
-                    let mut current_call_frame = self
+                    let mut executed_call_frame = self
                         .call_frames
                         .pop()
                         .ok_or(VMError::Internal(InternalError::CouldNotPopCallframe))?;
-                    let report = self.handle_opcode_error(error, &mut current_call_frame)?;
-                    if self.handle_return(&current_call_frame, &report)? {
+                    let report = self.handle_opcode_error(error, &mut executed_call_frame)?;
+                    if self.handle_return(&executed_call_frame, &report)? {
                         self.current_call_frame_mut()?.increment_pc_by(1)?;
                     } else {
                         return Ok(report);


### PR DESCRIPTION
**Motivation**

Give a better description of call_frame related variables in run_execution(). 

**Description**

- Use `executed_call_frame` in scenarios in which the callframe has already been executed.
- Use `parent_call_frame` in scenarios in which a callframe has been popped before, to we are working with the previous one. 

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2569 

