### PR TITLE
chore(l1): drop total difficulty panel from metrics exporter

### DIFF
--- a/crates/blockchain/metrics/provisioning/grafana_provisioning/dashboards/common_dashboards/ethereum_metrics_exporter.json
+++ b/crates/blockchain/metrics/provisioning/grafana_provisioning/dashboards/common_dashboards/ethereum_metrics_exporter.json
@@ -2354,7 +2354,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 5,
+        "w": 7,
         "x": 5,
         "y": 31
       },
@@ -2447,8 +2447,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 5,
-        "x": 10,
+        "w": 7,
+        "x": 12,
         "y": 31
       },
       "id": 39,
@@ -2541,7 +2541,7 @@
       "gridPos": {
         "h": 6,
         "w": 5,
-        "x": 15,
+        "x": 19,
         "y": 31
       },
       "id": 45,
@@ -2571,99 +2571,6 @@
         }
       ],
       "title": "Peers",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prom-001"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 31
-      },
-      "id": 47,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prom-001"
-          },
-          "exemplar": true,
-          "expr": "sum by (instance)(\n    eth_exe_block_head_total_difficulty_trillions{instance=~\"$instance\"}\n)",
-          "interval": "",
-          "legendFormat": "{{ instance }}",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Difficulty (trillions)",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
**Motivation**

Given that the blockchain total difficulty is deprecated for Ethereum Post Merge there's no need for a panel monitoring it in when exporting metrics for syncing.

**Description**

This pr deletes the Total Difficulty dashboard from the json used to show the metrics with grafana. It also changes the size of some remaining panels to have a tidy distribution of them on sight. 

Closes #3469

