### PR TITLE
docs(core): add LaTex support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ mermaid-init.js mermaid.min.js &:
 		&& exit 1)
 
 docs-deps: ## 📦 Install dependencies for generating the documentation
-	cargo install mdbook mdbook-alerts mdbook-mermaid mdbook-linkcheck
+	cargo install mdbook mdbook-alerts mdbook-mermaid mdbook-linkcheck mdbook-katex
 
 docs: mermaid-init.js mermaid.min.js ## 📚 Generate the documentation
 	mdbook build

--- a/book.toml
+++ b/book.toml
@@ -18,6 +18,11 @@ renderers = ["html", "linkcheck"]
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
 
+# To render LaTeX math expressions
+# https://github.com/lzanini/mdbook-katex
+[preprocessor.katex]
+after = ["links"]
+
 [output.html]
 git-repository-url = "https://github.com/lambdaclass/ethrex"
 # make sections collapsible, and start with everything collapsed

--- a/book.toml
+++ b/book.toml
@@ -19,6 +19,7 @@ renderers = ["html", "linkcheck"]
 command = "mdbook-mermaid"
 
 # To render LaTeX math expressions
+# Note: Warnings can be safely ignored
 # https://github.com/lzanini/mdbook-katex
 [preprocessor.katex]
 after = ["links"]


### PR DESCRIPTION
**Motivation**

https://docs.ethrex.xyz/, isn't rendering LaTex expression 

**Description**

This PR adds the [mdbook-katex](https://github.com/lzanini/mdbook-katex) preprocessor to `book.toml` to enable LaTeX rendering. 

Run the following command to check how the documentation looks

```bash
make docs-deps && make docs-serve
```

**Before**
![image](https://github.com/user-attachments/assets/393cf3f8-bd4a-455a-bba0-4e46cc4e42f0)

**After**
![image](https://github.com/user-attachments/assets/8e6954ad-9050-4161-ada2-2f3d0e13a804)