### PR TITLE
fix(levm): ignore DB storage values for destroyed accounts

### DIFF
--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -72,7 +72,7 @@ impl GeneralizedDatabase {
         key: H256,
     ) -> Result<U256, InternalError> {
         // If the account was destroyed then we cannot rely on the DB to obtain its previous value
-        // This is critical when executing block in batches, as an account may be destructed and created within the same batch
+        // This is critical when executing blocks in batches, as an account may be destroyed and created within the same batch
         if self.destroyed_accounts.contains(&address) {
             return Ok(Default::default());
         }

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -71,6 +71,10 @@ impl GeneralizedDatabase {
         address: Address,
         key: H256,
     ) -> Result<U256, InternalError> {
+        // If the account was destroyed then we cannot rely on the DB to obtain its previous value
+        if self.destroyed_accounts.contains(&address) {
+            return Ok(Default::default())
+        }
         let value = self.store.get_storage_value(address, key)?;
         // Account must already be in initial_accounts_state
         match self.initial_accounts_state.get_mut(&address) {

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -74,7 +74,7 @@ impl GeneralizedDatabase {
         // If the account was destroyed then we cannot rely on the DB to obtain its previous value
         // This is critical when executing block in batches, as an account may be destructed and created within the same batch
         if self.destroyed_accounts.contains(&address) {
-            return Ok(Default::default())
+            return Ok(Default::default());
         }
         let value = self.store.get_storage_value(address, key)?;
         // Account must already be in initial_accounts_state

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -72,6 +72,7 @@ impl GeneralizedDatabase {
         key: H256,
     ) -> Result<U256, InternalError> {
         // If the account was destroyed then we cannot rely on the DB to obtain its previous value
+        // This is critical when executing block in batches, as an account may be destructed and created within the same batch
         if self.destroyed_accounts.contains(&address) {
             return Ok(Default::default())
         }


### PR DESCRIPTION
**Motivation**
When executing blocks in batches an account may be destroyed and created again within the same batch. This can lead to errors as we might try to load a storage value from the DB (such as in an `SLOAD`) that doesn't exist in the newly created account but that used to be part of the now destroyed account, leading to the incorrect value being loaded.
This was detected on sepolia testnet block range 3302786-3302799 where a an account was destructed via `SELFDESTRUCT` and then created 6 blocks later via `CREATE`. The same transaction that created it then performed an `SSTORE` which was charged the default fee (100 gas) as the stored key and value matched the ones in the previously destroyed storage instead of charging the storage creation fee (2000 gas). The value was previously fetched from the DB by an `SLOAD` operation.
This PR solves this issue by first checking if the account was destroyed before looking up a storage value in the DB (The `Store`). If an account was destroyed then whatever was stored in the DB is no longer valid, so we return the default value (as we would do if the key doesn't exist)
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* (`levm` crate)`GeneralizedDatabase::get_value_from_database`: check if the account was destroyed before querying the DB. If the account was destroyed return default value
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

