### PR TITLE
fix(l1,levm): fix execution result when using levm

### DIFF
--- a/crates/vm/execution_result.rs
+++ b/crates/vm/execution_result.rs
@@ -96,19 +96,29 @@ impl From<RevmExecutionResult> for ExecutionResult {
         }
     }
 }
+
 impl From<LevmExecutionReport> for ExecutionResult {
     fn from(val: LevmExecutionReport) -> Self {
         match val.result {
             TxResult::Success => ExecutionResult::Success {
-                gas_used: val.gas_used - val.gas_refunded,
+                gas_used: val.gas_used,
                 gas_refunded: val.gas_refunded,
                 logs: val.logs,
                 output: val.output,
             },
-            TxResult::Revert(_error) => ExecutionResult::Revert {
-                gas_used: val.gas_used - val.gas_refunded,
-                output: val.output,
-            },
+            TxResult::Revert(error) => {
+                if error.is_revert_opcode() {
+                    ExecutionResult::Revert {
+                        gas_used: val.gas_used,
+                        output: val.output,
+                    }
+                } else {
+                    ExecutionResult::Halt {
+                        reason: error.to_string(),
+                        gas_used: val.gas_used,
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- ExecutionResult was inaccurate with LEVM, specially the gas used that subtracted the gas refunded but that's already done in LEVM.

We don't have the ideal endpoints to try this out because the only ones that use this are `eth_estimateGas` and `eth_call`. The only way to see if it works fine is to try out the former RPC method with a transaction that triggers refunds... It would be good to have `eth_simulateV1` I guess
Here's evidence that the gas_used in the VM is the `total gas used - refunded gas`
https://github.com/lambdaclass/ethrex/blob/1918c5cedaf3f76df1bc01aba3b20d1d95162c84/crates/vm/levm/src/hooks/default_hook.rs#L199-L201
Bear with me, `exec_gas_consumed` is the same as `actual_gas_used`
https://github.com/lambdaclass/ethrex/blob/1918c5cedaf3f76df1bc01aba3b20d1d95162c84/crates/vm/levm/src/hooks/default_hook.rs#L164


<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

