### PR TITLE
ci(l2): fix tdx nix image building add ci to prevent regressions

### DIFF
--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -15,23 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_tdx:
-    name: Build nix TDX image
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Set up Nix
-        uses: cachix/install-nix-action@v31
-
-      - name: Build image
-        run: |
-          sudo sysctl kernel.unprivileged_userns_apparmor_policy=0
-          sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
-          cd crates/l2/tee/quote-gen
-          make image.raw
-
   test:
     # "Test" is a required check, don't change the name
     name: Test

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -15,6 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_tdx:
+    name: Build nix TDX image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Build image
+        run: |
+          cd crates/l2/tee/quote-gen
+          make image.raw
+
   test:
     # "Test" is a required check, don't change the name
     name: Test

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Build image
         run: |
-          sysctl kernel.unprivileged_userns_apparmor_policy=0
-          sysctl kernel.apparmor_restrict_unprivileged_userns=0
+          sudo sysctl kernel.unprivileged_userns_apparmor_policy=0
+          sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
           cd crates/l2/tee/quote-gen
           make image.raw
 

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build image
         run: |
+          sysctl kernel.unprivileged_userns_apparmor_policy=0
+          sysctl kernel.apparmor_restrict_unprivileged_userns=0
           cd crates/l2/tee/quote-gen
           make image.raw
 

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -1,0 +1,34 @@
+name: L2 TDX build
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "**.nix"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/build-image.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build_tdx:
+    # "Test" is a required check, don't change the name
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Build image
+        run: |
+          sudo sysctl kernel.unprivileged_userns_apparmor_policy=0
+          sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+          cd crates/l2/tee/quote-gen
+          make image.raw

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -8,7 +8,7 @@ on:
       - "**.nix"
       - "**/Cargo.toml"
       - "**/Cargo.lock"
-      - ".github/workflows/build-image.yml"
+      - ".github/workflows/pr-main_l2_tdx_build.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -35,8 +35,10 @@ rand.workspace = true
 thiserror.workspace = true
 directories = "5.0.1"
 bincode = "1.3.3"
-spawned-concurrency = {git = "https://github.com/lambdaclass/spawned.git", tag = "v0.1.0-alpha"}
-spawned-rt = {git = "https://github.com/lambdaclass/spawned.git", tag = "v0.1.0-alpha"}
+# Changing the tag for spawned will break the TDX image build
+# When updating it try to build the TDX image and update service.nix with the new hash
+spawned-concurrency = { git = "https://github.com/lambdaclass/spawned.git", tag = "v0.1.0-alpha" }
+spawned-rt = { git = "https://github.com/lambdaclass/spawned.git", tag = "v0.1.0-alpha" }
 lazy_static.workspace = true
 
 zkvm_interface = { path = "./prover/zkvm/interface/" }

--- a/crates/l2/tee/quote-gen/service.nix
+++ b/crates/l2/tee/quote-gen/service.nix
@@ -20,6 +20,7 @@ let
       lockFile = ./Cargo.lock;
       outputHashes = {
         "bls12_381-0.8.0" = "sha256-8/pXRA7hVAPeMKCZ+PRPfQfxqstw5Ob4MJNp85pv5WQ=";
+        "spawned-concurrency-0.1.0" = "sha256-/RO23J4c1fNVpF6ZgHdVPp3C2mgpg+dCwLjg0JcZ0YI=";
       };
     };
 

--- a/crates/l2/tee/quote-gen/service.nix
+++ b/crates/l2/tee/quote-gen/service.nix
@@ -20,7 +20,6 @@ let
       lockFile = ./Cargo.lock;
       outputHashes = {
         "bls12_381-0.8.0" = "sha256-8/pXRA7hVAPeMKCZ+PRPfQfxqstw5Ob4MJNp85pv5WQ=";
-        "spawned-concurrency-0.1.0" = "sha256-/RO23J4c1fNVpF6ZgHdVPp3C2mgpg+dCwLjg0JcZ0YI=";
       };
     };
 


### PR DESCRIPTION
**Motivation**

Image building is failing because nix cant find the hash for spawned

**Description**

- adds the current sha256 hash for spawned

**How to test**
- Buy a tdx compatible intel cpu
- `cd crates/l2/tee/`
- `make run` should fail in main but succeed in this branch

