### PR TITLE
perf(levm): enable lto codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,11 @@ default-members = ["cmd/ethrex"]
 version = "0.1.0"
 edition = "2024"
 
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+
 [profile.release-with-debug]
 inherits = "release"
 debug = 2

--- a/cmd/ef_tests/blockchain/Makefile
+++ b/cmd/ef_tests/blockchain/Makefile
@@ -24,10 +24,10 @@ clean-vectors: ## 🗑️  Clean test vectors
 	rm -f $(SPECTEST_ARTIFACT)
 
 test-levm: $(SPECTEST_VECTORS_DIR) ## 🧪 Run blockchain tests with LEVM
-	cargo test --release --features levm
+	cargo test --profile release-with-debug --features levm
 
 test-revm: $(SPECTEST_VECTORS_DIR) ## 🧪 Run blockchain tests with REVM
-	cargo test --release
+	cargo test --profile release-with-debug
 
 test: $(SPECTEST_VECTORS_DIR) ## 🧪 Run blockchain tests with both VMs
 	$(MAKE) test-levm

--- a/cmd/ef_tests/state/Makefile
+++ b/cmd/ef_tests/state/Makefile
@@ -51,15 +51,15 @@ refresh-evm-ef-tests: clean-evm-ef-tests download-evm-ef-tests ## Cleans and re-
 
 run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	if [ "$(QUIET)" = "true" ]; then \
-		time cargo test --quiet --test all --release -- $(flags) --summary;\
+		time cargo test --quiet --test all --profile release-with-debug -- $(flags) --summary;\
 	elif [ "$(DEBUG)" = "true" ]; then \
 		time cargo test --test all -- $(flags);\
 	else \
-		time cargo test --test all --release -- $(flags);\
+		time cargo test --test all --profile release-with-debug -- $(flags);\
 	fi
 
 run-evm-ef-tests-ci: $(VECTORS_DIR) ## 🏃‍♂️ Run EF Tests only with LEVM and without spinner, for CI.
-	time cargo test -p ef_tests-state --test all --release -- --summary
+	time cargo test -p ef_tests-state --test all --profile release-with-debug -- --summary
 
 test-levm: $(VECTORS_DIR)
 	$(MAKE) run-evm-ef-tests flags="--summary"
@@ -101,14 +101,14 @@ samply-run-ef-tests-revm:
 	@for dir in $(SUBDIRS); do\
 		CARGO_PROFILE_RELEASE_DEBUG=true samply record --save-only \
 		-o levm_perfgraphs/samply/ef_tests/revm/prof_$$dir.json \
-		cargo test --release -p ef_tests-state --test all -- --summary --revm --tests $$dir;\
+		cargo test --profile release-with-debug -p ef_tests-state --test all -- --summary --revm --tests $$dir;\
 	done
 
 samply-run-ef-tests-levm:
 	@for dir in $(SUBDIRS); do\
 		CARGO_PROFILE_RELEASE_DEBUG=true samply record --save-only \
 		-o levm_perfgraphs/samply/ef_tests/state/prof_$$dir.json \
-		cargo test --release -p ef_tests-state --test all -- --summary --tests $$dir;\
+		cargo test --profile release-with-debug -p ef_tests-state --test all -- --summary --tests $$dir;\
 	done
 
 ################
@@ -129,11 +129,11 @@ define run_samply
 	# revm
 	CARGO_PROFILE_RELEASE_DEBUG=true samply record --save-only \
 	-o $(SAMPLY_DIR)/prof_revm_$(1).json \
-	cargo run --release -p revm_comparison --bin benchmark -- revm $(1) $($(2)) $($(3))
+	cargo run --profile release-with-debug -p revm_comparison --bin benchmark -- revm $(1) $($(2)) $($(3))
 	# levm
 	CARGO_PROFILE_RELEASE_DEBUG=true samply record --save-only \
 	-o $(SAMPLY_DIR)/prof_levm_$(1).json \
-	cargo run --release -p revm_comparison --bin benchmark -- levm $(1) $($(2)) $($(3))
+	cargo run --profile release-with-debug -p revm_comparison --bin benchmark -- levm $(1) $($(2)) $($(3))
 endef
 
 FLAMEGRAPH_DIR := levm_perfgraphs/flamegraph/bench
@@ -163,4 +163,4 @@ samply-benchmarks: ## ⚡️ Run benchmarks and create samply profiling file
 ## New EF state tests runner
 TESTS_PATH := ./vectors
 run-new-runner:
-	cargo test --package ef_tests-state --test new_runner --release -- $(TESTS_PATH)
+	cargo test --package ef_tests-state --test new_runner --profile release-with-debug -- $(TESTS_PATH)

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -198,7 +198,7 @@ rm-db-l2: ## 🛑 Removes the DB used by the L2
 	cargo run --release --manifest-path ../../Cargo.toml --bin ethrex -- l2 removedb --datadir ${ethrex_L2_DEV_LIBMDBX} --force
 
 test: ## 🚧 Runs the L2's integration test, run `make init` and in a new terminal make test
-	cargo test l2_integration_test --release -- --nocapture || (echo "The tests have failed.\n Is the L2 running? To start it, run:\n make rm-db-l1; make rm-db-l2; make restart" ; exit 1)
+	cargo test l2_integration_test --profile release-with-debug -- --nocapture || (echo "The tests have failed.\n Is the L2 running? To start it, run:\n make rm-db-l1; make rm-db-l2; make restart" ; exit 1)
 
 integration-test: rm-db-l2 rm-db-l1 # We create an empty .env file simply because if the file
 	# does not exist, the container fails to write to it.


### PR DESCRIPTION
**Motivation**

Lto seems to improve perfomance in some benches without regressions.

A question would be, do we add it as another profile that we use explicitly for releases or keep it as default for --release. I ask this question because the --release flag is used in lot of testing code and it would slow compile times of those

<img width="2560" height="2235" alt="image" src="https://github.com/user-attachments/assets/e79fbb09-237f-4e91-a843-5f91e9d4ecbb" />


