### PR TITLE
fix(l2): use github token to avoid rate limit

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -74,6 +74,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # also creates empty verification keys (as workflow runs with exec backend)
       - name: Build prover
@@ -142,7 +143,8 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build L1 docker image
         uses: docker/build-push-action@v6
         with:
@@ -238,9 +240,10 @@ jobs:
           push: false
 
       - name: Install solc
-        run: |
-          sudo add-apt-repository ppa:ethereum/ethereum
-          sudo apt-get update && sudo apt-get -y install solc
+        uses: pontem-network/get-solc@master
+        with:
+          version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start L1 & Deploy contracts
         run: |

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       # also creates empty verification keys (as workflow runs with exec backend)
       - name: Build prover
@@ -143,7 +143,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       - name: Build L1 docker image
         uses: docker/build-push-action@v6
@@ -243,7 +243,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       - name: Start L1 & Deploy contracts
         run: |

--- a/.github/workflows/pr-main_l2_contracts.yaml
+++ b/.github/workflows/pr-main_l2_contracts.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       - name: Caching
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr-main_l2_contracts.yaml
+++ b/.github/workflows/pr-main_l2_contracts.yaml
@@ -28,6 +28,8 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Caching
         uses: Swatinem/rust-cache@v2
       - name: Run test of deployer.rs

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -247,6 +247,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmarks
         run: |

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -247,7 +247,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       - name: Run benchmarks
         run: |

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN || '' }}
 
       - name: Download PR binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -84,6 +84,7 @@ jobs:
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download PR binaries
         uses: actions/download-artifact@v4


### PR DESCRIPTION
**Motivation**

Our CI is failing at the `Install solc` step in almost all jobs due to a `rate limit` error.

**Description**

Authenticates using a GitHub token to bypass the rate limit.

Closes None

