### PR TITLE
fix(l1): `read_account_snapshot` should only read up to `MAX_SNAPSHOT_READS`

### DIFF
--- a/crates/storage/store_db/libmdbx.rs
+++ b/crates/storage/store_db/libmdbx.rs
@@ -971,17 +971,17 @@ impl StoreEngine for Store {
         let cursor = txn
             .cursor::<StateSnapShot>()
             .map_err(StoreError::LibmdbxError)?;
-
-        let mut account_snapshots = Vec::new();
-        let mut cursor_it = cursor.walk(Some(start.into()));
-        while let Some(Ok((hash, acc))) = cursor_it.next() {
-            account_snapshots.push((hash.to()?, acc.to()?));
-        }
-
-        Ok(account_snapshots
-            .into_iter()
-            .take(MAX_SNAPSHOT_READS)
-            .collect::<Vec<_>>())
+        let iter = cursor
+            .walk(Some(start.into()))
+            .map_while(|res| {
+                res.ok().map(|(hash, acc)| match (hash.to(), acc.to()) {
+                    (Ok(hash), Ok(acc)) => Some((hash, acc)),
+                    _ => None,
+                })
+            })
+            .flatten()
+            .take(MAX_SNAPSHOT_READS);
+        Ok(iter.collect::<Vec<_>>())
     }
 
     async fn read_storage_snapshot(


### PR DESCRIPTION
**Motivation**
After a recent refactor the `Store:: read_account_snapshot` behaviour was changed to read and push all snapshot values into a vector and then take `MAX_SNAPSHOT_READS` from that vector. This doesn't make sense, as the purpose of having a `MAX_SNAPSHOT_READS` is to prevent performance hits due to very long reads.
This PR fixes this by restoring the previous behaviour, which took the snapshot values directly from the iterator, reading only up to `MAX_SNAPSHOT_READS`
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Restore previous `read_account_snapshot` logic & ensure we don't read the full amount of account snapshots on each request
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

