### PR TITLE
fix(l2): rename field  `from` of `PrivilegeL2Transaction` for serialization

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1863,7 +1863,7 @@ mod serde_impl {
                     .collect::<Vec<_>>(),
             )?;
             struct_serializer.serialize_field("chainId", &format!("{:#x}", self.chain_id))?;
-            struct_serializer.serialize_field("from", &self.from)?;
+            struct_serializer.serialize_field("sender", &self.from)?;
             struct_serializer.end()
         }
     }
@@ -2164,7 +2164,7 @@ mod serde_impl {
                     .into_iter()
                     .map(|v| (v.address, v.storage_keys))
                     .collect::<Vec<_>>(),
-                from: deserialize_field::<Address, D>(&mut map, "from")?,
+                from: deserialize_field::<Address, D>(&mut map, "sender")?,
             })
         }
     }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

The field `from` of the struct `PrivilegeL2Transaction` overlaps with the field `from` of [`RpcTransaction`](https://github.com/lambdaclass/ethrex/blob/main/crates/networking/rpc/types/transaction.rs#L15) during serialization (because the field `tx` is flattened by `serde`), making `RpcTransaction` deserializations invalid for `PrivilegeL2Transaction`s.

**Description**

Renames the field `from` of  `PrivilegeL2Transaction` (only for serialization and deserializations) to fix the deserializations of `RpcTransaction`s of `PrivilegeL2Transaction`.

