### PR TITLE
ci(l1): support multiple hive versions depending on simulation.

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -90,7 +90,7 @@ jobs:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
 
-  setup-hive:
+  setup-hive-fork:
     name: "Setup Hive"
     runs-on: ubuntu-latest
     env:
@@ -106,7 +106,26 @@ jobs:
       - name: Upload hive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: hive
+          name: hive-fork
+          path: hive
+
+  setup-hive-upstream:
+    name: "Setup Hive"
+    runs-on: ubuntu-latest
+    env:
+      HIVE_COMMIT_HASH: 276ca9deaee8e5831b11fa6e884a9479ee8ca140
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Hive
+        run: |
+          git clone --single-branch --branch master https://github.com/ethereum/hive
+          cd hive
+          git checkout --detach ${{ env.HIVE_COMMIT_HASH }}
+          go build .
+      - name: Upload hive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hive-upstream
           path: hive
 
   run-assertoor:
@@ -152,15 +171,17 @@ jobs:
   run-hive:
     name: Hive - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [docker_build, setup-hive]
+    needs: [docker_build, setup-hive-fork, setup-hive-upstream]
     if: ${{ github.event_name != 'merge_group' }}
     strategy:
       matrix:
         include:
           - name: "Rpc Compat tests"
+            hive_version: "fork"
             simulation: ethereum/rpc-compat
             test_pattern: ""
           - name: "Devp2p tests"
+            hive_version: "fork"
             simulation: devp2p
             test_pattern: discv4|eth|snap/Ping|Findnode/WithoutEndpointProof|Findnode/BasicFindnode|Findnode/PastExpiration|Amplification|Status|StorageRanges|ByteCodes|GetBlockHeaders|SimultaneousRequests|SameRequestID|ZeroRequestID|GetBlockBodies|MaliciousHandshake|MaliciousStatus|Transaction|NewPooledTxs|GetBlockReceipts|LargeTxRequest|InvalidTxs
             # AccountRange and GetTrieNodes don't pass anymore.
@@ -200,7 +221,7 @@ jobs:
       - name: Download hive artifacts
         uses: actions/download-artifact@v4
         with:
-          name: hive
+          name: hive-${{ matrix.hive_version || 'upstream' }}
 
       - name: Load image
         run: |


### PR DESCRIPTION
**Motivation**
We want to get rid of our hive fork and use the upstream. Unfortunately, we can't completely rely on it yet because it would break. 

**Description**
- While we fix the upstream, lets rely on two versions of Hive, our fork one and the upstream


