### PR TITLE
chore(levm): remove unused remove_account function from CacheDB

### DIFF
--- a/crates/vm/levm/src/db/cache.rs
+++ b/crates/vm/levm/src/db/cache.rs
@@ -29,10 +29,6 @@ pub fn insert_account(
     cached_accounts.insert(address, account)
 }
 
-pub fn remove_account(cached_accounts: &mut CacheDB, address: &Address) -> Option<Account> {
-    cached_accounts.remove(address)
-}
-
 pub fn is_account_cached(cached_accounts: &CacheDB, address: &Address) -> bool {
     cached_accounts.contains_key(address)
 }


### PR DESCRIPTION
**Motivation**

Remove unused method.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

