### PR TITLE
perf(levm): codecopy perf improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 2025-07-16
 
 - Improve levm memory model [#3564](https://github.com/lambdaclass/ethrex/pull/3564)
--
+
 ### 2025-07-15
 
 - Add sstore bench [#3552](https://github.com/lambdaclass/ethrex/pull/3552)


### PR DESCRIPTION
**Motivation**

Improves from 200 mgas to 790, this bench was made with this pr along memory, sstore and opcodes ones.

A 295% increase in perf.

Requires the pr #3564 

**Description**



