### PR TITLE
Docs: Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Hive tests are categorized by "simulations', and test instances can be filtered 
 ```bash
 make run-hive-debug SIMULATION=<simulation> TEST_PATTERN=<test-regex>
 ```
-This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specificaly
+This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specifically
 run chain id and transaction by hash rpc tests:
 ```bash
 make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_getTransactionByHash"

--- a/tooling/sync/readme.MD
+++ b/tooling/sync/readme.MD
@@ -29,7 +29,7 @@ The databases are stored in the `~/.local/share/` folder in Linux, and `~/Librar
 
 ## Running a sync
 
-Lighthouse must be running for the sync to work. Aditionally, a jwt has to be provided too. The SYNC_BLOCK_NUM also has to be one a batch ended on for that network and evm. *The sync will not work if not started from a block number like such*, so it's important to check the numebr carefully.
+Lighthouse must be running for the sync to work. Additionally, a jwt has to be provided too. The SYNC_BLOCK_NUM also has to be one a batch ended on for that network and evm. *The sync will not work if not started from a block number like such*, so it's important to check the number carefully.
 
 ## Commands
 


### PR DESCRIPTION


### **Description:**
```markdown
This PR contains minor typo fixes in the project's documentation.

- Corrected `specificaly` to `specifically` in `README.md`.
- Corrected `numebr` to `number` in `tooling/sync/readme.MD`.
```
