### PR TITLE
refactor(core): remove unused ProverDB trait implementations

### DIFF
--- a/cmd/ef_tests/state/runner/revm_runner.rs
+++ b/cmd/ef_tests/state/runner/revm_runner.rs
@@ -207,7 +207,7 @@ pub fn prepare_revm_for_tx<'state>(
         .with_external_context(
             RevmTracerEip3155::new(Box::new(std::io::stderr())).without_summary(),
         );
-    Ok(evm_builder.with_db(&mut initial_state.state).build())
+    Ok(evm_builder.with_db(&mut initial_state.inner).build())
 }
 
 pub fn compare_levm_revm_execution_results(

--- a/crates/vm/backends/revm/db.rs
+++ b/crates/vm/backends/revm/db.rs
@@ -12,41 +12,41 @@ use crate::{errors::EvmError, VmDatabase};
 ///
 /// Encapsulates state behaviour to be agnostic to the evm implementation for crate users.
 pub struct EvmState {
-    pub state: revm::db::State<DynVmDatabase>,
+    pub inner: revm::db::State<DynVmDatabase>,
 }
 
 // Needed because revm::db::State is not cloneable and we need to
 // restore the previous EVM state after executing a transaction in L2 mode whose resulting state diff doesn't fit in a blob.
 impl Clone for EvmState {
     fn clone(&self) -> Self {
-        let state = revm::db::State::<DynVmDatabase> {
-            cache: self.state.cache.clone(),
-            database: self.state.database.clone(),
-            transition_state: self.state.transition_state.clone(),
-            bundle_state: self.state.bundle_state.clone(),
-            use_preloaded_bundle: self.state.use_preloaded_bundle,
-            block_hashes: self.state.block_hashes.clone(),
+        let inner = revm::db::State::<DynVmDatabase> {
+            cache: self.inner.cache.clone(),
+            database: self.inner.database.clone(),
+            transition_state: self.inner.transition_state.clone(),
+            bundle_state: self.inner.bundle_state.clone(),
+            use_preloaded_bundle: self.inner.use_preloaded_bundle,
+            block_hashes: self.inner.block_hashes.clone(),
         };
 
-        Self { state }
+        Self { inner }
     }
 }
 
 impl EvmState {
     /// Gets the stored chain config
     pub fn chain_config(&self) -> Result<ChainConfig, EvmError> {
-        self.state.database.get_chain_config()
+        self.inner.database.get_chain_config()
     }
 }
 
 /// Builds EvmState from a Store
 pub fn evm_state(db: DynVmDatabase) -> EvmState {
-    let state = revm::db::State::builder()
+    let inner = revm::db::State::builder()
         .with_database(db)
         .with_bundle_update()
         .without_state_clear()
         .build();
-    EvmState { state }
+    EvmState { inner }
 }
 
 impl revm::Database for DynVmDatabase {

--- a/crates/vm/backends/revm/helpers.rs
+++ b/crates/vm/backends/revm/helpers.rs
@@ -83,7 +83,7 @@ fn create_access_list_inner(
         .with_external_context(&mut access_list_inspector);
     let tx_result = {
         let mut evm = evm_builder
-            .with_db(&mut state.state)
+            .with_db(&mut state.inner)
             .append_handler_register(inspector_handle_register)
             .build();
         evm.transact()?


### PR DESCRIPTION
**Motivation**

We only want to run our prover with LEVM

**Description**

- Replace EvmState enum with EvmState struct with inner attribute with type  `revm::db::State<DynVmDatabase>`
  - Impl clone for this struct
- Remove all trait implementations for ProverDB that are no longer used 



