### PR TITLE
fix(l2): integration tests quickfix

### DIFF
--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -1021,7 +1021,7 @@ async fn test_privileged_spammer(l1_client: &EthClient) -> Result<(), Box<dyn st
             &rich_wallet_private_key,
             caller_l1,
             "spam(address,uint256)",
-            &[Value::Address(bridge_address()?), Value::Uint(15.into())],
+            &[Value::Address(bridge_address()?), Value::Uint(5.into())],
         )
         .await;
     }


### PR DESCRIPTION
**Motivation**

after merging #3776 a tests was added that spams the bridge with big gas limit transactions. In #3851 we upped the gas limit of all transactions by x2 because the estimation was too low. These two contributed to exceed the block gas limit.

This PR lowers the amount of spam txs