### PR TITLE
fix(l1): add deposit request layout validations + return invalid deposit request error

### DIFF
--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -173,7 +173,7 @@ impl Deposit {
 
         // Compare two numbers with different byte count without padding
         let is_eq = |bytes: [u8; 32], u: usize| -> bool {
-            bytes[..16] == [0; 16] && bytes[16..] == u.to_le_bytes()
+            bytes[..24] == [0; 24] && bytes[24..] == u.to_le_bytes()
         };
 
         // Validate Offsets & Sizes

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -102,8 +102,10 @@ impl Requests {
         for r in receipts {
             for log in &r.logs {
                 if log.address == deposit_contract_address
-                    && log.topics.len() > 0
-                    && log.topics[0] == *DEPOSIT_TOPIC
+                    && log
+                        .topics
+                        .first()
+                        .is_some_and(|topic| topic == &*DEPOSIT_TOPIC)
                 {
                     deposits.push(Deposit::from_abi_byte_array(&log.data)?);
                 }

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -173,7 +173,7 @@ impl Deposit {
 
         // Compare two numbers with different byte count without padding
         let is_eq = |bytes: [u8; 32], u: usize| -> bool {
-            bytes[..24] == [0; 24] && bytes[24..] == u.to_le_bytes()
+            bytes[..24] == [0; 24] && bytes[24..] == u.to_be_bytes()
         };
 
         // Validate Offsets & Sizes

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -139,17 +139,65 @@ impl Deposit {
         //
         //-> Total len: 576 bytes
 
-        let mut p = 32 * 5 + 32;
+        const OFFSET_LEN: usize = 32;
 
-        let pub_key: Bytes48 = fixed_bytes::<48>(data, p);
-        p += 48 + 16 + 32;
-        let withdrawal_credentials: Bytes32 = fixed_bytes::<32>(data, p);
-        p += 32 + 32;
-        let amount: u64 = u64::from_le_bytes(fixed_bytes::<8>(data, p));
-        p += 8 + 24 + 32;
-        let signature: Bytes96 = fixed_bytes::<96>(data, p);
-        p += 96 + 32;
-        let index: u64 = u64::from_le_bytes(fixed_bytes::<8>(data, p));
+        const PUB_KEY_OFFSET: usize = 160;
+        const WITHDRAWAL_CREDENTIALS_OFFSET: usize = 256;
+        const AMOUNT_OFFSET: usize = 320;
+        const SIGNATURE_OFFSET: usize = 384;
+        const INDEX_OFFSET: usize = 512;
+
+        const OFFSETS: [usize; 5] = [
+            PUB_KEY_OFFSET,
+            WITHDRAWAL_CREDENTIALS_OFFSET,
+            AMOUNT_OFFSET,
+            SIGNATURE_OFFSET,
+            INDEX_OFFSET,
+        ];
+
+        const SIZE_LEN: usize = 32;
+
+        const PUB_KEY_SIZE: usize = 48;
+        const WITHDRAWAL_CREDENTIALS_SIZE: usize = 32;
+        const AMOUNT_SIZE: usize = 8;
+        const SIGNATURE_SIZE: usize = 96;
+        const INDEX_SIZE: usize = 8;
+
+        const SIZES: [usize; 5] = [
+            PUB_KEY_SIZE,
+            WITHDRAWAL_CREDENTIALS_SIZE,
+            AMOUNT_SIZE,
+            SIGNATURE_SIZE,
+            INDEX_SIZE,
+        ];
+
+        // Compare two numbers with different byte count without padding
+        let is_eq = |bytes: [u8; 32], u: usize| -> bool {
+            bytes[..8] == u.to_be_bytes() && bytes[8..] == [0; 16]
+        };
+
+        // Validate Offsets & Sizes
+        for (i, (expected_offset, expected_size)) in
+            OFFSETS.into_iter().zip(SIZES.into_iter()).enumerate()
+        {
+            let offset = fixed_bytes::<OFFSET_LEN>(data, i * OFFSET_LEN);
+            let size = fixed_bytes::<SIZE_LEN>(data, expected_offset);
+            if !is_eq(offset, expected_offset) || !is_eq(size, expected_size) {
+                return None;
+            }
+        }
+
+        // Extract Data
+        let pub_key: Bytes48 = fixed_bytes::<PUB_KEY_SIZE>(data, PUB_KEY_OFFSET + SIZE_LEN);
+        let withdrawal_credentials: Bytes32 = fixed_bytes::<WITHDRAWAL_CREDENTIALS_SIZE>(
+            data,
+            WITHDRAWAL_CREDENTIALS_OFFSET + SIZE_LEN,
+        );
+        let amount: u64 =
+            u64::from_le_bytes(fixed_bytes::<AMOUNT_SIZE>(data, AMOUNT_OFFSET + SIZE_LEN));
+        let signature: Bytes96 = fixed_bytes::<SIGNATURE_SIZE>(data, SIGNATURE_OFFSET + SIZE_LEN);
+        let index: u64 =
+            u64::from_le_bytes(fixed_bytes::<INDEX_SIZE>(data, INDEX_OFFSET + SIZE_LEN));
 
         Some(Deposit {
             pub_key,

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -173,7 +173,7 @@ impl Deposit {
 
         // Compare two numbers with different byte count without padding
         let is_eq = |bytes: [u8; 32], u: usize| -> bool {
-            bytes[..8] == u.to_be_bytes() && bytes[8..] == [0; 16]
+            bytes[..16] == [0; 16] && bytes[16..] == u.to_be_bytes()
         };
 
         // Validate Offsets & Sizes

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -173,7 +173,7 @@ impl Deposit {
 
         // Compare two numbers with different byte count without padding
         let is_eq = |bytes: [u8; 32], u: usize| -> bool {
-            bytes[..16] == [0; 16] && bytes[16..] == u.to_be_bytes()
+            bytes[..16] == [0; 16] && bytes[16..] == u.to_le_bytes()
         };
 
         // Validate Offsets & Sizes

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -84,22 +84,21 @@ impl Requests {
         EncodedRequests(Bytes::from(bytes))
     }
 
+    /// Returns None if any of the deposit requests couldn't be parsed
     pub fn from_deposit_receipts(
         deposit_contract_address: Address,
         receipts: &[Receipt],
-    ) -> Requests {
+    ) -> Option<Requests> {
         let mut deposits = vec![];
 
         for r in receipts {
             for log in &r.logs {
                 if log.address == deposit_contract_address {
-                    if let Some(d) = Deposit::from_abi_byte_array(&log.data) {
-                        deposits.push(d);
-                    }
+                    deposits.push(Deposit::from_abi_byte_array(&log.data)?);
                 }
             }
         }
-        Self::Deposit(deposits)
+        Some(Self::Deposit(deposits))
     }
 
     pub fn from_withdrawals_data(data: Vec<u8>) -> Requests {

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -648,7 +648,8 @@ pub fn extract_all_requests_levm(
         .output
         .into();
 
-    let deposits = Requests::from_deposit_receipts(chain_config.deposit_contract_address, receipts);
+    let deposits = Requests::from_deposit_receipts(chain_config.deposit_contract_address, receipts)
+        .ok_or(EvmError::InvalidDepositRequest)?;
     let withdrawals = Requests::from_withdrawals_data(withdrawals_data);
     let consolidation = Requests::from_consolidation_data(consolidation_data);
 

--- a/crates/vm/backends/revm/mod.rs
+++ b/crates/vm/backends/revm/mod.rs
@@ -747,7 +747,8 @@ pub fn extract_all_requests(
         }
     }
 
-    let deposits = Requests::from_deposit_receipts(config.deposit_contract_address, receipts);
+    let deposits = Requests::from_deposit_receipts(config.deposit_contract_address, receipts)
+        .ok_or(EvmError::InvalidDepositRequest)?;
     let withdrawals_data = REVM::read_withdrawal_requests(header, state)?;
     let consolidation_data = REVM::dequeue_consolidation_requests(header, state)?;
 

--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -26,6 +26,8 @@ pub enum EvmError {
     Custom(String),
     #[error("Levm Database error: {0}")]
     LevmDatabaseError(#[from] DatabaseError),
+    #[error("Invalid deposit request layout")]
+    InvalidDepositRequest,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
**Motivation**
Currently, when we fail to parse a deposit request we simply ignore it and keep the rest of the deposits, relying on the request hash check afterwards to notice the missing deposit request. This PR handles the error earlier and returns the appropriate `InvalidDepositRequest Error`. This will provide better debugging information and also more accurate testing via tools such as `execution-spec-tests` which rely on specific error returns.
We also were not correctly validating the layout according to the [EIP](https://eips.ethereum.org/EIPS/eip-6110), as we were only checking the total size and not the size and offset of each request field
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Check that the full layout of deposit requests is valid (aka the internal sizes and offsets of the encoded data)
* Handle errors when parsing deposit requests
* Check log topic matches deposit topic before parsing a request as a deposit request
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Allows us to address review comment  made on execution-specs-test PR https://github.com/ethereum/execution-spec-tests/pull/1607 + also closes #2132 

