### PR TITLE
ci: install `mdbook-mermaid` preprocessor

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install mdbook dependencies
         run: make docs-deps
 
-      - run: mdbook build
+      - name: Build documentation
+        run: make docs
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           mdbook-version: '0.4.51'
 
-      - name: Install mdbook-alerts
-        run: cargo install mdbook-alerts
+      - name: Install mdbook dependencies
+        run: make docs-deps
 
       - run: mdbook build
 


### PR DESCRIPTION
**Description**

This PR changes the mdbook build action to use the `docs-deps` and `docs` targets from the makefile to install dependencies and build documentation, instead of manually doing so like until now.