### PR TITLE
feat: invert feature flag logic from levm to revm

### DIFF
--- a/cmd/ef_tests/blockchain/Cargo.toml
+++ b/cmd/ef_tests/blockchain/Cargo.toml
@@ -27,7 +27,7 @@ path = "./lib.rs"
 default = ["c-kzg", "blst"]
 blst = ["ethrex-vm/blst"]
 c-kzg = ["ethrex-blockchain/c-kzg"]
-levm = []
+revm = []
 
 [[test]]
 name = "all"

--- a/cmd/ef_tests/blockchain/tests/all.rs
+++ b/cmd/ef_tests/blockchain/tests/all.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 const TEST_FOLDER: &str = "vectors/";
 
 fn parse_and_execute_runner(path: &Path) -> datatest_stable::Result<()> {
-    let engine = if cfg!(feature = "levm") {
-        EvmEngine::LEVM
-    } else {
+    let engine = if cfg!(feature = "revm") {
         EvmEngine::REVM
+    } else {
+        EvmEngine::LEVM
     };
 
     parse_and_execute(path, engine, None)


### PR DESCRIPTION
**Motivation**
to implement an revm feature flag
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Inverted the feature flag logic so that LEVM stays default and REVM is the optional feature which can be configured using the `--features revm` flag. The command `cargo test` defaults to LEVM.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3335 

