### PR TITLE
fix(blockchain): handle SystemTime error without using ? operator in block producer

### DIFF
--- a/crates/blockchain/dev/block_producer.rs
+++ b/crates/blockchain/dev/block_producer.rs
@@ -27,8 +27,16 @@ pub async fn start_block_producer(
             finalized_block_hash: head_block_hash,
         };
 
+        let timestamp = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_secs(),
+            Err(e) => {
+                return Err(EngineClientError::SystemFailed(format!(
+                    "SystemTime error: {e}"
+                )));
+            }
+        };
         let payload_attributes = PayloadAttributesV3 {
-            timestamp: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+            timestamp,
             prev_randao: H256::zero(),
             suggested_fee_recipient: coinbase_address,
             parent_beacon_block_root: Some(parent_beacon_block_root),


### PR DESCRIPTION
Replaced the use of the ? operator with explicit error handling for SystemTime::now().duration_since(UNIX_EPOCH) in the block producer.
Now, if a system time error occurs, the function returns an informative EngineClientError::SystemFailed with the error details.
This change ensures proper error propagation and prevents compilation issues related to the use of the ? operator in this context.