### PR TITLE
refactor(l1): `SIGTERM` handling

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -1,3 +1,4 @@
+# TODO: uncomment "if: ${{ always() && github.event_name == 'merge_group' }}" lines when reenabling this workflow in the merge queue
 name: L2 (SP1 Backend)
 on:
   push:
@@ -23,41 +24,41 @@ jobs:
         uses: dtolnay/rust-toolchain@1.87.0
 
       - name: Set up Rust cache
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
 
       - name: RISC-V SP1 toolchain install
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           . "$HOME/.cargo/env"
           curl -L https://sp1.succinct.xyz | bash
           ~/.sp1/bin/sp1up --version 5.0.0
 
       - name: Set up Docker Buildx
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         uses: docker/setup-buildx-action@v3
 
       # This step is needed because of an state bug in the GPU runner.
       # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.
       - name: Clean .env
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: rm -rf crates/l2/.env
 
       - name: Build prover
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           make build-prover
 
       - name: Build test
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cargo test l2 --no-run --release
 
       - name: Start L1 & Deploy contracts
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           touch .env
@@ -67,7 +68,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up contract_deployer
 
       - name: Start Sequencer
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           CI_ETHREX_WORKDIR=/usr/local/bin \
@@ -76,7 +77,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up ethrex_l2 --detach
 
       - name: Run test
-        if: ${{ always() && github.event_name == 'merge_group' }}
+        # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover &

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -84,6 +84,12 @@ jobs:
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex_prover -s SIGINT
 
+      - name: Destroy Docker containers
+        if: always()
+        run: |
+          cd crates/l2
+          docker compose -f docker-compose-l2.yaml down -t 0
+
       - name: Ensure admin permissions in _work
         if: always()
         run: sudo chown admin:admin -R /home/admin/actions-runner/_work/

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -88,7 +88,7 @@ jobs:
         if: always()
         run: |
           cd crates/l2
-          docker compose -f docker-compose-l2.yaml down -t 0
+          docker compose -f docker-compose-l2.yaml down
 
       - name: Ensure admin permissions in _work
         if: always()

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -84,12 +84,6 @@ jobs:
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex_prover -s SIGINT
 
-      - name: Destroy Docker containers
-        if: always()
-        run: |
-          cd crates/l2
-          docker compose -f docker-compose-l2.yaml down -t 0
-
       - name: Ensure admin permissions in _work
         if: always()
         run: sudo chown admin:admin -R /home/admin/actions-runner/_work/

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -1,4 +1,3 @@
-# TODO: uncomment "if: ${{ always() && github.event_name == 'merge_group' }}" lines when reenabling this workflow in the merge queue
 name: L2 (SP1 Backend)
 on:
   push:
@@ -24,41 +23,41 @@ jobs:
         uses: dtolnay/rust-toolchain@1.87.0
 
       - name: Set up Rust cache
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
 
       - name: RISC-V SP1 toolchain install
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           . "$HOME/.cargo/env"
           curl -L https://sp1.succinct.xyz | bash
           ~/.sp1/bin/sp1up --version 5.0.0
 
       - name: Set up Docker Buildx
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         uses: docker/setup-buildx-action@v3
 
       # This step is needed because of an state bug in the GPU runner.
       # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.
       - name: Clean .env
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: rm -rf crates/l2/.env
 
       - name: Build prover
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           make build-prover
 
       - name: Build test
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cargo test l2 --no-run --release
 
       - name: Start L1 & Deploy contracts
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           touch .env
@@ -68,7 +67,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up contract_deployer
 
       - name: Start Sequencer
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           CI_ETHREX_WORKDIR=/usr/local/bin \
@@ -77,7 +76,7 @@ jobs:
           docker compose -f docker-compose-l2.yaml up ethrex_l2 --detach
 
       - name: Run test
-        # if: ${{ always() && github.event_name == 'merge_group' }}
+        if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
           RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover &

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,7 @@ dependencies = [
  "sha3",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -7,7 +7,7 @@ use ethrex::{
     },
     utils::{NodeConfigFile, set_datadir, store_node_config_file},
 };
-use ethrex_p2p::network::peer_table;
+use ethrex_p2p::{kademlia::KademliaTable, network::peer_table, types::NodeRecord};
 #[cfg(feature = "sync-test")]
 use ethrex_storage::Store;
 #[cfg(feature = "sync-test")]
@@ -17,7 +17,7 @@ use tokio::{
     signal::unix::{SignalKind, signal},
     sync::Mutex,
 };
-use tokio_util::task::TaskTracker;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::info;
 
 #[cfg(feature = "l2")]
@@ -44,6 +44,22 @@ async fn set_sync_block(store: &Store) {
             .await
             .expect("Failed to set latest canonical block");
     }
+}
+
+async fn server_shutdown(
+    data_dir: String,
+    cancel_token: &CancellationToken,
+    peer_table: Arc<Mutex<KademliaTable>>,
+    local_node_record: Arc<Mutex<NodeRecord>>,
+) {
+    info!("Server shut down started...");
+    let node_config_path = PathBuf::from(data_dir + "/node_config.json");
+    info!("Storing config at {:?}...", node_config_path);
+    cancel_token.cancel();
+    let node_config = NodeConfigFile::new(peer_table, local_node_record.lock().await.clone()).await;
+    store_node_config_file(node_config, node_config_path).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    info!("Server shutting down!");
 }
 
 #[tokio::main]
@@ -137,24 +153,10 @@ async fn main() -> eyre::Result<()> {
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-            info!("Server shut down started...");
-            let node_config_path = PathBuf::from(data_dir + "/node_config.json");
-            info!("Storing config at {:?}...", node_config_path);
-            cancel_token.cancel();
-            let node_config = NodeConfigFile::new(peer_table, local_node_record.lock().await.clone()).await;
-            store_node_config_file(node_config, node_config_path).await;
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            info!("Server shutting down!");
+            server_shutdown(data_dir, &cancel_token, peer_table, local_node_record).await;
         }
         _ = signal_terminate.recv() => {
-            info!("Server shut down started...");
-            let node_config_path = PathBuf::from(data_dir + "/node_config.json");
-            info!("Storing config at {:?}...", node_config_path);
-            cancel_token.cancel();
-            let node_config = NodeConfigFile::new(peer_table, local_node_record.lock().await.clone()).await;
-            store_node_config_file(node_config, node_config_path).await;
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            info!("Server shutting down!");
+            server_shutdown(data_dir, &cancel_token, peer_table, local_node_record).await;
         }
     }
 

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -18,7 +18,7 @@ tracing.workspace = true
 bytes.workspace = true
 cfg-if = "1.0.0"
 tokio = { workspace = true, features = ["time", "rt"] }
-
+tokio-util.workspace = true
 k256 = { version = "0.13.3", features = ["ecdh"] }
 
 ethrex-metrics = { path = "./metrics", default-features = false }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -455,13 +455,7 @@ impl Blockchain {
         for (i, block) in blocks.iter().enumerate() {
             if cancellation_token.is_cancelled() {
                 info!("Received shutdown signal, aborting");
-                return Err((
-                    ChainError::Custom(String::from("shutdown signal")),
-                    Some(BatchBlockProcessingFailure {
-                        failed_block_hash: block.hash(),
-                        last_valid_hash,
-                    }),
-                ));
+                return Err((ChainError::Custom(String::from("shutdown signal")), None));
             }
             // for the first block, we need to query the store
             let parent_header = if i == 0 {

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -81,7 +81,7 @@ init-l1-levm: ## 🚀 Initializes an L1 Lambda ethrex Client with LEVM
     --datadir ${ethrex_L1_DEV_LIBMDBX}
 
 down-local-l1: ## 🛑 Shuts down the L1 Lambda ethrex Client
-	docker compose -f ${ethrex_DEV_DOCKER_COMPOSE_PATH} down -t 0
+	docker compose -f ${ethrex_DEV_DOCKER_COMPOSE_PATH} down
 	docker compose -f docker-compose-l2.yaml down
 
 restart-local-l1: down-local-l1 rm-db-l1 init-local-l1 ## 🔄 Restarts the L1 Lambda ethrex Client

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -443,7 +443,13 @@ impl Syncer {
         // Spawn a blocking task to not block the tokio runtime
         let res = {
             let blockchain = self.blockchain.clone();
-            Self::add_blocks(blockchain, blocks, sync_head_found).await
+            Self::add_blocks(
+                blockchain,
+                blocks,
+                sync_head_found,
+                self.cancel_token.clone(),
+            )
+            .await
         };
 
         if let Err((error, failure)) = res {
@@ -492,6 +498,7 @@ impl Syncer {
         blockchain: Arc<Blockchain>,
         blocks: Vec<Block>,
         sync_head_found: bool,
+        cancel_token: CancellationToken,
     ) -> Result<(), (ChainError, Option<BatchBlockProcessingFailure>)> {
         // If we found the sync head, run the blocks sequentially to store all the blocks's state
         if sync_head_found {
@@ -510,7 +517,7 @@ impl Syncer {
             }
             Ok(())
         } else {
-            blockchain.add_blocks_in_batch(blocks).await
+            blockchain.add_blocks_in_batch(blocks, cancel_token).await
         }
     }
 }


### PR DESCRIPTION
**Motivation**
Stopping an L1 Docker container sends a `SIGTERM` to the node process, but since the node doesn't handle this signal, it takes 10 seconds for the `SIGKILL` to force the shutdown.
Some temporary fixes were introduced to address this issue, but the correct solution is to handle the `SIGTERM` signal.


**Description**
This PR adds a `SIGTERM` handler to allow graceful shutdown without the 10-second delay.

It also reverts the temporary fixes that were introduced in previous PRs (https://github.com/lambdaclass/ethrex/commit/47a1d4c5b23a9ae03839556b92bce3c6dd029f17 and https://github.com/lambdaclass/ethrex/commit/67edcaff73624446f2b75c40b385df69aabe4882) in favor of this solution.

Note that when the node is syncing, shutdown isn’t immediate, as the node waits for the current batch to complete.
To handle this, the `CancellationToken` is propagated and checked before processing each block, which allows the node to terminate immediately, without waiting for the whole batch to complete.

Closes #2944
Closes #3236 

