### PR TITLE
fix(l1): fix hive daily workflow

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=7abf18e1ad5970232cf2646481024d8922194ec3 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1 --docker.nocache "ethereum/eest/*"
+        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=v4.5.0 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1 --docker.nocache "ethereum/eest/*"
         continue-on-error: true
 
       - name: Upload results

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=7abf18e1ad5970232cf2646481024d8922194ec3 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1
+        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=7abf18e1ad5970232cf2646481024d8922194ec3 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1 --docker.nocache
         continue-on-error: true
 
       - name: Upload results

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=7abf18e1ad5970232cf2646481024d8922194ec3 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1 --docker.nocache
+        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=7abf18e1ad5970232cf2646481024d8922194ec3 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1 --docker.nocache "ethereum/eest/*"
         continue-on-error: true
 
       - name: Upload results

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Run Hive Simulation
-        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1
+        run: cd hive && ./hive --client-file ../fixtures/network/hive_clients/ethrex.yml --client ethrex --sim ${{ matrix.test.simulation }} --sim.buildarg branch=7abf18e1ad5970232cf2646481024d8922194ec3 --sim.parallelism 16 ${{ env.HIVE_FLAGS }} --sim.loglevel 1
         continue-on-error: true
 
       - name: Upload results


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Some weeks ago the hive daily report stopped running

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

The problem was that the Ethereum Execution Spec Test Repo wasn't pinned in the workflow, now it's pinned to the release v4.5.0. Also the `docker.nocache` flag was set for the `eest` tests, without this flag there was a problem with the fixtures needed for the tests

With this changes the daily report work, but there amount of test that are being ran in the `Consume Engine test` has increase and there are failing tests, some test that used to work are no longer working. [Link](https://github.com/lambdaclass/ethrex/actions/runs/16481443742)

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3674
