### PR TITLE
chore(l2): pin rex commit

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -145,6 +145,7 @@ jobs:
           rustup default nightly
           git clone https://github.com/lambdaclass/rex.git
           cd rex
+          git checkout 1634d3bdd1b15d52cefb37cdc3127cf6667ce9d9
           make cli
           echo "rex install successfully at $(which rex)"
 


### PR DESCRIPTION
**Motivation**

The based integration test is broken. This is because [Rex](https://github.com/lambdaclass/rex) is under development and ongoing changes can break our CI.

Description

This PR pins a specific Rex commit in the CI.

Closes None

