### PR TITLE
fix(l1): abort `show_state_sync_progress` task 

### DIFF
--- a/crates/networking/p2p/sync/state_sync.rs
+++ b/crates/networking/p2p/sync/state_sync.rs
@@ -295,7 +295,7 @@ impl StateSyncProgress {
 }
 
 /// Continously shows the progress of state sync at set intervals
-/// This task is endless, called will need to abort it once it is no longer needed
+/// This task is endless, caller will need to abort it once it is no longer needed
 async fn show_state_sync_progress(progress: StateSyncProgress) {
     // Rest for one interval so we don't start computing on empty progress
     sleep(SHOW_PROGRESS_INTERVAL_DURATION).await;


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
The `show_state_sync_progress` task used to run until all `state_sync_segment` tasks had signaled their conclusion via `end_segment` method. This could cause the task to hand indeterminately if one of the tasks failed. This PR aims to fix this by removing the responsibility of signaling their end from `state_sync_segment` and instead have `state_sync` method (the one that launched both `show_state_sync_progress` & the `state_sync_segment` tasks) be the one to end the `show_state_sync_progress` task via an abort
**Description**
* Remove method `StateSyncProgress::end_segment` & associated field
* `show_state_sync_progress` is now an endless task
* `state_sync` now aborts `show_state_sync_progress` when no longer needed instead of waiting for it to finish
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


