### PR TITLE
fix(core): fix tokio dep on loadtest crate

### DIFF
--- a/tooling/load_test/Cargo.toml
+++ b/tooling/load_test/Cargo.toml
@@ -14,5 +14,5 @@ ethrex-blockchain.workspace = true
 ethrex-common.workspace = true
 eyre.workspace = true
 keccak-hash.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 futures = "0.3"


### PR DESCRIPTION
**Motivation**
After #2981 tokio's "full" feature was removed from the workspace dependency, crates relying on it had the feature added on their respective Cargo.toml's but we missed the `load_test` crate causing the flamegraph workflow to fail
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add "full" feature to tokio dep on `load_test` crate
<!-- A clear and concise general description of the changes this PR introduces -->

**Proof of Working Fix**
Manually triggered workflow: https://github.com/lambdaclass/ethrex/actions/runs/15418491746
<!-- Link to issues: Resolves #111, Resolves #222 -->

