### PR TITLE
fix(core): fix load test not running properly

### DIFF
--- a/cmd/load_test/src/main.rs
+++ b/cmd/load_test/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueEnum};
 use ethereum_types::{Address, H160, H256, U256};
+use ethrex_blockchain::constants::TX_GAS_COST;
 use ethrex_l2_sdk::calldata::{self, Value};
 use ethrex_l2_sdk::get_address_from_secret_key;
 use ethrex_rpc::clients::eth::BlockByNumber;
@@ -239,8 +240,9 @@ async fn load_test(
                             chain_id: Some(chain_id),
                             value,
                             nonce: Some(nonce + i),
-                            max_fee_per_gas: Some(10_u64.pow(6)),
+                            max_fee_per_gas: Some(u64::MAX),
                             max_priority_fee_per_gas: Some(10_u64),
+                            gas_limit: Some(TX_GAS_COST * 100),
                             ..Default::default()
                         },
                     )


### PR DESCRIPTION
**Motivation**

Due to changes to gas estimation the load test had to call estimage gas a lot which slowed downn the load test "setup". Also increased the max_fee_per_gas which was lowered in recent commits by mistake.


