### PR TITLE
add execution flags to runner

### DIFF
--- a/cmd/ef_tests/state/Makefile
+++ b/cmd/ef_tests/state/Makefile
@@ -161,6 +161,5 @@ samply-benchmarks: ## ⚡️ Run benchmarks and create samply profiling file
 	$(call run_samply,ERC20Mint,REPETITIONS_SLOW,BENCH_MINT_ITERATIONS)
 
 ## New EF state tests runner
-TESTS_PATH := ./vectors
 run-new-runner:
-	cargo test --package ef_tests-state --test new_runner --release -- $(TESTS_PATH)
+	cargo test --package ef_tests-state --test new_runner --release -- $(FLAGS)

--- a/cmd/ef_tests/state/runner_v2/parser.rs
+++ b/cmd/ef_tests/state/runner_v2/parser.rs
@@ -1,9 +1,28 @@
-use std::path::PathBuf;
-
 use crate::runner_v2::{
     error::RunnerError,
     types::{Test, Tests},
 };
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct RunnerOptions {
+    /// For running tests in a specific file (could be either a directory or a .json)
+    #[arg(
+        short,
+        long,
+        value_name = "PATH",
+        value_delimiter = ',',
+        default_value = "./vectors"
+    )]
+    pub path: String,
+    /// For running tests in specific .json files. If this is not empty, "path" flag will be ignored.
+    #[arg(short, long, value_name = "JSON_FILES", value_delimiter = ',')]
+    pub json_files: Vec<String>,
+    /// For skipping certain .json files
+    #[arg(long, value_name = "SKIP_FILES", value_delimiter = ',')]
+    pub skip_files: Vec<String>,
+}
 
 const IGNORED_TESTS: [&str; 12] = [
     "static_Call50000_sha256.json", // Skip because it takes longer to run than some tests, but not a huge deal.
@@ -21,17 +40,18 @@ const IGNORED_TESTS: [&str; 12] = [
 ];
 
 /// Parse a `.json` file of tests into a Vec<Test>.
-pub fn parse_file(path: PathBuf) -> Result<Vec<Test>, RunnerError> {
+pub fn parse_file(path: &String) -> Result<Vec<Test>, RunnerError> {
+    println!("Parsing file: {:?}", path);
     let test_file = std::fs::File::open(path.clone()).unwrap();
     let mut tests: Tests = serde_json::from_reader(test_file).unwrap();
     for test in tests.0.iter_mut() {
-        test.path = String::from(path.to_str().unwrap());
+        test.path = path.clone();
     }
     Ok(tests.0)
 }
 
 /// Parse a directory of tests into a Vec<Test>.
-pub fn parse_dir(path: PathBuf) -> Result<Vec<Test>, RunnerError> {
+pub fn parse_dir(path: &String, skipped: &Vec<String>) -> Result<Vec<Test>, RunnerError> {
     println!("Parsing test directory: {:?}", path);
     let mut tests = Vec::new();
     let dir_entries = std::fs::read_dir(path.clone()).unwrap().flatten();
@@ -41,19 +61,43 @@ pub fn parse_dir(path: PathBuf) -> Result<Vec<Test>, RunnerError> {
         // Check entry type
         let entry_type = entry.file_type().unwrap();
         if entry_type.is_dir() {
-            let dir_tests = parse_dir(entry.path())?;
+            let dir_tests = parse_dir(&String::from(entry.path().to_str().unwrap()), skipped)?;
             tests.push(dir_tests);
         } else {
             let is_json_file = entry.path().extension().is_some_and(|ext| ext == "json");
-            let is_not_skipped =
-                !IGNORED_TESTS.contains(&entry.path().file_name().unwrap().to_str().unwrap());
+            let is_not_skipped = !skipped.contains(&String::from(
+                entry.path().file_name().unwrap().to_str().unwrap(),
+            ));
             if is_json_file && is_not_skipped {
-                let file_tests = parse_file(entry.path())?;
+                let file_tests = parse_file(&String::from(entry.path().to_str().unwrap()))?;
                 tests.push(file_tests);
             }
         }
     }
     // Up to this point the parsing of every .json file has given a Vec<Test> as a result, so we have to concat
     // to obtain a single Vec<Test> from the Vec<Vec<Test>>.
+    Ok(tests.concat())
+}
+
+pub fn parse_tests(options: &mut RunnerOptions) -> Result<Vec<Test>, RunnerError> {
+    let mut tests = Vec::new();
+    let mut skipped: Vec<String> = IGNORED_TESTS.iter().map(|test| test.to_string()).collect();
+    skipped.append(&mut options.skip_files);
+
+    if !options.json_files.is_empty() {
+        for file in &options.json_files {
+            if skipped.contains(file) {
+                continue;
+            }
+            let file_tests = parse_file(file)?;
+            tests.push(file_tests);
+        }
+    } else if options.path.ends_with(".json") {
+        let file_tests = parse_file(&options.path)?;
+        tests.push(file_tests);
+    } else {
+        let dir_tests = parse_dir(&options.path, &skipped)?;
+        tests.push(dir_tests);
+    }
     Ok(tests.concat())
 }

--- a/cmd/ef_tests/state/runner_v2/run.rs
+++ b/cmd/ef_tests/state/runner_v2/run.rs
@@ -1,13 +1,18 @@
-use std::env;
-
-use ef_tests_state::runner_v2::{error::RunnerError, parser::parse_dir, runner::run_tests};
+use clap::Parser;
+use ef_tests_state::runner_v2::{
+    error::RunnerError,
+    parser::{RunnerOptions, parse_tests},
+    runner::run_tests,
+};
 
 #[tokio::main]
 pub async fn main() -> Result<(), RunnerError> {
-    let args: Vec<String> = env::args().collect();
-    let path = &args[1];
+    let mut runner_options = RunnerOptions::parse();
+    println!("Runner options: {:?}", runner_options);
+
     println!("\nParsing test files...");
-    let tests = parse_dir(path.into())?;
+    let tests = parse_tests(&mut runner_options)?;
+
     println!("\nFinished parsing. Executing tests...");
     run_tests(tests).await?;
     println!(

--- a/crates/common/serde_utils.rs
+++ b/crates/common/serde_utils.rs
@@ -46,12 +46,8 @@ pub mod u256 {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(d)?;
-        U256::from_str_radix(
-            value
-                .trim_start_matches("0x"),
-            16,
-        )
-        .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
+        U256::from_str_radix(value.trim_start_matches("0x"), 16)
+            .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
     }
 
     pub fn deser_hex_str_opt<'de, D>(d: D) -> Result<Option<U256>, D::Error>
@@ -60,12 +56,9 @@ pub mod u256 {
     {
         let s = Option::<String>::deserialize(d)?;
         match s {
-            Some(s) => U256::from_str_radix(
-                s.trim_start_matches("0x"),
-                16,
-            )
-            .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
-            .map(Some),
+            Some(s) => U256::from_str_radix(s.trim_start_matches("0x"), 16)
+                .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
+                .map(Some),
             None => Ok(None),
         }
     }
@@ -76,12 +69,8 @@ pub mod u256 {
     {
         let value = String::deserialize(d)?;
         if value.starts_with("0x") {
-            U256::from_str_radix(
-                value
-                    .trim_start_matches("0x"),
-                16,
-            )
-            .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
+            U256::from_str_radix(value.trim_start_matches("0x"), 16)
+                .map_err(|_| D::Error::custom("Failed to deserialize u256 value"))
         } else {
             U256::from_dec_str(&value).map_err(|e| D::Error::custom(e.to_string()))
         }


### PR DESCRIPTION
**Description**

This PR adds three types of execution flags to the runner of the EF tests: 
- a flag to run the tests in a specific path (could be either a `.json` file or a directory). 
- a flag to skip certain `.json` files from execution. 
- a flag to indicate specific `.json` files to be executed. 

This flags could be improved in a later iteration. 

Closes #3792 