### PR TITLE
chore(l1,l2): add contract creation to known selectors in ethrex replay

### DIFF
--- a/cmd/ethrex_replay/src/plot_composition.rs
+++ b/cmd/ethrex_replay/src/plot_composition.rs
@@ -68,7 +68,7 @@ fn categorize_selector(sel: [u8; 4]) -> String {
         "3ccfd60b" => "withdraw",
         "30c48952" => "swap&bridge", // swapAndStartBridgeTokensViaMayan
         "13d79a0b" => "swap",        // settle
-        "0x60806040" => "contract creation",
+        "60806040" => "contract creation",
         _ => &selector,
     }
     .to_string()

--- a/cmd/ethrex_replay/src/plot_composition.rs
+++ b/cmd/ethrex_replay/src/plot_composition.rs
@@ -68,6 +68,7 @@ fn categorize_selector(sel: [u8; 4]) -> String {
         "3ccfd60b" => "withdraw",
         "30c48952" => "swap&bridge", // swapAndStartBridgeTokensViaMayan
         "13d79a0b" => "swap",        // settle
+        "0x60806040" => "contract creation",
         _ => &selector,
     }
     .to_string()


### PR DESCRIPTION
**Motivation**

Adds the contract creation selector to the known method selectors.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

