### PR TITLE
fix(l1, l2): logs not appearing on subcommands

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -63,11 +63,11 @@ async fn server_shutdown(
 async fn main() -> eyre::Result<()> {
     let CLI { opts, command } = CLI::parse();
 
+    init_tracing(&opts);
+
     if let Some(subcommand) = command {
         return subcommand.run(&opts).await;
     }
-
-    init_tracing(&opts);
 
     let data_dir = set_datadir(&opts.datadir);
 


### PR DESCRIPTION
**Motivation**

Quick bug fix that makes logs not appear

**Description**

The function ```init_tracing(&opts)``` was being called after any subcommands (import, export, etc) were read, causing these (specially the import) not to output logs. This PR fixes that.

