### PR TITLE
chore(l1,l2): remove double Arc and Mutex from metrics

### DIFF
--- a/crates/blockchain/metrics/mod.rs
+++ b/crates/blockchain/metrics/mod.rs
@@ -58,8 +58,6 @@ pub enum MetricsApiError {
 #[derive(Debug, thiserror::Error)]
 pub enum MetricsError {
     #[error("MetricsL2Error: {0}")]
-    MutexLockError(String),
-    #[error("MetricsL2Error: {0}")]
     PrometheusErr(String),
     #[error("MetricsL2Error {0}")]
     TryInto(#[from] std::num::TryFromIntError),


### PR DESCRIPTION
**Motivation**

The underlying Gauges are already thread safe and behind Arcs internally, so the used Arc and Mutex wrapper were useless overhead.

<!-- Why does this pull request exist? What are its goals? -->

The types in the library derive from

```
pub struct GenericCounter<P: Atomic> {
    v: Arc<Value<P>>,
}
```

Which is clone safe, furthermore P is atomic so it doesnt need a lock.

**Description**

Remove unused Mutex and Arc

Closes #issue_number

