### PR TITLE
fix(l2): move hardcoded rpc url to WatcherConfig (#3696)

### DIFF
--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -47,7 +47,6 @@ pub struct EthConfig {
 
 #[derive(Clone, Debug)]
 pub struct L1WatcherConfig {
-    pub rpc_url: Vec<String>,
     pub bridge_address: Address,
     pub check_interval_ms: u64,
     pub max_block_step: U256,

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -47,6 +47,7 @@ pub struct EthConfig {
 
 #[derive(Clone, Debug)]
 pub struct L1WatcherConfig {
+    pub rpc_url: Vec<String>,
     pub bridge_address: Address,
     pub check_interval_ms: u64,
     pub max_block_step: U256,

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -55,7 +55,7 @@ impl L1Watcher {
         sequencer_state: SequencerState,
     ) -> Result<Self, L1WatcherError> {
         let eth_client = EthClient::new_with_multiple_urls(eth_config.rpc_url.clone())?;
-        let l2_client = EthClient::new("http://localhost:1729")?;
+        let l2_client = EthClient::new_with_multiple_urls(watcher_config.rpc_url.clone())?;
         let last_block_fetched = U256::zero();
         Ok(Self {
             store,

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -53,9 +53,10 @@ impl L1Watcher {
         eth_config: &EthConfig,
         watcher_config: &L1WatcherConfig,
         sequencer_state: SequencerState,
+        l2_url: String,
     ) -> Result<Self, L1WatcherError> {
         let eth_client = EthClient::new_with_multiple_urls(eth_config.rpc_url.clone())?;
-        let l2_client = EthClient::new_with_multiple_urls(watcher_config.rpc_url.clone())?;
+        let l2_client = EthClient::new(l2_url)?;
         let last_block_fetched = U256::zero();
         Ok(Self {
             store,
@@ -76,6 +77,7 @@ impl L1Watcher {
         blockchain: Arc<Blockchain>,
         cfg: SequencerConfig,
         sequencer_state: SequencerState,
+        l2_url: String,
     ) -> Result<(), L1WatcherError> {
         let state = Self::new(
             store,
@@ -83,6 +85,7 @@ impl L1Watcher {
             &cfg.eth,
             &cfg.l1_watcher,
             sequencer_state,
+            l2_url,
         )?;
         state.start();
         Ok(())

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -73,6 +73,7 @@ pub async fn start_l2(
         blockchain.clone(),
         cfg.clone(),
         shared_state.clone(),
+        l2_url.clone(),
     )
     .await
     .inspect_err(|err| {

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -39,7 +39,7 @@ pub async fn start_l2(
     blockchain: Arc<Blockchain>,
     cfg: SequencerConfig,
     cancellation_token: CancellationToken,
-    #[cfg(feature = "metrics")] l2_url: String,
+    l2_url: String,
 ) -> Result<(), errors::SequencerError> {
     let initial_status = if cfg.based.enabled {
         SequencerStatus::default()


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
The L2 RPC URL was previously hardcoded in the codebase, making it difficult to configure across different environments and deployments. This reduces flexibility and increases the likelihood of errors when changing RPC endpoints.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
This PR moves the L2 RPC URL into `WatcherConfig`, removing the hardcoded value. The URL can now be configured via the config file, improving modularity and making the setup more environment-agnostic. This change touches the watcher component responsible for connecting to L2.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3696


