### PR TITLE
chore(levm): update state tests and make state use blockchain's tests

### DIFF
--- a/cmd/ef_tests/blockchain/.fixtures_url
+++ b/cmd/ef_tests/blockchain/.fixtures_url
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/v4.3.0/fixtures_develop.tar.gz
+https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -25,7 +25,7 @@ ETH_TEST_TAG := v17.0
 COMMIT_LEGACY_TESTS_FOR_TAG := b3f67fe
 
 STATETEST_ARTIFACT := tests.tar.gz
-FIXTURES_FILE := ../blockchain/.fixtures_url
+FIXTURES_FILE := ../../../cmd/ef_tests/blockchain/.fixtures_url
 STATETEST_URL := $(shell cat $(FIXTURES_FILE))
 
 setup-test-dirs:

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -25,7 +25,7 @@ ETH_TEST_TAG := v17.0
 COMMIT_LEGACY_TESTS_FOR_TAG := b3f67fe
 
 STATETEST_ARTIFACT := tests.tar.gz
-FIXTURES_FILE := ../../../cmd/ef_tests/blockchain/.fixtures_url
+FIXTURES_FILE := https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz
 STATETEST_URL := $(shell cat $(FIXTURES_FILE))
 
 setup-test-dirs:

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -25,8 +25,7 @@ ETH_TEST_TAG := v17.0
 COMMIT_LEGACY_TESTS_FOR_TAG := b3f67fe
 
 STATETEST_ARTIFACT := tests.tar.gz
-FIXTURES_FILE := https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz
-STATETEST_URL := $(shell cat $(FIXTURES_FILE))
+STATETEST_URL := https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz
 
 setup-test-dirs:
 	mkdir -p $(VECTORS_DIR)

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -24,10 +24,9 @@ ETH_TEST_URL := https://github.com/ethereum/tests.git
 ETH_TEST_TAG := v17.0
 COMMIT_LEGACY_TESTS_FOR_TAG := b3f67fe
 
-STATETEST_VERSION := pectra-devnet-6%40v1.0.0
-STATETEST_NET := pectra-devnet-6
-STATETEST_ARTIFACT := fixtures_$(STATETEST_NET).tar.gz
-STATETEST_URL := https://github.com/ethereum/execution-spec-tests/releases/download/$(STATETEST_VERSION)/fixtures_$(STATETEST_NET).tar.gz
+STATETEST_ARTIFACT := tests.tar.gz
+FIXTURES_FILE := ../blockchain/.fixtures_url
+STATETEST_URL := $(shell cat $(FIXTURES_FILE))
 
 setup-test-dirs:
 	mkdir -p $(VECTORS_DIR)

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -30,7 +30,6 @@ STATETEST_URL := $(shell cat $(FIXTURES_FILE))
 
 setup-test-dirs:
 	mkdir -p $(VECTORS_DIR)
-	mkdir -p $(VECTORS_DIR)/LegacyTests/Constantinople/GeneralStateTests
 	mkdir -p $(VECTORS_DIR)/LegacyTests/Cancun/GeneralStateTests
 	mkdir -p $(VECTORS_DIR)/GeneralStateTests
 	mkdir -p $(VECTORS_DIR)/state_tests
@@ -40,7 +39,6 @@ clone-ef-tests: ## 📥 Download Ethereum Tests repository with submodules
 	git clone --recurse-submodules --depth 1 --branch $(ETH_TEST_TAG) $(ETH_TEST_URL) $(TESTS_REPO)
 	cd $(TESTS_REPO)/LegacyTests && git checkout $(COMMIT_LEGACY_TESTS_FOR_TAG)
 	cp -r $(TESTS_REPO)/GeneralStateTests/* $(VECTORS_DIR)/GeneralStateTests/
-	cp -r $(TESTS_REPO)/LegacyTests/Constantinople/GeneralStateTests/* $(VECTORS_DIR)/LegacyTests/Constantinople/GeneralStateTests/
 	cp -r $(TESTS_REPO)/LegacyTests/Cancun/GeneralStateTests/* $(VECTORS_DIR)/LegacyTests/Cancun/GeneralStateTests/;
 
 download-state-tests: ## 📥 Download and setup state tests fixtures


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

- Update blockchain tests from 4.3.0 to 4.5.0
- Update state tests from pectra-devnet-6 to 4.5.0
- Remove tests from old forks (Constantinople folder)

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

