### PR TITLE
fix(l2): privileged txs should not be filtered out of the building process by nonce

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1254,6 +1254,17 @@ impl Transaction {
         }
     }
 
+    pub fn is_privileged(&self) -> bool {
+        match &self {
+            Transaction::LegacyTransaction(_) => false,
+            Transaction::EIP2930Transaction(_) => false,
+            Transaction::EIP1559Transaction(_) => false,
+            Transaction::EIP4844Transaction(_) => false,
+            Transaction::EIP7702Transaction(_) => false,
+            Transaction::PrivilegedL2Transaction(_) => true,
+        }
+    }
+
     pub fn max_fee_per_gas(&self) -> Option<u64> {
         match self {
             Transaction::LegacyTransaction(_tx) => None,

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1255,14 +1255,7 @@ impl Transaction {
     }
 
     pub fn is_privileged(&self) -> bool {
-        match &self {
-            Transaction::LegacyTransaction(_) => false,
-            Transaction::EIP2930Transaction(_) => false,
-            Transaction::EIP1559Transaction(_) => false,
-            Transaction::EIP4844Transaction(_) => false,
-            Transaction::EIP7702Transaction(_) => false,
-            Transaction::PrivilegedL2Transaction(_) => true,
-        }
+        matches!(self, Transaction::PrivilegedL2Transaction(_))
     }
 
     pub fn max_fee_per_gas(&self) -> Option<u64> {

--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -171,7 +171,7 @@ pub async fn fill_transactions(
             .await?;
 
         if let Some(acc_info) = maybe_sender_acc_info {
-            if head_tx.nonce() < acc_info.nonce {
+            if head_tx.nonce() < acc_info.nonce && !head_tx.is_privileged() {
                 debug!("Removing transaction with nonce too low from mempool: {tx_hash:#x}");
                 txs.pop();
                 blockchain.remove_transaction_from_pool(&tx_hash)?;


### PR DESCRIPTION
**Motivation**

Privileged transactions essentialy ignore their nonce as it comes from the L1 contract instead. Filtering them out by having their nonce too low is incorrect and leads to bugs.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

