### PR TITLE
docs(levm): add docs explaining types of errors in the EVM

### DIFF
--- a/crates/vm/levm/docs/faq.md
+++ b/crates/vm/levm/docs/faq.md
@@ -65,3 +65,10 @@ Accessing a **cold** address incurs higher gas costs than accessing a **warm** a
 
 So if you want to access an account that's in the `CacheDB` it will be cheap for the EVM (because it won't look up in the `Database`) but if it was accessed in a transaction that never touched that account the address will still be **cold** and therefore the gas cost will be higher than if it was **warm**.
 
+## Errors
+
+These are the kinds of errors:
+- `InternalError`: These errors are triggered if there's a bug in the EVM implementation, things that shouldn't ever happen. For example, and overflow in the Program Counter or an underflow when substracting two values and we know for sure the first one is greater than the second. They are propagated and stop execution.
+- `DatabaseError`: Used by our trait `Database`, triggered when there's an error accessing the storage and the cause is usually external to the EVM. A concrete example would be when there's an unexpected error with libmdbx (actual L1 Client's database). Just like Internal Errors, they are propagated and stop execution.
+- `TxValidation`: These are thrown if the transaction doesn't pass the required validations, like the sender having enough value to pay for the transaction gas fees, or that the transaction nonce should match with sender's nonce. These errors **INVALIDATE** the transaction, they shouldn't make any changes to the state.
+- `EVM Error`: Any error that's contemplated in the EVM and is expected to happen, like Out-of-Gas and Stack Overflow. These errors cause the current executing context to **Revert**, most of the times consuming all context gas left (the only exception is `RevertOpcode` error). Any error that's not in the previous categories will be treated as an EVM Error.


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- Add docs about errors in the vm because maybe it isn't completely clear which are propagated and which are not.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Note: I was thinking that maybe we should be more clear with our errors struct. Maybe we should have a struct `LEVMError` that has inside 4 types of errors: `Internal`, `Database`, `TxValidation`, `EVM`. That way it's easier to understand I think. (We should also do some clearing up because it's quite messy and sometimes we don't even use the appropriate errors I've seen)

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1537

I opened [this issue](https://github.com/lambdaclass/ethrex/issues/2886) for refactoring errors because they are quite messy

