### PR TITLE
fix(l2): add validium check for blobs in OnChainProposer

### DIFF
--- a/crates/l2/contracts/src/l1/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/OnChainProposer.sol
@@ -269,6 +269,11 @@ contract OnChainProposer is
 
         // Blob is published in the (EIP-4844) transaction that calls this function.
         bytes32 blobVersionedHash = blobhash(0);
+        if (VALIDIUM) {
+            require(blobVersionedHash == 0, "L2 running as validium but blob was published");
+        } else {
+            require(blobVersionedHash != 0, "L2 running as rollup but blob was not published");
+        }
 
         batchCommitments[batchNumber] = BatchCommitmentInfo(
             newStateRoot,


### PR DESCRIPTION
**Motivation**

If the L2 is running as a rollup (non-validium) the sequencer is able to not publish blobs anyway, and viceversa. This check enforces the blob policy depending whether the contract was deployed for a rollup or validium L2.

