### PR TITLE
feat(l1): have failed tests output on the console

### DIFF
--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -117,8 +117,15 @@ jobs:
       - name: Check EF-TESTS from Paris to Prague is 100%
         run: |
           cd cmd/ef_tests/state
-          awk '/Prague:/, /Paris:/ {print $1, $3}' test_result_main.txt | sed 's/[()]//g' | grep -v '100.00%' && echo "All percentage are not 100%." && exit 1 || echo "All percentage are 100%."
-
+          awk '/Prague:/, /Paris:/ {print $1, $3}' test_result_main.txt | sed 's/[()]//g' | grep -v '100.00%' > failed_tests.txt"
+          if [ "$(awk '/Summary:/ {print $(NF)}' test_result_main_short.txt)" != "(100.00%)" ]; then
+              echo ""All percentage are not 100%. The following tests failed:"
+              cat failed_tests.txt
+              exit 1
+          else
+              echo "All percentage are 100%."
+          fi
+          
       - name: Check EF-TESTS status is 100%
         run: |
           cd cmd/ef_tests/state


### PR DESCRIPTION
**Motivation**

The pr-main_levm CI job should fail with a exit code if a test fails.

**Description**

 The ef-test-main job has been refactored to exit with an error code and output the failing tests in the console.

Closes #2887

