### PR TITLE
fix(l2): serde skip attributes incompatible with bincode

### DIFF
--- a/crates/l2/prover/zkvm/interface/src/io.rs
+++ b/crates/l2/prover/zkvm/interface/src/io.rs
@@ -16,6 +16,7 @@ pub struct ProgramInput {
     #[serde_as(as = "SerdeJSON")]
     pub blocks: Vec<Block>,
     /// database containing all the data necessary to execute
+    #[serde_as(as = "SerdeJSON")]
     pub db: ExecutionWitnessResult,
     /// value used to calculate base fee
     pub elasticity_multiplier: u64,


### PR DESCRIPTION
**Motivation**

same old problem which we brute fix by serializing into JSON first, was reintroduced with the addition of `ExecutionWitnessResult` (which has two fields that use `#[serde(skip)]`)
