### PR TITLE
perf(core): remove unneeded rlp encoding on mdbx keys

### DIFF
--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -3,11 +3,12 @@ use std::marker::PhantomData;
 
 use bytes::Bytes;
 use ethrex_common::{
-    H256,
     types::{
         AccountState, Block, BlockBody, BlockHash, BlockHeader, Receipt, payload::PayloadBundle,
     },
 };
+#[cfg(feature = "redb")]
+use ethrex_common::H256;
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_trie::Nibbles;
 #[cfg(feature = "libmdbx")]

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -18,8 +18,10 @@ use redb::TypeName;
 use std::any::type_name;
 
 // Account types
+#[cfg(feature = "redb")]
 pub type AccountCodeHashRLP = Rlp<H256>;
 pub type AccountCodeRLP = Rlp<Bytes>;
+#[cfg(feature = "redb")]
 pub type AccountHashRLP = Rlp<H256>;
 pub type AccountStateRLP = Rlp<AccountState>;
 pub type TriePathsRLP = Rlp<Vec<Nibbles>>;
@@ -35,6 +37,7 @@ pub type BlockRLP = Rlp<Block>;
 pub type ReceiptRLP = Rlp<Receipt>;
 
 // Transaction types
+#[cfg(feature = "redb")]
 pub type TransactionHashRLP = Rlp<H256>;
 
 // Payload type

--- a/crates/storage/rlp.rs
+++ b/crates/storage/rlp.rs
@@ -2,13 +2,11 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 use bytes::Bytes;
-use ethrex_common::{
-    types::{
-        AccountState, Block, BlockBody, BlockHash, BlockHeader, Receipt, payload::PayloadBundle,
-    },
-};
 #[cfg(feature = "redb")]
 use ethrex_common::H256;
+use ethrex_common::types::{
+    AccountState, Block, BlockBody, BlockHash, BlockHeader, Receipt, payload::PayloadBundle,
+};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_trie::Nibbles;
 #[cfg(feature = "libmdbx")]


### PR DESCRIPTION
**Motivation**

There is no need at all to rlp encode the keys when storing on the database, this pr removes it.

**Description**

While most of the encoding/decoding time is spent on the values and not the keys, i think it's still worthwhile to avoid it on the keys.

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

