### PR TITLE
ci(l2): patch `main_prover` workflow

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -62,10 +62,13 @@ jobs:
         run: |
           cargo test l2 --no-run --release
 
+      # The `rm -rf .env` command is needed because of an state bug in the
+      # GPU runner.
       - name: Deploy L1 Contracts
         run: |
           cd crates/l2
           cp configs/prover_client_config_example.toml configs/prover_client_config.toml
+          rm -rf .env
           touch .env
           CI_ETHREX_WORKDIR=/usr/local/bin \
           ETHREX_DEPLOYER_DEPLOY_RICH=true \

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -40,6 +40,11 @@ jobs:
         if: ${{ always() && github.event_name == 'merge_group' }}
         uses: docker/setup-buildx-action@v3
 
+      # This step is needed because of an state bug in the GPU runner.
+      - name: Clean .env
+        if: ${{ always() && github.event_name == 'merge_group' }}
+        run: rm -rf crates/l2/.env
+
       - name: Bake docker images
         if: ${{ always() && github.event_name == 'merge_group' }}
         uses: docker/bake-action@v6
@@ -62,13 +67,10 @@ jobs:
         run: |
           cargo test l2 --no-run --release
 
-      # The `rm -rf .env` command is needed because of an state bug in the
-      # GPU runner.
       - name: Deploy L1 Contracts
         run: |
           cd crates/l2
           cp configs/prover_client_config_example.toml configs/prover_client_config.toml
-          rm -rf .env
           touch .env
           CI_ETHREX_WORKDIR=/usr/local/bin \
           ETHREX_DEPLOYER_DEPLOY_RICH=true \

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -68,6 +68,7 @@ jobs:
           cargo test l2 --no-run --release
 
       - name: Deploy L1 Contracts
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           cp configs/prover_client_config_example.toml configs/prover_client_config.toml
@@ -78,6 +79,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up contract_deployer
 
       - name: Start Sequencer
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           CI_ETHREX_WORKDIR=/usr/local/bin \

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # This step is needed because of an state bug in the GPU runner.
+      # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.
       - name: Clean .env
         if: ${{ always() && github.event_name == 'merge_group' }}
         run: rm -rf crates/l2/.env


### PR DESCRIPTION
**Motivation**

There's a bug in our GPU runner where sometimes a `.env` directory is created, which causes the workflow to fail in different steps.

This only happens in our GPU runner. I filed an issue to tackle this https://github.com/lambdaclass/ethrex/pull/2741.

**Description**

Removes the `.env` dir if it exists.