### PR TITLE
refactor(l1, l2): decouple L2 metrics logic from L1's & remove l2 feature flag from `ethrex-blockchain`

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -75,7 +75,6 @@ l2 = [
   "dep:ethrex-l2-common",
   "dep:ethrex-sdk",
   "dep:ethrex-l2-rpc",
-  "ethrex-blockchain/l2",
   "ethrex-storage-rollup",
 ]
 rollup_storage_libmdbx = ["ethrex-storage-rollup/libmdbx"]

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -3,7 +3,7 @@ use crate::{
     cli::{self as ethrex_cli, Options as NodeOptions},
     initializers::{
         get_local_node_record, get_local_p2p_node, get_network, get_signer, init_blockchain,
-        init_metrics, init_network, init_store,
+        init_network, init_store,
     },
     l2::{self, options::Options},
     networks::Network,
@@ -173,7 +173,7 @@ impl Command {
 
                 // Initialize metrics if enabled
                 if opts.node_opts.metrics_enabled {
-                    init_metrics(&opts.node_opts, tracker.clone());
+                    l2::initializers::init_metrics(&opts.node_opts, tracker.clone());
                 }
 
                 if opts.node_opts.p2p_enabled {

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -101,3 +101,16 @@ pub async fn init_rollup_store(data_dir: &str) -> StoreRollup {
         .expect("Failed to init rollup store");
     rollup_store
 }
+
+pub fn init_metrics(opts: &L1Options, tracker: TaskTracker) {
+    tracing::info!(
+        "Starting metrics server on {}:{}",
+        opts.metrics_addr,
+        opts.metrics_port
+    );
+    let metrics_api = ethrex_metrics::l2::api::start_prometheus_metrics_api(
+        opts.metrics_addr.clone(),
+        opts.metrics_port.clone(),
+    );
+    tracker.spawn(metrics_api);
+}

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -33,7 +33,6 @@ path = "./blockchain.rs"
 
 [features]
 default = []
-l2 = []
 c-kzg = ["ethrex-common/c-kzg", "ethrex-vm/c-kzg"]
 metrics = ["ethrex-metrics/transactions"]
 

--- a/crates/blockchain/metrics/l2/api.rs
+++ b/crates/blockchain/metrics/l2/api.rs
@@ -1,6 +1,6 @@
 use axum::{Router, routing::get};
 
-use crate::{MetricsApiError, metrics_blocks::METRICS_BLOCKS, metrics_transactions::METRICS_TX};
+use crate::{MetricsApiError, api, l2::metrics::METRICS};
 
 pub async fn start_prometheus_metrics_api(
     address: String,
@@ -18,20 +18,14 @@ pub async fn start_prometheus_metrics_api(
 }
 
 #[allow(unused_mut)]
-pub(crate) async fn get_metrics() -> String {
-    let mut ret_string = match METRICS_TX.gather_metrics() {
-        Ok(string) => string,
-        Err(_) => {
-            tracing::error!("Failed to register METRICS_TX");
-            String::new()
-        }
-    };
+async fn get_metrics() -> String {
+    let mut ret_string = api::get_metrics().await;
 
     ret_string.push('\n');
-    match METRICS_BLOCKS.gather_metrics() {
+    match METRICS.gather_metrics() {
         Ok(string) => ret_string.push_str(&string),
         Err(_) => {
-            tracing::error!("Failed to register METRICS_BLOCKS");
+            tracing::error!("Failed to register METRICS_L2");
             return String::new();
         }
     }

--- a/crates/blockchain/metrics/l2/metrics.rs
+++ b/crates/blockchain/metrics/l2/metrics.rs
@@ -3,9 +3,9 @@ use std::sync::LazyLock;
 
 use crate::MetricsError;
 
-pub static METRICS_L2: LazyLock<MetricsL2> = LazyLock::new(MetricsL2::default);
+pub static METRICS: LazyLock<Metrics> = LazyLock::new(Metrics::default);
 
-pub struct MetricsL2 {
+pub struct Metrics {
     status_tracker: IntGaugeVec,
     operations_tracker: IntGaugeVec,
     l1_gas_price: IntGauge,
@@ -13,15 +13,15 @@ pub struct MetricsL2 {
     blob_usage: Gauge,
 }
 
-impl Default for MetricsL2 {
+impl Default for Metrics {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl MetricsL2 {
+impl Metrics {
     pub fn new() -> Self {
-        MetricsL2 {
+        Metrics {
             status_tracker: IntGaugeVec::new(
                 Opts::new(
                     "l2_blocks_tracker",

--- a/crates/blockchain/metrics/l2/mod.rs
+++ b/crates/blockchain/metrics/l2/mod.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod metrics;

--- a/crates/blockchain/metrics/mod.rs
+++ b/crates/blockchain/metrics/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "api")]
 pub mod api;
-#[cfg(any(feature = "api", feature = "l2", feature = "metrics"))]
+#[cfg(feature = "api")]
+pub mod l2;
+#[cfg(any(feature = "api", feature = "metrics"))]
 pub mod metrics_blocks;
-#[cfg(any(feature = "api", feature = "l2"))]
-pub mod metrics_l2;
 #[cfg(any(feature = "api", feature = "transactions"))]
 pub mod metrics_transactions;
 

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -65,4 +65,4 @@ panic = "deny"
 [features]
 default = ["l2"]
 metrics = ["ethrex-blockchain/metrics", "ethrex-metrics/l2"]
-l2 = ["ethrex-blockchain/l2", "zkvm_interface/l2"]
+l2 = ["zkvm_interface/l2"]

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -65,7 +65,6 @@ gpu = ["risc0-zkvm?/cuda", "sp1-sdk?/cuda"]
 l2 = [
   "dep:ethrex-l2-common",
   "zkvm_interface/l2",
-  "ethrex-blockchain/l2",
   "ethrex-l2/l2",
 ] # the prover can work with either l1 or l2 blocks
 

--- a/crates/l2/prover/zkvm/interface/risc0/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/risc0/Cargo.toml
@@ -27,4 +27,4 @@ secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "p
 ecdsa-core = { git = "https://github.com/sp1-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-v0.16.9" }
 
 [features]
-l2 = ["zkvm_interface/l2", "ethrex-blockchain/l2"]
+l2 = ["zkvm_interface/l2"]

--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
@@ -36,4 +36,4 @@ rsa = { git = "https://github.com/sp1-patches/RustCrypto-RSA", tag = "patch-0.9.
 # ecdsa = { git = "https://github.com/sp1-patches/signatures", tag = "patch-16.9-sp1-4.1.0" }
 
 [features]
-l2 = ["zkvm_interface/l2", "ethrex-blockchain/l2"]
+l2 = ["zkvm_interface/l2"]

--- a/crates/l2/prover/zkvm/interface/src/execution.rs
+++ b/crates/l2/prover/zkvm/interface/src/execution.rs
@@ -266,7 +266,10 @@ fn execute_stateless(
         .map_err(StatelessExecutionError::BlockValidationError)?;
 
         // Execute block
+        #[cfg(feature = "l2")]
         let mut vm = Evm::new_for_l2(EvmEngine::LEVM, db.clone())?;
+        #[cfg(not(feature = "l2"))]
+        let mut vm = Evm::new_for_l1(EvmEngine::LEVM, db.clone());
         let result = vm
             .execute_block(block)
             .map_err(StatelessExecutionError::EvmError)?;

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -35,4 +35,4 @@ secp256k1 = { version = "0.29.1", default-features = false, features = [
 
 [features]
 default = ["l2"]
-l2 = ["zkvm_interface/l2", "ethrex-blockchain/l2", "ethrex-l2/l2"]
+l2 = ["zkvm_interface/l2", "ethrex-l2/l2"]


### PR DESCRIPTION
**Motivation**

To completely remove the `l2` feature flag from `cmd/ethrex` in favor of having a single binary for running ethrex (L1 and L2), there are some local dependencies from which to remove this feature first. These are:

1. `ethrex-vm`.
2. `ethrex-levm`.
3. `ethrex-blockchain`. 

1 and 2 are removed in https://github.com/lambdaclass/ethrex/pull/3367, and 3 is meant to be removed in this PR.

**Description**

Decouples the L2 metrics logic from the L1's, allowing to remove the use of the `l2` feature flag from the crate `ethrex-blockchain`.

- Creates a `crates/blockchain/metrics/l2` module with `metrics.rs` and `api.rs` submodules.
- Makes use of this new module in `cmd/ethrex`.
- Removes `l2` feature flag from `ethrex-blockchain` crate.
- Removes the import of `ethrex-blockchain/l2` where needed.
