### PR TITLE
ci(core): fix lint pr title job

### DIFF
--- a/.github/workflows/pr_lint_pr_title.yml
+++ b/.github/workflows/pr_lint_pr_title.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
**Motivation**
Sometimes, there are PRs that are merged that do not satisfy the PR title conventions, but the job does't appear as failing. This aims