### PR TITLE
feat(l1): add `mempool_content` rpc endpoint

### DIFF
--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -199,6 +199,19 @@ impl Mempool {
 
         Ok(nonce)
     }
+
+    /// Returns all transactions currently in the pool
+    pub fn content(&self) -> Result<Vec<Transaction>, MempoolError> {
+        let pooled_transactions = self
+            .transaction_pool
+            .read()
+            .map_err(|error| StoreError::MempoolReadLock(error.to_string()))?;
+        Ok(pooled_transactions
+            .iter()
+            .map(|(_, mem_tx)| mem_tx.transaction())
+            .cloned()
+            .collect())
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -171,7 +171,7 @@ impl RpcHandler for GetTransactionByBlockNumberAndIndexRequest {
             tx.clone(),
             block_number,
             block_header.compute_block_hash(),
-            self.transaction_index,
+            Some(self.transaction_index),
         );
         serde_json::to_value(tx).map_err(|error| RpcErr::Internal(error.to_string()))
     }
@@ -214,8 +214,12 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
             Some(tx) => tx,
             None => return Ok(Value::Null),
         };
-        let tx =
-            RpcTransaction::build(tx.clone(), block_number, self.block, self.transaction_index);
+        let tx = RpcTransaction::build(
+            tx.clone(),
+            block_number,
+            self.block,
+            Some(self.transaction_index),
+        );
         serde_json::to_value(tx).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
@@ -258,7 +262,7 @@ impl RpcHandler for GetTransactionByHashRequest {
         };
 
         let transaction =
-            RpcTransaction::build(transaction, block_number, block_hash, index as usize);
+            RpcTransaction::build(transaction, block_number, block_hash, Some(index as usize));
         serde_json::to_value(transaction).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -169,7 +169,7 @@ impl RpcHandler for GetTransactionByBlockNumberAndIndexRequest {
         };
         let tx = RpcTransaction::build(
             tx.clone(),
-            block_number,
+            Some(block_number),
             block_header.compute_block_hash(),
             Some(self.transaction_index),
         );
@@ -216,7 +216,7 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
         };
         let tx = RpcTransaction::build(
             tx.clone(),
-            block_number,
+            Some(block_number),
             self.block,
             Some(self.transaction_index),
         );
@@ -261,8 +261,12 @@ impl RpcHandler for GetTransactionByHashRequest {
             _ => return Ok(Value::Null),
         };
 
-        let transaction =
-            RpcTransaction::build(transaction, block_number, block_hash, Some(index as usize));
+        let transaction = RpcTransaction::build(
+            transaction,
+            Some(block_number),
+            block_hash,
+            Some(index as usize),
+        );
         serde_json::to_value(transaction).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/networking/rpc/lib.rs
+++ b/crates/networking/rpc/lib.rs
@@ -6,6 +6,7 @@ mod engine;
 mod eth;
 #[cfg(feature = "l2")]
 pub mod l2;
+mod mempool;
 mod net;
 mod rpc;
 

--- a/crates/networking/rpc/mempool.rs
+++ b/crates/networking/rpc/mempool.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+use ethrex_common::Address;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{rpc::RpcApiContext, types::transaction::RpcTransaction, utils::RpcErr};
+
+/// Maps account sender to its transactions indexed by nonce
+type MempoolContentEntry = HashMap<Address, HashMap<u64, RpcTransaction>>;
+
+/// Full content of the mempool
+/// Transactions are grouped by sender and indexed by nonce
+#[derive(Serialize)]
+struct MempoolContent {
+    pending: MempoolContentEntry,
+    queued: MempoolContentEntry,
+}
+
+/// Handling of rpc endpoint `mempool_content`
+pub async fn content(context: RpcApiContext) -> Result<Value, RpcErr> {
+    let latest_block_number = context.storage.get_latest_block_number().await?;
+    let latest_block_hash = context
+        .storage
+        .get_canonical_block_hash(latest_block_number)
+        .await?
+        .ok_or(RpcErr::Internal("Missing latest block hash".to_string()))?;
+    let transactions = context.blockchain.mempool.content()?;
+    // Group transactions by sender and nonce and map them to rpc transactions
+    let mut mempool_content = MempoolContentEntry::new();
+    for tx in transactions {
+        let sender_entry = mempool_content.entry(tx.sender()).or_default();
+        sender_entry.insert(
+            tx.nonce(),
+            RpcTransaction::build(tx, latest_block_number, latest_block_hash, None),
+        );
+    }
+    let response = MempoolContent {
+        pending: mempool_content,
+        // We have no concept of "queued" transactions yet so we will leave this empty
+        queued: MempoolContentEntry::new(),
+    };
+    Ok(serde_json::to_value(response)?)
+}

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -478,7 +478,8 @@ pub async fn map_mempool_requests(
     contex: RpcApiContext,
 ) -> Result<Value, RpcErr> {
     match req.method.as_str() {
-        "mempool_content" => mempool::content(contex).await,
+        // TODO: The endpoint name matches geth's endpoint for compatibility, consider changing it in the future
+        "txpool_content" => mempool::content(contex).await,
         unknown_mempool_method => Err(RpcErr::MethodNotFound(unknown_mempool_method.to_owned())),
     }
 }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -9,7 +9,6 @@ use crate::engine::{
     },
     ExchangeCapabilitiesRequest,
 };
-use crate::eth;
 use crate::eth::{
     account::{
         GetBalanceRequest, GetCodeRequest, GetProofRequest, GetStorageAtRequest,
@@ -37,6 +36,7 @@ use crate::utils::{
     RpcSuccessResponse,
 };
 use crate::{admin, net};
+use crate::{eth, mempool};
 #[cfg(feature = "based")]
 use crate::{EngineClient, EthClient};
 use axum::extract::State;
@@ -304,6 +304,7 @@ pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Resu
         Ok(RpcNamespace::Debug) => map_debug_requests(req, context).await,
         Ok(RpcNamespace::Web3) => map_web3_requests(req, context),
         Ok(RpcNamespace::Net) => map_net_requests(req, context),
+        Ok(RpcNamespace::Mempool) => map_mempool_requests(req, context).await,
         Ok(RpcNamespace::Engine) => Err(RpcErr::Internal(
             "Engine namespace not allowed in map_http_requests".to_owned(),
         )),
@@ -469,6 +470,16 @@ pub fn map_net_requests(req: &RpcRequest, contex: RpcApiContext) -> Result<Value
         "net_version" => net::version(req, contex),
         "net_peerCount" => net::peer_count(req, contex),
         unknown_net_method => Err(RpcErr::MethodNotFound(unknown_net_method.to_owned())),
+    }
+}
+
+pub async fn map_mempool_requests(
+    req: &RpcRequest,
+    contex: RpcApiContext,
+) -> Result<Value, RpcErr> {
+    match req.method.as_str() {
+        "mempool_content" => mempool::content(contex).await,
+        unknown_mempool_method => Err(RpcErr::MethodNotFound(unknown_mempool_method.to_owned())),
     }
 }
 

--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -81,7 +81,7 @@ impl FullBlockBody {
         for (index, tx) in body.transactions.iter().enumerate() {
             transactions.push(RpcTransaction::build(
                 tx.clone(),
-                block_number,
+                Some(block_number),
                 block_hash,
                 Some(index),
             ));

--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -83,7 +83,7 @@ impl FullBlockBody {
                 tx.clone(),
                 block_number,
                 block_hash,
-                index,
+                Some(index),
             ));
         }
         FullBlockBody {

--- a/crates/networking/rpc/types/transaction.rs
+++ b/crates/networking/rpc/types/transaction.rs
@@ -20,8 +20,8 @@ pub struct RpcTransaction {
     block_hash: BlockHash,
     from: Address,
     pub hash: H256,
-    #[serde(with = "serde_utils::u64::hex_str")]
-    transaction_index: u64,
+    #[serde(with = "serde_utils::u64::hex_str_opt")]
+    transaction_index: Option<u64>,
 }
 
 impl RpcTransaction {
@@ -29,11 +29,11 @@ impl RpcTransaction {
         tx: Transaction,
         block_number: BlockNumber,
         block_hash: BlockHash,
-        transaction_index: usize,
+        transaction_index: Option<usize>,
     ) -> Self {
         let from = tx.sender();
         let hash = tx.compute_hash();
-        let transaction_index = transaction_index as u64;
+        let transaction_index = transaction_index.map(|n| n as u64);
         RpcTransaction {
             tx,
             block_number,

--- a/crates/networking/rpc/types/transaction.rs
+++ b/crates/networking/rpc/types/transaction.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 pub struct RpcTransaction {
     #[serde(flatten)]
     pub tx: Transaction,
-    #[serde(with = "serde_utils::u64::hex_str")]
-    block_number: BlockNumber,
+    #[serde(with = "serde_utils::u64::hex_str_opt")]
+    block_number: Option<BlockNumber>,
     block_hash: BlockHash,
     from: Address,
     pub hash: H256,
@@ -27,7 +27,7 @@ pub struct RpcTransaction {
 impl RpcTransaction {
     pub fn build(
         tx: Transaction,
-        block_number: BlockNumber,
+        block_number: Option<BlockNumber>,
         block_hash: BlockHash,
         transaction_index: Option<usize>,
     ) -> Self {

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -172,6 +172,7 @@ pub enum RpcNamespace {
     Debug,
     Web3,
     Net,
+    Mempool,
     #[cfg(feature = "l2")]
     EthrexL2,
     #[cfg(feature = "based")]
@@ -204,6 +205,7 @@ impl RpcRequest {
                 "debug" => Ok(RpcNamespace::Debug),
                 "web3" => Ok(RpcNamespace::Web3),
                 "net" => Ok(RpcNamespace::Net),
+                "mempool" => Ok(RpcNamespace::Mempool),
                 #[cfg(feature = "l2")]
                 "ethrex" => Ok(RpcNamespace::EthrexL2),
                 #[cfg(feature = "based")]

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -205,7 +205,8 @@ impl RpcRequest {
                 "debug" => Ok(RpcNamespace::Debug),
                 "web3" => Ok(RpcNamespace::Web3),
                 "net" => Ok(RpcNamespace::Net),
-                "mempool" => Ok(RpcNamespace::Mempool),
+                // TODO: The namespace is set to match geth's namespace for compatibility, consider changing it in the future
+                "txpool" => Ok(RpcNamespace::Mempool),
                 #[cfg(feature = "l2")]
                 "ethrex" => Ok(RpcNamespace::EthrexL2),
                 #[cfg(feature = "based")]


### PR DESCRIPTION
**Motivation**
Adds an RPC method that allows reading all transactions currently in the mempool.
This endpoint was based off of  Geth's `txpool_content` endpoint ([doc](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-content)) and follows the same response logic & format.
As we have no notion of `queued` mempool transactions currenlty, this field will be permanently left empty
The namescape and endpoint currently uses `txpool` instead of `mempool` for immediate compatibility with components compatible with geth, we should consider changing the name back to `mempool` to reflect our own types as this is not a standard endpoint and names differ between implementations.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `Mempool::content` method which returns all transactions
* Add `mempool_content` rpc endpoint which returns all mempool transactions grouped by sender and indexed by nonce
* (Misc) `RpcTransaction::build` now supports optional transaction index & block number
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2864 

