### PR TITLE
fix(l1): fix hive daily report

### DIFF
--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -3,7 +3,7 @@ name: Daily Reports
 on:
   schedule:
     # Every day at UTC midnight
-    - cron: "0 0 * * 1,2,3,4,5"
+    - cron: "0 3 * * 1,2,3,4,5"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -2,7 +2,7 @@ name: Daily Reports
 
 on:
   schedule:
-    # Every day at UTC midnight
+    # Every day at UTC 03:00
     - cron: "0 3 * * 1,2,3,4,5"
   workflow_dispatch:
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
The hive daily report is failing very often.

**Description**

By moving by 3 hours, the job is less probable to have conflicts with the merge queue.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3054

