### PR TITLE
feat(ci): add github workflow for releases

### DIFF
--- a/.github/workflows/tag_l2_release.yaml
+++ b/.github/workflows/tag_l2_release.yaml
@@ -1,0 +1,254 @@
+name: L2 Release
+
+on:
+  push:
+    tags:
+      - "l2_v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-l2:
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+        include:
+          - platform: ubuntu-latest
+            os: linux
+            arch: x86-64
+          - platform: ubuntu-24.04-arm
+            os: linux
+            arch: arm64
+          - platform: macos-latest
+            os: macos
+            arch: arm64
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build ethrex L2
+        run: |
+          cargo build --release --features l2 --bin ethrex
+          mv target/release/ethrex ethrex-${{ matrix.os }}_${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ethrex-${{ matrix.os }}_${{ matrix.arch }}
+          path: ethrex-${{ matrix.os }}_${{ matrix.arch }}
+
+  build-prover-sp1:
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+        backend:
+          - sp1
+          - exec
+        include:
+          - platform: ubuntu-latest
+            os: linux
+            arch: x86-64
+          - platform: ubuntu-24.04-arm
+            os: linux
+            arch: arm64
+          - platform: macos-latest
+            os: macos
+            arch: arm64
+          - backend: sp1
+            mode: sp1
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.82.0
+
+      - name: Install SP1
+        env:
+          SHELL: /bin/bash
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -L https://sp1up.succinct.xyz | bash
+          ~/.sp1/bin/sp1up --version 4.1.7
+
+      - name: Add Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build ethrex L2
+        run: |
+          cd crates/l2
+          make build-prover PROVER=${{ matrix.mode }}
+          cd ../../
+          mv target/release/ethrex_prover ethrex_prover_${{ matrix.backend }}-${{ matrix.os }}_${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ethrex_prover_${{ matrix.backend }}-${{ matrix.os }}_${{ matrix.arch }}
+          path: ethrex_prover_${{ matrix.backend }}-${{ matrix.os }}_${{ matrix.arch }}
+
+  build-prover-risc0:
+    if: false # Remove when fixed RISC0
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - macos-latest
+        include:
+          - platform: ubuntu-latest
+            os: linux
+            arch: x86-64
+          - platform: macos-latest
+            os: macos
+            arch: arm64
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.82.0
+
+      - name: Install RISC0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -L https://risczero.com/install | bash
+          ~/.risc0/bin/rzup install
+          ~/.risc0/bin/rzup install cargo-risczero 1.2.0
+          ~/.risc0/bin/rzup default cargo-risczero 1.2.0
+
+      - name: Add Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build ethrex L2
+        run: |
+          cd crates/l2
+          make build-prover PROVER=risc0
+          cd ../../
+          mv target/release/ethrex_prover ethrex_prover_risc0-${{ matrix.os }}_${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ethrex_prover_risc0-${{ matrix.os }}_${{ matrix.arch }}
+          path: ethrex_prover_risc0-${{ matrix.os }}_${{ matrix.arch }}
+
+  build-prover-pico:
+    if: false # Remove when fixed Pico
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+        include:
+          - platform: ubuntu-latest
+            os: linux
+            arch: x86-64
+          - platform: ubuntu-24.04-arm
+            os: linux
+            arch: arm64
+          - platform: macos-latest
+            os: macos
+            arch: arm64
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-11-27
+
+      - name: Install Pico
+        run: |
+          rustup component add rust-src --toolchain nightly-2024-11-27
+          cargo +nightly-2024-11-27 install --git https://github.com/brevis-network/pico pico-cli
+
+      - name: Add Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build ethrex L2
+        run: |
+          cd crates/l2
+          make build-prover TOOLCHAIN=+nightly-2024-11-27 PROVER=pico
+          cd ../../
+          mv target/release/ethrex_prover ethrex_prover_pico-${{ matrix.os }}_${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ethrex_prover_pico-${{ matrix.os }}_${{ matrix.arch }}
+          path: ethrex_prover_pico-${{ matrix.os }}_${{ matrix.arch }}
+
+  # Creates a draft release on GitHub with the binaries
+  finalize-release:
+    needs:
+      - build-l2
+      - build-prover-sp1
+    # - build-prover-risc0 # Uncomment when fixed RISC0
+    # - build-prover-pico # Uncomment when fixed Pico
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./bin
+          pattern: "ethrex*"
+
+      - name: Format name
+        run: echo "RELEASE_NAME=$(echo ${{ github.ref_name }} | cut -d_ -f2)" >> $GITHUB_ENV
+
+      - name: Get previous tag
+        run: |
+          name=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | tail -2 | head -1)
+          echo "PREVIOUS_TAG: $name"
+          echo "PREVIOUS_TAG=$name" >> $GITHUB_ENV
+
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fromTag: ${{ github.ref_name }}
+          toTag: ${{ env.PREVIOUS_TAG }}
+          writeToFile: false
+
+      - name: Finalize Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: ./bin/**/*
+          draft: false
+          prerelease: false
+          tag_name: ${{ github.ref_name }}
+          name: "L2: ${{ env.RELEASE_NAME }}"
+          body: ${{ steps.changelog.outputs.changes }}


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We need an automated way to make releases for the L2.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Added a new Github workflow that cross-compiles the L2 components and makes a new release with the binaries.
To trigger the workflow, a tag with name `l2_vX.Y.Z` has to be created. A changelog will be auto-generated based on the last tag before this one. Binaries are compiled for linux (x86-64 & arm64) and macos (arm64)

<!-- Link to issues: Resolves #111, Resolves #222 -->


