### PR TITLE
Move integration test back to normal GitHub Runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,3 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - gpu
-    - larger_runners

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -49,7 +49,7 @@ jobs:
 
   integration-test:
     name: Integration Test - ${{ matrix.name }}
-    runs-on: larger_runners
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -78,8 +78,6 @@ jobs:
         run: |
           cargo test l2 --no-run --release
 
-      # for some reason the "Start L1 & Deploy contracts" step does not build the ethrex_dev image, used
-      # for the L1. This does not happen on the rest of the jobs. Maybe it has to do with the "larger_runners".
       - name: Build L1 docker image
         run: docker build -t ethrex_dev:latest -f crates/blockchain/dev/Dockerfile .
 


### PR DESCRIPTION
**Motivation**

Go back to the normal GitHub runners, instead of larger runners, because the disk size constraint has been removed from this CI job

**Description**

* Changes `runs-on:` from `integration-test` job in `pr-main_l2.yaml` workflow.
* Removes actionlint label
* Removes related comment
