### PR TITLE
refactor(core): Refactor encode for primitive types, removing duplicate code

### DIFF
--- a/crates/common/rlp/encode.rs
+++ b/crates/common/rlp/encode.rs
@@ -47,129 +47,69 @@ impl RLPEncode for bool {
 
 // integer types impls
 
+fn impl_encode<const N: usize>(value_be: [u8; N], buf: &mut dyn BufMut) {
+    let mut is_multi_byte_case = false;
+
+    for n in value_be.iter().take(N - 1) {
+        // If we encounter a non 0 byte pattern before the last byte, we are
+        // at the multi byte case
+        if *n != 0 {
+            is_multi_byte_case = true;
+            break;
+        }
+    }
+
+    match value_be[N - 1] {
+        // 0, also known as null or the empty string is 0x80
+        0 if !is_multi_byte_case => buf.put_u8(RLP_NULL),
+        // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
+        n @ 1..=0x7f if !is_multi_byte_case => buf.put_u8(n),
+        // if a string is 0-55 bytes long, the RLP encoding consists of a
+        // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
+        _ => {
+            let mut bytes = ArrayVec::<[u8; 8]>::new();
+            bytes.extend_from_slice(&value_be);
+            let start = bytes.iter().position(|&x| x != 0).unwrap();
+            let len = bytes.len() - start;
+            buf.put_u8(RLP_NULL + len as u8);
+            buf.put_slice(&bytes[start..]);
+        }
+    }
+}
+
 impl RLPEncode for u8 {
     fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
+        impl_encode(self.to_be_bytes(), buf);
     }
 }
 
 impl RLPEncode for u16 {
     fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
+        impl_encode(self.to_be_bytes(), buf);
     }
 }
 
 impl RLPEncode for u32 {
     fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
+        impl_encode(self.to_be_bytes(), buf);
     }
 }
 
 impl RLPEncode for u64 {
     fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
+        impl_encode(self.to_be_bytes(), buf);
     }
 }
 
 impl RLPEncode for usize {
     fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 8]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
+        impl_encode(self.to_be_bytes(), buf);
     }
 }
 
 impl RLPEncode for u128 {
     fn encode(&self, buf: &mut dyn BufMut) {
-        match *self {
-            // 0, also known as null or the empty string is 0x80
-            0 => buf.put_u8(RLP_NULL),
-            // for a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
-            n @ 1..=0x7f => buf.put_u8(n as u8),
-            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a
-            // single byte with value RLP_NULL (0x80) plus the length of the string followed by the string.
-            n => {
-                let mut bytes = ArrayVec::<[u8; 16]>::new();
-                bytes.extend_from_slice(&n.to_be_bytes());
-                let start = bytes.iter().position(|&x| x != 0).unwrap();
-                let len = bytes.len() - start;
-                buf.put_u8(RLP_NULL + len as u8);
-                buf.put_slice(&bytes[start..]);
-            }
-        }
+        impl_encode(self.to_be_bytes(), buf);
     }
 }
 


### PR DESCRIPTION
**Motivation**

Removes duplicate code from the rlp encode for primitive types.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

