### PR TITLE
ci(core): updating hive revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := f9004c7e85de003bbdeb4fbcc4a9dbf8c3c4c9c2
+HIVE_REVISION := 40fca55fe5e04103c262e54df75c4f917f4ae31b
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).
@@ -85,10 +85,10 @@ QUIET ?= false
 
 hive:
 	if [ "$(QUIET)" = "true" ]; then \
-		git clone --quiet --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --quiet --single-branch --branch chore/updated-master-new --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --quiet --detach $(HIVE_REVISION) && go build .; \
 	else \
-		git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --single-branch --branch chore/updated-master-new --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --detach $(HIVE_REVISION) && go build .; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := 4734de9cd75a16f5d2df80d6d156aa6b4a9dcaf9
+HIVE_REVISION := 58654093e56af8876fce5a5bc22f72fddfe41344
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := 58654093e56af8876fce5a5bc22f72fddfe41344
+HIVE_REVISION := 4a1ed079ce5ebb46240e4ef9141d72e7236bca36
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).
@@ -85,10 +85,10 @@ QUIET ?= false
 
 hive:
 	if [ "$(QUIET)" = "true" ]; then \
-		git clone --quiet --single-branch --branch chore/updated-master-new --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --quiet --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --quiet --detach $(HIVE_REVISION) && go build .; \
 	else \
-		git clone --single-branch --branch chore/updated-master-new --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
+		git clone --single-branch --branch master --shallow-since=$(HIVE_SHALLOW_SINCE) https://github.com/lambdaclass/hive && \
 		cd hive && git checkout --detach $(HIVE_REVISION) && go build .; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ stop-localnet-silent:
 	@kurtosis enclave stop $(ENCLAVE) >/dev/null 2>&1 || true
 	@kurtosis enclave rm $(ENCLAVE) --force >/dev/null 2>&1 || true
 
-HIVE_REVISION := 40fca55fe5e04103c262e54df75c4f917f4ae31b
+HIVE_REVISION := 4734de9cd75a16f5d2df80d6d156aa6b4a9dcaf9
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ HIVE_REVISION := 4a1ed079ce5ebb46240e4ef9141d72e7236bca36
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our
 # target revision).
-HIVE_SHALLOW_SINCE := 2024-09-02
+HIVE_SHALLOW_SINCE := 2025-05-21
 QUIET ?= false
 
 hive:


### PR DESCRIPTION
**Motivation**

In our lambdaclass/hive fork, we have updated upstream. When [that PR](https://github.com/lambdaclass/hive/pull/28) is merged, we should update the branch name here and test it.

**Description**

- Updates the hive revision
- Also updates "HIVE_SHALLOW_SINCE"

Closes #2760

