### PR TITLE
ci(l1): comment out flaky findnode test

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -169,7 +169,7 @@ jobs:
           - name: "Devp2p tests"
             hive_version: "fork"
             simulation: devp2p
-            test_pattern: discv4|eth|snap/Ping|Findnode/WithoutEndpointProof|Findnode/BasicFindnode|Findnode/PastExpiration|Amplification|Status|StorageRanges|ByteCodes|GetBlockHeaders|SimultaneousRequests|SameRequestID|ZeroRequestID|GetBlockBodies|MaliciousHandshake|MaliciousStatus|Transaction|NewPooledTxs|GetBlockReceipts|LargeTxRequest|InvalidTxs
+            test_pattern: discv4|eth|snap/Ping|Findnode/WithoutEndpointProof|Findnode/PastExpiration|Amplification|Status|StorageRanges|ByteCodes|GetBlockHeaders|SimultaneousRequests|SameRequestID|ZeroRequestID|GetBlockBodies|MaliciousHandshake|MaliciousStatus|Transaction|NewPooledTxs|GetBlockReceipts|LargeTxRequest|InvalidTxs
             # AccountRange and GetTrieNodes don't pass anymore.
             #|BlobViolations
             # Findnode/UnsolicitedNeighbors and Findnode/BasicFindnode flaky in CI very occasionally. When fixed replace all "Findnode/<test>" with "Findnode"


### PR DESCRIPTION
I thought this test had already been commented out before but maybe it was reintroduced, I don't know. It's flaky though.
[Example run](https://github.com/lambdaclass/ethrex/actions/runs/16356024570/job/46215135795?pr=3626)