### PR TITLE
fix(l2): avoid proving already proved batch

### DIFF
--- a/crates/l2/sequencer/proof_coordinator.rs
+++ b/crates/l2/sequencer/proof_coordinator.rs
@@ -444,14 +444,27 @@ async fn handle_request(
     .await
     .map_err(|err| ProofCoordinatorError::InternalError(err.to_string()))?;
 
-    let response = if !state.rollup_store.contains_batch(&batch_to_verify).await? {
-        debug!("Sending empty BatchResponse");
-        ProofData::empty_batch_response()
-    } else {
-        let input = create_prover_input(state, batch_to_verify).await?;
-        debug!("Sending BatchResponse for block_number: {batch_to_verify}");
-        ProofData::batch_response(batch_to_verify, input)
-    };
+    let mut all_proofs_exist = true;
+    for proof_type in &state.needed_proof_types {
+        if state
+            .rollup_store
+            .get_proof_by_batch_and_type(batch_to_verify, *proof_type)
+            .await?
+            .is_none()
+        {
+            all_proofs_exist = false;
+        }
+    }
+
+    let response =
+        if all_proofs_exist || !state.rollup_store.contains_batch(&batch_to_verify).await? {
+            debug!("Sending empty BatchResponse");
+            ProofData::empty_batch_response()
+        } else {
+            let input = create_prover_input(state, batch_to_verify).await?;
+            debug!("Sending BatchResponse for block_number: {batch_to_verify}");
+            ProofData::batch_response(batch_to_verify, input)
+        };
 
     send_response(stream, &response).await?;
     info!("BatchResponse sent for batch number: {batch_to_verify}");


### PR DESCRIPTION
**Motivation**
Avoid this situation:
- Prover finishes proving batch n
- Prover asks for batch to prove gets batch n again
- Committer commits batch n + 1
- Prover is still proving batch n when it could start proving batch n + 1


**Description**

- Before sending a new batch to prove check if we already have all needed proofs for that batch stored in the DB in case we do send and empty response

Closes #3545

