### PR TITLE
fix(levm):  unused import warning

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -16,8 +16,7 @@ use bytes::Bytes;
 use ethrex_common::{
     types::{
         tx_fields::{AccessList, AuthorizationList},
-        BlockHeader, ChainConfig, Fork, ForkBlobSchedule, PrivilegedL2Transaction, Transaction,
-        TxKind,
+        BlockHeader, ChainConfig, Fork, ForkBlobSchedule, Transaction, TxKind,
     },
     Address, H256, U256,
 };
@@ -30,7 +29,7 @@ use std::{
 #[cfg(not(feature = "l2"))]
 use crate::hooks::DefaultHook;
 #[cfg(feature = "l2")]
-use crate::hooks::L2Hook;
+use {crate::hooks::L2Hook, ethrex_common::types::PrivilegedL2Transaction};
 
 pub type Storage = HashMap<U256, H256>;
 


### PR DESCRIPTION
**Motivation**
There is a variable being unconditionally imported that is only used in code under the `l2` feature. This causes an annoying unused import warning every time we compile the node. This PR fixes it by moving the import to the feature-gated import statement
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Move import only used under l2 feature to l2 feature-gated import statement
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes: None, fixes my sanity

