### PR TITLE
feat(l2): monitor add delay to scroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,7 +4213,7 @@ dependencies = [
  "futures-util",
  "hex",
  "lazy_static",
- "reqwest 0.12.22",
+ "reqwest 0.12.20",
  "revm 19.7.0",
  "revm-inspectors",
  "revm-primitives 15.2.0",

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -31,6 +31,8 @@ use crate::{
     sequencer::errors::MonitorError,
 };
 
+const SCROLL_DEBOUNCE_DURATION: u64 = 700; // milliseconds
+
 pub struct EthrexMonitor {
     pub title: String,
     pub should_quit: bool,
@@ -198,7 +200,7 @@ impl EthrexMonitor {
     }
 
     pub fn on_mouse_event(&mut self, kind: MouseEventKind) {
-        let scroll_delay = Duration::from_millis(700);
+        let scroll_delay = Duration::from_millis(SCROLL_DEBOUNCE_DURATION);
 
         let now = Instant::now();
         if now.duration_since(self.last_scroll) < scroll_delay {

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -50,6 +50,7 @@ pub struct EthrexMonitor {
     pub rollup_client: EthClient,
     pub store: Store,
     pub rollup_store: StoreRollup,
+    pub last_scroll: Instant,
 }
 
 impl EthrexMonitor {
@@ -107,6 +108,7 @@ impl EthrexMonitor {
             rollup_client,
             store,
             rollup_store,
+            last_scroll: Instant::now(),
         })
     }
 
@@ -196,6 +198,15 @@ impl EthrexMonitor {
     }
 
     pub fn on_mouse_event(&mut self, kind: MouseEventKind) {
+        let scroll_delay = Duration::from_millis(700);
+
+        let now = Instant::now();
+        if now.duration_since(self.last_scroll) < scroll_delay {
+            return; // Ignore the scroll — too soon
+        }
+
+        self.last_scroll = now;
+
         match (&self.tabs, kind) {
             (TabsState::Logs, MouseEventKind::ScrollDown) => {
                 self.logger.transition(TuiWidgetEvent::NextPageKey)

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -31,7 +31,7 @@ use crate::{
     sequencer::errors::MonitorError,
 };
 
-const SCROLL_DEBOUNCE_DURATION: u64 = 700; // milliseconds
+const SCROLL_DEBOUNCE_DURATION: Duration = Duration::from_millis(700); // 700ms
 
 pub struct EthrexMonitor {
     pub title: String,
@@ -200,10 +200,8 @@ impl EthrexMonitor {
     }
 
     pub fn on_mouse_event(&mut self, kind: MouseEventKind) {
-        let scroll_delay = Duration::from_millis(SCROLL_DEBOUNCE_DURATION);
-
         let now = Instant::now();
-        if now.duration_since(self.last_scroll) < scroll_delay {
+        if now.duration_since(self.last_scroll) < SCROLL_DEBOUNCE_DURATION {
             return; // Ignore the scroll — too soon
         }
 


### PR DESCRIPTION
**Motivation**
Monitor scroll goes too fast
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Added a delay for the log scroll
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
**How to Test**

- Add `--monitor` to the `init-l2-no-metrics` target in `crates/l2/Makefile`.
- Run a Sequencer (I suggest `make restart` in `crates/l2`).
- Run the prover with `make init-prover` in `crates/l2`.
- Run `make test` in `crates/l2`.
- Press Tab to change the Tab
- Scroll Up and Down to test the scroll

Closes https://github.com/orgs/lambdaclass/projects/37/views/10?pane=issue&itemId=118809801&issue=lambdaclass%7Cethrex%7C3514

