### PR TITLE
chore(l1): change logs in hive to info by default

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.parallelism 16 ${{ env.HIVE_FLAGS }}
+        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1
         continue-on-error: true
 
       - name: Upload results

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -214,7 +214,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Run Hive Simulation
-        run: chmod +x hive && ./hive --client-file fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 16
+        run: chmod +x hive && ./hive --client-file fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 16 --sim.loglevel 1
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ setup-hive: ## 🐝 Set up Hive testing framework
 	fi
 
 TEST_PATTERN ?= /
-SIM_LOG_LEVEL ?= 1
+SIM_LOG_LEVEL ?= 3
 SIM_PARALLELISM ?= 16
 
 # Runs a hive testing suite and opens an web interface on http://127.0.0.1:8080


### PR DESCRIPTION
**Motivation**

In the PR #2975 the default value for the `make run-hive` was changed to error. I propose changing this to info (3), as we usually run make hive to try to see a problem with the test. For the CI I propose we change it to log level error (1), as we can't actually look at those logs.

**Description**

- Changed makefile `SIM_LOG_LEVEL` default value to 3 (info)
- Added to the ci workflows `--sim.loglevel 1` which corresponds to error.


