### PR TITLE
refactor(l1): move hash from Block to BlockHeader

### DIFF
--- a/cmd/ef_tests/blockchain/types.rs
+++ b/cmd/ef_tests/blockchain/types.rs
@@ -275,6 +275,7 @@ impl From<Header> for BlockHeader {
             excess_blob_gas: val.excess_blob_gas.map(|x| x.as_u64()),
             parent_beacon_block_root: val.parent_beacon_block_root,
             requests_hash: val.requests_hash,
+            ..Default::default()
         }
     }
 }

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -127,6 +127,7 @@ pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block,
         requests_hash: chain_config
             .is_prague_activated(args.timestamp)
             .then_some(*DEFAULT_REQUESTS_HASH),
+        ..Default::default()
     };
 
     let body = BlockBody {

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -706,7 +706,6 @@ mod test {
     #[test]
     fn test_validate_block_header() {
         let parent_block = BlockHeader {
-            hash: OnceCell::new(),
             parent_hash: H256::from_str(
                 "0x0000000000000000000000000000000000000000000000000000000000000000",
             )
@@ -748,9 +747,9 @@ mod test {
             excess_blob_gas: Some(0x00),
             parent_beacon_block_root: Some(H256::zero()),
             requests_hash: Some(*EMPTY_KECCACK_HASH),
+            ..Default::default()
         };
         let block = BlockHeader {
-            hash: OnceCell::new(),
             parent_hash: H256::from_str(
                 "0x48e29e7357408113a4166e04e9f1aeff0680daa2b97ba93df6512a73ddf7a154",
             )
@@ -792,6 +791,7 @@ mod test {
             excess_blob_gas: Some(0x00),
             parent_beacon_block_root: Some(H256::zero()),
             requests_hash: Some(*EMPTY_KECCACK_HASH),
+            ..Default::default()
         };
         assert!(validate_block_header(&block, &parent_block, ELASTICITY_MULTIPLIER).is_ok())
     }

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -2,7 +2,6 @@ use bytes::Bytes;
 use ethereum_types::{Address, Bloom, H256, U256};
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_trie::Trie;
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use std::collections::{BTreeMap, HashMap};
@@ -322,7 +321,6 @@ impl Genesis {
         }
 
         BlockHeader {
-            hash: OnceCell::new(),
             parent_hash: H256::zero(),
             ommers_hash: *DEFAULT_OMMERS_HASH,
             coinbase: self.coinbase,
@@ -353,6 +351,7 @@ impl Genesis {
                 .config
                 .is_prague_activated(self.timestamp)
                 .then_some(self.requests_hash.unwrap_or(*DEFAULT_REQUESTS_HASH)),
+            ..Default::default()
         }
     }
 

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use ethereum_types::{Address, Bloom, H256, U256};
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_trie::Trie;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use std::collections::{BTreeMap, HashMap};
@@ -321,6 +322,7 @@ impl Genesis {
         }
 
         BlockHeader {
+            hash: OnceCell::new(),
             parent_hash: H256::zero(),
             ommers_hash: *DEFAULT_OMMERS_HASH,
             coinbase: self.coinbase,

--- a/crates/networking/rpc/eth/mod.rs
+++ b/crates/networking/rpc/eth/mod.rs
@@ -70,6 +70,7 @@ pub mod test_utils {
             excess_blob_gas: Some(0x00),
             parent_beacon_block_root: Some(H256::zero()),
             requests_hash: Some(*DEFAULT_REQUESTS_HASH),
+            ..Default::default()
         }
     }
 

--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -149,6 +149,7 @@ mod test {
             excess_blob_gas: Some(0x00),
             parent_beacon_block_root: Some(H256::zero()),
             requests_hash: Some(*EMPTY_KECCACK_HASH),
+            ..Default::default()
         };
 
         let tx = EIP1559Transaction {

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -132,6 +132,7 @@ impl ExecutionPayload {
             parent_beacon_block_root,
             // TODO: set the value properly
             requests_hash,
+            ..Default::default()
         };
 
         Ok(Block::new(header, body))

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1261,6 +1261,7 @@ mod tests {
             excess_blob_gas: Some(0x00),
             parent_beacon_block_root: Some(H256::zero()),
             requests_hash: Some(*EMPTY_KECCACK_HASH),
+            ..Default::default()
         };
         let block_body = BlockBody {
             transactions: vec![Transaction::decode(&hex::decode("b86f02f86c8330182480114e82f618946177843db3138ae69679a54b95cf345ed759450d870aa87bee53800080c080a0151ccc02146b9b11adf516e6787b59acae3e76544fdcd75e77e67c6b598ce65da064c5dd5aae2fbb535830ebbdad0234975cd7ece3562013b63ea18cc0df6c97d4").unwrap()).unwrap(),


### PR DESCRIPTION
**Motivation**

`Block` had the hash but the `BlockHeader` didn't so they had to be passed along together.
<!-- Why does this pull request exist? What are its goals? -->

**Description**

Move the hash into `BlockHeader`, making it accesible to it and also to `Block`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2841 

