### PR TITLE
Add cli import option to limit how many blocks to import

### DIFF
--- a/cmd/ethrex/bench/import_blocks_benchmark.rs
+++ b/cmd/ethrex/bench/import_blocks_benchmark.rs
@@ -23,6 +23,7 @@ fn block_import() {
         data_dir,
         network.get_genesis(),
         evm_engine,
+        None,
     ))
     .expect("Failed to import blocks on the Tokio runtime");
 }


### PR DESCRIPTION
**Motivation**

This is useful when benchmarking block imports from .rlp files with many blocks, to do a quick benchmark, for example if a hoodi file has 11k blocks and we want to measure the first 1k, we just pass `--limit 1000`

`time  ./target/release/ethrex --network cmd/ethrex/networks/hoodi/genesis.json import test_data/hoodi-blocks-first-thousand.rlp --limit 1000`

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

