### PR TITLE
fix(l2): p2p 2 rlpx test ipv6

### DIFF
--- a/crates/networking/p2p_2/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p_2/rlpx/connection/handshake.rs
@@ -138,7 +138,10 @@ pub(crate) async fn perform(
 }
 
 async fn tcp_stream(addr: SocketAddr) -> Result<TcpStream, std::io::Error> {
-    TcpSocket::new_v4()?.connect(addr).await
+    match addr {
+        SocketAddr::V4(_) => TcpSocket::new_v4()?.connect(addr).await,
+        SocketAddr::V6(_) => TcpSocket::new_v6()?.connect(addr).await,
+    }
 }
 
 async fn send_auth<S: AsyncWrite + std::marker::Unpin>(

--- a/crates/networking/p2p_2/types.rs
+++ b/crates/networking/p2p_2/types.rs
@@ -297,12 +297,24 @@ impl NodeRecord {
             seq,
             ..Default::default()
         };
-        record
-            .pairs
-            .push(("id".into(), "v4".encode_to_vec().into()));
-        record
-            .pairs
-            .push(("ip".into(), node.ip.encode_to_vec().into()));
+        match node.ip {
+            IpAddr::V4(ipv4_addr) => {
+                record
+                    .pairs
+                    .push(("id".into(), "v4".encode_to_vec().into()));
+                record
+                    .pairs
+                    .push(("ip".into(), ipv4_addr.encode_to_vec().into()));
+            },
+            IpAddr::V6(ipv6_addr) =>{ 
+                record
+                    .pairs
+                    .push(("id".into(), "v6".encode_to_vec().into()));
+                record
+                    .pairs
+                    .push(("ip6".into(), ipv6_addr.encode_to_vec().into()));
+            },
+        };
         record.pairs.push((
             "secp256k1".into(),
             signer


### PR DESCRIPTION
**Motivation**

Handle ipv6 as well as ipv4

**Description**

- Adds a rplx handshake in ipv6
- Creates an ipv6 node if the server only sends an ipv6


