### PR TITLE
fix(l1,l2): add git commit version to docker iamge build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,6 @@
 **/.DS_Store
 **/.vscode
 
-# Git
-.git/
-
 # CI/CD
 .github/
 


### PR DESCRIPTION
**Motivation**

The .git directory was being ignored in the .dockerignore

**Description**

- Remove .git from .dockerignore

