### PR TITLE
docs(levm): mention solidity compiler dependency for levm benchmark tool

### DIFF
--- a/crates/vm/levm/bench/revm_comparison/README.md
+++ b/crates/vm/levm/bench/revm_comparison/README.md
@@ -2,9 +2,19 @@
 This README explains how to run benchmarks to compare the performance of `levm` and `revm` when running different contracts. The benchmarking tool used to gather performance metrics is [hyperfine](https://github.com/sharkdp/hyperfine), and the obtained results will be included for reference.
 
 To run the benchmarks (from `levm`'s root):
+
 ```bash
 make revm-comparison
 ```
+
+Note that first you will need to install the solidity compiler
+On mac you can use homebrew:
+
+```bash
+brew install solidity
+```
+
+For other installation methods check out the [official solidity installation guide](https://docs.soliditylang.org/en/latest/installing-solidity.html)
 
 ## Factorial
 This program computes the nth factorial number, with n passed via calldata. We chose 1000 as n and ran the program on a loop 100,000 times.


### PR DESCRIPTION
**Motivation**
Following the `rev_comparison` levm bench tool's README to run the tool results in an error as the solidity compiler is not installed. This is not mentioned as a dependency, so this PR updates the README to mention that solidity compiler is required to use the tool and how to install it.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Mention solidity compiler dependency + how to install it on levm's `rev_comparison` benchmark tool README 
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

