### PR TITLE
feat(l1): add specific error message when import is used with the wrong network

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -407,10 +407,15 @@ pub async fn import_blocks(
                 continue;
             }
 
+
             blockchain
                 .add_block(block)
                 .await
-                .inspect_err(|_| warn!("Failed to add block {number} with hash {hash:#x}",))?;
+                .inspect_err(|err| match err {
+                    // Block number 1's parent not found, the chain must not belong to the same network as the genesis file
+                    ChainError::ParentNotFound if number == 1 => warn!("The chain file is not compatible genesis file. Are you sure you selected the correct network?"),
+                    _ => warn!("Failed to add block {number} with hash {hash:#x}"),
+                })?;
         }
 
         _ = store

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -407,7 +407,6 @@ pub async fn import_blocks(
                 continue;
             }
 
-
             blockchain
                 .add_block(block)
                 .await

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -412,7 +412,7 @@ pub async fn import_blocks(
                 .await
                 .inspect_err(|err| match err {
                     // Block number 1's parent not found, the chain must not belong to the same network as the genesis file
-                    ChainError::ParentNotFound if number == 1 => warn!("The chain file is not compatible genesis file. Are you sure you selected the correct network?"),
+                    ChainError::ParentNotFound if number == 1 => warn!("The chain file is not compatible with the genesis file. Are you sure you selected the correct network?"),
                     _ => warn!("Failed to add block {number} with hash {hash:#x}"),
                 })?;
         }


### PR DESCRIPTION
**Motivation**
When using `import` subcommand with a chain.rlp file that doesn't match the network, we issue the regular `Parent Block Not Found` error. We are able to distinguish this specific case as it will mean that the parent block of block number 1 (aka the genesis block) is not found. This PR takes advantage of this to issue a specific, more informative warning message for this specific case
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add a separate warning message when the imported chain file is not compatible with the genesis
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3813 

