### PR TITLE
feat(l1): add  `start-sepolia-metrics-docker` target to `tooling/sync/Makefile`

### DIFF
--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -1,4 +1,8 @@
-.PHONY = start_geth_holesky start_lighthouse_holesky gen_jwt
+.PHONY = help create_data_dir gen_jwt sync start_geth_holesky flamegraph-main  flamegraph \
+flamegraph-branch flamegraph-holesky flamegraph-hoodi start-lighthouse holesky-lighthouse \
+hoodi-lighthouse sepolia-lighthouse backup-db start-ethrex-hoodi start-ethrex-holesky \
+start-ethrex-sepolia start-hoodi-metrics-docker start-holesky-metrics-docker \
+start-sepolia-metrics-docker tail-syncing-logs tail-metrics-logs copy_flamegraph
 
 ETHREX_DIR ?= "../.."
 EVM ?= levm


### PR DESCRIPTION
**Motivation**
Add a way to start the metrics server when running in sepolia testnet

<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `start-sepolia-metrics-docker` target + necessary targets
* Upadte .PHONY
**Follow Up Work**
* Also add target for mainnet
* Make network parametrizable so we can remove repeated code
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

