### PR TITLE
fix(l2): use aligned sdk latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 [[package]]
 name = "aligned-sdk"
 version = "0.1.0"
-source = "git+https://github.com/yetanotherco/aligned_layer?rev=124eba82524bd95d1419ace19f8d959c492ffee0#124eba82524bd95d1419ace19f8d959c492ffee0"
+source = "git+https://github.com/yetanotherco/aligned_layer?tag=v0.16.1#d6c5ffd0b7e4952724c4ee167187bf0945238d0d"
 dependencies = [
  "ciborium",
  "dialoguer",

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -42,7 +42,7 @@ serde_with = "3.11.0"
 spawned-concurrency = { git = "https://github.com/lambdaclass/spawned.git", tag = "v0.1.0-alpha" }
 spawned-rt = { git = "https://github.com/lambdaclass/spawned.git", tag = "v0.1.0-alpha" }
 lazy_static.workspace = true
-aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", rev = "124eba82524bd95d1419ace19f8d959c492ffee0" }
+aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag="v0.16.1" }
 ethers = "2.0"
 cfg-if.workspace = true
 

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -413,18 +413,31 @@ impl EthClient {
             TxKind::Call(addr) => Some(format!("{addr:#x}")),
             TxKind::Create => None,
         };
-        let blob_versioned_hashes_str: Vec<_> = transaction
-            .blob_versioned_hashes
-            .into_iter()
-            .map(|hash| format!("{hash:#x}"))
-            .collect();
+
         let mut data = json!({
             "to": to,
             "input": format!("0x{:#x}", transaction.input),
             "from": format!("{:#x}", transaction.from),
             "value": format!("{:#x}", transaction.value),
-            "blobVersionedHashes": blob_versioned_hashes_str
+
         });
+
+        if !transaction.blob_versioned_hashes.is_empty() {
+            let blob_versioned_hashes_str: Vec<_> = transaction
+                .blob_versioned_hashes
+                .into_iter()
+                .map(|hash| format!("{hash:#x}"))
+                .collect();
+
+            data.as_object_mut()
+                .ok_or_else(|| {
+                    EthClientError::Custom("Failed to mut data in estimate_gas".to_owned())
+                })?
+                .insert(
+                    "blobVersionedHashes".to_owned(),
+                    json!(blob_versioned_hashes_str),
+                );
+        }
 
         // Add the nonce just if present, otherwise the RPC will use the latest nonce
         if let Some(nonce) = transaction.nonce {


### PR DESCRIPTION
**Motivation**

We are using a specific `aligned-sdk` commit. Now that we've bumped the SP1 version to `v5.0.0`, we can use the latest release.

**Description**

- Uses the latest release of the `aligned-sdk`.
- Refactors `estimate_gas` since some clients don't allow empty `blobVersionedHashes`, and `ethereum-package` doesn't work.

Closes #3169 

