### PR TITLE
fix(l1):  use p2p's `sync-test` feature in crate's `sync-test` feature

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -75,7 +75,7 @@ blst = ["ethrex-vm/blst"]
 rollup_storage_libmdbx = ["ethrex-storage-rollup/libmdbx"]
 rollup_storage_redb = ["ethrex-storage-rollup/redb"]
 rollup_storage_sql = ["ethrex-storage-rollup/sql"]
-sync-test = []
+sync-test = ["ethrex-p2p/sync-test"]
 [dev-dependencies]
 criterion = { version = "0.5.1", features = [
   "html_reports",


### PR DESCRIPTION
**Motivation**
`ethrex-p2p` crate has code gated behind a `sync-test` feature,  but this feature is not enabled within the crate's `sync-test` feature, causing this code not to be enabled when running ethrex with `sync-test` feature.
This causes issues such as the one reported by #3594 where `EXECUTE_BATCH_SIZE` env var is not used.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Include p2p's `sync-test` feature in crate's `sync-test` feature
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3594 

