### PR TITLE
ci(l1,l2): rename release binaries

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -63,14 +63,14 @@ jobs:
           - platform: ubuntu-22.04
             os: linux
             arch: x86_64
+            rustflags: -C target-cpu=native
           - platform: ubuntu-22.04-arm
             os: linux
             arch: aarch64
+            rustflags: -C target-cpu=native
           - platform: macos-latest
             os: macos
             arch: aarch64
-          - os: linux
-            rustflags: -C target-cpu=native
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
In Ansible, server architectures are read as `x86_64` and `aarch64`, so it's easier to download the binaries if they have that names, considering we didn't choose current names on any purpose.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Rename `x86-64` with `x86_64` and `amd64` with `aarch64`. Also made some refactor to simplify the strategies matrix and move big prover/replay `if`s to workflow level instead of shell

<!-- Link to issues: Resolves #111, Resolves #222 -->


