### PR TITLE
fix(l1): set base fee per gas only if we're past London hardfork

### DIFF
--- a/cmd/ethrex/networks.rs
+++ b/cmd/ethrex/networks.rs
@@ -136,3 +136,49 @@ fn get_genesis_contents(network: PublicNetwork) -> &'static str {
         PublicNetwork::Sepolia => SEPOLIA_GENESIS_CONTENTS,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use keccak_hash::H256;
+
+    use super::*;
+
+    fn assert_genesis_hash(network: PublicNetwork, expected_hash: &str) {
+        let genesis = Network::PublicNetwork(network).get_genesis().unwrap();
+        let genesis_hash = genesis.get_block().hash();
+        let expected_hash = hex::decode(expected_hash).unwrap();
+        assert_eq!(genesis_hash, H256::from_slice(&expected_hash));
+    }
+
+    #[test]
+    fn test_holesky_genesis_block_hash() {
+        assert_genesis_hash(
+            PublicNetwork::Holesky,
+            "b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4",
+        );
+    }
+
+    #[test]
+    fn test_sepolia_genesis_block_hash() {
+        assert_genesis_hash(
+            PublicNetwork::Sepolia,
+            "25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9",
+        );
+    }
+
+    #[test]
+    fn test_hoodi_genesis_block_hash() {
+        assert_genesis_hash(
+            PublicNetwork::Hoodi,
+            "bbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b",
+        );
+    }
+
+    #[test]
+    fn test_mainnet_genesis_block_hash() {
+        assert_genesis_hash(
+            PublicNetwork::Mainnet,
+            "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+        );
+    }
+}

--- a/cmd/ethrex/networks.rs
+++ b/cmd/ethrex/networks.rs
@@ -152,6 +152,8 @@ mod tests {
 
     #[test]
     fn test_holesky_genesis_block_hash() {
+        // Values taken from the geth codebase:
+        // https://github.com/ethereum/go-ethereum/blob/a327ffe9b35289719ac3c484b7332584985b598a/params/config.go#L30-L35
         assert_genesis_hash(
             PublicNetwork::Holesky,
             "b5f7f912443c940f21fd611f12828d75b534364ed9e95ca4e307729a4661bde4",
@@ -160,6 +162,8 @@ mod tests {
 
     #[test]
     fn test_sepolia_genesis_block_hash() {
+        // Values taken from the geth codebase:
+        // https://github.com/ethereum/go-ethereum/blob/a327ffe9b35289719ac3c484b7332584985b598a/params/config.go#L30-L35
         assert_genesis_hash(
             PublicNetwork::Sepolia,
             "25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9",
@@ -168,6 +172,8 @@ mod tests {
 
     #[test]
     fn test_hoodi_genesis_block_hash() {
+        // Values taken from the geth codebase:
+        // https://github.com/ethereum/go-ethereum/blob/a327ffe9b35289719ac3c484b7332584985b598a/params/config.go#L30-L35
         assert_genesis_hash(
             PublicNetwork::Hoodi,
             "bbe312868b376a3001692a646dd2d7d1e4406380dfd86b98aa8a34d1557c971b",
@@ -176,6 +182,8 @@ mod tests {
 
     #[test]
     fn test_mainnet_genesis_block_hash() {
+        // Values taken from the geth codebase:
+        // https://github.com/ethereum/go-ethereum/blob/a327ffe9b35289719ac3c484b7332584985b598a/params/config.go#L30-L35
         assert_genesis_hash(
             PublicNetwork::Mainnet,
             "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -364,6 +364,26 @@ impl Genesis {
                 excess_blob_gas = Some(self.excess_blob_gas.unwrap_or(0));
             }
         }
+        let base_fee_per_gas = self.base_fee_per_gas.or_else(|| {
+            self.config
+                .is_london_activated(0)
+                .then_some(INITIAL_BASE_FEE)
+        });
+
+        let withdrawals_root = self
+            .config
+            .is_shanghai_activated(self.timestamp)
+            .then_some(compute_withdrawals_root(&[]));
+
+        let parent_beacon_block_root = self
+            .config
+            .is_cancun_activated(self.timestamp)
+            .then_some(H256::zero());
+
+        let requests_hash = self
+            .config
+            .is_prague_activated(self.timestamp)
+            .then_some(self.requests_hash.unwrap_or(*DEFAULT_REQUESTS_HASH));
 
         BlockHeader {
             parent_hash: H256::zero(),
@@ -381,25 +401,12 @@ impl Genesis {
             extra_data: self.extra_data.clone(),
             prev_randao: self.mix_hash,
             nonce: self.nonce,
-            base_fee_per_gas: self.base_fee_per_gas.or_else(|| {
-                self.config
-                    .is_london_activated(0)
-                    .then_some(INITIAL_BASE_FEE)
-            }),
-            withdrawals_root: self
-                .config
-                .is_shanghai_activated(self.timestamp)
-                .then_some(compute_withdrawals_root(&[])),
+            base_fee_per_gas,
+            withdrawals_root,
             blob_gas_used,
             excess_blob_gas,
-            parent_beacon_block_root: self
-                .config
-                .is_cancun_activated(self.timestamp)
-                .then_some(H256::zero()),
-            requests_hash: self
-                .config
-                .is_prague_activated(self.timestamp)
-                .then_some(self.requests_hash.unwrap_or(*DEFAULT_REQUESTS_HASH)),
+            parent_beacon_block_root,
+            requests_hash,
             ..Default::default()
         }
     }

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -250,6 +250,10 @@ impl ChainConfig {
         self.istanbul_block.is_some_and(|num| num <= block_number)
     }
 
+    pub fn is_london_activated(&self, block_number: BlockNumber) -> bool {
+        self.london_block.is_some_and(|num| num <= block_number)
+    }
+
     pub fn is_eip155_activated(&self, block_number: BlockNumber) -> bool {
         self.eip155_block.is_some_and(|num| num <= block_number)
     }
@@ -377,7 +381,11 @@ impl Genesis {
             extra_data: self.extra_data.clone(),
             prev_randao: self.mix_hash,
             nonce: self.nonce,
-            base_fee_per_gas: self.base_fee_per_gas.or(Some(INITIAL_BASE_FEE)),
+            base_fee_per_gas: self.base_fee_per_gas.or_else(|| {
+                self.config
+                    .is_london_activated(0)
+                    .then_some(INITIAL_BASE_FEE)
+            }),
             withdrawals_root: self
                 .config
                 .is_shanghai_activated(self.timestamp)


### PR DESCRIPTION
**Motivation**

We found that we are computing the mainnet genesis block hash wrong.

**Description**

This PR changes our `Genesis::get_block_header` function to only set the `base_fee_per_gas` if we're past the London hardfork, which introduced this field. I also included some tests to verify the hash of each public network matches some hardcoded values, checked against `geth`.
