### PR TITLE
fix(l1,l2): remove cpu-target=native flag from release

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -60,11 +60,9 @@ jobs:
           - platform: ubuntu-22.04
             os: linux
             arch: x86_64
-            rustflags: -C target-cpu=native
           - platform: ubuntu-22.04-arm
             os: linux
             arch: aarch64
-            rustflags: -C target-cpu=native
           - platform: macos-latest
             os: macos
             arch: aarch64
@@ -132,7 +130,6 @@ jobs:
 
       - name: Build prover binary
         run: |
-          export RUSTFLAGS='-C target-cpu=native'
           cd crates/l2
           cargo build --release --features "sp1,gpu,l2" \
             --manifest-path ./prover/Cargo.toml \
@@ -182,7 +179,6 @@ jobs:
 
       - name: Build prover binary
         run: |
-          export RUSTFLAGS='-C target-cpu=native'
           export NVCC_PREPEND_FLAGS='-arch=sm_70'
           cd crates/l2
           cargo build --release --features "risc0,gpu,l2" \


### PR DESCRIPTION
**Motivation**

Using the `cpu-target=native` flag causes the binary to fail (Illegal Instruction) under CPUs that don't support the same features as the CI runner.

**Description**

Removes the flag, allowing the binary to work on other CPUs.
