### PR TITLE
fix(l1): flaky test `test_peer_scoring_system `

### DIFF
--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -772,7 +772,7 @@ mod tests {
 
         // Test weighted selection distribution
         let mut selection_counts = [0; 3];
-        for _ in 0..300 {
+        for _ in 0..600 {
             if let Some(selected) = table.get_peer_with_score_filter(&|_| true) {
                 for (i, &peer_id) in peer_ids.iter().enumerate() {
                     if selected.node.node_id() == peer_id {

--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -772,7 +772,7 @@ mod tests {
 
         // Test weighted selection distribution
         let mut selection_counts = [0; 3];
-        for _ in 0..600 {
+        for _ in 0..1000 {
             if let Some(selected) = table.get_peer_with_score_filter(&|_| true) {
                 for (i, &peer_id) in peer_ids.iter().enumerate() {
                     if selected.node.node_id() == peer_id {

--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -751,6 +751,8 @@ mod tests {
             .collect();
         let mut peer_ids = Vec::new();
 
+        let mut table = get_test_table();
+
         for key in &peer_keys {
             let node = Node::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0, 0, *key);
             table.insert_node(node);


### PR DESCRIPTION
**Motivation**
The test executes a function that selects peers randomly but prioritizing those with high score, and checks that the number of selections for each peer is proportional to its score. However given that the selection is somehow random, this is not always the case.

**Description**
Introduces the following changes in the test
* Increments the number of selections, which should reduce the probability of failure.
* Initializes a different `KademliaTable` for working with multiple peers.
   Note that the table used for multiple-peer scoring checks was the same as the one used for single-peer scoring tests. The problem is that a high-scoring peer from the initial phase remains in the table but is incorrectly omitted from subsequent multi-peer selection calculations, thus impacting the final outcome.

The following bash script can be used to get a sense of the failure rate of the test. It loops running the test and printing the total and failed runs.

With these changes, the failure rate dropped from (approximately) 4% to 0.025%.

```bash
#!/bin/bash

COMMAND=(cargo test --package=ethrex-p2p --lib -- --exact kademlia::tests::test_peer_scoring_system --nocapture)

total=0
failed=0

while true; do
    "${COMMAND[@]}" >/dev/null 2>&1
    exit_code=$?

    if [ $exit_code -ne 0 ]; then
        failed=$((failed + 1))
        echo "❌ failed"
    else
        echo "✅ ok"
    fi

    total=$((total + 1))
    echo "Total = $total, Failed = $failed"
    echo "---"
done

```



Closes #3191 

