### PR TITLE
feat(l1): cache `node_id` computation

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -39,7 +39,7 @@ async fn main() -> eyre::Result<()> {
 
     let local_p2p_node = get_local_p2p_node(&opts, &signer);
 
-    let peer_table = peer_table(local_p2p_node.node_id);
+    let peer_table = peer_table(local_p2p_node.node_id());
 
     // TODO: Check every module starts properly.
     let tracker = TaskTracker::new();
@@ -52,7 +52,7 @@ async fn main() -> eyre::Result<()> {
         &L2Options::default(),
         &signer,
         peer_table.clone(),
-        local_p2p_node,
+        local_p2p_node.clone(),
         store.clone(),
         blockchain.clone(),
         cancel_token.clone(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -137,7 +137,7 @@ pub async fn init_rpc_api(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let local_node_record = NodeRecord::from_node(local_p2p_node, enr_seq, signer)
+    let local_node_record = NodeRecord::from_node(&local_p2p_node, enr_seq, signer)
         .expect("Node record could not be created from local node");
 
     // Create SyncManager
@@ -302,22 +302,22 @@ pub fn get_bootnodes(opts: &Options, network: &str, data_dir: &str) -> Vec<Node>
 
     if network == networks::HOLESKY_GENESIS_PATH {
         info!("Adding holesky preset bootnodes");
-        bootnodes.extend(networks::HOLESKY_BOOTNODES.iter());
+        bootnodes.extend(networks::HOLESKY_BOOTNODES.clone());
     }
 
     if network == networks::SEPOLIA_GENESIS_PATH {
         info!("Adding sepolia preset bootnodes");
-        bootnodes.extend(networks::SEPOLIA_BOOTNODES.iter());
+        bootnodes.extend(networks::SEPOLIA_BOOTNODES.clone());
     }
 
     if network == networks::HOODI_GENESIS_PATH {
         info!("Adding hoodi preset bootnodes");
-        bootnodes.extend(networks::HOODI_BOOTNODES.iter());
+        bootnodes.extend(networks::HOODI_BOOTNODES.clone());
     }
 
     if network == networks::MAINNET_GENESIS_PATH {
         info!("Adding mainnet preset bootnodes");
-        bootnodes.extend(networks::MAINNET_BOOTNODES.iter());
+        bootnodes.extend(networks::MAINNET_BOOTNODES.clone());
     }
 
     if bootnodes.is_empty() {

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -73,7 +73,7 @@ impl Command {
 
                 let local_p2p_node = get_local_p2p_node(&opts.node_opts, &signer);
 
-                let peer_table = peer_table(signer.clone());
+                let peer_table = peer_table(local_p2p_node.node_id());
 
                 // TODO: Check every module starts properly.
                 let tracker = TaskTracker::new();
@@ -85,7 +85,7 @@ impl Command {
                     &opts,
                     &signer,
                     peer_table.clone(),
-                    local_p2p_node,
+                    local_p2p_node.clone(),
                     store.clone(),
                     blockchain.clone(),
                     cancel_token.clone(),

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -140,11 +140,11 @@ impl Discv4Server {
                     msg.from.tcp_port,
                     packet.get_public_key(),
                 );
-                self.pong(packet.get_hash(), node).await?;
+                self.pong(packet.get_hash(), &node).await?;
 
                 let peer = {
                     let table = self.ctx.table.lock().await;
-                    table.get_by_node_id(node.node_id).cloned()
+                    table.get_by_node_id(node.node_id()).cloned()
                 };
 
                 let Some(peer) = peer else {
@@ -155,12 +155,12 @@ impl Discv4Server {
                 // if peer was in the table and last ping was 12 hs ago
                 //  we need to re ping to re-validate the endpoint proof
                 if elapsed_time_since(peer.last_ping) / 3600 >= PROOF_EXPIRATION_IN_HS {
-                    self.ping(node).await?;
+                    self.ping(&node).await?;
                 }
                 if let Some(enr_seq) = msg.enr_seq {
                     if enr_seq > peer.record.seq && peer.is_proven {
                         debug!("Found outdated enr-seq, sending an enr_request");
-                        self.send_enr_request(peer.node, self.ctx.table.lock().await)
+                        self.send_enr_request(&peer.node, self.ctx.table.lock().await)
                             .await?;
                     }
                 }
@@ -196,11 +196,11 @@ impl Discv4Server {
                     .table
                     .lock()
                     .await
-                    .pong_answered(peer.node.node_id, current_unix_time());
+                    .pong_answered(peer.node.node_id(), current_unix_time());
                 if let Some(enr_seq) = msg.enr_seq {
                     if enr_seq > peer.record.seq {
                         debug!("Found outdated enr-seq, send an enr_request");
-                        self.send_enr_request(peer.node, self.ctx.table.lock().await)
+                        self.send_enr_request(&peer.node, self.ctx.table.lock().await)
                             .await?;
                     }
                 }
@@ -329,7 +329,7 @@ impl Discv4Server {
 
                 debug!("Storing neighbors in our table!");
                 for node in nodes {
-                    let _ = self.try_add_peer_and_ping(*node).await;
+                    let _ = self.try_add_peer_and_ping(node.clone()).await;
                 }
 
                 Ok(())
@@ -339,7 +339,7 @@ impl Discv4Server {
                     return Err(DiscoveryError::MessageExpired);
                 }
                 let Ok(node_record) =
-                    NodeRecord::from_node(self.ctx.local_node, self.ctx.enr_seq, &self.ctx.signer)
+                    NodeRecord::from_node(&self.ctx.local_node, self.ctx.enr_seq, &self.ctx.signer)
                 else {
                     return Err(DiscoveryError::InvalidMessage(
                         "could not build local node record".into(),
@@ -491,7 +491,7 @@ impl Discv4Server {
                     let new_peer = table_lock.replace_peer(node_id);
                     if let Some(new_peer) = new_peer {
                         drop(table_lock);
-                        let _ = self.ping(new_peer.node).await;
+                        let _ = self.ping(&new_peer.node).await;
                     }
                 }
             }
@@ -508,10 +508,10 @@ impl Discv4Server {
             previously_pinged_peers = HashSet::default();
             for peer in peers {
                 debug!("Pinging peer {:?} to re-validate!", peer.node.public_key);
-                let _ = self.ping(peer.node).await;
-                previously_pinged_peers.insert(peer.node.node_id);
+                let _ = self.ping(&peer.node).await;
+                previously_pinged_peers.insert(peer.node.node_id());
                 let mut table = self.ctx.table.lock().await;
-                let peer = table.get_by_node_id_mut(peer.node.node_id);
+                let peer = table.get_by_node_id_mut(peer.node.node_id());
                 if let Some(peer) = peer {
                     peer.revalidation = Some(false);
                 }
@@ -529,7 +529,7 @@ impl Discv4Server {
     async fn try_add_peer_and_ping<'a>(&self, node: Node) -> Result<(), DiscoveryError> {
         // sanity check to make sure we are not storing ourselves
         // a case that may happen in a neighbor message for example
-        if node.node_id == self.ctx.local_node.node_id {
+        if node.node_id() == self.ctx.local_node.node_id() {
             return Ok(());
         }
 
@@ -540,12 +540,12 @@ impl Discv4Server {
             table_lock.insert_node(node)
         };
         if let (Some(peer), true) = (peer, found) {
-            self.ping(peer.node).await?;
+            self.ping(&peer.node).await?;
         };
         Ok(())
     }
 
-    async fn ping<'a>(&self, node: Node) -> Result<(), DiscoveryError> {
+    async fn ping<'a>(&self, node: &Node) -> Result<(), DiscoveryError> {
         let mut buf = Vec::new();
         let expiration: u64 = get_msg_expiration_from_seconds(20);
         let from = Endpoint {
@@ -573,16 +573,16 @@ impl Discv4Server {
         }
 
         let hash = H256::from_slice(&buf[0..32]);
-        self.ctx
-            .table
-            .lock()
-            .await
-            .update_peer_ping(node.node_id, Some(hash), current_unix_time());
+        self.ctx.table.lock().await.update_peer_ping(
+            node.node_id(),
+            Some(hash),
+            current_unix_time(),
+        );
 
         Ok(())
     }
 
-    async fn pong(&self, ping_hash: H256, node: Node) -> Result<(), DiscoveryError> {
+    async fn pong(&self, ping_hash: H256, node: &Node) -> Result<(), DiscoveryError> {
         let mut buf = Vec::new();
         let expiration: u64 = get_msg_expiration_from_seconds(20);
         let to = Endpoint {
@@ -611,7 +611,7 @@ impl Discv4Server {
 
     async fn send_enr_request<'a>(
         &self,
-        node: Node,
+        node: &Node,
         mut table_lock: MutexGuard<'a, KademliaTable>,
     ) -> Result<(), DiscoveryError> {
         let mut buf = Vec::new();
@@ -629,7 +629,7 @@ impl Discv4Server {
         }
 
         let hash = H256::from_slice(&buf[0..32]);
-        if let Some(peer) = table_lock.get_by_node_id_mut(node.node_id) {
+        if let Some(peer) = table_lock.get_by_node_id_mut(node.node_id()) {
             peer.enr_request_hash = Some(hash);
         };
 
@@ -683,7 +683,7 @@ pub(super) mod tests {
         let storage =
             Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
         let blockchain = Arc::new(Blockchain::default_with_store(storage.clone()));
-        let table = Arc::new(Mutex::new(KademliaTable::new(local_node.node_id)));
+        let table = Arc::new(Mutex::new(KademliaTable::new(local_node.node_id())));
         let (broadcast, _) = tokio::sync::broadcast::channel::<(tokio::task::Id, Arc<RLPxMessage>)>(
             MAX_MESSAGES_TO_BROADCAST,
         );
@@ -724,7 +724,7 @@ pub(super) mod tests {
         server_b: &mut Discv4Server,
     ) -> Result<(), DiscoveryError> {
         server_a
-            .try_add_peer_and_ping(server_b.ctx.local_node)
+            .try_add_peer_and_ping(server_b.ctx.local_node.clone())
             .await?;
 
         // allow some time for the server to respond
@@ -760,7 +760,7 @@ pub(super) mod tests {
             sleep(Duration::from_millis(2500)).await;
             // by now, b should've send a revalidation to a
             let table = server_b.ctx.table.lock().await;
-            let node = table.get_by_node_id(server_a.ctx.local_node.node_id);
+            let node = table.get_by_node_id(server_a.ctx.local_node.node_id());
             assert!(node.is_some_and(|n| n.revalidation.is_some()));
         }
 
@@ -768,7 +768,7 @@ pub(super) mod tests {
         // we can do that by checking the liveness
         {
             let table = server_b.ctx.table.lock().await;
-            let node = table.get_by_node_id(server_a.ctx.local_node.node_id);
+            let node = table.get_by_node_id(server_a.ctx.local_node.node_id());
             assert_eq!(node.map_or(0, |n| n.liveness), 6);
         }
 
@@ -776,7 +776,7 @@ pub(super) mod tests {
         // so we'll instead change its port, so that no one responds
         {
             let mut table = server_b.ctx.table.lock().await;
-            let node = table.get_by_node_id_mut(server_a.ctx.local_node.node_id);
+            let node = table.get_by_node_id_mut(server_a.ctx.local_node.node_id());
             if let Some(node) = node {
                 node.node.udp_port = 0
             };
@@ -787,7 +787,7 @@ pub(super) mod tests {
         for _ in 0..2 {
             sleep(Duration::from_millis(2500)).await;
             let table = server_b.ctx.table.lock().await;
-            let node = table.get_by_node_id(server_a.ctx.local_node.node_id);
+            let node = table.get_by_node_id(server_a.ctx.local_node.node_id());
             assert!(node.is_some_and(|n| n.revalidation.is_some()));
         }
         sleep(Duration::from_millis(2500)).await;
@@ -795,7 +795,7 @@ pub(super) mod tests {
         // finally, `a`` should not exist anymore
         let table = server_b.ctx.table.lock().await;
         assert!(table
-            .get_by_node_id(server_a.ctx.local_node.node_id)
+            .get_by_node_id(server_a.ctx.local_node.node_id())
             .is_none());
         Ok(())
     }
@@ -822,7 +822,7 @@ pub(super) mod tests {
         sleep(Duration::from_millis(2500)).await;
 
         let expected_record = NodeRecord::from_node(
-            server_b.ctx.local_node,
+            &server_b.ctx.local_node,
             current_unix_time(),
             &server_b.ctx.signer,
         )
@@ -833,7 +833,7 @@ pub(super) mod tests {
             .table
             .lock()
             .await
-            .get_by_node_id(server_b.ctx.local_node.node_id)
+            .get_by_node_id(server_b.ctx.local_node.node_id())
             .cloned()
             .unwrap();
 
@@ -848,7 +848,7 @@ pub(super) mod tests {
             .table
             .lock()
             .await
-            .get_by_node_id_mut(server_b.ctx.local_node.node_id)
+            .get_by_node_id_mut(server_b.ctx.local_node.node_id())
             .unwrap()
             .node
             .tcp_port = 10;
@@ -860,7 +860,7 @@ pub(super) mod tests {
         // Send a ping from server_b to server_a.
         // server_a should notice the enr_seq is outdated
         // and trigger a enr-request to server_b to update the record.
-        server_b.ping(server_a.ctx.local_node).await?;
+        server_b.ping(&server_a.ctx.local_node).await?;
 
         // Wait for the update to propagate.
         sleep(Duration::from_millis(2500)).await;
@@ -868,7 +868,7 @@ pub(super) mod tests {
         // Verify that server_a has updated its record of server_b with the correct TCP port.
         let table_lock = server_a.ctx.table.lock().await;
         let server_a_node_b_record = table_lock
-            .get_by_node_id(server_b.ctx.local_node.node_id)
+            .get_by_node_id(server_b.ctx.local_node.node_id())
             .unwrap();
 
         assert!(server_a_node_b_record.node.tcp_port == server_b.ctx.local_node.tcp_port);

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -152,16 +152,16 @@ pub async fn handle_peer_as_initiator(context: P2PContext, node: Node) {
         Ok(result) => result,
         Err(e) => {
             log_peer_error(&node, &format!("Error creating tcp connection {e}"));
-            context.table.lock().await.replace_peer(node.node_id);
+            context.table.lock().await.replace_peer(node.node_id());
             return;
         }
     };
     let table = context.table.clone();
-    match handshake::as_initiator(context, node, stream).await {
+    match handshake::as_initiator(context, node.clone(), stream).await {
         Ok(mut conn) => conn.start(table).await,
         Err(e) => {
             log_peer_error(&node, &format!("Error creating tcp connection {e}"));
-            table.lock().await.replace_peer(node.node_id);
+            table.lock().await.replace_peer(node.node_id());
         }
     };
 }

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -175,9 +175,9 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
             // Note: we don't ping the node we let the validation service do its job
             {
                 let mut table_lock = table.lock().await;
-                table_lock.insert_node_forced(self.node);
+                table_lock.insert_node_forced(self.node.clone());
                 table_lock.init_backend_communication(
-                    self.node.node_id,
+                    self.node.node_id(),
                     peer_channels,
                     capabilities,
                 );
@@ -228,7 +228,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                     &self.node,
                     &format!("{error_text}: ({error}), discarding peer {remote_public_key}"),
                 );
-                table.lock().await.replace_peer(self.node.node_id);
+                table.lock().await.replace_peer(self.node.node_id());
             }
         }
 

--- a/crates/networking/rpc/admin/mod.rs
+++ b/crates/networking/rpc/admin/mod.rs
@@ -45,7 +45,7 @@ pub fn node_info(storage: Store, node_data: &NodeData) -> Result<Value, RpcErr> 
     let node_info = NodeInfo {
         enode: enode_url,
         enr: enr_url,
-        id: hex::encode(node_data.local_p2p_node.node_id),
+        id: hex::encode(node_data.local_p2p_node.node_id()),
         name: node_data.client_version.clone(),
         ip: node_data.local_p2p_node.ip.to_string(),
         ports: Ports {

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -545,7 +545,7 @@ mod tests {
             .await
             .unwrap();
         let context = default_context_with_storage(storage).await;
-        let local_p2p_node = context.node_data.local_p2p_node;
+        let local_p2p_node = context.node_data.local_p2p_node.clone();
 
         let enr_url = context.node_data.local_node_record.enr_url().unwrap();
         let result = map_http_requests(&request, context).await;

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -369,7 +369,7 @@ pub mod test_utils {
         let node = Node::new("127.0.0.1".parse().unwrap(), 30303, 30303, public_key_1);
         let signer = SigningKey::random(&mut rand::rngs::OsRng);
 
-        NodeRecord::from_node(node, 0, &signer).unwrap()
+        NodeRecord::from_node(&node, 0, &signer).unwrap()
     }
 
     // Util to start an api for testing on ports 8500 and 8501,


### PR DESCRIPTION
**Motivation**
Use `OnceLock` to cache node_id computation so we only do it once but at the same time don't need to do it unless we will use it. For example, when we receive a Neighbours message we will decode all received nodes but may not use them all if our kademlia table is full
<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

