### PR TITLE
perf(core): remove newly added body validation until we know its needed outside of syncing

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -13,7 +13,7 @@ use ethrex_common::constants::{GAS_PER_BLOB, MIN_BASE_FEE_PER_BLOB_GAS};
 use ethrex_common::types::requests::{compute_requests_hash, EncodedRequests, Requests};
 use ethrex_common::types::MempoolTransaction;
 use ethrex_common::types::{
-    compute_receipts_root, validate_block_body, validate_block_header,
+    compute_receipts_root, validate_block_header,
     validate_cancun_header_fields, validate_prague_header_fields,
     validate_pre_cancun_header_fields, AccountUpdate, Block, BlockHash, BlockHeader, BlockNumber,
     ChainConfig, EIP4844Transaction, Receipt, Transaction,
@@ -582,7 +582,6 @@ pub fn validate_block(
     // Verify initial header validity against parent
     validate_block_header(&block.header, parent_header, elasticity_multiplier)
         .map_err(InvalidBlockError::from)?;
-    validate_block_body(block).map_err(InvalidBlockError::from)?;
 
     if chain_config.is_prague_activated(block.header.timestamp) {
         validate_prague_header_fields(&block.header, parent_header, chain_config)


### PR DESCRIPTION
**Motivation**

This removes an additional validation done on the pre-execution of blocks as part of [this PR](https://github.com/lambdaclass/ethrex/pull/2658)

**Description**

Remove the call to the `validate_block_body` in `validate_block`

Closes #issue_number

