### PR TITLE
fix(l1): incorrect tx size check causing peers to be rejected

### DIFF
--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -5,7 +5,6 @@ use ethrex_blockchain::error::MempoolError;
 use ethrex_common::types::BlobsBundle;
 use ethrex_common::types::P2PTransaction;
 use ethrex_common::{H256, types::Transaction};
-use ethrex_rlp::encode::RLPEncode;
 use ethrex_rlp::{
     error::{RLPDecodeError, RLPEncodeError},
     structs::{Decoder, Encoder},
@@ -261,8 +260,8 @@ impl PooledTransactions {
             if tx.tx_type() as u8 != expected_type {
                 return Err(MempoolError::InvalidPooledTxType(expected_type));
             }
-            // remove the code from the encoding (-4)
-            if tx.encode_to_vec().len() - 4 != expected_size {
+            let tx_size = tx.encode_canonical_to_vec().len();
+            if tx_size != expected_size {
                 return Err(MempoolError::InvalidPooledTxSize);
             }
         }


### PR DESCRIPTION
**Motivation**
A bug currently causes peers' pooled transactions to be incorrectly rejected due to a mismatch in transaction size validation.

**Description**
When a `PooledTransactions` message is received, the implementation validates that the transactions match the originally requested ones (which are requested by sending `GetPooledTransactions`).

One of these validations checks that the size of each received transaction matches the expected size. However, the transaction size was being computed incorrectly, leading to false rejections.

This PR fixes the error by computing the transaction size in the right way. Now, the transaction size is computed according to the [specification](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08):

> `txsizeₙ` refers to the length of the 'consensus encoding' of a typed transaction, i.e. the byte size of `tx-type || tx-data` for typed transactions, and the size of the RLP-encoded `legacy-tx` for non-typed legacy transactions.

To achieve this, we now use the `encode_canonical_to_vec()` method, which returns the appropriate encoding for both typed and legacy transactions. The length of this encoding is then used as the transaction size.

This can be tested by setting up a localnet with `make localnet`, waiting around 2 minutes and checking that there are no logs like the following

```bash

2025-07-02T19:56:51.324981Z  WARN ethrex_p2p::rlpx::utils: [0x03dd…06fa(172.16.0.11:30303)]: disconnected from peer. Reason: Invalid pooled transaction size, differs from expected
```

Closes #3251 

