### PR TITLE
feat(l1): improve ancestor retrieval for canonical blocks

### DIFF
--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -34,8 +34,16 @@ impl VmDatabase for StoreVmDatabase {
 
     fn get_block_hash(&self, block_number: u64) -> Result<H256, EvmError> {
         // First check if our block is canonical, if it is then it's ancestor will also be canonical and we can look it up directly
-        if self.store.is_canonical_sync(self.block_hash)? {
-            if let Some(hash) = self.store.get_canonical_block_hash_sync(block_number)? {
+        if self
+            .store
+            .is_canonical_sync(self.block_hash)
+            .map_err(|err| EvmError::DB(err.to_string()))?
+        {
+            if let Some(hash) = self
+                .store
+                .get_canonical_block_hash_sync(block_number)
+                .map_err(|err| EvmError::DB(err.to_string()))?
+            {
                 return Ok(hash);
             }
         // If our block is not canonical then we must look for the target in our block's ancestors

--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -33,20 +33,28 @@ impl VmDatabase for StoreVmDatabase {
     }
 
     fn get_block_hash(&self, block_number: u64) -> Result<H256, EvmError> {
-        for ancestor_res in self.store.ancestors(self.block_hash) {
-            let (hash, ancestor) = ancestor_res.map_err(|e| EvmError::DB(e.to_string()))?;
-            match ancestor.number.cmp(&block_number) {
-                Ordering::Greater => continue,
-                Ordering::Equal => return Ok(hash),
-                Ordering::Less => {
-                    return Err(EvmError::DB(format!(
-                        "Block number requested {} is higher than the current block number {}",
-                        block_number, ancestor.number
-                    )))
+        // First check if our block is canonical, if it is then it's ancestor will also be canonical and we can look it up directly
+        if self.store.is_canonical_sync(self.block_hash)? {
+            if let Some(hash) = self.store.get_canonical_block_hash_sync(block_number)? {
+                return Ok(hash);
+            }
+        // If our block is not canonical then we must look for the target in our block's ancestors
+        } else {
+            for ancestor_res in self.store.ancestors(self.block_hash) {
+                let (hash, ancestor) = ancestor_res.map_err(|e| EvmError::DB(e.to_string()))?;
+                match ancestor.number.cmp(&block_number) {
+                    Ordering::Greater => continue,
+                    Ordering::Equal => return Ok(hash),
+                    Ordering::Less => {
+                        return Err(EvmError::DB(format!(
+                            "Block number requested {} is higher than the current block number {}",
+                            block_number, ancestor.number
+                        )))
+                    }
                 }
             }
         }
-
+        // Block not found
         Err(EvmError::DB(format!(
             "Block hash not found for block number {block_number}"
         )))

--- a/crates/storage/api.rs
+++ b/crates/storage/api.rs
@@ -391,4 +391,26 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
         &self,
         block: BlockHash,
     ) -> Result<Option<BlockHash>, StoreError>;
+
+    /// Obtain block number for a given hash
+    fn get_block_number_sync(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<BlockNumber>, StoreError>;
+
+    /// Get the canonical block hash for a given block number.
+    fn get_canonical_block_hash_sync(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHash>, StoreError>;
+
+    /// Checks if a given block belongs to the current canonical chain. Returns false if the block is not known
+    fn is_canonical_sync(&self, block_hash: BlockHash) -> Result<bool, StoreError> {
+        let Some(block_number) = self.get_block_number_sync(block_hash)? else {
+            return Ok(false);
+        };
+        Ok(self
+            .get_canonical_block_hash_sync(block_number)?
+            .is_some_and(|h| h == block_hash))
+    }
 }

--- a/crates/storage/api.rs
+++ b/crates/storage/api.rs
@@ -403,14 +403,4 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<BlockHash>, StoreError>;
-
-    /// Checks if a given block belongs to the current canonical chain. Returns false if the block is not known
-    fn is_canonical_sync(&self, block_hash: BlockHash) -> Result<bool, StoreError> {
-        let Some(block_number) = self.get_block_number_sync(block_hash)? else {
-            return Ok(false);
-        };
-        Ok(self
-            .get_canonical_block_hash_sync(block_number)?
-            .is_some_and(|h| h == block_hash))
-    }
 }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1117,7 +1117,13 @@ impl Store {
 
     /// Checks if a given block belongs to the current canonical chain. Returns false if the block is not known
     pub fn is_canonical_sync(&self, block_hash: BlockHash) -> Result<bool, StoreError> {
-        self.engine.is_canonical_sync(block_hash)
+        let Some(block_number) = self.engine.get_block_number_sync(block_hash)? else {
+            return Ok(false);
+        };
+        Ok(self
+            .engine
+            .get_canonical_block_hash_sync(block_number)?
+            .is_some_and(|h| h == block_hash))
     }
 }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1106,6 +1106,19 @@ impl Store {
             next_hash: block_hash,
         }
     }
+
+    /// Get the canonical block hash for a given block number.
+    pub fn get_canonical_block_hash_sync(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHash>, StoreError> {
+        self.engine.get_canonical_block_hash_sync(block_number)
+    }
+
+    /// Checks if a given block belongs to the current canonical chain. Returns false if the block is not known
+    pub fn is_canonical_sync(&self, block_hash: BlockHash) -> Result<bool, StoreError> {
+        self.engine.is_canonical_sync(block_hash)
+    }
 }
 
 pub struct AncestorIterator {

--- a/crates/storage/store_db/in_memory.rs
+++ b/crates/storage/store_db/in_memory.rs
@@ -214,11 +214,18 @@ impl StoreEngine for Store {
         Ok(())
     }
 
-    async fn get_block_number(
+    fn get_block_number_sync(
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<BlockNumber>, StoreError> {
         Ok(self.inner().block_numbers.get(&block_hash).copied())
+    }
+
+    async fn get_block_number(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        self.get_block_number_sync(block_hash)
     }
 
     async fn add_transaction_location(
@@ -406,11 +413,18 @@ impl StoreEngine for Store {
         Ok(())
     }
 
-    async fn get_canonical_block_hash(
+    fn get_canonical_block_hash_sync(
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<BlockHash>, StoreError> {
         Ok(self.inner().canonical_hashes.get(&block_number).cloned())
+    }
+
+    async fn get_canonical_block_hash(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHash>, StoreError> {
+        self.get_canonical_block_hash_sync(block_number)
     }
 
     async fn unset_canonical_block(&self, number: BlockNumber) -> Result<(), StoreError> {

--- a/crates/storage/store_db/libmdbx.rs
+++ b/crates/storage/store_db/libmdbx.rs
@@ -281,6 +281,13 @@ impl StoreEngine for Store {
         self.read::<BlockNumbers>(block_hash.into()).await
     }
 
+    fn get_block_number_sync(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        self.read_sync::<BlockNumbers>(block_hash.into())
+    }
+
     async fn add_account_code(&self, code_hash: H256, code: Bytes) -> Result<(), StoreError> {
         self.write::<AccountCodes>(code_hash.into(), code.into())
             .await
@@ -514,6 +521,14 @@ impl StoreEngine for Store {
     ) -> Result<Option<BlockHash>, StoreError> {
         self.read::<CanonicalBlockHashes>(number)
             .await
+            .map(|o| o.map(|hash_rlp| hash_rlp.to()))
+    }
+
+    fn get_canonical_block_hash_sync(
+        &self,
+        number: BlockNumber,
+    ) -> Result<Option<BlockHash>, StoreError> {
+        self.read_sync::<CanonicalBlockHashes>(number)
             .map(|o| o.map(|hash_rlp| hash_rlp.to()))
     }
 

--- a/crates/storage/store_db/redb.rs
+++ b/crates/storage/store_db/redb.rs
@@ -531,6 +531,19 @@ impl StoreEngine for RedBStore {
             .map(|b| b.value()))
     }
 
+    fn get_block_number_sync(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        Ok(self
+            .read_sync(
+                BLOCK_NUMBERS_TABLE,
+                <H256 as Into<BlockHashRLP>>::into(block_hash),
+            )
+            .await?
+            .map(|b| b.value()))
+    }
+
     async fn add_transaction_location(
         &self,
         transaction_hash: ethrex_common::H256,
@@ -655,6 +668,15 @@ impl StoreEngine for RedBStore {
         block_number: BlockNumber,
     ) -> Result<Option<BlockHash>, StoreError> {
         self.read(CANONICAL_BLOCK_HASHES_TABLE, block_number)
+            .await
+            .map(|o| o.map(|hash_rlp| hash_rlp.value().to()))
+    }
+
+    fn get_canonical_block_hash_sync(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHash>, StoreError> {
+        self.read_sync(CANONICAL_BLOCK_HASHES_TABLE, block_number)
             .await
             .map(|o| o.map(|hash_rlp| hash_rlp.value().to()))
     }

--- a/crates/storage/store_db/redb.rs
+++ b/crates/storage/store_db/redb.rs
@@ -539,8 +539,7 @@ impl StoreEngine for RedBStore {
             .read_sync(
                 BLOCK_NUMBERS_TABLE,
                 <H256 as Into<BlockHashRLP>>::into(block_hash),
-            )
-            .await?
+            )?
             .map(|b| b.value()))
     }
 
@@ -677,7 +676,6 @@ impl StoreEngine for RedBStore {
         block_number: BlockNumber,
     ) -> Result<Option<BlockHash>, StoreError> {
         self.read_sync(CANONICAL_BLOCK_HASHES_TABLE, block_number)
-            .await
             .map(|o| o.map(|hash_rlp| hash_rlp.value().to()))
     }
 


### PR DESCRIPTION
**Motivation**
During Evm execution, we might need to look for a block hash in the state. Previously we encountered bugs as we were looking up the canonical block hash for the given block number when we should be searching for the block hash in the current block's (the one the EvmState was built on) ancestors. While this was already fixed by #2965, it made block hash lookup much slower.
In our most common use cases (fork choice updates, new payloads, full sync). The current block will be a canonical one, so we know all of its ancestors will also be canonical, and there is no reason to go through all of its ancestors. So this PR now checks if the current block is canonical, if it is, it searches for the block hash in the canonical block hashes, and if it is not, it searches through its ancestors
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* `StoreVmDatabase::get_block_hash` now searches for the target hash in canonical hashes if its current block (the one set at creation) is canonical
* Add sync versions of `StoreEngine` methods `get_block_number` & `get_canonical_block_hash`
* Add `Store` method `is_canonical_sync` to check weather a block hash is canonical synchronously
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #2990

