### PR TITLE
refactor(l2): use modifier for pushing sequencers

### DIFF
--- a/crates/l2/contracts/src/l1/based/SequencerRegistry.sol
+++ b/crates/l2/contracts/src/l1/based/SequencerRegistry.sol
@@ -23,6 +23,14 @@ contract SequencerRegistry is
     address[] public sequencers;
     mapping(uint256 => address) public sequencerForBatch;
 
+    modifier onlyOnChainProposer() {
+        require(
+            msg.sender == ON_CHAIN_PROPOSER,
+            "SequencerRegistry: Only onChainProposer can push sequencer"
+        );
+        _;
+    }
+
     function initialize(
         address owner,
         address onChainProposer
@@ -39,11 +47,10 @@ contract SequencerRegistry is
         OwnableUpgradeable.__Ownable_init(owner);
     }
 
-    function pushSequencer(uint256 batchNumber, address sequencer) external {
-        require(
-            msg.sender == ON_CHAIN_PROPOSER,
-            "SequencerRegistry: Only onChainProposer can push sequencer"
-        );
+    function pushSequencer(
+        uint256 batchNumber,
+        address sequencer
+    ) external override onlyOnChainProposer {
         sequencerForBatch[batchNumber] = sequencer;
     }
 


### PR DESCRIPTION
**Motivation**

> [!IMPORTANT]
> Merge after #2999 

Instead of using a require on the function we want to use a modifier

**Description**

Introduce a new modifier called `onlyOnChainProposer()`. It checks that the one calling the functions must be the same address set in the initialization

Closes #3593 

