### PR TITLE
fix(l1,l2): eth client send blobs when calling eth_estimateGas 

### DIFF
--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -155,7 +155,7 @@ impl EthClient {
         for url in self.urls.iter() {
             response = self.send_request_to_url(url, &request).await;
             if response.is_ok() {
-                // Some RPC servers don't implement all the endpoints or don't implement them completly/correctly
+                // Some RPC servers don't implement all the endpoints or don't implement them completely/correctly
                 // so if the server returns Ok(RpcResponse::Error) we retry with the others
                 if let Ok(RpcResponse::Success(ref _a)) = response {
                     return response;


### PR DESCRIPTION
**Motivation**

When calling eth_estimateGas to estimate the gas for the L2 commitment the call was reverting because the blob was not included in the call

**Description**

- Add a function to add the blobs to a GenericTransaction
- Add the field "blobs" to the request if the blobs field is not empty

