### PR TITLE
fix(l2): move down `TDXVERIFIER` in contract

### DIFF
--- a/crates/l2/contracts/src/l1/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/OnChainProposer.sol
@@ -65,7 +65,6 @@ contract OnChainProposer is
     address public PICOVERIFIER;
     address public R0VERIFIER;
     address public SP1VERIFIER;
-    address public TDXVERIFIER;
 
     bytes32 public SP1_VERIFICATION_KEY;
 
@@ -78,6 +77,8 @@ contract OnChainProposer is
     /// @notice Indicates whether the contract operates in validium mode.
     /// @dev This value is immutable and can only be set during contract deployment.
     bool public VALIDIUM;
+
+    address public TDXVERIFIER;
 
     /// @notice The address of the AlignedProofAggregatorService contract.
     /// @dev This address is set during contract initialization and is used to verify aligned proofs.


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We set the `2dc43bd` commit as the base commit for future updates, so we have to keep upgrade compatibility from them. `TDXVERIFIER` introduction broke that compatibility.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Move the variable down to keep previous compatibility

<!-- Link to issues: Resolves #111, Resolves #222 -->


