### PR TITLE
fix(l2): fix committer migration

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,4 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - gpu
-    - fix-committer-migration
+    - ethrex_larger_runners

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,4 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - gpu
-    - ethrex_larger_runners
+    - larger_runners

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - gpu
+    - fix-committer-migration

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -75,7 +75,7 @@ jobs:
 
   integration-test:
     name: Integration Test - ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ethrex_larger_runners
     strategy:
       matrix:
         include:

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -75,7 +75,7 @@ jobs:
 
   integration-test:
     name: Integration Test - ${{ matrix.name }}
-    runs-on: ethrex_larger_runners
+    runs-on: larger_runners
     strategy:
       matrix:
         include:

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -160,6 +160,7 @@ impl GenServer for L1Committer {
 }
 
 async fn commit_next_batch_to_l1(state: &mut CommitterState) -> Result<(), CommitterError> {
+    info!("Running committer main loop");
     // Get the batch to commit
     let last_committed_batch_number = state
         .eth_client

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -172,7 +172,7 @@ async fn commit_next_batch_to_l1(state: &mut CommitterState) -> Result<(), Commi
         Some(batch) => batch,
         None => {
             let last_committed_blocks = state.rollup_store.get_block_numbers_by_batch(last_committed_batch_number).await?.ok_or(CommitterError::InternalError(format!("Failed to get batch with batch number {last_committed_batch_number}. Batch is missing when it should be present. This is a bug")))?;
-            let last_block = last_committed_blocks.last().unwrap();
+            let last_block = last_committed_blocks.last().ok_or(CommitterError::InternalError(format!("Last committed batch ({last_committed_batch_number}) doesn't have any blocks. This is probably a bug.")))?;
             let first_block_to_commit = last_block + 1;
 
             // Try to prepare batch

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -171,8 +171,18 @@ async fn commit_next_batch_to_l1(state: &mut CommitterState) -> Result<(), Commi
     let batch = match state.rollup_store.get_batch(batch_to_commit).await? {
         Some(batch) => batch,
         None => {
-            let last_committed_blocks = state.rollup_store.get_block_numbers_by_batch(last_committed_batch_number).await?.ok_or(CommitterError::InternalError(format!("Failed to get batch with batch number {last_committed_batch_number}. Batch is missing when it should be present. This is a bug")))?;
-            let last_block = last_committed_blocks.last().ok_or(CommitterError::InternalError(format!("Last committed batch ({last_committed_batch_number}) doesn't have any blocks. This is probably a bug.")))?;
+            let last_committed_blocks = state
+                .rollup_store
+                .get_block_numbers_by_batch(last_committed_batch_number)
+                .await?
+                .ok_or(
+                    CommitterError::InternalError(format!("Failed to get batch with batch number {last_committed_batch_number}. Batch is missing when it should be present. This is a bug"))
+                )?;
+            let last_block = last_committed_blocks
+                .last()
+                .ok_or(
+                    CommitterError::InternalError(format!("Last committed batch ({last_committed_batch_number}) doesn't have any blocks. This is probably a bug."))
+                )?;
             let first_block_to_commit = last_block + 1;
 
             // Try to prepare batch


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
When building a batch, it's not necessary to get the whole previous batch, but only the last block.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
With this changes a migration from previous version won't break as this table already existed before

<!-- Link to issues: Resolves #111, Resolves #222 -->


