### PR TITLE
feat(l1): engine_getBlobsV1 request endpoint implemented

### DIFF
--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -1,0 +1,67 @@
+use ethrex_common::{
+    H256, serde_utils,
+    types::{Blob, Proof},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::info;
+
+use crate::{
+    rpc::{RpcApiContext, RpcHandler},
+    utils::RpcErr,
+};
+
+// -> https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#specification-3
+const GET_BLOBS_V1_REQUEST_MAX_SIZE: usize = 128;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlobsV1Request {
+    blob_versioned_hashes: Vec<H256>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobsV1Response {
+    #[serde(with = "serde_utils::blob::vec")]
+    pub blobs: Vec<Blob>,
+    #[serde(with = "serde_utils::bytes48::vec")]
+    pub proofs: Vec<Proof>,
+}
+
+impl std::fmt::Display for BlobsV1Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Blob versioned hashes: {:#?}",
+            self.blob_versioned_hashes
+        )
+    }
+}
+
+impl RpcHandler for BlobsV1Request {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
+        };
+        Ok(BlobsV1Request {
+            blob_versioned_hashes: serde_json::from_value(params[0].clone())?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        info!("Received new engine request: {self}");
+        if self.blob_versioned_hashes.len() >= GET_BLOBS_V1_REQUEST_MAX_SIZE {
+            return Err(RpcErr::TooLargeRequest);
+        }
+
+        let mut blobs_bundles = Vec::new();
+        for hash in self.blob_versioned_hashes.iter() {
+            blobs_bundles.push(context.blockchain.mempool.get_blobs_bundle(*hash)?)
+        }
+
+        serde_json::to_value(blobs_bundles).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}

--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod blobs;
 pub mod exchange_transition_config;
 pub mod fork_choice;
 pub mod payload;
@@ -13,7 +14,7 @@ pub type ExchangeCapabilitiesRequest = Vec<String>;
 
 /// List of capabilities that the execution layer client supports. Add new capabilities here.
 /// More info: https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities
-pub const CAPABILITIES: [&str; 14] = [
+pub const CAPABILITIES: [&str; 15] = [
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",
@@ -28,6 +29,7 @@ pub const CAPABILITIES: [&str; 14] = [
     "engine_exchangeTransitionConfigurationV1",
     "engine_getPayloadBodiesByHashV1",
     "engine_getPayloadBodiesByRangeV1",
+    "engine_getBlobsV1",
 ];
 
 impl From<ExchangeCapabilitiesRequest> for RpcRequest {

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1,6 +1,7 @@
 use crate::authentication::authenticate;
 use crate::engine::{
     ExchangeCapabilitiesRequest,
+    blobs::BlobsV1Request,
     exchange_transition_config::ExchangeTransitionConfigV1Req,
     fork_choice::{ForkChoiceUpdatedV1, ForkChoiceUpdatedV2, ForkChoiceUpdatedV3},
     payload::{
@@ -372,6 +373,7 @@ pub async fn map_engine_requests(
         "engine_getPayloadBodiesByRangeV1" => {
             GetPayloadBodiesByRangeV1Request::call(req, context).await
         }
+        "engine_getBlobsV1" => BlobsV1Request::call(req, context).await,
         unknown_engine_method => Err(RpcErr::MethodNotFound(unknown_engine_method.to_owned())),
     }
 }


### PR DESCRIPTION
**Motivation**

We need to implement the RPC endpoint as it will be needed for Fusaka.

**Description**

This pr incorporates a new module to handle RPC endpoint for the engine_getBlobsV1 request.

Closes #3428

