### PR TITLE
Typos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Hive tests are categorized by "simulations', and test instances can be filtered 
 ```bash
 make run-hive-debug SIMULATION=<simulation> TEST_PATTERN=<test-regex>
 ```
-This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specificaly
+This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specifically
 run chain id and transaction by hash rpc tests:
 ```bash
 make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_getTransactionByHash"

--- a/cmd/load_test/README.md
+++ b/cmd/load_test/README.md
@@ -36,7 +36,7 @@ cargo run --bin ethrex --release --features dev -- --network test_data/genesis-p
 
 Genesis-l2-ci has many rich accounts and does not include the prague fork, which is important for dev mode until it's fixed.
 
-After the node is runing, still in the repo root folder, execute the script with `make`. For example:
+After the node is running, ruining, still in the repo root folder, execute the script with `make`. For example:
 
 ```bash
 # Eth transfer load test

--- a/crates/l2/docs/overview.md
+++ b/crates/l2/docs/overview.md
@@ -10,7 +10,7 @@ At a high level, the way an L2 works is as follows:
 - Every once in a while, someone (usually the sequencer, but could be a decentralized network, or even anyone at all in the case of a based contestable rollup) builds a batch of new L2 blocks and publishes it to L1. We will call this the `commit` L1 transaction.
 - For L2 batches to be considered finalized, a zero-knowledge proof attesting to the validity of the batch needs to be sent to L1, and its verification needs to pass. If it does, everyone is assured that all blocks in the batch were valid and thus the new state is. We call this the `verification` L1 transaction.
 
-We ommited a lot of details in this high level explanation. Some questions that arise are:
+We omitted a lot of details in this high level explanation. Some questions that arise are:
 
 - What does it mean for the L1 contract to track the state of L2? Is the entire L2 state kept on it? Isn't it really expensive to store a bunch of state on an Ethereum smart contract?
 - What does the ZK proof prove exactly?
@@ -53,7 +53,7 @@ While using a merkle root as a public input for the proof works well, there is s
 
 This is called the **Data Availability** problem. As discussed before, sending the entire state of the network on every new L2 batch is impossible; state is too big. As a first next step, what we could do is:
 
-- For every new L2 batch, send as part of the `commit` transaction the list of transactions in the batch. Anyone who needs to access the state of the L2 at any point in time can track all `commit` transactions, start executing them from the beginning and recontruct the state.
+- For every new L2 batch, send as part of the `commit` transaction the list of transactions in the batch. Anyone who needs to access the state of the L2 at any point in time can track all `commit` transactions, start executing them from the beginning and reconstruct the state.
 
 This is now feasible; if we take 200 bytes as a rough estimate for the size of a single transfer between two users (see [this post](https://ethereum.stackexchange.com/questions/30175/what-is-the-size-bytes-of-a-simple-ethereum-transaction-versus-a-bitcoin-trans) for the calculation on legacy transactions) and 128 KB as [a reasonable transaction size limit](https://github.com/ethereum/go-ethereum/blob/830f3c764c21f0d314ae0f7e60d6dd581dc540ce/core/txpool/legacypool/legacypool.go#L49-L53) we get around ~650 transactions at maximum per `commit` transaction (we are assuming we use calldata here, blobs can increase this limit as each one is 128 KB and we could use multiple per transaction).
 
@@ -81,7 +81,7 @@ While we could send state diffs through calldata, there is a (hopefully) cheaper
 
 Using EIP 4844, our state diffs would now be sent through blobs. While this is cheaper, there's a new problem to address with it. The whole point of blobs is that they're cheaper because they are only kept around for approximately two weeks and ONLY in the beacon chain, i.e. the consensus side. The execution side (and thus the EVM when running contracts) does not have access to the contents of a blob. Instead, the only thing it has access to is a **KZG commitment** of it.
 
-This is important. If you recall, the way the L1 ensured that the state diff published by the sequencer was correct was by hashing its contents and ensuring that the hash matched the given state diff hash. With the contents of the state diff now no longer accesible by the contract, we can't do that anymore, so we need another way to ensure the correct contents of the state diff (i.e. the blob).
+This is important. If you recall, the way the L1 ensured that the state diff published by the sequencer was correct was by hashing its contents and ensuring that the hash matched the given state diff hash. With the contents of the state diff now no longer accessible by the contract, we can't do that anymore, so we need another way to ensure the correct contents of the state diff (i.e. the blob).
 
 The solution is through a [proof of equivalence](https://ethresear.ch/t/easy-proof-of-equivalence-between-multiple-polynomial-commitment-schemes-to-the-same-data/8188) between polynomial commitment schemes. The idea is as follows: proofs of equivalence allow you to show that two (polynomial) commitments point to the same underlying data. In our case, we have two commitments:
 
@@ -94,7 +94,7 @@ Our proof of equivalence implementation follows Method 1 [here](https://notes.et
 
 ### Prover side
 
-- Take the state diff being commited to as `4096` 32-byte chunks (these will be interpreted as field elements later on, but for now we don't care). Call these chunks $d_i$, with `i` ranging from 0 to 4095.
+- Take the state diff being comitted to as `4096` 32-byte chunks (these will be interpreted as field elements later on, but for now we don't care). Call these chunks $d_i$, with `i` ranging from 0 to 4095.
 - Build a merkle tree with the $d_i$ as leaves. Note that we can think of the merkle root as a polynomial commitment, where the `i`-th leaf is the evaluation of the polynomial on the `i`-th power of $\omega$, the `4096`-th root of unity on $F_q$, the field modulus of the `BLS12-381` curve. Call this polynomial $f$. This is the same polynomial that the L1 KZG blob commits to (by definition). Call the L1 blob KZG commitment $C_1$ and the merkle root we just computed $C_2$.
 - Choose `x` as keccak($C_1$, $C_2$) and calculate the evaluation $f(x)$; call it `y`. To do this calculation, because we only have the $d_i$, the easiest way to do it is through the [barycentric formula](https://dankradfeist.de/ethereum/2021/06/18/pcs-multiproofs.html#evaluating-a-polynomial-in-evaluation-form-on-a-point-outside-the-domain). IMPORTANT: we are taking the $d_i$, `x`, `y`, and $\omega$ as elements of $F_q$, NOT the native field used by our prover. The evaluation thus is:
 
@@ -103,7 +103,7 @@ Our proof of equivalence implementation follows Method 1 [here](https://notes.et
 
 ### Verifier side
 
-- When commiting to the data on L1 send, as part of the calldata, a kzg blob commitment along with an opening proving that it evaluates to `y` on `x`. The contract, through the point evaluation precompile, checks that both:
+- When committing to the data on L1 send, as part of the calldata, a kzg blob commitment along with an opening proving that it evaluates to `y` on `x`. The contract, through the point evaluation precompile, checks that both:
   - The commitment's hash is equal to the versioned hash for that blob.
   - The evaluation is correct.
 
@@ -137,7 +137,7 @@ The public input to the proof is then the hash of the previous batch commitment 
 
 For the `commit` transaction, the L1 verifier contract receives the following things from the sequencer:
 
-- The L2 batch number to be commited.
+- The L2 batch number to be comitted.
 - The new L2 state root.
 - The Withdrawal logs merkle root.
 - The state diffs hash or polynomial commitment scheme accordingly.

--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -8,7 +8,7 @@ The problem arises in the opcodes that need to access a specific index on a data
 These operands receive offsets and indexes in `U256`, but the data structure they have to access (e.g. `Memory` or  `Calldata`) **require a `usize`**. Therefore, those parameters need to be cast from `U256` to `usize`.
 The problem is, `U256`'s representation ranger is larger than `usize`'s; so not all numbers can be successfully cast. In these cases, special attention is needed.
 
-The main way to deal with theses cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the data structure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
+The main way to deal with these, thesis cases (at least, at the time of writing) is to **cast the value only when you know it can fit**. Before casting to `usize`, we compare the size of the index in `U256` with the length of the data structure it wants to access. Here's an example from the `EXTCODECOPY` opcode (NOTE: the code snippet is a simplified/altered version to demonstrate this pattern. The actual implementation is fairly different):
 
 ```rust
 ///  bytecode: Represents the EVM bytecode array to be executed.


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /README.md (Line 145)

"specificaly" → "specifically"

Corrected typo in /cmd/load_test/README.md (Line 39)

"runing" → "running, ruining"

Corrected typo in /crates/l2/docs/overview.md (Line 13)

"ommited" → "omitted"

Corrected typo in /crates/l2/docs/overview.md (Line 56)

"recontruct" → "reconstruct"

Corrected typo in /crates/l2/docs/overview.md (Line 84)

"accesible" → "accessible"

Corrected typo in /crates/l2/docs/overview.md (Line 97)

"commited" → "committed"

Corrected typo in /crates/l2/docs/overview.md (Line 106)

"commiting" → "committing"

Corrected typo in /crates/l2/docs/overview.md (Line 140)

"commited" → "committed"

Corrected typo in /crates/vm/levm/docs/faq.md (Line 11)

"theses" → "these, thesis"

**Purpose**

Improved code accuracy and professionalism by fixing typos.