### PR TITLE
fix(makefile): solved make install-cli problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ clean-hive-logs: ## 🧹 Clean Hive logs
 	rm -rf ./hive/workspace/logs
 
 install-cli: ## 🛠️ Installs the ethrex-l2 cli
-	cargo install --path cmd/ethrex_l2/ --force
+	cargo install --path cmd/ethrex_l2/ --force --locked
 
 start-node-with-flamegraph: rm-test-db ## 🚀🔥 Starts an ethrex client used for testing
 	@if [ -z "$$L" ]; then \


### PR DESCRIPTION
**Motivation**

While trying to run the `make install-cli` command it failed.

**Description**

The problem was that the libmdbx crate was trying to install the 0.5.4 (not the one in the `Cargo.lock` file) version which needs a version of rust with the feature "edition2024", that is estable after the 1.85.0 version (Ethrex is using 1.82.0).
I found two solutions:
1. Upgrading the rust version to 1.85.0 in the `.tool-versions` file
2. Adding `--locked` flag to the makefile command

The first one may introduce more problems on the code. The second one ensures that the `cargo install` command, called by `make`, installs the versions specified in the `Cargo.lock` file, solving the error.
With this change the `make install-cli` command installs the ethrex l2 cli (As said in the makefile).

Closes #2870