### PR TITLE
fix(l2): panic because of double init tracing

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -16,7 +16,7 @@ use tracing::{Level, info, warn};
 
 use crate::{
     DEFAULT_DATADIR,
-    initializers::{get_network, init_blockchain, init_store, open_store},
+    initializers::{get_network, init_blockchain, init_store, init_tracing, open_store},
     l2,
     networks::Network,
     utils::{self, get_client_version, set_datadir},
@@ -284,6 +284,11 @@ pub enum Subcommand {
 
 impl Subcommand {
     pub async fn run(self, opts: &Options) -> eyre::Result<()> {
+        // L2 has its own init_tracing because of the Ethrex monitor
+        match self {
+            Self::L2(_) => {}
+            _ => init_tracing(opts),
+        }
         match self {
             Subcommand::RemoveDB { datadir, force } => {
                 remove_db(&datadir, force);

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -284,7 +284,7 @@ pub enum Subcommand {
 
 impl Subcommand {
     pub async fn run(self, opts: &Options) -> eyre::Result<()> {
-        // L2 has its own init_tracing because of the Ethrex monitor
+        // L2 has its own init_tracing because of the ethrex monitor
         match self {
             Self::L2(_) => {}
             _ => init_tracing(opts),

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -63,11 +63,11 @@ async fn server_shutdown(
 async fn main() -> eyre::Result<()> {
     let CLI { opts, command } = CLI::parse();
 
-    init_tracing(&opts);
-
     if let Some(subcommand) = command {
         return subcommand.run(&opts).await;
     }
+
+    init_tracing(&opts);
 
     let data_dir = set_datadir(&opts.datadir);
 


### PR DESCRIPTION
**Motivation**

Init L2 was panicking because of a double call to init_tracing

**Description**

- Move back the init tracing call to after the subcommand execution
- Inside the subcommands call init_tracing only if the subcommand is not `Subcommand::L2`

