### PR TITLE
Publish Ethrex docs on https://docs.ethrex.xyz/

### DIFF
--- a/.github/workflows/main_flamegraph_report.yaml
+++ b/.github/workflows/main_flamegraph_report.yaml
@@ -467,3 +467,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./flamegraphs
           destination_dir: flamegraphs
+          keep_files: true

--- a/.github/workflows/main_perf_blocks_exec.yml
+++ b/.github/workflows/main_perf_blocks_exec.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           tool: "cargo"
           output-file-path: cmd/ethrex/output.txt
-          benchmark-data-dir-path: "."
+          benchmark-data-dir-path: "benchmarks"
           # Access token to deploy GitHub Pages branch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,39 @@
+name: Publish Ethrex docs to https://docs.ethrex.xyz/
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+  pull_request:
+    paths:
+      - "docs/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: '0.4.51'
+
+      - name: Install mdbook-alerts
+        run: cargo install mdbook-alerts
+
+      - run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: book
+          destination_dir: .     # root of gh-pages
+          keep_files: true       # do not erase flamegraphs/ or benchmarks/
+          cname: docs.ethrex.xyz # always commit the CNAME file


### PR DESCRIPTION
**Motivation**

Publish the mdbook of this repo (book.toml) to https://docs.ethrex.xyz/

**Description**

This changes are to leave the setup like this:

* https://docs.ethrex.xyz/ will have the mdbook
* https://docs.ethrex.xyz/benchmarks will have the benchmarks graphs
* https://docs.ethrex.xyz/flamegraphs will have the flamegraphs