### PR TITLE
refactor(l2): replace JoinSet with tokio::spawn in init command

### DIFF
--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -39,7 +39,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{sync::Mutex, task::JoinSet};
+use tokio::sync::Mutex;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{error, info};
 


### PR DESCRIPTION
**Motivation**

The `Init` command only needs to manage a single background task, so using `JoinSet` adds unnecessary complexity.

**Description**

- Remove `JoinSet` import and instantiation.
- Spawn the L2 sequencer future directly with `tokio::spawn`, capturing its `JoinHandle`

closes #3721 