### PR TITLE
feat(l2): monitor handle panics

### DIFF
--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -90,7 +90,7 @@ impl EthrexMonitor {
                 &rollup_store,
             )
             .await?,
-            blocks_table: BlocksTable::new(&store).await,
+            blocks_table: BlocksTable::new(&store).await?,
             l1_to_l2_messages: L1ToL2MessagesTable::new(
                 cfg.l1_watcher.bridge_address,
                 &eth_client,
@@ -216,7 +216,7 @@ impl EthrexMonitor {
         self.batches_table
             .on_tick(&self.eth_client, &self.rollup_store)
             .await?;
-        self.blocks_table.on_tick(&self.store).await;
+        self.blocks_table.on_tick(&self.store).await?;
         self.l1_to_l2_messages
             .on_tick(&self.eth_client, &self.store)
             .await?;

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -58,14 +58,14 @@ impl EthrexMonitor {
         store: Store,
         rollup_store: StoreRollup,
         cfg: &SequencerConfig,
-    ) -> Self {
+    ) -> Result<Self, MonitorError> {
         let eth_client = EthClient::new(cfg.eth.rpc_url.first().expect("No RPC URLs provided"))
             .expect("Failed to create EthClient");
         // TODO: De-hardcode the rollup client URL
         let rollup_client =
             EthClient::new("http://localhost:1729").expect("Failed to create RollupClient");
 
-        EthrexMonitor {
+        Ok(EthrexMonitor {
             title: if cfg.based.based {
                 "Based Ethrex Monitor".to_string()
             } else {
@@ -96,18 +96,18 @@ impl EthrexMonitor {
                 &eth_client,
                 &store,
             )
-            .await,
+            .await?,
             l2_to_l1_messages: L2ToL1MessagesTable::new(
                 cfg.l1_watcher.bridge_address,
                 &eth_client,
                 &rollup_client,
             )
-            .await,
+            .await?,
             eth_client,
             rollup_client,
             store,
             rollup_store,
-        }
+        })
     }
 
     pub async fn start(mut self) -> Result<(), MonitorError> {
@@ -147,7 +147,7 @@ impl EthrexMonitor {
 
             let timeout = Duration::from_millis(self.tick_rate).saturating_sub(last_tick.elapsed());
             if !event::poll(timeout)? {
-                self.on_tick().await;
+                self.on_tick().await?;
                 last_tick = Instant::now();
                 continue;
             }
@@ -207,7 +207,7 @@ impl EthrexMonitor {
         }
     }
 
-    pub async fn on_tick(&mut self) {
+    pub async fn on_tick(&mut self) -> Result<(), MonitorError> {
         self.node_status.on_tick(&self.store).await;
         self.global_chain_status
             .on_tick(&self.eth_client, &self.store, &self.rollup_store)
@@ -219,10 +219,12 @@ impl EthrexMonitor {
         self.blocks_table.on_tick(&self.store).await;
         self.l1_to_l2_messages
             .on_tick(&self.eth_client, &self.store)
-            .await;
+            .await?;
         self.l2_to_l1_messages
             .on_tick(&self.eth_client, &self.rollup_client)
-            .await;
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -89,7 +89,7 @@ impl EthrexMonitor {
                 &eth_client,
                 &rollup_store,
             )
-            .await,
+            .await?,
             blocks_table: BlocksTable::new(&store).await,
             l1_to_l2_messages: L1ToL2MessagesTable::new(
                 cfg.l1_watcher.bridge_address,
@@ -215,7 +215,7 @@ impl EthrexMonitor {
         self.mempool.on_tick(&self.rollup_client).await;
         self.batches_table
             .on_tick(&self.eth_client, &self.rollup_store)
-            .await;
+            .await?;
         self.blocks_table.on_tick(&self.store).await;
         self.l1_to_l2_messages
             .on_tick(&self.eth_client, &self.store)

--- a/crates/l2/monitor/mod.rs
+++ b/crates/l2/monitor/mod.rs
@@ -1,6 +1,5 @@
 // TODO: Handle this expects
 #![expect(clippy::expect_used)]
-#![expect(clippy::panic)]
 #![expect(clippy::indexing_slicing)]
 
 pub(crate) mod app;
@@ -21,7 +20,7 @@ pub async fn start_monitor(
     rollup_store: StoreRollup,
     cfg: SequencerConfig,
 ) -> Result<(), SequencerError> {
-    let app = EthrexMonitor::new(sequencer_state, store, rollup_store, &cfg).await;
+    let app = EthrexMonitor::new(sequencer_state, store, rollup_store, &cfg).await?;
     app.start().await?;
     Ok(())
 }

--- a/crates/l2/monitor/mod.rs
+++ b/crates/l2/monitor/mod.rs
@@ -1,7 +1,7 @@
 // TODO: Handle this expects
 #![expect(clippy::expect_used)]
 #![expect(clippy::indexing_slicing)]
-
+#[allow(clippy::result_large_err)]
 pub(crate) mod app;
 pub(crate) mod utils;
 pub(crate) mod widget;

--- a/crates/l2/monitor/mod.rs
+++ b/crates/l2/monitor/mod.rs
@@ -1,7 +1,7 @@
 // TODO: Handle this expects
 #![expect(clippy::expect_used)]
 #![expect(clippy::indexing_slicing)]
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub(crate) mod app;
 pub(crate) mod utils;
 pub(crate) mod widget;

--- a/crates/l2/monitor/utils.rs
+++ b/crates/l2/monitor/utils.rs
@@ -33,10 +33,11 @@ pub async fn get_logs(
                     .collect(),
             )
             .await
-            .map_err(|_| {
+            .map_err(|e| {
                 MonitorError::LogsSignatures(
                     logs_signatures.iter().map(|s| s.to_string()).collect(),
                     emitter,
+                    e,
                 )
             })?;
 

--- a/crates/l2/monitor/utils.rs
+++ b/crates/l2/monitor/utils.rs
@@ -4,12 +4,14 @@ use ethrex_common::{Address, U256};
 use ethrex_rpc::{EthClient, types::receipt::RpcLog};
 use keccak_hash::keccak;
 
+use crate::sequencer::errors::MonitorError;
+
 pub async fn get_logs(
     last_block_fetched: &mut U256,
     emitter: Address,
     logs_signatures: Vec<&str>,
     client: &EthClient,
-) -> Vec<RpcLog> {
+) -> Result<Vec<RpcLog>, MonitorError> {
     let last_block_number = client
         .get_block_number()
         .await
@@ -31,7 +33,12 @@ pub async fn get_logs(
                     .collect(),
             )
             .await
-            .unwrap_or_else(|_| panic!("Failed to fetch {logs_signatures:?} logs from {emitter}"));
+            .map_err(|_| {
+                MonitorError::LogsSignatures(
+                    logs_signatures.iter().map(|s| s.to_string()).collect(),
+                    emitter,
+                )
+            })?;
 
         // Update the last L1 block fetched.
         *last_block_fetched = new_last_l1_fetched_block;
@@ -39,5 +46,5 @@ pub async fn get_logs(
         batch_committed_logs.extend_from_slice(&logs);
     }
 
-    batch_committed_logs
+    Ok(batch_committed_logs)
 }

--- a/crates/l2/monitor/widget/blocks.rs
+++ b/crates/l2/monitor/widget/blocks.rs
@@ -11,9 +11,12 @@ use ratatui::{
     widgets::{Row, StatefulWidget, Table, TableState},
 };
 
-use crate::monitor::widget::{
-    ADDRESS_LENGTH_IN_DIGITS, BLOCK_SIZE_LENGTH_IN_DIGITS, GAS_USED_LENGTH_IN_DIGITS,
-    HASH_LENGTH_IN_DIGITS, NUMBER_LENGTH_IN_DIGITS, TX_NUMBER_LENGTH_IN_DIGITS,
+use crate::{
+    monitor::widget::{
+        ADDRESS_LENGTH_IN_DIGITS, BLOCK_SIZE_LENGTH_IN_DIGITS, GAS_USED_LENGTH_IN_DIGITS,
+        HASH_LENGTH_IN_DIGITS, NUMBER_LENGTH_IN_DIGITS, TX_NUMBER_LENGTH_IN_DIGITS,
+    },
+    sequencer::errors::MonitorError,
 };
 
 pub struct BlocksTable {
@@ -24,35 +27,37 @@ pub struct BlocksTable {
 }
 
 impl BlocksTable {
-    pub async fn new(store: &Store) -> Self {
+    pub async fn new(store: &Store) -> Result<Self, MonitorError> {
         let mut last_l2_block_known = 0;
-        let items = Self::refresh_items(&mut last_l2_block_known, store).await;
-        Self {
+        let items = Self::refresh_items(&mut last_l2_block_known, store).await?;
+        Ok(Self {
             state: TableState::default(),
             items,
             last_l2_block_known,
-        }
+        })
     }
 
-    pub async fn on_tick(&mut self, store: &Store) {
-        let mut new_blocks = Self::refresh_items(&mut self.last_l2_block_known, store).await;
+    pub async fn on_tick(&mut self, store: &Store) -> Result<(), MonitorError> {
+        let mut new_blocks = Self::refresh_items(&mut self.last_l2_block_known, store).await?;
         new_blocks.truncate(50);
 
         let n_new_blocks = new_blocks.len();
         self.items.truncate(50 - n_new_blocks);
         self.items.extend_from_slice(&new_blocks);
         self.items.rotate_right(n_new_blocks);
+
+        Ok(())
     }
 
     async fn refresh_items(
         last_l2_block_known: &mut u64,
         store: &Store,
-    ) -> Vec<(String, String, String, String, String, String, String)> {
-        let new_blocks = Self::get_blocks(last_l2_block_known, store).await;
+    ) -> Result<Vec<(String, String, String, String, String, String, String)>, MonitorError> {
+        let new_blocks = Self::get_blocks(last_l2_block_known, store).await?;
 
         let new_blocks_processed = Self::process_blocks(new_blocks).await;
 
-        new_blocks_processed
+        Ok(new_blocks_processed
             .iter()
             .map(|(number, n_txs, hash, coinbase, gas, blob_gas, size)| {
                 (
@@ -65,10 +70,13 @@ impl BlocksTable {
                     size.to_string(),
                 )
             })
-            .collect()
+            .collect())
     }
 
-    async fn get_blocks(last_l2_block_known: &mut u64, store: &Store) -> Vec<Block> {
+    async fn get_blocks(
+        last_l2_block_known: &mut u64,
+        store: &Store,
+    ) -> Result<Vec<Block>, MonitorError> {
         let last_l2_block_number = store
             .get_latest_block_number()
             .await
@@ -81,12 +89,8 @@ impl BlocksTable {
             let new_block = store
                 .get_block_by_number(new_last_l1_fetched_block)
                 .await
-                .unwrap_or_else(|_| {
-                    panic!("Failed to get block  by number ({new_last_l1_fetched_block})")
-                })
-                .unwrap_or_else(|| {
-                    panic!("Block {new_last_l1_fetched_block} not found in the store")
-                });
+                .map_err(|_| MonitorError::GetBlockByNumber(new_last_l1_fetched_block))?
+                .ok_or(MonitorError::BlockNotFound(new_last_l1_fetched_block))?;
 
             // Update the last L1 block fetched.
             *last_l2_block_known = new_last_l1_fetched_block;
@@ -94,7 +98,7 @@ impl BlocksTable {
             new_blocks.push(new_block);
         }
 
-        new_blocks
+        Ok(new_blocks)
     }
 
     async fn process_blocks(

--- a/crates/l2/monitor/widget/blocks.rs
+++ b/crates/l2/monitor/widget/blocks.rs
@@ -89,7 +89,7 @@ impl BlocksTable {
             let new_block = store
                 .get_block_by_number(new_last_l1_fetched_block)
                 .await
-                .map_err(|_| MonitorError::GetBlockByNumber(new_last_l1_fetched_block))?
+                .map_err(|e| MonitorError::GetBlockByNumber(new_last_l1_fetched_block, e))?
                 .ok_or(MonitorError::BlockNotFound(new_last_l1_fetched_block))?;
 
             // Update the last L1 block fetched.

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -298,14 +298,14 @@ pub enum ConnectionHandlerError {
 pub enum MonitorError {
     #[error("Failed because of io error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Failed to fetch {0:?} logs from {1}")]
-    LogsSignatures(Vec<String>, Address),
+    #[error("Failed to fetch {0:?} logs from {1}, {2}")]
+    LogsSignatures(Vec<String>, Address, #[source] EthClientError),
     #[error("Failed to get batch by number {0}: {1}")]
     RollupStore(u64, #[source] RollupStoreError),
     #[error("Batch {0} not found in the rollup store")]
     BatchNotFound(u64),
-    #[error("Failed to get block by number {0}")]
-    GetBlockByNumber(u64),
+    #[error("Failed to get block by number {0}, {1}")]
+    GetBlockByNumber(u64, #[source] StoreError),
     #[error("Block {0} not found in the store")]
     BlockNotFound(u64),
 }

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -304,4 +304,8 @@ pub enum MonitorError {
     RollupStore(u64, #[source] RollupStoreError),
     #[error("Batch {0} not found in the rollup store")]
     BatchNotFound(u64),
+    #[error("Failed to get block by number {0}")]
+    GetBlockByNumber(u64),
+    #[error("Block {0} not found in the store")]
+    BlockNotFound(u64),
 }

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -3,6 +3,7 @@ use crate::based::state_updater::StateUpdaterError;
 use crate::utils::error::UtilsError;
 use ethereum_types::FromStrRadixErr;
 use ethrex_blockchain::error::{ChainError, InvalidForkChoice};
+use ethrex_common::Address;
 use ethrex_common::types::{BlobsBundleError, FakeExponentialError};
 use ethrex_l2_common::privileged_transactions::PrivilegedTransactionError;
 use ethrex_l2_common::prover::ProverType;
@@ -297,4 +298,6 @@ pub enum ConnectionHandlerError {
 pub enum MonitorError {
     #[error("Failed because of io error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Failed to fetch {0:?} logs from {1}")]
+    LogsSignatures(Vec<String>, Address),
 }

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -300,4 +300,8 @@ pub enum MonitorError {
     Io(#[from] std::io::Error),
     #[error("Failed to fetch {0:?} logs from {1}")]
     LogsSignatures(Vec<String>, Address),
+    #[error("Failed to get batch by number {0}: {1}")]
+    RollupStore(u64, #[source] RollupStoreError),
+    #[error("Batch {0} not found in the rollup store")]
+    BatchNotFound(u64),
 }


### PR DESCRIPTION
**Motivation**
Monitor had panics in its code.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Added new variants for `MonitorError` and used them to remove the panics in the monitor

<!-- A clear and concise general description of the changes this PR introduces -->

**How to test**

- Add `--monitor` to the `init-l2-no-metrics` target in `crates/l2/Makefile`.
- Run a Sequencer (I suggest `make restart` in `crates/l2`).
- Run the prover with `make init-prover` in `crates/l2`.
- Run `make test` in `crates/l2`.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/orgs/lambdaclass/projects/37/views/10?pane=issue&itemId=118823684&issue=lambdaclass%7Cethrex%7C3536

