### PR TITLE
refactor(l1): system contract errors

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -321,7 +321,7 @@ impl LEVM {
         match report.result {
             TxResult::Success => Ok(report),
             // EIP-7002 specifies that a failed system call invalidates the entire block.
-            TxResult::Revert(vm_error) => Err(EvmError::Custom(format!(
+            TxResult::Revert(vm_error) => Err(EvmError::SystemContractCallFailed(format!(
                 "REVERT when reading withdrawal requests with error: {:?}. According to EIP-7002, the revert of this system call invalidates the block.",
                 vm_error
             ))),
@@ -352,7 +352,7 @@ impl LEVM {
         match report.result {
             TxResult::Success => Ok(report),
             // EIP-7251 specifies that a failed system call invalidates the entire block.
-            TxResult::Revert(vm_error) => Err(EvmError::Custom(format!(
+            TxResult::Revert(vm_error) => Err(EvmError::SystemContractCallFailed(format!(
                 "REVERT when dequeuing consolidation requests with error: {:?}. According to EIP-7251, the revert of this system call invalidates the block.",
                 vm_error
             ))),

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -313,7 +313,9 @@ impl LEVM {
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7002.md
         let account = db.get_account(*WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS)?;
         if !account.has_code() {
-            return Err(EvmError::Custom("BlockException.SYSTEM_CONTRACT_EMPTY: WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS has no code after deployment".to_string()));
+            return Err(EvmError::SystemContractEmpty(
+                "WITHDRAWAL_REQUEST_PREDEPLOY".to_string(),
+            ));
         }
 
         match report.result {
@@ -342,7 +344,9 @@ impl LEVM {
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7251.md
         let acc = db.get_account(*CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS)?;
         if !acc.has_code() {
-            return Err(EvmError::Custom("BlockException.SYSTEM_CONTRACT_EMPTY: CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS has no code after deployment".to_string()));
+            return Err(EvmError::SystemContractEmpty(
+                "CONSOLIDATION_REQUEST_PREDEPLOY".to_string(),
+            ));
         }
 
         match report.result {

--- a/crates/vm/backends/revm/mod.rs
+++ b/crates/vm/backends/revm/mod.rs
@@ -219,7 +219,9 @@ impl REVM {
         let account_info =
             Self::system_contract_account_info(*WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, state)?;
         if account_info.is_empty_code_hash() {
-            return Err(EvmError::Custom("BlockException.SYSTEM_CONTRACT_EMPTY: WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS has no code after deployment".to_string()));
+            return Err(EvmError::SystemContractEmpty(
+                "WITHDRAWAL_REQUEST_PREDEPLOY".to_string(),
+            ));
         }
 
         match tx_result {
@@ -258,7 +260,9 @@ impl REVM {
         let account_info =
             Self::system_contract_account_info(*CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS, state)?;
         if account_info.is_empty_code_hash() {
-            return Err(EvmError::Custom("BlockException.SYSTEM_CONTRACT_EMPTY: CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS has no code after deployment".to_string()));
+            return Err(EvmError::SystemContractEmpty(
+                "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS".to_string(),
+            ));
         }
 
         match tx_result {

--- a/crates/vm/backends/revm/mod.rs
+++ b/crates/vm/backends/revm/mod.rs
@@ -234,11 +234,11 @@ impl REVM {
             // EIP-7002 specifies that a failed system call invalidates the entire block.
             ExecutionResult::Halt { reason, gas_used } => {
                 let err_str = format!("Transaction HALT when calling WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS with reason: {reason} and with used gas: {gas_used}");
-                Err(EvmError::Custom(err_str))
+                Err(EvmError::SystemContractCallFailed(err_str))
             }
             ExecutionResult::Revert { gas_used, output } => {
                 let err_str = format!("Transaction REVERT when calling WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS with output: {:?} and with used gas: {gas_used}", output);
-                Err(EvmError::Custom(err_str))
+                Err(EvmError::SystemContractCallFailed(err_str))
             }
         }
     }
@@ -275,11 +275,11 @@ impl REVM {
             // EIP-7251 specifies that a failed system call invalidates the entire block.
             ExecutionResult::Halt { reason, gas_used } => {
                 let err_str = format!("Transaction HALT when calling CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS with reason: {reason} and with used gas: {gas_used}");
-                Err(EvmError::Custom(err_str))
+                Err(EvmError::SystemContractCallFailed(err_str))
             }
             ExecutionResult::Revert { gas_used, output } => {
                 let err_str = format!("Transaction REVERT when calling CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS with output: {:?} and with used gas: {gas_used}", output);
-                Err(EvmError::Custom(err_str))
+                Err(EvmError::SystemContractCallFailed(err_str))
             }
         }
     }

--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -26,6 +26,10 @@ pub enum EvmError {
     Custom(String),
     #[error("Levm Database error: {0}")]
     LevmDatabaseError(#[from] DatabaseError),
+    #[error("Invalid deposit request layout")]
+    InvalidDepositRequest,
+    #[error("System contract: {0} has no code after deployment")]
+    SystemContractEmpty(String),
 }
 
 #[derive(Debug, Error)]

--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -30,6 +30,8 @@ pub enum EvmError {
     InvalidDepositRequest,
     #[error("System contract: {0} has no code after deployment")]
     SystemContractEmpty(String),
+    #[error("System call failed: {0}")]
+    SystemContractCallFailed(String),
 }
 
 #[derive(Debug, Error)]

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -94,7 +94,7 @@ pub enum TxValidationError {
     NonceMismatch { expected: u64, actual: u64 },
     #[error("Initcode size exceeded")]
     InitcodeSizeExceeded,
-    #[error("Priority fee greater than max fee per gas")]
+    #[error("Priority fee is greater than max fee per gas")]
     PriorityGreaterThanMaxFeePerGas,
     #[error("Intrinsic gas too low")]
     IntrinsicGasTooLow,


### PR DESCRIPTION
**Motivation**
Add specific error variants for system contract errors `SystemContractEmpty` & `SystemContractCallFailed`.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add error variants `SystemContractEmpty` & `SystemContractCallFailed`
* (Misc) minor change to error message
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Allows us to better map errors on execution-spec-tests

