### PR TITLE
feat(l1): add code offset by capability

### DIFF
--- a/crates/networking/p2p/rlpx/eth/blocks.rs
+++ b/crates/networking/p2p/rlpx/eth/blocks.rs
@@ -138,7 +138,7 @@ impl GetBlockHeaders {
 }
 
 impl RLPxMessage for GetBlockHeaders {
-    const CODE: u8 = 0x13;
+    const CODE: u8 = 0x03;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         let limit = self.limit;
@@ -179,7 +179,7 @@ impl BlockHeaders {
 }
 
 impl RLPxMessage for BlockHeaders {
-    const CODE: u8 = 0x14;
+    const CODE: u8 = 0x04;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         // Each message is encoded with its own
@@ -247,7 +247,7 @@ impl GetBlockBodies {
 }
 
 impl RLPxMessage for GetBlockBodies {
-    const CODE: u8 = 0x15;
+    const CODE: u8 = 0x05;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -286,7 +286,7 @@ impl BlockBodies {
 }
 
 impl RLPxMessage for BlockBodies {
-    const CODE: u8 = 0x16;
+    const CODE: u8 = 0x06;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/eth/receipts.rs
+++ b/crates/networking/p2p/rlpx/eth/receipts.rs
@@ -25,7 +25,7 @@ impl GetReceipts {
 }
 
 impl RLPxMessage for GetReceipts {
-    const CODE: u8 = 0x1F;
+    const CODE: u8 = 0x0F;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -64,7 +64,7 @@ impl Receipts {
 }
 
 impl RLPxMessage for Receipts {
-    const CODE: u8 = 0x20;
+    const CODE: u8 = 0x10;
 
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];

--- a/crates/networking/p2p/rlpx/eth/status.rs
+++ b/crates/networking/p2p/rlpx/eth/status.rs
@@ -23,7 +23,7 @@ pub(crate) struct StatusMessage {
 }
 
 impl RLPxMessage for StatusMessage {
-    const CODE: u8 = 0x10;
+    const CODE: u8 = 0x00;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -33,7 +33,7 @@ impl Transactions {
 }
 
 impl RLPxMessage for Transactions {
-    const CODE: u8 = 0x12;
+    const CODE: u8 = 0x02;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         let mut encoder = Encoder::new(&mut encoded_data);
@@ -121,7 +121,7 @@ impl NewPooledTransactionHashes {
 }
 
 impl RLPxMessage for NewPooledTransactionHashes {
-    const CODE: u8 = 0x18;
+    const CODE: u8 = 0x08;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -233,7 +233,7 @@ impl GetPooledTransactions {
 }
 
 impl RLPxMessage for GetPooledTransactions {
-    const CODE: u8 = 0x19;
+    const CODE: u8 = 0x09;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -300,7 +300,7 @@ impl PooledTransactions {
 }
 
 impl RLPxMessage for PooledTransactions {
-    const CODE: u8 = 0x1A;
+    const CODE: u8 = 0x0A;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)

--- a/crates/networking/p2p/rlpx/snap.rs
+++ b/crates/networking/p2p/rlpx/snap.rs
@@ -81,7 +81,7 @@ pub(crate) struct TrieNodes {
 }
 
 impl RLPxMessage for GetAccountRange {
-    const CODE: u8 = 0x21;
+    const CODE: u8 = 0x00;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -118,7 +118,7 @@ impl RLPxMessage for GetAccountRange {
 }
 
 impl RLPxMessage for AccountRange {
-    const CODE: u8 = 0x22;
+    const CODE: u8 = 0x01;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -149,7 +149,7 @@ impl RLPxMessage for AccountRange {
 }
 
 impl RLPxMessage for GetStorageRanges {
-    const CODE: u8 = 0x23;
+    const CODE: u8 = 0x02;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -195,7 +195,7 @@ impl RLPxMessage for GetStorageRanges {
 }
 
 impl RLPxMessage for StorageRanges {
-    const CODE: u8 = 0x24;
+    const CODE: u8 = 0x03;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -222,7 +222,7 @@ impl RLPxMessage for StorageRanges {
 }
 
 impl RLPxMessage for GetByteCodes {
-    const CODE: u8 = 0x25;
+    const CODE: u8 = 0x04;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -249,7 +249,7 @@ impl RLPxMessage for GetByteCodes {
 }
 
 impl RLPxMessage for ByteCodes {
-    const CODE: u8 = 0x26;
+    const CODE: u8 = 0x05;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -274,7 +274,7 @@ impl RLPxMessage for ByteCodes {
 }
 
 impl RLPxMessage for GetTrieNodes {
-    const CODE: u8 = 0x27;
+    const CODE: u8 = 0x06;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)
@@ -308,7 +308,7 @@ impl RLPxMessage for GetTrieNodes {
 }
 
 impl RLPxMessage for TrieNodes {
-    const CODE: u8 = 0x28;
+    const CODE: u8 = 0x07;
     fn encode(&self, buf: &mut dyn BufMut) -> Result<(), RLPEncodeError> {
         let mut encoded_data = vec![];
         Encoder::new(&mut encoded_data)


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

The protocol capability offset was hardcoded within the msg code. 

**Description**

In order to decouple the msg code from the protocol offset, a const was created with the len of the protocol.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

[geth reference](https://github.com/ethereum/go-ethereum/blob/20ad4f500e7fafab93f6d94fa171a5c0309de6ce/cmd/devp2p/internal/ethtest/protocol.go#L62)

Closes #2902 

