### PR TITLE
fix(l1, levm): propagate error that we were ignoring when getting account

### DIFF
--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -104,7 +104,7 @@ impl LevmDatabase for StoreWrapper {
         let acc_info = self
             .store
             .get_account_info_by_hash(self.block_hash, address)
-            .unwrap_or(None)
+            .map_err(|e| DatabaseError::Custom(e.to_string()))?
             .unwrap_or_default();
 
         let acc_code = self


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

- We shouldn't ignore the case in which there's a StoreError or a TrieError when trying to get an account's info. It is something that probably doesn't happen very often but I think it's a mistake to ignore it as we've been doing.

