### PR TITLE
refactor(levm): consider all forks after Prague and not just Osaka

### DIFF
--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -205,12 +205,6 @@ pub enum Fork {
     Osaka = 19,
 }
 
-impl Fork {
-    pub const fn as_u8(self) -> u8 {
-        self as u8
-    }
-}
-
 impl From<Fork> for &str {
     fn from(fork: Fork) -> Self {
         match fork {

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -205,6 +205,12 @@ pub enum Fork {
     Osaka = 19,
 }
 
+impl Fork {
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
 impl From<Fork> for &str {
     fn from(fork: Fork) -> Self {
         match fork {

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -90,24 +90,24 @@ impl EVMConfig {
         }
     }
 
-    const fn max_blobs_per_block(fork: Fork) -> u64 {
-        if fork.as_u8() >= Fork::Prague.as_u8() {
+    fn max_blobs_per_block(fork: Fork) -> u64 {
+        if fork >= Fork::Prague {
             MAX_BLOB_COUNT_ELECTRA
         } else {
             MAX_BLOB_COUNT
         }
     }
 
-    const fn get_blob_base_fee_update_fraction_value(fork: Fork) -> u64 {
-        if fork.as_u8() >= Fork::Prague.as_u8() {
+    fn get_blob_base_fee_update_fraction_value(fork: Fork) -> u64 {
+        if fork >= Fork::Prague {
             BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
         } else {
             BLOB_BASE_FEE_UPDATE_FRACTION
         }
     }
 
-    const fn get_target_blob_gas_per_block_(fork: Fork) -> u64 {
-        if fork.as_u8() >= Fork::Prague.as_u8() {
+    fn get_target_blob_gas_per_block_(fork: Fork) -> u64 {
+        if fork >= Fork::Prague {
             TARGET_BLOB_GAS_PER_BLOCK_PECTRA
         } else {
             TARGET_BLOB_GAS_PER_BLOCK

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -8,8 +8,6 @@ use crate::constants::{
     MAX_BLOB_COUNT_ELECTRA, TARGET_BLOB_GAS_PER_BLOCK, TARGET_BLOB_GAS_PER_BLOCK_PECTRA,
 };
 
-
-
 use std::collections::HashMap;
 /// [EIP-1153]: https://eips.ethereum.org/EIPS/eip-1153#reference-implementation
 pub type TransientStorage = HashMap<(Address, U256), U256>;

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -8,6 +8,8 @@ use crate::constants::{
     MAX_BLOB_COUNT_ELECTRA, TARGET_BLOB_GAS_PER_BLOCK, TARGET_BLOB_GAS_PER_BLOCK_PECTRA,
 };
 
+
+
 use std::collections::HashMap;
 /// [EIP-1153]: https://eips.ethereum.org/EIPS/eip-1153#reference-implementation
 pub type TransientStorage = HashMap<(Address, U256), U256>;
@@ -91,7 +93,7 @@ impl EVMConfig {
     }
 
     const fn max_blobs_per_block(fork: Fork) -> u64 {
-        if fork as u8 >= Fork::Prague as u8 {
+        if fork.as_u8() >= Fork::Prague.as_u8() {
             MAX_BLOB_COUNT_ELECTRA
         } else {
             MAX_BLOB_COUNT
@@ -99,7 +101,7 @@ impl EVMConfig {
     }
 
     const fn get_blob_base_fee_update_fraction_value(fork: Fork) -> u64 {
-        if fork as u8 >= Fork::Prague as u8 {
+        if fork.as_u8() >= Fork::Prague.as_u8() {
             BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
         } else {
             BLOB_BASE_FEE_UPDATE_FRACTION
@@ -107,7 +109,7 @@ impl EVMConfig {
     }
 
     const fn get_target_blob_gas_per_block_(fork: Fork) -> u64 {
-        if fork as u8 >= Fork::Prague as u8 {
+        if fork.as_u8() >= Fork::Prague.as_u8() {
             TARGET_BLOB_GAS_PER_BLOCK_PECTRA
         } else {
             TARGET_BLOB_GAS_PER_BLOCK

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -91,24 +91,26 @@ impl EVMConfig {
     }
 
     const fn max_blobs_per_block(fork: Fork) -> u64 {
-        match fork {
-            Fork::Prague => MAX_BLOB_COUNT_ELECTRA,
-            Fork::Osaka => MAX_BLOB_COUNT_ELECTRA,
-            _ => MAX_BLOB_COUNT,
+        if fork as u8 >= Fork::Prague as u8 {
+            MAX_BLOB_COUNT_ELECTRA
+        } else {
+            MAX_BLOB_COUNT
         }
     }
 
     const fn get_blob_base_fee_update_fraction_value(fork: Fork) -> u64 {
-        match fork {
-            Fork::Prague | Fork::Osaka => BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
-            _ => BLOB_BASE_FEE_UPDATE_FRACTION,
+        if fork as u8 >= Fork::Prague as u8 {
+            BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE
+        } else {
+            BLOB_BASE_FEE_UPDATE_FRACTION
         }
     }
 
     const fn get_target_blob_gas_per_block_(fork: Fork) -> u64 {
-        match fork {
-            Fork::Prague | Fork::Osaka => TARGET_BLOB_GAS_PER_BLOCK_PECTRA,
-            _ => TARGET_BLOB_GAS_PER_BLOCK,
+        if fork as u8 >= Fork::Prague as u8 {
+            TARGET_BLOB_GAS_PER_BLOCK_PECTRA
+        } else {
+            TARGET_BLOB_GAS_PER_BLOCK
         }
     }
 }


### PR DESCRIPTION
**Motivation**

This PR addresses issue #2773. 

Functions `max_blobs_per_block()`, `get_blob_base_fee_update_fraction_value()` and `get_target_blob_gas_per_block_()` in `environment.rs` consider three options: Prague fork, Osaka fork and other forks, where the first two have the same course of action. The idea is to consider two points: previous or posterior to Prague fork.

**Description**

Changes pattern matching to an `if` statement that checks whether we are previous to Prague fork or past that. 

Closes #2773

