### PR TITLE
refactor(core): make TrieDB::put a provided method

### DIFF
--- a/crates/common/trie/db.rs
+++ b/crates/common/trie/db.rs
@@ -6,9 +6,10 @@ use std::{
 
 pub trait TrieDB: Send + Sync {
     fn get(&self, key: NodeHash) -> Result<Option<Vec<u8>>, TrieError>;
-    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError>;
-    // fn put_batch(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), TrieError>;
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError>;
+    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError> {
+        self.put_batch(vec![(key, value)])
+    }
 }
 
 /// InMemory implementation for the TrieDB trait, with get and put operations.
@@ -35,14 +36,6 @@ impl TrieDB for InMemoryTrieDB {
             .map_err(|_| TrieError::LockError)?
             .get(&key)
             .cloned())
-    }
-
-    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError> {
-        self.inner
-            .lock()
-            .map_err(|_| TrieError::LockError)?
-            .insert(key, value);
-        Ok(())
     }
 
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {

--- a/crates/common/trie/trie.rs
+++ b/crates/common/trie/trie.rs
@@ -305,10 +305,6 @@ impl Trie {
                 Ok(None)
             }
 
-            fn put(&self, _key: NodeHash, _value: Vec<u8>) -> Result<(), TrieError> {
-                Ok(())
-            }
-
             fn put_batch(&self, _key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
                 Ok(())
             }

--- a/crates/storage/trie_db/libmdbx.rs
+++ b/crates/storage/trie_db/libmdbx.rs
@@ -30,12 +30,6 @@ where
         txn.get::<T>(key).map_err(TrieError::DbError)
     }
 
-    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError> {
-        let txn = self.db.begin_readwrite().map_err(TrieError::DbError)?;
-        txn.upsert::<T>(key, value).map_err(TrieError::DbError)?;
-        txn.commit().map_err(TrieError::DbError)
-    }
-
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let txn = self.db.begin_readwrite().map_err(TrieError::DbError)?;
         for (key, value) in key_values {

--- a/crates/storage/trie_db/libmdbx_dupsort.rs
+++ b/crates/storage/trie_db/libmdbx_dupsort.rs
@@ -43,16 +43,6 @@ where
             .map_err(TrieError::DbError)
     }
 
-    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError> {
-        let txn = self.db.begin_readwrite().map_err(TrieError::DbError)?;
-        txn.upsert::<T>(
-            (self.fixed_key.clone(), node_hash_to_fixed_size(key)),
-            value,
-        )
-        .map_err(TrieError::DbError)?;
-        txn.commit().map_err(TrieError::DbError)
-    }
-
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let txn = self.db.begin_readwrite().map_err(TrieError::DbError)?;
         for (key, value) in key_values {

--- a/crates/storage/trie_db/redb.rs
+++ b/crates/storage/trie_db/redb.rs
@@ -30,26 +30,6 @@ impl TrieDB for RedBTrie {
             .map(|value| value.value().to_vec()))
     }
 
-    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError> {
-        let write_txn = self
-            .db
-            .begin_write()
-            .map_err(|e| TrieError::DbError(e.into()))?;
-        {
-            let mut table = write_txn
-                .open_table(TABLE)
-                .map_err(|e| TrieError::DbError(e.into()))?;
-            table
-                .insert(key.as_ref(), &*value)
-                .map_err(|e| TrieError::DbError(e.into()))?;
-        }
-        write_txn
-            .commit()
-            .map_err(|e| TrieError::DbError(e.into()))?;
-
-        Ok(())
-    }
-
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let write_txn = self
             .db

--- a/crates/storage/trie_db/redb_multitable.rs
+++ b/crates/storage/trie_db/redb_multitable.rs
@@ -56,26 +56,6 @@ impl TrieDB for RedBMultiTableTrieDB {
         }
     }
 
-    fn put(&self, key: NodeHash, value: Vec<u8>) -> Result<(), TrieError> {
-        let write_txn = self
-            .db
-            .begin_write()
-            .map_err(|e| TrieError::DbError(e.into()))?;
-        {
-            let mut table = write_txn
-                .open_multimap_table(STORAGE_TRIE_NODES_TABLE)
-                .map_err(|e| TrieError::DbError(e.into()))?;
-            table
-                .insert((self.fixed_key, node_hash_to_fixed_size(key)), &*value)
-                .map_err(|e| TrieError::DbError(e.into()))?;
-        }
-        write_txn
-            .commit()
-            .map_err(|e| TrieError::DbError(e.into()))?;
-
-        Ok(())
-    }
-
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let write_txn = self
             .db


### PR DESCRIPTION
**Motivation**

Remove redundant code.

**Description**

Simplify the TraitDB implementations by treating `put` as a special
case of `put_batch`, implementing it as a provided method in the
trait itself.

**Discussion**

The method itself is only used in tests, so it might be better to
change the tests to use the actual `put_batch` and just delete the
`put` method.
