### PR TITLE
ci(l2): fix SP1 integration test

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -2,7 +2,7 @@
 name: L2 (SP1 Backend)
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -95,6 +95,12 @@ jobs:
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex_prover -s SIGINT
 
+      - name: Destroy Docker containers
+        if: always()
+        run: |
+          cd crates/l2
+          docker compose down -t 0 -f docker-compose-l2.yaml
+
       - name: Ensure admin permissions in _work
         if: always()
         run: sudo chown admin:admin -R /home/admin/actions-runner/_work/

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -2,7 +2,7 @@
 name: L2 (SP1 Backend)
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -99,7 +99,7 @@ jobs:
         if: always()
         run: |
           cd crates/l2
-          docker compose down -t 0 -f docker-compose-l2.yaml
+          docker compose -f docker-compose-l2.yaml down -t 0
 
       - name: Ensure admin permissions in _work
         if: always()


### PR DESCRIPTION
**Motivation**

Broken ci :(

**Description**

- After the ci finishes the docker containers remain because this is a self hosted action runner. This causes the contract deployment to fail because the contracts are already deployed
- The fix is using `docker compose down` to destroy the containers on exit


