### PR TITLE
fix(l2): seal a batch in a single DB transaction 

### DIFF
--- a/crates/l2/networking/rpc/l2/l1_message.rs
+++ b/crates/l2/networking/rpc/l2/l1_message.rs
@@ -36,21 +36,20 @@ impl RpcHandler for GetL1MessageProof {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.l1_ctx.storage;
-        dbg!(
+        info!(
             "Requested l1message proof for transaction {:#x}",
             self.transaction_hash,
         );
 
         // Gets the transaction from the storage
-        let (tx_block_number, _, tx_index) = match dbg!(
-            storage
-                .get_transaction_location(self.transaction_hash)
-                .await
-        )? {
+        let (tx_block_number, _, tx_index) = match storage
+            .get_transaction_location(self.transaction_hash)
+            .await?
+        {
             Some(location) => location,
             _ => return Ok(Value::Null),
         };
-        let tx_receipt = match dbg!(storage.get_receipt(tx_block_number, tx_index).await?) {
+        let tx_receipt = match storage.get_receipt(tx_block_number, tx_index).await? {
             Some(receipt) => receipt,
             _ => return Ok(Value::Null),
         };
@@ -63,23 +62,21 @@ impl RpcHandler for GetL1MessageProof {
             .collect::<HashMap<_, _>>();
 
         // Gets the batch number for the block
-        let batch_number = match dbg!(
-            context
-                .rollup_store
-                .get_batch_number_by_block(tx_block_number)
-                .await
-        )? {
+        let batch_number = match context
+            .rollup_store
+            .get_batch_number_by_block(tx_block_number)
+            .await?
+        {
             Some(location) => location,
             _ => return Ok(Value::Null),
         };
 
         // Gets the message hashes for the batch
-        let batch_message_hashes = match dbg!(
-            context
-                .rollup_store
-                .get_message_hashes_by_batch(batch_number)
-                .await
-        )? {
+        let batch_message_hashes = match context
+            .rollup_store
+            .get_message_hashes_by_batch(batch_number)
+            .await?
+        {
             Some(messages) => messages,
             _ => return Ok(Value::Null),
         };

--- a/crates/l2/networking/rpc/l2/l1_message.rs
+++ b/crates/l2/networking/rpc/l2/l1_message.rs
@@ -36,20 +36,21 @@ impl RpcHandler for GetL1MessageProof {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.l1_ctx.storage;
-        info!(
+        dbg!(
             "Requested l1message proof for transaction {:#x}",
             self.transaction_hash,
         );
 
         // Gets the transaction from the storage
-        let (tx_block_number, _, tx_index) = match storage
-            .get_transaction_location(self.transaction_hash)
-            .await?
-        {
+        let (tx_block_number, _, tx_index) = match dbg!(
+            storage
+                .get_transaction_location(self.transaction_hash)
+                .await
+        )? {
             Some(location) => location,
             _ => return Ok(Value::Null),
         };
-        let tx_receipt = match storage.get_receipt(tx_block_number, tx_index).await? {
+        let tx_receipt = match dbg!(storage.get_receipt(tx_block_number, tx_index).await?) {
             Some(receipt) => receipt,
             _ => return Ok(Value::Null),
         };
@@ -62,21 +63,23 @@ impl RpcHandler for GetL1MessageProof {
             .collect::<HashMap<_, _>>();
 
         // Gets the batch number for the block
-        let batch_number = match context
-            .rollup_store
-            .get_batch_number_by_block(tx_block_number)
-            .await?
-        {
+        let batch_number = match dbg!(
+            context
+                .rollup_store
+                .get_batch_number_by_block(tx_block_number)
+                .await
+        )? {
             Some(location) => location,
             _ => return Ok(Value::Null),
         };
 
         // Gets the message hashes for the batch
-        let batch_message_hashes = match context
-            .rollup_store
-            .get_message_hashes_by_batch(batch_number)
-            .await?
-        {
+        let batch_message_hashes = match dbg!(
+            context
+                .rollup_store
+                .get_message_hashes_by_batch(batch_number)
+                .await
+        )? {
             Some(messages) => messages,
             _ => return Ok(Value::Null),
         };

--- a/crates/l2/storage/src/api.rs
+++ b/crates/l2/storage/src/api.rs
@@ -20,32 +20,11 @@ pub trait StoreEngineRollup: Debug + Send + Sync {
         block_number: BlockNumber,
     ) -> Result<Option<u64>, RollupStoreError>;
 
-    /// Stores the batch number by a given block number.
-    async fn store_batch_number_by_block(
-        &self,
-        block_number: BlockNumber,
-        batch_number: u64,
-    ) -> Result<(), RollupStoreError>;
-
     /// Gets the message hashes by a given batch number.
     async fn get_message_hashes_by_batch(
         &self,
         batch_number: u64,
     ) -> Result<Option<Vec<H256>>, RollupStoreError>;
-
-    /// Stores the message hashes by a given batch number.
-    async fn store_message_hashes_by_batch(
-        &self,
-        batch_number: u64,
-        message_hashes: Vec<H256>,
-    ) -> Result<(), RollupStoreError>;
-
-    /// Stores the block numbers by a given batch_number
-    async fn store_block_numbers_by_batch(
-        &self,
-        batch_number: u64,
-        block_numbers: Vec<BlockNumber>,
-    ) -> Result<(), RollupStoreError>;
 
     /// Returns the block numbers by a given batch_number
     async fn get_block_numbers_by_batch(
@@ -53,33 +32,15 @@ pub trait StoreEngineRollup: Debug + Send + Sync {
         batch_number: u64,
     ) -> Result<Option<Vec<BlockNumber>>, RollupStoreError>;
 
-    async fn store_privileged_transactions_hash_by_batch_number(
-        &self,
-        batch_number: u64,
-        privileged_transactions_hash: H256,
-    ) -> Result<(), RollupStoreError>;
-
     async fn get_privileged_transactions_hash_by_batch_number(
         &self,
         batch_number: u64,
     ) -> Result<Option<H256>, RollupStoreError>;
 
-    async fn store_state_root_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_root: H256,
-    ) -> Result<(), RollupStoreError>;
-
     async fn get_state_root_by_batch_number(
         &self,
         batch_number: u64,
     ) -> Result<Option<H256>, RollupStoreError>;
-
-    async fn store_blob_bundle_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_diff: Vec<Blob>,
-    ) -> Result<(), RollupStoreError>;
 
     async fn get_blob_bundle_by_batch_number(
         &self,

--- a/crates/l2/storage/src/api.rs
+++ b/crates/l2/storage/src/api.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use ethrex_common::{
     H256,
-    types::{AccountUpdate, Blob, BlockNumber},
+    types::{AccountUpdate, Blob, BlockNumber, batch::Batch},
 };
 use ethrex_l2_common::prover::{BatchProof, ProverType};
 
@@ -96,6 +96,8 @@ pub trait StoreEngineRollup: Debug + Send + Sync {
         batch_number: u64,
         commit_tx: H256,
     ) -> Result<(), RollupStoreError>;
+
+    async fn seal_batch(&self, batch: Batch) -> Result<(), RollupStoreError>;
 
     async fn get_verify_tx_by_batch(
         &self,

--- a/crates/l2/storage/src/error.rs
+++ b/crates/l2/storage/src/error.rs
@@ -1,5 +1,3 @@
-use ethrex_rlp::error::RLPDecodeError;
-use ethrex_trie::TrieError;
 #[cfg(feature = "redb")]
 use redb::{CommitError, DatabaseError, StorageError, TableError, TransactionError};
 use thiserror::Error;
@@ -38,24 +36,6 @@ pub enum RollupStoreError {
     SQLInvalidTypeError,
     #[error("{0}")]
     Custom(String),
-    #[error(transparent)]
-    RLPDecode(#[from] RLPDecodeError),
-    #[error(transparent)]
-    Trie(#[from] TrieError),
-    #[error("missing store: is an execution DB being used instead?")]
-    MissingStore,
-    #[error("Could not open DB for reading")]
-    ReadError,
-    #[error("Could not instantiate cursor for table {0}")]
-    CursorError(String),
-    #[error("Missing latest block number")]
-    MissingLatestBlockNumber,
-    #[error("Missing earliest block number")]
-    MissingEarliestBlockNumber,
-    #[error("Failed to lock mempool for writing")]
-    MempoolWriteLock(String),
-    #[error("Failed to lock mempool for reading")]
-    MempoolReadLock(String),
     #[error("Bincode (de)serialization error: {0}")]
     BincodeError(#[from] bincode::Error),
 }

--- a/crates/l2/storage/src/store.rs
+++ b/crates/l2/storage/src/store.rs
@@ -83,17 +83,6 @@ impl Store {
         self.set_lastest_sent_batch_proof(0).await
     }
 
-    /// Stores the block numbers by a given batch_number
-    pub async fn store_block_numbers_by_batch(
-        &self,
-        batch_number: u64,
-        block_numbers: Vec<BlockNumber>,
-    ) -> Result<(), RollupStoreError> {
-        self.engine
-            .store_block_numbers_by_batch(batch_number, block_numbers)
-            .await
-    }
-
     /// Returns the block numbers by a given batch_number
     pub async fn get_block_numbers_by_batch(
         &self,
@@ -108,15 +97,6 @@ impl Store {
     ) -> Result<Option<u64>, RollupStoreError> {
         self.engine.get_batch_number_by_block(block_number).await
     }
-    pub async fn store_batch_number_by_block(
-        &self,
-        block_number: BlockNumber,
-        batch_number: u64,
-    ) -> Result<(), RollupStoreError> {
-        self.engine
-            .store_batch_number_by_block(block_number, batch_number)
-            .await
-    }
 
     pub async fn get_message_hashes_by_batch(
         &self,
@@ -125,35 +105,12 @@ impl Store {
         self.engine.get_message_hashes_by_batch(batch_number).await
     }
 
-    pub async fn store_message_hashes_by_batch(
-        &self,
-        batch_number: u64,
-        message_hashes: Vec<H256>,
-    ) -> Result<(), RollupStoreError> {
-        self.engine
-            .store_message_hashes_by_batch(batch_number, message_hashes)
-            .await
-    }
-
     pub async fn get_privileged_transactions_hash_by_batch(
         &self,
         batch_number: u64,
     ) -> Result<Option<H256>, RollupStoreError> {
         self.engine
             .get_privileged_transactions_hash_by_batch_number(batch_number)
-            .await
-    }
-
-    pub async fn store_privileged_transactions_hash_by_batch(
-        &self,
-        batch_number: u64,
-        privileged_transactions_hash: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.engine
-            .store_privileged_transactions_hash_by_batch_number(
-                batch_number,
-                privileged_transactions_hash,
-            )
             .await
     }
 
@@ -166,32 +123,12 @@ impl Store {
             .await
     }
 
-    pub async fn store_state_root_by_batch(
-        &self,
-        batch_number: u64,
-        state_root: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.engine
-            .store_state_root_by_batch_number(batch_number, state_root)
-            .await
-    }
-
     pub async fn get_blobs_by_batch(
         &self,
         batch_number: u64,
     ) -> Result<Option<Vec<Blob>>, RollupStoreError> {
         self.engine
             .get_blob_bundle_by_batch_number(batch_number)
-            .await
-    }
-
-    pub async fn store_blobs_by_batch(
-        &self,
-        batch_number: u64,
-        blobs: Vec<Blob>,
-    ) -> Result<(), RollupStoreError> {
-        self.engine
-            .store_blob_bundle_by_batch_number(batch_number, blobs)
             .await
     }
 

--- a/crates/l2/storage/src/store.rs
+++ b/crates/l2/storage/src/store.rs
@@ -290,34 +290,7 @@ impl Store {
     }
 
     pub async fn seal_batch(&self, batch: Batch) -> Result<(), RollupStoreError> {
-        let blocks: Vec<u64> = (batch.first_block..=batch.last_block).collect();
-
-        for block_number in blocks.iter() {
-            self.store_batch_number_by_block(*block_number, batch.number)
-                .await?;
-        }
-        self.store_block_numbers_by_batch(batch.number, blocks)
-            .await?;
-        self.store_message_hashes_by_batch(batch.number, batch.message_hashes)
-            .await?;
-        self.store_privileged_transactions_hash_by_batch(
-            batch.number,
-            batch.privileged_transactions_hash,
-        )
-        .await?;
-        self.store_blobs_by_batch(batch.number, batch.blobs_bundle.blobs)
-            .await?;
-        self.store_state_root_by_batch(batch.number, batch.state_root)
-            .await?;
-        if let Some(commit_tx) = batch.commit_tx {
-            self.store_commit_tx_by_batch(batch.number, commit_tx)
-                .await?;
-        }
-        if let Some(verify_tx) = batch.verify_tx {
-            self.store_verify_tx_by_batch(batch.number, verify_tx)
-                .await?;
-        }
-        Ok(())
+        self.engine.seal_batch(batch).await
     }
 
     pub async fn update_operations_count(

--- a/crates/l2/storage/src/store_db/in_memory.rs
+++ b/crates/l2/storage/src/store_db/in_memory.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::error::RollupStoreError;
 use ethrex_common::{
     H256,
-    types::{AccountUpdate, Blob, BlockNumber},
+    types::{AccountUpdate, Blob, BlockNumber, batch::Batch},
 };
 use ethrex_l2_common::prover::{BatchProof, ProverType};
 
@@ -307,6 +307,10 @@ impl StoreEngineRollup for Store {
         store.state_roots.retain(|batch, _| *batch <= batch_number);
         store.blobs.retain(|batch, _| *batch <= batch_number);
         Ok(())
+    }
+
+    async fn seal_batch(&self, _batch: Batch) -> Result<(), RollupStoreError> {
+        todo!()
     }
 }
 

--- a/crates/l2/storage/src/store_db/libmdbx.rs
+++ b/crates/l2/storage/src/store_db/libmdbx.rs
@@ -332,7 +332,7 @@ impl StoreEngineRollup for Store {
 
             for block in blocks.iter() {
                 transaction
-                    .upsert::<BatchesByBlockNumber>(batch.number, *block)
+                    .upsert::<BatchesByBlockNumber>(*block, batch.number)
                     .map_err(RollupStoreError::LibmdbxError)?;
             }
 

--- a/crates/l2/storage/src/store_db/libmdbx.rs
+++ b/crates/l2/storage/src/store_db/libmdbx.rs
@@ -112,15 +112,6 @@ impl StoreEngineRollup for Store {
         self.read::<BatchesByBlockNumber>(block_number).await
     }
 
-    async fn store_batch_number_by_block(
-        &self,
-        block_number: BlockNumber,
-        batch_number: u64,
-    ) -> Result<(), RollupStoreError> {
-        self.write::<BatchesByBlockNumber>(block_number, batch_number)
-            .await
-    }
-
     async fn get_message_hashes_by_batch(
         &self,
         batch_number: u64,
@@ -129,15 +120,6 @@ impl StoreEngineRollup for Store {
             .read::<MessageHashesByBatch>(batch_number)
             .await?
             .map(|w| w.to()))
-    }
-
-    async fn store_message_hashes_by_batch(
-        &self,
-        batch_number: u64,
-        messages: Vec<H256>,
-    ) -> Result<(), RollupStoreError> {
-        self.write::<MessageHashesByBatch>(batch_number, messages.into())
-            .await
     }
 
     async fn get_block_numbers_by_batch(
@@ -150,30 +132,6 @@ impl StoreEngineRollup for Store {
             .map(|numbers| numbers.to()))
     }
 
-    async fn store_block_numbers_by_batch(
-        &self,
-        batch_number: u64,
-        block_numbers: Vec<BlockNumber>,
-    ) -> Result<(), RollupStoreError> {
-        self.write::<BlockNumbersByBatch>(
-            batch_number,
-            BlockNumbersRLP::from_bytes(block_numbers.encode_to_vec()),
-        )
-        .await
-    }
-
-    async fn store_privileged_transactions_hash_by_batch_number(
-        &self,
-        batch_number: u64,
-        privileged_transactions_hash: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.write::<PrivilegedTransactionsHash>(
-            batch_number,
-            Rlp::from_bytes(privileged_transactions_hash.encode_to_vec()),
-        )
-        .await
-    }
-
     async fn get_privileged_transactions_hash_by_batch_number(
         &self,
         batch_number: u64,
@@ -184,15 +142,6 @@ impl StoreEngineRollup for Store {
             .map(|hash| hash.to()))
     }
 
-    async fn store_state_root_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_root: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.write::<StateRoots>(batch_number, Rlp::from_bytes(state_root.encode_to_vec()))
-            .await
-    }
-
     async fn get_state_root_by_batch_number(
         &self,
         batch_number: u64,
@@ -201,15 +150,6 @@ impl StoreEngineRollup for Store {
             .read::<StateRoots>(batch_number)
             .await?
             .map(|hash| hash.to()))
-    }
-
-    async fn store_blob_bundle_by_batch_number(
-        &self,
-        batch_number: u64,
-        blob_bundles: Vec<Blob>,
-    ) -> Result<(), RollupStoreError> {
-        self.write::<BlobsBundles>(batch_number, blob_bundles.into())
-            .await
     }
 
     async fn get_blob_bundle_by_batch_number(

--- a/crates/l2/storage/src/store_db/libmdbx.rs
+++ b/crates/l2/storage/src/store_db/libmdbx.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::error::RollupStoreError;
 use ethrex_common::{
     H256,
-    types::{AccountUpdate, Blob, BlockNumber},
+    types::{AccountUpdate, Blob, BlockNumber, batch::Batch},
 };
 use ethrex_l2_common::prover::{BatchProof, ProverType};
 use ethrex_rlp::encode::RLPEncode;
@@ -380,6 +380,10 @@ impl StoreEngineRollup for Store {
         delete_starting_at::<BlobsBundles>(&txn, batch_number + 1)?;
         txn.commit().map_err(RollupStoreError::LibmdbxError)?;
         Ok(())
+    }
+
+    async fn seal_batch(&self, _batch: Batch) -> Result<(), RollupStoreError> {
+        todo!()
     }
 }
 

--- a/crates/l2/storage/src/store_db/redb.rs
+++ b/crates/l2/storage/src/store_db/redb.rs
@@ -370,7 +370,7 @@ impl StoreEngineRollup for RedBStoreRollup {
             {
                 let mut table = transaction.open_table(BATCHES_BY_BLOCK_NUMBER_TABLE)?;
                 for block in blocks.iter() {
-                    table.insert(batch.number, *block)?;
+                    table.insert(*block, batch.number)?;
                 }
             }
 

--- a/crates/l2/storage/src/store_db/redb.rs
+++ b/crates/l2/storage/src/store_db/redb.rs
@@ -3,7 +3,7 @@ use std::{panic::RefUnwindSafe, sync::Arc};
 use crate::error::RollupStoreError;
 use ethrex_common::{
     H256,
-    types::{AccountUpdate, Blob, BlockNumber},
+    types::{AccountUpdate, Blob, BlockNumber, batch::Batch},
 };
 use ethrex_l2_common::prover::{BatchProof, ProverType};
 use ethrex_rlp::encode::RLPEncode;
@@ -425,6 +425,10 @@ impl StoreEngineRollup for RedBStoreRollup {
         delete_starting_at(&txn, BLOB_BUNDLES, batch_number + 1)?;
         txn.commit()?;
         Ok(())
+    }
+
+    async fn seal_batch(&self, _batch: Batch) -> Result<(), RollupStoreError> {
+        todo!()
     }
 }
 

--- a/crates/l2/storage/src/store_db/redb.rs
+++ b/crates/l2/storage/src/store_db/redb.rs
@@ -144,15 +144,6 @@ impl StoreEngineRollup for RedBStoreRollup {
             .map(|b| b.value()))
     }
 
-    async fn store_batch_number_by_block(
-        &self,
-        block_number: BlockNumber,
-        batch_number: u64,
-    ) -> Result<(), RollupStoreError> {
-        self.write(BATCHES_BY_BLOCK_NUMBER_TABLE, block_number, batch_number)
-            .await
-    }
-
     async fn get_message_hashes_by_batch(
         &self,
         batch_number: u64,
@@ -161,32 +152,6 @@ impl StoreEngineRollup for RedBStoreRollup {
             .read(MESSAGES_BY_BATCH, batch_number)
             .await?
             .map(|w| w.value().to()))
-    }
-
-    async fn store_message_hashes_by_batch(
-        &self,
-        batch_number: u64,
-        messages: Vec<H256>,
-    ) -> Result<(), RollupStoreError> {
-        self.write(
-            MESSAGES_BY_BATCH,
-            batch_number,
-            <Vec<H256> as Into<MessageHashesRLP>>::into(messages),
-        )
-        .await
-    }
-
-    async fn store_block_numbers_by_batch(
-        &self,
-        batch_number: u64,
-        block_numbers: Vec<BlockNumber>,
-    ) -> Result<(), RollupStoreError> {
-        self.write(
-            BLOCK_NUMBERS_BY_BATCH,
-            batch_number,
-            BlockNumbersRLP::from_bytes(block_numbers.encode_to_vec()),
-        )
-        .await
     }
 
     async fn get_block_numbers_by_batch(
@@ -207,19 +172,6 @@ impl StoreEngineRollup for RedBStoreRollup {
         Ok(exists)
     }
 
-    async fn store_privileged_transactions_hash_by_batch_number(
-        &self,
-        batch_number: u64,
-        privileged_transactions_hash: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.write(
-            PRIVILEGED_TRANSACTIONS_HASHES,
-            batch_number,
-            privileged_transactions_hash.into(),
-        )
-        .await
-    }
-
     async fn get_privileged_transactions_hash_by_batch_number(
         &self,
         batch_number: u64,
@@ -230,15 +182,6 @@ impl StoreEngineRollup for RedBStoreRollup {
             .map(|rlp| rlp.value().to()))
     }
 
-    async fn store_state_root_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_root: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.write(STATE_ROOTS, batch_number, state_root.into())
-            .await
-    }
-
     async fn get_state_root_by_batch_number(
         &self,
         batch_number: u64,
@@ -247,15 +190,6 @@ impl StoreEngineRollup for RedBStoreRollup {
             .read(STATE_ROOTS, batch_number)
             .await?
             .map(|rlp| rlp.value().to()))
-    }
-
-    async fn store_blob_bundle_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_diff: Vec<Blob>,
-    ) -> Result<(), RollupStoreError> {
-        self.write(BLOB_BUNDLES, batch_number, state_diff.into())
-            .await
     }
 
     async fn get_blob_bundle_by_batch_number(

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -285,6 +285,7 @@ impl StoreEngineRollup for SQLStore {
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<u64>, RollupStoreError> {
+        dbg!("get_batch_number_by_block");
         let mut rows = self
             .query(
                 "SELECT * from blocks WHERE block_number = ?1",
@@ -292,7 +293,7 @@ impl StoreEngineRollup for SQLStore {
             )
             .await?;
         if let Some(row) = rows.next().await? {
-            return Ok(Some(read_from_row_int(&row, 1)?));
+            return Ok(Some(dbg!(read_from_row_int(&row, 1))?));
         }
         Ok(None)
     }
@@ -302,6 +303,7 @@ impl StoreEngineRollup for SQLStore {
         &self,
         batch_number: u64,
     ) -> Result<Option<Vec<H256>>, RollupStoreError> {
+        dbg!("get_message_hashes_by_batch");
         let mut hashes = vec![];
         let mut rows = self
             .query(
@@ -310,14 +312,14 @@ impl StoreEngineRollup for SQLStore {
             )
             .await?;
         while let Some(row) = rows.next().await? {
-            let vec = read_from_row_blob(&row, 2)?;
-            hashes.push(H256::from_slice(&vec));
+            let vec = dbg!(read_from_row_blob(&row, 2))?;
+            hashes.push(dbg!(H256::from_slice(&vec)));
         }
-        if hashes.is_empty() {
+        dbg!(if hashes.is_empty() {
             Ok(None)
         } else {
             Ok(Some(hashes))
-        }
+        })
     }
 
     /// Returns the block numbers by a given batch_number

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -297,16 +297,6 @@ impl StoreEngineRollup for SQLStore {
         Ok(None)
     }
 
-    /// Stores the batch number by a given block number.
-    async fn store_batch_number_by_block(
-        &self,
-        block_number: BlockNumber,
-        batch_number: u64,
-    ) -> Result<(), RollupStoreError> {
-        self.store_batch_number_by_block_in_tx(block_number, batch_number, None)
-            .await
-    }
-
     /// Gets the message hashes by a given batch number.
     async fn get_message_hashes_by_batch(
         &self,
@@ -330,29 +320,6 @@ impl StoreEngineRollup for SQLStore {
         }
     }
 
-    /// Stores the withdrawal hashes by a given batch number.
-    async fn store_message_hashes_by_batch(
-        &self,
-        batch_number: u64,
-        message_hashes: Vec<H256>,
-    ) -> Result<(), RollupStoreError> {
-        self.store_message_hashes_by_batch_in_tx(batch_number, message_hashes, None)
-            .await
-    }
-
-    /// Stores the block numbers by a given batch_number
-    async fn store_block_numbers_by_batch(
-        &self,
-        batch_number: u64,
-        block_numbers: Vec<BlockNumber>,
-    ) -> Result<(), RollupStoreError> {
-        let conn = self.db.connect()?;
-        let tx = conn.transaction().await?;
-        self.store_block_numbers_by_batch_in_tx(batch_number, block_numbers, Some(&tx))
-            .await?;
-        tx.commit().await.map_err(RollupStoreError::from)
-    }
-
     /// Returns the block numbers by a given batch_number
     async fn get_block_numbers_by_batch(
         &self,
@@ -373,19 +340,6 @@ impl StoreEngineRollup for SQLStore {
         }
     }
 
-    async fn store_privileged_transactions_hash_by_batch_number(
-        &self,
-        batch_number: u64,
-        privileged_transactions_hash: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.store_privileged_transactions_hash_by_batch_number_in_tx(
-            batch_number,
-            privileged_transactions_hash,
-            None,
-        )
-        .await
-    }
-
     async fn get_privileged_transactions_hash_by_batch_number(
         &self,
         batch_number: u64,
@@ -403,15 +357,6 @@ impl StoreEngineRollup for SQLStore {
         Ok(None)
     }
 
-    async fn store_state_root_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_root: H256,
-    ) -> Result<(), RollupStoreError> {
-        self.store_state_root_by_batch_number_in_tx(batch_number, state_root, None)
-            .await
-    }
-
     async fn get_state_root_by_batch_number(
         &self,
         batch_number: u64,
@@ -427,15 +372,6 @@ impl StoreEngineRollup for SQLStore {
             return Ok(Some(H256::from_slice(&vec)));
         }
         Ok(None)
-    }
-
-    async fn store_blob_bundle_by_batch_number(
-        &self,
-        batch_number: u64,
-        state_diff: Vec<Blob>,
-    ) -> Result<(), RollupStoreError> {
-        self.store_blob_bundle_by_batch_number_in_tx(batch_number, state_diff, None)
-            .await
     }
 
     async fn get_blob_bundle_by_batch_number(

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -3,12 +3,12 @@ use std::fmt::Debug;
 use crate::{RollupStoreError, api::StoreEngineRollup};
 use ethrex_common::{
     H256,
-    types::{AccountUpdate, Blob, BlockNumber},
+    types::{AccountUpdate, Blob, BlockNumber, batch::Batch},
 };
 use ethrex_l2_common::prover::{BatchProof, ProverType};
 
 use libsql::{
-    Builder, Connection, Row, Rows, Value,
+    Builder, Connection, Row, Rows, Transaction, Value,
     params::{IntoParams, Params},
 };
 
@@ -68,16 +68,192 @@ impl SQLStore {
                 .iter()
                 .map(|v| (*v, empty_param.clone()))
                 .collect();
-            self.execute_in_tx(queries).await?;
+            self.execute_in_tx(queries, None).await?;
         }
         Ok(())
     }
-    async fn execute_in_tx(&self, queries: Vec<(&str, Params)>) -> Result<(), RollupStoreError> {
-        self.execute("BEGIN TRANSACTION", ()).await?;
-        for (query, params) in queries {
-            self.execute(query, params).await?;
+
+    /// Executes a set of queries in a SQL transaction
+    /// if the db_tx parameter is Some then it uses that transaction and does not commit to the DB after execution
+    /// if the db_tx parameter is None then it creates a transaction and commits to the DB after execution
+    async fn execute_in_tx(
+        &self,
+        queries: Vec<(&str, Params)>,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        if let Some(existing_tx) = db_tx {
+            for (query, params) in queries {
+                existing_tx.execute(query, params).await?;
+            }
+        } else {
+            let tx = self.conn.transaction().await?;
+            for (query, params) in queries {
+                tx.execute(query, params).await?;
+            }
+            tx.commit().await?;
         }
-        self.execute("COMMIT TRANSACTION", ()).await?;
+        Ok(())
+    }
+
+    async fn store_batch_number_by_block_in_tx(
+        &self,
+        block_number: u64,
+        batch_number: u64,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let queries = vec![
+            (
+                "DELETE FROM blocks WHERE block_number = ?1",
+                vec![block_number].into_params()?,
+            ),
+            (
+                "INSERT INTO blocks VALUES (?1, ?2)",
+                vec![block_number, batch_number].into_params()?,
+            ),
+        ];
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_message_hashes_by_batch_in_tx(
+        &self,
+        batch_number: u64,
+        message_hashes: Vec<H256>,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let mut queries = vec![(
+            "DELETE FROM messages WHERE batch = ?1",
+            vec![batch_number].into_params()?,
+        )];
+        for (index, hash) in message_hashes.iter().enumerate() {
+            let index = u64::try_from(index)
+                .map_err(|e| RollupStoreError::Custom(format!("conversion error: {e}")))?;
+            queries.push((
+                "INSERT INTO messages VALUES (?1, ?2, ?3)",
+                (batch_number, index, Vec::from(hash.to_fixed_bytes())).into_params()?,
+            ));
+        }
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_privileged_transactions_hash_by_batch_number_in_tx(
+        &self,
+        batch_number: u64,
+        privileged_transactions_hash: H256,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let queries = vec![
+            (
+                "DELETE FROM privileged_transactions WHERE batch = ?1",
+                vec![batch_number].into_params()?,
+            ),
+            (
+                "INSERT INTO privileged_transactions VALUES (?1, ?2)",
+                (
+                    batch_number,
+                    Vec::from(privileged_transactions_hash.to_fixed_bytes()),
+                )
+                    .into_params()?,
+            ),
+        ];
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_state_root_by_batch_number_in_tx(
+        &self,
+        batch_number: u64,
+        state_root: H256,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let queries = vec![
+            (
+                "DELETE FROM state_roots WHERE batch = ?1",
+                vec![batch_number].into_params()?,
+            ),
+            (
+                "INSERT INTO state_roots VALUES (?1, ?2)",
+                (batch_number, Vec::from(state_root.to_fixed_bytes())).into_params()?,
+            ),
+        ];
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_blob_bundle_by_batch_number_in_tx(
+        &self,
+        batch_number: u64,
+        state_diff: Vec<Blob>,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let mut queries = vec![(
+            "DELETE FROM blob_bundles WHERE batch = ?1",
+            vec![batch_number].into_params()?,
+        )];
+        for (index, blob) in state_diff.iter().enumerate() {
+            let index = u64::try_from(index)
+                .map_err(|e| RollupStoreError::Custom(format!("conversion error: {e}")))?;
+            queries.push((
+                "INSERT INTO blob_bundles VALUES (?1, ?2, ?3)",
+                (batch_number, index, blob.to_vec()).into_params()?,
+            ));
+        }
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_commit_tx_by_batch_in_tx(
+        &self,
+        batch_number: u64,
+        commit_tx: H256,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let queries = vec![(
+            "INSERT OR REPLACE INTO commit_txs VALUES (?1, ?2)",
+            (batch_number, Vec::from(commit_tx.to_fixed_bytes())).into_params()?,
+        )];
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_verify_tx_by_batch_in_tx(
+        &self,
+        batch_number: u64,
+        verify_tx: H256,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let queries = vec![(
+            "INSERT OR REPLACE INTO verify_txs VALUES (?1, ?2)",
+            (batch_number, Vec::from(verify_tx.to_fixed_bytes())).into_params()?,
+        )];
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_account_updates_by_block_number_in_tx(
+        &self,
+        block_number: BlockNumber,
+        account_updates: Vec<AccountUpdate>,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        let serialized = bincode::serialize(&account_updates)?;
+        let queries = vec![
+            (
+                "DELETE FROM account_updates WHERE block_number = ?1",
+                vec![block_number].into_params()?,
+            ),
+            (
+                "INSERT INTO account_updates VALUES (?1, ?2)",
+                (block_number, serialized).into_params()?,
+            ),
+        ];
+        self.execute_in_tx(queries, db_tx).await
+    }
+
+    async fn store_block_numbers_by_batch_in_tx(
+        &self,
+        batch_number: u64,
+        block_numbers: Vec<BlockNumber>,
+        db_tx: Option<&Transaction>,
+    ) -> Result<(), RollupStoreError> {
+        for block_number in block_numbers {
+            self.store_batch_number_by_block_in_tx(block_number, batch_number, db_tx)
+                .await?;
+        }
         Ok(())
     }
 }
@@ -125,17 +301,8 @@ impl StoreEngineRollup for SQLStore {
         block_number: BlockNumber,
         batch_number: u64,
     ) -> Result<(), RollupStoreError> {
-        self.execute_in_tx(vec![
-            (
-                "DELETE FROM blocks WHERE block_number = ?1",
-                vec![block_number].into_params()?,
-            ),
-            (
-                "INSERT INTO blocks VALUES (?1, ?2)",
-                vec![block_number, batch_number].into_params()?,
-            ),
-        ])
-        .await
+        self.store_batch_number_by_block_in_tx(block_number, batch_number, None)
+            .await
     }
 
     /// Gets the message hashes by a given batch number.
@@ -167,20 +334,8 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         message_hashes: Vec<H256>,
     ) -> Result<(), RollupStoreError> {
-        let mut queries = vec![(
-            "DELETE FROM messages WHERE batch = ?1",
-            vec![batch_number].into_params()?,
-        )];
-        for (index, hash) in message_hashes.iter().enumerate() {
-            let index = u64::try_from(index)
-                .map_err(|e| RollupStoreError::Custom(format!("conversion error: {e}")))?;
-            queries.push((
-                "INSERT INTO messages VALUES (?1, ?2, ?3)",
-                (batch_number, index, Vec::from(hash.to_fixed_bytes())).into_params()?,
-            ));
-        }
-        self.execute_in_tx(queries).await?;
-        Ok(())
+        self.store_message_hashes_by_batch_in_tx(batch_number, message_hashes, None)
+            .await
     }
 
     /// Stores the block numbers by a given batch_number
@@ -189,11 +344,10 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         block_numbers: Vec<BlockNumber>,
     ) -> Result<(), RollupStoreError> {
-        for block_number in block_numbers {
-            self.store_batch_number_by_block(block_number, batch_number)
-                .await?;
-        }
-        Ok(())
+        let tx = self.conn.transaction().await?;
+        self.store_block_numbers_by_batch_in_tx(batch_number, block_numbers, Some(&tx))
+            .await?;
+        tx.commit().await.map_err(RollupStoreError::from)
     }
 
     /// Returns the block numbers by a given batch_number
@@ -221,20 +375,11 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         privileged_transactions_hash: H256,
     ) -> Result<(), RollupStoreError> {
-        self.execute_in_tx(vec![
-            (
-                "DELETE FROM privileged_transactions WHERE batch = ?1",
-                vec![batch_number].into_params()?,
-            ),
-            (
-                "INSERT INTO privileged_transactions VALUES (?1, ?2)",
-                (
-                    batch_number,
-                    Vec::from(privileged_transactions_hash.to_fixed_bytes()),
-                )
-                    .into_params()?,
-            ),
-        ])
+        self.store_privileged_transactions_hash_by_batch_number_in_tx(
+            batch_number,
+            privileged_transactions_hash,
+            None,
+        )
         .await
     }
 
@@ -260,17 +405,8 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         state_root: H256,
     ) -> Result<(), RollupStoreError> {
-        self.execute_in_tx(vec![
-            (
-                "DELETE FROM state_roots WHERE batch = ?1",
-                vec![batch_number].into_params()?,
-            ),
-            (
-                "INSERT INTO state_roots VALUES (?1, ?2)",
-                (batch_number, Vec::from(state_root.to_fixed_bytes())).into_params()?,
-            ),
-        ])
-        .await
+        self.store_state_root_by_batch_number_in_tx(batch_number, state_root, None)
+            .await
     }
 
     async fn get_state_root_by_batch_number(
@@ -295,20 +431,8 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         state_diff: Vec<Blob>,
     ) -> Result<(), RollupStoreError> {
-        let mut queries = vec![(
-            "DELETE FROM blob_bundles WHERE batch = ?1",
-            vec![batch_number].into_params()?,
-        )];
-        for (index, blob) in state_diff.iter().enumerate() {
-            let index = u64::try_from(index)
-                .map_err(|e| RollupStoreError::Custom(format!("conversion error: {e}")))?;
-            queries.push((
-                "INSERT INTO blob_bundles VALUES (?1, ?2, ?3)",
-                (batch_number, index, blob.to_vec()).into_params()?,
-            ));
-        }
-        self.execute_in_tx(queries).await?;
-        Ok(())
+        self.store_blob_bundle_by_batch_number_in_tx(batch_number, state_diff, None)
+            .await
     }
 
     async fn get_blob_bundle_by_batch_number(
@@ -342,11 +466,8 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         commit_tx: H256,
     ) -> Result<(), RollupStoreError> {
-        self.execute_in_tx(vec![(
-            "INSERT OR REPLACE INTO commit_txs VALUES (?1, ?2)",
-            (batch_number, Vec::from(commit_tx.to_fixed_bytes())).into_params()?,
-        )])
-        .await
+        self.store_commit_tx_by_batch_in_tx(batch_number, commit_tx, None)
+            .await
     }
 
     async fn get_commit_tx_by_batch(
@@ -371,11 +492,8 @@ impl StoreEngineRollup for SQLStore {
         batch_number: u64,
         verify_tx: H256,
     ) -> Result<(), RollupStoreError> {
-        self.execute_in_tx(vec![(
-            "INSERT OR REPLACE INTO verify_txs VALUES (?1, ?2)",
-            (batch_number, Vec::from(verify_tx.to_fixed_bytes())).into_params()?,
-        )])
-        .await
+        self.store_verify_tx_by_batch_in_tx(batch_number, verify_tx, None)
+            .await
     }
 
     async fn get_verify_tx_by_batch(
@@ -470,22 +588,12 @@ impl StoreEngineRollup for SQLStore {
         block_number: BlockNumber,
         account_updates: Vec<AccountUpdate>,
     ) -> Result<(), RollupStoreError> {
-        let serialized = bincode::serialize(&account_updates)?;
-        self.execute_in_tx(vec![
-            (
-                "DELETE FROM account_updates WHERE block_number = ?1",
-                vec![block_number].into_params()?,
-            ),
-            (
-                "INSERT INTO account_updates VALUES (?1, ?2)",
-                (block_number, serialized).into_params()?,
-            ),
-        ])
-        .await
+        self.store_account_updates_by_block_number_in_tx(block_number, account_updates, None)
+            .await
     }
 
     async fn revert_to_batch(&self, batch_number: u64) -> Result<(), RollupStoreError> {
-        self.execute_in_tx(vec![
+        let queries = vec![
             (
                 "DELETE FROM blocks WHERE batch > ?1",
                 [batch_number].into_params()?,
@@ -510,9 +618,8 @@ impl StoreEngineRollup for SQLStore {
                 "DELETE FROM batch_proofs WHERE batch > ?1",
                 [batch_number].into_params()?,
             ),
-        ])
-        .await?;
-        Ok(())
+        ];
+        self.execute_in_tx(queries, None).await
     }
 
     async fn store_proof_by_batch_and_type(
@@ -523,18 +630,20 @@ impl StoreEngineRollup for SQLStore {
     ) -> Result<(), RollupStoreError> {
         let serialized_proof = bincode::serialize(&proof)?;
         let prover_type: u32 = prover_type.into();
-        self.execute_in_tx(vec![
-            (
-                "DELETE FROM batch_proofs WHERE batch = ?1 AND prover_type = ?2",
-                (batch_number, prover_type).into_params()?,
-            ),
-            (
-                "INSERT INTO batch_proofs VALUES (?1, ?2, ?3)",
-                (batch_number, prover_type, serialized_proof).into_params()?,
-            ),
-        ])
-        .await?;
-        Ok(())
+        self.execute_in_tx(
+            vec![
+                (
+                    "DELETE FROM batch_proofs WHERE batch = ?1 AND prover_type = ?2",
+                    (batch_number, prover_type).into_params()?,
+                ),
+                (
+                    "INSERT INTO batch_proofs VALUES (?1, ?2, ?3)",
+                    (batch_number, prover_type, serialized_proof).into_params()?,
+                ),
+            ],
+            None,
+        )
+        .await
     }
 
     async fn get_proof_by_batch_and_type(
@@ -555,6 +664,51 @@ impl StoreEngineRollup for SQLStore {
             return Ok(Some(bincode::deserialize(&vec)?));
         }
         Ok(None)
+    }
+
+    async fn seal_batch(&self, batch: Batch) -> Result<(), RollupStoreError> {
+        let blocks: Vec<u64> = (batch.first_block..=batch.last_block).collect();
+        let transaction = self.conn.transaction().await?;
+
+        for block_number in blocks.iter() {
+            self.store_batch_number_by_block_in_tx(*block_number, batch.number, Some(&transaction))
+                .await?;
+        }
+        self.store_block_numbers_by_batch_in_tx(batch.number, blocks, Some(&transaction))
+            .await?;
+        self.store_message_hashes_by_batch_in_tx(
+            batch.number,
+            batch.message_hashes,
+            Some(&transaction),
+        )
+        .await?;
+        self.store_privileged_transactions_hash_by_batch_number_in_tx(
+            batch.number,
+            batch.privileged_transactions_hash,
+            Some(&transaction),
+        )
+        .await?;
+        self.store_blob_bundle_by_batch_number_in_tx(
+            batch.number,
+            batch.blobs_bundle.blobs,
+            Some(&transaction),
+        )
+        .await?;
+        self.store_state_root_by_batch_number_in_tx(
+            batch.number,
+            batch.state_root,
+            Some(&transaction),
+        )
+        .await?;
+        if let Some(commit_tx) = batch.commit_tx {
+            self.store_commit_tx_by_batch_in_tx(batch.number, commit_tx, Some(&transaction))
+                .await?;
+        }
+        if let Some(verify_tx) = batch.verify_tx {
+            self.store_verify_tx_by_batch_in_tx(batch.number, verify_tx, Some(&transaction))
+                .await?;
+        }
+        transaction.commit().await.map_err(RollupStoreError::from)
     }
 }
 

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -15,8 +15,8 @@ use libsql::{
 
 /// ### SQLStore
 /// - `read_conn`: a connection to the database to be used for read only statements
-/// - `write_conn`: a connection to the database to be used for database writes. If writes are done using
-///   the read only connection `SQLite failure: database is locked` problems will arise
+/// - `write_conn`: a connection to the database to be used for writing, protected by a Mutex to enforce a maximum of 1 writer.
+///   If writes are done using the read only connection `SQLite failure: database is locked` problems will arise
 pub struct SQLStore {
     read_conn: Connection,
     write_conn: Arc<Mutex<Connection>>,

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -55,7 +55,7 @@ impl SQLStore {
             write_conn.busy_timeout(Duration::from_millis(5000))?;
             let store = SQLStore {
                 read_conn: db.connect()?,
-                write_conn: Arc::new(Mutex::new(db.connect()?)),
+                write_conn: Arc::new(Mutex::new(write_conn)),
             };
             store.init_db().await?;
             Ok(store)

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -285,7 +285,6 @@ impl StoreEngineRollup for SQLStore {
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<u64>, RollupStoreError> {
-        dbg!("get_batch_number_by_block");
         let mut rows = self
             .query(
                 "SELECT * from blocks WHERE block_number = ?1",
@@ -293,7 +292,7 @@ impl StoreEngineRollup for SQLStore {
             )
             .await?;
         if let Some(row) = rows.next().await? {
-            return Ok(Some(dbg!(read_from_row_int(&row, 1))?));
+            return Ok(Some(read_from_row_int(&row, 1)?));
         }
         Ok(None)
     }
@@ -303,7 +302,6 @@ impl StoreEngineRollup for SQLStore {
         &self,
         batch_number: u64,
     ) -> Result<Option<Vec<H256>>, RollupStoreError> {
-        dbg!("get_message_hashes_by_batch");
         let mut hashes = vec![];
         let mut rows = self
             .query(
@@ -312,14 +310,14 @@ impl StoreEngineRollup for SQLStore {
             )
             .await?;
         while let Some(row) = rows.next().await? {
-            let vec = dbg!(read_from_row_blob(&row, 2))?;
-            hashes.push(dbg!(H256::from_slice(&vec)));
+            let vec = read_from_row_blob(&row, 2)?;
+            hashes.push(H256::from_slice(&vec));
         }
-        dbg!(if hashes.is_empty() {
+        if hashes.is_empty() {
             Ok(None)
         } else {
             Ok(Some(hashes))
-        })
+        }
     }
 
     /// Returns the block numbers by a given batch_number


### PR DESCRIPTION
 **Motivation**

When deploying ethrex L2 some errors came up that are related to the seal_batch process not being done in a single DB transaction.

**Description**

- Move seal_batch to the `StoreEngineRollup` trait
- For sql rollup store engine
   - Wrap all the DB write functions from the trait with a <name>_in_tx that gets as an input an Option<Transaction> in case the transaction is Some then it uses the existing transaction, and does not commit. If its None it creates a new transaction and commits at the end of the function.
   - Modify the `SQLStore` struct to hold two instances of `Connection` one for reads and one for writes, the write connection is protected by a Mutex to enforce a maximum of 1 to prevent this error:
      ```
      failed because of a rollup store error: Limbo Query error: SQLite failure: `cannot start a transaction within a transaction`
      ``` 
   - Use `PRAGMA journal_mode=WAL` for [better concurrency](https://sqlite.org/wal.html#concurrency)
- For `libmdbx` , `redb` and `in-memory`
   - Implement the `seal_batch` function 
- Refactor: remove all the functions that were exposed by `store.rs` and were only part of seal_batch to prevent its usage outside of batch sealing.


Closes #3546 

