### PR TITLE
fix(l1): fix misleading `apply_fork_choice` error

### DIFF
--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -109,4 +109,6 @@ pub enum InvalidForkChoice {
     InvalidHead,
     #[error("Previously rejected block.")]
     InvalidAncestor(BlockHash),
+    #[error("Cannot find link between Head and the canonical chain")]
+    UnlinkedHead,
 }


### PR DESCRIPTION
**Motivation**
While the misleading errors reported by #1778 no longer exist, there is one new misleading error. When no link between the fcu head and the canonical chain is found, an error stating that the head and safe blocks are disconnected is returned, which doesn't make sense. This PR introduces a separate error for when the head has no link to the canonical chain
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Fix misleading error on `apply_fork_choice`
* (Misc) Reorder code in `find_link_with_canonical_chain` so that the block header is cloned after the first early return
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #1778

