### PR TITLE
refactor(l2): simplify l2 hook

### DIFF
--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -61,7 +61,7 @@ impl Hook for L2Hook {
         // NOT CHECKED: privileged transactions can't be of "create" type
 
         // (6) INTRINSIC_GAS_TOO_LOW
-        // CHANGED: the gas should be charged, but the transaction shoudn't error
+        // CHANGED: the gas should be charged, but the transaction shouldn't error
         if vm.add_intrinsic_gas().is_err() {
             tx_should_fail = true;
         }


### PR DESCRIPTION
**Motivation**

We want to reuse the default hook as much as possible. Since only privileged transactions need special handling, the l2 hook should focus on them.

**Description**

- Gas is not paid by privileged transactions
    - Therefore gas prices are irrelevant
- We don't want to overflow block limits. This is the only case when a privileged transaction can error out
- Privileged transactions can't _fail_ as that would cause them to not be included, stalling deposits
    - Instead, we make the transaction revert

Closes #3343

