### PR TITLE
fix(core): block_body validation when missing only one field

### DIFF
--- a/crates/l2/sdk/src/calldata.rs
+++ b/crates/l2/sdk/src/calldata.rs
@@ -72,7 +72,6 @@ fn parse_signature(signature: &str) -> Result<(String, Vec<String>), CalldataEnc
 
 fn compute_function_selector(name: &str, params: &[String]) -> Result<H32, CalldataEncodeError> {
     let normalized_signature = format!("{name}({})", params.join(","));
-
     let hash = keccak(normalized_signature.as_bytes());
 
     Ok(H32::from(&hash[..4].try_into().map_err(|_| {


### PR DESCRIPTION
**Motivation**

When validating blocks in the case of having only one of either `withdrawals_root` or block `withdrawals` we could still check:
- if we have `withdrawals_root` but not `withdrawals` that the root is the hash of an empty MPT


