### PR TITLE
refactor(l1): tooling/sync make targets to be generic across networks

### DIFF
--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -1,15 +1,14 @@
-.PHONY = start_geth_holesky start_lighthouse_holesky gen_jwt
+.PHONY = help create_data_dir gen_jwt sync start_geth_holesky flamegraph-main  flamegraph \
+flamegraph-branch flamegraph-holesky flamegraph-hoodi start-lighthouse start-ethrex \
+backup-db start-hoodi-metrics-docker start-holesky-metrics-docker \
+start-sepolia-metrics-docker tail-syncing-logs tail-metrics-logs copy_flamegraph
 
 ETHREX_DIR ?= "../.."
 EVM ?= levm
 NODE_NAME ?= ethrex
 ENGINE_PORT ?= 8551
-HOLESKY_CHECKPOINT_SYNC_URL ?= https://checkpoint-sync.holesky.ethpandaops.io
 LIGHTHOUSE_PORT ?= 9099
 LIGHTHOUSE_DISCOVERY_PORT ?= 9999
-HOLESKY_BOOTNODES=enode://a37d916374b92440247c20434389904f0f1f4ddf65e00ba7d482b551824e094db99a90b89124cc6ed98b89a9d5549afc3c307443e109c366a8e060bf27430c88@65.21.237.42:30303
-HOODI_CHECKPOINT_SYNC_URL ?= https://hoodi.beaconstate.ethstaker.cc
-HOODI_BOOTNODES ?= enode://60203fcb3524e07c5df60a14ae1c9c5b24023ea5d47463dfae051d2c9f3219f309657537576090ca0ae641f73d419f53d8e8000d7a464319d4784acd7d2abc41@209.38.124.160:30303
 CURRENT_DATETIME = $(shell date +'%y.%m.%d-%H.%M.%S')
 BATCH_SIZE ?= 1024
 OS = $(shell uname)
@@ -20,7 +19,7 @@ else
 endif
 
 # Set checkpoint sync url based on network
-NETWORK ?= mainnet
+NETWORK ?= mainnet# default network if not set
 ifeq ($(NETWORK), mainnet)
 CHECKPOINT_SYNC_URL ?= https://beaconstate.info
 endif
@@ -41,132 +40,70 @@ else
 BOOTNODES_FLAG ?= --bootnodes ${BOOTNODES}
 endif
 
-help: ## Display help for the makefile.
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+default: help
 
-create_data_dir: ## Create the data folder for the network. NETWORK environment variable required.
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
+help: ## Display help for the makefile.
+	@grep -E '^[%a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+create_data_dir: ## Create the data folder for the network. If NETWORK environment variable is not provided, mainnet will be used as default.
 	mkdir -p $(DATA_PATH)/$(NETWORK)_data
 
 gen-jwt: create_data_dir ## Create the jwt for a given network. NETWORK environment variable required.
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
 	openssl rand -hex 32 | tr -d "\n" | tee $(DATA_PATH)/$(NETWORK)_data/jwt.hex
 
-sync: create_data_dir ## Run the sync for a given network. NETWORK and SYNC_BLOCK_NUM environment variables required (for the network and block to start from respectively). EVM can also be set to select the evm to use.
+sync: create_data_dir ## Run the sync for a given network. SYNC_BLOCK_NUM environment variable required (for block to start from).  If NETWORK environment variable is not provided, mainnet will be used as default. EVM can also be set to select the evm to use.
 ifndef SYNC_BLOCK_NUM
 	$(error "Sync block number not set")
 endif	
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
 #	samply record --unstable-presymbolicate --save-only -- 
 	mkdir -p logs
 	make start-ethrex-$(NETWORK) >> ./logs/ethrex-sync-$(NETWORK)-$(EVM).log
 
 
-flamegraph-main: ## Run flamegraph on main branch. NETWORK and SYNC_BLOCK_NUM environment variables required (for the network and block to start from respectively). EVM can also be set to select the evm to use. Execution logs are output to log file.
+flamegraph-main: ## Run flamegraph on main branch. SYNC_BLOCK_NUM environment variable required (for block to start from). If NETWORK environment variable is not provided, mainnet will be used as default. EVM can also be set to select the evm to use. Execution logs are output to log file.
 ifndef SYNC_BLOCK_NUM
 	$(error "Sync block number not set)
-endif
-ifndef NETWORK
-	$(error "Sync network not provided")
 endif
 	cd $(ETHREX_DIR) && git checkout main
 	mkdir -p logs
-	make flamegraph-$(NETWORK) >> logs/ethrex-$(NETWORK)-$(EVM)-flamegraph-$(CURRENT_DATETIME)-main-block-$(SYNC_BLOCK_NUM)-$(LOGNAME).log
+	make flamegraph-inner >> logs/ethrex-$(NETWORK)-$(EVM)-flamegraph-$(CURRENT_DATETIME)-main-block-$(SYNC_BLOCK_NUM)-$(LOGNAME).log
 
-flamegraph: ## Run flamegraph on the currently checked out branch. NETWORK and SYNC_BLOCK_NUM environment variables required (for the network and block to start from respectively). EVM can also be set to select the evm to use. Execution logs are output to log file.
+flamegraph: ## Run flamegraph on the currently checked out branch. SYNC_BLOCK_NUM environment variable required (for block to start from).  If NETWORK environment variable is not provided, mainnet will be used as default. EVM can also be set to select the evm to use. Execution logs are output to log file.
 ifndef SYNC_BLOCK_NUM
 	$(error "Sync block number not set)
 endif
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
 	mkdir -p logs
-	make flamegraph-$(NETWORK) >> logs/ethrex-$(NETWORK)-$(EVM)-flamegraph-$(CURRENT_DATETIME)-main-block-$(SYNC_BLOCK_NUM)-$(LOGNAME).log
+	make flamegraph-inner >> logs/ethrex-$(NETWORK)-$(EVM)-flamegraph-$(CURRENT_DATETIME)-main-block-$(SYNC_BLOCK_NUM)-$(LOGNAME).log
 
-flamegraph-branch: ## Run flamegraph on custom branch. NETWORK and SYNC_BLOCK_NUM environment variables required (for the network and block to start from respectively). EVM can also be set to select the evm to use. xecution logs are output to log file.
+flamegraph-branch: ## Run flamegraph on custom branch. SYNC_BLOCK_NUM environment variable required (for block to start from).  If NETWORK environment variable is not provided, mainnet will be used as default. EVM can also be set to select the evm to use. Execution logs are output to log file.
 ifndef SYNC_BLOCK_NUM
 	$(error "Sync block number not set")
 endif
 ifndef BRANCH
 	$(error "Branch not specified")
 endif
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
 	cd $(ETHREX_DIR) && git checkout $(BRANCH)
 	mkdir -p logs
-	make flamegraph-$(NETWORK) >> logs/ethrex-$(NETWORK)-$(EVM)-flamegraph-$(CURRENT_DATETIME)-$(BRANCH)-block-$(SYNC_BLOCK_NUM)-$(LOGNAME).log
+	make flamegraph-inner >> logs/ethrex-$(NETWORK)-$(EVM)-flamegraph-$(CURRENT_DATETIME)-$(BRANCH)-block-$(SYNC_BLOCK_NUM)-$(LOGNAME).log
 
-flamegraph-holesky: ## Run flamegraph on holesky.
+
+flamegraph-inner: # Inner target used for flamegraph-related targets. Runs flamegraph on the network given by NETWORK.
 	cd $(ETHREX_DIR) && CARGO_PROFILE_RELEASE_DEBUG=true RUST_LOG=3 cargo flamegraph --features "libmdbx sync-test" --bin ethrex -- \
 		--http.port 8545 \
 		--authrpc.port 8551 \
 		--p2p.port 30303\
 		--discovery.port 30303 \
-		--network holesky \
-		--datadir holesky_data/ethrex/$(EVM) \
-		--authrpc.jwtsecret $(DATA_PATH)/holesky_data/jwt.hex \
-		--bootnodes $(HOLESKY_BOOTNODES) \
+		--network $(NETWORK) \
+		--datadir ${NETWORK}_data/ethrex/$(EVM) \
+		--authrpc.jwtsecret $(DATA_PATH)/${NETWORK}_data/jwt.hex \
+		$(BOOTNODES_FLAG) \
 		--evm $(EVM) \
 
-flamegraph-hoodi: ## Run flamegraph on hoodi.
-	cd $(ETHREX_DIR) && CARGO_PROFILE_RELEASE_DEBUG=true RUST_LOG=3 cargo flamegraph --features "libmdbx sync-test" --bin ethrex -- \
-		--http.port 8545 \
-		--authrpc.port 8551 \
-		--p2p.port 30303\
-		--discovery.port 30303 \
-		--network hoodi \
-		--datadir hoodi_data/ethrex/$(EVM) \
-		--authrpc.jwtsecret $(DATA_PATH)/hoodi_data/jwt.hex \
-		--bootnodes $(HOODI_BOOTNODES) \
-		--evm $(EVM)
+flamegraph-%: ## Run flamegraph on either mainnet, sepolia, holesky or hoodi network. For example, to run the flamgraph on hoodi, use `flamegraph-hoodi`
+	@export NETWORK=$*;\
+	make flamegraph-inner
 
-start-lighthouse: ## Start lighthouse for a given network. NETWORK environment variable required.
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
-	make $(NETWORK)-lighthouse
-
-holesky-lighthouse: ## Start lighthouse for holesky.
-	lighthouse bn \
-		--network holesky \
-		--execution-endpoint http://localhost:${ENGINE_PORT} \
-		--execution-jwt $(DATA_PATH)/holesky_data/jwt.hex \
-		--checkpoint-sync-url $(HOLESKY_CHECKPOINT_SYNC_URL) \
-		--http \
-		--http-address 0.0.0.0 \
-		--http-allow-origin "*" \
-		--metrics \
-  		--metrics-address 0.0.0.0 \
-  		--metrics-port 5054 \
-		--datadir $(DATA_PATH)/holesky_data/lighthouse_${NODE_NAME}_$(EVM) \
-		--disable-deposit-contract-sync --port $(LIGHTHOUSE_PORT) --discovery-port $(LIGHTHOUSE_DISCOVERY_PORT) --http-port 5053
-
-hoodi-lighthouse: ## Start lighthouse for hoodi.
-	lighthouse bn \
-		--network hoodi \
-		--execution-endpoint http://localhost:${ENGINE_PORT} \
-		--execution-jwt $(DATA_PATH)/hoodi_data/jwt.hex \
-		--checkpoint-sync-url $(HOODI_CHECKPOINT_SYNC_URL) \
-		--http \
-		--http-address 0.0.0.0 \
-		--http-allow-origin "*" \
-		--metrics \
-  		--metrics-address 0.0.0.0 \
-  		--metrics-port 5054 \
-		--datadir $(DATA_PATH)/hoodi_data/lighthouse_${NODE_NAME}_$(EVM) \
-		--disable-deposit-contract-sync --port $(LIGHTHOUSE_PORT) --discovery-port $(LIGHTHOUSE_DISCOVERY_PORT) --http-port 5053
-
-backup-db: ## Back-up the store db. EVM and NETWORK environment variables need to be provided to select which DB to back up.
-ifndef NETWORK
-	$(error "Sync network not provided")
-endif
+backup-db: ## Back-up the store db. EVM and NETWORK environment variables need to be provided to select which DB to back up. If NETWORK environment variable is not provided, mainnet will be used as default.
 	mkdir -p $(DATA_PATH)/ethrex_db_backups/$(NETWORK)/$(EVM)/db_backup_$(CURRENT_DATETIME)
 ifeq ($(OS), Darwin)
 	rsync -ah --progress $(DATA_PATH)/$(NETWORK)_data/ethrex/$(EVM)/mdbx.* $(DATA_PATH)/ethrex_db_backups/$(NETWORK)/$(EVM)/db_backup_$(CURRENT_DATETIME)
@@ -175,53 +112,6 @@ else
 	rsync -ah --info=progress2 $(DATA_PATH)/$(NETWORK)_data/ethrex/$(EVM)/mdbx.* $(DATA_PATH)/ethrex_db_backups/$(NETWORK)/$(EVM)/db_backup_$(CURRENT_DATETIME)
 	rsync -ah --info=progress2 ./logs/ethrex-sync-$(NETWORK)-$(EVM).log $(DATA_PATH)/ethrex_db_backups/$(NETWORK)/$(EVM)/db_backup_$(CURRENT_DATETIME)/ethrex-sync-$(NETWORK)-$(EVM).log
 endif
-
-
-start-ethrex-hoodi: ## Start ethrex for hoodi
-	cd $(ETHREX_DIR) && RUST_LOG=3 cargo run --release --features "libmdbx sync-test metrics" --bin ethrex -- \
-    		--http.addr 0.0.0.0 \
-    		--http.port 8545 \
-    		--authrpc.port 8551 \
-    		--p2p.port 30303\
-    		--metrics \
-    		--metrics.port 3701 \
-    		--discovery.port 30303 \
-    		--network hoodi \
-    		--datadir "hoodi_data/ethrex/$(EVM)" \
-    		--authrpc.jwtsecret $(DATA_PATH)/hoodi_data/jwt.hex \
-    		--bootnodes $(HOODI_BOOTNODES) \
-    		--evm $(EVM)
-
-start-ethrex-holesky: ## Start ethrex for holesky
-	cd $(ETHREX_DIR) && RUST_LOG=3 cargo run --release --features "libmdbx sync-test metrics" --bin ethrex -- \
-    		--http.addr 0.0.0.0 \
-    		--http.port 8545 \
-    		--authrpc.port 8551 \
-    		--p2p.port 30303\
-    		--metrics \
-    		--metrics.port 3701 \
-    		--discovery.port 30303 \
-    		--network holesky \
-    		--datadir "holesky_data/ethrex/$(EVM)" \
-    		--authrpc.jwtsecret $(DATA_PATH)/holesky_data/jwt.hex \
-    		--bootnodes $(HOLESKY_BOOTNODES) \
-    		--evm $(EVM)
-
-start-hoodi-metrics-docker: ## Start L1 docker compose, lighthouse in background, and ethrex for hoodi
-	@echo "Starting L1 docker compose with metrics..."
-	cd $(ETHREX_DIR)/metrics && docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l1.overrides.yaml up -d
-	@echo "Starting lighthouse in background..."
-	cd $(ETHREX_DIR)/tooling/sync && nohup make hoodi-lighthouse > /dev/null 2>&1 &
-	@echo "Starting ethrex..."
-	cd $(ETHREX_DIR)/tooling/sync && make start-ethrex-hoodi
-
-start-holesky-metrics-docker: ## Start L1 docker compose, lighthouse in background, and ethrex for holesky
-	@echo "Starting L1 docker compose with metrics..."
-	cd $(ETHREX_DIR)/metrics && docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l1.overrides.yaml up -d
-	@echo "Starting lighthouse in background..."
-	cd $(ETHREX_DIR)/tooling/sync && nohup make holesky-lighthouse > /dev/null 2>&1 &
-	@echo "Starting ethrex..."
-	cd $(ETHREX_DIR)/tooling/sync && make start-ethrex-holesky
 
 tail-syncing-logs: ## Tail the syncing logs for a given log file. Environment variable LOGNAME with the name of the file needs to be provided.
 ifndef LOGNAME
@@ -242,16 +132,19 @@ else
 	rsync -ah --info=progress2 $(ETHREX_DIR)/flamegraph.svg flamegraphs/flamegraph-$(GRAPHNAME).svg
 endif
 
+start-%-metrics-docker: ## Start L1 docker compose, lighthouse in background, and ethrex for either mainnet, sepolia, holesky or hoodi network. For example, to run on hoodi, use `start-hoodi-metrics-docker`
+	@export NETWORK=$*;\
+	make start-metrics-docker
 
-start-metrics-docker: ## Start L1 docker compose, lighthouse in background, and ethrex for the given network
+start-metrics-docker: ## Start L1 docker compose, lighthouse in background, and ethrex for the network given by NETWORK.
 	@echo "Starting L1 docker compose with metrics..."
 	cd $(ETHREX_DIR)/metrics && docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l1.overrides.yaml up -d
 	@echo "Starting lighthouse in background..."
-	cd $(ETHREX_DIR)/tooling/sync && nohup make metrics-lighthouse > /dev/null 2>&1 &
+	cd $(ETHREX_DIR)/tooling/sync && nohup make start-lighthouse > /dev/null 2>&1 &
 	@echo "Starting ethrex..."
-	cd $(ETHREX_DIR)/tooling/sync && make metrics-ethrex
+	cd $(ETHREX_DIR)/tooling/sync && make start-ethrex
 
-metrics-lighthouse: ## Start lighthouse for NETWORK.
+start-lighthouse: ## Start lighthouse for the network given by NETWORK.
 	lighthouse bn \
 		--network $(NETWORK) \
 		--execution-endpoint http://localhost:${ENGINE_PORT} \
@@ -266,7 +159,7 @@ metrics-lighthouse: ## Start lighthouse for NETWORK.
 		--datadir $(DATA_PATH)/${NETWORK}_data/lighthouse_${NODE_NAME}_$(EVM) \
 		--disable-deposit-contract-sync --port $(LIGHTHOUSE_PORT) --discovery-port $(LIGHTHOUSE_DISCOVERY_PORT) --http-port 5053
 
-metrics-ethrex: ## Start ethrex for hoodi
+start-ethrex: ## Start ethrex for the network given by NETWORK.
 	cd $(ETHREX_DIR) && RUST_LOG=3 cargo run --release --features "libmdbx sync-test metrics" --bin ethrex -- \
     		--http.addr 0.0.0.0 \
     		--http.port 8545 \

--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -1,7 +1,8 @@
 .PHONY = help create_data_dir gen_jwt sync start_geth_holesky flamegraph-main  flamegraph \
-flamegraph-branch flamegraph-holesky flamegraph-hoodi start-lighthouse start-ethrex \
-backup-db start-hoodi-metrics-docker start-holesky-metrics-docker \
-start-sepolia-metrics-docker tail-syncing-logs tail-metrics-logs copy_flamegraph
+flamegraph-branch flamegraph-inner flamegraph-mainnet flamegraph-sepolia flamegraph-holesky \
+flamegraph-hoodi start-lighthouse start-ethrex backup-db start-mainnet-metrics-docker \
+start-sepolia-metrics-docker start-holesky-metrics-docker start-hoodi-metrics-docker \
+start-metrics-docker tail-syncing-logs tail-metrics-logs copy_flamegraph
 
 ETHREX_DIR ?= "../.."
 EVM ?= levm

--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -19,6 +19,28 @@ else
 	DATA_PATH = ~/.local/share
 endif
 
+# Set checkpoint sync url based on network
+NETWORK ?= mainnet
+ifeq ($(NETWORK), mainnet)
+CHECKPOINT_SYNC_URL ?= https://beaconstate.info
+endif
+ifeq ($(NETWORK), sepolia)
+CHECKPOINT_SYNC_URL ?= https://checkpoint-sync.sepolia.ethpandaops.io
+endif
+ifeq ($(NETWORK), holesky)
+CHECKPOINT_SYNC_URL ?= https://checkpoint-sync.holesky.ethpandaops.io
+endif
+ifeq ($(NETWORK), hoodi)
+CHECKPOINT_SYNC_URL ?= https://hoodi.beaconstate.ethstaker.cc
+endif
+
+# Set bootnodes flag only if we have bootnodes
+ifndef BOOTNODES
+BOOTNODES_FLAG ?=
+else 
+BOOTNODES_FLAG ?= --bootnodes ${BOOTNODES}
+endif
+
 help: ## Display help for the makefile.
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -219,3 +241,42 @@ ifeq ($(OS), Darwin)
 else
 	rsync -ah --info=progress2 $(ETHREX_DIR)/flamegraph.svg flamegraphs/flamegraph-$(GRAPHNAME).svg
 endif
+
+
+start-metrics-docker: ## Start L1 docker compose, lighthouse in background, and ethrex for the given network
+	@echo "Starting L1 docker compose with metrics..."
+	cd $(ETHREX_DIR)/metrics && docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l1.overrides.yaml up -d
+	@echo "Starting lighthouse in background..."
+	cd $(ETHREX_DIR)/tooling/sync && nohup make metrics-lighthouse > /dev/null 2>&1 &
+	@echo "Starting ethrex..."
+	cd $(ETHREX_DIR)/tooling/sync && make metrics-ethrex
+
+metrics-lighthouse: ## Start lighthouse for NETWORK.
+	lighthouse bn \
+		--network $(NETWORK) \
+		--execution-endpoint http://localhost:${ENGINE_PORT} \
+		--execution-jwt $(DATA_PATH)/${NETWORK}_data/jwt.hex \
+		--checkpoint-sync-url $(CHECKPOINT_SYNC_URL) \
+		--http \
+		--http-address 0.0.0.0 \
+		--http-allow-origin "*" \
+		--metrics \
+		--metrics-address 0.0.0.0 \
+		--metrics-port 5054 \
+		--datadir $(DATA_PATH)/${NETWORK}_data/lighthouse_${NODE_NAME}_$(EVM) \
+		--disable-deposit-contract-sync --port $(LIGHTHOUSE_PORT) --discovery-port $(LIGHTHOUSE_DISCOVERY_PORT) --http-port 5053
+
+metrics-ethrex: ## Start ethrex for hoodi
+	cd $(ETHREX_DIR) && RUST_LOG=3 cargo run --release --features "libmdbx sync-test metrics" --bin ethrex -- \
+    		--http.addr 0.0.0.0 \
+    		--http.port 8545 \
+    		--authrpc.port 8551 \
+    		--p2p.port 30303\
+    		--metrics \
+    		--metrics.port 3701 \
+    		--discovery.port 30303 \
+    		--network $(NETWORK) \
+    		--datadir "${NETWORK}_data/ethrex/$(EVM)" \
+    		--authrpc.jwtsecret $(DATA_PATH)/${NETWORK}_data/jwt.hex \
+    		$(BOOTNODES_FLAG) \
+    		--evm $(EVM)

--- a/tooling/sync/README.md
+++ b/tooling/sync/README.md
@@ -3,9 +3,10 @@
 The targets provided by the makefile aim towards making starting a sync or running a benchmark on Ethrex much simpler. This readme will provide a quick explanation to get you started.
 
 ## Environment variables
+
 The commands use a number of environment variables, which can be easily passed alongside the `make` command to provide some settings to the target being run. Many of the commands *will not run* if requisite environment variables aren't set. These variables are:
 
-- `NETWORK`: network on which to sync (at the moment, only hoodi and holesky are supported as options). All commands which use this variable require it to be set by the user.
+- `NETWORK`: network on which to sync (at the moment, only mainnet, sepolia holesky and hoodi are supported as options). If this variable is not set `mainnet` will be used by default.
 
 - `EVM`: the EVM which will be used. `levm` is the default, but it can be set to `revm` as well.
 
@@ -33,6 +34,12 @@ Lighthouse must be running for the sync to work. Aditionally, a jwt has to be pr
 
 ## Running flamegraphs
 
+You will first need to install cargo-flamegraph by running:
+
+```=bash
+cargo install flamegraph
+```
+
 It's advisable to only run flamegraphs on blocks that have already been synced, so that the overhead of retrieving the headers and bodies from the network doesn't distort the measurements. The generated flamegraphs are stored by default in the ethrex root folder. You can run the flamegraph using the provided commands. The run has to be stopped manually interrupting it with `ctrl + c`. Afterwards, a script starts that creates a flamegraph from the gathered data. Once this script finishes, the flamegraph should be ready.
 
 ## Commands
@@ -43,7 +50,7 @@ It's advisable to only run flamegraphs on blocks that have already been synced, 
 
 - `make flamegraph-main` and `make flamegraph-branch` can be used to run benchmarks on the main branch of the repo or a custom branch, respectively; generating both a flamegraph and logs of the run. `NETWORK` and `SYNC_BLOCK_NUM` must be provided, `EVM` can be optionally provided too. `BRANCH` must be provided for `flamegraph-branch` as well. `make flamegraph` can also be used as a branch agnostic option.
 
-- `make start-lighthouse` can be used to start lighthouse. `NETWORK` must be provided.
+- `make start-lighthouse` can be used to start lighthouse. `NETWORK` must be provided or else mainnet will be used as default.
 
 - `make backup-db` can be used to create a backup of the database. `NETWORK` must be provided, and `EVM` should be provided too. Backups are stored in `~/.local/share/ethrex_db_backups` in Linux and `~/Library/Application Support/ethrex_db_backups` folder in MacOS. The logs up to that point are also backed up in the same folder.
 


### PR DESCRIPTION
**Motivation**
The current Makefile on tooling/sync has a bunch of different yet very similar targets that vary depending on whether they are used on hoodi or holesky networks. This is not much of an issue with just two networks, but would become quite bloated if we wanted to also add targets for sepolia and mainnet networks.
The aim of this PR is to refactor these duplicated targets into a single one leveraging the `NETWORK` env var and also allow these targets to support mainnet and sepolia networks
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Replace inner targets `holesky-lighthouse` & `hoodi-lighthouse` with generic `start-lighthouse` target that depends on `NETWORK` env var
* Replace inner targets `start-ethrex-holesky` & `start-ethrex-hoodi` with generic `start-ethrex` target that depends on `NETWORK` env var
* Replace targets `start-holesky-metrics-docker` & `start-hoodi-metrics-docker` with generic `start-metrics-docker` target that depends on `NETWORK` env var + A wildcard target `start-%-metrics-docker` that sets the `NETWORK` env var to the wildcard to that previous targets are still functional.
* Replace targets `flamegraph-holesky` & `flamegraph-hoodi` with generic `flamegraph-inner` target (as `flamegraph` is already its own target)   that depends on `NETWORK` env var + A wildcard target `flamegraph-%r` that sets the `NETWORK` env var to the wildcard to that previous targets are still functional.
* `NETWORK` env var is no longer strictly required, and has default value set to mainnet (Docs updated)
* Removed check for `NETWORK` env var being present (as it now uses default value)
* Updated handling of BOOTNODES:
  * Removed `HOLESKY_BOOTNODES` and `HOODI_BOOTNODES` as they are already present on the preset bootnodes file
  * Only set the `--bootnodes` flag when running ethrex if the `BOOTNODES` env var was set
* (Misc) Mention installing `flamegraph` crate on README`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

