### PR TITLE
chore: remove L2 flag from cmd/utils module

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -35,7 +35,7 @@ local-ip-address = "0.6"
 tokio-util.workspace = true
 redb = { workspace = true, optional = true }
 lazy_static.workspace = true
-secp256k1 = { workspace = true, optional = true }
+secp256k1 = { workspace = true }
 keccak-hash.workspace = true
 reqwest.workspace = true
 
@@ -70,7 +70,6 @@ l2 = [
   "ethrex-vm/l2",
   "ethrex-blockchain/l2",
   "ethrex-rpc/l2",
-  "dep:secp256k1",
   "ethrex-storage-rollup",
 ]
 rollup_storage_libmdbx = ["ethrex-storage-rollup/libmdbx"]

--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -10,7 +10,6 @@ use ethrex_p2p::{
 use ethrex_rlp::decode::RLPDecode;
 use ethrex_vm::EvmEngine;
 use hex::FromHexError;
-#[cfg(feature = "l2")]
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -134,7 +133,6 @@ pub async fn store_node_config_file(config: NodeConfigFile, file_path: PathBuf) 
     };
 }
 
-#[allow(dead_code)]
 pub fn read_node_config_file(file_path: PathBuf) -> Result<NodeConfigFile, String> {
     match std::fs::File::open(file_path) {
         Ok(file) => {
@@ -144,7 +142,6 @@ pub fn read_node_config_file(file_path: PathBuf) -> Result<NodeConfigFile, Strin
     }
 }
 
-#[cfg(feature = "l2")]
 pub fn parse_private_key(s: &str) -> eyre::Result<SecretKey> {
     Ok(SecretKey::from_slice(&parse_hex(s)?)?)
 }


### PR DESCRIPTION
**Motivation**

This PR is part of an ongoing effort to simplify the L2 code and remove the `l2` feature whenever possible.

**Description**

This PR removes the `l2` feature from the `cmd/utils.rs` file.

Closes #issue_number

