### PR TITLE
fix(l2): join verifier task

### DIFF
--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -173,17 +173,19 @@ pub async fn start_l2(
         .await?;
     }
 
-    if let Some(handle) = verifier_handle {
-        match handle.await {
-            Ok(Ok(_)) => {}
-            Ok(Err(err)) => {
-                error!("Error running verifier: {err}");
-            }
-            Err(err) => {
-                error!("Task error: {err}");
-            }
-        };
-    }
+    let Some(handle) = verifier_handle else {
+        return Ok(());
+    };
+
+    match handle.await {
+        Ok(Ok(_)) => {}
+        Ok(Err(err)) => {
+            error!("Error running verifier: {err}");
+        }
+        Err(err) => {
+            error!("Task error: {err}");
+        }
+    };
 
     Ok(())
 }

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -174,5 +174,24 @@ pub async fn start_l2(
         .await?;
     }
 
+    if let Some(res) = task_set.join_next().await {
+        // If a task finishes, the whole sequencer should stop
+        match res {
+            Ok(Ok(_)) => {}
+            Ok(Err(err)) => {
+                error!("Error starting Proposer: {err}");
+            }
+            Err(err) => {
+                error!("JoinSet error: {err}");
+            }
+        };
+        task_set.abort_all();
+    } else {
+        // If no tasks were spawned, we let the sequencer run until it is cancelled
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+
     Ok(())
 }

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -58,7 +58,7 @@ pub async fn start_l2(
         cfg.l1_committer.on_chain_proposer_address,
     )
     .await
-    .inspect_err(|e| error!("Error starting Proposer: {e}")) else {
+    .inspect_err(|e| error!("Error starting Sequencer: {e}")) else {
         return Ok(());
     };
 
@@ -179,7 +179,7 @@ pub async fn start_l2(
         match res {
             Ok(Ok(_)) => {}
             Ok(Err(err)) => {
-                error!("Error starting Proposer: {err}");
+                error!("Error starting Sequencer: {err}");
             }
             Err(err) => {
                 error!("JoinSet error: {err}");


### PR DESCRIPTION
**Motivation**

The `join()` of the verifier task was accidentally removed in #3635.

**Description**

This PR is a quick fix that restores the removed `join()`. The verifier task is being replaced by spawned in #3761.

Closes None

