### PR TITLE
fix(core): remove hardcoded gas_limits use eth_estimateGas

### DIFF
--- a/cmd/ethrex_l2/src/commands/wallet.rs
+++ b/cmd/ethrex_l2/src/commands/wallet.rs
@@ -331,7 +331,6 @@ impl Command {
                             },
                             nonce,
                             from: Some(cfg.wallet.address),
-                            gas_limit: Some(21000 * 100),
                             ..Default::default()
                         },
                     )
@@ -371,7 +370,6 @@ impl Command {
                             nonce,
                             from: Some(cfg.wallet.address),
                             value: Some(amount),
-                            gas_limit: Some(21000 * 2),
                             max_fee_per_gas: Some(800000000),
                             ..Default::default()
                         },

--- a/cmd/load_test/src/main.rs
+++ b/cmd/load_test/src/main.rs
@@ -242,7 +242,6 @@ async fn load_test(
                             nonce: Some(nonce + i),
                             max_fee_per_gas: Some(u64::MAX),
                             max_priority_fee_per_gas: Some(10),
-                            gas_limit: Some(TX_GAS_COST * 100),
                             ..Default::default()
                         },
                     )

--- a/cmd/load_test/src/main.rs
+++ b/cmd/load_test/src/main.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, ValueEnum};
 use ethereum_types::{Address, H160, H256, U256};
-use ethrex_blockchain::constants::TX_GAS_COST;
 use ethrex_l2_sdk::calldata::{self, Value};
 use ethrex_l2_sdk::get_address_from_secret_key;
 use ethrex_rpc::clients::eth::BlockByNumber;

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -175,7 +175,6 @@ pub async fn withdraw(
                 // Also we have some mismatches at the end of the L2 integration test.
                 max_fee_per_gas: Some(800000000),
                 max_priority_fee_per_gas: Some(800000000),
-                gas_limit: Some(21000 * 66),
                 ..Default::default()
             },
         )

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -758,6 +758,7 @@ impl EthClient {
         };
 
         transaction.from = from;
+        transaction.nonce = None;
         self.estimate_gas(transaction).await
     }
 


### PR DESCRIPTION
**Motivation**

Gas limit was hardcoded in some cases because we didn't have eth_estimateGas implemented now we do so we want to use it when possible
**Description**

- Replace instances of hardcoded gas_limit and remove it as `build_xxxx_transaction` functions already estimate gas if the override does not include it 
- Set nonce to none when estimating the gas so that doesn't fail when sending multiple txs at the same time


Closes #2782 

