### PR TITLE
chore(l2): remove default contract addresses from Makefile

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -68,7 +68,7 @@ L1_AUTH_PORT=8551
 # Matches the ports used by the blockchain/metrics dir
 L2_PROMETHEUS_METRICS_PORT = 3702
 
-PROVER_ENV_FILE ?= ".env.prover" 
+PROVER_ENV_FILE ?= ".env.prover"
 
 # Local L1
 init-local-l1: ## 🚀 Initializes an L1 Lambda ethrex Client with Docker (Used with make init)
@@ -135,8 +135,8 @@ update-system-contracts:
 # L2
 init-l2: init-metrics init-l2-no-metrics ## 🚀 Initializes an L2 Lambda ethrex Client with metrics
 
-DEFAULT_BRIDGE_ADDRESS=0x8ccf74999c496e4d27a2b02941673f41dd0dab2a
-DEFAULT_ON_CHAIN_PROPOSER_ADDRESS=0x9185452b7d40694572ca6623799223dd5ada60f7
+BRIDGE_ADDRESS=$$(grep ETHREX_WATCHER_BRIDGE_ADDRESS .env | cut -d= -f2)
+ON_CHAIN_PROPOSER_ADDRESS=$$(grep ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS .env | cut -d= -f2)
 
 init-l2-no-metrics: ## 🚀 Initializes an L2 Lambda ethrex Client
 	if [ -z "$$BASED" ]; then \
@@ -155,8 +155,8 @@ init-l2-no-metrics: ## 🚀 Initializes an L2 Lambda ethrex Client
 	--metrics.port ${L2_PROMETHEUS_METRICS_PORT} \
 	--evm levm \
 	--datadir ${ethrex_L2_DEV_LIBMDBX} \
-	--bridge-address ${DEFAULT_BRIDGE_ADDRESS} \
-	--on-chain-proposer-address ${DEFAULT_ON_CHAIN_PROPOSER_ADDRESS}
+	--bridge-address ${BRIDGE_ADDRESS} \
+	--on-chain-proposer-address ${ON_CHAIN_PROPOSER_ADDRESS}
 
 init-metrics: ## 🚀 Initializes Grafana and Prometheus with containers
 	docker compose -f ${ethrex_METRICS_DOCKER_COMPOSE_PATH} -f ${ethrex_METRICS_OVERRIDES_L2_DOCKER_COMPOSE_PATH} up -d
@@ -228,7 +228,7 @@ integration-test-gpu: rm-db-l2 rm-db-l1
 	ETHREX_PROPOSER_BLOCK_TIME_MS=${ETHREX_PROPOSER_BLOCK_TIME_MS} \
 	ETHREX_DEPLOYER_PICO_DEPLOY_VERIFIER=${ETHREX_DEPLOYER_PICO_DEPLOY_VERIFIER} \
 	docker compose -f ${ethrex_L2_DOCKER_COMPOSE_PATH} up --detach --build
-	
+
 	RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover & \
 	cargo test l2 --release -- --nocapture --test-threads=1
 	killall ethrex_prover -s SIGINT # if sent a SIGTERM, SP1 does not shuts down the sp1-gpu container
@@ -243,7 +243,7 @@ state-diff-test:
 	docker compose -f docker-compose-l2.yaml -f docker-compose-l2-store.overrides.yaml down
 	CI_ETHREX_WORKDIR=${CI_ETHREX_WORKDIR} \
 	docker compose -f docker-compose-l2.yaml -f docker-compose-l2-store.overrides.yaml up --detach
-	
+
 	cargo test state_reconstruct --release
 
 # Purge L2's state


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Contract addresses change frequently and they need to be changed in the Makefile.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Remove the default values and read the addresses from the `.env` file, which are written by the deployer in case of using. In case you want to use the `init-l2` flow without the deployer and the `.env` file, you have to set the variables `BRIDGE_ADDRESS` and `ON_CHAIN_PROPOSER_ADDRESS` when running the target, else it will fail with an error like `error: a value is required for '--bridge-address <ADDRESS>' but none was supplied`. For example:

```sh
make init-l2 BRIDGE_ADDRESS=0x8ccf74999c496e4d27a2b02941673f41dd0dab2a ON_CHAIN_PROPOSER_ADDRESS=0x60020c8cc59dac4716a0375f1d30e65da9915d3f
```

<!-- Link to issues: Resolves #111, Resolves #222 -->



