### PR TITLE
fix(l2): rebuild prover when necessary with init-prover

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -53,7 +53,6 @@ ethrex_METRICS_OVERRIDES_L1_DOCKER_COMPOSE_PATH=$(ethrex_PATH)/crates/blockchain
 ethrex_METRICS_OVERRIDES_L2_DOCKER_COMPOSE_PATH=$(ethrex_PATH)/crates/blockchain/metrics/docker-compose-metrics-l2.overrides.yaml
 CI_ETHREX_WORKDIR := /usr/local/bin
 
-ethrex_L2_CONFIGS_PATH=$(shell pwd)/configs
 ethrex_L2_CONTRACTS_PATH=./contracts
 L1_RPC_URL=http://localhost:8545
 L1_PRIVATE_KEY=0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924
@@ -169,13 +168,16 @@ down-l2: ## 🛑 Shuts down the L2 Lambda ethrex Client
 
 restart-l2: down-l2 rm-db-l2 init-l2 ## 🔄 Restarts the L2 Lambda ethrex Client
 
+PROVER_SRC_FILES := $(shell find prover -type f)
+
 init-prover: ../../target/release/ethrex_prover ## 🚀 Initializes the Prover
-	CONFIGS_PATH=${ethrex_L2_CONFIGS_PATH} \
 	../../target/release/ethrex_prover
 
-build-prover: ../../target/release/ethrex_prover
+build-prover:
+	rm -f ../../target/release/ethrex_prover
+	$(MAKE) ../../target/release/ethrex_prover
 
-../../target/release/ethrex_prover:
+../../target/release/ethrex_prover: $(PROVER_SRC_FILES)
 	@if [ -z "$$PROVER" ]; then \
 		echo "Error: ProverType (PROVER) is missing. Running in exec mode."; \
 		echo "Please provide it as an argument:"; \
@@ -189,7 +191,6 @@ build-prover: ../../target/release/ethrex_prover
 		GPU=",gpu"; \
 	fi; \
 
-	CONFIGS_PATH=${ethrex_L2_CONFIGS_PATH} \
 	RUSTFLAGS='-C target-cpu=native' \
 	cargo build --release --features "$$PROVER$$GPU,l2" \
 	--manifest-path ./prover/Cargo.toml  \

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -168,7 +168,7 @@ down-l2: ## 🛑 Shuts down the L2 Lambda ethrex Client
 
 restart-l2: down-l2 rm-db-l2 init-l2 ## 🔄 Restarts the L2 Lambda ethrex Client
 
-PROVER_SRC_FILES := $(shell find prover -type f)
+PROVER_SRC_FILES := $(shell find prover/src -type f)
 
 init-prover: ../../target/release/ethrex_prover ## 🚀 Initializes the Prover
 	../../target/release/ethrex_prover


### PR DESCRIPTION
**Motivation**

Running `make init-prover` didn't rebuild the binary when changes were made to the crate, this lead to errors and bad dev experience. 

**Description**

- Remove outdated `ethrex_L2_CONFIGS_PATH` var in Makefile
- `build-prover` now deletes the existing prover executable and always rebuilds it
- `init-prover` depends on target `../../target/release/ethrex_prover`
  - if the executable is outdated it's rebuilt & run otherwise it's just run
- `../../target/release/ethrex_prover` now depends on all the source files from `prover/` folder so it is only run if any of the files has a later modified date than `../../target/release/ethrex_prover`

One thing to keep in mind if that you can't change the prover backend by doing `make init-prover`. 
For example if you first do `make init-prover PROVER=sp1` and then do `make init-prover PROVER=risc0` the prover won't be rebuilt, you need to use `make build-prover PROVER=risc0` to do this or delete the executable at `../../target/release/ethrex_prover`


Closes #2794

