### PR TITLE
fix(l1): mute `spawned_concurrency` tracing when running metrics server

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -34,9 +34,13 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber, filter::Directive};
 pub fn init_tracing(opts: &Options) {
     let log_filter = EnvFilter::builder()
         .from_env_lossy()
-        .add_directive(Directive::from(opts.log_level))
-        .add_directive(Directive::from_str("spawned_concurrency::tasks::gen_server=off")
-        .expect("this can't fail"));
+        .add_directive(
+            // Filters all spawned logs
+            // TODO: revert #3467 when error logs are no longer emitted
+            Directive::from_str("spawned_concurrency::tasks::gen_server=off")
+                .expect("this can't fail"),
+        )
+        .add_directive(Directive::from(opts.log_level));
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(log_filter)
         .finish();


### PR DESCRIPTION
**Motivation**
When initializing tracing, we purposefully set the log level for `spawned_concurrency::spawned_concurrency::tasks::gen_server` to `OFF`. This is working fine when running ethrex as a binary (ie cargo run) but the directive gets overridden when we run the metrics server (ie start-holesky-metrics-docker target in tooling/sync).
This PR fixes this issue by reordering how the `EnvFilter` for tracing is built, it is know first built from the env and then has the directives added to it.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Reorder `EnvFilter` building in `init_tracing` to first build it from the env and then add the `spawned_concurrency` directive
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

