### PR TITLE
Refactor/capability struct instead of tuple

### DIFF
--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -194,7 +194,7 @@ pub async fn periodically_show_peer_stats(peer_table: Arc<Mutex<KademliaTable>>)
             .iter()
             .filter(|peer| -> bool {
                 peer.channels.as_ref().is_some()
-                    && peer.supported_capabilities.contains(&Capability::Snap)
+                    && peer.supported_capabilities.contains(&Capability::snap(1))
             })
             .count();
         info!("Snap Peers: {snap_active_peers} / Active Peers {active_peers} / Total Peers: {total_peers}");

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -94,7 +94,12 @@ impl PeerHandler {
                 skip: 0,
                 reverse: matches!(order, BlockRequestOrder::NewToOld),
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Eth).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability {
+                    protocol: "eth",
+                    version: 68,
+                })
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -137,7 +142,9 @@ impl PeerHandler {
                 id: request_id,
                 block_hashes: block_hashes.clone(),
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Eth).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::eth(68))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -182,7 +189,9 @@ impl PeerHandler {
                 id: request_id,
                 block_hashes: block_hashes.clone(),
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Eth).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::eth(68))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -236,7 +245,9 @@ impl PeerHandler {
                 limit_hash: limit,
                 response_bytes: MAX_RESPONSE_BYTES,
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::snap(1))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -297,7 +308,9 @@ impl PeerHandler {
                 hashes: hashes.clone(),
                 bytes: MAX_RESPONSE_BYTES,
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::snap(1))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -352,7 +365,9 @@ impl PeerHandler {
                 limit_hash: HASH_MAX,
                 response_bytes: MAX_RESPONSE_BYTES,
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::snap(1))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -451,7 +466,9 @@ impl PeerHandler {
                     .collect(),
                 bytes: MAX_RESPONSE_BYTES,
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::snap(1))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -523,7 +540,9 @@ impl PeerHandler {
                     .collect(),
                 bytes: MAX_RESPONSE_BYTES,
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::snap(1))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");
@@ -588,7 +607,9 @@ impl PeerHandler {
                 limit_hash: HASH_MAX,
                 response_bytes: MAX_RESPONSE_BYTES,
             });
-            let peer = self.get_peer_channel_with_retry(Capability::Snap).await?;
+            let peer = self
+                .get_peer_channel_with_retry(Capability::snap(1))
+                .await?;
             let mut receiver = peer.receiver.lock().await;
             if let Err(err) = peer.sender.send(request).await {
                 debug!("Failed to send message to peer: {err}");

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -45,10 +45,10 @@ use super::{
     eth::transactions::NewPooledTransactionHashes, p2p::DisconnectReason, utils::log_peer_warn,
 };
 
-const CAP_P2P_5: (Capability, u8) = (Capability::P2p, 5);
-const CAP_ETH_68: (Capability, u8) = (Capability::Eth, 68);
-const CAP_SNAP_1: (Capability, u8) = (Capability::Snap, 1);
-const SUPPORTED_CAPABILITIES: [(Capability, u8); 3] = [CAP_P2P_5, CAP_ETH_68, CAP_SNAP_1];
+const CAP_P2P_5: Capability = Capability::P2p(5);
+const CAP_ETH_68: Capability = Capability::Eth(68);
+const CAP_SNAP_1: Capability = Capability::Snap(1);
+const SUPPORTED_CAPABILITIES: [Capability; 3] = [CAP_P2P_5, CAP_ETH_68, CAP_SNAP_1];
 const PERIODIC_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 const PERIODIC_TX_BROADCAST_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 const PERIODIC_TASKS_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);


### PR DESCRIPTION
**Motivation**

The capability information was stored as a tuple
<!-- Why does this pull request exist? What are its goals? -->

**Description**

A new struct was created in order to improve the readability and also make place for future developments about the capability
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

