### PR TITLE
fix(l2): change watcher block delay to 10 blocks instead of 128

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -190,7 +190,7 @@ pub struct WatcherOptions {
     pub l2_proposer_private_key: SecretKey,
     #[arg(
         long = "watcher.block-delay",
-        default_value_t = 128, // 2 L1 epochs.
+        default_value_t = 10, // 2 L1 epochs.
         value_name = "UINT64",
         env = "ETHREX_WATCHER_BLOCK_DELAY",
         help = "Number of blocks the L1 watcher waits before trusting an L1 block.",


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

