### PR TITLE
feat(l2): add cancun network to ethrex-replay

### DIFF
--- a/cmd/ethrex_replay/src/constants.rs
+++ b/cmd/ethrex_replay/src/constants.rs
@@ -43,6 +43,10 @@ pub fn make_chainconfig(chain_id: u64) -> ChainConfig {
 pub fn get_chain_config(name: &str) -> eyre::Result<ChainConfig> {
     Ok(match name {
         "mainnet" => make_chainconfig(1),
+        "cancun" => ChainConfig {
+            prague_time: None,
+            ..make_chainconfig(1)
+        },
         "holesky" => make_chainconfig(17000),
         "hoodi" => make_chainconfig(560048),
         "sepolia" => make_chainconfig(11155111),


### PR DESCRIPTION
**Motivation**

The block currently in the CI uses cancun, and to re-create it we need a cancun chain-config.

**Description**

This adds a "cancun" network, with prague deactivated.

