### PR TITLE
fix: decode the fork ID as a list

### DIFF
--- a/crates/common/rlp/structs.rs
+++ b/crates/common/rlp/structs.rs
@@ -65,6 +65,7 @@ impl<'a> Decoder<'a> {
         };
         Ok((field, updated_self))
     }
+
     /// Returns the next field without decoding it, i.e. the payload bytes including its prefix.
     pub fn get_encoded_item(self) -> Result<(Vec<u8>, Self), RLPDecodeError> {
         match get_item_with_prefix(self.payload) {

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -267,8 +267,12 @@ impl NodeRecord {
                     decoded_pairs.secp256k1 = Some(H264::from_slice(&bytes))
                 }
                 "eth" => {
-                    // the first byte is ignored as an array within an array is received
-                    decoded_pairs.eth = ForkId::decode(&value[1..]).ok();
+                    let Ok(decoder) = Decoder::new(&value) else {
+                        continue;
+                    };
+                    let (fork_id, decoder) = decoder.decode_optional_field();
+                    decoder.finish_unchecked();
+                    decoded_pairs.eth = fork_id;
                 }
                 _ => {}
             }


### PR DESCRIPTION
This PR decodes the fork ID of a node record's "eth" entry as a list. Previously, we were assuming the list was small enough to have a length of a single byte.