### PR TITLE
fix(l2): fix L1 proof sender's wallet/signer

### DIFF
--- a/crates/l2/networking/rpc/signer.rs
+++ b/crates/l2/networking/rpc/signer.rs
@@ -50,7 +50,7 @@ impl From<RemoteSigner> for Signer {
 
 #[derive(Clone, Debug)]
 pub struct LocalSigner {
-    private_key: SecretKey,
+    pub private_key: SecretKey,
     pub address: Address,
 }
 


### PR DESCRIPTION
**Motivation**

The L1 proof sender was broken in #2714 by creating an invalid ethers' `Wallet` [here](github.com/lambdaclass/ethrex/pull/2714/files#r2216602944). This PR fixes it but only allows running the proof sender with a local signer.

To support a remote signer we must investigate if there's a way to create an ethers' signer that uses web3signer.

Thanks @avilagaston9 for noticing the bug!

