### PR TITLE
fix(l1): fix double tracer initialization in block execution benchmark

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -295,15 +295,7 @@ impl Subcommand {
             }
             Subcommand::Import { path, removedb, l2 } => {
                 if removedb {
-                    Box::pin(async {
-                        Self::RemoveDB {
-                            datadir: opts.datadir.clone(),
-                            force: opts.force,
-                        }
-                        .run(opts)
-                        .await
-                    })
-                    .await?;
+                    remove_db(&opts.datadir.clone(), opts.force);
                 }
 
                 let network = get_network(opts);


### PR DESCRIPTION
**Motivation**

Currently the block execution benchmark is [broken](https://github.com/lambdaclass/ethrex/actions/runs/16344656297/job/46175367153?pr=3590) as a result of calling `init_tracing` twice.

**Description**

This happens because, when the `--removedb` flag is used, RemoveDB is called as a command, which initializes the logger again.

This PR calls removedb directly instead.
