### PR TITLE
fix(l2): based CI

### DIFF
--- a/crates/l2/contracts/src/l1/based/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/based/OnChainProposer.sol
@@ -368,7 +368,7 @@ contract OnChainProposer is
         uint256 firstBatchNumber,
         bytes[] calldata alignedPublicInputsList,
         bytes32[][] calldata alignedMerkleProofsList
-    ) external override onlySequencer whenNotPaused {
+    ) external override {
         require(
             ALIGNEDPROOFAGGREGATOR != DEV_MODE,
             "OnChainProposer: ALIGNEDPROOFAGGREGATOR is not set"


### PR DESCRIPTION
**Motivation**

In #3242, `verifyBatchesAligned()` was updated in the based `OnChainProposer` to be consistent with the non-based one, but the `onlySequencer` identifier was added by mistake.

**Description**

Removes the `onlySequencer` identifier.

Closes None

