### PR TITLE
perf(core): use libmdbx cursor on TrieDB put batch to avoid reopening the table on every key value pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2025-06-04
+
+- Use libmdbx cursor on TrieDB put batch to avoid reopning the table on every key value pair. [3039](https://github.com/lambdaclass/ethrex/pull/3039)
+
 ### 2025-05-27
 
 - Improved the performance of shift instructions. [2933](https://github.com/lambdaclass/ethrex/pull/2933)

--- a/crates/storage/trie_db/libmdbx.rs
+++ b/crates/storage/trie_db/libmdbx.rs
@@ -38,8 +38,9 @@ where
 
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let txn = self.db.begin_readwrite().map_err(TrieError::DbError)?;
+        let mut cursor = txn.cursor::<T>().map_err(TrieError::DbError)?;
         for (key, value) in key_values {
-            txn.upsert::<T>(key, value).map_err(TrieError::DbError)?;
+            cursor.upsert(key, value).map_err(TrieError::DbError)?;
         }
         txn.commit().map_err(TrieError::DbError)
     }

--- a/crates/storage/trie_db/libmdbx_dupsort.rs
+++ b/crates/storage/trie_db/libmdbx_dupsort.rs
@@ -55,12 +55,15 @@ where
 
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let txn = self.db.begin_readwrite().map_err(TrieError::DbError)?;
+        let mut cursor = txn.cursor::<T>().map_err(TrieError::DbError)?;
+
         for (key, value) in key_values {
-            txn.upsert::<T>(
-                (self.fixed_key.clone(), node_hash_to_fixed_size(key)),
-                value,
-            )
-            .map_err(TrieError::DbError)?;
+            cursor
+                .upsert(
+                    (self.fixed_key.clone(), node_hash_to_fixed_size(key)),
+                    value,
+                )
+                .map_err(TrieError::DbError)?;
         }
         txn.commit().map_err(TrieError::DbError)
     }


### PR DESCRIPTION
Use libmdbx cursor on TrieDB put batch to avoid reopening the table on every key value pair.

**Motivation**

Using txn directly without a cursor makes it open the table every key value pair iteration, when using a cursor avoids this.


Before (samply):

![image](https://github.com/user-attachments/assets/b561cdba-8edd-4b2c-8bdd-ee2d49dc01ec)

After (samply):

![image](https://github.com/user-attachments/assets/84fa6722-de8d-4e51-b177-bd5199eca3f6)


Conclusion: less functions called internally in libmdbx, less runtime used