### PR TITLE
fix(levm): fix precompiles problem with eip7702

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -803,18 +803,6 @@ impl<'a> VM<'a> {
             self.increase_account_balance(to, value)?;
         }
 
-        if bytecode.is_empty() && is_delegation_7702 {
-            self.current_call_frame_mut()?.gas_used = self
-                .current_call_frame()?
-                .gas_used
-                .checked_sub(gas_limit)
-                .ok_or(InternalError::GasOverflow)?;
-            self.current_call_frame_mut()?
-                .stack
-                .push(SUCCESS_FOR_CALL)?;
-            return Ok(OpcodeResult::Continue { pc_increment: 1 });
-        }
-
         let new_call_frame = CallFrame::new(
             msg_sender,
             to,

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -78,7 +78,7 @@ impl<'a> VM<'a> {
             (account.is_empty(), address_was_cold)
         };
 
-        let (is_delegation, eip7702_gas_consumed, code_address, bytecode) =
+        let (is_delegation_7702, eip7702_gas_consumed, code_address, bytecode) =
             eip7702_get_code(self.db, &mut self.substate, callee)?;
 
         let gas_left = self
@@ -123,7 +123,7 @@ impl<'a> VM<'a> {
             return_data_start_offset,
             return_data_size,
             bytecode,
-            is_delegation,
+            is_delegation_7702,
         )
     }
 
@@ -179,7 +179,7 @@ impl<'a> VM<'a> {
         let (_account_info, address_was_cold) =
             self.db.access_account(&mut self.substate, code_address)?;
 
-        let (is_delegation, eip7702_gas_consumed, code_address, bytecode) =
+        let (is_delegation_7702, eip7702_gas_consumed, code_address, bytecode) =
             eip7702_get_code(self.db, &mut self.substate, code_address)?;
 
         let gas_left = self
@@ -223,7 +223,7 @@ impl<'a> VM<'a> {
             return_data_start_offset,
             return_data_size,
             bytecode,
-            is_delegation,
+            is_delegation_7702,
         )
     }
 
@@ -303,7 +303,7 @@ impl<'a> VM<'a> {
             calculate_memory_size(return_data_start_offset, return_data_size)?;
         let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
 
-        let (is_delegation, eip7702_gas_consumed, code_address, bytecode) =
+        let (is_delegation_7702, eip7702_gas_consumed, code_address, bytecode) =
             eip7702_get_code(self.db, &mut self.substate, code_address)?;
 
         let gas_left = self
@@ -347,7 +347,7 @@ impl<'a> VM<'a> {
             return_data_start_offset,
             return_data_size,
             bytecode,
-            is_delegation,
+            is_delegation_7702,
         )
     }
 
@@ -399,7 +399,7 @@ impl<'a> VM<'a> {
             calculate_memory_size(return_data_start_offset, return_data_size)?;
         let new_memory_size = new_memory_size_for_args.max(new_memory_size_for_return_data);
 
-        let (is_delegation, eip7702_gas_consumed, _, bytecode) =
+        let (is_delegation_7702, eip7702_gas_consumed, _, bytecode) =
             eip7702_get_code(self.db, &mut self.substate, code_address)?;
 
         let gas_left = self
@@ -440,7 +440,7 @@ impl<'a> VM<'a> {
             return_data_start_offset,
             return_data_size,
             bytecode,
-            is_delegation,
+            is_delegation_7702,
         )
     }
 
@@ -754,7 +754,7 @@ impl<'a> VM<'a> {
         ret_offset: U256,
         ret_size: usize,
         bytecode: Bytes,
-        is_delegation: bool,
+        is_delegation_7702: bool,
     ) -> Result<OpcodeResult, VMError> {
         let sender_balance = self
             .db
@@ -806,7 +806,7 @@ impl<'a> VM<'a> {
             self.increase_account_balance(to, value)?;
         }
 
-        if bytecode.is_empty() && is_delegation {
+        if bytecode.is_empty() && is_delegation_7702 {
             self.current_call_frame_mut()?.gas_used = self
                 .current_call_frame()?
                 .gas_used
@@ -835,7 +835,7 @@ impl<'a> VM<'a> {
         );
         self.call_frames.push(new_call_frame);
 
-        if self.is_precompile()? && !self.delegate_contracts_in_tx.contains(&code_address) {
+        if self.is_precompile()? && !is_delegation_7702 {
             let report = self.execute_precompile()?;
             self.handle_return(&report)?;
         } else {

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -2,10 +2,7 @@ use crate::{
     call_frame::CallFrame,
     constants::{CREATE_DEPLOYMENT_FAIL, INIT_CODE_MAX_SIZE, REVERT_FOR_CALL, SUCCESS_FOR_CALL},
     db::cache,
-    errors::{
-        ExecutionReport, InternalError, OpcodeResult, OutOfGasError, PrecompileError, TxResult,
-        VMError,
-    },
+    errors::{ExecutionReport, InternalError, OpcodeResult, OutOfGasError, TxResult, VMError},
     gas_cost::{self, max_message_call_gas},
     memory::{self, calculate_memory_size},
     utils::{address_to_word, word_to_address, *},
@@ -835,7 +832,7 @@ impl<'a> VM<'a> {
         );
         self.call_frames.push(new_call_frame);
 
-        if self.is_precompile()? && !is_delegation_7702 {
+        if self.is_precompile(&code_address) && !is_delegation_7702 {
             let report = self.execute_precompile()?;
             self.handle_return(&report)?;
         } else {

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -473,6 +473,9 @@ impl<'a> VM<'a> {
             // 9. Increase the nonce of authority by one.
             self.increment_account_nonce(authority_address)
                 .map_err(|_| VMError::TxValidation(TxValidationError::NonceIsMax))?;
+
+            // If delegation was successful insert target of delegation into "delegate contracts" set
+            self.delegate_contracts_in_tx.insert(auth_tuple.address);
         }
 
         self.substate.refunded_gas = refunded_gas;
@@ -704,12 +707,5 @@ impl<'a> VM<'a> {
                 Ok(created_address)
             }
         }
-    }
-
-    /// Checks if an address is delegation target in current transaction.
-    pub fn is_delegation_target(&self, address: Address) -> bool {
-        self.tx.authorization_list().as_ref().map_or(false, |list| {
-            list.iter().any(|item| item.address == address)
-        })
     }
 }

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -473,9 +473,6 @@ impl<'a> VM<'a> {
             // 9. Increase the nonce of authority by one.
             self.increment_account_nonce(authority_address)
                 .map_err(|_| VMError::TxValidation(TxValidationError::NonceIsMax))?;
-
-            // If delegation was successful insert target of delegation into "delegate contracts" set
-            self.delegate_contracts_in_tx.insert(auth_tuple.address);
         }
 
         self.substate.refunded_gas = refunded_gas;
@@ -608,11 +605,8 @@ impl<'a> VM<'a> {
         Ok(min_gas_used)
     }
 
-    pub fn is_precompile(&self) -> Result<bool, VMError> {
-        Ok(is_precompile(
-            &self.current_call_frame()?.code_address,
-            self.env.config.fork,
-        ))
+    pub fn is_precompile(&self, address: &Address) -> bool {
+        is_precompile(address, self.env.config.fork)
     }
 
     /// Backup of Substate, a copy of the current substate to restore if sub-context is reverted

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -166,6 +166,7 @@ impl<'a> VM<'a> {
         }
     }
 
+    /// Executes precompile and handles the output that it returns, generating a report.
     pub fn execute_precompile(&mut self) -> Result<ExecutionReport, VMError> {
         let callframe = self.current_call_frame_mut()?;
 


### PR DESCRIPTION
**Motivation**

- Fix holesky Prague syncing with LEVM

**Description**

- I previously misunderstood the behavior between [EIP 7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) and precompiles and because of that some edge cases were breaking our VM. The current solution I believe is implemented correctly and is also simpler than what I thought.

Before we were luckily (unluckily I'd say) passing all EFTests despite this misimplementation. 


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

