### PR TITLE
docs(core): add `mdbook-mermaid` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,8 @@ prof_*.json
 prof.json
 profile.json.gz
 
-# Mdbook artifacts
-book
+# mdbook artifacts
+book/
+# mdbook-mermaid artifacts
+mermaid-init.js
+mermaid.min.js

--- a/Makefile
+++ b/Makefile
@@ -167,3 +167,19 @@ test_data/ERC20/ERC20.bin: ## 🔨 Build the ERC20 contract for the load test
 
 sort-genesis-files:
 	cd ./tooling/genesis && cargo run
+
+# Using & so make calls this recipe only once per run
+mermaid-init.js mermaid.min.js &:
+	@# Required for mdbook-mermaid to work
+	@mdbook-mermaid install . \
+		|| (echo "mdbook-mermaid invocation failed, remember to install docs dependencies first with \`make docs-deps\`" \
+		&& exit 1)
+
+docs-deps: ## 📦 Install dependencies for generating the documentation
+	cargo install mdbook mdbook-alerts mdbook-mermaid mdbook-linkcheck
+
+docs: mermaid-init.js mermaid.min.js ## 📚 Generate the documentation
+	mdbook build
+
+docs-serve: mermaid-init.js mermaid.min.js ## 📚 Generate and serve the documentation
+	mdbook serve --open

--- a/README.md
+++ b/README.md
@@ -38,8 +38,12 @@ Read more about our engineering philosophy [here](https://blog.lambdaclass.com/l
 ## Documentation
 
 We have markdown documentation under [`docs/`](./docs/), rendered using mdbook.
-You can render and serve it locally by running `mdbook serve --open`, after installing it [as explained in their documentation](https://rust-lang.github.io/mdBook/guide/installation.html), with `cargo install mdbook`.
-We also use the [`alerts` preprocessor](https://github.com/lambdalisue/rs-mdbook-alerts) for custom markdown syntax, and you need to install it with `cargo install mdbook-alerts`.
+You can render and serve it locally by running `make docs-serve`, after installing it [as explained in their documentation](https://rust-lang.github.io/mdBook/guide/installation.html), or with `cargo install mdbook`.
+We also use some `mdbook` preprocessors and backends for additional features, which can be installed running `make docs-deps`, or manually:
+
+- [`mdbook-alerts` preprocessor](https://github.com/lambdalisue/rs-mdbook-alerts) for custom markdown syntax. Needs to be installed with `cargo install mdbook-alerts`.
+- [`mdbook-mermaid` preprocessor](https://github.com/badboy/mdbook-mermaid) for mermaid diagrams. Needs to be installed with `cargo install mdbook-mermaid`.
+- [`mdbook-linkcheck` backend](https://github.com/Michael-F-Bryan/mdbook-linkcheck) that checks for broken links. This one is optional, and can be installed with `cargo install mdbook-linkcheck`.
 
 # ethrex L1
 

--- a/book.toml
+++ b/book.toml
@@ -13,10 +13,18 @@ edition = "2024"
 # This is to avoid warnings about incomplete links on each alert
 renderers = ["html", "linkcheck"]
 
+# To render Mermaid diagrams
+# https://github.com/badboy/mdbook-mermaid
+[preprocessor.mermaid]
+command = "mdbook-mermaid"
+
 [output.html]
 git-repository-url = "https://github.com/lambdaclass/ethrex"
 # make sections collapsible, and start with everything collapsed
 fold = { enable = true, level = 0 }
+
+# Required for mdbook-mermaid
+additional-js = ["mermaid.min.js", "mermaid-init.js"]
 
 # Broken-link checker
 # https://github.com/Michael-F-Bryan/mdbook-linkcheck


### PR DESCRIPTION
**Motivation**

We want to include diagrams in the mdbook. The easiest way to manage diagrams with `git` is to declare them with `mermaid`.

**Description**

This PR adds [the `mdbook-mermaid` preprocessor](https://github.com/badboy/mdbook-mermaid), which automatically renders the mermaid diagrams in our docs.

As part of this, it also adds make targets to automatically install preprocessors/backends, and to generate the files required by `mdbook-mermaid`.

<img width="836" alt="example mermaid diagram in the L2 docs" src="https://github.com/user-attachments/assets/d14d57f4-4c73-4c99-82e3-281f1693ee84" />

