### PR TITLE
docs(l2): add quotes on init-prover command

### DIFF
--- a/docs/l2/prover.md
+++ b/docs/l2/prover.md
@@ -66,7 +66,7 @@ make init-prover T="prover_type (risc0,sp1) G=true"
    - Init the L1 in a docker container on port `8545`.
    - Deploy the needed contracts for the L2 on the L1.
    - Start the L2 locally on port `1729`.
-4. In a new terminal &rarr; `make init-prover T=(sp1,risc0)`.
+4. In a new terminal &rarr; `make init-prover T="(sp1,risc0)"`.
 
 After this initialization we should have the prover running in `dev_mode` &rarr; No real proofs.
 
@@ -107,6 +107,7 @@ Two servers are required: one for the `Prover` and another for the `sequencer`. 
   - `make init-prover T=(sp1,risc0) G=true`
 
 2. `ProofCoordinator`/`sequencer` &rarr; this server just needs rust installed.
+
    1. `cd ethrex/crates/l2`
    2. Create a `.env` file with the following content:
 


### PR DESCRIPTION
**Motivation**
Copy paste on the command provided in the docs doesn't work

**Description**
- Added quotes to the command mentioned

Closes: none
