### PR TITLE
feat(l1, l2): implement `EthClient::tx_pool_content`

### DIFF
--- a/crates/networking/rpc/clients/eth/errors.rs
+++ b/crates/networking/rpc/clients/eth/errors.rs
@@ -52,6 +52,8 @@ pub enum EthClientError {
     ParseUrlError(String),
     #[error("Failed to sign payload: {0}")]
     FailedToSignPayload(String),
+    #[error("Failed to get transaction pool: {0}")]
+    FailedToGetTxPool(#[from] TxPoolContentError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -240,4 +242,12 @@ pub enum GetMaxPriorityFeeError {
     RPCError(String),
     #[error("{0}")]
     ParseIntError(#[from] std::num::ParseIntError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TxPoolContentError {
+    #[error("{0}")]
+    SerdeJSONError(#[from] serde_json::Error),
+    #[error("{0}")]
+    RPCError(String),
 }

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
 use crate::{
+    clients::eth::errors::TxPoolContentError,
+    mempool::MempoolContent,
     types::{
         block::RpcBlock,
         receipt::{RpcLog, RpcReceipt},
@@ -1295,6 +1297,25 @@ impl EthClient {
         }
 
         self.get_fee_from_override_or_get_gas_price(None).await
+    }
+
+    pub async fn tx_pool_content(&self) -> Result<MempoolContent, EthClientError> {
+        let request = RpcRequest {
+            id: RpcRequestId::Number(1),
+            jsonrpc: "2.0".to_string(),
+            method: "txpool_content".to_string(),
+            params: None,
+        };
+
+        match self.send_request(request).await {
+            Ok(RpcResponse::Success(result)) => serde_json::from_value(result.result)
+                .map_err(TxPoolContentError::SerdeJSONError)
+                .map_err(EthClientError::from),
+            Ok(RpcResponse::Error(error_response)) => {
+                Err(TxPoolContentError::RPCError(error_response.error.message).into())
+            }
+            Err(error) => Err(error),
+        }
     }
 }
 

--- a/crates/networking/rpc/mempool.rs
+++ b/crates/networking/rpc/mempool.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use ethrex_common::{Address, H256};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{rpc::RpcApiContext, types::transaction::RpcTransaction, utils::RpcErr};
@@ -11,13 +11,13 @@ type MempoolContentEntry = HashMap<Address, HashMap<u64, RpcTransaction>>;
 
 /// Full content of the mempool
 /// Transactions are grouped by sender and indexed by nonce
-#[derive(Serialize)]
-struct MempoolContent {
+#[derive(Serialize, Deserialize)]
+pub struct MempoolContent {
     pending: MempoolContentEntry,
     queued: MempoolContentEntry,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct MempoolStatus {
     pending: String,
     queued: String,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

We need a way to get the mempool content from the `EthClient`.

**Description**

- Implements `tx_pool_content` for `EthClient`.
- Implements `TxPoolContentError`.
- Makes the `MempoolContent` struct public.
- Implements `Deserialize` for `MempoolContent`.
- Implements `Deserialize` for `MempoolStatus`.

