### PR TITLE
fix(core): remove hardcoded max_fee_per_gas & max_priority_fee_per_gas

### DIFF
--- a/cmd/ethrex_l2/src/commands/wallet.rs
+++ b/cmd/ethrex_l2/src/commands/wallet.rs
@@ -371,8 +371,6 @@ impl Command {
                             nonce,
                             from: Some(cfg.wallet.address),
                             value: Some(amount),
-                            gas_limit: Some(21000 * 2),
-                            max_fee_per_gas: Some(800000000),
                             ..Default::default()
                         },
                     )

--- a/cmd/load_test/src/main.rs
+++ b/cmd/load_test/src/main.rs
@@ -1,6 +1,5 @@
 use clap::{Parser, ValueEnum};
 use ethereum_types::{Address, H160, H256, U256};
-use ethrex_blockchain::constants::TX_GAS_COST;
 use ethrex_l2_sdk::calldata::{self, Value};
 use ethrex_l2_sdk::get_address_from_secret_key;
 use ethrex_rpc::clients::eth::BlockByNumber;
@@ -240,9 +239,6 @@ async fn load_test(
                             chain_id: Some(chain_id),
                             value,
                             nonce: Some(nonce + i),
-                            max_fee_per_gas: Some(u64::MAX),
-                            max_priority_fee_per_gas: Some(10),
-                            gas_limit: Some(TX_GAS_COST * 100),
                             ..Default::default()
                         },
                     )

--- a/crates/l2/contracts/bin/deployer/main.rs
+++ b/crates/l2/contracts/bin/deployer/main.rs
@@ -19,7 +19,7 @@ use ethrex_l2_sdk::{
     initialize_contract,
 };
 use ethrex_rpc::{
-    clients::{eth::BlockByNumber, EthClientError, Overrides},
+    clients::{eth::BlockByNumber, Overrides},
     EthClient,
 };
 use keccak_hash::H256;
@@ -418,15 +418,9 @@ async fn make_deposits(
             .checked_div(U256::from_str("2").unwrap_or(U256::zero()))
             .unwrap_or(U256::zero());
 
-        let gas_price = eth_client.get_gas_price().await?.try_into().map_err(|_| {
-            EthClientError::InternalError("Failed to convert gas_price to a u64".to_owned())
-        })?;
-
         let overrides = Overrides {
             value: Some(value_to_deposit),
             from: Some(address),
-            max_fee_per_gas: Some(gas_price),
-            max_priority_fee_per_gas: Some(gas_price),
             ..Overrides::default()
         };
 

--- a/crates/l2/sdk/src/l1_to_l2_tx_data.rs
+++ b/crates/l2/sdk/src/l1_to_l2_tx_data.rs
@@ -88,16 +88,10 @@ pub async fn send_l1_to_l2_tx(
 ) -> Result<H256, EthClientError> {
     let l1_calldata = l1_to_l2_tx_data.to_calldata()?;
 
-    let l1_gas_price = eth_client.get_gas_price().await?.try_into().map_err(|_| {
-        EthClientError::InternalError("Failed to convert gas_price to a u64".to_owned())
-    })?;
-
     let l1_tx_overrides = Overrides {
         value: l1_value.map(Into::into),
         from: Some(l1_from),
-        gas_limit: l1_gas_limit.or(Some(21000 * 5)),
-        max_fee_per_gas: Some(l1_gas_price),
-        max_priority_fee_per_gas: Some(l1_gas_price),
+        gas_limit: l1_gas_limit,
         ..Overrides::default()
     };
 

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -173,9 +173,6 @@ pub async fn withdraw(
                 // CHECK: If we don't set max_fee_per_gas and max_priority_fee_per_gas
                 // The transaction is not included on the L2.
                 // Also we have some mismatches at the end of the L2 integration test.
-                max_fee_per_gas: Some(800000000),
-                max_priority_fee_per_gas: Some(800000000),
-                gas_limit: Some(21000 * 66),
                 ..Default::default()
             },
         )

--- a/crates/networking/rpc/clients/eth/errors.rs
+++ b/crates/networking/rpc/clients/eth/errors.rs
@@ -36,6 +36,8 @@ pub enum EthClientError {
     GetTransactionByHashError(#[from] GetTransactionByHashError),
     #[error("ethrex_getWithdrawalProof request error: {0}")]
     GetWithdrawalProofError(#[from] GetWithdrawalProofError),
+    #[error("eth_maxPriorityFeePerGas request error: {0}")]
+    GetMaxPriorityFeeError(#[from] GetMaxPriorityFeeError),
     #[error("Unreachable nonce")]
     UnrecheableNonce,
     #[error("Error: {0}")]
@@ -214,6 +216,18 @@ pub enum CalldataEncodeError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum GetWithdrawalProofError {
+    #[error("{0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
+    #[error("{0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GetMaxPriorityFeeError {
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("{0}")]

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -11,7 +11,8 @@ use bytes::Bytes;
 use errors::{
     EstimateGasPriceError, EthClientError, GetBalanceError, GetBlockByHashError,
     GetBlockByNumberError, GetBlockNumberError, GetCodeError, GetGasPriceError, GetLogsError,
-    GetNonceError, GetTransactionByHashError, GetTransactionReceiptError, SendRawTransactionError,
+    GetMaxPriorityFeeError, GetNonceError, GetTransactionByHashError, GetTransactionReceiptError,
+    SendRawTransactionError,
 };
 use eth_sender::Overrides;
 use ethrex_common::{
@@ -432,6 +433,25 @@ impl EthClient {
         }
     }
 
+    pub async fn get_max_priority_fee(&self) -> Result<u64, EthClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "eth_maxPriorityFeePerGas".to_string(),
+            params: None,
+        };
+
+        match self.send_request(request).await {
+            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
+                .map_err(GetMaxPriorityFeeError::SerdeJSONError)
+                .map_err(EthClientError::from),
+            Ok(RpcResponse::Error(error_response)) => {
+                Err(GetMaxPriorityFeeError::RPCError(error_response.error.message).into())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub async fn get_gas_price(&self) -> Result<U256, EthClientError> {
         let request = RpcRequest {
             id: RpcRequestId::Number(1),
@@ -773,7 +793,6 @@ impl EthClient {
         calldata: Bytes,
         overrides: Overrides,
     ) -> Result<EIP1559Transaction, EthClientError> {
-        let mut get_gas_price = 1;
         let mut tx = EIP1559Transaction {
             to: overrides.to.clone().unwrap_or(TxKind::Call(to)),
             chain_id: if let Some(chain_id) = overrides.chain_id {
@@ -786,16 +805,14 @@ impl EthClient {
             nonce: self
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
-            max_fee_per_gas: if let Some(gas_price) = overrides.max_fee_per_gas {
-                gas_price
-            } else {
-                get_gas_price = self.get_gas_price().await?.try_into().map_err(|_| {
-                    EthClientError::Custom("Failed at gas_price.try_into()".to_owned())
-                })?;
-
-                get_gas_price
-            },
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(get_gas_price),
+            max_fee_per_gas: self
+                .get_fee_from_override_or_get_gas_price(overrides.max_priority_fee_per_gas)
+                .await?,
+            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
+                self.get_max_priority_fee()
+                    .await
+                    .unwrap_or(self.get_fee_from_override_or_get_gas_price(None).await?),
+            ),
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
@@ -829,7 +846,7 @@ impl EthClient {
         blobs_bundle: BlobsBundle,
     ) -> Result<WrappedEIP4844Transaction, EthClientError> {
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
-        let mut get_gas_price = 1;
+
         let tx = EIP4844Transaction {
             to,
             chain_id: if let Some(chain_id) = overrides.chain_id {
@@ -842,16 +859,14 @@ impl EthClient {
             nonce: self
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
-            max_fee_per_gas: if let Some(gas_price) = overrides.max_fee_per_gas {
-                gas_price
-            } else {
-                get_gas_price = self.get_gas_price().await?.try_into().map_err(|_| {
-                    EthClientError::Custom("Failed at gas_price.try_into()".to_owned())
-                })?;
-
-                get_gas_price
-            },
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(get_gas_price),
+            max_fee_per_gas: self
+                .get_fee_from_override_or_get_gas_price(overrides.max_priority_fee_per_gas)
+                .await?,
+            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
+                self.get_max_priority_fee()
+                    .await
+                    .unwrap_or(self.get_fee_from_override_or_get_gas_price(None).await?),
+            ),
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
@@ -887,7 +902,6 @@ impl EthClient {
         calldata: Bytes,
         overrides: Overrides,
     ) -> Result<PrivilegedL2Transaction, EthClientError> {
-        let mut get_gas_price = 1;
         let mut tx = PrivilegedL2Transaction {
             to: TxKind::Call(to),
             recipient,
@@ -901,16 +915,14 @@ impl EthClient {
             nonce: self
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
-            max_fee_per_gas: if let Some(gas_price) = overrides.max_fee_per_gas {
-                gas_price
-            } else {
-                get_gas_price = self.get_gas_price().await?.try_into().map_err(|_| {
-                    EthClientError::Custom("Failed at gas_price.try_into()".to_owned())
-                })?;
-
-                get_gas_price
-            },
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(get_gas_price),
+            max_fee_per_gas: self
+                .get_fee_from_override_or_get_gas_price(overrides.max_priority_fee_per_gas)
+                .await?,
+            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
+                self.get_max_priority_fee()
+                    .await
+                    .unwrap_or(self.get_fee_from_override_or_get_gas_price(None).await?),
+            ),
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
@@ -1142,6 +1154,19 @@ impl EthClient {
         }
         withdrawal_proof.ok_or(EthClientError::Custom(
             "Withdrawal proof is None".to_owned(),
+        ))
+    }
+
+    async fn get_fee_from_override_or_get_gas_price(
+        &self,
+        maybe_gas_fee: Option<u64>,
+    ) -> Result<u64, EthClientError> {
+        Ok(maybe_gas_fee.unwrap_or(
+            self.get_gas_price()
+                .await
+                .map_err(EthClientError::from)?
+                .try_into()
+                .map_err(|_| EthClientError::Custom("Failed to get gas for fee".to_owned()))?,
         ))
     }
 }

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -807,7 +807,7 @@ impl EthClient {
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
             max_fee_per_gas: self
-                .get_fee_from_override_or_get_gas_price(overrides.max_priority_fee_per_gas)
+                .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
                 .await?,
             max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
                 self.get_max_priority_fee()
@@ -861,7 +861,7 @@ impl EthClient {
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
             max_fee_per_gas: self
-                .get_fee_from_override_or_get_gas_price(overrides.max_priority_fee_per_gas)
+                .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
                 .await?,
             max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
                 self.get_max_priority_fee()
@@ -917,7 +917,7 @@ impl EthClient {
                 .get_nonce_from_overrides_or_rpc(&overrides, from)
                 .await?,
             max_fee_per_gas: self
-                .get_fee_from_override_or_get_gas_price(overrides.max_priority_fee_per_gas)
+                .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
                 .await?,
             max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
                 self.get_max_priority_fee()


### PR DESCRIPTION
**Motivation**

This values should be set dinmically 

**Description**

- Add `get_max_priority_fee` to `EthClient` to call `eth_maxPriorityFeePerGas` endpoint
- When calling `build_xxxx_transaction` without `max_fee_per_gas` override
   - Set it to the result of calling `eth_gasPrice` endpoint
- When calling `build_xxxx_transaction` without `max_fee_per_gas` override
  - Set it to the result of calling `eth_maxPriorityFeePerGas`
     - Because `eth_maxPriorityFeePerGas` in Ethrex can return null if it does set it to the result of calling `eth_gasPrice`

Closes #2795 

