### PR TITLE
chore(l2): stop L1 dev container faster

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -96,7 +96,7 @@ init-l1-levm: ## 🚀 Initializes an L1 Lambda ethrex Client with LEVM
     --datadir ${ethrex_L1_DEV_LIBMDBX}
 
 down-local-l1: ## 🛑 Shuts down the L1 Lambda ethrex Client
-	docker compose -f ${ethrex_DEV_DOCKER_COMPOSE_PATH} down
+	docker compose -f ${ethrex_DEV_DOCKER_COMPOSE_PATH} down -t 0
 	docker compose -f docker-compose-l2.yaml down
 
 restart-local-l1: down-local-l1 rm-db-l1 init-local-l1 ## 🔄 Restarts the L1 Lambda ethrex Client


### PR DESCRIPTION
As of today, it's the same thing to rush the time it takes to bring down the container because by default we're bringing it down after 10 seconds, and because the Makefile target is only used in cases where you don't care about the state of the DB (since it will be deleted).

Here, I created an issue to tackle the root of the problem: https://github.com/lambdaclass/ethrex/issues/2944
