### PR TITLE
feat(l2): use all RPCs when using Aligned SDK

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -10,6 +10,7 @@ use ethrex_rpc::clients::eth::{
     BACKOFF_FACTOR, MAX_NUMBER_OF_RETRIES, MAX_RETRY_DELAY, MIN_RETRY_DELAY,
     get_address_from_secret_key,
 };
+use reqwest::Url;
 use secp256k1::SecretKey;
 use std::net::{IpAddr, Ipv4Addr};
 
@@ -165,7 +166,7 @@ pub struct EthOptions {
         env = "ETHREX_ETH_RPC_URL",
         help = "List of rpc urls to use.",
         help_heading = "Eth options",
-        num_args = 1..10
+        num_args = 1..
     )]
     pub rpc_url: Vec<String>,
     #[arg(
@@ -450,9 +451,9 @@ pub struct AlignedOptions {
         env = "ETHREX_ALIGNED_BEACON_URL",
         help = "List of beacon urls to use.",
         help_heading = "Aligned options",
-        num_args = 1..10
+        num_args = 1..,
     )]
-    pub beacon_url: Option<Vec<String>>,
+    pub beacon_url: Option<Vec<Url>>,
     #[arg(
         long,
         value_name = "ETHREX_ALIGNED_NETWORK",
@@ -489,7 +490,7 @@ impl Default for AlignedOptions {
         Self {
             aligned: false,
             aligned_verifier_interval_ms: 5000,
-            beacon_url: Some(vec!["http://127.0.0.1:58801".to_string()]),
+            beacon_url: Some(vec![Url::parse("http://127.0.0.1:58801").unwrap()]),
             aligned_network: Some("devnet".to_string()),
             fee_estimate: "instant".to_string(),
             aligned_sp1_elf_path: Some(format!(

--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -146,7 +146,7 @@ impl From<SequencerOptions> for SequencerConfig {
             aligned: AlignedConfig {
                 aligned_mode: opts.aligned_opts.aligned,
                 aligned_verifier_interval_ms: opts.aligned_opts.aligned_verifier_interval_ms,
-                beacon_url: opts.aligned_opts.beacon_url.unwrap_or_default(),
+                beacon_urls: opts.aligned_opts.beacon_url.unwrap_or_default(),
                 network: resolve_aligned_network(
                     &opts.aligned_opts.aligned_network.unwrap_or_default(),
                 ),
@@ -448,10 +448,11 @@ pub struct AlignedOptions {
         value_name = "BEACON_URL",
         required_if_eq("aligned", "true"),
         env = "ETHREX_ALIGNED_BEACON_URL",
-        help = "Beacon url to use.",
-        help_heading = "Aligned options"
+        help = "List of beacon urls to use.",
+        help_heading = "Aligned options",
+        num_args = 1..10
     )]
-    pub beacon_url: Option<String>,
+    pub beacon_url: Option<Vec<String>>,
     #[arg(
         long,
         value_name = "ETHREX_ALIGNED_NETWORK",
@@ -488,7 +489,7 @@ impl Default for AlignedOptions {
         Self {
             aligned: false,
             aligned_verifier_interval_ms: 5000,
-            beacon_url: Some("http://127.0.0.1:58801".to_string()),
+            beacon_url: Some(vec!["http://127.0.0.1:58801".to_string()]),
             aligned_network: Some("devnet".to_string()),
             fee_estimate: "instant".to_string(),
             aligned_sp1_elf_path: Some(format!(

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -1,5 +1,6 @@
 use aligned_sdk::common::types::Network;
 use ethrex_common::{Address, U256};
+use reqwest::Url;
 use secp256k1::SecretKey;
 use std::net::IpAddr;
 
@@ -85,7 +86,7 @@ pub struct BlockFetcherConfig {
 pub struct AlignedConfig {
     pub aligned_mode: bool,
     pub aligned_verifier_interval_ms: u64,
-    pub beacon_urls: Vec<String>,
+    pub beacon_urls: Vec<Url>,
     pub network: Network,
     pub fee_estimate: String,
     pub aligned_sp1_elf_path: String,

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -85,7 +85,7 @@ pub struct BlockFetcherConfig {
 pub struct AlignedConfig {
     pub aligned_mode: bool,
     pub aligned_verifier_interval_ms: u64,
-    pub beacon_url: String,
+    pub beacon_urls: Vec<String>,
     pub network: Network,
     pub fee_estimate: String,
     pub aligned_sp1_elf_path: String,

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -275,10 +275,6 @@ async fn send_proof_to_aligned(
 
 /// Performs a call to aligned SDK estimate_fee function with retries over all RPC URLs.
 async fn estimate_fee(state: &L1ProofSenderState) -> Result<ethers::types::U256, ProofSenderError> {
-    let result = Err(ProofSenderError::AlignedFeeEstimateError(
-        "All Ethereum RPC URLs failed".to_string(),
-    ));
-
     for rpc_url in &state.eth_client.urls {
         if let Ok(estimation) =
             aligned_estimate_fee(rpc_url.as_str(), state.fee_estimate.clone()).await
@@ -286,7 +282,9 @@ async fn estimate_fee(state: &L1ProofSenderState) -> Result<ethers::types::U256,
             return Ok(estimation);
         }
     }
-    result
+    Err(ProofSenderError::AlignedFeeEstimateError(
+        "All Ethereum RPC URLs failed".to_string(),
+    ))
 }
 
 pub async fn send_proof_to_contract(

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use aligned_sdk::{
     common::types::{FeeEstimationType, Network, ProvingSystemId, VerificationData},
-    verification_layer::{estimate_fee, get_nonce_from_batcher, submit},
+    verification_layer::{estimate_fee as aligned_estimate_fee, get_nonce_from_batcher, submit},
 };
 
 // TODO: Remove this import once it's no longer required by the SDK.
@@ -241,18 +241,7 @@ async fn send_proof_to_aligned(
         pub_input: None,
     };
 
-    let rpc_url = state
-        .eth_client
-        .urls
-        .first()
-        .ok_or_else(|| {
-            ProofSenderError::InternalError("No Ethereum RPC URL configured".to_owned())
-        })?
-        .as_str();
-
-    let fee_estimation = estimate_fee(rpc_url, state.fee_estimate.clone())
-        .await
-        .map_err(|err| ProofSenderError::AlignedFeeEstimateError(err.to_string()))?;
+    let fee_estimation = estimate_fee(state).await?;
 
     let nonce = get_nonce_from_batcher(state.network.clone(), state.l1_address.0.into())
         .await
@@ -282,6 +271,22 @@ async fn send_proof_to_aligned(
     info!("Proof for batch {batch_number} sent to Aligned");
 
     Ok(())
+}
+
+/// Performs a call to aligned SDK estimate_fee function with retries over all RPC URLs.
+async fn estimate_fee(state: &L1ProofSenderState) -> Result<ethers::types::U256, ProofSenderError> {
+    let result = Err(ProofSenderError::AlignedFeeEstimateError(
+        "All Ethereum RPC URLs failed".to_string(),
+    ));
+
+    for rpc_url in &state.eth_client.urls {
+        if let Ok(estimation) =
+            aligned_estimate_fee(rpc_url.as_str(), state.fee_estimate.clone()).await
+        {
+            return Ok(estimation);
+        }
+    }
+    result
 }
 
 pub async fn send_proof_to_contract(

--- a/crates/l2/sequencer/l1_proof_verifier.rs
+++ b/crates/l2/sequencer/l1_proof_verifier.rs
@@ -1,5 +1,8 @@
 use aligned_sdk::{
-    aggregation_layer::{AggregationModeVerificationData, ProofStatus, check_proof_verification},
+    aggregation_layer::{
+        AggregationModeVerificationData, ProofStatus, ProofVerificationAggModeError,
+        check_proof_verification as aligned_check_proof_verification,
+    },
     common::types::Network,
 };
 use ethrex_common::{Address, H256, U256};
@@ -39,7 +42,7 @@ pub async fn start_l1_proof_verifier(cfg: SequencerConfig) -> Result<(), Sequenc
 
 struct L1ProofVerifier {
     eth_client: EthClient,
-    beacon_url: String,
+    beacon_urls: Vec<String>,
     l1_address: Address,
     l1_private_key: SecretKey,
     on_chain_proposer_address: Address,
@@ -63,7 +66,7 @@ impl L1ProofVerifier {
 
         Ok(Self {
             eth_client,
-            beacon_url: aligned_cfg.beacon_url.clone(),
+            beacon_urls: aligned_cfg.beacon_urls.clone(),
             network: aligned_cfg.network.clone(),
             l1_address: proof_coordinator_cfg.l1_address,
             l1_private_key: proof_coordinator_cfg.l1_private_key,
@@ -206,7 +209,7 @@ impl L1ProofVerifier {
             let commitment = H256(verification_data.commitment());
 
             if let Some((merkle_root, merkle_path)) =
-                self.check_proof_verification(verification_data).await?
+                self.check_proof_aggregation(verification_data).await?
             {
                 info!(
                     "Proof for batch {batch_number} aggregated by Aligned with commitment {commitment:#x} and Merkle root {merkle_root:#x}"
@@ -218,23 +221,11 @@ impl L1ProofVerifier {
     }
 
     /// Checks if the received proof was aggregated by Aligned.
-    async fn check_proof_verification(
+    async fn check_proof_aggregation(
         &self,
         verification_data: AggregationModeVerificationData,
     ) -> Result<Option<(H256, Vec<[u8; 32]>)>, ProofVerifierError> {
-        let rpc_url = self.eth_client.urls.first().ok_or_else(|| {
-            ProofVerifierError::InternalError("No Ethereum RPC URL configured".to_owned())
-        })?;
-
-        let proof_status = check_proof_verification(
-            &verification_data,
-            self.network.clone(),
-            rpc_url.as_str().into(),
-            self.beacon_url.clone(),
-            None,
-        )
-        .await
-        .map_err(|e| ProofVerifierError::InternalError(format!("{:?}", e)))?;
+        let proof_status = self.check_proof_verification(&verification_data).await?;
 
         let (merkle_root, merkle_path) = match proof_status {
             ProofStatus::Verified {
@@ -255,5 +246,34 @@ impl L1ProofVerifier {
         let merkle_root = H256(merkle_root);
 
         Ok(Some((merkle_root, merkle_path)))
+    }
+
+    /// Performs the call to the aligned proof verification function with retries over multiple RPC URLs and beacon URLs.
+    async fn check_proof_verification(
+        &self,
+        verification_data: &AggregationModeVerificationData,
+    ) -> Result<ProofStatus, ProofVerifierError> {
+        let result = Err(ProofVerifierError::InternalError(
+            "Verification failed. All RPC URLs were exhausted.".to_string(),
+        ));
+        for rpc_url in &self.eth_client.urls {
+            for beacon_url in &self.beacon_urls {
+                match aligned_check_proof_verification(
+                    &verification_data,
+                    self.network.clone(),
+                    rpc_url.as_str().into(),
+                    beacon_url.clone(),
+                    None,
+                )
+                .await
+                {
+                    Ok(proof_status) => return Ok(proof_status),
+                    Err(ProofVerificationAggModeError::BeaconClient(_)) => continue,
+                    Err(ProofVerificationAggModeError::EthereumProviderError(_)) => break,
+                    Err(e) => return Err(ProofVerifierError::InternalError(format!("{:?}", e))),
+                }
+            }
+        }
+        result
     }
 }

--- a/crates/l2/sequencer/l1_proof_verifier.rs
+++ b/crates/l2/sequencer/l1_proof_verifier.rs
@@ -281,7 +281,7 @@ impl L1ProofVerifier {
 
 fn parse_beacon_urls(beacon_urls: &[Url]) -> Vec<String> {
     beacon_urls
-        .into_iter()
+        .iter()
         .map(|url| {
             url.as_str()
                 .strip_suffix('/')

--- a/crates/l2/sequencer/l1_proof_verifier.rs
+++ b/crates/l2/sequencer/l1_proof_verifier.rs
@@ -259,7 +259,7 @@ impl L1ProofVerifier {
         for rpc_url in &self.eth_client.urls {
             for beacon_url in &self.beacon_urls {
                 match aligned_check_proof_verification(
-                    &verification_data,
+                    verification_data,
                     self.network.clone(),
                     rpc_url.as_str().into(),
                     beacon_url.clone(),

--- a/crates/l2/sequencer/l1_proof_verifier.rs
+++ b/crates/l2/sequencer/l1_proof_verifier.rs
@@ -253,9 +253,6 @@ impl L1ProofVerifier {
         &self,
         verification_data: &AggregationModeVerificationData,
     ) -> Result<ProofStatus, ProofVerifierError> {
-        let result = Err(ProofVerifierError::InternalError(
-            "Verification failed. All RPC URLs were exhausted.".to_string(),
-        ));
         for rpc_url in &self.eth_client.urls {
             for beacon_url in &self.beacon_urls {
                 match aligned_check_proof_verification(
@@ -274,6 +271,8 @@ impl L1ProofVerifier {
                 }
             }
         }
-        result
+        Err(ProofVerifierError::InternalError(
+            "Verification failed. All RPC URLs were exhausted.".to_string(),
+        ))
     }
 }

--- a/docs/l2/aligned_mode.md
+++ b/docs/l2/aligned_mode.md
@@ -213,9 +213,9 @@ ETHREX_PROOF_COORDINATOR_DEV_MODE=false cargo run --release --manifest-path ../.
 > Set `BRIDGE_ADDRESS` and `ON_CHAIN_PROPOSER_ADDRESS` with the values printed in step 1.
 
 Suggestion:
-When running the integration test, consider increasing the `commit-time-ms` to 2 minutes. This helps avoid having to aggregate the proofs twice. You can do this by adding the following flag to the `init-l2-no-metrics` target:
+When running the integration test, consider increasing the `--committer.commit-time` to 2 minutes. This helps avoid having to aggregate the proofs twice. You can do this by adding the following flag to the `init-l2-no-metrics` target:
 ```
---commit-time-ms 120000
+--committer.commit-time 120000
 ```
 
 4. Start prover:


### PR DESCRIPTION
> [!WARNING]
> Merge after #3242 

**Motivation**

In case one RPC or Beacon client fails, we should retry with others to avoid getting stuck.

**Description**

- Implements a wrapper over `aligned_sdk::estimate_fee()` to retry using all available RPC urls.
- Implements a wrapper over `aligned_sdk::check_proof_verification()` to retry using all available RPC and Beacon clients.

Closes #3059


