### PR TITLE
perf(levm): use inline(always) for blake2

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -846,6 +846,7 @@ const R4: u32 = 63;
 /// v[0..15].  The full modified vector is returned.
 /// Based on https://datatracker.ietf.org/doc/html/rfc7693#section-3.1
 #[allow(clippy::indexing_slicing)]
+#[inline(always)]
 fn g(v: [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) -> [u64; 16] {
     let mut ret = v;
     ret[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
@@ -862,6 +863,7 @@ fn g(v: [u64; 16], a: usize, b: usize, c: usize, d: usize, x: u64, y: u64) -> [u
 
 /// Perform the permutations on the work vector given the rounds to permute and the message block
 #[allow(clippy::indexing_slicing)]
+#[inline(always)]
 fn word_permutation(rounds_to_permute: usize, v: [u64; 16], m: &[u64; 16]) -> [u64; 16] {
     let mut ret = v;
 
@@ -885,6 +887,7 @@ fn word_permutation(rounds_to_permute: usize, v: [u64; 16], m: &[u64; 16]) -> [u
 }
 
 /// Based on https://datatracker.ietf.org/doc/html/rfc7693#section-3.2
+#[inline(always)]
 fn blake2f_compress_f(
     rounds: usize, // Specifies the rounds to permute
     h: [u64; 8],   // State vector, defines the work vector (v) and affects the XOR process


### PR DESCRIPTION
**Motivation**

Currently our blake2 implementation is slower compared to other clients.

While a hand-optimized AVX2 implementation was considered, it turns out adding inlining (and thus preventing copying values to the stack) gives most of the performance benefits. The cost in code complexity is not worth it considering the benefit observed with AVX (v. just inlining) was only ~20%.

**Description**

Gas benchmarks show a significant improvement in calls to the precompile

## PR
Title                      |p50 (MGas/s) | p95 (MGas/s) | p99 (MGas/s) | Min (MGas/s)
-----------------|-------------|-------------|-------------|----------------
Blake1MRounds  |2652.10|2852.53|3559.37|1527.22
Blake1Round.      |3790.12|2943.87|4345.18|1510.71
Blake1KRounds   |2914.33|3562.87|4697.05|1830.10
Blake10MRounds|2601.21|3282.72|4206.81|1550.06
## MAIN
Title                      |p50 (MGas/s)|p95 (MGas/s)|p99 (MGas/s)|Min (MGas/s)
-----------------|-------------|---------------|--------------|----------------
Blake1MRounds. |62.61              |69.43              |77.61               |54.11
Blake1Round.      |116.95             |128.63            |142.78            |114.16
Blake1KRounds.  |66.55              |74.33              |80.59             |64.76
Blake10MRounds|73.41               |82.06             |89.10              |68.84
