### PR TITLE
chore(l1): reduce p2p error and info logs

### DIFF
--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -6,7 +6,7 @@ use crate::rlpx::{
 use crate::types::{Node, NodeRecord};
 use crate::{
     discv4::server::{DiscoveryError, Discv4Server},
-    rlpx::utils::{log_peer_debug, log_peer_error},
+    rlpx::utils::log_peer_debug,
 };
 use ethrex_blockchain::Blockchain;
 use ethrex_common::{H256, H512};
@@ -159,7 +159,7 @@ pub async fn handle_peer_as_initiator(context: P2PContext, node: Node) {
     match handshake::as_initiator(context, node.clone(), stream).await {
         Ok(mut conn) => conn.start(table, false).await,
         Err(e) => {
-            log_peer_error(&node, &format!("Error creating tcp connection {e}"));
+            log_peer_debug(&node, &format!("Error creating tcp connection {e}"));
             table.lock().await.replace_peer(node.node_id());
         }
     };

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -6,7 +6,7 @@ use crate::rlpx::{
 use crate::types::{Node, NodeRecord};
 use crate::{
     discv4::server::{DiscoveryError, Discv4Server},
-    rlpx::utils::log_peer_error,
+    rlpx::utils::{log_peer_debug, log_peer_error},
 };
 use ethrex_blockchain::Blockchain;
 use ethrex_common::{H256, H512};
@@ -150,7 +150,7 @@ pub async fn handle_peer_as_initiator(context: P2PContext, node: Node) {
     let stream = match tcp_stream(addr).await {
         Ok(result) => result,
         Err(e) => {
-            log_peer_error(&node, &format!("Error creating tcp connection {e}"));
+            log_peer_debug(&node, &format!("Error creating tcp connection {e}"));
             context.table.lock().await.replace_peer(node.node_id());
             return;
         }

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -206,7 +206,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         error: RLPxError,
         table: Arc<Mutex<crate::kademlia::KademliaTable>>,
     ) {
-        log_peer_error(&self.node, &format!("{error_text}: ({error})"));
+        log_peer_debug(&self.node, &format!("{error_text}: ({error})"));
 
         // Send disconnect message only if error is different than RLPxError::DisconnectRequested
         // because if it is a DisconnectRequested error it means that the peer requested the disconnection, not us.
@@ -224,7 +224,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
             }
             _ => {
                 let remote_public_key = self.node.public_key;
-                log_peer_error(
+                log_peer_debug(
                     &self.node,
                     &format!("{error_text}: ({error}), discarding peer {remote_public_key}"),
                 );

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -43,7 +43,7 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
-use tracing::info;
+use tracing::debug;
 
 use super::{
     eth::transactions::NewPooledTransactionHashes, p2p::DisconnectReason, utils::log_peer_warn,
@@ -305,11 +305,11 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
                 if negotiated_eth_version == 0 {
                     return Err(RLPxError::NoMatchingCapabilities());
                 }
-                info!("Negotatied eth version: eth/{}", negotiated_eth_version);
+                debug!("Negotatied eth version: eth/{}", negotiated_eth_version);
                 self.negotiated_eth_capability = Some(Capability::eth(negotiated_eth_version));
 
                 if negotiated_snap_version != 0 {
-                    info!("Negotatied snap version: snap/{}", negotiated_snap_version);
+                    debug!("Negotatied snap version: snap/{}", negotiated_snap_version);
                     self.negotiated_snap_capability =
                         Some(Capability::snap(negotiated_snap_version));
                 }

--- a/crates/networking/p2p/rlpx/connection.rs
+++ b/crates/networking/p2p/rlpx/connection.rs
@@ -193,7 +193,7 @@ impl<S: AsyncWrite + AsyncRead + std::marker::Unpin> RLPxConnection<S> {
         self.send(Message::Disconnect(DisconnectMessage { reason }))
             .await
             .unwrap_or_else(|_| {
-                log_peer_error(
+                log_peer_debug(
                     &self.node,
                     &format!("Could not send Disconnect message: ({:?}).", reason),
                 );

--- a/crates/networking/p2p/rlpx/eth/blocks.rs
+++ b/crates/networking/p2p/rlpx/eth/blocks.rs
@@ -128,9 +128,7 @@ impl GetBlockHeaders {
                 // TODO(#1073)
                 // Research what we should do when an error is found in a P2P request.
                 Err(err) => {
-                    tracing::error!(
-                        "Error accessing DB while building header response for peer: {err}"
-                    );
+                    error!("Error accessing DB while building header response for peer: {err}");
                     return vec![];
                 }
             }
@@ -237,7 +235,7 @@ impl GetBlockBodies {
                     continue;
                 }
                 Err(err) => {
-                    tracing::error!(
+                    error!(
                         "Error accessing DB while building block bodies response for peer: {err}"
                     );
                     return vec![];

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -11,7 +11,7 @@ use tokio::{
     time::{sleep, Duration},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     peer_handler::PeerHandler,
@@ -115,7 +115,7 @@ impl SyncManager {
 
         tokio::spawn(async move {
             let Ok(Some(current_head)) = store.get_latest_canonical_block_hash().await else {
-                tracing::error!("Failed to fetch latest canonical block, unable to sync");
+                error!("Failed to fetch latest canonical block, unable to sync");
                 return;
             };
 
@@ -127,7 +127,7 @@ impl SyncManager {
                 let sync_head = {
                     // Read latest fcu head without holding the lock for longer than needed
                     let Ok(sync_head) = sync_head.try_lock() else {
-                        tracing::error!("Failed to read latest fcu head, unable to sync");
+                        error!("Failed to read latest fcu head, unable to sync");
                         return;
                     };
                     *sync_head


### PR DESCRIPTION
**Motivation**

When running the node, even without `debug` the logs are pretty difficult to follow, specially due to p2p errors and infos

**Description**

Make every individual peer error use `debug` instead of `error` level (except for boradcasting issues) and remove the capabilities negotiated `info` level log.

#### Logs Before

![image](https://github.com/user-attachments/assets/c99aef44-e02f-494d-bd5c-7a27169be388)


#### Logs After

![image](https://github.com/user-attachments/assets/8373aab5-3b99-4c35-ae3a-fc32ebc0067f)
