### PR TITLE
fix(core): fix config file name

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -288,7 +288,7 @@ pub fn get_bootnodes(opts: &Options, network: &str, data_dir: &str) -> Vec<Node>
         warn!("No bootnodes specified. This node will not be able to connect to the network.");
     }
 
-    let config_file = PathBuf::from(data_dir.to_owned() + "/config.json");
+    let config_file = PathBuf::from(data_dir.to_owned() + "/node_config.json");
 
     info!("Reading known peers from config file {:?}", config_file);
 


### PR DESCRIPTION
**Motivation**

I were having some issues with peers note being persisted between runs

**Description**

Fixes the name of the config file from where peers are check.

