### PR TITLE
perf(l2): enable solc optimizer flag for contract compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ rm-test-db:  ## 🛑 Removes the DB used by the ethrex client used for testing
 	sudo cargo run --release --bin ethrex -- removedb --force --datadir test_ethrex
 
 fixtures/ERC20/ERC20.bin: ## 🔨 Build the ERC20 contract for the load test
-	solc ./fixtures/contracts/ERC20/ERC20.sol -o $@
+	solc --optimize ./fixtures/contracts/ERC20/ERC20.sol -o $@
 
 sort-genesis-files:
 	cd ./tooling/genesis && cargo run

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -361,6 +361,7 @@ pub fn compile_contract(
 
     // Both the contract path and the output path are relative to where the Makefile is.
     if !Command::new("solc")
+        .arg("--optimize")
         .arg(bin_flag)
         .arg(
             "@openzeppelin/contracts=".to_string()

--- a/crates/l2/tee/contracts/Makefile
+++ b/crates/l2/tee/contracts/Makefile
@@ -42,7 +42,7 @@ lib/openzeppelin-contracts:
 
 solc_out/TDXVerifier.bin: src/TDXVerifier.sol lib/openzeppelin-contracts
 	mkdir -p solc_out
-	solc src/TDXVerifier.sol --bin --allow-paths lib/ -o solc_out/ --overwrite
+	solc --optimize src/TDXVerifier.sol --bin --allow-paths lib/ -o solc_out/ --overwrite
 
 deploy: solc_out/TDXVerifier.bin
 	$(eval CONTRACT_BIN := $(shell cat solc_out/TDXVerifier.bin))


### PR DESCRIPTION
**Motivation**

Currently, L2 contract compilation does not enable the solidity optimizer => larger bytecode size and higher gas usage.

**Description**

Adds the `--optimize` flag when invoking `solc` to compile L2 contracts. 

Closes #3438