### PR TITLE
refactor(core): remove proverdb from levm_bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7802,8 +7802,10 @@ name = "revm_comparison"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "ethrex-blockchain",
  "ethrex-common",
  "ethrex-levm",
+ "ethrex-storage",
  "ethrex-vm",
  "hex",
  "revm 9.0.0",

--- a/crates/vm/levm/bench/revm_comparison/Cargo.toml
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/lib.rs"
 ethrex-levm = { path = "../../" }
 ethrex-vm.workspace = true
 ethrex-common.workspace = true
+ethrex-storage.workspace = true
+ethrex-blockchain.workspace = true
 hex.workspace = true
 bytes.workspace = true
 

--- a/crates/vm/levm/bench/revm_comparison/src/lib.rs
+++ b/crates/vm/levm/bench/revm_comparison/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run_with_levm(program: &str, runs: u64, calldata: &str) {
         ),
     ];
 
+    // The store type for this bench shouldn't matter as all operations use the LEVM cache
     let in_memory_db = Store::new("", ethrex_storage::EngineType::InMemory).unwrap();
     let store: DynVmDatabase = Box::new(StoreVmDatabase::new(in_memory_db, H256::zero()));
     let mut db = GeneralizedDatabase::new(Arc::new(store), CacheDB::new());


### PR DESCRIPTION
**Motivation**

The bench is using the proverdb for its execution, the proverDb is undergoing many changes. This pr changes the levm bench to use an in memory db, this shouldn't affect performance numbers as everything was being added to the cache and read from there


