### PR TITLE
perf(levm): Add with_capacity on valid_jump_destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2025-05-23
+
+- Add with_capacity on valid_jump_destinations in get_valid_jump_destinations [2902](https://github.com/lambdaclass/ethrex/pull/2902)
+
 ### 2025-05-20
 
 - Reduce account clone overhead when account data is retrieved [2684](https://github.com/lambdaclass/ethrex/pull/2684)

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -104,7 +104,9 @@ pub fn calculate_create2_address(
 /// JUMPDEST (jump destination) is opcode "5B" but not everytime there's a "5B" in the code it means it's a JUMPDEST.
 /// Example: PUSH4 75BC5B42. In this case the 5B is inside a value being pushed and therefore it's not the JUMPDEST opcode.
 pub fn get_valid_jump_destinations(code: &Bytes) -> Result<HashSet<usize>, VMError> {
-    let mut valid_jump_destinations = HashSet::new();
+    // We do lot of inserts, so with capacity is useful here, since it's a usize
+    // we can use a sizeable number without much memory cost.
+    let mut valid_jump_destinations = HashSet::with_capacity(8096);
     let mut pc = 0;
 
     while let Some(&opcode_number) = code.get(pc) {


### PR DESCRIPTION
Ran a profile and noticed reserve inside the insert on this hashset took quite lot of time, so i added with_capacity and saw about 8~ seconds improvement on the import bench

```
time cargo run --bin ethrex --profile=release-with-debug -- --network test_data/genesis-perf-ci.json --force import ./test_data/l2-1k-erc20.rlp --removedb
```

