### PR TITLE
fix(core): more accurate throughput

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -530,11 +530,11 @@ impl Blockchain {
             .await
             .map_err(|e| (e.into(), None))?;
 
-        let elapsed_seconds = interval.elapsed().as_millis() / 1000;
+        let elapsed_seconds = interval.elapsed().as_secs_f64();
         let mut throughput = 0.0;
-        if elapsed_seconds != 0 && total_gas_used != 0 {
+        if elapsed_seconds > 0.0 && total_gas_used != 0 {
             let as_gigas = (total_gas_used as f64).div(10_f64.powf(9_f64));
-            throughput = (as_gigas) / (elapsed_seconds as f64);
+            throughput = as_gigas / elapsed_seconds;
         }
 
         metrics!(

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -31,7 +31,7 @@ use mempool::Mempool;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::{ops::Div, time::Instant};
+use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use vm::StoreVmDatabase;
@@ -533,7 +533,7 @@ impl Blockchain {
         let elapsed_seconds = interval.elapsed().as_secs_f64();
         let mut throughput = 0.0;
         if elapsed_seconds > 0.0 && total_gas_used != 0 {
-            let as_gigas = (total_gas_used as f64).div(10_f64.powf(9_f64));
+            let as_gigas = (total_gas_used as f64) / 1e9;
             throughput = as_gigas / elapsed_seconds;
         }
 


### PR DESCRIPTION
Throughput in the logged metrics was computed over a truncated number of
seconds, which meant the same block taking 1999ms or 1000ms reports the
same throughput, when one is indeed twice as slow as the other.
This fixes it by asking for the `as_secs_f64` directly rather than
taking an integer number of millis, dividing (with integer semantics) by
1000 and then casting.
