### PR TITLE
Remove `storage` dep from `vm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,7 +3465,6 @@ dependencies = [
  "ethrex-common",
  "ethrex-levm",
  "ethrex-rlp",
- "ethrex-storage",
  "ethrex-trie",
  "hex",
  "lazy_static",

--- a/crates/l2/prover/src/backends/exec.rs
+++ b/crates/l2/prover/src/backends/exec.rs
@@ -3,7 +3,7 @@ use ethrex_common::types::AccountUpdate;
 use ethrex_common::Address;
 use ethrex_l2::utils::prover::proving_systems::{ProofCalldata, ProverType};
 use ethrex_l2_sdk::calldata::Value;
-use ethrex_vm::Evm;
+use ethrex_vm::{Evm, EvmEngine};
 use std::collections::HashMap;
 use tracing::warn;
 #[cfg(feature = "l2")]
@@ -81,7 +81,7 @@ pub fn execution_program(input: ProgramInput) -> Result<ProgramOutput, Box<dyn s
         )?;
 
         // Execute block
-        let mut vm = Evm::from_prover_db(db.clone());
+        let mut vm = Evm::new(EvmEngine::LEVM, db.clone());
         let result = vm.execute_block(&block)?;
         let receipts = result.receipts;
         let account_updates = vm.get_state_transitions()?;

--- a/crates/l2/utils/prover/db.rs
+++ b/crates/l2/utils/prover/db.rs
@@ -12,7 +12,9 @@ use ethrex_vm::backends::levm::db::DatabaseLogger;
 use ethrex_vm::{DynVmDatabase, Evm, ProverDB, ProverDBError};
 
 pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, ProverDBError> {
-    let chain_config = store.get_chain_config()?;
+    let chain_config = store
+        .get_chain_config()
+        .map_err(|e| ProverDBError::Store(e.to_string()))?;
     let Some(first_block_parent_hash) = blocks.first().map(|e| e.header.parent_hash) else {
         return Err(ProverDBError::Custom("Unable to get first block".into()));
     };
@@ -64,7 +66,11 @@ pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, P
             store
                 .get_account_info_by_hash(first_block_parent_hash, *address)
                 .transpose()
-                .map(|account| Ok((*address, account?)))
+                .map(|account| {
+                    account
+                        .map(|a| (*address, a))
+                        .map_err(|e| ProverDBError::Store(e.to_string()))
+                })
         })
         .collect::<Result<HashMap<_, _>, ProverDBError>>()?;
 
@@ -79,10 +85,11 @@ pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, P
         .map(|account| account.code_hash)
         .chain(code_accessed.into_iter())
         .filter_map(|hash| {
-            store
-                .get_account_code(hash)
-                .transpose()
-                .map(|account| Ok((hash, account?)))
+            store.get_account_code(hash).transpose().map(|account| {
+                account
+                    .map(|a| (hash, a))
+                    .map_err(|e| ProverDBError::Store(e.to_string()))
+            })
         })
         .collect::<Result<HashMap<_, _>, ProverDBError>>()?;
 
@@ -106,7 +113,11 @@ pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, P
                     store
                         .get_storage_at_hash(first_block_parent_hash, address, *key)
                         .transpose()
-                        .map(|value| Ok((*key, value?)))
+                        .map(|value| {
+                            value
+                                .map(|v| (*key, v))
+                                .map_err(|e| ProverDBError::Store(e.to_string()))
+                        })
                 })
                 .collect();
             Ok((address, keys?))
@@ -124,10 +135,12 @@ pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, P
 
     // get account proofs
     let state_trie = store
-        .state_trie(last_block.hash())?
+        .state_trie(last_block.hash())
+        .map_err(|e| ProverDBError::Store(e.to_string()))?
         .ok_or(ProverDBError::NewMissingStateTrie(last_block.hash()))?;
     let parent_state_trie = store
-        .state_trie(first_block_parent_hash)?
+        .state_trie(first_block_parent_hash)
+        .map_err(|e| ProverDBError::Store(e.to_string()))?
         .ok_or(ProverDBError::NewMissingStateTrie(first_block_parent_hash))?;
     let hashed_addresses: Vec<_> = state_accessed.keys().map(hash_address).collect();
     let initial_state_proofs = parent_state_trie.get_proofs(&hashed_addresses)?;
@@ -149,15 +162,21 @@ pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, P
     let mut storage_proofs = HashMap::new();
     let mut final_storage_proofs = HashMap::new();
     for (address, storage_keys) in state_accessed {
-        let Some(parent_storage_trie) = store.storage_trie(first_block_parent_hash, address)?
+        let Some(parent_storage_trie) = store
+            .storage_trie(first_block_parent_hash, address)
+            .map_err(|e| ProverDBError::Store(e.to_string()))?
         else {
             // the storage of this account was empty or the account is newly created, either
             // way the storage trie was initially empty so there aren't any proofs to add.
             continue;
         };
-        let storage_trie = store.storage_trie(last_block.hash(), address)?.ok_or(
-            ProverDBError::NewMissingStorageTrie(last_block.hash(), address),
-        )?;
+        let storage_trie = store
+            .storage_trie(last_block.hash(), address)
+            .map_err(|e| ProverDBError::Store(e.to_string()))?
+            .ok_or(ProverDBError::NewMissingStorageTrie(
+                last_block.hash(),
+                address,
+            ))?;
         let paths = storage_keys.iter().map(hash_key).collect::<Vec<_>>();
 
         let initial_proofs = parent_storage_trie.get_proofs(&paths)?;

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 ethrex-common.workspace = true
-ethrex-storage.workspace = true
 ethrex-levm.workspace = true
 ethrex-trie.workspace = true
 ethrex-rlp.workspace = true

--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -1,7 +1,6 @@
 use ethrex_common::types::Account;
 use ethrex_common::U256 as CoreU256;
 use ethrex_common::{Address as CoreAddress, H256 as CoreH256};
-// use ethrex_levm::constants::EMPTY_CODE_HASH;
 use ethrex_levm::db::Database as LevmDatabase;
 
 use crate::db::DynVmDatabase;
@@ -146,69 +145,3 @@ impl LevmDatabase for DynVmDatabase {
             .map_err(|e| DatabaseError::Custom(e.to_string()))
     }
 }
-
-// impl LevmDatabase for ProverDBError {
-//     fn get_account(&self, address: CoreAddress) -> Result<Account, DatabaseError> {
-//         let Some(acc_info) = self.accounts.get(&address) else {
-//             return Ok(Account::default());
-//         };
-
-//         let acc_code = if acc_info.code_hash != EMPTY_CODE_HASH {
-//             self.code
-//                 .get(&acc_info.code_hash)
-//                 .ok_or(DatabaseError::Custom(format!(
-//                     "Could not find account's code hash {}",
-//                     &acc_info.code_hash
-//                 )))?
-//         } else {
-//             &bytes::Bytes::new()
-//         };
-
-//         Ok(Account::new(
-//             acc_info.balance,
-//             acc_code.clone(),
-//             acc_info.nonce,
-//             HashMap::new(),
-//         ))
-//     }
-
-//     fn account_exists(&self, address: CoreAddress) -> bool {
-//         self.accounts.contains_key(&address)
-//     }
-
-//     fn get_block_hash(&self, block_number: u64) -> Result<CoreH256, DatabaseError> {
-//         self.block_hashes
-//             .get(&block_number)
-//             .cloned()
-//             .ok_or_else(|| {
-//                 DatabaseError::Custom(format!(
-//                     "Block hash not found for block number {block_number}"
-//                 ))
-//             })
-//     }
-
-//     fn get_storage_value(
-//         &self,
-//         address: CoreAddress,
-//         key: CoreH256,
-//     ) -> Result<CoreU256, DatabaseError> {
-//         let Some(storage) = self.storage.get(&address) else {
-//             return Ok(CoreU256::default());
-//         };
-//         Ok(*storage.get(&key).unwrap_or(&CoreU256::default()))
-//     }
-
-//     fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
-//         Ok(self.get_chain_config())
-//     }
-
-//     fn get_account_code(&self, code_hash: CoreH256) -> Result<bytes::Bytes, DatabaseError> {
-//         match self.code.get(&code_hash) {
-//             Some(code) => Ok(code.clone()),
-//             None => Err(DatabaseError::Custom(format!(
-//                 "Could not find code for hash {}",
-//                 code_hash
-//             ))),
-//         }
-//     }
-// }

--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -1,11 +1,11 @@
 use ethrex_common::types::Account;
 use ethrex_common::U256 as CoreU256;
 use ethrex_common::{Address as CoreAddress, H256 as CoreH256};
-use ethrex_levm::constants::EMPTY_CODE_HASH;
+// use ethrex_levm::constants::EMPTY_CODE_HASH;
 use ethrex_levm::db::Database as LevmDatabase;
 
 use crate::db::DynVmDatabase;
-use crate::{ProverDB, VmDatabase};
+use crate::VmDatabase;
 use ethrex_levm::db::error::DatabaseError;
 use std::collections::HashMap;
 use std::result::Result;
@@ -147,68 +147,68 @@ impl LevmDatabase for DynVmDatabase {
     }
 }
 
-impl LevmDatabase for ProverDB {
-    fn get_account(&self, address: CoreAddress) -> Result<Account, DatabaseError> {
-        let Some(acc_info) = self.accounts.get(&address) else {
-            return Ok(Account::default());
-        };
+// impl LevmDatabase for ProverDBError {
+//     fn get_account(&self, address: CoreAddress) -> Result<Account, DatabaseError> {
+//         let Some(acc_info) = self.accounts.get(&address) else {
+//             return Ok(Account::default());
+//         };
 
-        let acc_code = if acc_info.code_hash != EMPTY_CODE_HASH {
-            self.code
-                .get(&acc_info.code_hash)
-                .ok_or(DatabaseError::Custom(format!(
-                    "Could not find account's code hash {}",
-                    &acc_info.code_hash
-                )))?
-        } else {
-            &bytes::Bytes::new()
-        };
+//         let acc_code = if acc_info.code_hash != EMPTY_CODE_HASH {
+//             self.code
+//                 .get(&acc_info.code_hash)
+//                 .ok_or(DatabaseError::Custom(format!(
+//                     "Could not find account's code hash {}",
+//                     &acc_info.code_hash
+//                 )))?
+//         } else {
+//             &bytes::Bytes::new()
+//         };
 
-        Ok(Account::new(
-            acc_info.balance,
-            acc_code.clone(),
-            acc_info.nonce,
-            HashMap::new(),
-        ))
-    }
+//         Ok(Account::new(
+//             acc_info.balance,
+//             acc_code.clone(),
+//             acc_info.nonce,
+//             HashMap::new(),
+//         ))
+//     }
 
-    fn account_exists(&self, address: CoreAddress) -> bool {
-        self.accounts.contains_key(&address)
-    }
+//     fn account_exists(&self, address: CoreAddress) -> bool {
+//         self.accounts.contains_key(&address)
+//     }
 
-    fn get_block_hash(&self, block_number: u64) -> Result<CoreH256, DatabaseError> {
-        self.block_hashes
-            .get(&block_number)
-            .cloned()
-            .ok_or_else(|| {
-                DatabaseError::Custom(format!(
-                    "Block hash not found for block number {block_number}"
-                ))
-            })
-    }
+//     fn get_block_hash(&self, block_number: u64) -> Result<CoreH256, DatabaseError> {
+//         self.block_hashes
+//             .get(&block_number)
+//             .cloned()
+//             .ok_or_else(|| {
+//                 DatabaseError::Custom(format!(
+//                     "Block hash not found for block number {block_number}"
+//                 ))
+//             })
+//     }
 
-    fn get_storage_value(
-        &self,
-        address: CoreAddress,
-        key: CoreH256,
-    ) -> Result<CoreU256, DatabaseError> {
-        let Some(storage) = self.storage.get(&address) else {
-            return Ok(CoreU256::default());
-        };
-        Ok(*storage.get(&key).unwrap_or(&CoreU256::default()))
-    }
+//     fn get_storage_value(
+//         &self,
+//         address: CoreAddress,
+//         key: CoreH256,
+//     ) -> Result<CoreU256, DatabaseError> {
+//         let Some(storage) = self.storage.get(&address) else {
+//             return Ok(CoreU256::default());
+//         };
+//         Ok(*storage.get(&key).unwrap_or(&CoreU256::default()))
+//     }
 
-    fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
-        Ok(self.get_chain_config())
-    }
+//     fn get_chain_config(&self) -> Result<ethrex_common::types::ChainConfig, DatabaseError> {
+//         Ok(self.get_chain_config())
+//     }
 
-    fn get_account_code(&self, code_hash: CoreH256) -> Result<bytes::Bytes, DatabaseError> {
-        match self.code.get(&code_hash) {
-            Some(code) => Ok(code.clone()),
-            None => Err(DatabaseError::Custom(format!(
-                "Could not find code for hash {}",
-                code_hash
-            ))),
-        }
-    }
-}
+//     fn get_account_code(&self, code_hash: CoreH256) -> Result<bytes::Bytes, DatabaseError> {
+//         match self.code.get(&code_hash) {
+//             Some(code) => Ok(code.clone()),
+//             None => Err(DatabaseError::Custom(format!(
+//                 "Could not find code for hash {}",
+//                 code_hash
+//             ))),
+//         }
+//     }
+// }

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -15,7 +15,7 @@ use ethrex_common::types::{
 use ethrex_common::Address;
 pub use ethrex_levm::call_frame::CallFrameBackup;
 use ethrex_levm::db::gen_db::GeneralizedDatabase;
-use ethrex_levm::db::{CacheDB, Database};
+use ethrex_levm::db::{CacheDB, Database as LevmDatabase};
 use levm::LEVM;
 use revm::db::EvmState;
 use revm::REVM;
@@ -83,15 +83,17 @@ impl Evm {
         }
     }
 
-    pub fn new_from_db(store: Arc<impl Database + 'static>) -> Self {
+    pub fn new_from_db(store: Arc<impl LevmDatabase + 'static>) -> Self {
         Evm::LEVM {
             db: GeneralizedDatabase::new(store, CacheDB::new()),
         }
     }
 
     pub fn from_prover_db(db: ProverDB) -> Self {
+        let wrapped_db: DynVmDatabase = Box::new(db);
+
         Evm::LEVM {
-            db: GeneralizedDatabase::new(Arc::new(db), CacheDB::new()),
+            db: GeneralizedDatabase::new(Arc::new(wrapped_db), CacheDB::new()),
         }
     }
 

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -6,7 +6,6 @@ use crate::db::{DynVmDatabase, VmDatabase};
 use crate::errors::EvmError;
 use crate::execution_result::ExecutionResult;
 use crate::helpers::{fork_to_spec_id, spec_id, SpecId};
-use crate::ProverDB;
 use ethrex_common::types::requests::Requests;
 use ethrex_common::types::{
     AccessList, AccountUpdate, Block, BlockHeader, Fork, GenericTransaction, Receipt, Transaction,
@@ -86,14 +85,6 @@ impl Evm {
     pub fn new_from_db(store: Arc<impl LevmDatabase + 'static>) -> Self {
         Evm::LEVM {
             db: GeneralizedDatabase::new(store, CacheDB::new()),
-        }
-    }
-
-    pub fn from_prover_db(db: ProverDB) -> Self {
-        let wrapped_db: DynVmDatabase = Box::new(db);
-
-        Evm::LEVM {
-            db: GeneralizedDatabase::new(Arc::new(wrapped_db), CacheDB::new()),
         }
     }
 

--- a/crates/vm/backends/revm/db.rs
+++ b/crates/vm/backends/revm/db.rs
@@ -66,51 +66,6 @@ impl From<DynVmDatabase> for EvmState {
     }
 }
 
-// impl DatabaseRef for ProverDB {
-//     /// The database error type.
-//     type Error = ProverDBError;
-
-//     /// Get basic account information.
-//     fn basic_ref(&self, address: RevmAddress) -> Result<Option<RevmAccountInfo>, Self::Error> {
-//         let Some(account_info) = self.accounts.get(&CoreAddress::from(address.0.as_ref())) else {
-//             return Ok(None);
-//         };
-
-//         Ok(Some(RevmAccountInfo {
-//             balance: RevmU256::from_limbs(account_info.balance.0),
-//             nonce: account_info.nonce,
-//             code_hash: RevmB256::from_slice(&account_info.code_hash.0),
-//             code: None,
-//         }))
-//     }
-
-//     /// Get account code by its hash.
-//     fn code_by_hash_ref(&self, code_hash: RevmB256) -> Result<RevmBytecode, Self::Error> {
-//         self.code
-//             .get(&CoreH256::from(code_hash.as_ref()))
-//             .map(|b| RevmBytecode::new_raw(RevmBytes(b.clone())))
-//             .ok_or(ProverDBError::CodeNotFound(code_hash))
-//     }
-
-//     /// Get storage value of address at index.
-//     fn storage_ref(&self, address: RevmAddress, index: RevmU256) -> Result<RevmU256, Self::Error> {
-//         self.storage
-//             .get(&CoreAddress::from(address.0.as_ref()))
-//             .ok_or(ProverDBError::AccountNotFound(address))?
-//             .get(&CoreH256::from(index.to_be_bytes()))
-//             .map(|v| RevmU256::from_limbs(v.0))
-//             .ok_or(ProverDBError::StorageValueNotFound(address, index))
-//     }
-
-//     /// Get block hash by block number.
-//     fn block_hash_ref(&self, number: u64) -> Result<RevmB256, Self::Error> {
-//         self.block_hashes
-//             .get(&number)
-//             .map(|h| RevmB256::from_slice(&h.0))
-//             .ok_or(ProverDBError::BlockHashNotFound(number))
-//     }
-// }
-
 impl revm::Database for DynVmDatabase {
     type Error = EvmError;
 

--- a/crates/vm/backends/revm/mod.rs
+++ b/crates/vm/backends/revm/mod.rs
@@ -380,7 +380,7 @@ impl REVM {
                     // Update account info in DB
                     if let Some(new_acc_info) = account.info() {
                         // If code changed, update
-                        if matches!(db.db.accounts.get(&address), Some(account) if B256::from(account.code_hash.0) != new_acc_info.code_hash)
+                        if matches!(db.db.get_account_info(address), Ok(Some(account)) if B256::from(account.code_hash.0) != new_acc_info.code_hash)
                         {
                             account_update.code = new_acc_info
                                 .code

--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -1,7 +1,6 @@
 use ethereum_types::{H160, H256};
 use ethrex_common::{types::BlockHash, Address};
 use ethrex_levm::{db::error::DatabaseError, errors::VMError};
-use ethrex_storage::error::StoreError;
 use ethrex_trie::TrieError;
 use revm::primitives::{
     result::EVMError as RevmError, Address as RevmAddress, B256 as RevmB256, U256 as RevmU256,
@@ -96,18 +95,6 @@ pub enum StateProofsError {
     StorageProofNotFound(RevmAddress, RevmU256),
 }
 
-impl From<RevmError<StoreError>> for EvmError {
-    fn from(value: RevmError<StoreError>) -> Self {
-        match value {
-            RevmError::Transaction(err) => EvmError::Transaction(err.to_string()),
-            RevmError::Header(err) => EvmError::Header(err.to_string()),
-            RevmError::Database(err) => EvmError::DB(err.to_string()),
-            RevmError::Custom(err) => EvmError::Custom(err),
-            RevmError::Precompile(err) => EvmError::Precompile(err),
-        }
-    }
-}
-
 impl From<RevmError<EvmError>> for EvmError {
     fn from(value: RevmError<EvmError>) -> Self {
         match value {
@@ -140,11 +127,5 @@ impl From<VMError> for EvmError {
             // If an error is not internal it means it is a transaction validation error.
             EvmError::Transaction(value.to_string())
         }
-    }
-}
-
-impl From<StoreError> for ProverDBError {
-    fn from(err: StoreError) -> Self {
-        ProverDBError::Store(err.to_string())
     }
 }

--- a/crates/vm/levm/bench/revm_comparison/src/lib.rs
+++ b/crates/vm/levm/bench/revm_comparison/src/lib.rs
@@ -9,7 +9,8 @@ use ethrex_levm::{
     vm::VM,
     Environment,
 };
-use ethrex_vm::ProverDB;
+use ethrex_vm::{DynVmDatabase, ProverDB};
+// use ethrex_vm::ProverDB;
 use revm::{
     db::BenchmarkDB,
     primitives::{address, Address, Bytecode, TransactTo},
@@ -61,7 +62,10 @@ pub fn run_with_levm(program: &str, runs: u64, calldata: &str) {
         prover_db.accounts.insert(*address, account.info.clone());
     });
 
-    let mut db = GeneralizedDatabase::new(Arc::new(prover_db), CacheDB::new());
+    let mut db = GeneralizedDatabase::new(
+        Arc::new(Box::new(prover_db) as DynVmDatabase),
+        CacheDB::new(),
+    );
 
     cache::insert_account(
         &mut db.cache,

--- a/crates/vm/prover_db.rs
+++ b/crates/vm/prover_db.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use ethereum_types::H160;
 use ethrex_common::{
-    types::{AccountInfo, AccountUpdate, ChainConfig},
+    types::{AccountInfo, AccountUpdate, ChainConfig, EMPTY_KECCACK_HASH},
     Address, H256, U256,
 };
 use ethrex_trie::{NodeRLP, Trie, TrieError};
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::errors::ProverDBError;
+use crate::{EvmError, VmDatabase};
 
 /// In-memory EVM database for single batch execution data.
 ///
@@ -101,5 +102,43 @@ impl ProverDB {
                 }
             }
         }
+    }
+}
+
+impl VmDatabase for ProverDB {
+    fn get_account_info(&self, address: Address) -> Result<Option<AccountInfo>, EvmError> {
+        Ok(self.accounts.get(&address).cloned())
+    }
+
+    fn get_storage_slot(&self, address: Address, key: H256) -> Result<Option<U256>, EvmError> {
+        Ok(self.storage
+            .get(&address)
+            .and_then(|storage| storage.get(&key).cloned()))
+    }
+
+    fn get_block_hash(&self, block_number: u64) -> Result<H256, EvmError> {
+        self.block_hashes
+            .get(&block_number)
+            .cloned()
+            .ok_or_else(|| EvmError::DB(format!(
+                "Block hash not found for block number {block_number}"
+            )))
+    }
+
+    fn get_chain_config(&self) -> Result<ChainConfig, EvmError> {
+        Ok(self.get_chain_config())
+    }
+
+    fn get_account_code(&self, code_hash: H256) -> Result<Bytes, EvmError> {
+        if code_hash == *EMPTY_KECCACK_HASH {
+            return Ok(Bytes::new());
+        }
+        self.code
+            .get(&code_hash)
+            .cloned()
+            .ok_or_else(|| EvmError::DB(format!(
+                "Code not found for hash: {:?}",
+                code_hash
+            )))
     }
 }


### PR DESCRIPTION
**Motivation**
Decouple storage crate from vm crate

**Description**
- Implements `VmDatabase` from `ProverDB`.
- Removes the last bit of references to `storage` from within `vm`.

