### PR TITLE
fix(l1): `eth_getProof` was returning null when it should return proof of exculsion

### DIFF
--- a/crates/networking/rpc/eth/account.rs
+++ b/crates/networking/rpc/eth/account.rs
@@ -246,24 +246,14 @@ impl RpcHandler for GetProofRequest {
             };
             storage_proofs.push(storage_proof);
         }
-        let (balance, code_hash, nonce, storage_hash) = if let Some(account) = account {
-            (
-                account.balance,
-                account.code_hash,
-                account.nonce,
-                account.storage_root,
-            )
-        } else {
-            (U256::zero(), H256::zero(), 0_u64, H256::zero())
-        };
-
+        let account = account.unwrap_or_default();
         let account_proof = AccountProof {
             account_proof,
             address: self.address,
-            balance,
-            code_hash,
-            nonce,
-            storage_hash,
+            balance: account.balance,
+            code_hash: account.code_hash,
+            nonce: account.nonce,
+            storage_hash: account.storage_root,
             storage_proof: storage_proofs,
         };
         serde_json::to_value(account_proof).map_err(|error| RpcErr::Internal(error.to_string()))


### PR DESCRIPTION
**Motivation**

The endpoint `eth_getProof` was returning null instead of a proof of exclusion when the account did not exist in the trie

**Description**

- When the account does not exist create the proof anyway and return that proof + the default values for account.
- For storage if the account does not exist return an empty array for the storage proofs. If the account exists but the storage doesn't return the exclusion proof and a value of 0x0 for that key

**How to test**

in `crates/l2`

```shell
make restart
```

Account that exists:

```Shell
curl 'http://localhost:8545' --data '{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "eth_getProof",
  "params": [
    "0x04d12759b371c0ac1e3eb9e9593a46343ffac412",
    [  "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "0x0000000000000000000000000000000000000000000000000000000000000001" ],
    "latest"
  ]
}' -H 'accept: application/json'
```
This should return a proof for the account, an exclusion proof for the first storage slot, and a inclusion proof for the second one with a value != 0

Account that does not exist:

```Shell
curl 'http://localhost:8545' --data '{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "eth_getProof",
  "params": [
    "0x04d12759b371c0ac1e3eb9e9593a46343ffac413",
    [  "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421", "0x0000000000000000000000000000000000000000000000000000000000000001" ],
    "latest"
  ]
}' -H 'accept: application/json'
```
This should return an exclusion proof for the account and empty arrays for the storage

Closes #2761

