### PR TITLE
fix(l2): use SP1 embedded allocator

### DIFF
--- a/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
+++ b/crates/l2/prover/zkvm/interface/sp1/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [workspace]
 
 [dependencies]
-sp1-zkvm = "5.0.0"
+sp1-zkvm = { version = "5.0.0", features = ["embedded"] }
 zkvm_interface = { path = "../" }
 
 ethrex-common = { path = "../../../../../common", default-features = false }


### PR DESCRIPTION
**Motivation**

SP1 by default uses a "[bump allocator](https://docs.succinct.xyz/docs/sp1/generating-proofs/advanced#embedded-allocator)" which never deallocs zkvm memory. If we try to prove a batch with ~1500 empty blocks, SP1 panics with an OOM error.

By enabling the `embedded-alloc` allocator the proof is generated correctly for this big batch. Tests are being made to find the new number of empty blocks which make SP1 OOM again.

