### PR TITLE
feat(l1, l2): overwrite txs in mempool if fees are higher

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -569,7 +569,9 @@ impl Blockchain {
         let sender = transaction.sender()?;
 
         // Validate transaction
-        self.validate_transaction(&transaction, sender).await?;
+        if let Some(tx_to_replace) = self.validate_transaction(&transaction, sender).await? {
+            self.remove_transaction_from_pool(&tx_to_replace)?;
+        }
 
         // Add transaction and blobs bundle to storage
         let hash = transaction.compute_hash();
@@ -590,7 +592,9 @@ impl Blockchain {
         }
         let sender = transaction.sender()?;
         // Validate transaction
-        self.validate_transaction(&transaction, sender).await?;
+        if let Some(tx_to_replace) = self.validate_transaction(&transaction, sender).await? {
+            self.remove_transaction_from_pool(&tx_to_replace)?;
+        }
 
         let hash = transaction.compute_hash();
 
@@ -637,16 +641,16 @@ impl Blockchain {
     5. Ensure the transactor is able to add a new transaction. The number of transactions sent by an account may be limited by a certain configured value
 
     */
-
+    /// Returns the hash of the transaction to replace in case the nonce already exists
     pub async fn validate_transaction(
         &self,
         tx: &Transaction,
         sender: Address,
-    ) -> Result<(), MempoolError> {
+    ) -> Result<Option<H256>, MempoolError> {
         let nonce = tx.nonce();
 
         if matches!(tx, &Transaction::PrivilegedL2Transaction(_)) {
-            return Ok(());
+            return Ok(None);
         }
 
         let header_no = self.storage.get_latest_block_number().await?;
@@ -713,12 +717,39 @@ impl Blockchain {
         }
 
         // Check the nonce of pendings TXs in the mempool from the same sender
-        if self
+        // If it exists check if the new tx has higher fees
+        let tx_to_replace_hash = self
             .mempool
             .contains_sender_nonce(sender, nonce, tx.compute_hash())?
-        {
-            return Err(MempoolError::InvalidNonce);
-        }
+            .and_then(|tx_in_pool| {
+                // EIP-1559 values
+                let old_tx_max_fee_per_gas = tx_in_pool.max_fee_per_gas().unwrap_or_default();
+                let old_tx_max_priority_fee_per_gas =
+                    tx_in_pool.max_priority_fee().unwrap_or_default();
+                let new_tx_max_fee_per_gas = tx.max_fee_per_gas().unwrap_or_default();
+                let new_tx_max_priority_fee_per_gas = tx.max_priority_fee().unwrap_or_default();
+                // Legacy tx values
+                let old_tx_gas_price = tx_in_pool.gas_price();
+                let new_tx_gas_price = tx.gas_price();
+                // EIP-4844 values
+                let old_tx_max_fee_per_blob = tx_in_pool.max_fee_per_blob_gas();
+                let new_tx_max_fee_per_blob = tx.max_fee_per_blob_gas();
+
+                let eip4844_higher_fees = match (old_tx_max_fee_per_blob, new_tx_max_fee_per_blob) {
+                    (Some(old), Some(new)) => new > old,
+                    _ => true,
+                };
+
+                let eip1559_higher_fees = new_tx_max_fee_per_gas > old_tx_max_fee_per_gas
+                    && new_tx_max_priority_fee_per_gas > old_tx_max_priority_fee_per_gas;
+                let legacy_higher_fees = new_tx_gas_price > old_tx_gas_price;
+
+                if eip4844_higher_fees && (eip1559_higher_fees || legacy_higher_fees) {
+                    Some(tx_in_pool.compute_hash())
+                } else {
+                    None
+                }
+            });
 
         if let Some(chain_id) = tx.chain_id() {
             if chain_id != config.chain_id {
@@ -726,7 +757,7 @@ impl Blockchain {
             }
         }
 
-        Ok(())
+        Ok(tx_to_replace_hash)
     }
 
     /// Marks the node's chain as up to date with the current chain

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -718,38 +718,39 @@ impl Blockchain {
 
         // Check the nonce of pendings TXs in the mempool from the same sender
         // If it exists check if the new tx has higher fees
-        let tx_to_replace_hash = self
-            .mempool
-            .contains_sender_nonce(sender, nonce, tx.compute_hash())?
-            .and_then(|tx_in_pool| {
-                // EIP-1559 values
-                let old_tx_max_fee_per_gas = tx_in_pool.max_fee_per_gas().unwrap_or_default();
-                let old_tx_max_priority_fee_per_gas =
-                    tx_in_pool.max_priority_fee().unwrap_or_default();
-                let new_tx_max_fee_per_gas = tx.max_fee_per_gas().unwrap_or_default();
-                let new_tx_max_priority_fee_per_gas = tx.max_priority_fee().unwrap_or_default();
-                // Legacy tx values
-                let old_tx_gas_price = tx_in_pool.gas_price();
-                let new_tx_gas_price = tx.gas_price();
-                // EIP-4844 values
-                let old_tx_max_fee_per_blob = tx_in_pool.max_fee_per_blob_gas();
-                let new_tx_max_fee_per_blob = tx.max_fee_per_blob_gas();
+        let tx_to_replace_hash = if let Some(tx_in_pool) =
+            self.mempool
+                .contains_sender_nonce(sender, nonce, tx.compute_hash())?
+        {
+            // EIP-1559 values
+            let old_tx_max_fee_per_gas = tx_in_pool.max_fee_per_gas().unwrap_or_default();
+            let old_tx_max_priority_fee_per_gas = tx_in_pool.max_priority_fee().unwrap_or_default();
+            let new_tx_max_fee_per_gas = tx.max_fee_per_gas().unwrap_or_default();
+            let new_tx_max_priority_fee_per_gas = tx.max_priority_fee().unwrap_or_default();
+            // Legacy tx values
+            let old_tx_gas_price = tx_in_pool.gas_price();
+            let new_tx_gas_price = tx.gas_price();
+            // EIP-4844 values
+            let old_tx_max_fee_per_blob = tx_in_pool.max_fee_per_blob_gas();
+            let new_tx_max_fee_per_blob = tx.max_fee_per_blob_gas();
 
-                let eip4844_higher_fees = match (old_tx_max_fee_per_blob, new_tx_max_fee_per_blob) {
-                    (Some(old), Some(new)) => new > old,
-                    _ => true,
-                };
+            let eip4844_higher_fees = match (old_tx_max_fee_per_blob, new_tx_max_fee_per_blob) {
+                (Some(old), Some(new)) => new > old,
+                _ => true, // We are marking it as always true if the tx is not eip-4844
+            };
 
-                let eip1559_higher_fees = new_tx_max_fee_per_gas > old_tx_max_fee_per_gas
-                    && new_tx_max_priority_fee_per_gas > old_tx_max_priority_fee_per_gas;
-                let legacy_higher_fees = new_tx_gas_price > old_tx_gas_price;
+            let eip1559_higher_fees = new_tx_max_fee_per_gas > old_tx_max_fee_per_gas
+                && new_tx_max_priority_fee_per_gas > old_tx_max_priority_fee_per_gas;
+            let legacy_higher_fees = new_tx_gas_price > old_tx_gas_price;
 
-                if eip4844_higher_fees && (eip1559_higher_fees || legacy_higher_fees) {
-                    Some(tx_in_pool.compute_hash())
-                } else {
-                    None
-                }
-            });
+            if eip4844_higher_fees && (eip1559_higher_fees || legacy_higher_fees) {
+                Some(tx_in_pool.compute_hash())
+            } else {
+                return Err(MempoolError::NonceTooLow);
+            }
+        } else {
+            None
+        };
 
         if let Some(chain_id) = tx.chain_id() {
             if chain_id != config.chain_id {

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -267,6 +267,53 @@ impl Mempool {
 
         Ok(txs.pop())
     }
+
+    pub fn find_tx_to_replace(
+        &self,
+        sender: Address,
+        nonce: u64,
+        tx: &Transaction,
+    ) -> Result<Option<H256>, MempoolError> {
+        let Some(tx_in_pool) = self.contains_sender_nonce(sender, nonce, tx.compute_hash())? else {
+            return Ok(None);
+        };
+
+        let is_a_replacement_tx = {
+            // EIP-1559 values
+            let old_tx_max_fee_per_gas = tx_in_pool.max_fee_per_gas().unwrap_or_default();
+            let old_tx_max_priority_fee_per_gas = tx_in_pool.max_priority_fee().unwrap_or_default();
+            let new_tx_max_fee_per_gas = tx.max_fee_per_gas().unwrap_or_default();
+            let new_tx_max_priority_fee_per_gas = tx.max_priority_fee().unwrap_or_default();
+
+            // Legacy tx values
+            let old_tx_gas_price = tx_in_pool.gas_price();
+            let new_tx_gas_price = tx.gas_price();
+
+            // EIP-4844 values
+            let old_tx_max_fee_per_blob = tx_in_pool.max_fee_per_blob_gas();
+            let new_tx_max_fee_per_blob = tx.max_fee_per_blob_gas();
+
+            let eip4844_higher_fees = if let (Some(old_blob_fee), Some(new_blob_fee)) =
+                (old_tx_max_fee_per_blob, new_tx_max_fee_per_blob)
+            {
+                new_blob_fee > old_blob_fee
+            } else {
+                true // We are marking it as always true if the tx is not eip-4844
+            };
+
+            let eip1559_higher_fees = new_tx_max_fee_per_gas > old_tx_max_fee_per_gas
+                && new_tx_max_priority_fee_per_gas > old_tx_max_priority_fee_per_gas;
+            let legacy_higher_fees = new_tx_gas_price > old_tx_gas_price;
+
+            eip4844_higher_fees && (eip1559_higher_fees || legacy_higher_fees)
+        };
+
+        if !is_a_replacement_tx {
+            return Err(MempoolError::NonceTooLow);
+        }
+
+        Ok(Some(tx_in_pool.compute_hash()))
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
**Motivation**

Most Ethereum clients let you speed up or overwrite transactions by accepting new transactions with the same nonce but higher fees.
This PR adds validations similar to what [Geth does](https://github.com/ethereum/go-ethereum/blob/09289fd154a45420ec916eb842bfb172df7e0d83/core/txpool/legacypool/list.go#L298-L345)  but without the `PriceBump` minimum bump percentage

**Description**

- for eip-1559 check that both `max_fee_per_gas` and `max_priority_fee_per_gas` are greater in the new tx
- for legacy tx check that new `gas_price` is greater in the new tx
- for eip-4844 txs check that `max_fee_per_gas`, `max_priority_fee_per_gas` and `max_fee_per_blob_gas` are grater in the new tx

**How to test**

- Send a tx with very low gas price

```shell
rex send --gas-price 1 --priority-gas-price 1 --rpc-url http://localhost:1729 0x2B29Bea668B044b2b355C370f85b729bcb43EC40 100000000000000 0x8f87d3aca3eff8132256f69e17df5ba3c605e1b5f4e2071d56f7e6cd66047cc2
```

- Check tx pool the you should see something like  `"maxPriorityFeePerGas":"0x1","maxFeePerGas":"0x1","gasPrice":"0x1"` the tx will probably get stuck

```
curl 'http://localhost:1729' --data '{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "txpool_content",
  "params": []
}' -H 'accept: application/json' -H 'Content-Type: application/json'
```

- Send tx with higher gas

```shell
rex send --gas-price 100000000 --priority-gas-price 100000000 --rpc-url http://localhost:1729 0x2B29Bea668B044b2b355C370f85b729bcb43EC40 100000000000000 0x8f87d3aca3eff8132256f69e17df5ba3c605e1b5f4e2071d56f7e6cd66047cc2
```

- Check that the tx pool you should see something like `"maxPriorityFeePerGas":"0x5f5e100","maxFeePerGas":"0x5f5e100","gasPrice":"0x5f5e100"`

```shell
curl 'http://localhost:1729' --data '{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "txpool_content",
  "params": []
}' -H 'accept: application/json' -H 'Content-Type: application/json'
```