### PR TITLE
chore(l1): move network_params_ethrex_only.yaml to the fixtures folder 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ localnet-assertoor-blob: stop-localnet-silent build-image checkout-ethereum-pack
 	docker logs -f $$(docker ps -q --filter ancestor=ethrex)
 
 localnet-assertoor-ethrex-only: stop-localnet-silent build-image checkout-ethereum-package ## 🌐 Start local network with assertoor test
-	kurtosis run --enclave $(ENCLAVE) ethereum-package --args-file .github/config/assertoor/network_params_ethrex_only.yaml
+	kurtosis run --enclave $(ENCLAVE) ethereum-package --args-file fixtures/network/network_params_ethrex_only.yaml
 	docker logs -f $$(docker ps -q -n 1 --filter ancestor=ethrex)
 
 localnet-assertoor-different-cl: stop-localnet-silent build-image checkout-ethereum-package ## 🌐 Start local network with assertoor test


### PR DESCRIPTION
**Motivation**

The localnet ethrex_only was used for CI, now it isn't but the network_params_ethrex_only.yaml was kept for testing but it still was in the `.github/config/assertoor` folder

**Description**

In PR #3324 the file was moved into `fixtures/network`
Changed path to file in the `Makefile` so that `make localnet-ethrex-only` works again

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3625 

