### PR TITLE
fix(l2): fix transactions getting stuck in the mempool forever due to low nonce

### DIFF
--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -108,6 +108,7 @@ pub async fn fill_transactions(
 
     debug!("Fetching transactions from mempool");
     // Fetch mempool transactions
+    let latest_block_number = store.get_latest_block_number().await?;
     let (mut plain_txs, mut blob_txs) = blockchain.fetch_mempool_transactions(context)?;
     // Execute and add transactions to payload (if suitable)
     loop {
@@ -163,8 +164,24 @@ pub async fn fill_transactions(
             // Pull transaction from the mempool
             debug!("Ignoring replay-protected transaction: {}", tx_hash);
             txs.pop();
-            blockchain.remove_transaction_from_pool(&head_tx.tx.compute_hash())?;
+            blockchain.remove_transaction_from_pool(&tx_hash)?;
             continue;
+        }
+
+        let maybe_sender_acc_info = store
+            .get_account_info(latest_block_number, head_tx.tx.sender())
+            .await?;
+
+        if let Some(acc_info) = maybe_sender_acc_info {
+            if head_tx.nonce() < acc_info.nonce {
+                debug!(
+                    "Removing transaction with nonce too low from mempool: {}",
+                    tx_hash
+                );
+                txs.pop();
+                blockchain.remove_transaction_from_pool(&tx_hash)?;
+                continue;
+            }
         }
 
         // Execute tx


### PR DESCRIPTION
**Motivation**

The changes make the payload builder check if a transaction has a stale nonce and discard it if so. This is not a full solution as I'm pretty certain there could be other reasons for transactions to get stuck in the mempool, though this is the only one we have encountered so far. In the future we may want to have some more involved logic to eventually evict txs from the mempool but for now this suffices

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

