### PR TITLE
fix(core): add tokio as dev-dependency for ethrex-storage

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -35,6 +35,7 @@ redb = ["dep:redb", "dep:tokio"]
 hex.workspace = true
 hex-literal.workspace = true
 tempdir = "0.3.7"
+tokio.workspace = true
 
 [lib]
 path = "./lib.rs"


### PR DESCRIPTION
**Motivation**
When running the tests for the ethrex-storage package (via cargo t --package `ethrex-storage`) due to `tokio` being used by the test module but not being declared as a dependency. This PR fixes this issue by adding it as a dev-dependency. 
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* add `tokio` as dev-dependency for `ethrex-storage` crate
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but fixes developer experience

