### PR TITLE
refactor(levm): use common functions to deserialize in EF tests runner

### DIFF
--- a/cmd/ef_tests/state/runner_v2/types.rs
+++ b/cmd/ef_tests/state/runner_v2/types.rs
@@ -1,11 +1,9 @@
 use crate::runner_v2::{
     deserialize::{
         deserialize_access_lists, deserialize_authorization_lists,
-        deserialize_ef_post_value_indexes, deserialize_h256_vec_optional_safe,
-        deserialize_hex_bytes, deserialize_hex_bytes_vec, deserialize_post,
-        deserialize_transaction_expected_exception, deserialize_u64_safe, deserialize_u64_vec_safe,
-        deserialize_u256_optional_safe, deserialize_u256_safe,
-        deserialize_u256_valued_hashmap_safe, deserialize_u256_vec_safe,
+        deserialize_ef_post_value_indexes, deserialize_h256_vec_optional_safe, deserialize_post,
+        deserialize_transaction_expected_exception, deserialize_u256_valued_hashmap_safe,
+        deserialize_u256_vec_safe,
     },
     error::RunnerError,
 };
@@ -14,6 +12,11 @@ use bytes::Bytes;
 
 use ethrex_common::{
     Address, H256, U256,
+    serde_utils::{
+        bytes::{deserialize as deserialize_bytes, vec::deserialize as deserialize_bytes_vec},
+        u64::hex_str::{deser_u64_vec as deserialize_u64_vec, deserialize as deserialize_u64},
+        u256::{deser_hex_str as deserialize_u256, deser_hex_str_opt as deserialize_option_u256},
+    },
     types::{AuthorizationTuple, Fork, Genesis, GenesisAccount, TxKind},
 };
 
@@ -280,19 +283,19 @@ pub struct Info {
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct Env {
-    #[serde(default, deserialize_with = "deserialize_u256_optional_safe")]
+    #[serde(default, deserialize_with = "deserialize_option_u256")]
     pub current_base_fee: Option<U256>,
     pub current_coinbase: Address,
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub current_difficulty: U256,
-    #[serde(default, deserialize_with = "deserialize_u256_optional_safe")]
+    #[serde(default, deserialize_with = "deserialize_option_u256")]
     pub current_excess_blob_gas: Option<U256>,
-    #[serde(deserialize_with = "deserialize_u64_safe")]
+    #[serde(deserialize_with = "deserialize_u64")]
     pub current_gas_limit: u64,
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub current_number: U256,
     pub current_random: Option<H256>,
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub current_timestamp: U256,
 }
 
@@ -337,11 +340,11 @@ pub struct Post {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AccountState {
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub balance: U256,
-    #[serde(deserialize_with = "deserialize_hex_bytes")]
+    #[serde(deserialize_with = "deserialize_bytes")]
     pub code: Bytes,
-    #[serde(deserialize_with = "deserialize_u64_safe")]
+    #[serde(deserialize_with = "deserialize_u64")]
     pub nonce: u64,
     #[serde(deserialize_with = "deserialize_u256_valued_hashmap_safe")]
     pub storage: HashMap<U256, U256>,
@@ -390,16 +393,16 @@ pub struct AccessListItem {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthorizationListTuple {
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub chain_id: U256,
     pub address: Address,
-    #[serde(deserialize_with = "deserialize_u64_safe")]
+    #[serde(deserialize_with = "deserialize_u64")]
     pub nonce: u64,
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub v: U256,
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub r: U256,
-    #[serde(deserialize_with = "deserialize_u256_safe")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub s: U256,
     pub signer: Option<Address>,
 }
@@ -440,7 +443,7 @@ pub struct RawPostValue {
     pub indexes: HashMap<String, U256>,
     pub logs: H256,
     // we add the default because some tests don't have this field
-    #[serde(default, deserialize_with = "deserialize_hex_bytes")]
+    #[serde(default, deserialize_with = "deserialize_bytes")]
     pub txbytes: Bytes,
     pub state: Option<HashMap<Address, AccountState>>,
 }
@@ -448,24 +451,24 @@ pub struct RawPostValue {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawTransaction {
-    #[serde(deserialize_with = "deserialize_hex_bytes_vec")]
+    #[serde(deserialize_with = "deserialize_bytes_vec")]
     pub data: Vec<Bytes>,
-    #[serde(deserialize_with = "deserialize_u64_vec_safe")]
+    #[serde(deserialize_with = "deserialize_u64_vec")]
     pub gas_limit: Vec<u64>,
-    #[serde(default, deserialize_with = "deserialize_u256_optional_safe")]
+    #[serde(default, deserialize_with = "deserialize_option_u256")]
     pub gas_price: Option<U256>,
-    #[serde(deserialize_with = "deserialize_u64_safe")]
+    #[serde(deserialize_with = "deserialize_u64")]
     pub nonce: u64,
     pub secret_key: H256,
     pub sender: Address,
     pub to: TxKind,
     #[serde(deserialize_with = "deserialize_u256_vec_safe")]
     pub value: Vec<U256>,
-    #[serde(default, deserialize_with = "deserialize_u256_optional_safe")]
+    #[serde(default, deserialize_with = "deserialize_option_u256")]
     pub max_fee_per_gas: Option<U256>,
-    #[serde(default, deserialize_with = "deserialize_u256_optional_safe")]
+    #[serde(default, deserialize_with = "deserialize_option_u256")]
     pub max_priority_fee_per_gas: Option<U256>,
-    #[serde(default, deserialize_with = "deserialize_u256_optional_safe")]
+    #[serde(default, deserialize_with = "deserialize_option_u256")]
     pub max_fee_per_blob_gas: Option<U256>,
     #[serde(default, deserialize_with = "deserialize_h256_vec_optional_safe")]
     pub blob_versioned_hashes: Option<Vec<H256>>,

--- a/crates/common/serde_utils.rs
+++ b/crates/common/serde_utils.rs
@@ -46,8 +46,20 @@ pub mod u256 {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(d)?;
-        U256::from_str_radix(value.trim_start_matches("0x"), 16)
+        U256::from_str_radix(value.trim_start_matches("0x:bigint ").trim_start_matches("0x"), 16)
             .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
+    }
+
+    pub fn deser_hex_str_opt<'de, D>(d: D) -> Result<Option<U256>, D::Error>
+    where
+        D: Deserializer<'de>
+    {
+        let s = Option::<String>::deserialize(d)?;
+        match s {
+            Some(s) => U256::from_str_radix(s.trim_start_matches("0x:bigint ").trim_start_matches("0x"), 16)
+            .map_err(|_| D::Error::custom("Failed to deserialize u256 value")).map(Some),
+            None => Ok(None)
+        }
     }
 
     pub fn deser_hex_or_dec_str<'de, D>(d: D) -> Result<U256, D::Error>
@@ -117,6 +129,8 @@ pub mod u256 {
 }
 
 pub mod u64 {
+    use serde::de::IntoDeserializer;
+
     use super::*;
 
     pub mod hex_str {
@@ -129,6 +143,20 @@ pub mod u64 {
             let value = String::deserialize(d)?;
             u64::from_str_radix(value.trim_start_matches("0x"), 16)
                 .map_err(|_| D::Error::custom("Failed to deserialize u64 value"))
+        }
+
+        pub fn deser_u64_vec<'de, D>(deserializer: D) -> Result<Vec<u64>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let raw_vec = Vec::<String>::deserialize(deserializer)?;
+            raw_vec
+                .into_iter()
+                .map(|s| {
+                    let deser = s.into_deserializer();
+                    deserialize(deser)
+                })
+                .collect()
         }
 
         pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
@@ -225,6 +253,8 @@ pub mod u64 {
                 .map_err(|_| D::Error::custom("Failed to deserialize u64 value"))
         }
     }
+
+
 }
 
 pub mod u128 {


### PR DESCRIPTION
**Description**

The current EF state tests runner has its own implementation for deserializing every value that comes from the tests JSONs. The idea is to use already implemented common functions in the `common` crate or to update the existing functions to satisfy the runner's requirements as well. 

Closes #3793 

