### PR TITLE
fix(l2): store batch before sending

### DIFF
--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -186,6 +186,15 @@ async fn commit_next_batch_to_l1(state: &mut CommitterState) -> Result<(), Commi
     }
 
     let withdrawal_logs_merkle_root = get_withdrawals_merkle_root(withdrawal_hashes.clone())?;
+    state
+        .rollup_store
+        .store_batch(
+            batch_to_commit,
+            first_block_to_commit,
+            last_block_of_batch,
+            withdrawal_hashes,
+        )
+        .await?;
 
     info!("Sending commitment for batch {batch_to_commit}. first_block: {first_block_to_commit}, last_block: {last_block_of_batch}");
 
@@ -217,7 +226,6 @@ async fn commit_next_batch_to_l1(state: &mut CommitterState) -> Result<(), Commi
                 info!(
                     "Sent commitment for batch {batch_to_commit}, with tx hash {commit_tx_hash:#x}.",
                 );
-                state.rollup_store.store_batch(batch_to_commit, first_block_to_commit, last_block_of_batch, withdrawal_hashes).await?;
                 Ok(())
             }
             Err(error) => Err(CommitterError::FailedToSendCommitment(format!(

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -112,6 +112,16 @@ impl L1ProofSender {
             .get_last_verified_batch(self.on_chain_proposer_address)
             .await?;
 
+        let last_committed_batch = self
+            .eth_client
+            .get_last_committed_batch(self.on_chain_proposer_address)
+            .await?;
+
+        if last_committed_batch != batch_to_verify {
+            info!("Next batch to verify ({batch_to_verify}) is not yet committed");
+            return Ok(());
+        }
+
         if batch_number_has_all_needed_proofs(batch_to_verify, &self.needed_proof_types)
             .is_ok_and(|has_all_proofs| has_all_proofs)
         {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
There's a bug where the L1 committer sends a transaction and it's not confirmed within the expected period, so the committer assumes a failure and returns an error. Then, if the transaction is eventually executed, the batch is never stored. This provokes that the proof coordinator doesn't have the batch to send to the prover, so the batch is never verified.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Store the batch before sending the commitment transaction. Then, in the proof sender, check that the next batch to verify corresponds with the last committed block.

<!-- Link to issues: Resolves #111, Resolves #222 -->



