### PR TITLE
feat(l1): measure & speed up healing during snap sync

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -316,18 +316,6 @@ impl Syncer {
                     let block_number = block.header.number;
                     info!("Executing block: {block_number}");
 
-                    // TODO: The following code block is for debugging purposes only, please remove 
-                    {
-                        // Check if we have the parent
-                        let parent_block = store
-                            .get_block_by_hash(block.header.parent_hash)
-                            .await
-                            .unwrap()
-                            .unwrap();
-                        if !store.contains_state_node(parent_block.header.state_root)? {
-                            panic!("Missing state root for parent block")
-                        }
-                    }
                     self.blockchain.add_block(&block).await?;
                     store.set_canonical_block(block_number, *hash).await?;
                     store.update_latest_block_number(block_number).await?;

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -292,7 +292,7 @@ impl Syncer {
                     pivot_header.number
                 );
                 let store_bodies_handle = tokio::spawn(store_block_bodies(
-                    all_block_hashes[pivot_idx + 1..].to_vec(),
+                    all_block_hashes[pivot_idx..].to_vec(),
                     self.peers.clone(),
                     store.clone(),
                 ));

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -15,7 +15,7 @@ use ethrex_common::{
 };
 use ethrex_rlp::error::RLPDecodeError;
 use ethrex_storage::{EngineType, STATE_TRIE_SEGMENTS, Store, error::StoreError};
-use ethrex_trie::{Nibbles, Node, NodeRef, TrieError};
+use ethrex_trie::{Nibbles, Node, TrieDB, TrieError};
 use state_healing::heal_state_trie;
 use state_sync::state_sync;
 use std::{
@@ -316,7 +316,7 @@ impl Syncer {
                     let block_number = block.header.number;
                     info!("Executing block: {block_number}");
 
-                    // TODO: The following code block is for debugging purposes only, please remove
+                    // TODO: The following code block is for debugging purposes only, please remove 
                     {
                         // Check if we have the parent
                         let parent_block = store
@@ -790,31 +790,22 @@ impl Syncer {
 }
 
 /// Returns the partial paths to the node's children if they are not already part of the trie state
-/// Receives the account hash if the node is a storage node or None if it is a state node
 fn node_missing_children(
     node: &Node,
     parent_path: &Nibbles,
-    store: &Store,
-    account_hash: Option<H256>,
-) -> Result<Vec<Nibbles>, StoreError> {
-    let contains_node = |child: &NodeRef| -> Result<bool, StoreError> {
-        if let Some(account_hash) = account_hash {
-            store.contains_storage_node(account_hash, child.compute_hash().finalize())
-        } else {
-            store.contains_state_node(child.compute_hash().finalize())
-        }
-    };
+    trie_state: &dyn TrieDB,
+) -> Result<Vec<Nibbles>, TrieError> {
     let mut paths = Vec::new();
     match &node {
         Node::Branch(node) => {
             for (index, child) in node.choices.iter().enumerate() {
-                if child.is_valid() && contains_node(child)? {
+                if child.is_valid() && child.get_node(trie_state)?.is_none() {
                     paths.push(parent_path.append_new(index as u8));
                 }
             }
         }
         Node::Extension(node) => {
-            if node.child.is_valid() && contains_node(&node.child)? {
+            if node.child.is_valid() && node.child.get_node(trie_state)?.is_none() {
                 paths.push(parent_path.concat(node.prefix.clone()));
             }
         }

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -314,6 +314,20 @@ impl Syncer {
                         .await?
                         .ok_or(SyncError::CorruptDB)?;
                     let block_number = block.header.number;
+                    info!("Executing block: {block_number}");
+
+                    // TODO: The following code block is for debugging purposes only, please remove 
+                    {
+                        // Check if we have the parent
+                        let parent_block = store
+                            .get_block_by_hash(block.header.parent_hash)
+                            .await
+                            .unwrap()
+                            .unwrap();
+                        if !store.contains_state_node(parent_block.header.state_root)? {
+                            panic!("Missing state root for parent block")
+                        }
+                    }
                     self.blockchain.add_block(&block).await?;
                     store.set_canonical_block(block_number, *hash).await?;
                     store.update_latest_block_number(block_number).await?;

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -314,8 +314,6 @@ impl Syncer {
                         .await?
                         .ok_or(SyncError::CorruptDB)?;
                     let block_number = block.header.number;
-                    info!("Executing block: {block_number}");
-
                     self.blockchain.add_block(&block).await?;
                     store.set_canonical_block(block_number, *hash).await?;
                     store.update_latest_block_number(block_number).await?;

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -57,10 +57,10 @@ pub(crate) async fn heal_state_trie(
             let speed = healing_start
                 .elapsed()
                 .as_millis()
-                .checked_div(total_healed as u128)
+                .checked_div((total_healed/100) as u128)
                 .unwrap_or(9999);
             info!(
-                "State Healing in Progress, pending paths: {}, healing speed: {}ms/node",
+                "State Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
                 paths.len(),
                 speed
             );

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -35,7 +35,7 @@ pub(crate) async fn heal_state_trie(
     peers: PeerHandler,
 ) -> Result<bool, SyncError> {
     let mut paths = store.get_state_heal_paths().await?.unwrap_or_default();
-    info!(
+    debug!(
         "Starting state healing, pre-existing paths: {}",
         paths.len()
     );

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -130,10 +130,9 @@ async fn heal_state_batch(
         // - If it is a leaf, request its bytecode & storage
         // - If it is a leaf, add its path & value to the trie
         {
-            let trie = store.open_state_trie(*EMPTY_TRIE_HASH)?;
             for node in nodes.iter() {
                 let path = batch.remove(0);
-                batch.extend(node_missing_children(node, &path, trie.db())?);
+                batch.extend(node_missing_children(node, &path, &store, None)?);
                 if let Node::Leaf(node) = &node {
                     // Fetch bytecode & storage
                     let account = AccountState::decode(&node.value)?;
@@ -157,6 +156,7 @@ async fn heal_state_batch(
                 }
             }
             // Write nodes to trie
+            let trie = store.open_state_trie(*EMPTY_TRIE_HASH)?;
             trie.db()
                 .put_batch_async(
                     nodes

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -57,7 +57,7 @@ pub(crate) async fn heal_state_trie(
             let speed = healing_start
                 .elapsed()
                 .as_millis()
-                .checked_div((total_healed/100) as u128)
+                .checked_div((total_healed / 100) as u128)
                 .unwrap_or(9999);
             info!(
                 "State Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
@@ -156,15 +156,17 @@ async fn heal_state_batch(
                 }
             }
             // Write nodes to trie
-            trie.db().put_batch(
-                nodes
-                    .into_iter()
-                    .filter_map(|node| match node.compute_hash() {
-                        hash @ NodeHash::Hashed(_) => Some((hash, node.encode_to_vec())),
-                        NodeHash::Inline(_) => None,
-                    })
-                    .collect(),
-            )?;
+            trie.db()
+                .put_batch_async(
+                    nodes
+                        .into_iter()
+                        .filter_map(|node| match node.compute_hash() {
+                            hash @ NodeHash::Hashed(_) => Some((hash, node.encode_to_vec())),
+                            NodeHash::Inline(_) => None,
+                        })
+                        .collect(),
+                )
+                .await?;
         }
         // Send storage & bytecode requests
         if !hashed_addresses.is_empty() {

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -130,9 +130,10 @@ async fn heal_state_batch(
         // - If it is a leaf, request its bytecode & storage
         // - If it is a leaf, add its path & value to the trie
         {
+            let trie = store.open_state_trie(*EMPTY_TRIE_HASH)?;
             for node in nodes.iter() {
                 let path = batch.remove(0);
-                batch.extend(node_missing_children(node, &path, &store, None)?);
+                batch.extend(node_missing_children(node, &path, trie.db())?);
                 if let Node::Leaf(node) = &node {
                     // Fetch bytecode & storage
                     let account = AccountState::decode(&node.value)?;
@@ -156,7 +157,6 @@ async fn heal_state_batch(
                 }
             }
             // Write nodes to trie
-            let trie = store.open_state_trie(*EMPTY_TRIE_HASH)?;
             trie.db()
                 .put_batch_async(
                     nodes

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -54,7 +54,7 @@ pub(crate) async fn heal_state_trie(
     while !paths.is_empty() {
         if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             last_update = Instant::now();
-            let speed = healing_start.elapsed().as_millis() / total_healed as u128;
+            let speed = healing_start.elapsed().as_millis().checked_div(total_healed as u128).unwrap_or(9999);
             info!(
                 "State Healing in Progress, pending paths: {}, healing speed: {}ms/node",
                 paths.len(),

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -57,13 +57,14 @@ pub(crate) async fn heal_state_trie(
             let speed = healing_start
                 .elapsed()
                 .as_millis()
-                .checked_div((total_healed / 100) as u128)
-                .unwrap_or(9999);
-            info!(
-                "State Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
-                paths.len(),
-                speed
-            );
+                .checked_div((total_healed / 100) as u128);
+            if let Some(speed) = speed {
+                info!(
+                    "State Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
+                    paths.len(),
+                    speed
+                );
+            }
         }
         // Spawn multiple parallel requests
         let mut state_tasks = tokio::task::JoinSet::new();

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -54,7 +54,11 @@ pub(crate) async fn heal_state_trie(
     while !paths.is_empty() {
         if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             last_update = Instant::now();
-            let speed = healing_start.elapsed().as_millis().checked_div(total_healed as u128).unwrap_or(9999);
+            let speed = healing_start
+                .elapsed()
+                .as_millis()
+                .checked_div(total_healed as u128)
+                .unwrap_or(9999);
             info!(
                 "State Healing in Progress, pending paths: {}, healing speed: {}ms/node",
                 paths.len(),
@@ -90,10 +94,10 @@ pub(crate) async fn heal_state_trie(
             break;
         }
     }
-    debug!("State Healing stopped, signaling storage healer");
+    info!("State Healing stopped, signaling storage healer");
     // Save paths for the next cycle
     if !paths.is_empty() {
-        debug!("Caching {} paths for the next cycle", paths.len());
+        info!("Caching {} paths for the next cycle", paths.len());
         store.set_state_heal_paths(paths.clone()).await?;
     }
     // Send empty batch to signal that no more batches are incoming

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -95,10 +95,10 @@ pub(crate) async fn heal_state_trie(
             break;
         }
     }
-    info!("State Healing stopped, signaling storage healer");
+    debug!("State Healing stopped, signaling storage healer");
     // Save paths for the next cycle
     if !paths.is_empty() {
-        info!("Caching {} paths for the next cycle", paths.len());
+        debug!("Caching {} paths for the next cycle", paths.len());
         store.set_state_heal_paths(paths.clone()).await?;
     }
     // Send empty batch to signal that no more batches are incoming

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -55,12 +55,14 @@ pub(crate) async fn storage_healer(
                 .elapsed()
                 .as_millis()
                 .checked_div((total_healed / 100) as u128)
-                .unwrap_or(9999);
-            info!(
-                "Storage Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
-                pending_paths.len(),
-                speed
-            );
+                .checked_div((total_healed / 100) as u128);
+            if let Some(speed) = speed {
+                info!(
+                    "Storage Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
+                    pending_paths.len(),
+                    speed
+                );
+            }
         }
         // If we have few storages in queue, fetch more from the store
         // We won't be retrieving all of them as the read can become quite long and we may not end up using all of the paths in this cycle

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -54,7 +54,6 @@ pub(crate) async fn storage_healer(
             let speed = healing_start
                 .elapsed()
                 .as_millis()
-                .checked_div((total_healed / 100) as u128)
                 .checked_div((total_healed / 100) as u128);
             if let Some(speed) = speed {
                 info!(

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -54,10 +54,10 @@ pub(crate) async fn storage_healer(
             let speed = healing_start
                 .elapsed()
                 .as_millis()
-                .checked_div(total_healed as u128)
+                .checked_div((total_healed/100) as u128)
                 .unwrap_or(9999);
             info!(
-                "Storage Healing in Progress, pending paths: {}, healing speed: {}ms/node",
+                "Storage Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
                 pending_paths.len(),
                 speed
             );

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -54,7 +54,7 @@ pub(crate) async fn storage_healer(
             let speed = healing_start
                 .elapsed()
                 .as_millis()
-                .checked_div((total_healed/100) as u128)
+                .checked_div((total_healed / 100) as u128)
                 .unwrap_or(9999);
             info!(
                 "Storage Healing in Progress, pending paths: {}, healing speed: {}ms/100nodes",
@@ -143,15 +143,17 @@ async fn heal_storage_batch(
                 .collect::<Result<Vec<_>, _>>()?;
             paths.extend(children.into_iter().flatten());
             // Write nodes to trie
-            trie.db().put_batch(
-                nodes
-                    .iter()
-                    .filter_map(|node| match node.compute_hash() {
-                        hash @ NodeHash::Hashed(_) => Some((hash, node.encode_to_vec())),
-                        NodeHash::Inline(_) => None,
-                    })
-                    .collect(),
-            )?;
+            trie.db()
+                .put_batch_async(
+                    nodes
+                        .iter()
+                        .filter_map(|node| match node.compute_hash() {
+                            hash @ NodeHash::Hashed(_) => Some((hash, node.encode_to_vec())),
+                            NodeHash::Inline(_) => None,
+                        })
+                        .collect(),
+                )
+                .await?;
             if nodes.is_empty() {
                 break;
             }

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -47,8 +47,7 @@ pub(crate) async fn storage_healer(
     let healing_start = Instant::now();
     let mut total_healed = 0;
     while !(stale || cancel_token.is_cancelled()) {
-        if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION
-        {
+        if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             last_update = Instant::now();
             let speed = healing_start
                 .elapsed()

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -133,7 +133,6 @@ async fn heal_storage_batch(
         // Sort nodes by trie & update current batch
         let mut nodes_to_commit = HashMap::new();
         for (acc_path, paths) in batch.iter_mut() {
-            // TODO: check if we can do this without opening a trie
             let trie = store.open_storage_trie(*acc_path, *EMPTY_TRIE_HASH)?;
             // Collect fetched nodes for that particular trie
             let trie_nodes = nodes

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -47,8 +47,7 @@ pub(crate) async fn storage_healer(
     let healing_start = Instant::now();
     let mut total_healed = 0;
     while !(stale || cancel_token.is_cancelled()) {
-        if true
-        /*last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION*/
+        if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION
         {
             last_update = Instant::now();
             let speed = healing_start

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -15,7 +15,7 @@ use std::{
 
 use ethrex_common::H256;
 use ethrex_storage::Store;
-use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, NodeHash};
+use ethrex_trie::{Nibbles, NodeHash};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
@@ -133,8 +133,6 @@ async fn heal_storage_batch(
         // Sort nodes by trie & update current batch
         let mut nodes_to_commit = HashMap::new();
         for (acc_path, paths) in batch.iter_mut() {
-            // TODO: check if we can do this without opening a trie
-            let trie = store.open_storage_trie(*acc_path, *EMPTY_TRIE_HASH)?;
             // Collect fetched nodes for that particular trie
             let trie_nodes = nodes
                 .drain(..paths.len().min(nodes.len()))
@@ -143,7 +141,7 @@ async fn heal_storage_batch(
             let missing_children = trie_nodes
                 .iter()
                 .zip(paths.drain(..trie_nodes.len()))
-                .map(|(node, path)| node_missing_children(node, &path, trie.db()))
+                .map(|(node, path)| node_missing_children(node, &path, &store, Some(*acc_path)))
                 .collect::<Result<Vec<_>, _>>()?;
             // Add the missing children paths of the nodes we fetched to the batch
             paths.extend(missing_children.into_iter().flatten());


### PR DESCRIPTION
Based on #2447 (It relies on the async trie write methods added by it)
**Motivation**
This PR aims to measure and improve the healing stage of snap sync.
Measuring: Measures the time taken to heal 100 state/storage nodes
Improvements: Write nodes asynchronously + Commit storage nodes from different tries at once. Observed improvements in hoodi testnet amounted to halved healing times in both state and storage healing

<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Use async methods to store nodes obtained from peers during healing phase
* Store nodes from different tries in a single operation for storage nodes
* Measure and show healing speed (in ms/100nodes)
* Fix: also fetch pivot block body before executing post-pivot blocks (as validation now requires parent body to be present)
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

