### PR TITLE
ci(l2): fix prover workflow

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -73,7 +73,6 @@ jobs:
           docker compose -f docker-compose-l2.yaml up --build contract_deployer
 
       - name: Ensure admin permissions in _work
-        if: always()
         run: sudo chown admin:admin -R /home/admin/actions-runner/_work/
 
       - name: Start Sequencer


### PR DESCRIPTION
**Motivation**

The Integration Test Prover Sp1 workflow was broken due to several issues:
- It was using outdated `contract_deployer` and `ethrex_l2` images.
- There were permission issues on the `_work` directory.
- `solc` was not installed.

Here is a successful run of the workflow: https://github.com/lambdaclass/ethrex/actions/runs/16037084316/job/45251233852?pr=3445

Closes: None


