### PR TITLE
ci(l2): follow logs before running tests

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -102,8 +102,8 @@ jobs:
         run: |
           cd crates/l2
           RUST_LOG=info,ethrex_prover_lib=debug make init-prover &
-          PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1 &
-          docker logs --follow ethrex_l2
+          docker logs --follow ethrex_l2 &
+          PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex_prover -s SIGINT
 
   state-diff-test:


### PR DESCRIPTION
**Motivation**

The integration test is running forever and timing out because we are running `docker logs --follow ethrex_l2` this command never exits so the step never ends

**Description**

Modify the order of execution, first follow the logs then run the test



