### PR TITLE
ci(l1): fix assertoor tests 

### DIFF
--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -1,10 +1,13 @@
 participants:
   - el_type: geth
+    el_image: ethereum/client-go:v1.16.1
     cl_type: lighthouse
+    cl_image: sigp/lighthouse:v7.1.0
     validator_count: 32
     count: 2
   - el_type: ethrex
     cl_type: lighthouse
+    cl_image: sigp/lighthouse:v7.1.0
     validator_count: 32
 
 network_params:

--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -1,13 +1,10 @@
 participants:
   - el_type: geth
-    el_image: ethereum/client-go:v1.15.2
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v7.0.0-beta.0
     validator_count: 32
     count: 2
   - el_type: ethrex
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v7.0.0-beta.0
     validator_count: 32
 
 network_params:

--- a/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
+++ b/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
@@ -1,17 +1,14 @@
 participants:
   - el_type: ethrex
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v7.0.0-beta.0
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     cl_type: teku
-    cl_image: consensys/teku:latest
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     cl_type: prysm
-    cl_image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
 

--- a/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
+++ b/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
@@ -1,14 +1,17 @@
 participants:
   - el_type: ethrex
     cl_type: lighthouse
+    cl_image: sigp/lighthouse:v7.1.0
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     cl_type: teku
+    cl_image: consensys/teku:25.6.0
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     cl_type: prysm
+    cl_image: gcr.io/offchainlabs/prysm/beacon-chain:v6.0.4
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
 

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -1,12 +1,9 @@
 participants:
   - el_type: geth
-    el_image: ethereum/client-go:v1.15.2
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v7.0.0-beta.0
     validator_count: 32
   - el_type: ethrex
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v7.0.0-beta.0
     validator_count: 32
 
 additional_services:

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -1,9 +1,12 @@
 participants:
   - el_type: geth
+    el_image: ethereum/client-go:v1.16.1
     cl_type: lighthouse
+    cl_image: sigp/lighthouse:v7.1.0
     validator_count: 32
   - el_type: ethrex
     cl_type: lighthouse
+    cl_image: sigp/lighthouse:v7.1.0
     validator_count: 32
 
 additional_services:

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -149,9 +149,9 @@ jobs:
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
           enclave_name: ${{ matrix.enclave_name }}
-          kurtosis_version: "latest"
+          kurtosis_version: "1.10.2"
           ethereum_package_url: "github.com/lambdaclass/ethereum-package"
-          ethereum_package_branch: "main"
+          ethereum_package_branch: "7d0d6c6d91f1745a6b396b3965df69d580cf70a9"
           ethereum_package_args: ${{ matrix.ethereum_package_args }}
 
   run-hive:

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -149,9 +149,9 @@ jobs:
         uses: ethpandaops/kurtosis-assertoor-github-action@v1
         with:
           enclave_name: ${{ matrix.enclave_name }}
-          kurtosis_version: "1.6.0"
+          kurtosis_version: "latest"
           ethereum_package_url: "github.com/lambdaclass/ethereum-package"
-          ethereum_package_branch: "ethrex-integration-pectra"
+          ethereum_package_branch: "main"
           ethereum_package_args: ${{ matrix.ethereum_package_args }}
 
   run-hive:


### PR DESCRIPTION
**Motivation**

We were using an old kurtosis version and when the `ethrex-only-different-cl` job was failing because of this

**Description**

In this PR the kurtosis version used in Github actions was updated to latest from 1.6 (up to now the current version is 1.10.2)
Also the el and cl images used in those jobs were removed, by doing this the default one is used
This PR changes the `lambda/ethereum-package` branch into main.

⚠️ **Depends on this [PR](https://github.com/lambdaclass/ethereum-package/pull/16)** ⚠️


Closes #3712 
