### PR TITLE
ci(l1,l2): fix GitHub Pages deployments

### DIFF
--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -60,7 +60,7 @@ jobs:
           name: "L1 block proving benchmark"
           tool: "customBiggerIsBetter"
           output-file-path: cmd/ethrex_replay/bench_latest.json
-          benchmark-data-dir-path: "."
+          benchmark-data-dir-path: "benchmarks"
           # Access token to deploy GitHub Pages branch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "docs/**"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: book
+          publish_dir: book/html
           destination_dir: .     # root of gh-pages
           keep_files: true       # do not erase flamegraphs/ or benchmarks/
           cname: docs.ethrex.xyz # always commit the CNAME file


### PR DESCRIPTION
**Motivation**

Fix for #3217

**Description**

Fixes lack of permissions for mdbook workflow, and new path to publish L1 block proving benchmark

