### PR TITLE
chore(l1): avoid running EF blockchain tests on `make test`

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -48,9 +48,13 @@ jobs:
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
-      - name: Run tests
+      - name: Run unit tests
         run: |
           make test
+
+      - name: Run Blockchain EF tests
+        run: |
+          make -C cmd/ef_tests/blockchain test
 
   docker_build:
     name: Build Docker

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ lint: ## 🧹 Linter check
 CRATE ?= *
 test: ## 🧪 Run each crate's tests
 	cargo test -p '$(CRATE)' --workspace --exclude ethrex-levm --exclude ef_tests-blockchain --exclude ef_tests-state --exclude ethrex-l2 -- --skip test_contract_compilation
-	$(MAKE) -C cmd/ef_tests/blockchain test
 
 clean: clean-vectors ## 🧹 Remove build artifacts
 	cargo clean


### PR DESCRIPTION
**Motivation**
They take a some time and `make test` should be more of a healthcheck imo. They run in the CI anyway.
