### PR TITLE
refactor(l2): remove l2 txhash from L1Message

### DIFF
--- a/crates/l2/based/block_fetcher.rs
+++ b/crates/l2/based/block_fetcher.rs
@@ -482,7 +482,7 @@ async fn extract_block_messages(
         txs.push(tx.clone());
         receipts.push(receipt);
     }
-    Ok(get_block_l1_messages(&txs, &receipts))
+    Ok(get_block_l1_messages(&receipts))
 }
 
 async fn get_batch(

--- a/crates/l2/common/src/state_diff.rs
+++ b/crates/l2/common/src/state_diff.rs
@@ -225,7 +225,6 @@ impl StateDiff {
 
         let mut l1messages = Vec::with_capacity(l1messages_len.into());
         for _ in 0..l1messages_len {
-            let tx = decoder.get_h256()?;
             let from = decoder.get_address()?;
             let data = decoder.get_h256()?;
             let index = decoder.get_u256()?;
@@ -233,7 +232,6 @@ impl StateDiff {
             l1messages.push(L1Message {
                 from,
                 data_hash: data,
-                tx_hash: tx,
                 message_id: index,
             });
         }

--- a/crates/l2/contracts/src/l1/CommonBridge.sol
+++ b/crates/l2/contracts/src/l1/CommonBridge.sol
@@ -263,14 +263,12 @@ contract CommonBridge is
 
     /// @inheritdoc ICommonBridge
     function claimWithdrawal(
-        bytes32 l2WithdrawalTxHash,
         uint256 claimedAmount,
         uint256 withdrawalBatchNumber,
         uint256 withdrawalMessageId,
         bytes32[] calldata withdrawalProof
     ) public {
         _claimWithdrawal(
-            l2WithdrawalTxHash,
             ETH_TOKEN,
             ETH_TOKEN,
             claimedAmount,
@@ -284,7 +282,6 @@ contract CommonBridge is
 
     /// @inheritdoc ICommonBridge
     function claimWithdrawalERC20(
-        bytes32 l2WithdrawalTxHash,
         address tokenL1,
         address tokenL2,
         uint256 claimedAmount,
@@ -293,7 +290,6 @@ contract CommonBridge is
         bytes32[] calldata withdrawalProof
     ) public nonReentrant {
         _claimWithdrawal(
-            l2WithdrawalTxHash,
             tokenL1,
             tokenL2,
             claimedAmount,
@@ -309,7 +305,6 @@ contract CommonBridge is
     }
 
     function _claimWithdrawal(
-        bytes32 l2WithdrawalTxHash,
         address tokenL1,
         address tokenL2,
         uint256 claimedAmount,
@@ -342,7 +337,6 @@ contract CommonBridge is
         emit WithdrawalClaimed(withdrawalMessageId);
         require(
             _verifyMessageProof(
-                l2WithdrawalTxHash,
                 msgHash,
                 withdrawalBatchNumber,
                 withdrawalMessageId,
@@ -353,7 +347,6 @@ contract CommonBridge is
     }
 
     function _verifyMessageProof(
-        bytes32 l2WithdrawalTxHash,
         bytes32 msgHash,
         uint256 withdrawalBatchNumber,
         uint256 withdrawalMessageId,
@@ -361,7 +354,6 @@ contract CommonBridge is
     ) internal view returns (bool) {
         bytes32 withdrawalLeaf = keccak256(
             abi.encodePacked(
-                l2WithdrawalTxHash,
                 L2_BRIDGE_ADDRESS,
                 msgHash,
                 withdrawalMessageId

--- a/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
+++ b/crates/l2/contracts/src/l1/interfaces/ICommonBridge.sol
@@ -111,7 +111,6 @@ interface ICommonBridge {
     /// @dev We do not need to check that the claimee is the same as the
     /// beneficiary of the withdrawal, because the withdrawal proof already
     /// contains the beneficiary.
-    /// @param l2WithdrawalTxHash the hash of the L2 withdrawal transaction.
     /// @param claimedAmount the amount that will be claimed.
     /// @param withdrawalProof the merkle path to the withdrawal log.
     /// @param withdrawalLogIndex the index of the message log in the block.
@@ -119,7 +118,6 @@ interface ICommonBridge {
     /// @param l2WithdrawalBatchNumber the batch number where the withdrawal log
     /// was emitted.
     function claimWithdrawal(
-        bytes32 l2WithdrawalTxHash,
         uint256 claimedAmount,
         uint256 l2WithdrawalBatchNumber,
         uint256 withdrawalLogIndex,
@@ -127,7 +125,6 @@ interface ICommonBridge {
     ) external;
 
     /// @notice Claims an ERC20 withdrawal
-    /// @param l2WithdrawalTxHash the hash of the L2 withdrawal transaction.
     /// @param tokenL1 Address of the token on the L1
     /// @param tokenL2 Address of the token on the L2
     /// @param claimedAmount the amount that will be claimed.
@@ -136,7 +133,6 @@ interface ICommonBridge {
     /// @param l2WithdrawalBatchNumber the batch number where the withdrawal log
     /// was emitted.
     function claimWithdrawalERC20(
-        bytes32 l2WithdrawalTxHash,
         address tokenL1,
         address tokenL2,
         uint256 claimedAmount,

--- a/crates/l2/prover/zkvm/interface/src/execution.rs
+++ b/crates/l2/prover/zkvm/interface/src/execution.rs
@@ -335,7 +335,7 @@ fn get_batch_l1messages_and_privileged_transactions(
     for (block, receipts) in blocks.iter().zip(receipts) {
         let txs = &block.body.transactions;
         privileged_transactions.extend(get_block_privileged_transactions(txs));
-        l1messages.extend(get_block_l1_messages(txs, receipts));
+        l1messages.extend(get_block_l1_messages(receipts));
     }
 
     Ok((l1messages, privileged_transactions))

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -163,7 +163,6 @@ pub async fn withdraw(
 
 pub async fn claim_withdraw(
     amount: U256,
-    l2_withdrawal_tx_hash: H256,
     from: Address,
     from_pk: SecretKey,
     eth_client: &EthClient,
@@ -171,13 +170,9 @@ pub async fn claim_withdraw(
 ) -> Result<H256, EthClientError> {
     println!("Claiming {amount} from bridge to {from:#x}");
 
-    const CLAIM_WITHDRAWAL_SIGNATURE: &str =
-        "claimWithdrawal(bytes32,uint256,uint256,uint256,bytes32[])";
+    const CLAIM_WITHDRAWAL_SIGNATURE: &str = "claimWithdrawal(uint256,uint256,uint256,bytes32[])";
 
     let calldata_values = vec![
-        Value::Uint(U256::from_big_endian(
-            l2_withdrawal_tx_hash.as_fixed_bytes(),
-        )),
         Value::Uint(amount),
         Value::Uint(message_proof.batch_number.into()),
         Value::Uint(message_proof.message_id),
@@ -218,19 +213,15 @@ pub async fn claim_erc20withdraw(
     token_l1: Address,
     token_l2: Address,
     amount: U256,
-    l2_withdrawal_tx_hash: H256,
     from_pk: SecretKey,
     eth_client: &EthClient,
     message_proof: &L1MessageProof,
 ) -> Result<H256, EthClientError> {
     let from = get_address_from_secret_key(&from_pk)?;
     const CLAIM_WITHDRAWAL_ERC20_SIGNATURE: &str =
-        "claimWithdrawalERC20(bytes32,address,address,uint256,uint256,uint256,bytes32[])";
+        "claimWithdrawalERC20(address,address,uint256,uint256,uint256,bytes32[])";
 
     let calldata_values = vec![
-        Value::Uint(U256::from_big_endian(
-            l2_withdrawal_tx_hash.as_fixed_bytes(),
-        )),
         Value::Address(token_l1),
         Value::Address(token_l2),
         Value::Uint(amount),

--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -399,9 +399,7 @@ fn calculate_tx_diff_size(
     if is_privileged_tx(head_tx) {
         tx_state_diff_size += privileged_tx_log_len;
     }
-    tx_state_diff_size +=
-        get_block_l1_messages(&[Transaction::from(head_tx.clone())], &[receipt.clone()]).len()
-            * messages_log_len;
+    tx_state_diff_size += get_block_l1_messages(&[receipt.clone()]).len() * messages_log_len;
 
     Ok((tx_state_diff_size, new_accounts_diff_size))
 }

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -342,7 +342,7 @@ async fn prepare_batch_from_block(
                 .unwrap_or(0)
         );
         // Get block messages and privileged transactions
-        let messages = get_block_l1_messages(&txs, &receipts);
+        let messages = get_block_l1_messages(&receipts);
         let privileged_transactions = get_block_privileged_transactions(&txs);
 
         // Get block account updates.

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -373,7 +373,6 @@ async fn test_erc20_roundtrip(
         token_l1,
         token_l2,
         token_amount,
-        res.tx_info.transaction_hash,
         rich_wallet_private_key,
         l1_client,
         &proof,
@@ -915,12 +914,11 @@ async fn test_n_withdraws(
 
     let mut withdraw_claim_txs_receipts = vec![];
 
-    for (x, (tx, proof)) in withdraw_txs.iter().zip(proofs.iter()).enumerate() {
+    for (x, proof) in proofs.iter().enumerate() {
         println!("Claiming withdrawal on L1 {x}/{n}");
 
         let withdraw_claim_tx = ethrex_l2_sdk::claim_withdraw(
             withdraw_value,
-            *tx,
             withdrawer_address,
             *withdrawer_private_key,
             eth_client,


### PR DESCRIPTION
**Motivation**

After adding a unique message id to each L1Message, the need for the l2 transaction hash has gone away. It should be removed.

**Description**

Removes l2 tx hash from the L1Message structure, and simplifies `ethrex_getMessageProof` logic.

Closes #3434

