### PR TITLE
ci(l1): add the posibility to pin execution-spec-test ref

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -77,11 +77,15 @@ jobs:
       - name: Setup Hive
         run: make setup-hive
 
+      # Set custom args defined in Dockerfile to pin execution-spec-tests versions
+      # See: https://github.com/ethereum/hive/blob/c2dab60f898b94afe8eeac505f60dcde59205e77/simulators/ethereum/eest/consume-rlp/Dockerfile#L4-L8
+      # We use the `main` branch for now since its working, but if we can pin it to a specific release if necessary
       - name: Set custom hive flags
         run: |
           if [[ "${{ matrix.test.simulation }}" == "ethereum/eest/consume-engine" || "${{ matrix.test.simulation }}" == "ethereum/eest/consume-rlp" ]]; then
             EEST_FIXTURES=$(cat cmd/ef_tests/blockchain/.fixtures_url)
-            echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
+            EEST_BRANCH=main
+            echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' branch=$EEST_BRANCH --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
           fi
 
       - name: Run Hive Simulation

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -79,7 +79,7 @@ jobs:
 
       # Set custom args defined in Dockerfile to pin execution-spec-tests versions
       # See: https://github.com/ethereum/hive/blob/c2dab60f898b94afe8eeac505f60dcde59205e77/simulators/ethereum/eest/consume-rlp/Dockerfile#L4-L8
-      # We use the `main` branch for now since its working, but if we can pin it to a specific release if necessary
+      # We use the `main` branch for now since it's working, but we can pin it to a specific release if necessary
       - name: Set custom hive flags
         run: |
           if [[ "${{ matrix.test.simulation }}" == "ethereum/eest/consume-engine" || "${{ matrix.test.simulation }}" == "ethereum/eest/consume-rlp" ]]; then

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           if [[ "${{ matrix.test.simulation }}" == "ethereum/eest/consume-engine" || "${{ matrix.test.simulation }}" == "ethereum/eest/consume-rlp" ]]; then
             EEST_FIXTURES=$(cat cmd/ef_tests/blockchain/.fixtures_url)
             EEST_BRANCH=main
-            echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' branch=$EEST_BRANCH --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
+            echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' branch='"$EEST_BRANCH"' --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
           fi
 
       - name: Run Hive Simulation

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -85,7 +85,7 @@ jobs:
           if [[ "${{ matrix.test.simulation }}" == "ethereum/eest/consume-engine" || "${{ matrix.test.simulation }}" == "ethereum/eest/consume-rlp" ]]; then
             EEST_FIXTURES=$(cat cmd/ef_tests/blockchain/.fixtures_url)
             EEST_BRANCH=main
-            echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' branch='"$EEST_BRANCH"' --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
+            echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' --sim.buildarg branch='"$EEST_BRANCH"' --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
           fi
 
       - name: Run Hive Simulation


### PR DESCRIPTION
**Motivation**
Recently the daily Hive job broke because we're using the `main` branch of https://github.com/lambdaclass/execution-spec-tests and a commit might have broken. This has been fixed but I want to make it explicit that we're using `main`. Don't think there's a need to pin right now.

Closes https://github.com/lambdaclass/ethrex/issues/3674

