### PR TITLE
chore(l2): remove leftover l2 feature flag references

### DIFF
--- a/.github/workflows/tag_l2_release.yaml
+++ b/.github/workflows/tag_l2_release.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build ethrex L2
         run: |
-          cargo build --release --features l2 --bin ethrex
+          cargo build --release --bin ethrex
           mv target/release/ethrex ethrex-${{ matrix.os }}_${{ matrix.arch }}
 
       - name: Upload artifact

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -195,7 +195,7 @@ build-prover:
 	--bin ethrex_prover
 
 rm-db-l2: ## 🛑 Removes the DB used by the L2
-	cargo run --release --manifest-path ../../Cargo.toml --bin ethrex --features l2 -- l2 removedb --datadir ${ethrex_L2_DEV_LIBMDBX} --force
+	cargo run --release --manifest-path ../../Cargo.toml --bin ethrex -- l2 removedb --datadir ${ethrex_L2_DEV_LIBMDBX} --force
 
 test: ## 🚧 Runs the L2's integration test, run `make init` and in a new terminal make test
 	cargo test l2_integration_test --release -- --nocapture || (echo "The tests have failed.\n Is the L2 running? To start it, run:\n make rm-db-l1; make rm-db-l2; make restart" ; exit 1)

--- a/crates/l2/based/README.md
+++ b/crates/l2/based/README.md
@@ -170,7 +170,7 @@ export $(cat .env | xargs)
 
 In a console inside the same directory (`crates/l2`), run the following command to start a based L2 node:
 ```bash
-cargo run --release --manifest-path ../../Cargo.toml --bin ethrex --features l2 -- l2 init \
+cargo run --release --manifest-path ../../Cargo.toml --bin ethrex -- l2 init \
   --watcher.block-delay 0 \
   --eth.rpc-url http://localhost:8545 \
   --block-producer.coinbase-address 0xacb3bb54d7c5295c158184044bdeedd9aa426607 \

--- a/docs/l2/sequencer.md
+++ b/docs/l2/sequencer.md
@@ -39,4 +39,4 @@ The L1 Proof Sender is responsible for interacting with Ethereum L1 to manage pr
 
 ## Configuration
 
-Configuration is done either by CLI flags or through environment variables. Run `cargo run --release --bin ethrex --features l2 -- l2 init --help` in the repository's root directory to see the available CLI flags and envs.
+Configuration is done either by CLI flags or through environment variables. Run `cargo run --release --bin ethrex -- l2 init --help` in the repository's root directory to see the available CLI flags and envs.


### PR DESCRIPTION
**Motivation**

The `make rm-db-l2` command was broken due to a leftover reference to the removed `l2` feature flag. This PR also removes a few other outdated references.

Closes: None

