### PR TITLE
ci(l2): fix RPC prover on main

### DIFF
--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -53,6 +53,7 @@ jobs:
           cp test_data/rpc_prover/cache_22240087.json crates/l2/prover/bench
           cd crates/l2/prover/bench
           make prove-sp1-gpu-ci BLOCK_NUMBER=22240087
+          git stash
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.lock
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "derive_more 1.0.0",
+ "dyn-clone",
  "ethereum-types",
  "ethrex-common",
  "ethrex-levm",


### PR DESCRIPTION
**Motivation**

Broken ci :(

**Why this happened**

Because the action that uploads to github pages has to checkout to a branch but the cargo.lock was modified git couldn't checkout to gh-pages branch 

**Why it wont happen again**
Now we run git stash after we finish proving the block so this shouldn't happen again. This is a band-aid fix but it should work forever
