### PR TITLE
refactor(l1): group node data in RpcContext

### DIFF
--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -348,7 +348,7 @@ pub mod test_utils {
     use ethrex_storage::{EngineType, Store};
     use k256::ecdsa::SigningKey;
 
-    use crate::rpc::{start_api, RpcApiContext};
+    use crate::rpc::{start_api, NodeData, RpcApiContext};
     #[cfg(feature = "based")]
     use crate::{EngineClient, EthClient};
     #[cfg(feature = "based")]
@@ -447,12 +447,14 @@ pub mod test_utils {
         RpcApiContext {
             storage,
             blockchain,
-            jwt_secret: Default::default(),
-            local_p2p_node: example_p2p_node(),
-            local_node_record: example_local_node_record(),
             active_filters: Default::default(),
             syncer: Arc::new(SyncManager::dummy()),
-            client_version: "ethrex/test".to_string(),
+            node_data: NodeData {
+                jwt_secret: Default::default(),
+                local_p2p_node: example_p2p_node(),
+                local_node_record: example_local_node_record(),
+                client_version: "ethrex/test".to_string(),
+            },
             #[cfg(feature = "based")]
             gateway_eth_client: EthClient::new(""),
             #[cfg(feature = "based")]


### PR DESCRIPTION
**Motivation**
`RpcContext` has become quite extensive lately, so we need to group some of its fields into individual structures that hold data used for similar purposes. This PR  groups static data related to the node (such as p2p address, version, etc) into a `NodeData` struct in order to simplify it.

**Description**
* Group static data about the node held in `RpcContext` into `NodeData`
* (Misc) Remove duplicated code between test functions
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Addresses review comment: https://github.com/lambdaclass/ethrex/pull/2732#discussion_r2084894577

