### PR TITLE
feat(l2): add cli option to compute genesis state root

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -235,6 +235,19 @@ pub enum Subcommand {
         #[arg(long = "removedb", action = ArgAction::SetTrue)]
         removedb: bool,
     },
+    #[command(
+        name = "compute-state-root",
+        about = "Compute the state root from a genesis file"
+    )]
+    ComputeStateRoot {
+        #[arg(
+            required = true,
+            long = "path",
+            value_name = "GENESIS_FILE_PATH",
+            help = "Path to the genesis json file"
+        )]
+        genesis_path: String,
+    },
     #[cfg(any(feature = "l2", feature = "based"))]
     #[command(subcommand)]
     L2(l2::Command),
@@ -265,6 +278,9 @@ impl Subcommand {
                     .expect("--network is required and it was not provided");
 
                 import_blocks(&path, &opts.datadir, network, opts.evm).await;
+            }
+            Subcommand::ComputeStateRoot { genesis_path } => {
+                compute_state_root(genesis_path.as_str());
             }
             #[cfg(any(feature = "l2", feature = "based"))]
             Subcommand::L2(command) => command.run().await?,
@@ -352,4 +368,10 @@ pub async fn import_blocks(path: &str, data_dir: &str, network: &str, evm: EvmEn
     }
 
     info!("Added {size} blocks to blockchain");
+}
+
+pub fn compute_state_root(genesis_path: &str) {
+    let genesis = utils::read_genesis_file(genesis_path);
+    let state_root = genesis.compute_state_root();
+    println!("{:#x}", state_root);
 }


### PR DESCRIPTION
**Motivation**

Add a subcommand to compute a state root given a genesis file path

**Description**

* Add new variant to `Subcommand` struct called `ComputeStateRoot`
* It has a required argument for the file path
* Calls the existing function `pub fn compute_state_root(&self) -> H256`

**How to use**

run:
`cargo run --bin ethrex --release -- compute-state-root --path test_data/genesis-l2.json`

