### PR TITLE
fix(levm): fix custom bytecode runner

### DIFF
--- a/crates/vm/levm/runner/src/main.rs
+++ b/crates/vm/levm/runner/src/main.rs
@@ -179,7 +179,7 @@ fn main() {
     }
 
     // Print final stack and memory
-    let callframe = vm.pop_call_frame().unwrap();
+    let callframe = vm.current_call_frame;
     info!(
         "Final Stack (bottom to top): {:?}",
         &callframe.stack.values[callframe.stack.offset..]


### PR DESCRIPTION
**Motivation**

Due to the callframe change the runner stopped working, because it tries to pop the callframe when it should just use current_callframe

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

