### PR TITLE
ci(l1): fix missing space bug in yaml

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -202,7 +202,7 @@ jobs:
               Syncing=False|
               Payload Build after New Invalid Payload|
               Invalid NewPayload|
-              Invalid Missing Ancestor" # Invalid Missing Ancestor Syncing ReOrG is flaky with high parallelism, tested with 8 and works
+             Invalid Missing Ancestor" # Invalid Missing Ancestor Syncing ReOrG is flaky with high parallelism, tested with 8 and works
             ethrex_flags: ""
           - name: "Paris Engine tests"
             simulation: ethereum/engine

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -206,53 +206,53 @@ jobs:
             ethrex_flags: ""
           - name: "Paris Engine tests"
             simulation: ethereum/engine
-            test_pattern: "engine-api/RPC|
-              Bad Hash on NewPayload|
-              Build Payload|
-              Fork ID|
-              In-Order Consecutive Payload Execution|
-              Inconsistent|
-              Invalid Missing Ancestor ReOrg|
-              Invalid NewPayload|
-              Invalid PayloadAttributes|
-              Multiple New Payloads|
-              NewPayload with|
-              ParentHash equals BlockHash on NewPayload|
-              Payload Build|
-              PrevRandao Opcode Transactions|
-              Re-Execute Payload|
-              Re-Org Back|
-              Re-org to Previously Validated Sidechain Payload|
-              RPC:|
-              Safe Re-Org|
-              Suggested Fee|
-              Transaction Re-Org|
-              Unique Payload ID|
-              Unknown|
-              Valid NewPayload->ForkchoiceUpdated" # |Invalid P9 -> flaky
+            test_pattern: "engine-api/RPC
+              |Bad Hash on NewPayload
+              |Build Payload
+              |Fork ID
+              |In-Order Consecutive Payload Execution
+              |Inconsistent
+              |Invalid Missing Ancestor ReOrg
+              |Invalid NewPayload
+              |Invalid PayloadAttributes
+              |Multiple New Payloads
+              |NewPayload with
+              |ParentHash equals BlockHash on NewPayload
+              |Payload Build
+              |PrevRandao Opcode Transactions
+              |Re-Execute Payload
+              |Re-Org Back
+              |Re-org to Previously Validated Sidechain Payload
+              |RPC:
+              |Safe Re-Org
+              |Suggested Fee
+              |Transaction Re-Org
+              |Unique Payload ID
+              |Unknown
+              |Valid NewPayload->ForkchoiceUpdated" # |Invalid P9 -> flaky
             ethrex_flags: ""
           - name: "Engine withdrawal tests"
             simulation: ethereum/engine
             test_pattern: "engine-withdrawals/
-              Corrupted Block Hash Payload|
-              Empty Withdrawals|
-              engine-withdrawals test loader|
-              GetPayloadBodies|
-              GetPayloadV2 Block Value|
-              Max Initcode Size|
-              Sync after 2 blocks - Withdrawals on Genesis|
-              Withdraw many accounts|
-              Withdraw to a single account|
-              Withdraw to two accounts|
-              Withdraw zero amount|
-              Withdraw many accounts|
-              Withdrawals Fork on Block 1 - 1 Block Re-Org|
-              Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload|
-              Withdrawals Fork on Block 2|
-              Withdrawals Fork on Block 3|
-              Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload|
-              Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org [^S]|
-              Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org [^S]"
+              Corrupted Block Hash Payload
+              |Empty Withdrawals
+              |engine-withdrawals test loader
+              |GetPayloadBodies
+              |GetPayloadV2 Block Value
+              |Max Initcode Size
+              |Sync after 2 blocks - Withdrawals on Genesis
+              |Withdraw many accounts
+              |Withdraw to a single account
+              |Withdraw to two accounts
+              |Withdraw zero amount
+              |Withdraw many accounts
+              |Withdrawals Fork on Block 1 - 1 Block Re-Org
+              |Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload
+              |Withdrawals Fork on Block 2
+              |Withdrawals Fork on Block 3
+              |Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload
+              |Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org [^S]
+              |Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org [^S]"
             ethrex_flags: ""
           - name: "Sync full"
             simulation: ethereum/sync
@@ -283,7 +283,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Run Hive Simulation
-        run: chmod +x hive && ./hive --client-file test_data/hive_clients.yml --client ethrex --ethrex.flags "${{ matrix.ethrex_flags }}" --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 8
+        run: chmod +x hive && ./hive --client-file test_data/hive_clients.yml --client ethrex --ethrex.flags "${{ matrix.ethrex_flags }}" --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 1
         # We use 8 here instead of 16 due to performance issues in some tests
         # Notably the tests "Invalid Missing Ancestor Syncing ReOrG" in engine cancun
 

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -158,99 +158,15 @@ jobs:
             ethrex_flags: ""
           - name: "Cancun Engine tests"
             simulation: ethereum/engine
-            test_pattern: "engine-cancun/Blob Transactions On Block 1
-              |Blob Transaction Ordering
-              |Parallel Blob Transactions
-              |ForkchoiceUpdatedV3
-              |ForkchoiceUpdatedV2
-              |ForkchoiceUpdated Version
-              |GetPayload
-              |NewPayloadV3 After Cancun
-              |NewPayloadV3 Before Cancun
-              |NewPayloadV3 Versioned Hashes
-              |Incorrect BlobGasUsed
-              |ParentHash equals BlockHash
-              |RPC:
-              |in ForkchoiceState
-              |Unknown SafeBlockHash
-              |Unknown FinalizedBlockHash
-              |Unique
-              |Re-Execute Payload
-              |Multiple New Payloads
-              |NewPayload with
-              |Build Payload with
-              |Re-org to Previously
-              |Safe Re-Org to Side Chain
-              |Transaction Re-Org
-              |Re-Org Back into Canonical Chain
-              |Suggested Fee Recipient Test
-              |PrevRandao Opcode
-              |Fork ID: *
-              |Request Blob Pooled Transactions
-              |Invalid NewPayload, Incomplete Transactions
-              |Re-Org Back to Canonical Chain*
-              |Invalid PayloadAttributes*
-              |Invalid NewPayload, VersionedHashes
-              |Invalid NewPayload, Incomplete VersionedHashes
-              |Invalid NewPayload, Extra VersionedHashes
-              |Bad Hash on NewPayload
-              |Unknown HeadBlockHash
-              |In-Order Consecutive Payload Execution
-              |Valid NewPayload->ForkchoiceUpdated
-              |Invalid NewPayload, ParentHash
-              |Syncing=False
-              |Payload Build after New Invalid Payload
-              |Invalid NewPayload
-              |Invalid Missing Ancestor ReOrg" # Invalid Missing Ancestor Syncing ReOrG is flaky
+            test_pattern: "engine-cancun/Blob Transactions On Block 1|Blob Transaction Ordering|Parallel Blob Transactions|ForkchoiceUpdatedV3|ForkchoiceUpdatedV2|ForkchoiceUpdated Version|GetPayload|NewPayloadV3 After Cancun|NewPayloadV3 Before Cancun|NewPayloadV3 Versioned Hashes|Incorrect BlobGasUsed|ParentHash equals BlockHash|RPC:|in ForkchoiceState|Unknown SafeBlockHash|Unknown FinalizedBlockHash|Unique|Re-Execute Payload|Multiple New Payloads|NewPayload with|Build Payload with|Re-org to Previously|Safe Re-Org to Side Chain|Transaction Re-Org|Re-Org Back into Canonical Chain|Suggested Fee Recipient Test|PrevRandao Opcode|Fork ID: *|Request Blob Pooled Transactions|Invalid NewPayload, Incomplete Transactions|Re-Org Back to Canonical Chain*|Invalid PayloadAttributes*|Invalid NewPayload, VersionedHashes|Invalid NewPayload, Incomplete VersionedHashes|Invalid NewPayload, Extra VersionedHashes|Bad Hash on NewPayload|Unknown HeadBlockHash|In-Order Consecutive Payload Execution|Valid NewPayload->ForkchoiceUpdated|Invalid NewPayload, ParentHash|Syncing=False|Payload Build after New Invalid Payload|Invalid NewPayload|Invalid Missing Ancestor ReOrg" # Invalid Missing Ancestor Syncing ReOrG is flaky
             ethrex_flags: ""
           - name: "Paris Engine tests"
             simulation: ethereum/engine
-            test_pattern: "engine-api/RPC
-              |Bad Hash on NewPayload
-              |Build Payload
-              |Fork ID
-              |In-Order Consecutive Payload Execution
-              |Inconsistent
-              |Invalid Missing Ancestor ReOrg
-              |Invalid NewPayload
-              |Invalid PayloadAttributes
-              |Multiple New Payloads
-              |NewPayload with
-              |ParentHash equals BlockHash on NewPayload
-              |Payload Build
-              |PrevRandao Opcode Transactions
-              |Re-Execute Payload
-              |Re-Org Back
-              |Re-org to Previously Validated Sidechain Payload
-              |RPC:
-              |Safe Re-Org
-              |Suggested Fee
-              |Transaction Re-Org
-              |Unique Payload ID
-              |Unknown
-              |Valid NewPayload->ForkchoiceUpdated" # |Invalid P9 -> flaky
+            test_pattern: "engine-api/RPC|Bad Hash on NewPayload|Build Payload|Fork ID|In-Order Consecutive Payload Execution|Inconsistent|Invalid Missing Ancestor ReOrg|Invalid NewPayload|Invalid PayloadAttributes|Multiple New Payloads|NewPayload with|ParentHash equals BlockHash on NewPayload|Payload Build|PrevRandao Opcode Transactions|Re-Execute Payload|Re-Org Back|Re-org to Previously Validated Sidechain Payload|RPC:|Safe Re-Org|Suggested Fee|Transaction Re-Org|Unique Payload ID|Unknown|Valid NewPayload->ForkchoiceUpdated" # |Invalid P9 -> flaky
             ethrex_flags: ""
           - name: "Engine withdrawal tests"
             simulation: ethereum/engine
-            test_pattern: "engine-withdrawals/Corrupted Block Hash Payload
-              |Empty Withdrawals
-              |engine-withdrawals test loader
-              |GetPayloadBodies
-              |GetPayloadV2 Block Value
-              |Max Initcode Size
-              |Sync after 2 blocks - Withdrawals on Genesis
-              |Withdraw many accounts
-              |Withdraw to a single account
-              |Withdraw to two accounts
-              |Withdraw zero amount
-              |Withdraw many accounts
-              |Withdrawals Fork on Block 1 - 1 Block Re-Org
-              |Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload
-              |Withdrawals Fork on Block 2
-              |Withdrawals Fork on Block 3
-              |Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload
-              |Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org [^S]
-              |Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org [^S]"
+            test_pattern: "engine-withdrawals/Corrupted Block Hash Payload|Empty Withdrawals|engine-withdrawals test loader|GetPayloadBodies|GetPayloadV2 Block Value|Max Initcode Size|Sync after 2 blocks - Withdrawals on Genesis|Withdraw many accounts|Withdraw to a single account|Withdraw to two accounts|Withdraw zero amount|Withdraw many accounts|Withdrawals Fork on Block 1 - 1 Block Re-Org|Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload|Withdrawals Fork on Block 2|Withdrawals Fork on Block 3|Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload|Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org [^S]|Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org [^S]"
             ethrex_flags: ""
           - name: "Sync full"
             simulation: ethereum/sync

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -160,7 +160,6 @@ jobs:
             simulation: ethereum/engine
             test_pattern: "engine-cancun/Blob Transactions On Block 1
               |Blob Transaction Ordering
-              |Replace Blob Transactions
               |Parallel Blob Transactions
               |ForkchoiceUpdatedV3
               |ForkchoiceUpdatedV2

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -158,51 +158,51 @@ jobs:
             ethrex_flags: ""
           - name: "Cancun Engine tests"
             simulation: ethereum/engine
-            test_pattern: "engine-cancun/Blob Transactions On Block 1|
-              Blob Transaction Ordering|
-              Replace Blob Transactions|
-              Parallel Blob Transactions|
-              ForkchoiceUpdatedV3|
-              ForkchoiceUpdatedV2|
-              ForkchoiceUpdated Version|
-              GetPayload|
-              NewPayloadV3 After Cancun|
-              NewPayloadV3 Before Cancun|
-              NewPayloadV3 Versioned Hashes|
-              Incorrect BlobGasUsed|
-              ParentHash equals BlockHash|
-              RPC:|
-              in ForkchoiceState|
-              Unknown SafeBlockHash|
-              Unknown FinalizedBlockHash|
-              Unique|
-              Re-Execute Payload|
-              Multiple New Payloads|
-              NewPayload with|
-              Build Payload with|
-              Re-org to Previously|
-              Safe Re-Org to Side Chain|
-              Transaction Re-Org|
-              Re-Org Back into Canonical Chain|
-              Suggested Fee Recipient Test|
-              PrevRandao Opcode|
-              Fork ID: *|
-              Request Blob Pooled Transactions|
-              Invalid NewPayload, Incomplete Transactions|
-              Re-Org Back to Canonical Chain*|
-              Invalid PayloadAttributes*|
-              Invalid NewPayload, VersionedHashes|
-              Invalid NewPayload, Incomplete VersionedHashes|
-              Invalid NewPayload, Extra VersionedHashes|
-              Bad Hash on NewPayload|
-              Unknown HeadBlockHash|
-              In-Order Consecutive Payload Execution|
-              Valid NewPayload->ForkchoiceUpdated|
-              Invalid NewPayload, ParentHash|
-              Syncing=False|
-              Payload Build after New Invalid Payload|
-              Invalid NewPayload|
-             Invalid Missing Ancestor" # Invalid Missing Ancestor Syncing ReOrG is flaky with high parallelism, tested with 8 and works
+            test_pattern: "engine-cancun/Blob Transactions On Block 1
+              |Blob Transaction Ordering
+              |Replace Blob Transactions
+              |Parallel Blob Transactions
+              |ForkchoiceUpdatedV3
+              |ForkchoiceUpdatedV2
+              |ForkchoiceUpdated Version
+              |GetPayload
+              |NewPayloadV3 After Cancun
+              |NewPayloadV3 Before Cancun
+              |NewPayloadV3 Versioned Hashes
+              |Incorrect BlobGasUsed
+              |ParentHash equals BlockHash
+              |RPC:
+              |in ForkchoiceState
+              |Unknown SafeBlockHash
+              |Unknown FinalizedBlockHash
+              |Unique
+              |Re-Execute Payload
+              |Multiple New Payloads
+              |NewPayload with
+              |Build Payload with
+              |Re-org to Previously
+              |Safe Re-Org to Side Chain
+              |Transaction Re-Org
+              |Re-Org Back into Canonical Chain
+              |Suggested Fee Recipient Test
+              |PrevRandao Opcode
+              |Fork ID: *
+              |Request Blob Pooled Transactions
+              |Invalid NewPayload, Incomplete Transactions
+              |Re-Org Back to Canonical Chain*
+              |Invalid PayloadAttributes*
+              |Invalid NewPayload, VersionedHashes
+              |Invalid NewPayload, Incomplete VersionedHashes
+              |Invalid NewPayload, Extra VersionedHashes
+              |Bad Hash on NewPayload
+              |Unknown HeadBlockHash
+              |In-Order Consecutive Payload Execution
+              |Valid NewPayload->ForkchoiceUpdated
+              |Invalid NewPayload, ParentHash
+              |Syncing=False
+              |Payload Build after New Invalid Payload
+              |Invalid NewPayload
+              |Invalid Missing Ancestor" # Invalid Missing Ancestor Syncing ReOrG is flaky with high parallelism, tested with 8 and works
             ethrex_flags: ""
           - name: "Paris Engine tests"
             simulation: ethereum/engine

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -202,7 +202,7 @@ jobs:
               |Syncing=False
               |Payload Build after New Invalid Payload
               |Invalid NewPayload
-              |Invalid Missing Ancestor" # Invalid Missing Ancestor Syncing ReOrG is flaky with high parallelism, tested with 8 and works
+              |Invalid Missing Ancestor ReOrg" # Invalid Missing Ancestor Syncing ReOrG is flaky
             ethrex_flags: ""
           - name: "Paris Engine tests"
             simulation: ethereum/engine
@@ -233,8 +233,7 @@ jobs:
             ethrex_flags: ""
           - name: "Engine withdrawal tests"
             simulation: ethereum/engine
-            test_pattern: "engine-withdrawals/
-              Corrupted Block Hash Payload
+            test_pattern: "engine-withdrawals/Corrupted Block Hash Payload
               |Empty Withdrawals
               |engine-withdrawals test loader
               |GetPayloadBodies
@@ -283,7 +282,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Run Hive Simulation
-        run: chmod +x hive && ./hive --client-file test_data/hive_clients.yml --client ethrex --ethrex.flags "${{ matrix.ethrex_flags }}" --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 1
+        run: chmod +x hive && ./hive --client-file test_data/hive_clients.yml --client ethrex --ethrex.flags "${{ matrix.ethrex_flags }}" --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 16
         # We use 8 here instead of 16 due to performance issues in some tests
         # Notably the tests "Invalid Missing Ancestor Syncing ReOrG" in engine cancun
 


### PR DESCRIPTION
**Motivation**

CI tests weren't executing due to the extra spaces introduces by yaml multiline.

**Description**

* Returned every engine test to a single line

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

