### PR TITLE
Fix broken state test docs link to point to Ethereum Tests readthedocs

### DIFF
--- a/cmd/ef_tests/state/README.md
+++ b/cmd/ef_tests/state/README.md
@@ -1,7 +1,7 @@
 # State Tests
 
 The state tests are individual transactions not related one to each other that test particular behavior of the EVM. Tests are usually run for multiple forks and the result of execution may vary between forks.
-Some [docs](https://ethereum.github.io/execution-spec-tests/main/consuming_tests/state_test/).
+Some [docs](https://ethereum-tests.readthedocs.io/en/latest/state-transition-ref.html).
 
 ## Running the tests
 


### PR DESCRIPTION
Replaced the outdated and broken link to state test documentation in cmd/ef_tests/state/README.md with the current, working URL (https://ethereum-tests.readthedocs.io/en/latest/state-transition-ref.html) for up-to-date information on state transition tests.