### PR TITLE
fix(l1): `RpcBlock` `uncles` field should have the hashes and not the block headers

### DIFF
--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -30,7 +30,7 @@ pub enum BlockBodyWrapper {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FullBlockBody {
     pub transactions: Vec<RpcTransaction>,
-    pub uncles: Vec<BlockHeader>,
+    pub uncles: Vec<H256>,
     pub withdrawals: Vec<Withdrawal>,
 }
 
@@ -38,7 +38,7 @@ pub struct FullBlockBody {
 pub struct OnlyHashesBlockBody {
     // Only tx hashes
     pub transactions: Vec<H256>,
-    pub uncles: Vec<BlockHeader>,
+    pub uncles: Vec<H256>,
     pub withdrawals: Vec<Withdrawal>,
 }
 
@@ -57,7 +57,7 @@ impl RpcBlock {
         } else {
             BlockBodyWrapper::OnlyHashes(OnlyHashesBlockBody {
                 transactions: body.transactions.iter().map(|t| t.compute_hash()).collect(),
-                uncles: body.ommers,
+                uncles: body.ommers.iter().map(|ommer| ommer.hash()).collect(),
                 withdrawals: body.withdrawals.unwrap_or_default(),
             })
         };
@@ -88,7 +88,7 @@ impl FullBlockBody {
         }
         Ok(FullBlockBody {
             transactions,
-            uncles: body.ommers,
+            uncles: body.ommers.iter().map(|ommer| ommer.hash()).collect(),
             withdrawals: body.withdrawals.unwrap_or_default(),
         })
     }


### PR DESCRIPTION
**Motivation**
Fix inconsistencies between our RPC outputs and the spec.
According to the spec endpoints such as `eth_getBlockByNumber` return a block where the `uncles` field contains the hashes of the uncle blocks, while we return the full headers.
This has not been a problem for us as we have been mainly using post-merge blocks without uncles, but it will become a problem if we need to export/import older blocks via rpc
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Change `uncles` field of `RpcBlock` from `Vec<BlockHeader>` to `Vec<H256`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

