### PR TITLE
fix(l2): remove bogus parameter from Makefile

### DIFF
--- a/cmd/ethrex_replay/Makefile
+++ b/cmd/ethrex_replay/Makefile
@@ -32,30 +32,30 @@ endif
 # Proving
 ifdef BLOCK_NUMBER
 prove-sp1:
-	SP1_PROVER=cpu cargo r -r --features sp1 -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	SP1_PROVER=cpu cargo r -r --features sp1 -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 prove-sp1-gpu:
-	SP1_PROVER=cuda cargo r -r --features "sp1,gpu" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	SP1_PROVER=cuda cargo r -r --features "sp1,gpu" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 prove-sp1-gpu-ci:
-	SP1_PROVER=cuda cargo r -r --features "sp1,gpu,ci" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	SP1_PROVER=cuda cargo r -r --features "sp1,gpu,ci" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 prove-risc0:
-	cargo r -r --no-default-features --features risc0 -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	cargo r -r --no-default-features --features risc0 -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 prove-risc0-gpu:
-	cargo r -r --no-default-features --features "risc0,gpu" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	cargo r -r --no-default-features --features "risc0,gpu" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 pico:
-	cargo +nightly r -r --features pico -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	cargo +nightly r -r --features pico -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 pico-gpu:
-	cargo +nightly r -r --features "pico,gpu" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} --prove 
+	cargo +nightly r -r --features "pico,gpu" -- prove block ${BLOCK_NUMBER} --rpc-url ${RPC_URL} 
 else
 prove-sp1:
-	SP1_PROVER=cpu cargo r -r --features sp1 -- prove block $--rpc-url ${RPC_URL} --prove
+	SP1_PROVER=cpu cargo r -r --features sp1 -- prove block $--rpc-url ${RPC_URL}
 prove-sp1-gpu:
-	SP1_PROVER=cuda cargo r -r --features "sp1,gpu" -- prove block --rpc-url ${RPC_URL} --prove
+	SP1_PROVER=cuda cargo r -r --features "sp1,gpu" -- prove block --rpc-url ${RPC_URL}
 prove-risc0:
-	cargo r -r --no-default-features --features risc0 -- prove block --rpc-url ${RPC_URL} --prove
+	cargo r -r --no-default-features --features risc0 -- prove block --rpc-url ${RPC_URL}
 prove-risc0-gpu:
-	cargo r -r --no-default-features --features "risc0,gpu" -- prove block --rpc-url ${RPC_URL} --prove
+	cargo r -r --no-default-features --features "risc0,gpu" -- prove block --rpc-url ${RPC_URL}
 pico:
-	cargo +nightly r -r --features pico -- prove block --rpc-url ${RPC_URL} --prove
+	cargo +nightly r -r --features pico -- prove block --rpc-url ${RPC_URL}
 pico-gpu:
-	cargo +nightly r -r --features "pico,gpu" -- prove block --rpc-url ${RPC_URL} --prove
+	cargo +nightly r -r --features "pico,gpu" -- prove block --rpc-url ${RPC_URL}
 endif


### PR DESCRIPTION
**Motivation**

Merging #2929 [broke a test](https://github.com/lambdaclass/ethrex/actions/runs/15310214843/job/43072861820).

**Description**

In #2929 the bench cli changed it's parameters and the Makefile was updated, and one of the arguments (--prove) was no longer needed, but wasn't removed.
