### PR TITLE
chore(levm): simplify blake2f_compress_f

### DIFF
--- a/crates/common/crypto/blake2f/portable.rs
+++ b/crates/common/crypto/blake2f/portable.rs
@@ -105,7 +105,7 @@ pub fn blake2f_compress_f(
         clippy::arithmetic_side_effects,
         reason = "index is within constant bounds"
     )]
-    std::array::from_fn(|i| h[i] ^ v[i] ^ h[i + 8])
+    std::array::from_fn(|i| h[i] ^ v[i] ^ v[i + 8])
 }
 
 #[cfg(test)]

--- a/crates/common/crypto/blake2f/portable.rs
+++ b/crates/common/crypto/blake2f/portable.rs
@@ -102,8 +102,13 @@ pub fn blake2f_compress_f(
     let mut output = [0; 8];
 
     // XOR the two halves, put the results in the output slice
-    for (i, pos) in output.iter_mut().enumerate() {
-        *pos = h.get(i).unwrap() ^ v.get(i).unwrap() ^ v.get(i.overflowing_add(8).0).unwrap();
+    #[expect(
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        reason = "index is within constant bounds"
+    )]
+    for i in 0..8 {
+        output[i] = h[i] ^ v[i] ^ v[i + 8];
     }
 
     output

--- a/crates/common/crypto/blake2f/portable.rs
+++ b/crates/common/crypto/blake2f/portable.rs
@@ -99,19 +99,13 @@ pub fn blake2f_compress_f(
 
     v = word_permutation(rounds, v, m);
 
-    let mut output = [0; 8];
-
-    // XOR the two halves, put the results in the output slice
+    // XOR the two halves and return the result
     #[expect(
         clippy::indexing_slicing,
         clippy::arithmetic_side_effects,
         reason = "index is within constant bounds"
     )]
-    for i in 0..8 {
-        output[i] = h[i] ^ v[i] ^ v[i + 8];
-    }
-
-    output
+    std::array::from_fn(|i| h[i] ^ v[i] ^ h[i + 8])
 }
 
 #[cfg(test)]

--- a/crates/common/crypto/blake2f/portable.rs
+++ b/crates/common/crypto/blake2f/portable.rs
@@ -100,11 +100,6 @@ pub fn blake2f_compress_f(
     v = word_permutation(rounds, v, m);
 
     // XOR the two halves and return the result
-    #[expect(
-        clippy::indexing_slicing,
-        clippy::arithmetic_side_effects,
-        reason = "index is within constant bounds"
-    )]
     std::array::from_fn(|i| h[i] ^ v[i] ^ v[i + 8])
 }
 


### PR DESCRIPTION
Use index and addition operators rather than the checked versions for compile-time known-correct sizes.
This makes the code a little bit less noisy and the function infallible.
