### PR TITLE
chore(l2): bump sp1 version to 5.0.8

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           . "$HOME/.cargo/env"
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0
+          ~/.sp1/bin/sp1up --version 5.0.8
 
       - name: Set up Docker Buildx
         # if: ${{ always() && github.event_name == 'merge_group' }}

--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -46,7 +46,7 @@ jobs:
         if: matrix.backend == 'sp1'
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0
+          ~/.sp1/bin/sp1up --version 5.0.8
 
       - name: Build
         run: |

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L https://sp1.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0
+          ~/.sp1/bin/sp1up --version 5.0.8
 
       - name: Check ${{ matrix.backend }} backend
         run: |

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -122,7 +122,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -L https://sp1up.succinct.xyz | bash
-          ~/.sp1/bin/sp1up --version 5.0.0
+          ~/.sp1/bin/sp1up --version 5.0.8
 
       - name: Set up QEMU
         if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10616,9 +10616,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.0.5"
+version = "5.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5563b406d74b417ce07c0d7e0d8184b423f3bc3eacd1e98b105691a167f47c8f"
+checksum = "88d96525859507f33edf4389c16470d21f6515d33ae7a2c73d5fb0aea36f5aba"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -10961,9 +10961,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.0.5"
+version = "5.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40fc06701180ce02d6079370d00ca74b8d86c84d85909a3684eddc8bfd8c1bf"
+checksum = "cb0f48c722ad9319b3bc02ac2e61f5a82f8b8584fcdab5fe60db0b2292972857"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10987,9 +10987,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.0.6"
+version = "5.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05114cab7a33f251cf8d470ed85497297dd127a4727569a1a11f759f02136357"
+checksum = "bb6f73c5efb1f55c0b6dca8a9427124eff4e36bd57108a96a7eb5a6034cf61a1"
 dependencies = [
  "alloy-primitives 1.2.1",
  "anyhow",

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -35,10 +35,10 @@ ethrex-sdk.workspace = true
 zkvm_interface = { path = "./zkvm/interface", default-features = false }
 
 risc0-zkvm = { version = "2.1.0", optional = true }
-risc0-zkp = {version = "2.0.1", optional = true }
+risc0-zkp = { version = "2.0.1", optional = true }
 
-sp1-sdk = { version = "5.0.0", optional = true }
-sp1-recursion-gnark-ffi = { version = "5.0.0", optional = true }
+sp1-sdk = { version = "=5.0.8", optional = true }
+sp1-recursion-gnark-ffi = { version = "=5.0.8", optional = true }
 
 [dev-dependencies]
 ethrex-storage.workspace = true
@@ -55,11 +55,7 @@ path = "src/main.rs"
 # TODO(#2662) Prover shouldn't have l2 as a default but cargo complains about missing field in struct
 default = ["l2"]
 # prover backends
-risc0 = [
-  "zkvm_interface/risc0",
-  "dep:risc0-zkvm",
-  "dep:risc0-zkp",
-]
+risc0 = ["zkvm_interface/risc0", "dep:risc0-zkvm", "dep:risc0-zkp"]
 sp1 = ["zkvm_interface/sp1", "dep:sp1-sdk"]
 
 gpu = ["risc0-zkvm?/cuda", "sp1-sdk?/cuda"]

--- a/crates/l2/prover/zkvm/interface/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/Cargo.toml
@@ -20,8 +20,8 @@ ethrex-l2-common = { path = "../../../common", default-features = false }
 [build-dependencies]
 risc0-build = { version = "2.1.2", optional = true }
 risc0-zkvm = { version = "2.1.0", optional = true }
-sp1-build = { version = "5.0.0", optional = true }
-sp1-sdk = { version = "5.0.0", optional = true }
+sp1-build = { version = "=5.0.8", optional = true }
+sp1-sdk = { version = "=5.0.8", optional = true }
 
 [package.metadata.risc0]
 methods = ["risc0"]

--- a/crates/l2/prover/zkvm/interface/build.rs
+++ b/crates/l2/prover/zkvm/interface/build.rs
@@ -59,7 +59,7 @@ fn build_sp1_program() {
             elf_name: Some("riscv32im-succinct-zkvm-elf".to_string()),
             features,
             docker: true,
-            tag: "v5.0.0".to_string(),
+            tag: "v5.0.8".to_string(),
             workspace_directory: Some(format!("{}/../../../../../", env!("CARGO_MANIFEST_DIR"))),
             ..Default::default()
         },

--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.lock
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.lock
@@ -3262,12 +3262,13 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "5.0.5"
+version = "5.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aae088b8816da83224f4eec9bb08d81b62c02c6e74b1a8c7076fe8d45cd438"
+checksum = "5d36441aa04268afe6684b4eca1726599bcb64892cbbe376dafc77c87f5e5fd0"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "lazy_static",
  "libm",
  "rand 0.8.5",

--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [workspace]
 
 [dependencies]
-sp1-zkvm = "5.0.0"
+sp1-zkvm = "=5.0.8"
 zkvm_interface = { path = "../" }
 
 ethrex-common = { path = "../../../../../common", default-features = false }

--- a/docs/ethrex_replay/ethrex_replay.md
+++ b/docs/ethrex_replay/ethrex_replay.md
@@ -20,7 +20,7 @@ rzup install rust
 
 ```sh
 curl -L https://sp1up.succinct.xyz | bash
-sp1up --version 5.0.0
+sp1up --version 5.0.8
 ```
 
 ### Environment Variables

--- a/docs/l2/prover.md
+++ b/docs/l2/prover.md
@@ -36,7 +36,7 @@ sequenceDiagram
   2. `rzup install cargo-risczero 1.2.0`
 - [SP1](https://docs.succinct.xyz/docs/sp1/introduction)
   1. `curl -L https://sp1up.succinct.xyz | bash`
-  2. `sp1up --version 5.0.0`
+  2. `sp1up --version 5.0.8`
 - [SOLC](https://docs.soliditylang.org/en/latest/installing-solidity.html)
 
 After installing the toolchains, a quick test can be performed to check if we have everything installed correctly.


### PR DESCRIPTION
**Motivation**

Some PRs that updated the Cargo.lock and bumped sp1 to 5.0.8 were failing because sp1up was installing version 5.0.0.

**Description**

- Bump and lock all versions of sp1 to 5.0.8

