### PR TITLE
feat(l2): remove public inputs from verify() function in OnChainProposer

### DIFF
--- a/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
@@ -51,28 +51,23 @@ interface IOnChainProposer {
     /// @notice Method used to verify a batch of L2 blocks.
     /// @dev This method is used by the operator when a batch is ready to be
     /// verified (this is after proved).
+    /// Public inputs are retrieved from the committed batch data instead of being passed as parameters.
     /// @param batchNumber is the number of the batch to be verified.
     /// ----------------------------------------------------------------------
     /// @param risc0BlockProof is the proof of the batch to be verified.
     /// @param risc0ImageId Digest of the zkVM imageid.
-    /// @param risc0Journal public_inputs aka journal
     /// ----------------------------------------------------------------------
-    /// @param sp1PublicValues Values used to perform the execution
     /// @param sp1ProofBytes Groth16 proof
     /// ----------------------------------------------------------------------
-    /// @param tdxPublicValues Values used to perform the execution
     /// @param tdxSignature TDX signature
     function verifyBatch(
         uint256 batchNumber,
         //risc0
         bytes memory risc0BlockProof,
         bytes32 risc0ImageId,
-        bytes calldata risc0Journal,
         //sp1
-        bytes calldata sp1PublicValues,
         bytes memory sp1ProofBytes,
         //tdx
-        bytes calldata tdxPublicValues,
         bytes memory tdxSignature
     ) external;
     // TODO: imageid, programvkey and riscvvkey should be constants

--- a/crates/l2/prover/src/backends/risc0.rs
+++ b/crates/l2/prover/src/backends/risc0.rs
@@ -1,4 +1,4 @@
-use ethrex_l2::utils::prover::proving_systems::{ProofCalldata, ProverType};
+use ethrex_l2::utils::prover::proving_systems::{BatchProof, ProofCalldata, ProverType};
 use ethrex_l2_sdk::calldata::Value;
 use risc0_ethereum_contracts::encode_seal;
 use risc0_zkvm::{
@@ -47,16 +47,15 @@ pub fn verify(receipt: &Receipt) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub fn to_batch_proof(
-    proof: ProveOutput,
+    proof: Receipt,
     _aligned_mode: bool,
-) -> Result<ProofData, Box<dyn std::error::Error>> {
+) -> Result<BatchProof, Box<dyn std::error::Error>> {
     Ok(BatchProof::ProofCalldata(to_calldata(proof)))
 }
 
 fn to_calldata(receipt: Receipt) -> ProofCalldata {
-    let seal = encode_seal(&receipt)?;
+    let seal = encode_seal(&receipt).unwrap();
     let image_id = ZKVM_RISC0_PROGRAM_ID;
-    let journal = receipt.journal.bytes;
 
     // convert image_id into bytes
     let image_id = {
@@ -68,12 +67,10 @@ fn to_calldata(receipt: Receipt) -> ProofCalldata {
     };
 
     // bytes calldata seal,
-    // bytes32 imageId,
-    // bytes32 journal
+    // bytes32 imageId
     let calldata = vec![
         Value::Bytes(seal.into()),
         Value::FixedBytes(image_id.into()),
-        Value::Bytes(journal.into()),
     ];
 
     ProofCalldata {

--- a/crates/l2/prover/src/backends/sp1.rs
+++ b/crates/l2/prover/src/backends/sp1.rs
@@ -107,10 +107,10 @@ pub fn to_batch_proof(
 }
 
 fn to_calldata(proof: ProveOutput) -> ProofCalldata {
-    // bytes calldata publicValues,
-    // bytes calldata proofBytes
+    // bytes32 sp1ProgramVKey,
+    // bytes calldata sp1ProofBytes
     let calldata = vec![
-        Value::Bytes(proof.proof.public_values.to_vec().into()),
+        Value::FixedBytes(proof.vk.hash_bytes().to_vec().into()),
         Value::Bytes(proof.proof.bytes().into()),
     ];
 

--- a/crates/l2/prover/zkvm/interface/risc0/src/main.rs
+++ b/crates/l2/prover/zkvm/interface/risc0/src/main.rs
@@ -5,5 +5,5 @@ fn main() {
     let input: ProgramInput = env::read();
     let output = execution_program(input).unwrap();
 
-    env::commit(&output);
+    env::commit_slice(&output.encode());
 }

--- a/crates/l2/prover/zkvm/interface/sp1/src/main.rs
+++ b/crates/l2/prover/zkvm/interface/sp1/src/main.rs
@@ -8,5 +8,5 @@ pub fn main() {
     let input = sp1_zkvm::io::read::<ProgramInput>();
     let output = execution_program(input).unwrap();
 
-    sp1_zkvm::io::commit(&output.encode());
+    sp1_zkvm::io::commit_slice(&output.encode());
 }

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -28,8 +28,7 @@ use tracing::{debug, error, info};
 // TODO: Remove this import once it's no longer required by the SDK.
 use ethers::signers::{Signer, Wallet};
 
-const VERIFY_FUNCTION_SIGNATURE: &str =
-    "verifyBatch(uint256,bytes,bytes32,bytes,bytes,bytes,bytes,bytes)";
+const VERIFY_FUNCTION_SIGNATURE: &str = "verifyBatch(uint256,bytes,bytes32,bytes,bytes)";
 
 #[derive(Clone)]
 pub struct L1ProofSenderState {

--- a/crates/l2/utils/prover/proving_systems.rs
+++ b/crates/l2/utils/prover/proving_systems.rs
@@ -27,21 +27,23 @@ impl ProverType {
     }
 
     /// Used to get the empty_calldata structure for that specific prover
-    /// It has to match the `OnChainProposer.sol` verify() function
+    /// It has to match the `OnChainProposer.sol` verifyBatch() function
     pub fn empty_calldata(&self) -> Vec<Value> {
         match self {
             ProverType::RISC0 => {
                 vec![
-                    Value::Bytes(vec![].into()),
-                    Value::FixedBytes(H256::zero().to_fixed_bytes().to_vec().into()),
-                    Value::Bytes(vec![].into()),
+                    Value::Bytes(vec![].into()),                                      // seal
+                    Value::FixedBytes(H256::zero().to_fixed_bytes().to_vec().into()), // imageId
                 ]
             }
             ProverType::SP1 => {
-                vec![Value::Bytes(vec![].into()), Value::Bytes(vec![].into())]
+                vec![
+                    Value::FixedBytes(H256::zero().to_fixed_bytes().to_vec().into()), // vkey
+                    Value::Bytes(vec![].into()),                                      // proofBytes
+                ]
             }
             ProverType::TDX => {
-                vec![Value::Bytes(vec![].into()), Value::Bytes(vec![].into())]
+                vec![Value::Bytes(vec![].into())] // Only signature, no public values
             }
             ProverType::Exec => unimplemented!("Doesn't need to generate an empty calldata."),
             ProverType::Aligned => unimplemented!("Doesn't need to generate an empty calldata."),


### PR DESCRIPTION
**Motivation**
<!-- Why does this pull request exist? What are its goals? -->
This PR implements the removal of public inputs from the `verifyBatch()` function in the OnChainProposer contract. Public inputs are now retrieved from the committed batch data instead of being passed as parameters.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

This PR removes public inputs from the `verifyBatch` function signature and instead reconstructs them from already-committed batch data. This simplifies the interface and reduces calldata size.

### OnChainProposer.sol
- **Modified `verifyBatch` function signature**: Removed all public input parameters
  - Removed `sp1PublicValues` parameter (SP1 now only needs `sp1ProofBytes`)
  - Removed `tdxPublicValues` parameter (TDX now only needs `tdxSignature`)
  - Note: Pico has been removed from the codebase in main branch
- **Added `_getPublicInputsFromCommitment` function**: Internal function that reconstructs 160-byte public inputs from committed batch data
  - bytes 0-32: Initial state root (from last verified batch)
  - bytes 32-64: Final state root (from current batch)
  - bytes 64-96: Withdrawals merkle root
  - bytes 96-128: Deposits log hash
  - bytes 128-160: Last block hash
- **Updated all verifiers to use reconstructed public inputs**:
  - RISC0: Uses `sha256(publicInputs)`
  - SP1: Uses `publicInputs` directly
  - TDX: Uses `publicInputs` directly

### zkVM Interface Updates
- **SP1**: Updated to use `commit_slice` for output
- **RISC0**: Updated to use `commit_slice` for output
- Both interfaces now output only the encoded result without public inputs prefix

### l1_proof_sender.rs
- Updated `VERIFY_FUNCTION_SIGNATURE` constant to match new contract signature
- Removed extraction logic for proof parts (no longer needed)
- Simplified calldata construction

### proving_systems.rs
- Updated `empty_calldata()` method for proving systems
- SP1 now only includes vkey and proof bytes
- TDX now only includes signature
- Removed Pico as it was removed from main branch

Closes #2804