### PR TITLE
fix(l1): compute logs_bloom when building payloads

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -10,9 +10,9 @@ use ethrex_common::{
     constants::{DEFAULT_OMMERS_HASH, DEFAULT_REQUESTS_HASH, GAS_PER_BLOB},
     types::{
         AccountUpdate, BlobsBundle, Block, BlockBody, BlockHash, BlockHeader, BlockNumber,
-        ChainConfig, MempoolTransaction, Receipt, Transaction, Withdrawal, calc_excess_blob_gas,
-        calculate_base_fee_per_blob_gas, calculate_base_fee_per_gas, compute_receipts_root,
-        compute_transactions_root, compute_withdrawals_root,
+        ChainConfig, MempoolTransaction, Receipt, Transaction, Withdrawal, bloom_from_logs,
+        calc_excess_blob_gas, calculate_base_fee_per_blob_gas, calculate_base_fee_per_gas,
+        compute_receipts_root, compute_transactions_root, compute_withdrawals_root,
         requests::{EncodedRequests, compute_requests_hash},
     },
 };
@@ -540,6 +540,15 @@ impl Blockchain {
         context.payload.header.requests_hash = context.requests_hash;
         context.payload.header.gas_used = context.payload.header.gas_limit - context.remaining_gas;
         context.account_updates = account_updates;
+
+        let mut logs = vec![];
+        for receipt in context.receipts.iter().cloned() {
+            for log in receipt.logs {
+                logs.push(log);
+            }
+        }
+
+        context.payload.header.logs_bloom = bloom_from_logs(&logs);
         Ok(())
     }
 }


### PR DESCRIPTION
**Motivation**

Our build payload process was not computing and setting the `logs_bloom` field on the block's header, which resulted in other clients rejecting blocks built by us. This came up when testing setting up a localnet with ethrex along with other clients.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

