### PR TITLE
perf(levm): lazy invalid jumpdest calculation + cache

### DIFF
--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::STACK_LIMIT,
     errors::{ExceptionalHalt, InternalError, VMError},
     memory::Memory,
-    utils::{get_invalid_jump_destinations, restore_cache_state},
+    utils::restore_cache_state,
     vm::VM,
 };
 use bytes::Bytes;
@@ -228,9 +228,6 @@ pub struct CallFrame {
     pub is_static: bool,
     /// Call stack current depth
     pub depth: usize,
-    /// Sorted blacklist of jump targets. Contains all offsets of 0x5B (JUMPDEST) in literals (after
-    /// push instructions).
-    pub invalid_jump_destinations: Box<[usize]>,
     /// This is set to true if the function that created this callframe is CREATE or CREATE2
     pub is_create: bool,
     /// Everytime we want to write an account during execution of a callframe we store the pre-write state so that we can restore if it reverts
@@ -301,8 +298,6 @@ impl CallFrame {
         stack: Stack,
         memory: Memory,
     ) -> Self {
-        let invalid_jump_destinations =
-            Box::default();
         // Note: Do not use ..Default::default() because it has runtime cost.
         Self {
             gas_limit,
@@ -315,7 +310,6 @@ impl CallFrame {
             calldata,
             is_static,
             depth,
-            invalid_jump_destinations,
             should_transfer_value,
             is_create,
             ret_offset,
@@ -354,7 +348,6 @@ impl CallFrame {
     }
 
     pub fn set_code(&mut self, code: Bytes) -> Result<(), VMError> {
-        //self.invalid_jump_destinations = get_invalid_jump_destinations(&code)?;
         self.bytecode = code;
         Ok(())
     }

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -329,7 +329,7 @@ impl<'a> VM<'a> {
 
     /// Check if the jump destination is valid by:
     ///   - Checking that the byte at the requested target PC is a JUMPDEST (0x5B).
-    ///   - Ensuring the byte is not blacklisted. In other words, the 0x5B value is not part of a
+    ///   - Ensuring the byte, the 0x5B value, is not part of a
     ///     constant associated with a push instruction.
     fn target_address_is_valid(call_frame: &CallFrame, jump_address: usize) -> bool {
         #[expect(clippy::as_conversions)]
@@ -347,8 +347,7 @@ impl<'a> VM<'a> {
                     .take(diff);
 
                 while let Some((i, op)) = iter.next() {
-                    let op_code = Opcode::from(*op);
-                    if (Opcode::PUSH1..=Opcode::PUSH32).contains(&op_code) {
+                    if *op >= (Opcode::PUSH1 as u8) && *op <= (Opcode::PUSH32 as u8) {
                         #[allow(clippy::arithmetic_side_effects, clippy::as_conversions)]
                         let num_bytes = (op - u8::from(Opcode::PUSH0)) as usize;
                         if i.wrapping_add(num_bytes) >= jump_address {


### PR DESCRIPTION
**Motivation**

Adds a cache for invalid jump destinations and also delays its calculation until a jump is reached. 

This makes the path where no jump is ever reached to not waste cycles calculating invalid jump dests, and also caches it. For now the cache is per created vm, which is not shared across txs/blocks, but this could be improved further.

This results in a 13.75% increase in mgas on Address

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

