### PR TITLE
ci(testing): add pr to project automatically

### DIFF
--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -15,8 +15,19 @@ jobs:
     name: Add pull request to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
-        if: contains(github.event.pull_request.title, 'l1') || contains(github.event.pull_request.title, 'levm') || contains(github.event.pull_request.title, 'core')
+      - name: Check PR title with regex
+        id: check_title
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          if [[ "$title" =~ .*l1.* || "$title" =~ .*levm.* || "$title" =~ .*core.* ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+          else
+            echo "match=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add to project if title matches
+        if: steps.check_title.outputs.match == 'true'
+        uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 project number
+          project-url: https://github.com/orgs/lambdaclass/projects/31
           github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,4 +1,4 @@
-name: Add to Project
+name: Add to Projectt
 
 on:
   push:

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,12 +1,7 @@
 name: Add to Project
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-  workflow_dispatch:
+  push:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/add-to-project@1.0.2
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 number
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -20,7 +20,7 @@ jobs:
         id: check_title
         run: |
           title="${{ github.event.pull_request.title }}"
-          if [[ "$title" =~ .*l1.* || "$title" =~ .*levm.* || "$title" =~ .*core.* ]]; then
+          if [[ "$title" =~ \(.*l1.*\) || "$title" =~ \(.*levm.*\) || "$title" =~ \(.*core.*\) ]]; then
             echo "match=true" >> $GITHUB_OUTPUT
           else
             echo "match=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -18,9 +18,10 @@ jobs:
     steps:
       - name: Check PR title with regex
         id: check_title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          title="${{ github.event.pull_request.title }}"
-          if [[ "$title" =~ \(.*l1.*\) || "$title" =~ \(.*levm.*\) || "$title" =~ \(.*core.*\) ]]; then
+          if [[ "$TITLE" =~ \(.*l1.*\) || "$TITLE" =~ \(.*levm.*\) || "$TITLE" =~ \(.*core.*\) ]]; then
             echo "match=true" >> $GITHUB_OUTPUT
           else
             echo "match=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -13,27 +13,43 @@ concurrency:
 
 jobs:
   add-to-project:
-    name: Add pull request to project
+    name: Add pull request to appropriate project(s)
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR title and choose project
+      - name: Match PR title to projects
         id: check_title
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if [[ "$TITLE" =~ \(.*l1.*\) || "$TITLE" =~ \(.*levm.*\) || "$TITLE" =~ \(.*core.*\) ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-            echo "project=https://github.com/orgs/lambdaclass/projects/31" >> $GITHUB_OUTPUT
-          elif [[ "$TITLE" =~ \(.*l2.*\) ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-            echo "project=https://github.com/orgs/lambdaclass/projects/37" >> $GITHUB_OUTPUT
-          else
-            echo "match=false" >> $GITHUB_OUTPUT
+          match_ethrex_l1=false
+          match_ethrex_l2=false
+
+          if [[ "$TITLE" =~ \(.*l1.*\) || "$TITLE" =~ \(.*levm.*\) ]]; then
+            match_ethrex_l1=true
           fi
 
-      - name: Add to project if title matches
-        if: steps.check_title.outputs.match == 'true'
+          if [[ "$TITLE" =~ \(.*l2.*\) ]]; then
+            match_ethrex_l2=true
+          fi
+
+          if [[ "$TITLE" =~ \(.*core.*\) ]]; then
+            match_ethrex_l1=true
+            match_ethrex_l2=true
+          fi
+
+          echo "match_ethrex_l1=$match_ethrex_l1" >> $GITHUB_OUTPUT
+          echo "match_ethrex_l2=$match_ethrex_l2" >> $GITHUB_OUTPUT
+
+      - name: Add PR to ethrex_l1 project
+        if: steps.check_title.outputs.match_ethrex_l1 == 'true'
         uses: actions/add-to-project@v1.0.2
         with:
-          project-url: ${{ steps.check_title.outputs.project }}
+          project-url: https://github.com/orgs/lambdaclass/projects/31
+          github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Add PR to ethrex_l2 project
+        if: steps.check_title.outputs.match_ethrex_l2 == 'true'
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/lambdaclass/projects/37
           github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -11,10 +11,8 @@ jobs:
   add-to-project:
     name: Add pull request to project
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 number
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,4 +1,4 @@
-name: PR title
+name: Add to Project
 
 on:
   pull_request_target:
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -15,6 +16,8 @@ jobs:
   add-to-project:
     name: Add pull request to project
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/add-to-project@1.0.2
         with:

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -3,7 +3,8 @@ name: Add to Projectt
 on:
   pull_request:
     types:
-      - labeled
+      - opened
+      - edited
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -18,4 +19,3 @@ jobs:
         with:
           project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 number
           github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}
-          labeled: ci

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,7 +1,9 @@
 name: Add to Projectt
 
 on:
-  push:
+  pull_request:
+    types:
+      - labeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -16,3 +18,4 @@ jobs:
         with:
           project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 number
           github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}
+          labeled: ci

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -16,13 +16,17 @@ jobs:
     name: Add pull request to project
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR title with regex
+      - name: Check PR title and choose project
         id: check_title
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [[ "$TITLE" =~ \(.*l1.*\) || "$TITLE" =~ \(.*levm.*\) || "$TITLE" =~ \(.*core.*\) ]]; then
             echo "match=true" >> $GITHUB_OUTPUT
+            echo "project=https://github.com/orgs/lambdaclass/projects/31" >> $GITHUB_OUTPUT
+          elif [[ "$TITLE" =~ \(.*l2.*\) ]]; then
+            echo "match=true" >> $GITHUB_OUTPUT
+            echo "project=https://github.com/orgs/lambdaclass/projects/37" >> $GITHUB_OUTPUT
           else
             echo "match=false" >> $GITHUB_OUTPUT
           fi
@@ -31,5 +35,5 @@ jobs:
         if: steps.check_title.outputs.match == 'true'
         uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/orgs/lambdaclass/projects/31
+          project-url: ${{ steps.check_title.outputs.project }}
           github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,7 +1,7 @@
 name: Add PR to Project
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,7 +1,7 @@
 name: Add PR to Project
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,0 +1,22 @@
+name: PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  add-to-project:
+    name: Add pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@1.0.2
+        with:
+          project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 number
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -1,4 +1,4 @@
-name: Add to Projectt
+name: Add PR to Project
 
 on:
   pull_request:
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v1.0.2
+        if: contains(github.event.pull_request.title, 'l1') || contains(github.event.pull_request.title, 'levm') || contains(github.event.pull_request.title, 'core')
         with:
-          project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 number
+          project-url: https://github.com/orgs/lambdaclass/projects/31 # ethrex_l1 project number
           github-token: ${{ secrets.GH_PROJECT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/add_to_project.yaml
+++ b/.github/workflows/add_to_project.yaml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Add PR to ethrex_l1 project
         if: steps.check_title.outputs.match_ethrex_l1 == 'true'
+        continue-on-error: true
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/lambdaclass/projects/31
@@ -49,6 +50,7 @@ jobs:
 
       - name: Add PR to ethrex_l2 project
         if: steps.check_title.outputs.match_ethrex_l2 == 'true'
+        continue-on-error: true
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/lambdaclass/projects/37


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

Adds PR automatically to a project by looking at the title, depending on the scope.
`l1` or `levm`: Assign to `ethrex_l1`
`l2`: Assign to `ethrex_l2`
`core`: Assign to both projects.

This requires a Github Personal Access Token (PAT) because the assignment of a PR to a project has to be attached to an user (sadly). For this I created a PAT of my own and gave access **only** to the projects I know of.
I believe there may be a slightly better approach in terms of privacy but if we decide to move on with this we can change the approach in a follow-up.


Update: I'm exploring alternatives to this.

Replaced by #3463 