### PR TITLE
ci(l1,l2): run "main-prover-l1" only on merge to main

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -1,8 +1,7 @@
 name: L2 (SP1 Backend)
 on:
-  pull_request:
-    branches: ["**"]
-  merge_group:
+  push:
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
**Motivation**

This is not a required check anymore, so we only will run it on a merge to main instead of each PR.
**Description**

- Simply make the yml worklfow run on a merge to main


