### PR TITLE
chore(l1): add total gas used to execution metrics when syncing

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -305,8 +305,8 @@ impl Blockchain {
         }
 
         info!(
-            "[METRICS] Executed and stored: Range: {}, Total transactions: {}, Throughput: {} Gigagas/s",
-            blocks_len, transactions_count, throughput
+            "[METRICS] Executed and stored: Range: {}, Total transactions: {}, Total Gas: {}, Throughput: {} Gigagas/s",
+            blocks_len, transactions_count, total_gas_used, throughput
         );
 
         Ok(())


### PR DESCRIPTION
**Motivation**

Looking at execution metrics while syncing I found myself wanting to see not just total transactions of the batch, but also total gas. The total number of transactions can be misleading since they could be a small number of very heavy txs, or they could just be a small number of transfers, and that changes a great deal about what is being executed. Total gas is a better proxy to how heavy a batch is.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

