### PR TITLE
fix(levm): account was already empty don't count as update if it remains empty

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -239,7 +239,9 @@ impl LEVM {
             };
 
             // "At the end of the transaction, any account touched by the execution of that transaction which is now empty SHALL instead become non-existent (i.e. deleted)."
-            let removed = new_state_account.is_empty();
+            // If the account was already empty then this is not an update
+            let was_empty = initial_state_account.is_empty();
+            let removed = new_state_account.is_empty() && !was_empty;
 
             if !removed && !acc_info_updated && !storage_updated {
                 // Account hasn't been updated


### PR DESCRIPTION
**Motivation**

The l2 committer was stuck because it failed when trying to encode state diffs of an account that was initially empty, remained empty after the transaction so the AccountUpdate was completely empty and state diff creation failed with `StateDiffError::EmptyAccountDiff`

**Description**

- `LEVM::get_state_transitions` now checks if the account was initially empty, in case it was and it remains empty after the transaction do not count it as an AccountUpdate

