### PR TITLE
fix(l1): remove panics in blockchain tests, re run stateless as separate suite

### DIFF
--- a/cmd/ef_tests/blockchain/tests/all.rs
+++ b/cmd/ef_tests/blockchain/tests/all.rs
@@ -11,7 +11,21 @@ fn parse_and_execute_runner(path: &Path) -> datatest_stable::Result<()> {
         EvmEngine::REVM
     };
 
-    parse_and_execute(path, engine, None)
+    parse_and_execute(path, engine, None, false)
 }
 
+#[cfg(feature = "levm")]
+fn parse_and_execute_stateless_runner(path: &Path) -> datatest_stable::Result<()> {
+    parse_and_execute(path, EvmEngine::LEVM, None, true)
+}
+#[cfg(feature = "levm")]
+datatest_stable::harness!(
+    parse_and_execute_runner,
+    TEST_FOLDER,
+    r".*",
+    parse_and_execute_stateless_runner,
+    TEST_FOLDER,
+    r".*"
+);
+#[cfg(not(feature = "levm"))]
 datatest_stable::harness!(parse_and_execute_runner, TEST_FOLDER, r".*",);


### PR DESCRIPTION
**Motivation**

The logic that did stateless execution for blockchain tests had panics that stopped the whole suite run instead of failing only that test.

**Description**
- Remove all panics from `re_run_stateless` function, `return Result<(), String>`
- Modify `parse_and_execute` function to accept a boolean as parameter that when set to true enables stateless execution
   - Add when running with levm, a new function `parse_and_execute_stateless_runner` that enables this flag as a second suite of tests.

Closes #3859

