### PR TITLE
fix(levm): fix last blockchain tests for LEVM

### DIFF
--- a/cmd/ef_tests/blockchain/tests/prague.rs
+++ b/cmd/ef_tests/blockchain/tests/prague.rs
@@ -4,22 +4,14 @@ use ef_tests_blockchain::test_runner::parse_and_execute;
 use ethrex_vm::EvmEngine;
 
 #[cfg(not(feature = "levm"))]
-const SKIPPED_TESTS_REVM: [&str; 1] = [
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]", // Skipped because REVM doesn't support this.
-];
-
-#[cfg(feature = "levm")]
-const SKIPPED_TESTS_LEVM: [&str; 0] = [];
-
-#[cfg(not(feature = "levm"))]
 fn parse_and_execute_with_revm(path: &Path) -> datatest_stable::Result<()> {
-    parse_and_execute(path, EvmEngine::REVM, Some(&SKIPPED_TESTS_REVM));
+    parse_and_execute(path, EvmEngine::REVM, None);
     Ok(())
 }
 
 #[cfg(feature = "levm")]
 fn parse_and_execute_with_levm(path: &Path) -> datatest_stable::Result<()> {
-    parse_and_execute(path, EvmEngine::LEVM, Some(&SKIPPED_TESTS_LEVM));
+    parse_and_execute(path, EvmEngine::LEVM, None);
     Ok(())
 }
 

--- a/cmd/ef_tests/blockchain/tests/prague.rs
+++ b/cmd/ef_tests/blockchain/tests/prague.rs
@@ -3,49 +3,13 @@ use std::path::Path;
 use ef_tests_blockchain::test_runner::parse_and_execute;
 use ethrex_vm::EvmEngine;
 
-// TODO: enable these tests once the evm is updated.
 #[cfg(not(feature = "levm"))]
 const SKIPPED_TESTS_REVM: [&str; 1] = [
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]",
+    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_non_empty_storage[fork_Prague-blockchain_test-zero_nonce]", // Skipped because REVM doesn't support this.
 ];
 
 #[cfg(feature = "levm")]
-const SKIPPED_TESTS_LEVM: [&str; 34] = [
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000006-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000011-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000009-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000b-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x000000000000000000000000000000000000000e-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000004-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000009-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000c-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x000000000000000000000000000000000000000c-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000a-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000008-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000001-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000006-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x000000000000000000000000000000000000000f-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000010-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000f-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000011-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000002-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x000000000000000000000000000000000000000b-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000e-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000005-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x000000000000000000000000000000000000000d-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000001-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000004-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000007-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000003-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000005-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000010-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000007-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x000000000000000000000000000000000000000d-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000008-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x0000000000000000000000000000000000000002-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile_not_enough_gas_for_precompile_execution[fork_Prague-precompile_0x000000000000000000000000000000000000000a-blockchain_test_from_state_test]",
-    "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_precompile[fork_Prague-precompile_0x0000000000000000000000000000000000000003-call_opcode_CALL-evm_code_type_LEGACY-blockchain_test_from_state_test]",
-];
+const SKIPPED_TESTS_LEVM: [&str; 0] = [];
 
 // NOTE: These 3 tests fail on LEVM with a stack overflow if we do not increase the stack size by using RUST_MIN_STACK=11000000
 //"tests/prague/eip6110_deposits/test_deposits.py::test_deposit[fork_Prague-blockchain_test-single_deposit_from_contract_call_high_depth]",

--- a/cmd/ef_tests/blockchain/tests/prague.rs
+++ b/cmd/ef_tests/blockchain/tests/prague.rs
@@ -11,11 +11,6 @@ const SKIPPED_TESTS_REVM: [&str; 1] = [
 #[cfg(feature = "levm")]
 const SKIPPED_TESTS_LEVM: [&str; 0] = [];
 
-// NOTE: These 3 tests fail on LEVM with a stack overflow if we do not increase the stack size by using RUST_MIN_STACK=11000000
-//"tests/prague/eip6110_deposits/test_deposits.py::test_deposit[fork_Prague-blockchain_test-single_deposit_from_contract_call_high_depth]",
-//"tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_max_depth_call_stack[fork_Prague-blockchain_test]",
-//"tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py::test_pointer_contract_pointer_loop[fork_Prague-blockchain_test]",
-
 #[cfg(not(feature = "levm"))]
 fn parse_and_execute_with_revm(path: &Path) -> datatest_stable::Result<()> {
     parse_and_execute(path, EvmEngine::REVM, Some(&SKIPPED_TESTS_REVM));

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -707,4 +707,11 @@ impl<'a> VM<'a> {
 
         Ok((callee, code))
     }
+
+    /// Checks if an address is delegation target in current transaction.
+    pub fn is_delegation_target(&self, address: Address) -> bool {
+        self.tx.authorization_list().as_ref().map_or(false, |list| {
+            list.iter().any(|item| item.address == address)
+        })
+    }
 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -155,8 +155,8 @@ impl<'a> VM<'a> {
     pub fn execute_precompile(&mut self) -> Result<ExecutionReport, VMError> {
         let precompile_address = self.current_call_frame()?.code_address;
 
-        // Avoid executing precompile if it is target of a delegation in EIP-7702 transaction.
         let precompile_result = match self.is_delegation_target(precompile_address) {
+            // Avoid executing precompile if it is target of a delegation in EIP-7702 transaction.
             true => {
                 let gas_limit = self.current_call_frame()?.gas_limit;
                 if gas_limit == 0 {
@@ -166,6 +166,7 @@ impl<'a> VM<'a> {
                     Ok(Bytes::new())
                 }
             }
+            // Otherwise, execute precompile
             false => {
                 let callframe = self.current_call_frame_mut()?;
                 execute_precompile(

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -145,13 +145,6 @@ impl<'a> VM<'a> {
         }
     }
 
-    /// Checks if an address is delegation target in current transaction.
-    fn is_delegation_target(&self, address: Address) -> bool {
-        self.tx.authorization_list().as_ref().map_or(false, |list| {
-            list.iter().any(|item| item.address == address)
-        })
-    }
-
     pub fn execute_precompile(&mut self) -> Result<ExecutionReport, VMError> {
         let precompile_address = self.current_call_frame()?.code_address;
 


### PR DESCRIPTION
**Motivation**

- Fix remaining blockchain tests for Prague with LEVM.

**Description**

- Precompiles shouldn't be executed in case they are delegation target of the same transaction in which they are being called.
- It also fixes a problem in the transfer of value in CALL. (It just moves the place where the value transfer is performed)

After this there are no more `blockchain` tests we need to fix.


<!-- Link to issues: Resolves #111, Resolves #222 -->

Co-authored-by: @DiegoCivi 
