### PR TITLE
perf(levm): add fib recursive bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ book/
 # mdbook-mermaid artifacts
 mermaid-init.js
 mermaid.min.js
+
+bench-results/

--- a/crates/vm/levm/Makefile
+++ b/crates/vm/levm/Makefile
@@ -30,6 +30,7 @@ REPETITIONS_SLOW := 200
 BENCH_FACT_ITERATIONS := 57
 BENCH_FACT_REC_ITERATIONS := 57
 BENCH_FIB_ITERATIONS := 57
+BENCH_FIB_REC_ITERATIONS := 15
 BENCH_HASHES_ITERATIONS := 57
 BENCH_BUBBLESORT_ITERATIONS := 100 # Size of the array to sort
 BENCH_MINT_ITERATIONS := 500
@@ -76,6 +77,7 @@ compile-contracts:
 revm-comparison: compile-contracts ## 📊 Run benchmarks of fibonacci and factorial for both REVM and LEVM
 	$(MAKE) build-revm-comparison
 	$(call run_benchmark,Fibonacci,REPETITIONS,BENCH_FIB_ITERATIONS)
+	$(call run_benchmark,FibonacciRecursive,REPETITIONS_SLOW,BENCH_FIB_REC_ITERATIONS)
 	$(call run_benchmark,Factorial,REPETITIONS,BENCH_FACT_ITERATIONS)
 	$(call run_benchmark,FactorialRecursive,REPETITIONS,BENCH_FACT_REC_ITERATIONS)
 	$(call run_benchmark,Push,REPETITIONS,BENCH_PUSH_ITERATIONS)
@@ -88,6 +90,7 @@ revm-comparison: compile-contracts ## 📊 Run benchmarks of fibonacci and facto
 revm-comparison-ci: compile-contracts
 	mkdir -p ../../../benchmark_comparison_results
 	$(call run_benchmark_ci,Fibonacci,REPETITIONS,BENCH_FIB_ITERATIONS)
+	$(call run_benchmark_ci,FibonacciRecursive,REPETITIONS_SLOW,BENCH_FIB_REC_ITERATIONS)
 	$(call run_benchmark_ci,Factorial,REPETITIONS,BENCH_FACT_ITERATIONS)
 	$(call run_benchmark_ci,FactorialRecursive,REPETITIONS,BENCH_FACT_ITERATIONS)
 	$(call run_benchmark_ci,Push,REPETITIONS,BENCH_PUSH_ITERATIONS)
@@ -102,6 +105,7 @@ render-benches:
 
 flamegraph-levm-benchmark:
 	$(MAKE) flamegraph-levm-bench-generic name=Fibonacci repetitions=$(REPETITIONS) iterations=$(BENCH_FIB_ITERATIONS)
+	$(MAKE) flamegraph-levm-bench-generic name=FibonacciRecursive repetitions=$(REPETITIONS_SLOW) iterations=$(BENCH_FIB_REC_ITERATIONS)
 	$(MAKE) flamegraph-levm-bench-generic name=Factorial repetitions=$(REPETITIONS) iterations=$(BENCH_FACT_ITERATIONS)
 	$(MAKE) flamegraph-levm-bench-generic name=FactorialRecursive repetitions=$(REPETITIONS) iterations=$(BENCH_FACT_REC_ITERATIONS)
 	$(MAKE) flamegraph-levm-bench-generic name=ManyHashes repetitions=$(REPETITIONS_SLOW) iterations=$(BENCH_HASHES_ITERATIONS)

--- a/crates/vm/levm/bench/revm_comparison/contracts/FibonacciRecursive.sol
+++ b/crates/vm/levm/bench/revm_comparison/contracts/FibonacciRecursive.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+contract FibonacciRecursive {
+    function Benchmark(uint256 n) public view returns (uint256 result) {
+        if (n <= 1) return n;
+
+        uint256 rec = this.Benchmark(n - 1) + this.Benchmark(n - 2);
+
+        // Check for overflow
+        if (rec > (type(uint256).max / n)) {
+            return type(uint256).max;
+        }
+
+        result = rec;
+        return result;
+    }
+}


### PR DESCRIPTION
**Motivation**
The fibonacci recursive can show perfomance results of stack reuse that the factorial recursive one can't because factorial will never be able to "reuse" the stack.

See also https://github.com/lambdaclass/ethrex/pull/3386

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

