### PR TITLE
ci(l2): always run TDX lints

### DIFF
--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -39,6 +39,14 @@ jobs:
       - name: Clippy exec
         run: |
             cargo clippy -p ethrex-prover --all-targets
+      - name: Check tdx
+        run: |
+            cd crates/l2/tee/quote-gen
+            cargo check
+      - name: Clippy tdx
+        run: |
+            cd crates/l2/tee/quote-gen
+            cargo clippy --all-targets
 
   test:
     # "Test" is a required check, don't change the name

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -8,7 +8,6 @@ on:
       - "crates/l2/tee/**"
       - "crates/l2/contracts/**"
       - "test_data/**"
-      - "crates/blockchain/dev/**"
       - ".github/workflows/pr-main_l2_tdx.yaml"
 
 concurrency:
@@ -16,26 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    # "Lint" is a required check, don't change the name
-    name: Lint
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
-      - name: Check exec
-        run: |
-            cd crates/l2/tee/quote-gen
-            cargo check
-      - name: Clippy exec
-        run: |
-            cd crates/l2/tee/quote-gen
-            cargo clippy --all-targets
-
   test:
     # "Test" is a required check, don't change the name
     name: Test


### PR DESCRIPTION
**Motivation**

In #2867 a change broke TDX, but this wasn't caught by the CI because the TDX workflow isn't executed on PRs that do not change TDX-related files.

**Description**

This moves the lint task with the other prover lints, so that it runs on every PR.

The TDX test is still only executed selectively.
