### PR TITLE
fix(l1,l2): pin libmdbx and redb versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ async-trait = "0.1.88"
 ethereum-types = { version = "0.15.1", features = ["serialize"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
-libmdbx = { version = "0.5.0", features = ["orm"] }
+libmdbx = { version = "=0.5.3", features = ["orm"] }
 bytes = { version = "1.6.0", features = ["serde"] }
 tokio = { version = "1.41.1", features = ["full"] }
 thiserror = "2.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
   "crates/storage",
   "crates/vm",
   "crates/vm/levm",
-  "crates/vm/levm/bench/revm_comparison"
+  "crates/vm/levm/bench/revm_comparison",
 ]
 resolver = "2"
 
@@ -74,7 +74,7 @@ jsonwebtoken = "9.3.0"
 rand = "0.8.5"
 cfg-if = "1.0.0"
 reqwest = { version = "0.12.7", features = ["json"] }
-redb = "2.2.0"
+redb = "=2.4.0"
 snap = "1.1.1"
 k256 = { version = "0.13.3", features = ["ecdh"] }
 secp256k1 = { version = "0.29.1", default-features = false, features = [


### PR DESCRIPTION
**Motivation**

libmdbx 0.5.4 bumps mdbx-sys to version 12.13.0 (previously 12.12.0) which uses features of Edition 2024, which is incompatible with ethrex.

update: same problem encountered with redb, pinned to 2.4.0.

