### PR TITLE
fix(l1): client discarding repeated tx when received from different peers

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -459,7 +459,7 @@ impl Blockchain {
 
         if let Some(sender_acc_info) = maybe_sender_acc_info {
             if nonce < sender_acc_info.nonce || nonce == u64::MAX {
-                return Err(MempoolError::InvalidNonce);
+                return Err(MempoolError::NonceTooLow);
             }
 
             let tx_cost = tx
@@ -475,7 +475,7 @@ impl Blockchain {
         }
 
         // Check the nonce of pendings TXs in the mempool from the same sender
-        if self.mempool.contains_sender_nonce(sender, nonce)? {
+        if self.mempool.contains_sender_nonce(sender, nonce, tx)? {
             return Err(MempoolError::InvalidNonce);
         }
 

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -73,6 +73,8 @@ pub enum MempoolError {
     #[error("Blob transaction submited without blobs bundle")]
     BlobTxNoBlobsBundle,
     #[error("Nonce for account too low")]
+    NonceTooLow,
+    #[error("Nonce already used")]
     InvalidNonce,
     #[error("Transaction chain id mismatch, expected chain id: {0}")]
     InvalidChainId(u64),

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -232,7 +232,12 @@ impl Mempool {
             .collect())
     }
 
-    pub fn contains_sender_nonce(&self, sender: Address, nonce: u64) -> Result<bool, MempoolError> {
+    pub fn contains_sender_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+        received_tx: &Transaction,
+    ) -> Result<bool, MempoolError> {
         let pooled_transactions = self
             .transaction_pool
             .read()
@@ -240,7 +245,9 @@ impl Mempool {
 
         let count = pooled_transactions
             .iter()
-            .filter(|(_, tx)| tx.nonce() == nonce && tx.sender() == sender)
+            .filter(|(_, tx)| {
+                tx.nonce() == nonce && tx.sender() == sender && tx.transaction() != received_tx
+            })
             .count();
 
         Ok(count > 0)


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We noticed that when the same tx was received from two different peers, the first one will be OK but the second one will be discarded and no been broadcasted.

**Description**

The fix is to check if the tx is the same when validating the nonce in the mempool.

Also improves the error msg
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

