### PR TITLE
ci(l2): add Codeowners to L2 contracts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Lambdaclass core team
 * @lambdaclass/lambda-execution-reviewers
+crates/l2/contracts/src @jrchatruc @manuelbilbao

--- a/crates/l2/contracts/src/l1/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/OnChainProposer.sol
@@ -14,7 +14,7 @@ import {ITDXVerifier} from "./interfaces/ITDXVerifier.sol";
 
 /// @title OnChainProposer contract.
 /// @author LambdaClass
-contract OnChainProposer2 is
+contract OnChainProposer is
     IOnChainProposer,
     Initializable,
     UUPSUpgradeable,

--- a/crates/l2/contracts/src/l1/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/OnChainProposer.sol
@@ -14,7 +14,7 @@ import {ITDXVerifier} from "./interfaces/ITDXVerifier.sol";
 
 /// @title OnChainProposer contract.
 /// @author LambdaClass
-contract OnChainProposer is
+contract OnChainProposer2 is
     IOnChainProposer,
     Initializable,
     UUPSUpgradeable,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Changes to L2 contracts are sensible and can break already deployed networks.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Added members that are currently actively working on L2 deployments to request their approval before merging.

<!-- Link to issues: Resolves #111, Resolves #222 -->


