### PR TITLE
feat(l2): prove block hashes

### DIFF
--- a/cmd/ethrex_replay/src/cache.rs
+++ b/cmd/ethrex_replay/src/cache.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct Cache {
     pub block: Block,
-    pub parent_block_header: BlockHeader,
+    pub block_headers: Vec<BlockHeader>,
     pub db: ProverDB,
 }
 

--- a/cmd/ethrex_replay/src/run.rs
+++ b/cmd/ethrex_replay/src/run.rs
@@ -5,7 +5,7 @@ use zkvm_interface::io::ProgramInput;
 pub async fn exec(cache: Cache) -> eyre::Result<String> {
     let Cache {
         block,
-        parent_block_header,
+        block_headers,
         db,
     } = cache;
     #[cfg(any(feature = "sp1", feature = "risc0", feature = "pico"))]
@@ -23,7 +23,7 @@ pub async fn exec(cache: Cache) -> eyre::Result<String> {
     {
         let out = ethrex_prover_lib::execution_program(ProgramInput {
             blocks: vec![block],
-            parent_block_header,
+            block_headers,
             db,
             elasticity_multiplier: ELASTICITY_MULTIPLIER,
         })
@@ -35,12 +35,12 @@ pub async fn exec(cache: Cache) -> eyre::Result<String> {
 pub async fn prove(cache: Cache) -> eyre::Result<String> {
     let Cache {
         block,
-        parent_block_header,
+        block_headers,
         db,
     } = cache;
     let out = ethrex_prover_lib::prove(ProgramInput {
         blocks: vec![block],
-        parent_block_header,
+        block_headers,
         db,
         elasticity_multiplier: ELASTICITY_MULTIPLIER,
     })

--- a/crates/l2/prover/src/prover.rs
+++ b/crates/l2/prover/src/prover.rs
@@ -90,7 +90,7 @@ impl Prover {
             batch_number,
             input: ProgramInput {
                 blocks: input.blocks,
-                parent_block_header: input.parent_block_header,
+                block_headers: input.block_headers,
                 db: input.db,
                 elasticity_multiplier: input.elasticity_multiplier,
             },

--- a/crates/l2/prover/zkvm/interface/src/io.rs
+++ b/crates/l2/prover/zkvm/interface/src/io.rs
@@ -13,9 +13,9 @@ pub struct ProgramInput {
     /// blocks to execute
     #[serde_as(as = "SerdeJSON")]
     pub blocks: Vec<Block>,
-    /// header of the previous block
+    /// headers of previous blocks
     #[serde_as(as = "SerdeJSON")]
-    pub parent_block_header: BlockHeader,
+    pub block_headers: Vec<BlockHeader>,
     /// database containing only the data necessary to execute
     pub db: ProverDB,
     /// value used to calculate base fee

--- a/crates/l2/utils/error.rs
+++ b/crates/l2/utils/error.rs
@@ -15,6 +15,8 @@ pub enum ProverInputError {
     ChainError(#[from] ChainError),
     #[error("ProverDB error: {0}")]
     ProverDBError(#[from] ProverDBError),
+    #[error("Internal error: {0}")]
+    InternalError(String)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/l2/utils/prover/db.rs
+++ b/crates/l2/utils/prover/db.rs
@@ -13,9 +13,11 @@ use ethrex_vm::{DynVmDatabase, Evm, ProverDB, ProverDBError};
 
 pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, ProverDBError> {
     let chain_config = store.get_chain_config()?;
-    let Some(first_block_parent_hash) = blocks.first().map(|e| e.header.parent_hash) else {
+    let Some(first_block) = blocks.first() else {
         return Err(ProverDBError::Custom("Unable to get first block".into()));
     };
+    let first_block_parent_hash = first_block.header.parent_hash;
+
     let Some(last_block) = blocks.last() else {
         return Err(ProverDBError::Custom("Unable to get last block".into()));
     };
@@ -120,6 +122,7 @@ pub async fn to_prover_db(store: &Store, blocks: &[Block]) -> Result<ProverDB, P
         .clone()
         .into_iter()
         .map(|(num, hash)| (num, H256::from(hash.0)))
+        .chain([(first_block.header.number - 1, first_block_parent_hash)])
         .collect();
 
     // get account proofs

--- a/crates/l2/utils/test_data_io.rs
+++ b/crates/l2/utils/test_data_io.rs
@@ -69,6 +69,7 @@ pub async fn generate_program_input(
         .get(block_number)
         .ok_or(ProverInputError::InvalidBlockNumber(block_number))?
         .clone();
+    let block_number = block.header.number;
 
     // create store
     let store = Store::new("memory", EngineType::InMemory)?;
@@ -79,18 +80,35 @@ pub async fn generate_program_input(
         rt.block_on(blockchain.add_block(&block))?;
     }
 
-    let parent_hash = block.header.parent_hash;
-    let parent_block_header = store
-        .get_block_header_by_hash(block.header.parent_hash)?
-        .ok_or(ProverInputError::InvalidParentBlock(parent_hash))?;
     let elasticity_multiplier = ELASTICITY_MULTIPLIER;
     let blocks = vec![block];
     let db = to_prover_db(&store, &blocks).await?;
 
+    let mut block_headers = Vec::new();
+    let oldest_required_block_number =
+        db.block_hashes
+            .keys()
+            .min()
+            .ok_or(ProverInputError::InternalError(
+                "no block hashes required (should at least contain parent hash)".to_string(),
+            ))?;
+    // from oldest required to parent:
+    for number in *oldest_required_block_number..block_number {
+        let number_usize = number.try_into().map_err(|_| {
+            ProverInputError::InternalError(
+                "failed to convert block number from u64 to usize".to_string(),
+            )
+        })?;
+        let header = store
+            .get_block_header(number)?
+            .ok_or(ProverInputError::InvalidBlockNumber(number_usize))?;
+        block_headers.push(header);
+    }
+
     Ok(ProgramInput {
         db,
         blocks,
-        parent_block_header,
+        block_headers,
         elasticity_multiplier,
     })
 }


### PR DESCRIPTION
**Motivation**

The idea is to:
1. Take the oldest required block hash
2. Store all block headers from the oldest to the newest (which would be the batch's parent block header)
3. For all block headers:
    1. Check that the next block header's hash is the hash of the current one
4. Check that the oldest block hash in `ProverDb` is contained in the validated hashes

This way we check that block headers are part of the canonical chain, whose head is the batch's parent block.

Closes #2893 
