### PR TITLE
fix(l1): ignore unknown protocols in capability exchange

### DIFF
--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -534,7 +534,7 @@ where
 
             // Check if we have any capability in common and store the highest version
             for cap in &hello_message.capabilities {
-                match cap.protocol {
+                match cap.protocol() {
                     "eth" => {
                         if SUPPORTED_ETH_CAPABILITIES.contains(cap)
                             && cap.version > negotiated_eth_version

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -69,7 +69,7 @@ impl Capability {
 impl RLPEncode for Capability {
     fn encode(&self, buf: &mut dyn BufMut) {
         Encoder::new(buf)
-            .encode_field(&self.protocol)
+            .encode_field(&self.protocol())
             .encode_field(&self.version)
             .finish();
     }
@@ -342,9 +342,17 @@ impl RLPxMessage for PongMessage {
 
 #[cfg(test)]
 mod tests {
-    use ethrex_rlp::decode::RLPDecode;
+    use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 
     use crate::rlpx::p2p::Capability;
+
+    #[test]
+    fn test_encode_capability() {
+        let capability = Capability::eth(8);
+        let encoded = capability.encode_to_vec();
+
+        assert_eq!(&encoded, &[197_u8, 131, b'e', b't', b'h', 8]);
+    }
 
     #[test]
     fn test_decode_capability() {

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -38,6 +38,7 @@ const fn pad_right<const N: usize>(input: &[u8; N]) -> [u8; 8] {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// A capability is identified by a short ASCII name (max eight characters) and version number
 pub struct Capability {
     protocol: [u8; CAPABILITY_NAME_MAX_LENGTH],
     pub version: u8,

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -18,7 +18,11 @@ pub const SUPPORTED_ETH_CAPABILITIES: [Capability; 1] = [Capability::eth(68)];
 pub const SUPPORTED_SNAP_CAPABILITIES: [Capability; 1] = [Capability::snap(1)];
 pub const SUPPORTED_P2P_CAPABILITIES: [Capability; 1] = [Capability::p2p(5)];
 
+// Pads the input array to the right with zeros to ensure it is 8 bytes long.
+// Panics if the input is longer than 8 bytes.
 const fn pad_right<const N: usize>(input: &[u8; N]) -> [u8; 8] {
+    assert!(N <= 8, "Input array must be 8 bytes or less");
+
     let mut padded = [0_u8; 8];
     let mut i = 0;
     while i < input.len() {

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -18,39 +18,47 @@ pub const SUPPORTED_ETH_CAPABILITIES: [Capability; 1] = [Capability::eth(68)];
 pub const SUPPORTED_SNAP_CAPABILITIES: [Capability; 1] = [Capability::snap(1)];
 pub const SUPPORTED_P2P_CAPABILITIES: [Capability; 1] = [Capability::p2p(5)];
 
+const fn pad_right<const N: usize>(input: &[u8; N]) -> [u8; 8] {
+    let mut padded = [0_u8; 8];
+    let mut i = 0;
+    while i < input.len() {
+        padded[i] = input[i];
+        i += 1;
+    }
+    padded
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Capability {
-    pub protocol: &'static str,
+    protocol: [u8; 8],
     pub version: u8,
 }
 
 impl Capability {
     pub const fn eth(version: u8) -> Self {
         Capability {
-            protocol: "eth",
+            protocol: pad_right(b"eth"),
             version,
         }
     }
 
     pub const fn p2p(version: u8) -> Self {
         Capability {
-            protocol: "p2p",
+            protocol: pad_right(b"p2p"),
             version,
         }
     }
 
     pub const fn snap(version: u8) -> Self {
         Capability {
-            protocol: "snap",
+            protocol: pad_right(b"snap"),
             version,
         }
     }
 
-    pub fn other(version: u8) -> Self {
-        Capability {
-            protocol: "other",
-            version,
-        }
+    pub fn protocol(&self) -> &str {
+        let len = self.protocol.iter().position(|c| c != &b'\0').unwrap_or(8);
+        str::from_utf8(&self.protocol[..len]).expect("value parsed as utf8 in RLPDecode")
     }
 }
 
@@ -65,14 +73,14 @@ impl RLPEncode for Capability {
 
 impl RLPDecode for Capability {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
-        let (protocol, rest) = String::decode_unfinished(&rlp[1..])?;
-        let (version, rest) = u8::decode_unfinished(rest)?;
-        match protocol.as_str() {
-            "eth" => Ok((Capability::eth(version), rest)),
-            "p2p" => Ok((Capability::p2p(version), rest)),
-            "snap" => Ok((Capability::snap(version), rest)),
-            _ => Ok((Capability::other(version), rest)),
+        let (protocol_name, rest) = String::decode_unfinished(&rlp[1..])?;
+        if protocol_name.len() > 8 {
+            return Err(RLPDecodeError::InvalidLength);
         }
+        let (version, rest) = u8::decode_unfinished(rest)?;
+        let mut protocol = [0; 8];
+        protocol[..protocol_name.len()].copy_from_slice(protocol_name.as_bytes());
+        Ok((Capability { protocol, version }, rest))
     }
 }
 
@@ -81,7 +89,7 @@ impl Serialize for Capability {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("{}/{}", self.protocol, self.version))
+        serializer.serialize_str(&format!("{}/{}", "self.protocol", self.version))
     }
 }
 
@@ -325,5 +333,20 @@ impl RLPxMessage for PongMessage {
         assert_eq!(payload, empty, "Pong payload should be &[]");
         assert_eq!(remaining, empty, "Pong remaining should be &[]");
         Ok(Self {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ethrex_rlp::decode::RLPDecode;
+
+    use crate::rlpx::p2p::Capability;
+
+    #[test]
+    fn test_decode_capability() {
+        let encoded_bytes = &[197_u8, 131, b'e', b't', b'h', 8];
+        let decoded = Capability::decode(encoded_bytes).unwrap();
+
+        assert_eq!(decoded, Capability::eth(8));
     }
 }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -45,6 +45,13 @@ impl Capability {
             version,
         }
     }
+
+    pub fn other(version: u8) -> Self {
+        Capability {
+            protocol: "other",
+            version,
+        }
+    }
 }
 
 impl RLPEncode for Capability {
@@ -64,7 +71,7 @@ impl RLPDecode for Capability {
             "eth" => Ok((Capability::eth(version), rest)),
             "p2p" => Ok((Capability::p2p(version), rest)),
             "snap" => Ok((Capability::snap(version), rest)),
-            _ => Err(RLPDecodeError::MalformedData),
+            _ => Ok((Capability::other(version), rest)),
         }
     }
 }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -57,7 +57,7 @@ impl Capability {
     }
 
     pub fn protocol(&self) -> &str {
-        let len = self.protocol.iter().position(|c| c != &b'\0').unwrap_or(8);
+        let len = self.protocol.iter().position(|c| c == &b'\0').unwrap_or(8);
         str::from_utf8(&self.protocol[..len]).expect("value parsed as utf8 in RLPDecode")
     }
 }
@@ -348,5 +348,12 @@ mod tests {
         let decoded = Capability::decode(encoded_bytes).unwrap();
 
         assert_eq!(decoded, Capability::eth(8));
+    }
+
+    #[test]
+    fn test_protocol() {
+        let capability = Capability::eth(68);
+
+        assert_eq!(capability.protocol(), "eth");
     }
 }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -18,12 +18,17 @@ pub const SUPPORTED_ETH_CAPABILITIES: [Capability; 1] = [Capability::eth(68)];
 pub const SUPPORTED_SNAP_CAPABILITIES: [Capability; 1] = [Capability::snap(1)];
 pub const SUPPORTED_P2P_CAPABILITIES: [Capability; 1] = [Capability::p2p(5)];
 
+const CAPABILITY_NAME_MAX_LENGTH: usize = 8;
+
 // Pads the input array to the right with zeros to ensure it is 8 bytes long.
 // Panics if the input is longer than 8 bytes.
 const fn pad_right<const N: usize>(input: &[u8; N]) -> [u8; 8] {
-    assert!(N <= 8, "Input array must be 8 bytes or less");
+    assert!(
+        N <= CAPABILITY_NAME_MAX_LENGTH,
+        "Input array must be 8 bytes or less"
+    );
 
-    let mut padded = [0_u8; 8];
+    let mut padded = [0_u8; CAPABILITY_NAME_MAX_LENGTH];
     let mut i = 0;
     while i < input.len() {
         padded[i] = input[i];
@@ -34,7 +39,7 @@ const fn pad_right<const N: usize>(input: &[u8; N]) -> [u8; 8] {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Capability {
-    protocol: [u8; 8],
+    protocol: [u8; CAPABILITY_NAME_MAX_LENGTH],
     pub version: u8,
 }
 
@@ -61,7 +66,11 @@ impl Capability {
     }
 
     pub fn protocol(&self) -> &str {
-        let len = self.protocol.iter().position(|c| c == &b'\0').unwrap_or(8);
+        let len = self
+            .protocol
+            .iter()
+            .position(|c| c == &b'\0')
+            .unwrap_or(CAPABILITY_NAME_MAX_LENGTH);
         str::from_utf8(&self.protocol[..len]).expect("value parsed as utf8 in RLPDecode")
     }
 }
@@ -78,11 +87,11 @@ impl RLPEncode for Capability {
 impl RLPDecode for Capability {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
         let (protocol_name, rest) = String::decode_unfinished(&rlp[1..])?;
-        if protocol_name.len() > 8 {
+        if protocol_name.len() > CAPABILITY_NAME_MAX_LENGTH {
             return Err(RLPDecodeError::InvalidLength);
         }
         let (version, rest) = u8::decode_unfinished(rest)?;
-        let mut protocol = [0; 8];
+        let mut protocol = [0; CAPABILITY_NAME_MAX_LENGTH];
         protocol[..protocol_name.len()].copy_from_slice(protocol_name.as_bytes());
         Ok((Capability { protocol, version }, rest))
     }

--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -89,7 +89,7 @@ impl Serialize for Capability {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("{}/{}", "self.protocol", self.version))
+        serializer.serialize_str(&format!("{}/{}", self.protocol(), self.version))
     }
 }
 

--- a/crates/networking/rpc/admin/peers.rs
+++ b/crates/networking/rpc/admin/peers.rs
@@ -49,7 +49,7 @@ impl From<PeerData> for RpcPeer {
         let mut protocols = Protocols::default();
         // Fill protocol data
         for cap in &peer.supported_capabilities {
-            match cap.protocol {
+            match cap.protocol() {
                 "p2p" => {
                     protocols.p2p = Some(ProtocolData {
                         version: cap.version,

--- a/crates/networking/rpc/admin/peers.rs
+++ b/crates/networking/rpc/admin/peers.rs
@@ -111,16 +111,7 @@ mod tests {
         // Set node capabilities and other relevant data
         peer.is_connected = true;
         peer.is_connection_inbound = false;
-        peer.supported_capabilities = vec![
-            Capability {
-                protocol: "eth",
-                version: 68,
-            },
-            Capability {
-                protocol: "snap",
-                version: 1,
-            },
-        ];
+        peer.supported_capabilities = vec![Capability::eth(68), Capability::snap(1)];
         peer.node.version = Some("ethrex/test".to_string());
         // The first serialized peer shown in geth's documentation example: https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin#admin-peers
         // The fields "localAddress", "static", "trusted" and "name" were removed as we do not have the necessary information to show them


### PR DESCRIPTION
**Motivation**

Failing due to a peer having extra capabilities can make us lose exceptional peers. Hence, we want to ignore any extra capabilities they have.

**Description**

This PR changes `Capability.protocol` to be an 8-byte array instead of a string, allowing us to store any string we receive.
