### PR TITLE
feat(l2): add instance info to Grafana alerts

### DIFF
--- a/crates/blockchain/metrics/docker-compose-metrics-alerts.overrides.yaml
+++ b/crates/blockchain/metrics/docker-compose-metrics-alerts.overrides.yaml
@@ -5,3 +5,4 @@ services:
     environment:
       - ALERTS_SLACK_TOKEN=${GRAFANA_SLACK_TOKEN:?Slack token is needed for alerts}
       - ALERTS_SLACK_CHANNEL=${GRAFANA_SLACK_CHANNEL:?Slack channel is needed for alerts}
+      - INSTANCE=${GRAFANA_INSTANCE:-docker}

--- a/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/alerts.json
+++ b/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/alerts.json
@@ -97,7 +97,8 @@
           "execErrState": "Error",
           "annotations": {
             "description": "L1 Committer balance is lower than 0.1 ETH",
-            "summary": "L1 Committer is running out of funds"
+            "summary": "L1 Committer is running out of funds",
+            "instance": "$HOSTNAME"
           },
           "isPaused": false,
           "notification_settings": { "receiver": "Slack" }
@@ -192,7 +193,8 @@
           "execErrState": "Error",
           "annotations": {
             "description": "Proof Sender balance is lower than 0.1 ETH",
-            "summary": "Proof Sender is running out of funds"
+            "summary": "Proof Sender is running out of funds",
+            "instance": "$HOSTNAME"
           },
           "isPaused": false,
           "notification_settings": { "receiver": "Slack" }
@@ -275,7 +277,8 @@
           "execErrState": "Error",
           "annotations": {
             "description": "Last batch commitment was sent more than an hour ago to L1",
-            "summary": "L1 Committer is stuck"
+            "summary": "L1 Committer is stuck",
+            "instance": "$HOSTNAME"
           },
           "isPaused": false,
           "notification_settings": {
@@ -352,7 +355,8 @@
           "execErrState": "Error",
           "annotations": {
             "description": "Last batch verification was sent more than an hour ago to L1",
-            "summary": "Proof Sender is stuck"
+            "summary": "Proof Sender is stuck",
+            "instance": "$HOSTNAME"
           },
           "isPaused": false,
           "notification_settings": {
@@ -429,7 +433,8 @@
           "execErrState": "Error",
           "annotations": {
             "description": "The L2 is not generating new blocks",
-            "summary": "L2 is stuck"
+            "summary": "L2 is stuck",
+            "instance": "$HOSTNAME"
           },
           "isPaused": false,
           "notification_settings": {
@@ -510,7 +515,8 @@
           "execErrState": "Error",
           "annotations": {
             "description": "The mempool has grown a lot in the last minute",
-            "summary": "Mempool transactions are increasing fast"
+            "summary": "Mempool transactions are increasing fast",
+            "instance": "$HOSTNAME"
           },
           "isPaused": false,
           "notification_settings": {

--- a/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/alerts.json
+++ b/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/alerts.json
@@ -97,8 +97,7 @@
           "execErrState": "Error",
           "annotations": {
             "description": "L1 Committer balance is lower than 0.1 ETH",
-            "summary": "L1 Committer is running out of funds",
-            "instance": "$HOSTNAME"
+            "summary": "L1 Committer is running out of funds"
           },
           "isPaused": false,
           "notification_settings": { "receiver": "Slack" }
@@ -193,8 +192,7 @@
           "execErrState": "Error",
           "annotations": {
             "description": "Proof Sender balance is lower than 0.1 ETH",
-            "summary": "Proof Sender is running out of funds",
-            "instance": "$HOSTNAME"
+            "summary": "Proof Sender is running out of funds"
           },
           "isPaused": false,
           "notification_settings": { "receiver": "Slack" }
@@ -277,8 +275,7 @@
           "execErrState": "Error",
           "annotations": {
             "description": "Last batch commitment was sent more than an hour ago to L1",
-            "summary": "L1 Committer is stuck",
-            "instance": "$HOSTNAME"
+            "summary": "L1 Committer is stuck"
           },
           "isPaused": false,
           "notification_settings": {
@@ -355,8 +352,7 @@
           "execErrState": "Error",
           "annotations": {
             "description": "Last batch verification was sent more than an hour ago to L1",
-            "summary": "Proof Sender is stuck",
-            "instance": "$HOSTNAME"
+            "summary": "Proof Sender is stuck"
           },
           "isPaused": false,
           "notification_settings": {
@@ -433,8 +429,7 @@
           "execErrState": "Error",
           "annotations": {
             "description": "The L2 is not generating new blocks",
-            "summary": "L2 is stuck",
-            "instance": "$HOSTNAME"
+            "summary": "L2 is stuck"
           },
           "isPaused": false,
           "notification_settings": {
@@ -515,8 +510,7 @@
           "execErrState": "Error",
           "annotations": {
             "description": "The mempool has grown a lot in the last minute",
-            "summary": "Mempool transactions are increasing fast",
-            "instance": "$HOSTNAME"
+            "summary": "Mempool transactions are increasing fast"
           },
           "isPaused": false,
           "notification_settings": {

--- a/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/contact_points.json
+++ b/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/contact_points.json
@@ -10,7 +10,7 @@
           "type": "slack",
           "settings": {
             "recipient": "${ALERTS_SLACK_CHANNEL}",
-            "text": "{{ define \"slack.body\" -}}\n{{ .CommonAnnotations.description }}\n{{- end }}\n{{ template \"slack.body\" . }}",
+            "text": "{{ define \"slack.body\" -}}\n[{{ .CommonAnnotations.instance }}]\n{{ .CommonAnnotations.description }}\n{{- end }}\n{{ template \"slack.body\" . }}",
             "title": "{{ define \"slack.title\" -}}{{- if eq .Status \"firing\" -}}🚨{{- else -}}✅ [SOLVED]{{- end }} {{ .CommonAnnotations.summary }}{{- end }}{{ template \"slack.title\" . }}",
             "token": "${ALERTS_SLACK_TOKEN}"
           },

--- a/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/contact_points.json
+++ b/crates/blockchain/metrics/provisioning/grafana_provisioning/alerting/contact_points.json
@@ -10,7 +10,7 @@
           "type": "slack",
           "settings": {
             "recipient": "${ALERTS_SLACK_CHANNEL}",
-            "text": "{{ define \"slack.body\" -}}\n[{{ .CommonAnnotations.instance }}]\n{{ .CommonAnnotations.description }}\n{{- end }}\n{{ template \"slack.body\" . }}",
+            "text": "{{ define \"slack.body\" -}}\n[$INSTANCE]\n{{ .CommonAnnotations.description }}\n{{- end }}\n{{ template \"slack.body\" . }}",
             "title": "{{ define \"slack.title\" -}}{{- if eq .Status \"firing\" -}}🚨{{- else -}}✅ [SOLVED]{{- end }} {{ .CommonAnnotations.summary }}{{- end }}{{ template \"slack.title\" . }}",
             "token": "${ALERTS_SLACK_TOKEN}"
           },


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We need to easily differentiate between environments when alerts come up (staging-1, staging-2, etc.).

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Add an "$INSTANCE" variable in the Slack contact point so it's over-ridden with an env var.

<!-- Link to issues: Resolves #111, Resolves #222 -->


