### PR TITLE
chore: hide spawned errors

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -17,12 +17,13 @@ use ethrex_vm::EvmEngine;
 use k256::ecdsa::SigningKey;
 use local_ip_address::local_ip;
 use rand::rngs::OsRng;
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     fs,
     net::{Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
+    str::FromStr,
     sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::Mutex;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -31,8 +32,11 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber, filter::Directive};
 
 pub fn init_tracing(opts: &Options) {
     let log_filter = EnvFilter::builder()
-        .with_default_directive(Directive::from(opts.log_level))
-        .from_env_lossy();
+        .with_default_directive(
+            Directive::from_str("spawned_concurrency::tasks::gen_server=off").unwrap(),
+        )
+        .from_env_lossy()
+        .add_directive(Directive::from(opts.log_level));
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(log_filter)
         .finish();


### PR DESCRIPTION
**Motivation**

We're seeing many false error logs in spawned genservers.

**Description**

This PR hides these logs by adding a default filter of `spawned_concurrency::tasks::gen_server=off`. This also replaces the global log level specified in the env with the one from CLI flags.


