### PR TITLE
fix(l2): fix conversion factor in benchmark

### DIFF
--- a/crates/l2/prover/bench/src/main.rs
+++ b/crates/l2/prover/bench/src/main.rs
@@ -109,7 +109,7 @@ async fn main() {
 }
 
 fn write_benchmark_file(gas_used: f64, elapsed: f64) {
-    let rate = gas_used / 10e6 / elapsed;
+    let rate = gas_used / 1e6 / elapsed;
 
     let backend = if cfg!(feature = "sp1") {
         "SP1"


### PR DESCRIPTION
**Motivation**

The factor used to convert from gas to Mgas is incorrect.

**Description**

Changes to the correct factor (1e6 = 1 million).
