### PR TITLE
fix(l2): `make deploy-l1`

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -119,7 +119,8 @@ deploy-l1: ## 📜 Deploys the L1 contracts
 	--contracts-path contracts \
 	--sp1.verifier-address 0x00000000000000000000000000000000000000aa \
 	--pico.verifier-address 0x00000000000000000000000000000000000000aa \
-	--risc0.verifier-address 0x00000000000000000000000000000000000000aa
+	--risc0.verifier-address 0x00000000000000000000000000000000000000aa \
+	--deposit-rich
 
 ## Same as deploy-l1 but does not do deposits for rich accounts since that doesn't make sense for deployments to devnets/testnets i.e Sepolia
 deploy-l1-testnet: ## 📜 Deploys the L1 contracts

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -114,8 +114,8 @@ restart-contract-deps: clean-contract-deps ## 🔄 Restarts the dependencies for
 
 deploy-l1: ## 📜 Deploys the L1 contracts
 	cargo run --release --bin ethrex_l2_l1_deployer --manifest-path contracts/Cargo.toml -- \
-	--private-keys-file-path ../../../test_data/private_keys_l1.txt \
-	--genesis-l1-path ../../../test_data/genesis-l1-dev.json \
+	--private-keys-file-path ../../test_data/private_keys_l1.txt \
+	--genesis-l1-path ../../test_data/genesis-l1-dev.json \
 	--contracts-path contracts \
 	--sp1.verifier-address 0x00000000000000000000000000000000000000aa \
 	--pico.verifier-address 0x00000000000000000000000000000000000000aa \


### PR DESCRIPTION
**Motivation**

- `--deposit-rich` flag is missing in `make deploy-l1`.
- `--private-keys-file-path` path is wrong in `make deploy-l1`.
- `--genesis-l1-path` path is wrong in `make deploy-l1`.

