### PR TITLE
feat(l2): allow changing listen addresses in Makefile

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -63,6 +63,9 @@ ethrex_L1_DEV_LIBMDBX=dev_ethrex_l1
 L1_PORT=8545
 L2_PORT=1729
 L1_AUTH_PORT=8551
+L1_RPC_ADDRESS=0.0.0.0
+L2_RPC_ADDRESS=0.0.0.0
+PROOF_COORINATOR_ADDRESS=127.0.0.1
 
 # Matches the ports used by the blockchain/metrics dir
 L2_PROMETHEUS_METRICS_PORT = 3702
@@ -75,7 +78,7 @@ init-l1: ## 🚀 Initializes an L1 Lambda ethrex Client
 	cargo run --release --manifest-path ../../Cargo.toml --bin ethrex --features "dev" -- \
 	--network ${L1_GENESIS_FILE_PATH} \
 	--http.port ${L1_PORT} \
-	--http.addr 0.0.0.0 \
+	--http.addr ${L1_RPC_ADDRESS} \
 	--authrpc.port ${L1_AUTH_PORT} \
 	--dev \
 	--datadir ${ethrex_L1_DEV_LIBMDBX}
@@ -87,7 +90,7 @@ init-l1-levm: ## 🚀 Initializes an L1 Lambda ethrex Client with LEVM
     --features "dev" -- \
     --network ${L1_GENESIS_FILE_PATH} \
     --http.port ${L1_PORT} \
-    --http.addr 0.0.0.0 \
+    --http.addr ${L1_RPC_ADDRESS} \
     --authrpc.port ${L1_AUTH_PORT} \
 	--evm levm \
 	--dev \
@@ -150,13 +153,14 @@ init-l2-no-metrics: ## 🚀 Initializes an L2 Lambda ethrex Client
 	l2 init \
 	--network ${L2_GENESIS_FILE_PATH} \
 	--http.port ${L2_PORT} \
-	--http.addr 0.0.0.0 \
+	--http.addr ${L2_RPC_ADDRESS} \
 	--metrics \
 	--metrics.port ${L2_PROMETHEUS_METRICS_PORT} \
 	--evm levm \
 	--datadir ${ethrex_L2_DEV_LIBMDBX} \
 	--bridge-address ${BRIDGE_ADDRESS} \
-	--on-chain-proposer-address ${ON_CHAIN_PROPOSER_ADDRESS}
+	--on-chain-proposer-address ${ON_CHAIN_PROPOSER_ADDRESS} \
+	--proof-coordinator-listen-ip ${PROOF_COORINATOR_ADDRESS}
 
 init-metrics: ## 🚀 Initializes Grafana and Prometheus with containers
 	docker compose -f ${ethrex_METRICS_DOCKER_COMPOSE_PATH} -f ${ethrex_METRICS_OVERRIDES_L2_DOCKER_COMPOSE_PATH} up -d


### PR DESCRIPTION
**Motivation**

For running TDX, it's useful to set proof_coordinator_listen_ip to 0.0.0.0 while in other contexts 127.0.0.1 might make more sense.

**Description**

This PR adds support for setting listen ips in the l2 Makefile for proof_coordinator_listen_ip and the L1&L2 RPCs.

