### PR TITLE
ci(core): fix Makefile space

### DIFF
--- a/cmd/ethrex_replay/Makefile
+++ b/cmd/ethrex_replay/Makefile
@@ -1,4 +1,5 @@
-.PHONY: sp1
+.PHONY: sp1 sp1-gpu risc0 risc0-gpu pico pico-gpu prove-sp1 prove-sp1-gpu \
+		prove-sp1-gpu-ci prove-risc0 prove-risc0-gpu pico pico-gpu
 
 NETWORK ?= mainnet
 ifdef BLOCK_NUMBER

--- a/cmd/ethrex_replay/Makefile
+++ b/cmd/ethrex_replay/Makefile
@@ -26,7 +26,7 @@ prove-sp1:
 prove-sp1-gpu:
 	SP1_PROVER=cuda cargo r -r --features "sp1,gpu" -- prove block ${REPLAY_ARGS}
 prove-sp1-gpu-ci:
-        SP1_PROVER=cuda cargo r -r --features "sp1,gpu,ci" -- prove block ${REPLAY_ARGS}
+	SP1_PROVER=cuda cargo r -r --features "sp1,gpu,ci" -- prove block ${REPLAY_ARGS}
 prove-risc0:
 	cargo r -r --no-default-features --features risc0 -- prove block ${REPLAY_ARGS}
 prove-risc0-gpu:


### PR DESCRIPTION
**Motivation**

Currently prove-sp1-gpu-ci does nothing: `make: Nothing to be done for `prove-sp1-gpu-ci'`

**Description**

The Makefile had incorrect spacing, so it didn't recognize the contents of the target.

