### PR TITLE
chore(l1): add metrics port to ethrex client

### DIFF
--- a/.github/config/assertoor/network_params_ethrex_only.yaml
+++ b/.github/config/assertoor/network_params_ethrex_only.yaml
@@ -4,6 +4,7 @@ participants:
     cl_image: sigp/lighthouse:v7.0.0-beta.0
     validator_count: 32
     count: 3
+    ethereum_metrics_exporter_enabled: true
 
 network_params:
   # The address of the staking contract address on the Eth1 chain

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean: clean-vectors ## 🧹 Remove build artifacts
 
 STAMP_FILE := .docker_build_stamp
 $(STAMP_FILE): $(shell find crates cmd -type f -name '*.rs') Cargo.toml Dockerfile
-	docker build -t ethrex .
+	docker build -t ethrex . --build-arg BUILD_FLAGS="--features metrics"
 	touch $(STAMP_FILE)
 
 build-image: $(STAMP_FILE) ## 🐳 Build the Docker image
@@ -40,7 +40,7 @@ dev: ## 🏃 Run the ethrex client in DEV_MODE with the InMemory Engine
 			--dev \
 			--datadir memory
 
-ETHEREUM_PACKAGE_REVISION := 7d7864cf1cc34138b427c3c7d0e36623efc19300
+ETHEREUM_PACKAGE_REVISION := 6a896a15e6d686b0a60adf4ee97954065bc82435
 
 # Shallow clones can't specify a single revision, but at least we avoid working
 # the whole history by making it shallow since a given date (one day before our


### PR DESCRIPTION
**Motivation**

When running a localnet with kurtosis the ethrex client wasn't exposing a metrics port.

**Description**

To expose the metrics port, the ETHEREUM_PACKAGE_REVISION in the Makefile was updated to the latest commit in our fork of ethereum-package. Additionally, the metrics feature flag was enabled when building the Docker image (without it, metrics won't work).
The ethereum_metrics_exporter_enabled setting was also enabled for all participants in the ethrex-only localnet.
With these changes, we are now able to use metrics with ethrex clients.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3213

