### PR TITLE
fix(l1) yield inbetween blocks during batch execution

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -526,6 +526,7 @@ impl Blockchain {
             all_receipts.push((block.hash(), receipts));
 
             log_batch_progress(blocks_len, i);
+            tokio::task::yield_now().await;
         }
 
         let account_updates = vm


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Recently, while running full sync on sepolia network it has become a common occurrence to suddenly lose all connected peers due to a `Broken Pipe` error. Upon further investigation this seems to be due to block execution being too intensive and leaving p2p unresponsive.
A quick fix for this was to add yields in-between block executions when executing blocks in batches. This has solved the problem for sepolia testnet (Over 1 Day without incidents).
This could also be improved by further integrating `spawned` into the full sync process.
**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
* Add yields inbetween each block execution when executing blocks in batches
<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

