### PR TITLE
Updated spawned to 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11082,9 +11082,9 @@ dependencies = [
 
 [[package]]
 name = "spawned-concurrency"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bd46fef02d70d06e3e169d89eaddf1a3c8db6cb689a541705463f7a12260d7"
+checksum = "239ab1253b4872aa9104a64e2d884859d909b075444e3fa8a2f3a1b51f0d3df3"
 dependencies = [
  "futures",
  "spawned-rt",
@@ -11094,9 +11094,9 @@ dependencies = [
 
 [[package]]
 name = "spawned-rt"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7105ceb2a49ea3566f29c57bdc164397d81db934ff6241e1a555df76069b657"
+checksum = "972bbfe83337d386c1ba0a464b3bc6371b285b59cc35dfc3f605a0790f6558b1"
 dependencies = [
  "crossbeam",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,8 @@ url = "2.5.4"
 kzg-rs = "0.2.6"
 libsql = "0.9.10"
 futures = "0.3.31"
-spawned-concurrency = "0.1.5"
-spawned-rt = "0.1.5"
+spawned-concurrency = "0.1.7"
+spawned-rt = "0.1.7"
 lambdaworks-crypto = "0.11.0"
 tui-logger = { version = "0.17.3", features = ["tracing-support"] }
 

--- a/crates/l2/based/block_fetcher.rs
+++ b/crates/l2/based/block_fetcher.rs
@@ -116,6 +116,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct BlockFetcher;
 
 impl BlockFetcher {
@@ -142,10 +143,6 @@ impl GenServer for BlockFetcher {
     type OutMsg = OutMessage;
     type State = BlockFetcherState;
     type Error = BlockFetcherError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,

--- a/crates/l2/based/state_updater.rs
+++ b/crates/l2/based/state_updater.rs
@@ -86,6 +86,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct StateUpdater;
 
 impl StateUpdater {
@@ -110,10 +111,6 @@ impl GenServer for StateUpdater {
     type OutMsg = OutMessage;
     type State = StateUpdaterState;
     type Error = StateUpdaterError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -81,7 +81,7 @@ pub enum OutMessage {
 }
 
 #[derive(Default)]
-pub struct EthrexMonitor {}
+pub struct EthrexMonitor;
 
 impl EthrexMonitor {
     pub async fn spawn(
@@ -107,10 +107,6 @@ impl GenServer for EthrexMonitor {
     type OutMsg = OutMessage;
     type State = EthrexMonitorState;
     type Error = MonitorError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn init(
         &mut self,

--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -80,6 +80,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct BlockProducer;
 
 impl BlockProducer {
@@ -113,10 +114,6 @@ impl GenServer for BlockProducer {
     type State = BlockProducerState;
 
     type Error = BlockProducerError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -110,6 +110,7 @@ pub enum OutMessage {
     Error,
 }
 
+#[derive(Default)]
 pub struct L1Committer;
 
 impl L1Committer {
@@ -142,12 +143,7 @@ impl GenServer for L1Committer {
     type CastMsg = InMessage;
     type OutMsg = OutMessage;
     type State = CommitterState;
-
     type Error = CommitterError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -107,6 +107,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct L1ProofSender;
 
 impl L1ProofSender {
@@ -139,12 +140,7 @@ impl GenServer for L1ProofSender {
     type CastMsg = InMessage;
     type OutMsg = OutMessage;
     type State = L1ProofSenderState;
-
     type Error = ProofSenderError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -72,6 +72,7 @@ pub enum OutMessage {
     Error,
 }
 
+#[derive(Default)]
 pub struct L1Watcher;
 
 impl L1Watcher {
@@ -99,10 +100,6 @@ impl GenServer for L1Watcher {
     type OutMsg = OutMessage;
     type State = L1WatcherState;
     type Error = L1WatcherError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn init(
         &mut self,

--- a/crates/l2/sequencer/metrics.rs
+++ b/crates/l2/sequencer/metrics.rs
@@ -51,6 +51,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct MetricsGatherer;
 
 impl MetricsGatherer {
@@ -75,12 +76,7 @@ impl GenServer for MetricsGatherer {
     type CastMsg = InMessage;
     type OutMsg = OutMessage;
     type State = MetricsGathererState;
-
     type Error = MetricsGathererError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_call(
         &mut self,

--- a/crates/l2/sequencer/proof_coordinator.rs
+++ b/crates/l2/sequencer/proof_coordinator.rs
@@ -224,6 +224,7 @@ pub enum ProofCordOutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct ProofCoordinator;
 
 impl ProofCoordinator {
@@ -261,10 +262,6 @@ impl GenServer for ProofCoordinator {
     type OutMsg = ProofCordOutMessage;
     type State = ProofCoordinatorState;
     type Error = ProofCoordinatorError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,
@@ -307,6 +304,7 @@ async fn handle_listens(state: &ProofCoordinatorState, listener: Arc<TcpListener
     }
 }
 
+#[derive(Default)]
 struct ConnectionHandler;
 
 impl ConnectionHandler {
@@ -345,10 +343,6 @@ impl GenServer for ConnectionHandler {
     type OutMsg = ConnOutMessage;
     type State = ProofCoordinatorState;
     type Error = ProofCoordinatorError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_cast(
         &mut self,

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -160,8 +160,8 @@ pub enum OutMessage {
     Error,
 }
 
-#[derive(Debug)]
-pub struct RLPxConnection {}
+#[derive(Debug, Default)]
+pub struct RLPxConnection;
 
 impl RLPxConnection {
     pub async fn spawn_as_receiver(
@@ -185,10 +185,6 @@ impl GenServer for RLPxConnection {
     type OutMsg = MsgResult;
     type State = RLPxConnectionState;
     type Error = RLPxError;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn init(
         &mut self,


### PR DESCRIPTION
**Motivation**

Spawned 0.1.7 has some minor QoL improvements

**Description**

We can now remove all empty implementations of `fn new()` that was previously required by `GenServer` Trait. We need only to derive `Default`, that is less cumbersome  than the `fn new()`
