### PR TITLE
fix(l2): properly get needed proof types

### DIFF
--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -76,7 +76,7 @@ impl L1ProofSender {
             let response = eth_client
                 .call(
                     committer_cfg.on_chain_proposer_address,
-                    calldata.into(),
+                    calldata,
                     Overrides::default(),
                 )
                 .await?;


### PR DESCRIPTION
**Motivation**

In #2950, we removed the processing of the contract call response, which resulted in all proof types being marked as needed.

**Description**

Properly handles the contract call response.

Closes None