### PR TITLE
feat(levm): add backup hook

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -114,6 +114,23 @@ impl CallFrameBackup {
         self.original_accounts_info.clear();
         self.original_account_storage_slots.clear();
     }
+
+    pub fn extend(&mut self, other: CallFrameBackup) {
+        for (address, account) in &other.original_accounts_info {
+            self.original_accounts_info
+                .entry(*address)
+                .or_insert_with(|| account.clone());
+        }
+        for (address, storage) in &other.original_account_storage_slots {
+            let entry = self
+                .original_account_storage_slots
+                .entry(*address)
+                .or_default();
+            for (slot, value) in storage {
+                entry.entry(*slot).or_insert(*value);
+            }
+        }
+    }
 }
 
 impl CallFrame {

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -27,7 +27,7 @@ impl Hook for DefaultHook {
     /// - It adds value to receiver balance.
     /// - It calculates and adds intrinsic gas to the 'gas used' of callframe and environment.
     ///   See 'docs' for more information about validations.
-    fn prepare_execution(&self, vm: &mut VM<'_>) -> Result<(), VMError> {
+    fn prepare_execution(&mut self, vm: &mut VM<'_>) -> Result<(), VMError> {
         let sender_address = vm.env.origin;
         let (sender_balance, sender_nonce) = {
             let sender_account = vm.db.get_account(sender_address)?;
@@ -122,7 +122,7 @@ impl Hook for DefaultHook {
     /// 3. Pay coinbase fee
     /// 4. Destruct addresses in selfdestruct set.
     fn finalize_execution(
-        &self,
+        &mut self,
         vm: &mut VM<'_>,
         report: &mut ExecutionReport,
     ) -> Result<(), VMError> {

--- a/crates/vm/levm/src/hooks/hook.rs
+++ b/crates/vm/levm/src/hooks/hook.rs
@@ -1,3 +1,7 @@
+use std::{cell::RefCell, rc::Rc};
+
+use ethrex_common::types::Transaction;
+
 use crate::{
     errors::{ExecutionReport, VMError},
     vm::VM,
@@ -11,4 +15,33 @@ pub trait Hook {
         vm: &mut VM<'_>,
         report: &mut ExecutionReport,
     ) -> Result<(), VMError>;
+}
+
+/// Returns the appropriate VM hooks based on whether the `l2` feature is enabled.
+pub fn get_hooks(_tx: &Transaction) -> Vec<Rc<RefCell<dyn Hook + 'static>>> {
+    #[cfg(not(feature = "l2"))]
+    let hooks: Vec<Rc<RefCell<dyn Hook>>> = vec![Rc::new(RefCell::new(DefaultHook))];
+
+    #[cfg(feature = "l2")]
+    let hooks: Vec<Rc<RefCell<dyn Hook>>> = {
+        use crate::{call_frame::CallFrameBackup, hooks::L2Hook};
+        use ethrex_common::types::PrivilegedL2Transaction;
+
+        let recipient = if let Transaction::PrivilegedL2Transaction(PrivilegedL2Transaction {
+            recipient,
+            ..
+        }) = _tx
+        {
+            Some(*recipient)
+        } else {
+            None
+        };
+
+        vec![Rc::new(RefCell::new(L2Hook {
+            recipient,
+            callframe_backup: CallFrameBackup::default(), // It will be modified afterwards.
+        }))]
+    };
+
+    hooks
 }

--- a/crates/vm/levm/src/hooks/hook.rs
+++ b/crates/vm/levm/src/hooks/hook.rs
@@ -4,10 +4,10 @@ use crate::{
 };
 
 pub trait Hook {
-    fn prepare_execution(&self, vm: &mut VM<'_>) -> Result<(), VMError>;
+    fn prepare_execution(&mut self, vm: &mut VM<'_>) -> Result<(), VMError>;
 
     fn finalize_execution(
-        &self,
+        &mut self,
         vm: &mut VM<'_>,
         report: &mut ExecutionReport,
     ) -> Result<(), VMError>;

--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -1,5 +1,4 @@
 use crate::{
-    call_frame::CallFrameBackup,
     errors::{ExecutionReport, InternalError, TxValidationError, VMError},
     hooks::{default_hook, hook::Hook},
     vm::VM,
@@ -9,7 +8,6 @@ use ethrex_common::{types::Fork, Address, U256};
 
 pub struct L2Hook {
     pub recipient: Option<Address>,
-    pub callframe_backup: CallFrameBackup,
 }
 
 impl Hook for L2Hook {
@@ -114,10 +112,6 @@ impl Hook for L2Hook {
 
         default_hook::set_bytecode_and_code_address(vm)?;
 
-        // Here we need to backup the callframe because in the L2 we want to undo a transaction if it exceeds blob size
-        // even if the transaction succeeds.
-        self.callframe_backup = vm.current_call_frame()?.call_frame_backup.clone();
-
         Ok(())
     }
 
@@ -149,12 +143,6 @@ impl Hook for L2Hook {
         }
 
         default_hook::delete_self_destruct_accounts(vm)?;
-
-        // We want to restore to the initial state, this includes reverting the changes made by the prepare execution
-        // and the changes made by the execution itself.
-        let execution_backup = &mut vm.current_call_frame_mut()?.call_frame_backup;
-        let pre_execution_backup = std::mem::take(&mut self.callframe_backup);
-        execution_backup.extend(pre_execution_backup);
 
         Ok(())
     }

--- a/crates/vm/levm/src/hooks/mod.rs
+++ b/crates/vm/levm/src/hooks/mod.rs
@@ -1,3 +1,4 @@
+pub mod backup_hook;
 pub mod default_hook;
 pub mod hook;
 #[cfg(feature = "l2")]

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -33,9 +33,6 @@ use sha3::{Digest, Keccak256};
 use std::collections::{BTreeSet, HashMap, HashSet};
 pub type Storage = HashMap<U256, H256>;
 
-#[cfg(not(feature = "l2"))]
-use crate::hooks::DefaultHook;
-
 // ================== Address related functions ======================
 /// Converts address (H160) to word (U256)
 pub fn address_to_word(address: Address) -> U256 {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -3,7 +3,7 @@ use crate::{
     db::gen_db::GeneralizedDatabase,
     environment::Environment,
     errors::{ExecutionReport, OpcodeResult, VMError},
-    hooks::hook::Hook,
+    hooks::hook::{get_hooks, Hook},
     precompiles::execute_precompile,
     tracing::LevmCallTracer,
     TransientStorage,
@@ -54,7 +54,7 @@ impl<'a> VM<'a> {
         tx: &Transaction,
         tracer: LevmCallTracer,
     ) -> Self {
-        let hooks = Self::get_hooks(tx);
+        let hooks = get_hooks(tx);
 
         Self {
             call_frames: vec![],


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- Add a new Backup Hook that is specifically for restoring state. It allows us to do that cleanly in various parts of the code. 

**Description**

- The goal is to make code cleaner and to utilize the backup hook in `stateless_execute`. Before we were cloning the whole cache and it was expensive. With this solution we can seamlessly restore the state 😄 

Closes #3068
