### PR TITLE
refactor(l2): use spawned for monitor

### DIFF
--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -39,7 +39,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, task::JoinSet};
 use tokio_util::task::TaskTracker;
 use tracing::info;
 
@@ -155,6 +155,7 @@ impl Command {
 
                 // TODO: Check every module starts properly.
                 let tracker = TaskTracker::new();
+                let mut join_set = JoinSet::new();
 
                 let cancel_token = tokio_util::sync::CancellationToken::new();
 
@@ -191,7 +192,7 @@ impl Command {
                         signer,
                         peer_table.clone(),
                         store.clone(),
-                        tracker.clone(),
+                        tracker,
                         blockchain.clone(),
                     )
                     .await;
@@ -214,10 +215,20 @@ impl Command {
                 )
                 .into_future();
 
-                tracker.spawn(l2_sequencer);
+                join_set.spawn(l2_sequencer);
 
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {
+                        info!("Server shut down started...");
+                        let node_config_path = PathBuf::from(data_dir + "/node_config.json");
+                        info!("Storing config at {:?}...", node_config_path);
+                        cancel_token.cancel();
+                        let node_config = NodeConfigFile::new(peer_table, local_node_record.lock().await.clone()).await;
+                        store_node_config_file(node_config, node_config_path).await;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        info!("Server shutting down!");
+                    }
+                    _ = join_set.join_next() => {
                         info!("Server shut down started...");
                         let node_config_path = PathBuf::from(data_dir + "/node_config.json");
                         info!("Storing config at {:?}...", node_config_path);

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -226,6 +226,7 @@ impl Command {
                         let node_config = NodeConfigFile::new(peer_table, local_node_record.lock().await.clone()).await;
                         store_node_config_file(node_config, node_config_path).await;
                         tokio::time::sleep(Duration::from_secs(1)).await;
+                        join_set.abort_all();
                         info!("Server shutting down!");
                     }
                     _ = join_set.join_next() => {

--- a/crates/l2/monitor/mod.rs
+++ b/crates/l2/monitor/mod.rs
@@ -13,14 +13,3 @@ use ethrex_storage_rollup::StoreRollup;
 use crate::SequencerConfig;
 use crate::based::sequencer_state::SequencerState;
 use crate::sequencer::errors::SequencerError;
-
-pub async fn start_monitor(
-    sequencer_state: SequencerState,
-    store: Store,
-    rollup_store: StoreRollup,
-    cfg: SequencerConfig,
-) -> Result<(), SequencerError> {
-    let app = EthrexMonitor::new(sequencer_state, store, rollup_store, &cfg).await?;
-    app.start().await?;
-    Ok(())
-}

--- a/crates/l2/monitor/widget/batches.rs
+++ b/crates/l2/monitor/widget/batches.rs
@@ -14,6 +14,7 @@ use crate::{
     sequencer::errors::MonitorError,
 };
 
+#[derive(Clone)]
 pub struct BatchesTable {
     pub state: TableState,
     // batch number | # blocks | # messages | commit tx hash | verify tx hash

--- a/crates/l2/monitor/widget/blocks.rs
+++ b/crates/l2/monitor/widget/blocks.rs
@@ -19,6 +19,7 @@ use crate::{
     sequencer::errors::MonitorError,
 };
 
+#[derive(Clone)]
 pub struct BlocksTable {
     pub state: TableState,
     // block number | #transactions | hash | coinbase | gas | blob gas | size

--- a/crates/l2/monitor/widget/chain_status.rs
+++ b/crates/l2/monitor/widget/chain_status.rs
@@ -13,6 +13,7 @@ use ratatui::{
 
 use crate::SequencerConfig;
 
+#[derive(Clone)]
 pub struct GlobalChainStatusTable {
     pub state: TableState,
     pub items: Vec<(String, String)>,

--- a/crates/l2/monitor/widget/l1_to_l2_messages.rs
+++ b/crates/l2/monitor/widget/l1_to_l2_messages.rs
@@ -21,6 +21,7 @@ use crate::{
 // kind | status | L1 tx hash | L2 tx hash | amount
 pub type L1ToL2MessagesRow = (L1ToL2MessageKind, L1ToL2MessageStatus, H256, H256, U256);
 
+#[derive(Clone)]
 pub struct L1ToL2MessagesTable {
     pub state: TableState,
     pub items: Vec<L1ToL2MessagesRow>,

--- a/crates/l2/monitor/widget/l2_to_l1_messages.rs
+++ b/crates/l2/monitor/widget/l2_to_l1_messages.rs
@@ -98,6 +98,7 @@ pub type L2ToL1MessageRow = (
     H256,    // L2 tx hash
 );
 
+#[derive(Clone)]
 pub struct L2ToL1MessagesTable {
     pub state: TableState,
     pub items: Vec<L2ToL1MessageRow>,

--- a/crates/l2/monitor/widget/mempool.rs
+++ b/crates/l2/monitor/widget/mempool.rs
@@ -11,6 +11,7 @@ use crate::monitor::widget::{
     ADDRESS_LENGTH_IN_DIGITS, HASH_LENGTH_IN_DIGITS, NUMBER_LENGTH_IN_DIGITS,
 };
 
+#[derive(Clone)]
 pub struct MempoolTable {
     pub state: TableState,
     // type | hash | sender | nonce

--- a/crates/l2/monitor/widget/node_status.rs
+++ b/crates/l2/monitor/widget/node_status.rs
@@ -9,6 +9,7 @@ use ratatui::{
 
 use crate::based::sequencer_state::SequencerState;
 
+#[derive(Clone)]
 pub struct NodeStatusTable {
     pub state: TableState,
     pub items: [(String, String); 5],

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -308,4 +308,8 @@ pub enum MonitorError {
     GetBlockByNumber(u64, #[source] StoreError),
     #[error("Block {0} not found in the store")]
     BlockNotFound(u64),
+    // TODO: Avoid propagating GenServerErrors outside GenServer modules
+    // See https://github.com/lambdaclass/ethrex/issues/3376
+    #[error("Spawned GenServer Error")]
+    GenServerError(GenServerError),
 }

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -169,21 +169,18 @@ pub async fn start_l2(
         ));
     }
 
-    while let Some(res) = task_set.join_next().await {
+    if let Some(res) = task_set.join_next().await {
         match res {
             Ok(Ok(_)) => {
                 task_set.abort_all();
-                break;
             }
             Ok(Err(err)) => {
                 error!("Error starting Proposer: {err}");
                 task_set.abort_all();
-                break;
             }
             Err(err) => {
                 error!("JoinSet error: {err}");
                 task_set.abort_all();
-                break;
             }
         };
     }

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -171,7 +171,9 @@ pub async fn start_l2(
 
     while let Some(res) = task_set.join_next().await {
         match res {
-            Ok(Ok(_)) => {}
+            Ok(Ok(_)) => {
+                break;
+            }
             Ok(Err(err)) => {
                 error!("Error starting Proposer: {err}");
                 task_set.abort_all();

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -170,6 +170,7 @@ pub async fn start_l2(
     }
 
     if let Some(res) = task_set.join_next().await {
+        // If a task finishes, the whole sequencer should stop
         match res {
             Ok(Ok(_)) => {
                 task_set.abort_all();
@@ -183,5 +184,10 @@ pub async fn start_l2(
                 task_set.abort_all();
             }
         };
+    } else {
+        // If no tasks were spawned, we let the sequencer run until it is cancelled
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
     }
 }

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -172,6 +172,7 @@ pub async fn start_l2(
     while let Some(res) = task_set.join_next().await {
         match res {
             Ok(Ok(_)) => {
+                task_set.abort_all();
                 break;
             }
             Ok(Err(err)) => {

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -166,7 +166,7 @@ pub async fn start_l2(
             shared_state.clone(),
             store.clone(),
             rollup_store.clone(),
-            cfg,
+            &cfg,
         )
         .await
         .inspect_err(|err| {


### PR DESCRIPTION
**Motivation**
Refactor monitor so that it uses spawned crate
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Currently the monitor is a tokio task, refactor it to use spawned
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/orgs/lambdaclass/projects/37/views/10?pane=issue&itemId=118809943&issue=lambdaclass%7Cethrex%7C3515

