### PR TITLE
feat(l2): monitor custom table sizes

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -209,6 +209,11 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
             monitor: MonitorConfig {
                 enabled: opts.monitor,
                 tick_rate: opts.monitor_opts.tick_rate,
+                batch_widget_height: opts.monitor_opts.batch_widget_height,
+                block_widget_height: opts.monitor_opts.block_widget_height,
+                mempool_widget_height: opts.monitor_opts.mempool_widget_height,
+                l1_l2_messages_widget_height: opts.monitor_opts.l1_l2_messages_widget_height,
+                l2_l1_messages_widget_height: opts.monitor_opts.l2_l1_messages_widget_height,
             },
         })
     }
@@ -672,4 +677,14 @@ pub struct MonitorOptions {
     /// time in ms between two ticks.
     #[arg(short, long, default_value_t = 1000)]
     tick_rate: u64,
+    #[arg(long, default_value_t = 10)]
+    batch_widget_height: u16,
+    #[arg(long, default_value_t = 10)]
+    block_widget_height: u16,
+    #[arg(long, default_value_t = 10)]
+    mempool_widget_height: u16,
+    #[arg(long, default_value_t = 10)]
+    l1_l2_messages_widget_height: u16,
+    #[arg(long, default_value_t = 10)]
+    l2_l1_messages_widget_height: u16,
 }

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -98,4 +98,14 @@ pub struct MonitorConfig {
     pub enabled: bool,
     /// time in ms between two ticks.
     pub tick_rate: u64,
+    /// height in lines of the batch widget
+    pub batch_widget_height: u16,
+    /// height in lines of the block widget
+    pub block_widget_height: u16,
+    /// height in lines of the mempool widget
+    pub mempool_widget_height: u16,
+    /// height in lines of the L1 to L2 messages widget
+    pub l1_l2_messages_widget_height: u16,
+    /// height in lines of the L2 to L1 messages widget
+    pub l2_l1_messages_widget_height: u16,
 }


### PR DESCRIPTION
**Motivation**
Make monitor tables size configurable
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Adds parameters to make the different tables sizes configurable
<!-- A clear and concise general description of the changes this PR introduces -->

**How to Test**

- Add `--monitor` to the `init-l2-no-metrics` target in `crates/l2/Makefile`.
- Run a Sequencer (I suggest `make restart` in `crates/l2`).

That would show the default values

Add the following to `init-l2-no-metrics` target in `crates/l2/Makefile` to use different sizes

`--batch-widget-height 30 --block-widget-height 40 --mempool-widget-height 50 --l2-l1-messages-widget-height 40 --l1-l2-messages-widget-height 30`


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/3528, Closes https://github.com/lambdaclass/ethrex/issues/3529, Closes https://github.com/lambdaclass/ethrex/issues/3530, Closes https://github.com/lambdaclass/ethrex/issues/3531, Closes https://github.com/lambdaclass/ethrex/issues/3532

