### PR TITLE
feat(l2): refactor l1_proof_verifier to use spawned

### DIFF
--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -179,6 +179,10 @@ pub enum ProofVerifierError {
         existing_hex: String,
         latest_hex: String,
     },
+    // TODO: Avoid propagating GenServerErrors outside GenServer modules
+    // See https://github.com/lambdaclass/ethrex/issues/3376
+    #[error("Spawned GenServer Error")]
+    GenServer(GenServerError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/l2/sequencer/l1_proof_verifier.rs
+++ b/crates/l2/sequencer/l1_proof_verifier.rs
@@ -59,7 +59,7 @@ impl L1ProofVerifier {
             eth_cfg,
             aligned_cfg,
             rollup_store,
-            needed_proof_types
+            needed_proof_types,
         )
         .await?;
         let mut handle = L1ProofVerifier::start(state);


### PR DESCRIPTION
**Motivation**
`l1_proof_verifier` verifier still uses a Join Set
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Refactor the `l1_proof_verifier` to use spawned crate
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/3692

