### PR TITLE
refactor(l2): store one byte for recovery id

### DIFF
--- a/crates/l2/storage/src/api.rs
+++ b/crates/l2/storage/src/api.rs
@@ -87,27 +87,27 @@ pub trait StoreEngineRollup: Debug + Send + Sync {
     async fn store_signature_by_block(
         &self,
         block_hash: H256,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError>;
 
     /// Retrieves the sequencer signature for a given block hash.
     async fn get_signature_by_block(
         &self,
         block_hash: H256,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError>;
+    ) -> Result<Option<[u8; 65]>, RollupStoreError>;
 
     /// Stores the sequencer signature for a given batch number.
     async fn store_signature_by_batch(
         &self,
         batch_number: u64,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError>;
 
     /// Retrieves the sequencer signature for a given batch number.
     async fn get_signature_by_batch(
         &self,
         batch_number: u64,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError>;
+    ) -> Result<Option<[u8; 65]>, RollupStoreError>;
 
     async fn get_lastest_sent_batch_proof(&self) -> Result<u64, RollupStoreError>;
 

--- a/crates/l2/storage/src/store.rs
+++ b/crates/l2/storage/src/store.rs
@@ -256,7 +256,7 @@ impl Store {
     pub async fn store_signature_by_block(
         &self,
         block_hash: H256,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.engine
             .store_signature_by_block(block_hash, signature)
@@ -269,7 +269,7 @@ impl Store {
     pub async fn get_signature_by_block(
         &self,
         block_hash: H256,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         self.engine.get_signature_by_block(block_hash).await
     }
 
@@ -280,7 +280,7 @@ impl Store {
     pub async fn store_signature_by_batch(
         &self,
         batch_number: u64,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.engine
             .store_signature_by_batch(batch_number, signature)
@@ -293,7 +293,7 @@ impl Store {
     pub async fn get_signature_by_batch(
         &self,
         batch_number: u64,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         self.engine.get_signature_by_batch(batch_number).await
     }
 

--- a/crates/l2/storage/src/store_db/in_memory.rs
+++ b/crates/l2/storage/src/store_db/in_memory.rs
@@ -35,9 +35,9 @@ struct StoreInner {
     /// Metrics for transaction, deposits and messages count
     operations_counts: [u64; 3],
     /// Map of signatures from the sequencer by block hashes
-    signatures_by_block: HashMap<H256, [u8; 68]>,
+    signatures_by_block: HashMap<H256, [u8; 65]>,
     /// Map of signatures from the sequencer by batch numbers
-    signatures_by_batch: HashMap<u64, [u8; 68]>,
+    signatures_by_batch: HashMap<u64, [u8; 65]>,
     /// Map of block number to account updates
     account_updates_by_block_number: HashMap<BlockNumber, Vec<AccountUpdate>>,
     /// Map of (ProverType, batch_number) to batch proof data
@@ -176,7 +176,7 @@ impl StoreEngineRollup for Store {
     async fn store_signature_by_block(
         &self,
         block_hash: H256,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.inner()?
             .signatures_by_block
@@ -187,14 +187,14 @@ impl StoreEngineRollup for Store {
     async fn get_signature_by_block(
         &self,
         block_hash: H256,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         Ok(self.inner()?.signatures_by_block.get(&block_hash).cloned())
     }
 
     async fn store_signature_by_batch(
         &self,
         batch_number: u64,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.inner()?
             .signatures_by_batch
@@ -205,7 +205,7 @@ impl StoreEngineRollup for Store {
     async fn get_signature_by_batch(
         &self,
         batch_number: u64,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         Ok(self
             .inner()?
             .signatures_by_batch

--- a/crates/l2/storage/src/store_db/libmdbx.rs
+++ b/crates/l2/storage/src/store_db/libmdbx.rs
@@ -252,7 +252,7 @@ impl StoreEngineRollup for Store {
     async fn store_signature_by_block(
         &self,
         block_hash: H256,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         let key = block_hash.as_fixed_bytes();
         self.write::<SignatureByBlockHash>(*key, signature).await
@@ -261,7 +261,7 @@ impl StoreEngineRollup for Store {
     async fn get_signature_by_block(
         &self,
         block_hash: H256,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         let key = block_hash.as_fixed_bytes();
         self.read::<SignatureByBlockHash>(*key).await
     }
@@ -269,7 +269,7 @@ impl StoreEngineRollup for Store {
     async fn store_signature_by_batch(
         &self,
         batch_number: u64,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.write::<SignatureByBatch>(batch_number, signature)
             .await
@@ -278,7 +278,7 @@ impl StoreEngineRollup for Store {
     async fn get_signature_by_batch(
         &self,
         batch_number: u64,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         self.read::<SignatureByBatch>(batch_number).await
     }
 
@@ -454,12 +454,12 @@ table!(
 
 table!(
     /// Signature by block hash
-    ( SignatureByBlockHash ) [u8; 32] => [u8; 68]
+    ( SignatureByBlockHash ) [u8; 32] => [u8; 65]
 );
 
 table!(
     /// Signature by batch number
-    ( SignatureByBatch ) u64 => [u8; 68]
+    ( SignatureByBatch ) u64 => [u8; 65]
 );
 
 table!(

--- a/crates/l2/storage/src/store_db/redb.rs
+++ b/crates/l2/storage/src/store_db/redb.rs
@@ -35,10 +35,10 @@ const PRIVILEGED_TRANSACTIONS_HASHES: TableDefinition<u64, Rlp<H256>> =
 
 const LAST_SENT_BATCH_PROOF: TableDefinition<u64, u64> = TableDefinition::new("LastSentBatchProof");
 
-const SIGNATURES_BY_BLOCK: TableDefinition<[u8; 32], [u8; 68]> =
+const SIGNATURES_BY_BLOCK: TableDefinition<[u8; 32], [u8; 65]> =
     TableDefinition::new("SignaturesByBlock");
 
-const SIGNATURES_BY_BATCH: TableDefinition<u64, [u8; 68]> =
+const SIGNATURES_BY_BATCH: TableDefinition<u64, [u8; 65]> =
     TableDefinition::new("SignaturesByBatch");
 
 const ACCOUNT_UPDATES_BY_BLOCK_NUMBER: TableDefinition<BlockNumber, Vec<u8>> =
@@ -306,7 +306,7 @@ impl StoreEngineRollup for RedBStoreRollup {
     async fn store_signature_by_block(
         &self,
         block_hash: H256,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.write(SIGNATURES_BY_BLOCK, block_hash.into(), signature)
             .await
@@ -314,7 +314,7 @@ impl StoreEngineRollup for RedBStoreRollup {
     async fn get_signature_by_block(
         &self,
         block_hash: H256,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         Ok(self
             .read(SIGNATURES_BY_BLOCK, block_hash.into())
             .await?
@@ -323,7 +323,7 @@ impl StoreEngineRollup for RedBStoreRollup {
     async fn store_signature_by_batch(
         &self,
         batch_number: u64,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.write(SIGNATURES_BY_BATCH, batch_number, signature)
             .await
@@ -331,7 +331,7 @@ impl StoreEngineRollup for RedBStoreRollup {
     async fn get_signature_by_batch(
         &self,
         batch_number: u64,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         Ok(self
             .read(SIGNATURES_BY_BATCH, batch_number)
             .await?

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -677,7 +677,7 @@ impl StoreEngineRollup for SQLStore {
     async fn store_signature_by_block(
         &self,
         block_hash: H256,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.execute_in_tx(
             vec![
@@ -698,7 +698,7 @@ impl StoreEngineRollup for SQLStore {
     async fn get_signature_by_block(
         &self,
         block_hash: H256,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         let mut rows = self
             .query(
                 "SELECT signature FROM block_signatures WHERE block_hash = ?1",
@@ -720,7 +720,7 @@ impl StoreEngineRollup for SQLStore {
     async fn store_signature_by_batch(
         &self,
         batch_number: u64,
-        signature: [u8; 68],
+        signature: [u8; 65],
     ) -> Result<(), RollupStoreError> {
         self.execute_in_tx(
             vec![
@@ -741,7 +741,7 @@ impl StoreEngineRollup for SQLStore {
     async fn get_signature_by_batch(
         &self,
         batch_number: u64,
-    ) -> Result<Option<[u8; 68]>, RollupStoreError> {
+    ) -> Result<Option<[u8; 65]>, RollupStoreError> {
         let mut rows = self
             .query(
                 "SELECT signature FROM batch_signatures WHERE batch = ?1",

--- a/crates/networking/p2p/rlpx/utils.rs
+++ b/crates/networking/p2p/rlpx/utils.rs
@@ -98,14 +98,13 @@ pub(crate) fn log_peer_warn(node: &Node, text: &str) {
 }
 
 pub fn recover_address(
-    recovery_id: [u8; 4],
+    recovery_id: u8,
     signature: &[u8; 64],
     payload: [u8; 32],
 ) -> Result<Address, CryptographyError> {
-    let recovery_id: i32 = i32::from_be_bytes(recovery_id);
     let signature = secp256k1::ecdsa::RecoverableSignature::from_compact(
         signature,
-        RecoveryId::from_i32(recovery_id).expect("Invalid recovery ID"), // cannot fail
+        RecoveryId::from_i32(recovery_id.into()).expect("Invalid recovery ID"), // cannot fail
     )
     .map_err(|error| CryptographyError::CouldNotGetKeyFromSecret(error.to_string()))?;
 


### PR DESCRIPTION
> [!IMPORTANT]
> Merge after #2999 

**Motivation**

We want to store one byte instead of four bytes for the recovery id of the signature.

**Description**

- Change all `[u8; 4]` types for the recovery id to `u8`.
- Change `l2/store` methods to use one byte

Closes #3596

