### PR TITLE
ci(l2): check if the sp1 cargo.lock is modified but not committed

### DIFF
--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Clippy sp1
         run: |
           cargo clippy -r -p ethrex-prover --all-targets -F sp1
+      - name: Check sp1 cargo.lock modified but not committed
+        run: |
+          git diff --exit-code -- Cargo.lock
       - name: Check exec
         run: |
           cargo check -p ethrex-prover

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -35,7 +35,7 @@ jobs:
           cargo clippy -r -p ethrex-prover --all-targets -F sp1
       - name: Check sp1 cargo.lock modified but not committed
         run: |
-          git diff --exit-code -- Cargo.lock
+          git diff --exit-code -- crates/l2/prover/zkvm/interface/sp1/Cargo.lock
       - name: Check exec
         run: |
           cargo check -p ethrex-prover


### PR DESCRIPTION
**Motivation**

RPC prover ci is constantly breaking because Cargo.lock is modified but not committed in PRs

**Description**

- Add a check in the Lint job that executes `git diff --exit-code -- crates/l2/prover/zkvm/interface/sp1/Cargo.lock` and fails if there is a diff
- Update cargo check to fix currently broken ci

