### PR TITLE
fix(core): remove eager rpc calls calls from eth client

### DIFF
--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -1195,12 +1195,11 @@ impl EthClient {
         if let Some(gas_fee) = maybe_gas_fee {
             return Ok(gas_fee);
         }
-        Ok(self
-            .get_gas_price()
+        self.get_gas_price()
             .await
             .map_err(EthClientError::from)?
             .try_into()
-            .map_err(|_| EthClientError::Custom("Failed to get gas for fee".to_owned()))?)
+            .map_err(|_| EthClientError::Custom("Failed to get gas for fee".to_owned()))
     }
 
     async fn priority_fee_from_override_or_rpc(

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use crate::{
-    eth::max_priority_fee,
     types::{
         block::RpcBlock,
         receipt::{RpcLog, RpcReceipt},
@@ -1196,13 +1195,12 @@ impl EthClient {
         if let Some(gas_fee) = maybe_gas_fee {
             return Ok(gas_fee);
         }
-        Ok(maybe_gas_fee.unwrap_or(
-            self.get_gas_price()
-                .await
-                .map_err(EthClientError::from)?
-                .try_into()
-                .map_err(|_| EthClientError::Custom("Failed to get gas for fee".to_owned()))?,
-        ))
+        Ok(self
+            .get_gas_price()
+            .await
+            .map_err(EthClientError::from)?
+            .try_into()
+            .map_err(|_| EthClientError::Custom("Failed to get gas for fee".to_owned()))?)
     }
 
     async fn priority_fee_from_override_or_rpc(
@@ -1217,7 +1215,7 @@ impl EthClient {
             return Ok(priority_fee);
         }
 
-        Ok(self.get_fee_from_override_or_get_gas_price(None).await?)
+        self.get_fee_from_override_or_get_gas_price(None).await
     }
 }
 

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -845,11 +845,13 @@ impl EthClient {
             max_fee_per_gas: self
                 .get_fee_from_override_or_get_gas_price(overrides.max_fee_per_gas)
                 .await?,
-            max_priority_fee_per_gas: overrides.max_priority_fee_per_gas.unwrap_or(
+            max_priority_fee_per_gas: if let Some(max_priority_fee_per_gas) = overrides.max_priority_fee_per_gas {
+                max_priority_fee_per_gas
+            } else {
                 self.get_max_priority_fee()
                     .await
-                    .unwrap_or(self.get_fee_from_override_or_get_gas_price(None).await?),
-            ),
+                    .unwrap_or(self.get_fee_from_override_or_get_gas_price(None).await?)
+            },
             value: overrides.value.unwrap_or_default(),
             data: calldata,
             access_list: overrides.access_list,
@@ -1198,6 +1200,9 @@ impl EthClient {
         &self,
         maybe_gas_fee: Option<u64>,
     ) -> Result<u64, EthClientError> {
+        if let Some(gas_fee) = maybe_gas_fee {
+            return Ok(gas_fee);
+        }
         Ok(maybe_gas_fee.unwrap_or(
             self.get_gas_price()
                 .await


### PR DESCRIPTION
The eth client was calling gas price and max gas price even if the overrides where set. That heavily impacted load test in particular, but it also made overrides pointless. With this small change, the RPC calls are only called in the case that overrides are not provided.
