### PR TITLE
fix(l2): fix l2 integration test job

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -78,6 +78,11 @@ jobs:
         run: |
           cargo test l2 --no-run --release
 
+      # for some reason the "Start L1 & Deploy contracts" step does not build the ethrex_dev image, used
+      # for the L1. This does not happen on the rest of the jobs. Maybe it has to do with the "larger_runners".
+      - name: Build L1 docker image
+        run: docker build -t ethrex_dev:latest -f crates/blockchain/dev/Dockerfile .
+
       - name: Start L1 & Deploy contracts
         run: |
           cd crates/l2


### PR DESCRIPTION
**Motivation**

This was failing on multiple PRs because the ethrex_dev image was not being built.

The difference between the failing job and the others (which were succeeding) is the runner (larger_runners). Maybe that has something to do with it.

**Description**

- adds a step to build ethrex_dev explicitly

