### PR TITLE
fix(l1,l2): spawned gen server implementations need to derive default trait

### DIFF
--- a/crates/l2/based/block_fetcher.rs
+++ b/crates/l2/based/block_fetcher.rs
@@ -116,6 +116,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct BlockFetcher;
 
 impl BlockFetcher {

--- a/crates/l2/based/state_updater.rs
+++ b/crates/l2/based/state_updater.rs
@@ -86,6 +86,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct StateUpdater;
 
 impl StateUpdater {

--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -80,6 +80,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct BlockProducer;
 
 impl BlockProducer {

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -110,6 +110,7 @@ pub enum OutMessage {
     Error,
 }
 
+#[derive(Default)]
 pub struct L1Committer;
 
 impl L1Committer {

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -107,6 +107,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct L1ProofSender;
 
 impl L1ProofSender {

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -72,6 +72,7 @@ pub enum OutMessage {
     Error,
 }
 
+#[derive(Default)]
 pub struct L1Watcher;
 
 impl L1Watcher {

--- a/crates/l2/sequencer/metrics.rs
+++ b/crates/l2/sequencer/metrics.rs
@@ -51,6 +51,7 @@ pub enum OutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct MetricsGatherer;
 
 impl MetricsGatherer {

--- a/crates/l2/sequencer/proof_coordinator.rs
+++ b/crates/l2/sequencer/proof_coordinator.rs
@@ -308,6 +308,7 @@ async fn handle_listens(state: &ProofCoordinatorState, listener: Arc<TcpListener
     }
 }
 
+#[derive(Default)]
 struct ConnectionHandler;
 
 impl ConnectionHandler {

--- a/crates/l2/sequencer/proof_coordinator.rs
+++ b/crates/l2/sequencer/proof_coordinator.rs
@@ -224,6 +224,7 @@ pub enum ProofCordOutMessage {
     Done,
 }
 
+#[derive(Default)]
 pub struct ProofCoordinator;
 
 impl ProofCoordinator {

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -160,7 +160,7 @@ pub enum OutMessage {
     Error,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RLPxConnection {}
 
 impl RLPxConnection {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
When using the ethrex repo in a another project, some error appears from structs that implements `GenServer` but doesn't implement the `Default` trait.

**Description**

Added the derive Default trait to the structs that implement GenServer
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

