### PR TITLE
fix(l2): use GITHUB_TOKEN for sp1up and rzup actions

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -27,10 +27,12 @@ jobs:
 
       - name: RISC-V SP1 toolchain install
         # if: ${{ always() && github.event_name == 'merge_group' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . "$HOME/.cargo/env"
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0 --token ${{ secrets.GITHUB_TOKEN }}
+          ~/.sp1/bin/sp1up --version 5.0.0
 
       - name: Set up Docker Buildx
         # if: ${{ always() && github.event_name == 'merge_group' }}

--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -41,10 +41,12 @@ jobs:
           ~/.risc0/bin/rzup install cargo-risczero 2.1.0
           ~/.risc0/bin/rzup install rust
       - name: RISC-V SP1 toolchain install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.backend == 'sp1'
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0 --token ${{ secrets.GITHUB_TOKEN }}
+          ~/.sp1/bin/sp1up --version 5.0.0
 
       - name: Build
         run: |

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -46,9 +46,11 @@ jobs:
 
       - name: RISC-V SP1 toolchain install
         if: matrix.backend == 'sp1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0 --token ${{ secrets.GITHUB_TOKEN }}
+          ~/.sp1/bin/sp1up --version 5.0.0
 
       - name: Check ${{ matrix.backend }} backend
         run: |

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -138,7 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L https://sp1up.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0 --token ${{ secrets.GITHUB_TOKEN }}
+          ~/.sp1/bin/sp1up --version 5.0.0
 
       - name: Set up QEMU
         if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}


### PR DESCRIPTION
**Motivation**

The SP1 toolchain fails sometimes to install with a generic "Failed to fetch releases list" error, but the cause may be an [API rate limit](https://github.com/succinctlabs/sp1/issues/2320#issuecomment-2955903435)

The Risc0 toolchain has the same problem, explicitly returning an API rate limit error.

We bypass this by authenticating using the `GITHUB_TOKEN`
