### PR TITLE
ci(l2): fix L2 sp1 prover integration test steps were skipped on merge to main

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -1,3 +1,4 @@
+# TODO: uncomment "if: ${{ always() && github.event_name == 'merge_group' }}" lines when reenabling this workflow in the merge queue
 name: L2 (SP1 Backend)
 on:
   push:
@@ -23,30 +24,30 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Rust cache
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
 
       - name: RISC-V SP1 toolchain install
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           . "$HOME/.cargo/env"
           curl -L https://sp1.succinct.xyz | bash
           ~/.sp1/bin/sp1up --version 4.1.7
 
       - name: Set up Docker Buildx
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         uses: docker/setup-buildx-action@v3
 
       # This step is needed because of an state bug in the GPU runner.
       # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.
       - name: Clean .env
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: rm -rf crates/l2/.env
 
       - name: Bake docker images
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         uses: docker/bake-action@v6
         with:
           workdir: "crates/l2"
@@ -57,18 +58,18 @@ jobs:
             *.cache-from=type=gha
 
       - name: Build prover
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           make build-prover
 
       - name: Build test
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cargo test l2 --no-run --release
 
       - name: Start L1 & Deploy contracts
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           touch .env
@@ -78,7 +79,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up contract_deployer
 
       - name: Start Sequencer
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           CI_ETHREX_WORKDIR=/usr/local/bin \
@@ -87,7 +88,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up ethrex_l2 --detach
 
       - name: Run test
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover &


### PR DESCRIPTION
**Motivation**

Fix broken ci

**Description**

- Comment conditional running that only run the steps on the merge queue
- Left comment with TODO to uncomment when we re enable this job in the merge queue


