### PR TITLE
refactor(l1): add detail to syncing logs

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -7,7 +7,7 @@ mod smoke_test;
 pub mod tracing;
 pub mod vm;
 
-use ::tracing::info;
+use ::tracing::{debug, info};
 use constants::{MAX_INITCODE_SIZE, MAX_TRANSACTION_DATA_SIZE};
 use error::MempoolError;
 use error::{ChainError, InvalidBlockError};
@@ -508,7 +508,7 @@ impl Blockchain {
                         }),
                     )
                 })?;
-
+            debug!("Executed block with hash {}", block.hash());
             last_valid_hash = block.hash();
             total_gas_used += block.header.gas_used;
             transactions_count += block.body.transactions.len();

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -453,14 +453,14 @@ impl Syncer {
         };
 
         if let Err((error, failure)) = res {
-
             if let Some(BatchBlockProcessingFailure {
                 failed_block_hash,
                 last_valid_hash,
             }) = failure
             {
-                warn!("Failed to add block with hash {failed_block_hash} during FullSync - error: {error}");
-                info!("Saving last valid block with hash {last_valid_hash}"); 
+                warn!(
+                    "Failed to add block with hash {failed_block_hash} during FullSync - error: {error}"
+                );
                 store
                     .set_latest_valid_ancestor(failed_block_hash, last_valid_hash)
                     .await?;

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -453,12 +453,14 @@ impl Syncer {
         };
 
         if let Err((error, failure)) = res {
-            warn!("Failed to add block during FullSync: {error}");
+
             if let Some(BatchBlockProcessingFailure {
                 failed_block_hash,
                 last_valid_hash,
             }) = failure
             {
+                warn!("Failed to add block with hash {failed_block_hash} during FullSync - error: {error}");
+                info!("Saving last valid block with hash {last_valid_hash}"); 
                 store
                     .set_latest_valid_ancestor(failed_block_hash, last_valid_hash)
                     .await?;


### PR DESCRIPTION
This PR solves part of issue #2838. 

Take into account that: 
1. Processed batch percentage was previously solved [here](https://github.com/lambdaclass/ethrex/blob/a4b9be8dcc42f3cee82994e537927678ccea30e8/crates/blockchain/blockchain.rs#L79-L80) . 
2. Chosen EVM log was previously solved [here](https://github.com/lambdaclass/ethrex/blob/a4b9be8dcc42f3cee82994e537927678ccea30e8/cmd/ethrex/initializers.rs#L90-L91)

This PR adds more detail to failed batch including failing block hash and logs in debug mode whenever a new block was executed in a batch. 

