### PR TITLE
ci(l2): build docker images for all l2 tests

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -127,6 +127,9 @@ jobs:
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Build L1 docker image
+        run: docker build -t ethrex_dev:latest -f crates/blockchain/dev/Dockerfile .
+
       # also creates empty verification keys (as workflow runs with exec backend)
       - name: Build prover
         run: |
@@ -203,6 +206,9 @@ jobs:
 
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Build L1 docker image
+        run: docker build -t ethrex_dev:latest -f crates/blockchain/dev/Dockerfile .
 
       - name: Install solc
         run: |


### PR DESCRIPTION
**Motivation**

After #3338 state reconstruct test and based tests started failing
**Description**

- build the docker image for those steps too


