### PR TITLE
ci(l1,l2): add 'build block' benchmark to PR checks

### DIFF
--- a/.github/workflows/pr_perf_build_block_bench.yml
+++ b/.github/workflows/pr_perf_build_block_bench.yml
@@ -1,4 +1,4 @@
-name: '"Build block" benchmark'
+name: Benchmark Block building
 
 on:
   pull_request:


### PR DESCRIPTION
**Motivation**

Make the "build block" benchmark run in the CI.


