### PR TITLE
fix(l1,levm): improve vm database methods

### DIFF
--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -45,9 +45,14 @@ impl VmDatabase for StoreVmDatabase {
             .map_err(|e| EvmError::DB(e.to_string()))
     }
 
-    fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, EvmError> {
-        self.store
-            .get_account_code(code_hash)
-            .map_err(|e| EvmError::DB(e.to_string()))
+    fn get_account_code(&self, code_hash: H256) -> Result<Bytes, EvmError> {
+        match self.store.get_account_code(code_hash) {
+            Ok(Some(code)) => Ok(code),
+            Ok(None) => Err(EvmError::DB(format!(
+                "Code not found for hash: {:?}",
+                code_hash
+            ))),
+            Err(e) => Err(EvmError::DB(e.to_string())),
+        }
     }
 }

--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use ethrex_common::{
-    types::{AccountInfo, BlockHash, ChainConfig},
+    types::{AccountInfo, BlockHash, ChainConfig, EMPTY_KECCACK_HASH},
     Address, H256, U256,
 };
 use ethrex_storage::Store;
@@ -48,6 +48,9 @@ impl VmDatabase for StoreVmDatabase {
     }
 
     fn get_account_code(&self, code_hash: H256) -> Result<Bytes, EvmError> {
+        if code_hash == *EMPTY_KECCACK_HASH {
+            return Ok(Bytes::new());
+        }
         match self.store.get_account_code(code_hash) {
             Ok(Some(code)) => Ok(code),
             Ok(None) => Err(EvmError::DB(format!(

--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -39,8 +39,10 @@ impl VmDatabase for StoreVmDatabase {
             .map(|header| H256::from(header.compute_block_hash().0)))
     }
 
-    fn get_chain_config(&self) -> ChainConfig {
-        self.store.get_chain_config().unwrap()
+    fn get_chain_config(&self) -> Result<ChainConfig, EvmError> {
+        self.store
+            .get_chain_config()
+            .map_err(|e| EvmError::DB(e.to_string()))
     }
 
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, EvmError> {

--- a/crates/l2/prover/bench/src/rpc/db.rs
+++ b/crates/l2/prover/bench/src/rpc/db.rs
@@ -425,8 +425,11 @@ impl LevmDatabase for RpcDB {
             .is_ok_and(|account| matches!(account, Account::Existing { .. }))
     }
 
-    fn get_account_code(&self, _code_hash: H256) -> Result<Option<Bytes>, DatabaseError> {
-        Ok(None) // code is stored in account info
+    fn get_account_code(&self, _code_hash: H256) -> Result<Bytes, DatabaseError> {
+        Err(DatabaseError::Custom(
+            "get_account_code is not supported for RpcDB: code is stored in account info"
+                .to_string(),
+        ))
     }
 
     fn get_account(

--- a/crates/l2/prover/bench/src/rpc/db.rs
+++ b/crates/l2/prover/bench/src/rpc/db.rs
@@ -491,8 +491,8 @@ impl LevmDatabase for RpcDB {
         Ok(Some(hash))
     }
 
-    fn get_chain_config(&self) -> ethrex_common::types::ChainConfig {
-        *CANCUN_CONFIG
+    fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
+        Ok(*CANCUN_CONFIG)
     }
 }
 

--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -80,7 +80,7 @@ impl LevmDatabase for DatabaseLogger {
         Ok(block_hash)
     }
 
-    fn get_chain_config(&self) -> ethrex_common::types::ChainConfig {
+    fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
         self.store.lock().unwrap().get_chain_config()
     }
 
@@ -139,8 +139,9 @@ impl LevmDatabase for DynVmDatabase {
             .map_err(|e| DatabaseError::Custom(e.to_string()))
     }
 
-    fn get_chain_config(&self) -> ethrex_common::types::ChainConfig {
+    fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
         <dyn VmDatabase>::get_chain_config(self.as_ref())
+            .map_err(|e| DatabaseError::Custom(e.to_string()))
     }
 
     fn get_account_code(&self, code_hash: CoreH256) -> Result<Option<bytes::Bytes>, DatabaseError> {
@@ -193,8 +194,8 @@ impl LevmDatabase for ProverDB {
         Ok(*storage.get(&key).unwrap_or(&CoreU256::default()))
     }
 
-    fn get_chain_config(&self) -> ethrex_common::types::ChainConfig {
-        self.get_chain_config()
+    fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
+        Ok(self.get_chain_config())
     }
 
     fn get_account_code(&self, code_hash: CoreH256) -> Result<Option<bytes::Bytes>, DatabaseError> {

--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -84,7 +84,7 @@ impl LevmDatabase for DatabaseLogger {
         self.store.lock().unwrap().get_chain_config()
     }
 
-    fn get_account_code(&self, code_hash: CoreH256) -> Result<Option<bytes::Bytes>, DatabaseError> {
+    fn get_account_code(&self, code_hash: CoreH256) -> Result<bytes::Bytes, DatabaseError> {
         {
             let mut code_accessed = self
                 .code_accessed
@@ -106,8 +106,7 @@ impl LevmDatabase for DynVmDatabase {
             .unwrap_or_default();
 
         let acc_code = <dyn VmDatabase>::get_account_code(self.as_ref(), acc_info.code_hash)
-            .map_err(|e| DatabaseError::Custom(e.to_string()))?
-            .unwrap_or_default();
+            .map_err(|e| DatabaseError::Custom(e.to_string()))?;
 
         Ok(Account::new(
             acc_info.balance,
@@ -144,7 +143,7 @@ impl LevmDatabase for DynVmDatabase {
             .map_err(|e| DatabaseError::Custom(e.to_string()))
     }
 
-    fn get_account_code(&self, code_hash: CoreH256) -> Result<Option<bytes::Bytes>, DatabaseError> {
+    fn get_account_code(&self, code_hash: CoreH256) -> Result<bytes::Bytes, DatabaseError> {
         <dyn VmDatabase>::get_account_code(self.as_ref(), code_hash)
             .map_err(|e| DatabaseError::Custom(e.to_string()))
     }
@@ -198,7 +197,13 @@ impl LevmDatabase for ProverDB {
         Ok(self.get_chain_config())
     }
 
-    fn get_account_code(&self, code_hash: CoreH256) -> Result<Option<bytes::Bytes>, DatabaseError> {
-        Ok(self.code.get(&code_hash).cloned())
+    fn get_account_code(&self, code_hash: CoreH256) -> Result<bytes::Bytes, DatabaseError> {
+        match self.code.get(&code_hash) {
+            Some(code) => Ok(code.clone()),
+            None => Err(DatabaseError::Custom(format!(
+                "Could not find code for hash {}",
+                code_hash
+            ))),
+        }
     }
 }

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -46,7 +46,7 @@ impl LEVM {
     ) -> Result<BlockExecutionResult, EvmError> {
         cfg_if::cfg_if! {
             if #[cfg(not(feature = "l2"))] {
-                let chain_config = db.store.get_chain_config();
+                let chain_config = db.store.get_chain_config()?;
                 let block_header = &block.header;
                 let fork = chain_config.fork(block_header.timestamp);
                 if block_header.parent_beacon_block_root.is_some() && fork >= Fork::Cancun {
@@ -99,7 +99,7 @@ impl LEVM {
         block_header: &BlockHeader,
         db: &mut GeneralizedDatabase,
     ) -> Result<Environment, EvmError> {
-        let chain_config = db.store.get_chain_config();
+        let chain_config = db.store.get_chain_config()?;
         let gas_price: U256 = tx
             .effective_gas_price(block_header.base_fee_per_gas)
             .ok_or(VMError::TxValidation(
@@ -436,7 +436,7 @@ pub fn generic_system_contract_levm(
     contract_address: Address,
     system_address: Address,
 ) -> Result<ExecutionReport, EvmError> {
-    let chain_config = db.store.get_chain_config();
+    let chain_config = db.store.get_chain_config()?;
     let config = EVMConfig::new_from_chain_config(&chain_config, block_header);
     let system_account_backup = db.cache.get(&system_address).cloned();
     let coinbase_backup = db.cache.get(&block_header.coinbase).cloned();
@@ -492,7 +492,7 @@ pub fn extract_all_requests_levm(
     db: &mut GeneralizedDatabase,
     header: &BlockHeader,
 ) -> Result<Vec<Requests>, EvmError> {
-    let chain_config = db.store.get_chain_config();
+    let chain_config = db.store.get_chain_config()?;
     let fork = chain_config.fork(header.timestamp);
 
     if fork < Fork::Prague {
@@ -564,7 +564,7 @@ fn env_from_generic(
     header: &BlockHeader,
     db: &GeneralizedDatabase,
 ) -> Result<Environment, VMError> {
-    let chain_config = db.store.get_chain_config();
+    let chain_config = db.store.get_chain_config()?;
     let gas_price = calculate_gas_price(tx, header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE));
     let config = EVMConfig::new_from_chain_config(&chain_config, header);
     Ok(Environment {

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -211,7 +211,7 @@ impl Evm {
                 Ok(())
             }
             Evm::LEVM { db } => {
-                let chain_config = db.store.get_chain_config();
+                let chain_config = db.store.get_chain_config()?;
                 let fork = chain_config.fork(block_header.timestamp);
 
                 if block_header.parent_beacon_block_root.is_some() && fork >= Fork::Cancun {

--- a/crates/vm/backends/revm/db.rs
+++ b/crates/vm/backends/revm/db.rs
@@ -49,7 +49,7 @@ impl EvmState {
     /// Gets the stored chain config
     pub fn chain_config(&self) -> Result<ChainConfig, EvmError> {
         match self {
-            EvmState::Store(db) => Ok(db.database.get_chain_config()),
+            EvmState::Store(db) => db.database.get_chain_config(),
             EvmState::Execution(db) => Ok(db.db.get_chain_config()),
         }
     }

--- a/crates/vm/backends/revm/db.rs
+++ b/crates/vm/backends/revm/db.rs
@@ -128,21 +128,20 @@ impl revm::Database for DynVmDatabase {
             None => return Ok(None),
             Some(acc_info) => acc_info,
         };
-        let code = <dyn VmDatabase>::get_account_code(self.as_ref(), acc_info.code_hash)?
-            .map(|b| RevmBytecode::new_raw(RevmBytes(b)));
+        let code = self.code_by_hash(acc_info.code_hash.0.into())?;
 
         Ok(Some(RevmAccountInfo {
             balance: RevmU256::from_limbs(acc_info.balance.0),
             nonce: acc_info.nonce,
             code_hash: RevmB256::from(acc_info.code_hash.0),
-            code,
+            code: Some(code),
         }))
     }
 
     fn code_by_hash(&mut self, code_hash: RevmB256) -> Result<RevmBytecode, Self::Error> {
-        <dyn VmDatabase>::get_account_code(self.as_ref(), CoreH256::from(code_hash.as_ref()))?
-            .map(|b| RevmBytecode::new_raw(RevmBytes(b)))
-            .ok_or_else(|| EvmError::DB(format!("No code for hash {code_hash}")))
+        let code =
+            <dyn VmDatabase>::get_account_code(self.as_ref(), CoreH256::from(code_hash.as_ref()))?;
+        Ok(RevmBytecode::new_raw(RevmBytes(code)))
     }
 
     fn storage(&mut self, address: RevmAddress, index: RevmU256) -> Result<RevmU256, Self::Error> {
@@ -173,21 +172,20 @@ impl revm::DatabaseRef for DynVmDatabase {
             None => return Ok(None),
             Some(acc_info) => acc_info,
         };
-        let code = <dyn VmDatabase>::get_account_code(self.as_ref(), acc_info.code_hash)?
-            .map(|b| RevmBytecode::new_raw(RevmBytes(b)));
+        let code = self.code_by_hash_ref(acc_info.code_hash.0.into())?;
 
         Ok(Some(RevmAccountInfo {
             balance: RevmU256::from_limbs(acc_info.balance.0),
             nonce: acc_info.nonce,
             code_hash: RevmB256::from(acc_info.code_hash.0),
-            code,
+            code: Some(code),
         }))
     }
 
     fn code_by_hash_ref(&self, code_hash: RevmB256) -> Result<RevmBytecode, Self::Error> {
-        <dyn VmDatabase>::get_account_code(self.as_ref(), CoreH256::from(code_hash.as_ref()))?
-            .map(|b| RevmBytecode::new_raw(RevmBytes(b)))
-            .ok_or_else(|| EvmError::DB(format!("No code for hash {code_hash}")))
+        let code =
+            <dyn VmDatabase>::get_account_code(self.as_ref(), CoreH256::from(code_hash.as_ref()))?;
+        Ok(RevmBytecode::new_raw(RevmBytes(code)))
     }
 
     fn storage_ref(&self, address: RevmAddress, index: RevmU256) -> Result<RevmU256, Self::Error> {

--- a/crates/vm/db.rs
+++ b/crates/vm/db.rs
@@ -10,7 +10,7 @@ pub trait VmDatabase: Send + Sync + DynClone {
     fn get_account_info(&self, address: Address) -> Result<Option<AccountInfo>, EvmError>;
     fn get_storage_slot(&self, address: Address, key: H256) -> Result<Option<U256>, EvmError>;
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>, EvmError>;
-    fn get_chain_config(&self) -> ChainConfig;
+    fn get_chain_config(&self) -> Result<ChainConfig, EvmError>;
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, EvmError>;
 }
 

--- a/crates/vm/db.rs
+++ b/crates/vm/db.rs
@@ -11,7 +11,7 @@ pub trait VmDatabase: Send + Sync + DynClone {
     fn get_storage_slot(&self, address: Address, key: H256) -> Result<Option<U256>, EvmError>;
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>, EvmError>;
     fn get_chain_config(&self) -> Result<ChainConfig, EvmError>;
-    fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, EvmError>;
+    fn get_account_code(&self, code_hash: H256) -> Result<Bytes, EvmError>;
 }
 
 dyn_clone::clone_trait_object!(VmDatabase);

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -16,5 +16,5 @@ pub trait Database: Send + Sync {
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>, DatabaseError>;
     fn account_exists(&self, address: Address) -> bool;
     fn get_chain_config(&self) -> Result<ChainConfig, DatabaseError>;
-    fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, DatabaseError>;
+    fn get_account_code(&self, code_hash: H256) -> Result<Bytes, DatabaseError>;
 }

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -15,6 +15,6 @@ pub trait Database: Send + Sync {
     fn get_storage_value(&self, address: Address, key: H256) -> Result<U256, DatabaseError>;
     fn get_block_hash(&self, block_number: u64) -> Result<Option<H256>, DatabaseError>;
     fn account_exists(&self, address: Address) -> bool;
-    fn get_chain_config(&self) -> ChainConfig;
+    fn get_chain_config(&self) -> Result<ChainConfig, DatabaseError>;
     fn get_account_code(&self, code_hash: H256) -> Result<Option<Bytes>, DatabaseError>;
 }


### PR DESCRIPTION
**Motivation**

- Be more accurate in the VM database when things go wrong. Propagating errors when adequate instead of unwrapping or ignoring them.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Stop doing unwrap when getting ChainConfig.
    - This never failed yet but we shouldn’t unwrap in case it does.
- Stop returning an `Option` when getting account code from DB, if code is not found we throw an error now.

Note: If the `code_hash` that's being looked for is `EMPTY_KECCAK_HASH` then return empty bytes.