### PR TITLE
perf(levm): refactor levm jump opcodes

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -9,45 +9,118 @@ use crate::{
 use bytes::Bytes;
 use ethrex_common::{Address, U256, types::Account};
 use keccak_hash::H256;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 /// The EVM uses a stack-based architecture and does not use registers like some other VMs.
 pub struct Stack {
-    pub stack: Vec<U256>,
+    pub values: Box<[U256; STACK_LIMIT]>,
+    pub offset: usize,
 }
 
 impl Stack {
-    pub fn pop(&mut self) -> Result<U256, ExceptionalHalt> {
-        self.stack.pop().ok_or(ExceptionalHalt::StackUnderflow)
+    pub fn pop<const N: usize>(&mut self) -> Result<&[U256; N], ExceptionalHalt> {
+        // Compile-time check for stack underflow.
+        if N > STACK_LIMIT {
+            return Err(ExceptionalHalt::StackUnderflow);
+        }
+
+        // The following operation can never overflow as both `self.offset` and N are within
+        // STACK_LIMIT (1024).
+        #[allow(clippy::arithmetic_side_effects)]
+        let next_offset = self.offset + N;
+
+        // The index cannot fail because `self.offset` is known to be valid. The `first_chunk()`
+        // method will ensure that `next_offset` is within `STACK_LIMIT`, so there's no need to
+        // check it again.
+        #[allow(clippy::indexing_slicing)]
+        let values = self.values[self.offset..]
+            .first_chunk::<N>()
+            .ok_or(ExceptionalHalt::StackUnderflow)?;
+        self.offset = next_offset;
+
+        Ok(values)
     }
 
-    pub fn push(&mut self, value: U256) -> Result<(), ExceptionalHalt> {
-        if self.stack.len() >= STACK_LIMIT {
-            return Err(ExceptionalHalt::StackOverflow);
-        }
-        self.stack.push(value);
+    pub fn push<const N: usize>(&mut self, values: &[U256; N]) -> Result<(), ExceptionalHalt> {
+        // Since the stack grows downwards, when an offset underflow is detected the stack is
+        // overflowing.
+        let next_offset = self
+            .offset
+            .checked_sub(N)
+            .ok_or(ExceptionalHalt::StackOverflow)?;
+
+        // The following index cannot fail because `next_offset` has already been checked and
+        // `self.offset` is known to be within `STACK_LIMIT`.
+        #[allow(clippy::indexing_slicing)]
+        self.values[next_offset..self.offset].copy_from_slice(values);
+        self.offset = next_offset;
+
         Ok(())
     }
 
     pub fn len(&self) -> usize {
-        self.stack.len()
+        // The following operation cannot underflow because `self.offset` is known to be less than
+        // or equal to `self.values.len()` (aka. `STACK_LIMIT`).
+        #[allow(clippy::arithmetic_side_effects)]
+        {
+            self.values.len() - self.offset
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.stack.is_empty()
+        self.offset == self.values.len()
     }
 
     pub fn get(&self, index: usize) -> Result<&U256, ExceptionalHalt> {
-        self.stack.get(index).ok_or(ExceptionalHalt::StackUnderflow)
+        // The following index cannot fail because `self.offset` is known to be within
+        // `STACK_LIMIT`.
+        #[allow(clippy::indexing_slicing)]
+        self.values[self.offset..]
+            .get(index)
+            .ok_or(ExceptionalHalt::StackUnderflow)
     }
 
-    pub fn swap(&mut self, a: usize, b: usize) -> Result<(), ExceptionalHalt> {
-        if a >= self.stack.len() || b >= self.stack.len() {
+    pub fn swap(&mut self, index: usize) -> Result<(), ExceptionalHalt> {
+        let index = self
+            .offset
+            .checked_add(index)
+            .ok_or(ExceptionalHalt::StackUnderflow)?;
+        if index >= self.values.len() {
             return Err(ExceptionalHalt::StackUnderflow);
         }
-        self.stack.swap(a, b);
+
+        self.values.swap(self.offset, index);
         Ok(())
+    }
+}
+
+impl Default for Stack {
+    fn default() -> Self {
+        Self {
+            values: Box::new([U256::zero(); 1024]),
+            offset: 1024,
+        }
+    }
+}
+
+impl fmt::Debug for Stack {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct StackValues<'a>(&'a [U256]);
+
+        impl fmt::Debug for StackValues<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_list().entries(self.0.iter().rev()).finish()
+            }
+        }
+
+        #[allow(clippy::indexing_slicing)]
+        f.debug_tuple("Stack")
+            .field(&StackValues(&self.values[self.offset..]))
+            .finish()
     }
 }
 

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -3,16 +3,13 @@ use crate::{
     errors::{ExceptionalHalt, InternalError, VMError},
     memory::Memory,
     opcodes::Opcode,
-    utils::{get_valid_jump_destinations, restore_cache_state},
+    utils::{get_invalid_jump_destinations, restore_cache_state},
     vm::VM,
 };
 use bytes::Bytes;
 use ethrex_common::{Address, U256, types::Account};
 use keccak_hash::H256;
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::{collections::HashMap, fmt};
 
 #[derive(Clone, PartialEq, Eq)]
 /// The EVM uses a stack-based architecture and does not use registers like some other VMs.
@@ -158,8 +155,9 @@ pub struct CallFrame {
     pub is_static: bool,
     /// Call stack current depth
     pub depth: usize,
-    /// Set of valid jump destinations (where a JUMP or JUMPI can jump to)
-    pub valid_jump_destinations: HashSet<usize>,
+    /// Sorted blacklist of jump targets. Contains all offsets of 0x5B (JUMPDEST) in literals (after
+    /// push instructions).
+    pub invalid_jump_destinations: Box<[usize]>,
     /// This is set to true if the function that created this callframe is CREATE or CREATE2
     pub is_create: bool,
     /// Everytime we want to write an account during execution of a callframe we store the pre-write state so that we can restore if it reverts
@@ -209,7 +207,8 @@ impl CallFrame {
         ret_offset: U256,
         ret_size: usize,
     ) -> Self {
-        let valid_jump_destinations = get_valid_jump_destinations(&bytecode).unwrap_or_default();
+        let invalid_jump_destinations =
+            get_invalid_jump_destinations(&bytecode).unwrap_or_default();
         Self {
             gas_limit,
             msg_sender,
@@ -220,7 +219,7 @@ impl CallFrame {
             calldata,
             is_static,
             depth,
-            valid_jump_destinations,
+            invalid_jump_destinations,
             should_transfer_value,
             is_create,
             ret_offset,
@@ -260,7 +259,7 @@ impl CallFrame {
     }
 
     pub fn set_code(&mut self, code: Bytes) -> Result<(), VMError> {
-        self.valid_jump_destinations = get_valid_jump_destinations(&code)?;
+        self.invalid_jump_destinations = get_invalid_jump_destinations(&code)?;
         self.bytecode = code;
         Ok(())
     }

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -3,7 +3,6 @@ use crate::{
     errors::{ContextResult, ExceptionalHalt, InternalError, OpcodeResult, TxResult, VMError},
     gas_cost::CODE_DEPOSIT_COST,
     opcodes::Opcode,
-    utils::*,
     vm::VM,
 };
 
@@ -77,8 +76,9 @@ impl<'a> VM<'a> {
             Opcode::PUSH0 => self.op_push0(),
             // PUSHn
             op if (Opcode::PUSH1..=Opcode::PUSH32).contains(&op) => {
-                let n_bytes = get_n_value(op, Opcode::PUSH1)?;
-                self.op_push(n_bytes)
+                // The following conversions and operation cannot fail due to known operand ranges.
+                #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
+                self.op_push(op as usize - Opcode::PUSH0 as usize)
             }
             Opcode::AND => self.op_and(),
             Opcode::OR => self.op_or(),
@@ -90,19 +90,22 @@ impl<'a> VM<'a> {
             Opcode::SAR => self.op_sar(),
             // DUPn
             op if (Opcode::DUP1..=Opcode::DUP16).contains(&op) => {
-                let depth = get_n_value(op, Opcode::DUP1)?;
-                self.op_dup(depth)
+                // The following conversions and operation cannot fail due to known operand ranges.
+                #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
+                self.op_dup(op as usize - Opcode::DUP1 as usize)
             }
             // SWAPn
             op if (Opcode::SWAP1..=Opcode::SWAP16).contains(&op) => {
-                let depth = get_n_value(op, Opcode::SWAP1)?;
-                self.op_swap(depth)
+                // The following conversions and operation cannot fail due to known operand ranges.
+                #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
+                self.op_swap(op as usize - Opcode::SWAP1 as usize + 1)
             }
             Opcode::POP => self.op_pop(),
-            op if (Opcode::LOG0..=Opcode::LOG4).contains(&op) => {
-                let number_of_topics = get_number_of_topics(op)?;
-                self.op_log(number_of_topics)
-            }
+            Opcode::LOG0 => self.op_log::<0>(),
+            Opcode::LOG1 => self.op_log::<1>(),
+            Opcode::LOG2 => self.op_log::<2>(),
+            Opcode::LOG3 => self.op_log::<3>(),
+            Opcode::LOG4 => self.op_log::<4>(),
             Opcode::MLOAD => self.op_mload(),
             Opcode::MSTORE => self.op_mstore(),
             Opcode::MSTORE8 => self.op_mstore8(),

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -338,12 +338,15 @@ pub fn log(
     new_memory_size: usize,
     current_memory_size: usize,
     size: usize,
-    number_of_topics: u8,
+    number_of_topics: usize,
 ) -> Result<u64, VMError> {
     let memory_expansion_cost = memory::expansion_cost(new_memory_size, current_memory_size)?;
 
+    // The following conversion can never fail on systems where `usize` is at most 64 bits, which
+    // covers every system in production today.
+    #[allow(clippy::as_conversions)]
     let topics_cost = LOGN_DYNAMIC_BASE
-        .checked_mul(number_of_topics.into())
+        .checked_mul(number_of_topics as u64)
         .ok_or(OutOfGas)?;
 
     let size: u64 = size

--- a/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
+++ b/crates/vm/levm/src/opcode_handlers/bitwise_comparison.rs
@@ -14,10 +14,9 @@ impl<'a> VM<'a> {
     pub fn op_lt(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::LT)?;
-        let lho = current_call_frame.stack.pop()?;
-        let rho = current_call_frame.stack.pop()?;
+        let [lho, rho] = *current_call_frame.stack.pop()?;
         let result = u256_from_bool(lho < rho);
-        current_call_frame.stack.push(result)?;
+        current_call_frame.stack.push(&[result])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -26,10 +25,9 @@ impl<'a> VM<'a> {
     pub fn op_gt(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::GT)?;
-        let lho = current_call_frame.stack.pop()?;
-        let rho = current_call_frame.stack.pop()?;
+        let [lho, rho] = *current_call_frame.stack.pop()?;
         let result = u256_from_bool(lho > rho);
-        current_call_frame.stack.push(result)?;
+        current_call_frame.stack.push(&[result])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -38,8 +36,7 @@ impl<'a> VM<'a> {
     pub fn op_slt(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::SLT)?;
-        let lho = current_call_frame.stack.pop()?;
-        let rho = current_call_frame.stack.pop()?;
+        let [lho, rho] = *current_call_frame.stack.pop()?;
         let lho_is_negative = lho.bit(255);
         let rho_is_negative = rho.bit(255);
         let result = if lho_is_negative == rho_is_negative {
@@ -49,7 +46,7 @@ impl<'a> VM<'a> {
             // Negative is smaller if signs differ
             u256_from_bool(lho_is_negative)
         };
-        current_call_frame.stack.push(result)?;
+        current_call_frame.stack.push(&[result])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -58,8 +55,7 @@ impl<'a> VM<'a> {
     pub fn op_sgt(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::SGT)?;
-        let lho = current_call_frame.stack.pop()?;
-        let rho = current_call_frame.stack.pop()?;
+        let [lho, rho] = *current_call_frame.stack.pop()?;
         let lho_is_negative = lho.bit(255);
         let rho_is_negative = rho.bit(255);
         let result = if lho_is_negative == rho_is_negative {
@@ -69,7 +65,7 @@ impl<'a> VM<'a> {
             // Positive is bigger if signs differ
             u256_from_bool(rho_is_negative)
         };
-        current_call_frame.stack.push(result)?;
+        current_call_frame.stack.push(&[result])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -78,11 +74,10 @@ impl<'a> VM<'a> {
     pub fn op_eq(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::EQ)?;
-        let lho = current_call_frame.stack.pop()?;
-        let rho = current_call_frame.stack.pop()?;
+        let [lho, rho] = *current_call_frame.stack.pop()?;
         let result = u256_from_bool(lho == rho);
 
-        current_call_frame.stack.push(result)?;
+        current_call_frame.stack.push(&[result])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -92,10 +87,10 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::ISZERO)?;
 
-        let operand = current_call_frame.stack.pop()?;
+        let [operand] = current_call_frame.stack.pop()?;
         let result = u256_from_bool(operand.is_zero());
 
-        current_call_frame.stack.push(result)?;
+        current_call_frame.stack.push(&[result])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -104,9 +99,8 @@ impl<'a> VM<'a> {
     pub fn op_and(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::AND)?;
-        let a = current_call_frame.stack.pop()?;
-        let b = current_call_frame.stack.pop()?;
-        current_call_frame.stack.push(a & b)?;
+        let [a, b] = *current_call_frame.stack.pop()?;
+        current_call_frame.stack.push(&[a & b])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -115,9 +109,8 @@ impl<'a> VM<'a> {
     pub fn op_or(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::OR)?;
-        let a = current_call_frame.stack.pop()?;
-        let b = current_call_frame.stack.pop()?;
-        current_call_frame.stack.push(a | b)?;
+        let [a, b] = *current_call_frame.stack.pop()?;
+        current_call_frame.stack.push(&[a | b])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -126,9 +119,8 @@ impl<'a> VM<'a> {
     pub fn op_xor(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::XOR)?;
-        let a = current_call_frame.stack.pop()?;
-        let b = current_call_frame.stack.pop()?;
-        current_call_frame.stack.push(a ^ b)?;
+        let [a, b] = *current_call_frame.stack.pop()?;
+        current_call_frame.stack.push(&[a ^ b])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -137,8 +129,8 @@ impl<'a> VM<'a> {
     pub fn op_not(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::NOT)?;
-        let a = current_call_frame.stack.pop()?;
-        current_call_frame.stack.push(!a)?;
+        let [a] = *current_call_frame.stack.pop()?;
+        current_call_frame.stack.push(&[!a])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -147,13 +139,12 @@ impl<'a> VM<'a> {
     pub fn op_byte(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::BYTE)?;
-        let op1 = current_call_frame.stack.pop()?;
-        let op2 = current_call_frame.stack.pop()?;
+        let [op1, op2] = *current_call_frame.stack.pop()?;
         let byte_index = match op1.try_into() {
             Ok(byte_index) => byte_index,
             Err(_) => {
                 // Index is out of bounds, then push 0
-                current_call_frame.stack.push(U256::zero())?;
+                current_call_frame.stack.push(&[U256::zero()])?;
                 return Ok(OpcodeResult::Continue { pc_increment: 1 });
             }
         };
@@ -166,9 +157,9 @@ impl<'a> VM<'a> {
                 .ok_or(InternalError::Underflow)?; // Same case as above
             current_call_frame
                 .stack
-                .push(U256::from(op2.byte(byte_to_push)))?;
+                .push(&[U256::from(op2.byte(byte_to_push))])?;
         } else {
-            current_call_frame.stack.push(U256::zero())?;
+            current_call_frame.stack.push(&[U256::zero()])?;
         }
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
@@ -179,13 +170,12 @@ impl<'a> VM<'a> {
     pub fn op_shl(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::SHL)?;
-        let shift = current_call_frame.stack.pop()?;
-        let value = current_call_frame.stack.pop()?;
+        let [shift, value] = *current_call_frame.stack.pop()?;
 
         if shift < U256::from(256) {
-            current_call_frame.stack.push(value << shift)?;
+            current_call_frame.stack.push(&[value << shift])?;
         } else {
-            current_call_frame.stack.push(U256::zero())?;
+            current_call_frame.stack.push(&[U256::zero()])?;
         }
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
@@ -196,13 +186,12 @@ impl<'a> VM<'a> {
     pub fn op_shr(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::SHR)?;
-        let shift = current_call_frame.stack.pop()?;
-        let value = current_call_frame.stack.pop()?;
+        let [shift, value] = *current_call_frame.stack.pop()?;
 
         if shift < U256::from(256) {
-            current_call_frame.stack.push(value >> shift)?;
+            current_call_frame.stack.push(&[value >> shift])?;
         } else {
-            current_call_frame.stack.push(U256::zero())?;
+            current_call_frame.stack.push(&[U256::zero()])?;
         }
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
@@ -213,8 +202,7 @@ impl<'a> VM<'a> {
     pub fn op_sar(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::SAR)?;
-        let shift = current_call_frame.stack.pop()?;
-        let value = current_call_frame.stack.pop()?;
+        let [shift, value] = *current_call_frame.stack.pop()?;
 
         // In 2's complement arithmetic, the most significant bit being one means the number is negative
         let is_negative = value.bit(255);
@@ -230,7 +218,7 @@ impl<'a> VM<'a> {
         } else {
             U256::zero()
         };
-        current_call_frame.stack.push(res)?;
+        current_call_frame.stack.push(&[res])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -17,13 +17,13 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::BLOCKHASH)?;
 
-        let block_number = current_call_frame.stack.pop()?;
+        let [block_number] = *current_call_frame.stack.pop()?;
 
         // If the block number is not valid, return zero
         if block_number < current_block.saturating_sub(LAST_AVAILABLE_BLOCK_LIMIT)
             || block_number >= current_block
         {
-            current_call_frame.stack.push(U256::zero())?;
+            current_call_frame.stack.push(&[U256::zero()])?;
             return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
@@ -34,7 +34,7 @@ impl<'a> VM<'a> {
         let block_hash = self.db.store.get_block_hash(block_number)?;
         self.current_call_frame_mut()?
             .stack
-            .push(U256::from_big_endian(block_hash.as_bytes()))?;
+            .push(&[U256::from_big_endian(block_hash.as_bytes())])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -45,7 +45,9 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::COINBASE)?;
 
-        current_call_frame.stack.push(address_to_word(coinbase))?;
+        current_call_frame
+            .stack
+            .push(&[address_to_word(coinbase)])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -56,7 +58,7 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::TIMESTAMP)?;
 
-        current_call_frame.stack.push(timestamp)?;
+        current_call_frame.stack.push(&[timestamp])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -67,7 +69,7 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::NUMBER)?;
 
-        current_call_frame.stack.push(block_number)?;
+        current_call_frame.stack.push(&[block_number])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -80,7 +82,7 @@ impl<'a> VM<'a> {
 
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::PREVRANDAO)?;
-        current_call_frame.stack.push(randao)?;
+        current_call_frame.stack.push(&[randao])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -91,7 +93,7 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::GASLIMIT)?;
 
-        current_call_frame.stack.push(block_gas_limit.into())?;
+        current_call_frame.stack.push(&[block_gas_limit.into()])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -102,7 +104,7 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::CHAINID)?;
 
-        current_call_frame.stack.push(chain_id)?;
+        current_call_frame.stack.push(&[chain_id])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -118,7 +120,7 @@ impl<'a> VM<'a> {
             .info
             .balance;
 
-        self.current_call_frame_mut()?.stack.push(balance)?;
+        self.current_call_frame_mut()?.stack.push(&[balance])?;
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
@@ -129,7 +131,7 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::BASEFEE)?;
 
-        current_call_frame.stack.push(base_fee_per_gas)?;
+        current_call_frame.stack.push(&[base_fee_per_gas])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -144,11 +146,11 @@ impl<'a> VM<'a> {
         self.current_call_frame_mut()?
             .increase_consumed_gas(gas_cost::BLOBHASH)?;
 
-        let index = self.current_call_frame_mut()?.stack.pop()?;
+        let [index] = *self.current_call_frame_mut()?.stack.pop()?;
 
         let blob_hashes = &self.env.tx_blob_hashes;
         if index >= blob_hashes.len().into() {
-            self.current_call_frame_mut()?.stack.push(U256::zero())?;
+            self.current_call_frame_mut()?.stack.push(&[U256::zero()])?;
             return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
@@ -160,7 +162,7 @@ impl<'a> VM<'a> {
         let blob_hash = blob_hashes.get(index).ok_or(InternalError::Slicing)?;
         let hash = U256::from_big_endian(blob_hash.as_bytes());
 
-        self.current_call_frame_mut()?.stack.push(hash)?;
+        self.current_call_frame_mut()?.stack.push(&[hash])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -178,7 +180,9 @@ impl<'a> VM<'a> {
         let blob_base_fee =
             get_base_fee_per_blob_gas(self.env.block_excess_blob_gas, &self.env.config)?;
 
-        self.current_call_frame_mut()?.stack.push(blob_base_fee)?;
+        self.current_call_frame_mut()?
+            .stack
+            .push(&[blob_base_fee])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/dup.rs
+++ b/crates/vm/levm/src/opcode_handlers/dup.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::{ExceptionalHalt, OpcodeResult, VMError},
+    errors::{OpcodeResult, VMError},
     gas_cost,
     vm::VM,
 };
@@ -14,22 +14,11 @@ impl<'a> VM<'a> {
         // Increase the consumed gas
         current_call_frame.increase_consumed_gas(gas_cost::DUPN)?;
 
-        // Ensure the stack has enough elements to duplicate
-        if current_call_frame.stack.len() < depth {
-            return Err(ExceptionalHalt::StackUnderflow.into());
-        }
-
         // Get the value at the specified depth
-        let value_at_depth = current_call_frame.stack.get(
-            current_call_frame
-                .stack
-                .len()
-                .checked_sub(depth)
-                .ok_or(ExceptionalHalt::StackUnderflow)?,
-        )?;
+        let value_at_depth = *current_call_frame.stack.get(depth)?;
 
         // Push the duplicated value onto the stack
-        current_call_frame.stack.push(*value_at_depth)?;
+        current_call_frame.stack.push(&[value_at_depth])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/exchange.rs
+++ b/crates/vm/levm/src/opcode_handlers/exchange.rs
@@ -13,21 +13,10 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::SWAPN)?;
 
-        let stack_top_index = current_call_frame
-            .stack
-            .len()
-            .checked_sub(1)
-            .ok_or(ExceptionalHalt::StackUnderflow)?;
-
         if current_call_frame.stack.len() < depth {
             return Err(ExceptionalHalt::StackUnderflow.into());
         }
-        let to_swap_index = stack_top_index
-            .checked_sub(depth)
-            .ok_or(ExceptionalHalt::StackUnderflow)?;
-        current_call_frame
-            .stack
-            .swap(stack_top_index, to_swap_index)?;
+        current_call_frame.stack.swap(depth)?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -13,10 +13,8 @@ use sha3::{Digest, Keccak256};
 impl<'a> VM<'a> {
     pub fn op_keccak256(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
-        let offset = current_call_frame.stack.pop()?;
-        let size: usize = current_call_frame
-            .stack
-            .pop()?
+        let [offset, size] = *current_call_frame.stack.pop()?;
+        let size: usize = size
             .try_into()
             .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
 
@@ -36,7 +34,7 @@ impl<'a> VM<'a> {
         )?);
         current_call_frame
             .stack
-            .push(U256::from_big_endian(&hasher.finalize()))?;
+            .push(&[U256::from_big_endian(&hasher.finalize())])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -20,7 +20,7 @@ impl<'a> VM<'a> {
 
         current_call_frame
             .stack
-            .push(U256::from_big_endian(read_n_bytes))?;
+            .push(&[U256::from_big_endian(read_n_bytes)])?;
 
         // The n_bytes that you push to the stack + 1 for the next instruction
         let increment_pc_by = n_bytes.wrapping_add(1);
@@ -40,7 +40,7 @@ impl<'a> VM<'a> {
 
         current_call_frame.increase_consumed_gas(gas_cost::PUSH0)?;
 
-        current_call_frame.stack.push(U256::zero())?;
+        current_call_frame.stack.push(&[U256::zero()])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -16,7 +16,7 @@ impl<'a> VM<'a> {
     pub fn op_pop(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::POP)?;
-        current_call_frame.stack.pop()?;
+        current_call_frame.stack.pop::<1>()?;
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
@@ -27,7 +27,7 @@ impl<'a> VM<'a> {
             return Err(ExceptionalHalt::InvalidOpcode.into());
         }
 
-        let key = self.current_call_frame_mut()?.stack.pop()?;
+        let [key] = *self.current_call_frame_mut()?.stack.pop()?;
         let to = self.current_call_frame()?.to;
         let value = self
             .substate
@@ -40,7 +40,7 @@ impl<'a> VM<'a> {
 
         current_call_frame.increase_consumed_gas(gas_cost::TLOAD)?;
 
-        current_call_frame.stack.push(value)?;
+        current_call_frame.stack.push(&[value])?;
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
@@ -59,8 +59,7 @@ impl<'a> VM<'a> {
                 return Err(ExceptionalHalt::OpcodeNotAllowedInStaticContext.into());
             }
 
-            let key = current_call_frame.stack.pop()?;
-            let value = current_call_frame.stack.pop()?;
+            let [key, value] = *current_call_frame.stack.pop()?;
             (key, value, current_call_frame.to)
         };
         self.substate.transient_storage.insert((to, key), value);
@@ -71,7 +70,7 @@ impl<'a> VM<'a> {
     // MLOAD operation
     pub fn op_mload(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
-        let offset = current_call_frame.stack.pop()?;
+        let [offset] = *current_call_frame.stack.pop()?;
 
         let new_memory_size = calculate_memory_size(offset, WORD_SIZE_IN_BYTES_USIZE)?;
 
@@ -82,15 +81,14 @@ impl<'a> VM<'a> {
 
         current_call_frame
             .stack
-            .push(memory::load_word(&mut current_call_frame.memory, offset)?)?;
+            .push(&[memory::load_word(&mut current_call_frame.memory, offset)?])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // MSTORE operation
     pub fn op_mstore(&mut self) -> Result<OpcodeResult, VMError> {
-        let offset = self.current_call_frame_mut()?.stack.pop()?;
-        let value = self.current_call_frame_mut()?.stack.pop()?;
+        let [offset, value] = *self.current_call_frame_mut()?.stack.pop()?;
 
         // This is only for debugging purposes of special solidity contracts that enable printing text on screen.
         if self.debug_mode.handle_debug(offset, value)? {
@@ -119,7 +117,7 @@ impl<'a> VM<'a> {
     pub fn op_mstore8(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
 
-        let offset = current_call_frame.stack.pop()?;
+        let [offset] = *current_call_frame.stack.pop()?;
 
         let new_memory_size = calculate_memory_size(offset, 1)?;
 
@@ -128,7 +126,7 @@ impl<'a> VM<'a> {
             current_call_frame.memory.len(),
         )?)?;
 
-        let value = current_call_frame.stack.pop()?;
+        let [value] = current_call_frame.stack.pop()?;
 
         memory::try_store_data(
             &mut current_call_frame.memory,
@@ -143,7 +141,7 @@ impl<'a> VM<'a> {
     pub fn op_sload(&mut self) -> Result<OpcodeResult, VMError> {
         let (storage_slot_key, address) = {
             let current_call_frame = self.current_call_frame_mut()?;
-            let storage_slot_key = current_call_frame.stack.pop()?;
+            let [storage_slot_key] = *current_call_frame.stack.pop()?;
             let address = current_call_frame.to;
             (storage_slot_key, address)
         };
@@ -156,7 +154,7 @@ impl<'a> VM<'a> {
 
         current_call_frame.increase_consumed_gas(gas_cost::sload(storage_slot_was_cold)?)?;
 
-        current_call_frame.stack.push(value)?;
+        current_call_frame.stack.push(&[value])?;
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
@@ -168,8 +166,7 @@ impl<'a> VM<'a> {
 
         let (storage_slot_key, new_storage_slot_value, to) = {
             let current_call_frame = self.current_call_frame_mut()?;
-            let storage_slot_key = current_call_frame.stack.pop()?;
-            let new_storage_slot_value = current_call_frame.stack.pop()?;
+            let [storage_slot_key, new_storage_slot_value] = *current_call_frame.stack.pop()?;
             let to = current_call_frame.to;
             (storage_slot_key, new_storage_slot_value, to)
         };
@@ -198,7 +195,7 @@ impl<'a> VM<'a> {
 
         if new_storage_slot_value != current_value {
             if current_value == original_value {
-                if original_value != U256::zero() && new_storage_slot_value == U256::zero() {
+                if !original_value.is_zero() && new_storage_slot_value.is_zero() {
                     gas_refunds = gas_refunds
                         .checked_add(remove_slot_cost)
                         .ok_or(InternalError::Overflow)?;
@@ -209,7 +206,7 @@ impl<'a> VM<'a> {
                         gas_refunds = gas_refunds
                             .checked_sub(remove_slot_cost)
                             .ok_or(InternalError::Underflow)?;
-                    } else if new_storage_slot_value == U256::zero() {
+                    } else if new_storage_slot_value.is_zero() {
                         gas_refunds = gas_refunds
                             .checked_add(remove_slot_cost)
                             .ok_or(InternalError::Overflow)?;
@@ -249,7 +246,7 @@ impl<'a> VM<'a> {
         current_call_frame.increase_consumed_gas(gas_cost::MSIZE)?;
         current_call_frame
             .stack
-            .push(current_call_frame.memory.len().into())?;
+            .push(&[current_call_frame.memory.len().into()])?;
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
@@ -263,7 +260,7 @@ impl<'a> VM<'a> {
             .checked_sub(current_call_frame.gas_used)
             .ok_or(InternalError::Underflow)?;
         // Note: These are not consumed gas calculations, but are related, so I used this wrapping here
-        current_call_frame.stack.push(remaining_gas.into())?;
+        current_call_frame.stack.push(&[remaining_gas.into()])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
@@ -275,11 +272,8 @@ impl<'a> VM<'a> {
             return Err(ExceptionalHalt::InvalidOpcode.into());
         }
         let current_call_frame = self.current_call_frame_mut()?;
-        let dest_offset = current_call_frame.stack.pop()?;
-        let src_offset = current_call_frame.stack.pop()?;
-        let size: usize = current_call_frame
-            .stack
-            .pop()?
+        let [dest_offset, src_offset, size] = *current_call_frame.stack.pop()?;
+        let size: usize = size
             .try_into()
             .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
 
@@ -308,7 +302,7 @@ impl<'a> VM<'a> {
         let current_call_frame = self.current_call_frame_mut()?;
         current_call_frame.increase_consumed_gas(gas_cost::JUMP)?;
 
-        let jump_address = current_call_frame.stack.pop()?;
+        let [jump_address] = *current_call_frame.stack.pop()?;
         Self::jump(current_call_frame, jump_address)?;
 
         Ok(OpcodeResult::Continue { pc_increment: 0 })
@@ -332,20 +326,18 @@ impl<'a> VM<'a> {
             .try_into()
             .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
 
-        match Self::is_valid_jump_addr(call_frame, jump_address_usize) {
-            true => {
-                call_frame.pc = jump_address_usize;
-                Ok(())
-            }
-            false => Err(ExceptionalHalt::InvalidJump.into()),
+        if Self::is_valid_jump_addr(call_frame, jump_address_usize) {
+            call_frame.pc = jump_address_usize;
+            Ok(())
+        } else {
+            Err(ExceptionalHalt::InvalidJump.into())
         }
     }
 
     // JUMPI operation
     pub fn op_jumpi(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
-        let jump_address = current_call_frame.stack.pop()?;
-        let condition = current_call_frame.stack.pop()?;
+        let [jump_address, condition] = *current_call_frame.stack.pop()?;
 
         current_call_frame.increase_consumed_gas(gas_cost::JUMPI)?;
 
@@ -373,7 +365,7 @@ impl<'a> VM<'a> {
 
         current_call_frame
             .stack
-            .push(U256::from(current_call_frame.pc))?;
+            .push(&[U256::from(current_call_frame.pc)])?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -30,19 +30,20 @@ impl<'a> VM<'a> {
             return_data_size,
         ) = {
             let current_call_frame = self.current_call_frame_mut()?;
-            let gas = current_call_frame.stack.pop()?;
-            let callee: Address = word_to_address(current_call_frame.stack.pop()?);
-            let value_to_transfer: U256 = current_call_frame.stack.pop()?;
-            let args_start_offset = current_call_frame.stack.pop()?;
-            let args_size = current_call_frame
-                .stack
-                .pop()?
+            let [
+                gas,
+                callee,
+                value_to_transfer,
+                args_start_offset,
+                args_size,
+                return_data_start_offset,
+                return_data_size,
+            ] = *current_call_frame.stack.pop()?;
+            let callee: Address = word_to_address(callee);
+            let args_size = args_size
                 .try_into()
                 .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset = current_call_frame.stack.pop()?;
-            let return_data_size: usize = current_call_frame
-                .stack
-                .pop()?
+            let return_data_size: usize = return_data_size
                 .try_into()
                 .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
             let current_memory_size = current_call_frame.memory.len();
@@ -137,19 +138,20 @@ impl<'a> VM<'a> {
             return_data_size,
         ) = {
             let current_call_frame = self.current_call_frame_mut()?;
-            let gas = current_call_frame.stack.pop()?;
-            let code_address = word_to_address(current_call_frame.stack.pop()?);
-            let value_to_transfer = current_call_frame.stack.pop()?;
-            let args_start_offset = current_call_frame.stack.pop()?;
-            let args_size = current_call_frame
-                .stack
-                .pop()?
+            let [
+                gas,
+                code_address,
+                value_to_transfer,
+                args_start_offset,
+                args_size,
+                return_data_start_offset,
+                return_data_size,
+            ] = *current_call_frame.stack.pop()?;
+            let code_address = word_to_address(code_address);
+            let args_size = args_size
                 .try_into()
                 .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset = current_call_frame.stack.pop()?;
-            let return_data_size = current_call_frame
-                .stack
-                .pop()?
+            let return_data_size = return_data_size
                 .try_into()
                 .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
             let current_memory_size = current_call_frame.memory.len();
@@ -227,10 +229,8 @@ impl<'a> VM<'a> {
     // RETURN operation
     pub fn op_return(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = self.current_call_frame_mut()?;
-        let offset = current_call_frame.stack.pop()?;
-        let size = current_call_frame
-            .stack
-            .pop()?
+        let [offset, size] = *current_call_frame.stack.pop()?;
+        let size = size
             .try_into()
             .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
 
@@ -265,18 +265,19 @@ impl<'a> VM<'a> {
             return_data_size,
         ) = {
             let current_call_frame = self.current_call_frame_mut()?;
-            let gas = current_call_frame.stack.pop()?;
-            let code_address = word_to_address(current_call_frame.stack.pop()?);
-            let args_start_offset = current_call_frame.stack.pop()?;
-            let args_size = current_call_frame
-                .stack
-                .pop()?
+            let [
+                gas,
+                code_address,
+                args_start_offset,
+                args_size,
+                return_data_start_offset,
+                return_data_size,
+            ] = *current_call_frame.stack.pop()?;
+            let code_address = word_to_address(code_address);
+            let args_size = args_size
                 .try_into()
                 .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset = current_call_frame.stack.pop()?;
-            let return_data_size = current_call_frame
-                .stack
-                .pop()?
+            let return_data_size = return_data_size
                 .try_into()
                 .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
             let current_memory_size = current_call_frame.memory.len();
@@ -362,18 +363,19 @@ impl<'a> VM<'a> {
             return_data_size,
         ) = {
             let current_call_frame = self.current_call_frame_mut()?;
-            let gas = current_call_frame.stack.pop()?;
-            let code_address = word_to_address(current_call_frame.stack.pop()?);
-            let args_start_offset = current_call_frame.stack.pop()?;
-            let args_size = current_call_frame
-                .stack
-                .pop()?
+            let [
+                gas,
+                code_address,
+                args_start_offset,
+                args_size,
+                return_data_start_offset,
+                return_data_size,
+            ] = *current_call_frame.stack.pop()?;
+            let code_address = word_to_address(code_address);
+            let args_size = args_size
                 .try_into()
                 .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset = current_call_frame.stack.pop()?;
-            let return_data_size = current_call_frame
-                .stack
-                .pop()?
+            let return_data_size = return_data_size
                 .try_into()
                 .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
             let current_memory_size = current_call_frame.memory.len();
@@ -449,11 +451,12 @@ impl<'a> VM<'a> {
     pub fn op_create(&mut self) -> Result<OpcodeResult, VMError> {
         let fork = self.env.config.fork;
         let current_call_frame = self.current_call_frame_mut()?;
-        let value_in_wei_to_send = current_call_frame.stack.pop()?;
-        let code_offset_in_memory = current_call_frame.stack.pop()?;
-        let code_size_in_memory: usize = current_call_frame
-            .stack
-            .pop()?
+        let [
+            value_in_wei_to_send,
+            code_offset_in_memory,
+            code_size_in_memory,
+        ] = *current_call_frame.stack.pop()?;
+        let code_size_in_memory: usize = code_size_in_memory
             .try_into()
             .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
 
@@ -478,14 +481,15 @@ impl<'a> VM<'a> {
     pub fn op_create2(&mut self) -> Result<OpcodeResult, VMError> {
         let fork = self.env.config.fork;
         let current_call_frame = self.current_call_frame_mut()?;
-        let value_in_wei_to_send = current_call_frame.stack.pop()?;
-        let code_offset_in_memory = current_call_frame.stack.pop()?;
-        let code_size_in_memory: usize = current_call_frame
-            .stack
-            .pop()?
+        let [
+            value_in_wei_to_send,
+            code_offset_in_memory,
+            code_size_in_memory,
+            salt,
+        ] = *current_call_frame.stack.pop()?;
+        let code_size_in_memory: usize = code_size_in_memory
             .try_into()
             .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-        let salt = current_call_frame.stack.pop()?;
 
         let new_size = calculate_memory_size(code_offset_in_memory, code_size_in_memory)?;
 
@@ -512,13 +516,10 @@ impl<'a> VM<'a> {
         //      The actual reversion of changes is made in the execute() function.
         let current_call_frame = self.current_call_frame_mut()?;
 
-        let offset = current_call_frame.stack.pop()?;
-
-        let size = current_call_frame
-            .stack
-            .pop()?
+        let [offset, size] = *current_call_frame.stack.pop()?;
+        let size = size
             .try_into()
-            .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
+            .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
 
         let new_memory_size = calculate_memory_size(offset, size)?;
         let current_memory_size = current_call_frame.memory.len();
@@ -557,7 +558,7 @@ impl<'a> VM<'a> {
             if current_call_frame.is_static {
                 return Err(ExceptionalHalt::OpcodeNotAllowedInStaticContext.into());
             }
-            let target_address = word_to_address(current_call_frame.stack.pop()?);
+            let target_address = word_to_address(current_call_frame.stack.pop::<1>()?[0]);
             let to = current_call_frame.to;
             (target_address, to)
         };
@@ -694,7 +695,7 @@ impl<'a> VM<'a> {
         // Deployment will fail (consuming all gas) if the contract already exists.
         let new_account = self.get_account_mut(new_address)?;
         if new_account.has_code_or_nonce() {
-            self.current_call_frame_mut()?.stack.push(FAIL)?;
+            self.current_call_frame_mut()?.stack.push(&[FAIL])?;
             self.tracer
                 .exit_early(gas_limit, Some("CreateAccExists".to_string()))?;
             return Ok(OpcodeResult::Continue { pc_increment: 1 });
@@ -866,11 +867,11 @@ impl<'a> VM<'a> {
         // What to do, depending on TxResult
         match &ctx_result.result {
             TxResult::Success => {
-                self.current_call_frame_mut()?.stack.push(SUCCESS)?;
+                self.current_call_frame_mut()?.stack.push(&[SUCCESS])?;
                 self.merge_call_frame_backup_with_parent(&executed_call_frame.call_frame_backup)?;
             }
             TxResult::Revert(_) => {
-                self.current_call_frame_mut()?.stack.push(FAIL)?;
+                self.current_call_frame_mut()?.stack.push(&[FAIL])?;
             }
         };
 
@@ -903,7 +904,7 @@ impl<'a> VM<'a> {
         // What to do, depending on TxResult
         match ctx_result.result.clone() {
             TxResult::Success => {
-                parent_call_frame.stack.push(address_to_word(to))?;
+                parent_call_frame.stack.push(&[address_to_word(to)])?;
                 self.merge_call_frame_backup_with_parent(&call_frame_backup)?;
             }
             TxResult::Revert(err) => {
@@ -912,7 +913,7 @@ impl<'a> VM<'a> {
                     parent_call_frame.sub_return_data = ctx_result.output.clone();
                 }
 
-                parent_call_frame.stack.push(FAIL)?;
+                parent_call_frame.stack.push(&[FAIL])?;
             }
         };
 
@@ -934,7 +935,7 @@ impl<'a> VM<'a> {
             .gas_used
             .checked_sub(gas_limit)
             .ok_or(InternalError::Underflow)?;
-        callframe.stack.push(FAIL)?; // It's the same as revert for CREATE
+        callframe.stack.push(&[FAIL])?; // It's the same as revert for CREATE
 
         self.tracer.exit_early(0, Some(reason))?;
         Ok(())

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -211,26 +211,6 @@ pub fn get_blob_gas_price(
     Ok(blob_fee)
 }
 
-// =================== Opcode related functions ======================
-
-pub fn get_n_value(op: Opcode, base_opcode: Opcode) -> Result<usize, VMError> {
-    let offset = (usize::from(op))
-        .checked_sub(usize::from(base_opcode))
-        .ok_or(ExceptionalHalt::InvalidOpcode)?
-        .checked_add(1)
-        .ok_or(ExceptionalHalt::InvalidOpcode)?;
-
-    Ok(offset)
-}
-
-pub fn get_number_of_topics(op: Opcode) -> Result<u8, VMError> {
-    let number_of_topics = (u8::from(op))
-        .checked_sub(u8::from(Opcode::LOG0))
-        .ok_or(ExceptionalHalt::InvalidOpcode)?;
-
-    Ok(number_of_topics)
-}
-
 // ==================== Word related functions =======================
 pub fn word_to_address(word: U256) -> Address {
     Address::from_slice(&word.to_big_endian()[12..])


### PR DESCRIPTION
**Motivation**

The `JUMP` and `JUMPI` opcodes need to check the target address's validity. This is currently done with a `HashSet` of valid target addresses, which caused the hashing to become a significant part of the profiling time when checking for address validity.

**Description**

This PR rewrites the `JUMPDEST` checks so that instead of having a whitelist, we do the following:
  - Check the program bytecode directly. The jump target's value should be a `JUMPDEST`.
  - Check a blacklist of values 0x5B (`JUMPDEST`) that are NOT opcodes (they are part of push literals).

The blacklist is not a `HashMap`, but rather a sorted slice that can be checked efficiently using the binary search algorithm, which should terminate on average after the first or second step.

Rational: After extracting stats of the first 10k hoodi blocks, I found out that...
  - There are almost 60 times more `JUMPDEST` than values 0x5B in push literals.
  - On average, there are less than 2 values in the blacklist. If we were to use a whitelist as before, there would be about 70 entries on average.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

