### PR TITLE
refactor(l2): remove the dev_mode CLI option and infer dev mode from on‑chain proof getters

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -174,7 +174,6 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
                 listen_ip: opts.proof_coordinator_opts.listen_ip,
                 listen_port: opts.proof_coordinator_opts.listen_port,
                 proof_send_interval_ms: opts.proof_coordinator_opts.proof_send_interval_ms,
-                dev_mode: opts.proof_coordinator_opts.dev_mode,
                 signer: proof_coordinator_signer,
                 tdx_private_key: opts
                     .proof_coordinator_opts
@@ -512,14 +511,6 @@ pub struct ProofCoordinatorOptions {
         help_heading = "Proof coordinator options"
     )]
     pub proof_send_interval_ms: u64,
-    #[arg(
-        long = "proof-coordinator.dev-mode",
-        default_value = "false",
-        value_name = "BOOLEAN",
-        env = "ETHREX_PROOF_COORDINATOR_DEV_MODE",
-        help_heading = "Proof coordinator options"
-    )]
-    pub dev_mode: bool,
 }
 
 impl Default for ProofCoordinatorOptions {
@@ -535,7 +526,6 @@ impl Default for ProofCoordinatorOptions {
             listen_ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 3900,
             proof_send_interval_ms: 5000,
-            dev_mode: false,
             proof_coordinator_tdx_private_key:
                 "0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d"
                     .parse()

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -58,7 +58,6 @@ pub struct ProofCoordinatorConfig {
     pub listen_ip: IpAddr,
     pub listen_port: u16,
     pub proof_send_interval_ms: u64,
-    pub dev_mode: bool,
     pub signer: Signer,
     pub validium: bool,
     pub tdx_private_key: SecretKey,

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -65,22 +65,6 @@ impl L1ProofSenderState {
         let fee_estimate = resolve_fee_estimate(&aligned_cfg.fee_estimate)?;
         let aligned_sp1_elf_path = aligned_cfg.aligned_sp1_elf_path.clone();
 
-        if cfg.dev_mode {
-            return Ok(Self {
-                eth_client,
-                signer: cfg.signer.clone(),
-                on_chain_proposer_address: committer_cfg.on_chain_proposer_address,
-                needed_proof_types: vec![ProverType::Exec],
-                proof_send_interval_ms: cfg.proof_send_interval_ms,
-                sequencer_state,
-                rollup_store,
-                l1_chain_id,
-                network: aligned_cfg.network.clone(),
-                fee_estimate,
-                aligned_sp1_elf_path,
-            });
-        }
-
         Ok(Self {
             eth_client,
             signer: cfg.signer.clone(),

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -53,7 +53,6 @@ pub async fn start_l2(
     let shared_state = SequencerState::from(initial_status);
 
     let Ok(needed_proof_types) = get_needed_proof_types(
-        cfg.proof_coordinator.dev_mode,
         cfg.eth.rpc_url.clone(),
         cfg.l1_committer.on_chain_proposer_address,
     )

--- a/crates/l2/sequencer/utils.rs
+++ b/crates/l2/sequencer/utils.rs
@@ -83,8 +83,12 @@ pub async fn get_needed_proof_types(
             let resp = eth_client
                 .call(on_chain_proposer_address, sig.into(), Overrides::default())
                 .await?;
-            let addr = Address::from_str(&format!("0x{}", &resp[26..]))
-                .map_err(|_| EthClientError::Custom("invalid on‑chain response".into()))?;
+            let addr = Address::from_str(&format!("0x{}", &resp[26..])).map_err(|e| {
+                EthClientError::InternalError(format!(
+                    "Invalid on‑chain response: {:?}, parse error: {}",
+                    resp, e
+                ))
+            })?;
 
             if addr != DEV_MODE_ADDRESS {
                 info!("{pt} proof needed");

--- a/crates/l2/sequencer/utils.rs
+++ b/crates/l2/sequencer/utils.rs
@@ -70,45 +70,34 @@ pub async fn send_verify_tx(
 }
 
 pub async fn get_needed_proof_types(
-    dev_mode: bool,
     rpc_urls: Vec<String>,
     on_chain_proposer_address: Address,
 ) -> Result<Vec<ProverType>, EthClientError> {
     let eth_client = EthClient::new_with_multiple_urls(rpc_urls)?;
 
     let mut needed_proof_types = vec![];
-    if !dev_mode {
-        for prover_type in ProverType::all() {
-            let Some(getter) = prover_type.verifier_getter() else {
-                continue;
-            };
-            let calldata = keccak(getter)[..4].to_vec();
 
-            let response = eth_client
-                .call(
-                    on_chain_proposer_address,
-                    calldata.into(),
-                    Overrides::default(),
-                )
+    for pt in ProverType::all() {
+        if let Some(getter) = pt.verifier_getter() {
+            let sig = keccak(getter)[..4].to_vec();
+            let resp = eth_client
+                .call(on_chain_proposer_address, sig.into(), Overrides::default())
                 .await?;
-            // trim to 20 bytes, also removes 0x prefix
-            let trimmed_response = &response[26..];
+            let addr = Address::from_str(&format!("0x{}", &resp[26..]))
+                .map_err(|_| EthClientError::Custom("invalid on‑chain response".into()))?;
 
-            let address = Address::from_str(&format!("0x{trimmed_response}")).map_err(|_| {
-                EthClientError::Custom(format!(
-                    "Failed to parse OnChainProposer response {response}"
-                ))
-            })?;
-
-            if address != DEV_MODE_ADDRESS {
-                info!("{prover_type} proof needed");
-                needed_proof_types.push(prover_type);
+            if addr != DEV_MODE_ADDRESS {
+                info!("{pt} proof needed");
+                needed_proof_types.push(pt);
             }
         }
-    } else {
-        needed_proof_types.push(ProverType::Exec);
     }
-    Ok(needed_proof_types)
+    // if nothing was required by the contract, fall back to Exec‑only "dev mode"
+    Ok(if needed_proof_types.is_empty() {
+        vec![ProverType::Exec]
+    } else {
+        needed_proof_types
+    })
 }
 
 pub async fn get_latest_sent_batch(


### PR DESCRIPTION
**Motivation**

“dev mode” is now simply the case where the on‑chain proposer contract returns only the `DEV_MODE_ADDRESS` for all proof getters, in which case we fall back to the Exec prover. Removing the CLI option shifts the truth to on‑chain configuration.

**Description**
- Remove the dev_mode field from all L2 CLI structs and configs.
- Delete all code paths that branched on the old flag.
- Update `get_needed_proof_types` to always call the on‑chain getters for every ProverType and collect those whose addresses differ from `DEV_MODE_ADDRESS`. If the resulting list is empty, return `vec![ProverType::Exec]` as the implicit dev‑mode fallback.


Closes #3698 

