### PR TITLE
fix(l2): correct private key for load test account

### DIFF
--- a/cmd/load_test/src/main.rs
+++ b/cmd/load_test/src/main.rs
@@ -78,8 +78,8 @@ pub enum TestType {
 const RETRIES: u64 = 1000;
 const ETH_TRANSFER_VALUE: u64 = 1000;
 
-// Private key for the rich account present in the gesesis_l2.json file.
-const RICH_ACCOUNT: &str = "0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924";
+// Private key for the rich account after making the initial deposits on the L2.
+const RICH_ACCOUNT: &str = "0xbcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31";
 
 async fn deploy_contract(
     client: EthClient,


### PR DESCRIPTION
**Motivation**

After the changes introduced in #2781. The rich account needed for the load test no longer has funds to make the deploy and the transactions.

**Description**

Change the private key to one of the rich accounts that is used on the initial deposit in the deployment of the L2

**How to test**

Running: `cargo run --manifest-path ../../cmd/load_test/Cargo.toml -- -k ../../test_data/private_keys.txt -t erc20 -N 50 -n http://localhost:1729`

This won't lead to panic.

But in main we get:
```
ERC20 Load test starting
Deploying ERC20 contract...
thread 'main' panicked at cmd/load_test/src/main.rs:358:18:
Failed to deploy ERC20 contract: eth_sendRawTransaction request error: Invalid params: Account does not have enough balance to cover the tx cost

Caused by:
    Invalid params: Account does not have enough balance to cover the tx cost
```

