### PR TITLE
perf(levm): lazy invalid jumpdest calculation + cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### 2025-07-21
 
+- Calculate invalid jump destinations lazily and cache them [#3809](https://github.com/lambdaclass/ethrex/pull/3809)
+
+### 2025-07-21
+
 - Use `rayon` to recover the sender address from transactions [#3709](https://github.com/lambdaclass/ethrex/pull/3709)
 
 ### 2025-07-18

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -753,6 +753,7 @@ impl<'a> VM<'a> {
             0,
             stack,
             next_memory,
+            self.jump_cache.clone()
         );
         self.call_frames.push(new_call_frame);
 
@@ -832,6 +833,7 @@ impl<'a> VM<'a> {
             ret_size,
             stack,
             next_memory,
+            self.jump_cache.clone()
         );
         self.call_frames.push(new_call_frame);
 

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -753,7 +753,7 @@ impl<'a> VM<'a> {
             0,
             stack,
             next_memory,
-            self.jump_cache.clone()
+            self.jump_cache.clone(),
         );
         self.call_frames.push(new_call_frame);
 
@@ -833,7 +833,7 @@ impl<'a> VM<'a> {
             ret_size,
             stack,
             next_memory,
-            self.jump_cache.clone()
+            self.jump_cache.clone(),
         );
         self.call_frames.push(new_call_frame);
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -64,6 +64,7 @@ pub struct VM<'a> {
     /// A pool of stacks to avoid reallocating too much when creating new call frames.
     pub stack_pool: Vec<Stack>,
     pub vm_type: VMType,
+    pub jump_cache: Rc<RefCell<BTreeMap<Address, Box<[usize]>>>>,
 }
 
 impl<'a> VM<'a> {
@@ -89,6 +90,7 @@ impl<'a> VM<'a> {
             debug_mode: DebugMode::disabled(),
             stack_pool: Vec::new(),
             vm_type,
+            jump_cache: Default::default(),
         };
 
         vm.setup_vm()?;
@@ -122,6 +124,7 @@ impl<'a> VM<'a> {
             0,
             Stack::default(),
             Memory::default(),
+            self.jump_cache.clone()
         );
 
         self.call_frames.push(initial_call_frame);

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -124,7 +124,7 @@ impl<'a> VM<'a> {
             0,
             Stack::default(),
             Memory::default(),
-            self.jump_cache.clone()
+            self.jump_cache.clone(),
         );
 
         self.call_frames.push(initial_call_frame);


### PR DESCRIPTION
**Motivation**

Adds a cache for invalid jump destinations and also delays its calculation until a jump is reached.

This makes the path where no jump is ever reached to not waste cycles calculating invalid jump dests, and also caches it. For now the cache is per created vm, which is not shared across txs/blocks, but this could be improved further.

This results in a 13.75% increase in mgas on Address, should also improve CallerPop and Caller

Closes #3778

Closes #3779

Closes #3777

Positive % = better performance

<img width="3024" height="3826" alt="image" src="https://github.com/user-attachments/assets/74908f7d-7869-4d48-ae88-7d396e3d04d4" />


