### PR TITLE
fix(core): allow preset networks on `import` subcommand

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -272,12 +272,9 @@ impl Subcommand {
                     .await?;
                 }
 
-                let network = opts
-                    .network
-                    .as_ref()
-                    .expect("--network is required and it was not provided");
+                let network = get_network(opts);
 
-                import_blocks(&path, &opts.datadir, network, opts.evm).await;
+                import_blocks(&path, &opts.datadir, &network, opts.evm).await;
             }
             Subcommand::ComputeStateRoot { genesis_path } => {
                 compute_state_root(genesis_path.to_str().expect("Invalid genesis path"));


### PR DESCRIPTION
**Motivation**
Currenlty, the `import` subcommand obtains the network directly from the cli instead of using `get_network` function which maps known network names to their preset genesis files. This prevents us from using the `import` subcommand as a means of syncing the node to a network by exporting blocks from a node that is currently synced.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Use `get_network` function to obtain the network in `import` subcommand
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but will probably be useful for #2875 

