### PR TITLE
refactor(l1): don't persist `is_synced` + add doc

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -486,7 +486,7 @@ impl Blockchain {
         self.is_synced.store(true, Ordering::Relaxed);
     }
 
-    /// Returns whether the node's chain is up to date with the actual chain
+    /// Returns whether the node's chain is up to date with the current chain
     /// This will be true if the initial sync has already taken place and does not reflect whether there is an ongoing sync process
     /// The node should accept incoming p2p transactions if this method returns true
     pub fn is_synced(&self) -> bool {

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -480,7 +480,7 @@ impl Blockchain {
         Ok(())
     }
 
-    /// Marks the node's chain is up to date with the actual chain
+    /// Marks the node's chain as up to date with the current chain
     /// Once the initial sync has taken place, the node will be consireded as sync
     pub fn set_synced(&self) {
         self.is_synced.store(true, Ordering::Relaxed);

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -21,6 +21,7 @@ use ethrex_common::types::{BlobsBundle, Fork, ELASTICITY_MULTIPLIER};
 use ethrex_common::{Address, H256};
 use mempool::Mempool;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{ops::Div, time::Instant};
 
 use ethrex_storage::error::StoreError;
@@ -36,6 +37,10 @@ pub struct Blockchain {
     pub evm_engine: EvmEngine,
     storage: Store,
     pub mempool: Mempool,
+    /// Whether the node's chain is in or out of sync with the current chain
+    /// This will be set to true once the initial sync has taken place and wont be set to false after
+    /// This does not reflect whether there is an ongoing sync process
+    is_synced: AtomicBool,
 }
 
 #[derive(Debug, Clone)]
@@ -50,6 +55,7 @@ impl Blockchain {
             evm_engine,
             storage: store,
             mempool: Mempool::new(),
+            is_synced: AtomicBool::new(false),
         }
     }
 
@@ -58,6 +64,7 @@ impl Blockchain {
             evm_engine: EvmEngine::default(),
             storage: store,
             mempool: Mempool::new(),
+            is_synced: AtomicBool::new(false),
         }
     }
 
@@ -471,6 +478,19 @@ impl Blockchain {
         }
 
         Ok(())
+    }
+
+    /// Marks the node's chain is up to date with the actual chain
+    /// Once the initial sync has taken place, the node will be consireded as sync
+    pub fn set_synced(&self) {
+        self.is_synced.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns whether the node's chain is up to date with the actual chain
+    /// This will be true if the initial sync has already taken place and does not reflect whether there is an ongoing sync process
+    /// The node should accept incoming p2p transactions if this method returns true
+    pub fn is_synced(&self) -> bool {
+        self.is_synced.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -124,7 +124,6 @@ pub async fn apply_fork_choice(
         store.update_safe_block_number(safe.number).await?;
     }
     store.update_latest_block_number(head.number).await?;
-    store.update_sync_status(true).await?;
 
     Ok(head)
 }

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -264,7 +264,7 @@ async fn handle_forkchoice(
     .await
     {
         Ok(head) => {
-            // Forck Choice was succesful, the node is up to date with the current chain
+            // Fork Choice was succesful, the node is up to date with the current chain
             context.blockchain.set_synced();
             // Remove included transactions from the mempool after we accept the fork choice
             // TODO(#797): The remove of transactions from the mempool could be incomplete (i.e. REORGS)

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -264,6 +264,8 @@ async fn handle_forkchoice(
     .await
     {
         Ok(head) => {
+            // Forck Choice was succesful, the node is up to date with the current chain
+            context.blockchain.set_synced();
             // Remove included transactions from the mempool after we accept the fork choice
             // TODO(#797): The remove of transactions from the mempool could be incomplete (i.e. REORGS)
             match context
@@ -304,11 +306,6 @@ async fn handle_forkchoice(
                 ),
                 InvalidForkChoice::Syncing => {
                     // Start sync
-                    context
-                        .storage
-                        .update_sync_status(false)
-                        .await
-                        .map_err(|e| RpcErr::Internal(e.to_string()))?;
                     context
                         .syncer
                         .sync_to_head(fork_choice_state.head_block_hash);

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -717,11 +717,6 @@ async fn try_execute_payload(
     match context.blockchain.add_block(block).await {
         Err(ChainError::ParentNotFound) => {
             // Start sync
-            context
-                .storage
-                .update_sync_status(false)
-                .await
-                .map_err(|e| RpcErr::Internal(e.to_string()))?;
             context.syncer.sync_to_head(block_hash);
             Ok(PayloadStatus::syncing())
         }

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -30,7 +30,6 @@ impl RpcHandler for Syncing {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        let is_synced = context.storage.is_synced().await?;
-        Ok(Value::Bool(!is_synced))
+        Ok(Value::Bool(!context.blockchain.is_synced()))
     }
 }

--- a/crates/storage/api.rs
+++ b/crates/storage/api.rs
@@ -316,10 +316,6 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
     /// Clears all checkpoint data created during the last snap sync
     async fn clear_snap_state(&self) -> Result<(), StoreError>;
 
-    async fn is_synced(&self) -> Result<bool, StoreError>;
-
-    async fn update_sync_status(&self, is_synced: bool) -> Result<(), StoreError>;
-
     /// Write an account batch into the current state snapshot
     async fn write_snapshot_account_batch(
         &self,

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -443,9 +443,6 @@ impl Store {
     }
 
     pub async fn add_initial_state(&self, genesis: Genesis) -> Result<(), StoreError> {
-        info!("Setting initial sync status to false");
-        self.update_sync_status(false).await?;
-
         info!("Storing initial state from genesis");
 
         // Obtain genesis block
@@ -971,13 +968,6 @@ impl Store {
     /// Gets the state trie paths in need of healing
     pub async fn get_state_heal_paths(&self) -> Result<Option<Vec<Nibbles>>, StoreError> {
         self.engine.get_state_heal_paths().await
-    }
-
-    pub async fn is_synced(&self) -> Result<bool, StoreError> {
-        self.engine.is_synced().await
-    }
-    pub async fn update_sync_status(&self, is_synced: bool) -> Result<(), StoreError> {
-        self.engine.update_sync_status(is_synced).await
     }
 
     /// Write an account batch into the current state snapshot

--- a/crates/storage/store_db/in_memory.rs
+++ b/crates/storage/store_db/in_memory.rs
@@ -57,7 +57,6 @@ struct ChainData {
     safe_block_number: Option<BlockNumber>,
     latest_block_number: Option<BlockNumber>,
     pending_block_number: Option<BlockNumber>,
-    is_synced: bool,
 }
 
 // Keeps track of the state left by the latest snap attempt
@@ -550,15 +549,6 @@ impl StoreEngine for Store {
 
     async fn clear_snap_state(&self) -> Result<(), StoreError> {
         self.inner().snap_state = Default::default();
-        Ok(())
-    }
-
-    async fn is_synced(&self) -> Result<bool, StoreError> {
-        Ok(self.inner().chain_data.is_synced)
-    }
-
-    async fn update_sync_status(&self, is_synced: bool) -> Result<(), StoreError> {
-        self.inner().chain_data.is_synced = is_synced;
         Ok(())
     }
 

--- a/crates/storage/store_db/libmdbx.rs
+++ b/crates/storage/store_db/libmdbx.rs
@@ -761,18 +761,6 @@ impl StoreEngine for Store {
         Ok(res)
     }
 
-    async fn is_synced(&self) -> Result<bool, StoreError> {
-        match self.read::<ChainData>(ChainDataIndex::IsSynced).await? {
-            None => Err(StoreError::Custom("Sync status not found".to_string())),
-            Some(ref rlp) => RLPDecode::decode(rlp).map_err(|_| StoreError::DecodeError),
-        }
-    }
-
-    async fn update_sync_status(&self, is_synced: bool) -> Result<(), StoreError> {
-        self.write::<ChainData>(ChainDataIndex::IsSynced, is_synced.encode_to_vec())
-            .await
-    }
-
     async fn set_state_heal_paths(&self, paths: Vec<Nibbles>) -> Result<(), StoreError> {
         self.write::<SnapState>(SnapStateIndex::StateHealPaths, paths.encode_to_vec())
             .await

--- a/crates/storage/store_db/redb.rs
+++ b/crates/storage/store_db/redb.rs
@@ -1018,25 +1018,6 @@ impl StoreEngine for RedBStore {
         Ok(res)
     }
 
-    async fn is_synced(&self) -> Result<bool, StoreError> {
-        match self
-            .read(CHAIN_DATA_TABLE, ChainDataIndex::IsSynced)
-            .await?
-        {
-            None => Err(StoreError::Custom("Sync status not found".to_string())),
-            Some(ref rlp) => RLPDecode::decode(&rlp.value()).map_err(|_| StoreError::DecodeError),
-        }
-    }
-
-    async fn update_sync_status(&self, is_synced: bool) -> Result<(), StoreError> {
-        self.write(
-            CHAIN_DATA_TABLE,
-            ChainDataIndex::IsSynced,
-            is_synced.encode_to_vec(),
-        )
-        .await
-    }
-
     async fn set_state_heal_paths(&self, paths: Vec<Nibbles>) -> Result<(), StoreError> {
         self.write(
             SNAP_STATE_TABLE,

--- a/crates/storage/utils.rs
+++ b/crates/storage/utils.rs
@@ -8,7 +8,6 @@ pub enum ChainDataIndex {
     SafeBlockNumber = 3,
     LatestBlockNumber = 4,
     PendingBlockNumber = 5,
-    IsSynced = 6,
 }
 
 impl From<u8> for ChainDataIndex {
@@ -26,7 +25,6 @@ impl From<u8> for ChainDataIndex {
             x if x == ChainDataIndex::PendingBlockNumber as u8 => {
                 ChainDataIndex::PendingBlockNumber
             }
-            x if x == ChainDataIndex::IsSynced as u8 => ChainDataIndex::IsSynced,
             _ => panic!("Invalid value when casting to ChainDataIndex: {}", value),
         }
     }


### PR DESCRIPTION
**Motivation**
The method `Store::is_synced`  is quite confusing. This method aims to clarify what "being synced" means for its specific use case via documentation. It also removes it from the DB as we don't need to persist it (persisting it means that we need to purposefully set it to false upon startup each time). It also removes cases where it was being set to false after the initial sync had taken place.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Move `is_synced` method from `Store` (persisted) to `Blockchain` (not persisted)
* Change `update_sync_status` to `set_synced` so we don't go back to unsynced state after the initial sync had taken place (This is the same behaviour geth follows)
* Remove instances where the sync status was updated outside of applying fork choices
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


