### PR TITLE
refactor(l1): add `node_id` field to Node (node_id refactor 2/3)

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -39,7 +39,7 @@ async fn main() -> eyre::Result<()> {
 
     let local_p2p_node = get_local_p2p_node(&opts, &signer);
 
-    let peer_table = peer_table(signer.clone());
+    let peer_table = peer_table(local_p2p_node.node_id);
 
     // TODO: Check every module starts properly.
     let tracker = TaskTracker::new();

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -374,12 +374,12 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SigningKey) -> Node {
 
     let local_public_key = public_key_from_signing_key(signer);
 
-    let node = Node {
-        ip: p2p_node_ip,
-        udp_port: udp_socket_addr.port(),
-        tcp_port: tcp_socket_addr.port(),
-        public_key: local_public_key,
-    };
+    let node = Node::new(
+        p2p_node_ip,
+        udp_socket_addr.port(),
+        tcp_socket_addr.port(),
+        local_public_key,
+    );
 
     // TODO Find a proper place to show node information
     // https://github.com/lambdaclass/ethrex/issues/836

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -73,7 +73,7 @@ impl Command {
 
                 let local_p2p_node = get_local_p2p_node(&opts.node_opts, &signer);
 
-                let peer_table = peer_table(signer.clone());
+                let peer_table = peer_table(local_p2p_node.node_id);
 
                 // TODO: Check every module starts properly.
                 let tracker = TaskTracker::new();

--- a/crates/networking/docs/Network.md
+++ b/crates/networking/docs/Network.md
@@ -21,18 +21,16 @@ Before starting these tasks, we run a [startup](#startup) process to connect to 
 
 Before diving into what each task does, first, we need to understand how we are storing our nodes. Nodes are stored in an in-memory matrix which we call a [Kademlia table](https://github.com/lambdaclass/ethrex/blob/main/crates/networking/p2p/kademlia.rs#L25-L28), though it isn't really a Kademlia table as we don't thoroughly follow the spec but we take it as a reference, you can read more [here](https://en.wikipedia.org/wiki/Kademlia). This table holds:
 
--   Our `public_key`: The 64 bytes starting from index 1 of the encoded pub key.
+-   Our `node_id`: The node's unique identifier computed by obtaining the keccak hash of the 64 bytes starting from index 1 of the encoded pub key.
 -   A vector of 256 `bucket`s which holds:
     -   `peers`: a vector of 16 elements of type `PeersData` where we save the node record and other related data that we'll see later.
     -   `replacements`: a vector of 16 elements of `PeersData` that are not connected to us, but we consider them as potential replacements for those nodes that have disconnected from us.
 
-Peers are not assigned to any bucket but they are assigned based on its $0 \le \text{distance} \le 255$ to our `public_key`. Distance is defined by:
+Peers are not assigned to any bucket but they are assigned based on its $0 \le \text{distance} \le 255$ to our `node_id`. Distance is defined by:
 
 ```rust
-pub fn distance(public_key_1: H512, public_key_2: H512) -> usize {
-    let hash_1 = Keccak256::digest(public_key_1);
-    let hash_2 = Keccak256::digest(public_key_2);
-    let xor = H256(hash_1.into()) ^ H256(hash_2.into());
+pub fn distance(node_id_1: H512, node_id_2: H512) -> usize {
+    let xor = node_id_1 ^ node_id_2;
     let distance = U256::from_big_endian(xor.as_bytes());
     distance.bits().saturating_sub(1)
 }

--- a/crates/networking/p2p/discv4/lookup.rs
+++ b/crates/networking/p2p/discv4/lookup.rs
@@ -74,7 +74,7 @@ impl Discv4LookupHandler {
 
             debug!("Starting lookup");
 
-            // lookup closest to our public_key
+            // lookup closest to our node_id
             self.ctx.tracker.spawn({
                 let self_clone = self.clone();
                 async move {

--- a/crates/networking/p2p/discv4/lookup.rs
+++ b/crates/networking/p2p/discv4/lookup.rs
@@ -12,7 +12,6 @@ use crate::{
 use ethrex_common::{H256, H512};
 use k256::ecdsa::SigningKey;
 use rand::rngs::OsRng;
-use sha3::{Digest, Keccak256};
 use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::net::UdpSocket;
 use tracing::debug;

--- a/crates/networking/p2p/discv4/lookup.rs
+++ b/crates/networking/p2p/discv4/lookup.rs
@@ -8,9 +8,10 @@ use crate::{
     network::{public_key_from_signing_key, P2PContext},
     types::Node,
 };
-use ethrex_common::H512;
+use ethrex_common::{H256, H512};
 use k256::ecdsa::SigningKey;
 use rand::rngs::OsRng;
+use sha3::{Digest, Keccak256};
 use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::net::UdpSocket;
 use tracing::debug;
@@ -99,9 +100,16 @@ impl Discv4LookupHandler {
         }
     }
 
+    /// We use the public key instead of the node_id as target as we might need to perform a FindNode request
     async fn recursive_lookup(&self, target: H512) {
         // lookups start with the closest nodes to the target from our table
-        let mut peers_to_ask: Vec<Node> = self.ctx.table.lock().await.get_closest_nodes(target);
+        let target_node_id = H256(Keccak256::new_with_prefix(target).finalize().into());
+        let mut peers_to_ask: Vec<Node> = self
+            .ctx
+            .table
+            .lock()
+            .await
+            .get_closest_nodes(target_node_id);
         // stores the peers in peers_to_ask + the peers that were in peers_to_ask but were replaced by closer targets
         let mut seen_peers: HashSet<H512> = HashSet::default();
         let mut asked_peers = HashSet::default();
@@ -117,7 +125,7 @@ impl Discv4LookupHandler {
             for node in nodes_found {
                 if !seen_peers.contains(&node.public_key) {
                     seen_peers.insert(node.public_key);
-                    self.peers_to_ask_push(&mut peers_to_ask, target, node);
+                    self.peers_to_ask_push(&mut peers_to_ask, target_node_id, node);
                 }
             }
 
@@ -129,6 +137,7 @@ impl Discv4LookupHandler {
         }
     }
 
+    /// We use the public key instead of the node_id as target as we might need to perform a FindNode request
     async fn lookup(
         &self,
         target: H512,
@@ -145,7 +154,7 @@ impl Discv4LookupHandler {
                 continue;
             }
             let mut locked_table = self.ctx.table.lock().await;
-            if let Some(peer) = locked_table.get_by_public_key_mut(node.public_key) {
+            if let Some(peer) = locked_table.get_by_node_id_mut(node.node_id) {
                 // if the peer has an ongoing find_node request, don't query
                 if peer.find_node_request.is_none() {
                     let (tx, mut receiver) = tokio::sync::mpsc::unbounded_channel::<Vec<Node>>();
@@ -163,12 +172,7 @@ impl Discv4LookupHandler {
                         nodes.append(&mut found_nodes);
                     }
 
-                    if let Some(peer) = self
-                        .ctx
-                        .table
-                        .lock()
-                        .await
-                        .get_by_public_key_mut(node.public_key)
+                    if let Some(peer) = self.ctx.table.lock().await.get_by_node_id_mut(node.node_id)
                     {
                         peer.find_node_request = None;
                     };
@@ -185,8 +189,8 @@ impl Discv4LookupHandler {
 
     /// Adds a node to `peers_to_ask` if there's space; otherwise, replaces the farthest node
     /// from `target` if the new node is closer.
-    fn peers_to_ask_push(&self, peers_to_ask: &mut Vec<Node>, target: H512, node: Node) {
-        let distance = bucket_number(target, node.public_key);
+    fn peers_to_ask_push(&self, peers_to_ask: &mut Vec<Node>, target_node_id: H256, node: Node) {
+        let distance = bucket_number(target_node_id, node.node_id);
 
         if peers_to_ask.len() < MAX_NODES_PER_BUCKET {
             peers_to_ask.push(node);
@@ -197,7 +201,7 @@ impl Discv4LookupHandler {
         let (mut idx_to_replace, mut highest_distance) = (None, 0);
 
         for (i, peer) in peers_to_ask.iter().enumerate() {
-            let current_distance = bucket_number(peer.public_key, target);
+            let current_distance = bucket_number(peer.node_id, target_node_id);
 
             if distance < current_distance && current_distance >= highest_distance {
                 highest_distance = current_distance;
@@ -213,12 +217,12 @@ impl Discv4LookupHandler {
     async fn find_node_and_wait_for_response(
         &self,
         node: Node,
-        target_id: H512,
+        target: H512,
         request_receiver: &mut tokio::sync::mpsc::UnboundedReceiver<Vec<Node>>,
     ) -> Result<Vec<Node>, DiscoveryError> {
         let expiration: u64 = get_msg_expiration_from_seconds(20);
 
-        let msg = Message::FindNode(FindNodeMessage::new(target_id, expiration));
+        let msg = Message::FindNode(FindNodeMessage::new(target, expiration));
 
         let mut buf = Vec::new();
         msg.encode_with_header(&mut buf, &self.ctx.signer);
@@ -293,18 +297,18 @@ mod tests {
         // because the table is filled, before making the connection, remove a node from the `b` bucket
         // otherwise it won't be added.
         let b_bucket = bucket_number(
-            server_a.ctx.local_node.public_key,
-            server_b.ctx.local_node.public_key,
+            server_a.ctx.local_node.node_id,
+            server_b.ctx.local_node.node_id,
         );
-        let public_key_to_remove = server_a.ctx.table.lock().await.buckets()[b_bucket].peers[0]
+        let node_id_to_remove = server_a.ctx.table.lock().await.buckets()[b_bucket].peers[0]
             .node
-            .public_key;
+            .node_id;
         server_a
             .ctx
             .table
             .lock()
             .await
-            .replace_peer_on_custom_bucket(public_key_to_remove, b_bucket);
+            .replace_peer_on_custom_bucket(node_id_to_remove, b_bucket);
 
         connect_servers(&mut server_a, &mut server_b).await?;
 
@@ -314,13 +318,13 @@ mod tests {
             .table
             .lock()
             .await
-            .get_closest_nodes(server_b.ctx.local_node.public_key);
+            .get_closest_nodes(server_b.ctx.local_node.node_id);
         let nodes_to_ask = server_b
             .ctx
             .table
             .lock()
             .await
-            .get_closest_nodes(server_b.ctx.local_node.public_key);
+            .get_closest_nodes(server_b.ctx.local_node.node_id);
 
         let lookup_handler = lookup_handler_from_server(server_b.clone());
         lookup_handler
@@ -337,10 +341,10 @@ mod tests {
         // now all peers should've been inserted
         for peer in closets_peers_to_b_from_a {
             let table = server_b.ctx.table.lock().await;
-            let node = table.get_by_public_key(peer.public_key);
+            let node = table.get_by_node_id(peer.node_id);
             // sometimes nodes can send ourselves as a neighbor
             // make sure we don't add it
-            if peer.public_key == server_b.ctx.local_node.public_key {
+            if peer.node_id == server_b.ctx.local_node.node_id {
                 assert!(node.is_none());
             } else {
                 assert!(node.is_some());
@@ -380,7 +384,7 @@ mod tests {
                 .table
                 .lock()
                 .await
-                .get_closest_nodes(server_a.ctx.local_node.public_key),
+                .get_closest_nodes(server_a.ctx.local_node.node_id),
         );
         expected_peers.extend(
             server_c
@@ -388,7 +392,7 @@ mod tests {
                 .table
                 .lock()
                 .await
-                .get_closest_nodes(server_a.ctx.local_node.public_key),
+                .get_closest_nodes(server_a.ctx.local_node.node_id),
         );
         expected_peers.extend(
             server_d
@@ -396,7 +400,7 @@ mod tests {
                 .table
                 .lock()
                 .await
-                .get_closest_nodes(server_a.ctx.local_node.public_key),
+                .get_closest_nodes(server_a.ctx.local_node.node_id),
         );
 
         let lookup_handler = lookup_handler_from_server(server_a.clone());
@@ -410,9 +414,9 @@ mod tests {
         // make sure we don't add it
         for peer in expected_peers {
             let table = server_a.ctx.table.lock().await;
-            let node = table.get_by_public_key(peer.public_key);
+            let node = table.get_by_node_id(peer.node_id);
 
-            if peer.public_key == server_a.ctx.local_node.public_key {
+            if peer.node_id == server_a.ctx.local_node.node_id {
                 assert!(node.is_none());
             } else {
                 assert!(node.is_some());

--- a/crates/networking/p2p/discv4/lookup.rs
+++ b/crates/networking/p2p/discv4/lookup.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::{
     kademlia::{bucket_number, MAX_NODES_PER_BUCKET},
     network::{public_key_from_signing_key, P2PContext},
+    rlpx::utils::node_id,
     types::Node,
 };
 use ethrex_common::{H256, H512};
@@ -103,7 +104,7 @@ impl Discv4LookupHandler {
     /// We use the public key instead of the node_id as target as we might need to perform a FindNode request
     async fn recursive_lookup(&self, target: H512) {
         // lookups start with the closest nodes to the target from our table
-        let target_node_id = H256(Keccak256::new_with_prefix(target).finalize().into());
+        let target_node_id = node_id(&target);
         let mut peers_to_ask: Vec<Node> = self
             .ctx
             .table

--- a/crates/networking/p2p/discv4/messages.rs
+++ b/crates/networking/p2p/discv4/messages.rs
@@ -91,6 +91,14 @@ impl Packet {
     pub fn get_public_key(&self) -> H512 {
         self.public_key
     }
+
+    pub fn get_node_id(&self) -> H256 {
+        H256(
+            Keccak256::new_with_prefix(&self.public_key)
+                .finalize()
+                .into(),
+        )
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -638,20 +646,15 @@ mod tests {
     fn test_encode_neighbors_message() {
         let expiration: u64 = 17195043770;
         let public_key_1 = H512::from_str("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666").unwrap();
-        let node_1 = Node {
-            ip: "127.0.0.1".parse().unwrap(),
-            udp_port: 30303,
-            tcp_port: 30303,
-            public_key: public_key_1,
-        };
+        let node_1 = Node::new("127.0.0.1".parse().unwrap(), 30303, 30303, public_key_1);
 
         let public_key_2 = H512::from_str("11f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f50").unwrap();
-        let node_2 = Node {
-            ip: "190.191.188.57".parse().unwrap(),
-            udp_port: 30303,
-            tcp_port: 30303,
-            public_key: public_key_2,
-        };
+        let node_2 = Node::new(
+            "190.191.188.57".parse().unwrap(),
+            30303,
+            30303,
+            public_key_2,
+        );
         let key_bytes =
             H256::from_str("577d8278cc7748fad214b5378669b420f8221afb45ce930b7f22da49cbc545f3")
                 .unwrap();
@@ -970,13 +973,7 @@ mod tests {
         let decoded = Message::decode_with_type(0x04, &decode_hex(encoded).unwrap()).unwrap();
         let expiration: u64 = 17195043770;
         let public_key = H512::from_str("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666").unwrap();
-        let node = Node {
-            ip: "127.0.0.1".parse().unwrap(),
-            udp_port: 30303,
-            tcp_port: 30303,
-            public_key,
-        };
-
+        let node = Node::new("127.0.0.1".parse().unwrap(), 30303, 30303, public_key);
         let expected = Message::Neighbors(NeighborsMessage::new(vec![node], expiration));
         assert_eq!(decoded, expected);
     }

--- a/crates/networking/p2p/discv4/messages.rs
+++ b/crates/networking/p2p/discv4/messages.rs
@@ -1,5 +1,8 @@
 use super::helpers::current_unix_time;
-use crate::types::{Endpoint, Node, NodeRecord};
+use crate::{
+    rlpx::utils::node_id,
+    types::{Endpoint, Node, NodeRecord},
+};
 use bytes::BufMut;
 use ethrex_common::{H256, H512, H520};
 use ethrex_rlp::{
@@ -93,11 +96,7 @@ impl Packet {
     }
 
     pub fn get_node_id(&self) -> H256 {
-        H256(
-            Keccak256::new_with_prefix(&self.public_key)
-                .finalize()
-                .into(),
-        )
+        node_id(&self.public_key)
     }
 }
 

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::{
     kademlia::{KademliaTable, MAX_NODES_PER_BUCKET},
     network::{handle_peer_as_initiator, P2PContext},
-    rlpx::connection::MAX_PEERS_TCP_CONNECTIONS,
+    rlpx::{connection::MAX_PEERS_TCP_CONNECTIONS, utils::node_id},
     types::{Endpoint, Node, NodeRecord},
 };
 use ethrex_common::H256;
@@ -252,9 +252,7 @@ impl Discv4Server {
 
                 let nodes = {
                     let table = self.ctx.table.lock().await;
-                    table.get_closest_nodes(H256(
-                        Keccak256::new_with_prefix(&msg.target).finalize().into(),
-                    ))
+                    table.get_closest_nodes(node_id(&msg.target))
                 };
                 let nodes_chunks = nodes.chunks(4);
                 let expiration = get_msg_expiration_from_seconds(20);

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -530,7 +530,7 @@ impl Discv4Server {
     async fn try_add_peer_and_ping<'a>(&self, node: Node) -> Result<(), DiscoveryError> {
         // sanity check to make sure we are not storing ourselves
         // a case that may happen in a neighbor message for example
-        if node.public_key == self.ctx.local_node.public_key {
+        if node.node_id == self.ctx.local_node.node_id {
             return Ok(());
         }
 

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use ethrex_common::H256;
 use k256::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
-use sha3::{Digest, Keccak256};
 use std::{
     collections::HashSet,
     net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -426,13 +426,12 @@ impl PeerChannels {
 
 #[cfg(test)]
 mod tests {
-    use crate::network::public_key_from_signing_key;
+    use crate::{network::public_key_from_signing_key, rlpx::utils::node_id};
 
     use super::*;
     use ethrex_common::H512;
     use hex_literal::hex;
     use k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
-    use sha3::{Digest, Keccak256};
     use std::{
         net::{IpAddr, Ipv4Addr},
         time::{Duration, SystemTime, UNIX_EPOCH},
@@ -442,8 +441,8 @@ mod tests {
     fn bucket_number_works_as_expected() {
         let public_key_1 = H512(hex!("4dc429669029ceb17d6438a35c80c29e09ca2c25cc810d690f5ee690aa322274043a504b8d42740079c4f4cef50777c991010208b333b80bee7b9ae8e5f6b6f0"));
         let public_key_2 = H512(hex!("034ee575a025a661e19f8cda2b6fd8b2fd4fe062f6f2f75f0ec3447e23c1bb59beb1e91b2337b264c7386150b24b621b8224180c9e4aaf3e00584402dc4a8386"));
-        let node_id_1 = H256(Keccak256::new_with_prefix(public_key_1).finalize().into());
-        let node_id_2 = H256(Keccak256::new_with_prefix(public_key_2).finalize().into());
+        let node_id_1 = node_id(&public_key_1);
+        let node_id_2 = node_id(&public_key_2);
         let expected_bucket = 255;
         let result = bucket_number(node_id_1, node_id_2);
         assert_eq!(result, expected_bucket);
@@ -469,11 +468,7 @@ mod tests {
     fn get_test_table() -> KademliaTable {
         let signer = SigningKey::random(&mut OsRng);
         let local_public_key = public_key_from_signing_key(&signer);
-        let local_node_id = H256(
-            Keccak256::new_with_prefix(local_public_key)
-                .finalize()
-                .into(),
-        );
+        let local_node_id = node_id(&local_public_key);
 
         KademliaTable::new(local_node_id)
     }
@@ -489,7 +484,7 @@ mod tests {
                 0,
                 node_1_pubkey,
             ));
-            let node_1_id = H256(Keccak256::new_with_prefix(node_1_pubkey).finalize().into());
+            let node_1_id = node_id(&node_1_pubkey);
             table.get_by_node_id_mut(node_1_id).unwrap().last_pong = (SystemTime::now()
                 - Duration::from_secs(12 * 60 * 60))
             .duration_since(UNIX_EPOCH)
@@ -505,7 +500,7 @@ mod tests {
                 0,
                 node_2_pubkey,
             ));
-            let node_2_id = H256(Keccak256::new_with_prefix(node_2_pubkey).finalize().into());
+            let node_2_id = node_id(&node_2_pubkey);
             table.get_by_node_id_mut(node_2_id).unwrap().last_pong = (SystemTime::now()
                 - Duration::from_secs(36 * 60 * 60))
             .duration_since(UNIX_EPOCH)
@@ -521,7 +516,7 @@ mod tests {
                 0,
                 node_3_pubkey,
             ));
-            let node_3_id = H256(Keccak256::new_with_prefix(node_3_pubkey).finalize().into());
+            let node_3_id = node_id(&node_3_pubkey);
             table.get_by_node_id_mut(node_3_id).unwrap().last_pong = (SystemTime::now()
                 - Duration::from_secs(10 * 60 * 60))
             .duration_since(UNIX_EPOCH)

--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -5,8 +5,7 @@ use crate::{
     rlpx::{message::Message as RLPxMessage, p2p::Capability},
     types::{Node, NodeRecord},
 };
-use ethrex_common::{H256, H512, U256};
-use sha3::{Digest, Keccak256};
+use ethrex_common::{H256, U256};
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{mpsc, Mutex};
 use tracing::debug;
@@ -23,15 +22,15 @@ pub struct Bucket {
 
 #[derive(Debug)]
 pub struct KademliaTable {
-    local_public_key: H512,
+    local_node_id: H256,
     buckets: Vec<Bucket>,
 }
 
 impl KademliaTable {
-    pub fn new(local_public_key: H512) -> Self {
+    pub fn new(local_node_id: H256) -> Self {
         let buckets: Vec<Bucket> = vec![Bucket::default(); NUMBER_OF_BUCKETS];
         Self {
-            local_public_key,
+            local_node_id,
             buckets,
         }
     }
@@ -41,20 +40,20 @@ impl KademliaTable {
         &self.buckets
     }
 
-    pub fn get_by_public_key(&self, public_key: H512) -> Option<&PeerData> {
-        let bucket = &self.buckets[bucket_number(public_key, self.local_public_key)];
+    pub fn get_by_node_id(&self, node_id: H256) -> Option<&PeerData> {
+        let bucket = &self.buckets[bucket_number(node_id, self.local_node_id)];
         bucket
             .peers
             .iter()
-            .find(|entry| entry.node.public_key == public_key)
+            .find(|entry| entry.node.node_id == node_id)
     }
 
-    pub fn get_by_public_key_mut(&mut self, public_key: H512) -> Option<&mut PeerData> {
-        let bucket = &mut self.buckets[bucket_number(public_key, self.local_public_key)];
+    pub fn get_by_node_id_mut(&mut self, node_id: H256) -> Option<&mut PeerData> {
+        let bucket = &mut self.buckets[bucket_number(node_id, self.local_node_id)];
         bucket
             .peers
             .iter_mut()
-            .find(|entry| entry.node.public_key == public_key)
+            .find(|entry| entry.node.node_id == node_id)
     }
 
     /// Will try to insert a node into the table. If the table is full then it pushes it to the replacement list.
@@ -63,8 +62,7 @@ impl KademliaTable {
     ///     1. PeerData: none if the peer was already in the table or as a potential replacement
     ///     2. A bool indicating if the node was inserted to the table
     pub fn insert_node(&mut self, node: Node) -> (Option<PeerData>, bool) {
-        let public_key = node.public_key;
-        let bucket_idx = bucket_number(public_key, self.local_public_key);
+        let bucket_idx = bucket_number(node.node_id, self.local_node_id);
 
         self.insert_node_inner(node, bucket_idx, false)
     }
@@ -75,8 +73,7 @@ impl KademliaTable {
     ///     1. PeerData: none if the peer was already in the table or as a potential replacement
     ///     2. A bool indicating if the node was inserted to the table
     pub fn insert_node_forced(&mut self, node: Node) -> (Option<PeerData>, bool) {
-        let public_key = node.public_key;
-        let bucket_idx = bucket_number(public_key, self.local_public_key);
+        let bucket_idx = bucket_number(node.node_id, self.local_node_id);
 
         self.insert_node_inner(node, bucket_idx, true)
     }
@@ -96,19 +93,17 @@ impl KademliaTable {
         bucket_idx: usize,
         force_push: bool,
     ) -> (Option<PeerData>, bool) {
-        let public_key = node.public_key;
-
         let peer_already_in_table = self.buckets[bucket_idx]
             .peers
             .iter()
-            .any(|p| p.node.public_key == public_key);
+            .any(|p| p.node.node_id == node.node_id);
         if peer_already_in_table {
             return (None, false);
         }
         let peer_already_in_replacements = self.buckets[bucket_idx]
             .replacements
             .iter()
-            .any(|p| p.node.public_key == public_key);
+            .any(|p| p.node.node_id == node.node_id);
         if peer_already_in_replacements {
             return (None, false);
         }
@@ -120,7 +115,7 @@ impl KademliaTable {
             self.insert_as_replacement(&peer, bucket_idx);
             (Some(peer), false)
         } else {
-            self.remove_from_replacements(public_key, bucket_idx);
+            self.remove_from_replacements(node.node_id, bucket_idx);
             self.buckets[bucket_idx].peers.push(peer.clone());
             (Some(peer), true)
         }
@@ -134,24 +129,24 @@ impl KademliaTable {
         bucket.replacements.push(node.clone());
     }
 
-    fn remove_from_replacements(&mut self, public_key: H512, bucket_idx: usize) {
+    fn remove_from_replacements(&mut self, node_id: H256, bucket_idx: usize) {
         let bucket = &mut self.buckets[bucket_idx];
 
         bucket.replacements = bucket
             .replacements
             .drain(..)
-            .filter(|r| r.node.public_key != public_key)
+            .filter(|r| r.node.node_id != node_id)
             .collect();
     }
 
-    pub fn get_closest_nodes(&self, public_key: H512) -> Vec<Node> {
+    pub fn get_closest_nodes(&self, node_id: H256) -> Vec<Node> {
         let mut nodes: Vec<(Node, usize)> = vec![];
 
         // todo see if there is a more efficient way of doing this
         // though the bucket isn't that large and it shouldn't be an issue I guess
         for bucket in &self.buckets {
             for peer in &bucket.peers {
-                let distance = bucket_number(public_key, peer.node.public_key);
+                let distance = bucket_number(node_id, peer.node.node_id);
                 if nodes.len() < MAX_NODES_PER_BUCKET {
                     nodes.push((peer.node, distance));
                 } else {
@@ -168,8 +163,8 @@ impl KademliaTable {
         nodes.iter().map(|a| a.0).collect()
     }
 
-    pub fn pong_answered(&mut self, public_key: H512, pong_at: u64) {
-        let peer = self.get_by_public_key_mut(public_key);
+    pub fn pong_answered(&mut self, node_id: H256, pong_at: u64) {
+        let peer = self.get_by_node_id_mut(node_id);
         if peer.is_none() {
             return;
         }
@@ -181,8 +176,8 @@ impl KademliaTable {
         peer.revalidation = peer.revalidation.and(Some(true));
     }
 
-    pub fn update_peer_ping(&mut self, public_key: H512, ping_hash: Option<H256>, ping_at: u64) {
-        let peer = self.get_by_public_key_mut(public_key);
+    pub fn update_peer_ping(&mut self, node_id: H256, ping_hash: Option<H256>, ping_at: u64) {
+        let peer = self.get_by_node_id_mut(node_id);
         if peer.is_none() {
             return;
         }
@@ -262,25 +257,25 @@ impl KademliaTable {
     /// # Returns
     ///
     /// A mutable reference to the inserted peer or None in case there was no replacement
-    pub fn replace_peer(&mut self, public_key: H512) -> Option<PeerData> {
-        let bucket_idx = bucket_number(self.local_public_key, public_key);
-        self.replace_peer_inner(public_key, bucket_idx)
+    pub fn replace_peer(&mut self, node_id: H256) -> Option<PeerData> {
+        let bucket_idx = bucket_number(self.local_node_id, node_id);
+        self.replace_peer_inner(node_id, bucket_idx)
     }
 
     #[cfg(test)]
     pub fn replace_peer_on_custom_bucket(
         &mut self,
-        public_key: H512,
+        node_id: H256,
         bucket_idx: usize,
     ) -> Option<PeerData> {
-        self.replace_peer_inner(public_key, bucket_idx)
+        self.replace_peer_inner(node_id, bucket_idx)
     }
 
-    fn replace_peer_inner(&mut self, public_key: H512, bucket_idx: usize) -> Option<PeerData> {
+    fn replace_peer_inner(&mut self, node_id: H256, bucket_idx: usize) -> Option<PeerData> {
         let idx_to_remove = self.buckets[bucket_idx]
             .peers
             .iter()
-            .position(|peer| peer.node.public_key == public_key);
+            .position(|peer| peer.node.node_id == node_id);
 
         if let Some(idx) = idx_to_remove {
             let bucket = &mut self.buckets[bucket_idx];
@@ -304,19 +299,19 @@ impl KademliaTable {
     /// This function should be called each time a connection is established so the backend can send requests to the peers
     pub(crate) fn init_backend_communication(
         &mut self,
-        public_key: H512,
+        node_id: H256,
         channels: PeerChannels,
         capabilities: Vec<Capability>,
     ) {
-        let peer = self.get_by_public_key_mut(public_key);
+        let peer = self.get_by_node_id_mut(node_id);
         if let Some(peer) = peer {
             peer.channels = Some(channels);
             peer.supported_capabilities = capabilities;
             peer.is_connected = true;
         } else {
             debug!(
-                "[PEERS] Peer with public_key {:?} not found in the kademlia table when trying to init backend communication",
-                public_key
+                "[PEERS] Peer with node_id {:?} not found in the kademlia table when trying to init backend communication",
+                node_id
             );
         }
     }
@@ -336,10 +331,8 @@ impl KademliaTable {
 /// Computes the distance between two nodes according to the discv4 protocol
 /// and returns the corresponding bucket number
 /// <https://github.com/ethereum/devp2p/blob/master/discv4.md#node-identities>
-pub fn bucket_number(public_key_1: H512, public_key_2: H512) -> usize {
-    let hash_1 = Keccak256::digest(public_key_1);
-    let hash_2 = Keccak256::digest(public_key_2);
-    let xor = H256(hash_1.into()) ^ H256(hash_2.into());
+pub fn bucket_number(node_id_1: H256, node_id_2: H256) -> usize {
+    let xor = node_id_1 ^ node_id_2;
     let distance = U256::from_big_endian(xor.as_bytes());
     distance.bits().saturating_sub(1)
 }
@@ -436,8 +429,10 @@ mod tests {
     use crate::network::public_key_from_signing_key;
 
     use super::*;
+    use ethrex_common::H512;
     use hex_literal::hex;
     use k256::{ecdsa::SigningKey, elliptic_curve::rand_core::OsRng};
+    use sha3::{Digest, Keccak256};
     use std::{
         net::{IpAddr, Ipv4Addr},
         time::{Duration, SystemTime, UNIX_EPOCH},
@@ -447,8 +442,10 @@ mod tests {
     fn bucket_number_works_as_expected() {
         let public_key_1 = H512(hex!("4dc429669029ceb17d6438a35c80c29e09ca2c25cc810d690f5ee690aa322274043a504b8d42740079c4f4cef50777c991010208b333b80bee7b9ae8e5f6b6f0"));
         let public_key_2 = H512(hex!("034ee575a025a661e19f8cda2b6fd8b2fd4fe062f6f2f75f0ec3447e23c1bb59beb1e91b2337b264c7386150b24b621b8224180c9e4aaf3e00584402dc4a8386"));
+        let node_id_1 = H256(Keccak256::new_with_prefix(public_key_1).finalize().into());
+        let node_id_2 = H256(Keccak256::new_with_prefix(public_key_2).finalize().into());
         let expected_bucket = 255;
-        let result = bucket_number(public_key_1, public_key_2);
+        let result = bucket_number(node_id_1, node_id_2);
         assert_eq!(result, expected_bucket);
     }
 
@@ -457,12 +454,7 @@ mod tests {
         bucket_idx: usize,
     ) -> (Option<PeerData>, bool) {
         let public_key = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
-        let node = Node {
-            ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            tcp_port: 0,
-            udp_port: 0,
-            public_key,
-        };
+        let node = Node::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0, 0, public_key);
         table.insert_node_on_custom_bucket(node, bucket_idx)
     }
 
@@ -477,52 +469,60 @@ mod tests {
     fn get_test_table() -> KademliaTable {
         let signer = SigningKey::random(&mut OsRng);
         let local_public_key = public_key_from_signing_key(&signer);
+        let local_node_id = H256(
+            Keccak256::new_with_prefix(local_public_key)
+                .finalize()
+                .into(),
+        );
 
-        KademliaTable::new(local_public_key)
+        KademliaTable::new(local_node_id)
     }
 
     #[test]
     fn get_least_recently_pinged_peers_should_return_the_right_peers() {
         let mut table = get_test_table();
-        let node_1_id = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
+        let node_1_pubkey = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
         {
-            table.insert_node(Node {
-                ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                tcp_port: 0,
-                udp_port: 0,
-                public_key: node_1_id,
-            });
-            table.get_by_public_key_mut(node_1_id).unwrap().last_pong = (SystemTime::now()
+            table.insert_node(Node::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                0,
+                0,
+                node_1_pubkey,
+            ));
+            let node_1_id = H256(Keccak256::new_with_prefix(node_1_pubkey).finalize().into());
+            table.get_by_node_id_mut(node_1_id).unwrap().last_pong = (SystemTime::now()
                 - Duration::from_secs(12 * 60 * 60))
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
         }
 
-        let node_2_id = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
+        let node_2_pubkey = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
         {
-            table.insert_node(Node {
-                ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                tcp_port: 0,
-                udp_port: 0,
-                public_key: node_2_id,
-            });
-            table.get_by_public_key_mut(node_2_id).unwrap().last_pong = (SystemTime::now()
+            table.insert_node(Node::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                0,
+                0,
+                node_2_pubkey,
+            ));
+            let node_2_id = H256(Keccak256::new_with_prefix(node_2_pubkey).finalize().into());
+            table.get_by_node_id_mut(node_2_id).unwrap().last_pong = (SystemTime::now()
                 - Duration::from_secs(36 * 60 * 60))
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
         }
 
-        let node_3_id = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
+        let node_3_pubkey = public_key_from_signing_key(&SigningKey::random(&mut OsRng));
         {
-            table.insert_node(Node {
-                ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                tcp_port: 0,
-                udp_port: 0,
-                public_key: node_3_id,
-            });
-            table.get_by_public_key_mut(node_3_id).unwrap().last_pong = (SystemTime::now()
+            table.insert_node(Node::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                0,
+                0,
+                node_3_pubkey,
+            ));
+            let node_3_id = H256(Keccak256::new_with_prefix(node_3_pubkey).finalize().into());
+            table.get_by_node_id_mut(node_3_id).unwrap().last_pong = (SystemTime::now()
                 - Duration::from_secs(10 * 60 * 60))
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -536,9 +536,9 @@ mod tests {
             .map(|p| p.node.public_key)
             .collect();
 
-        assert!(peers.contains(&node_1_id));
-        assert!(peers.contains(&node_2_id));
-        assert!(!peers.contains(&node_3_id));
+        assert!(peers.contains(&node_1_pubkey));
+        assert!(peers.contains(&node_2_pubkey));
+        assert!(!peers.contains(&node_3_pubkey));
     }
 
     #[test]
@@ -598,16 +598,16 @@ mod tests {
         let replacement_peer = replacement_peer.unwrap();
         assert!(!inserted_to_table);
 
-        let public_key_to_replace = table.buckets[bucket_idx].peers[0].node.public_key;
-        let replacement = table.replace_peer_on_custom_bucket(public_key_to_replace, bucket_idx);
+        let node_id_to_replace = table.buckets[bucket_idx].peers[0].node.node_id;
+        let replacement = table.replace_peer_on_custom_bucket(node_id_to_replace, bucket_idx);
 
         assert_eq!(
-            replacement.unwrap().node.public_key,
-            replacement_peer.node.public_key
+            replacement.unwrap().node.node_id,
+            replacement_peer.node.node_id
         );
         assert_eq!(
-            table.buckets[bucket_idx].peers[0].node.public_key,
-            replacement_peer.node.public_key
+            table.buckets[bucket_idx].peers[0].node.node_id,
+            replacement_peer.node.node_id
         );
     }
     #[test]
@@ -617,9 +617,9 @@ mod tests {
         let bucket_idx = 0;
         fill_table_with_random_nodes(&mut table);
 
-        let public_key_to_replace = table.buckets[bucket_idx].peers[0].node.public_key;
+        let node_id_to_replace = table.buckets[bucket_idx].peers[0].node.node_id;
         let len_before = table.buckets[bucket_idx].peers.len();
-        let replacement = table.replace_peer_on_custom_bucket(public_key_to_replace, bucket_idx);
+        let replacement = table.replace_peer_on_custom_bucket(node_id_to_replace, bucket_idx);
         let len_after = table.buckets[bucket_idx].peers.len();
 
         assert!(replacement.is_none());

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -177,7 +177,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                 let mut table_lock = table.lock().await;
                 table_lock.insert_node_forced(self.node);
                 table_lock.init_backend_communication(
-                    self.node.public_key,
+                    self.node.node_id,
                     peer_channels,
                     capabilities,
                 );
@@ -228,7 +228,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                     &self.node,
                     &format!("{error_text}: ({error}), discarding peer {remote_public_key}"),
                 );
-                table.lock().await.replace_peer(remote_public_key);
+                table.lock().await.replace_peer(self.node.node_id);
             }
         }
 

--- a/crates/networking/p2p/rlpx/handshake.rs
+++ b/crates/networking/p2p/rlpx/handshake.rs
@@ -47,12 +47,12 @@ where
     let local_state = send_ack(remote_state.public_key, &mut stream).await?;
     let hashed_nonces: [u8; 32] =
         Keccak256::digest([local_state.nonce.0, remote_state.nonce.0].concat()).into();
-    let node = Node {
-        ip: peer_addr.ip(),
-        udp_port: peer_addr.port(),
-        tcp_port: peer_addr.port(),
-        public_key: remote_state.public_key,
-    };
+    let node = Node::new(
+        peer_addr.ip(),
+        peer_addr.port(),
+        peer_addr.port(),
+        remote_state.public_key,
+    );
     let codec = RLPxCodec::new(&local_state, &remote_state, hashed_nonces);
     log_peer_debug(&node, "Completed handshake as receiver!");
     Ok(RLPxConnection::new(

--- a/crates/networking/p2p/rlpx/utils.rs
+++ b/crates/networking/p2p/rlpx/utils.rs
@@ -1,10 +1,11 @@
 use crate::types::Node;
-use ethrex_common::H512;
+use ethrex_common::{H256, H512};
 use ethrex_rlp::error::{RLPDecodeError, RLPEncodeError};
 use k256::{
     elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
     EncodedPoint, PublicKey, SecretKey,
 };
+use sha3::{Digest, Keccak256};
 use snap::raw::{max_compress_len, Decoder as SnappyDecoder, Encoder as SnappyEncoder};
 use tracing::{debug, error, warn};
 
@@ -35,6 +36,11 @@ pub fn ecdh_xchng(secret_key: &SecretKey, public_key: &PublicKey) -> [u8; 32] {
 pub fn kdf(secret: &[u8], output: &mut [u8]) {
     // We don't use the `other_info` field
     concat_kdf::derive_key_into::<k256::sha2::Sha256>(secret, &[], output).unwrap();
+}
+
+/// Cpmputes the node_id from a public key (aka computes the Keccak256 hash of the given public key)
+pub fn node_id(public_key: &H512) -> H256 {
+    H256(Keccak256::new_with_prefix(public_key).finalize().into())
 }
 
 /// Decompresses the received public key

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -420,8 +420,8 @@ mod tests {
         let socket_address = SocketAddr::from_str("18.138.108.67:30303").unwrap();
         let expected_bootnode = Node::new(
             socket_address.ip(),
-            socket_address.port(),
             30305,
+            socket_address.port(),
             public_key,
         );
         assert_eq!(node, expected_bootnode);

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -61,6 +61,7 @@ pub struct Node {
     pub udp_port: u16,
     pub tcp_port: u16,
     pub public_key: H512,
+    pub node_id: H256,
 }
 
 impl RLPDecode for Node {
@@ -72,12 +73,7 @@ impl RLPDecode for Node {
         let (public_key, decoder) = decoder.decode_field("public_key")?;
         let remaining = decoder.finish_unchecked();
 
-        let node = Node {
-            ip,
-            udp_port,
-            tcp_port,
-            public_key,
-        };
+        let node = Node::new(ip, udp_port, tcp_port, public_key);
         Ok((node, remaining))
     }
 }
@@ -104,6 +100,16 @@ impl FromStr for Node {
 }
 
 impl Node {
+    pub fn new(ip: IpAddr, udp_port: u16, tcp_port: u16, public_key: H512) -> Self {
+        Self {
+            ip,
+            udp_port,
+            tcp_port,
+            public_key,
+            node_id: H256(Keccak256::new_with_prefix(&public_key).finalize().into()),
+        }
+    }
+
     pub fn from_enode_url(enode: &str) -> Result<Self, String> {
         let public_key =
             H512::from_str(&enode[8..136]).map_err(|_| "Could not parse public_key")?;
@@ -130,12 +136,7 @@ impl Node {
             None => port,
         };
 
-        Ok(Self {
-            public_key,
-            ip,
-            tcp_port: port,
-            udp_port,
-        })
+        Ok(Self::new(ip, udp_port, port, public_key))
     }
 
     pub fn from_enr_url(enr: &str) -> Result<Self, String> {
@@ -165,12 +166,7 @@ impl Node {
             .or(pairs.udp_port)
             .ok_or("No port found in record")?;
 
-        Ok(Self {
-            ip,
-            public_key,
-            tcp_port,
-            udp_port,
-        })
+        Ok(Self::new(ip, udp_port, tcp_port, public_key))
     }
 
     pub fn enode_url(&self) -> String {
@@ -191,15 +187,6 @@ impl Node {
 
     pub fn tcp_addr(self) -> SocketAddr {
         SocketAddr::new(self.ip, self.tcp_port)
-    }
-
-    /// Returns the keccak256 hash of the node's public key
-    pub fn node_id(&self) -> H256 {
-        H256(
-            Keccak256::new_with_prefix(self.public_key)
-                .finalize()
-                .into(),
-        )
     }
 }
 
@@ -412,12 +399,12 @@ mod tests {
             "d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666")
             .unwrap();
         let socket_address = SocketAddr::from_str("18.138.108.67:30303").unwrap();
-        let expected_bootnode = Node {
-            ip: socket_address.ip(),
+        let expected_bootnode = Node::new(
+            socket_address.ip(),
+            socket_address.port(),
+            socket_address.port(),
             public_key,
-            tcp_port: socket_address.port(),
-            udp_port: socket_address.port(),
-        };
+        );
         assert_eq!(bootnode, expected_bootnode);
     }
 
@@ -429,12 +416,12 @@ mod tests {
             "d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666")
             .unwrap();
         let socket_address = SocketAddr::from_str("18.138.108.67:30303").unwrap();
-        let expected_bootnode = Node {
-            ip: socket_address.ip(),
+        let expected_bootnode = Node::new(
+            socket_address.ip(),
+            socket_address.port(),
+            30305,
             public_key,
-            tcp_port: socket_address.port(),
-            udp_port: 30305,
-        };
+        );
         assert_eq!(node, expected_bootnode);
     }
 
@@ -447,12 +434,12 @@ mod tests {
             H512::from_str("0xca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f")
                 .unwrap();
         let socket_address = SocketAddr::from_str("127.0.0.1:30303").unwrap();
-        let expected_node = Node {
-            ip: socket_address.ip(),
+        let expected_node = Node::new(
+            socket_address.ip(),
+            socket_address.port(),
+            socket_address.port(),
             public_key,
-            tcp_port: socket_address.port(),
-            udp_port: socket_address.port(),
-        };
+        );
         assert_eq!(node, expected_node);
     }
 
@@ -465,12 +452,12 @@ mod tests {
         ])
         .unwrap();
         let addr = std::net::SocketAddr::from_str("127.0.0.1:30303").unwrap();
-        let node = Node {
-            ip: addr.ip(),
-            public_key: public_key_from_signing_key(&signer),
-            tcp_port: addr.port(),
-            udp_port: addr.port(),
-        };
+        let node = Node::new(
+            addr.ip(),
+            addr.port(),
+            addr.port(),
+            public_key_from_signing_key(&signer),
+        );
         let record = NodeRecord::from_node(node, 0, &signer).unwrap();
         let expected_enr_string = "enr:-Iu4QDOLZWVEdbtRUtrZ8PU1vxUJ0t_TUpVghJhJuakBUyYKE_ZfvhR2EKxDyJ8Z5wwoJE4mTSItAcYsErU0NrB7uzCAgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJtSDUljLLg3EYuRCp8QJvH8G2F9rmUAQtPKlZjq_O7loN0Y3CCdl-DdWRwgnZf";
 

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -14,6 +14,8 @@ use std::{
     str::FromStr,
 };
 
+use crate::rlpx::utils::node_id;
+
 const MAX_NODE_RECORD_ENCODED_SIZE: usize = 300;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -106,7 +108,7 @@ impl Node {
             udp_port,
             tcp_port,
             public_key,
-            node_id: H256(Keccak256::new_with_prefix(&public_key).finalize().into()),
+            node_id: node_id(&public_key),
         }
     }
 

--- a/crates/networking/rpc/admin/mod.rs
+++ b/crates/networking/rpc/admin/mod.rs
@@ -45,7 +45,7 @@ pub fn node_info(storage: Store, node_data: &NodeData) -> Result<Value, RpcErr> 
     let node_info = NodeInfo {
         enode: enode_url,
         enr: enr_url,
-        id: hex::encode(node_data.local_p2p_node.node_id()),
+        id: hex::encode(node_data.local_p2p_node.node_id),
         name: node_data.client_version.clone(),
         ip: node_data.local_p2p_node.ip.to_string(),
         ports: Ports {

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -361,22 +361,12 @@ pub mod test_utils {
     pub const TEST_GENESIS: &str = include_str!("../../../test_data/genesis-l1.json");
     pub fn example_p2p_node() -> Node {
         let public_key_1 = H512::from_str("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666").unwrap();
-        Node {
-            ip: "127.0.0.1".parse().unwrap(),
-            udp_port: 30303,
-            tcp_port: 30303,
-            public_key: public_key_1,
-        }
+        Node::new("127.0.0.1".parse().unwrap(), 30303, 30303, public_key_1)
     }
 
     pub fn example_local_node_record() -> NodeRecord {
         let public_key_1 = H512::from_str("d860a01f9722d78051619d1e2351aba3f43f943f6f00718d1b9baa4101932a1f5011f16bb2b1bb35db20d6fe28fa0bf09636d26a87d31de9ec6203eeedb1f666").unwrap();
-        let node = Node {
-            ip: "127.0.0.1".parse().unwrap(),
-            udp_port: 30303,
-            tcp_port: 30303,
-            public_key: public_key_1,
-        };
+        let node = Node::new("127.0.0.1".parse().unwrap(), 30303, 30303, public_key_1);
         let signer = SigningKey::random(&mut rand::rngs::OsRng);
 
         NodeRecord::from_node(node, 0, &signer).unwrap()


### PR DESCRIPTION
Based on #2778 
**Motivation**
Avoid constantly hashing the node's public key on kademlia operations by adding `node_id` field. Before this PR we would hash the node's public key every time we needed to add, remove or find a node in the kademlia table, which is pretty often.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `Node` field `node_id`
* Add `new` method for `Node` which handles node_id computation
* Use `node_id` for kademlia table (and some other) operations instead of the public key so we no longer need to hash it when calculating the bucket index (this affects most kademlia table reads/writes)

**Follow-Up Work**
Use `OnceLock` to cache for `node_id` computation  (replacing the field added by this PR) #2789
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

