### PR TITLE
feat(l1): add gas used diff in error

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -940,7 +940,10 @@ pub fn validate_gas_used(
         // dbg!(last.cumulative_gas_used);
         // dbg!(block_header.gas_used);
         if last.cumulative_gas_used != block_header.gas_used {
-            return Err(ChainError::InvalidBlock(InvalidBlockError::GasUsedMismatch));
+            return Err(ChainError::InvalidBlock(InvalidBlockError::GasUsedMismatch(
+                last.cumulative_gas_used,
+                block_header.gas_used,
+            )));
         }
     }
     Ok(())

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -58,8 +58,8 @@ pub enum InvalidBlockError {
     ExceededMaxBlobGasPerBlock,
     #[error("Exceeded MAX_BLOB_NUMBER_PER_BLOCK")]
     ExceededMaxBlobNumberPerBlock,
-    #[error("Gas used doesn't match value in header")]
-    GasUsedMismatch,
+    #[error("Gas used doesn't match value in header. Used: {0}, Expected: {1}")]
+    GasUsedMismatch(u64, u64),
     #[error("Blob gas used doesn't match value in header")]
     BlobGasUsedMismatch,
     #[error("Invalid transaction: {0}")]


### PR DESCRIPTION
**Motivation**

When there's a gas mismatch, there's no way to tell what is the mismatch unless we print it manually. If it's present in the error, at least it appears in the test logs when it happens.

**Description**

- Adds used and expected fields for the GasUsedMismatchError.
- Adds the fields in the block gas post-exec validation.