### PR TITLE
feat(levm): change feature flag to revm

### DIFF
--- a/tooling/ef_tests/blockchain/Cargo.toml
+++ b/tooling/ef_tests/blockchain/Cargo.toml
@@ -28,7 +28,7 @@ path = "./lib.rs"
 default = ["c-kzg", "blst"]
 blst = ["ethrex-vm/blst"]
 c-kzg = ["ethrex-blockchain/c-kzg"]
-levm = []
+revm = []
 
 [[test]]
 name = "all"

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -24,10 +24,10 @@ clean-vectors: ## 🗑️  Clean test vectors
 	rm -f $(SPECTEST_ARTIFACT)
 
 test-levm: $(SPECTEST_VECTORS_DIR) ## 🧪 Run blockchain tests with LEVM
-	cargo test --profile release-with-debug --features levm
+	cargo test --profile release-with-debug 
 
 test-revm: $(SPECTEST_VECTORS_DIR) ## 🧪 Run blockchain tests with REVM
-	cargo test --profile release-with-debug
+	cargo test --profile release-with-debug --features revm
 
 test: $(SPECTEST_VECTORS_DIR) ## 🧪 Run blockchain tests with both VMs
 	$(MAKE) test-levm

--- a/tooling/ef_tests/blockchain/tests/all.rs
+++ b/tooling/ef_tests/blockchain/tests/all.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 const TEST_FOLDER: &str = "vectors/";
 
 fn parse_and_execute_runner(path: &Path) -> datatest_stable::Result<()> {
-    let engine = if cfg!(feature = "levm") {
-        EvmEngine::LEVM
-    } else {
+    let engine = if cfg!(feature = "revm") {
         EvmEngine::REVM
+    } else {
+        EvmEngine::LEVM
     };
 
     parse_and_execute(path, engine, None, false)


### PR DESCRIPTION
**Motivation**

Change feature flag to `revm`

**Description**

  - Rename feature flag from `levm` to `revm` in Cargo.toml
  - Update Makefile to run LEVM by default and REVM with feature flag
  - Invert EVM engine selection logic to use LEVM as default

Closes #3335 

