### PR TITLE
ci(l2): cargo.lock check was done before compiling

### DIFF
--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -22,10 +22,6 @@ jobs:
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Check ${{ matrix.backend }} Cargo.lock modified but not committed
-        run: |
-          git diff --exit-code -- crates/l2/prover/zkvm/interface/${{ matrix.backend }}/Cargo.lock
-
       - name: RISC-V Risc0 toolchain install
         if: matrix.backend == 'risc0'
         env:
@@ -49,9 +45,14 @@ jobs:
         run: |
           cargo check -r -p ethrex-prover -F ${{ matrix.backend }}
           cargo check -r -p ethrex-replay -F ${{ matrix.backend }}
+
       - name: Clippy ${{ matrix.backend }} backend
         run: |
           cargo clippy -r -p ethrex-prover --all-targets -F ${{ matrix.backend }}
+
+      - name: Check ${{ matrix.backend }} Cargo.lock modified but not committed
+        run: |
+          git diff --exit-code -- crates/l2/prover/zkvm/interface/${{ matrix.backend }}/Cargo.lock
 
   lint_exec:
     name: Lint exec backend


### PR DESCRIPTION
**Motivation**

The check for if the Cargo.lock was not committed was being done before compiling the zkvm

**Description**

- Move the check to after running cargo clippy