### PR TITLE
chore(ci): bump version of 'actions/attest-build-provenance'

### DIFF
--- a/.github/workflows/main_docker_publish.yaml
+++ b/.github/workflows/main_docker_publish.yaml
@@ -49,7 +49,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
**Motivation**

Reviewing https://github.com/lambdaclass/rex/pull/125, we found that the version used of `actions/attest-build-provenance` is v1, while the latest one is v2.

**Description**

This PR bumps the version of `actions/attest-build-provenance` to v2.


