### PR TITLE
docs: fix readme links and improve L1 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Minimalist, stable, modular and fast implementation of the Ethereum protocol in 
 [tg-badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fethrex_client%2F&logo=telegram&label=chat&color=neon
 [tg-url]: https://t.me/ethrex_client
 
-# L1 and L2 support
+## L1 and L2 support
 
 This client supports running in two different modes:
 
@@ -17,18 +17,13 @@ This client supports running in two different modes:
 
 We call the first one ethrex L1 and the second one ethrex L2.
 
-## 📖 L1 and L2 Documentation
-
-- [L1 Documentation](docs/l1/README.md)
-- [L2 Documentation](docs/l2/README.md)
-
 ## Philosophy
 
 Many long-established clients accumulate bloat over time. This often occurs due to the need to support legacy features for existing users or through attempts to implement overly ambitious software. The result is often complex, difficult-to-maintain, and error-prone systems.
 
 In contrast, our philosophy is rooted in simplicity. We strive to write minimal code, prioritize clarity, and embrace simplicity in design. We believe this approach is the best way to build a client that is both fast and resilient. By adhering to these principles, we will be able to iterate fast and explore next-generation features early, either from the Ethereum roadmap or from innovations from the L2s.
 
-Read more about our engineering philosophy [here](https://blog.lambdaclass.com/lambdas-engineering-philosophy/)
+Read more about our engineering philosophy [in this post of our blog](https://blog.lambdaclass.com/lambdas-engineering-philosophy/).
 
 ## Design Principles
 
@@ -42,13 +37,15 @@ Read more about our engineering philosophy [here](https://blog.lambdaclass.com/l
 
 ## 🗺️ Roadmap
 
-You can find our current and planned features in the [Roadmap](docs/getting-started/roadmap.md) document.
+You can find our current and planned features in our roadmap page.
 
-[View the Roadmap →](docs/getting-started/roadmap.md)
+[View the roadmap →](https://docs.ethrex.xyz/l2/roadmap.html)
 
-## Documentation
+## 📖 Documentation
 
 Full documentation is available in the [`docs/`](./docs/) directory. Please refer to it for setup, usage, and development details.
+For better viewing, we have it hosted in [docs.ethrex.xyz](https://docs.ethrex.xyz/).
+This includes both [L1](https://docs.ethrex.xyz/l1/index.html) and [L2](https://docs.ethrex.xyz/l2/index.html) documentation.
 
 ## 📚 References and acknowledgements
 
@@ -74,7 +71,7 @@ The following links, repos, companies and projects have been important in the de
 
 If we forgot to include anyone, please file an issue so we can add you. We always strive to reference the inspirations and code we use, but as an organization with multiple people, mistakes can happen, and someone might forget to include a reference.
 
-# Security
+## Security
 
 We take security seriously. If you discover a vulnerability in this project, please report it responsibly.
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -7,4 +7,5 @@ This client supports running in two different modes:
 - As a regular Ethereum execution client
 - As a multi-prover ZK-Rollup (supporting SP1, RISC Zero and TEEs), where block execution is proven and the proof sent to an L1 network for verification, thus inheriting the L1's security. Support for based sequencing is currently in the works.
 
-We call the first one ethrex L1 and the second one ethrex L2.
+We call the first one "ethrex L1" and the second one "ethrex L2".
+You can find more information on our [L1](../l1) or [L2](../l2) docs, respectively.

--- a/docs/l1/README.md
+++ b/docs/l1/README.md
@@ -1,1 +1,7 @@
-# Layer 1
+# Ethrex L1
+
+Ethrex is a minimalist Ethereum Rust execution client.
+
+To quickly get started, visit [our quick-start page](./quick-start-l1.md).
+
+If you're looking to experiment with the codebase, ["L1 dev setup" will be of help](./dev-setup-l1.md).

--- a/docs/l1/dev-setup-l1.md
+++ b/docs/l1/dev-setup-l1.md
@@ -1,19 +1,25 @@
 # Dev Setup L1
+
 ## Build
 
 ### Rust
+
 To build the node, you will need the rust toolchain. To do so, use `rustup` following [this link](https://www.rust-lang.org/tools/install)
 
 ## Database
+
 Currently, the database is `libmdbx`, it will be set up
 when you start the client. The location of the db's files will depend on your OS:
+
 - Mac: `~/Library/Application Support/ethrex`
 - Linux: `~/.config/ethrex`
 
 You can delete the db with:
+
 ```bash
 cargo run --bin ethrex -- removedb
 ```
+
 ## Dev Mode
 In order to run `ethrex` without a Consensus Client and with the `InMemory` engine, to start from scratch each time we fire it up, the following make target can be used:
 
@@ -46,7 +52,9 @@ The second kind are each crate's tests, you can run them like this:
 ```bash
 make test CRATE=<crate>
 ```
+
 For example:
+
 ```bash
 make test CRATE="ethrex-blockchain"
 ```
@@ -62,6 +70,7 @@ Hive is a system which simply sends RPC commands to our node,
 and expects a certain response. You can read more about it [here](https://github.com/ethereum/hive/blob/master/docs/overview.md).
 
 #### Prereqs
+
 We need to have go installed for the first time we run hive, an easy way to do this is adding the asdf go plugin:
 
 ```shell
@@ -71,30 +80,39 @@ asdf plugin add golang https://github.com/asdf-community/asdf-golang.git
 ```
 
 And uncommenting the golang line in the asdf `.tool-versions` file:
-```
+
+```text
 rust 1.87.0
 golang 1.23.2
 ```
 
 #### Running Simulations
+
 Hive tests are categorized by "simulations', and test instances can be filtered with a regex:
+
 ```bash
 make run-hive-debug SIMULATION=<simulation> TEST_PATTERN=<test-regex>
 ```
+
 This is an example of a Hive simulation called `ethereum/rpc-compat`, which will specificaly
 run chain id and transaction by hash rpc tests:
+
 ```bash
 make run-hive SIMULATION=ethereum/rpc-compat TEST_PATTERN="/eth_chainId|eth_getTransactionByHash"
 ```
+
 If you want debug output from hive, use the run-hive-debug instead:
+
 ```bash
 make run-hive-debug SIMULATION=ethereum/rpc-compat TEST_PATTERN="*"
 ```
+
 This example runs **every** test under rpc, with debug output
 
 #### Assertoor
 
 We run some assertoot checks on our CI, to execute them locally you can run the following:
+
 ```bash
 make localnet-assertoor-tx
 # or
@@ -104,17 +122,20 @@ make localnet-assertoor-blob
 Those are two different set of assertoor checks the details are as follows:
 
 *assertoor-tx*
+
 - [eoa-transaction-test](https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/eoa-transactions-test.yaml)
 
 *assertoor-blob*
+
 - [blob-transaction-test](https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/blob-transactions-test.yaml)
-- _Custom_ [el-stability-check](https://raw.githubusercontent.com/lambdaclass/ethrex/refs/heads/main/.github/config/assertoor/el-stability-check.yaml)
+- *Custom* [el-stability-check](https://raw.githubusercontent.com/lambdaclass/ethrex/refs/heads/main/.github/config/assertoor/el-stability-check.yaml)
 
 For reference on each individual check see the [assertoor-wiki](https://github.com/ethpandaops/assertoor/wiki#supported-tasks-in-assertoor)
 
 ## Run
 
 Example run:
+
 ```bash
 cargo run --bin ethrex -- --network test_data/genesis-kurtosis.json
 ```
@@ -276,7 +297,7 @@ lighthouse bn --network holesky --execution-endpoint http://localhost:8551 --exe
 
 When using lighthouse directly from its repository, replace `lighthouse bn` with `cargo run --bin lighthouse -- bn`
 
-Aside from holesky, these steps can also be used to connect to other supported networks by replacing the `--network` argument by another supported network and looking up a checkpoint sync endpoint for that network [here](https://eth-clients.github.io/checkpoint-sync-endpoints/)
+Aside from holesky, these steps can also be used to connect to other supported networks by replacing the `--network` argument by another supported network and looking up a checkpoint sync endpoint for that network [in this community-maintained list](https://eth-clients.github.io/checkpoint-sync-endpoints/)
 
 If you have a running execution node that you want to connect to your ethrex node you can do so by passing its enode as a bootnode using the `--bootnodes` flag
 
@@ -289,6 +310,7 @@ INFO ethrex_p2p::sync::trie_rebuild: State Trie Rebuild Progress: 68%, estimated
 ```
 
 If you want to restart the sync from the very start you can do so by wiping the database using the following command:
+
 ```bash
 cargo run --bin ethrex -- removedb
 ```

--- a/docs/l1/dev-setup-l1.md
+++ b/docs/l1/dev-setup-l1.md
@@ -1,4 +1,4 @@
-# Dev Setup L1
+# L1 dev setup
 
 ## Build
 
@@ -21,6 +21,7 @@ cargo run --bin ethrex -- removedb
 ```
 
 ## Dev Mode
+
 In order to run `ethrex` without a Consensus Client and with the `InMemory` engine, to start from scratch each time we fire it up, the following make target can be used:
 
 ```bash

--- a/docs/l1/quick-start-l1.md
+++ b/docs/l1/quick-start-l1.md
@@ -1,21 +1,31 @@
 # Quick Start (L1 localnet)
 
+This page will show you how to quickly spin up a local development network with ethrex.
+
 ## Prerequisites
+
 - [Kurtosis](https://docs.kurtosis.com/install/#ii-install-the-cli)
-- [Rust](#rust)
+- [Rust](https://www.rust-lang.org/tools/install)
 - [Docker](https://docs.docker.com/engine/install/)
+
+## Starting a local devnet
+
 ```shell
 make localnet
 ```
 
 This make target will:
+
 1. Build our node inside a docker image.
 2. Fetch our fork [ethereum package](https://github.com/ethpandaops/ethereum-package), a private testnet on which multiple ethereum clients can interact.
 3. Start the localnet with kurtosis.
 
-If everything went well, you should be faced with our client's logs (ctrl-c to leave)
+If everything went well, you should be faced with our client's logs (ctrl-c to leave).
+
+## Stopping a local devnet
 
 To stop everything, simply run:
+
 ```shell
 make stop-localnet
 ```

--- a/docs/l2/getting_started.md
+++ b/docs/l2/getting_started.md
@@ -23,4 +23,4 @@ More information is available in [the documentation for each component](./compon
 
 ## Guides
 
-For more information on how to perform certain operations, go to [Guides](./guides/README.md).
+For more information on how to perform certain operations, go to [Guides](./guides).


### PR DESCRIPTION
**Motivation**

The current readme links to the unrendered documentation instead of our hosted book. Also, the general landing page doesn't have any links or pointers on where to go next, while the L1 landing page is empty.

**Description**

This PR addresses the previous issues, adding some content to the L1 landing page and generally cleaning up the docs. It also merges the two documentation sections in the readme and updates links to point to docs.ethrex.xyz 
