### PR TITLE
chore(core): add `--num-blocks` flag to the import command

### DIFF
--- a/cmd/ethrex/bench/import_blocks_benchmark.rs
+++ b/cmd/ethrex/bench/import_blocks_benchmark.rs
@@ -25,7 +25,7 @@ fn block_import() {
         data_dir,
         genesis,
         evm_engine,
-        None,
+        ..,
     ))
     .expect("Failed to import blocks on the Tokio runtime");
 }


### PR DESCRIPTION
**Motivation**

Right now we can only time and profile everything in the input file. With this, we'll be able to time and profile only relevant portions of the input file.

**Description**

Add a block limit argument to truncate the number of blocks to import.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

