### PR TITLE
chore(l1): downgrade rpc api read requests to debug.

### DIFF
--- a/crates/l2/networking/rpc/l2/batch.rs
+++ b/crates/l2/networking/rpc/l2/batch.rs
@@ -2,7 +2,7 @@ use ethrex_common::types::{BlockHash, batch::Batch};
 use ethrex_storage::Store;
 use serde::Serialize;
 use serde_json::Value;
-use tracing::info;
+use tracing::debug;
 
 use crate::{
     rpc::{RpcApiContext, RpcHandler},
@@ -91,7 +91,7 @@ impl RpcHandler for GetBatchByBatchNumberRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!("Requested batch with number: {}", self.batch_number);
+        debug!("Requested batch with number: {}", self.batch_number);
         let Some(batch) = context.rollup_store.get_batch(self.batch_number).await? else {
             return Ok(Value::Null);
         };

--- a/crates/networking/rpc/engine/exchange_transition_config.rs
+++ b/crates/networking/rpc/engine/exchange_transition_config.rs
@@ -48,7 +48,7 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        debug!("Requrested new engine request: {self}");
+        debug!("Requested new engine request: {self}");
         let payload = &self.payload;
 
         let chain_config = context.storage.get_chain_config()?;

--- a/crates/networking/rpc/engine/exchange_transition_config.rs
+++ b/crates/networking/rpc/engine/exchange_transition_config.rs
@@ -1,7 +1,7 @@
 use ethrex_common::{H256, serde_utils};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 use crate::{
     rpc::{RpcApiContext, RpcHandler},
@@ -48,7 +48,7 @@ impl RpcHandler for ExchangeTransitionConfigV1Req {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!("Received new engine request: {self}");
+        debug!("Requrested new engine request: {self}");
         let payload = &self.payload;
 
         let chain_config = context.storage.get_chain_config()?;

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -148,7 +148,7 @@ fn parse(
             match serde_json::from_value::<Option<PayloadAttributesV3>>(params[1].clone()) {
                 Ok(attributes) => attributes,
                 Err(error) => {
-                    warn!("Could not parse params {}", error);
+                    warn!("Could not parse payload attributes {}", error);
                     None
                 }
             };

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -148,7 +148,7 @@ fn parse(
             match serde_json::from_value::<Option<PayloadAttributesV3>>(params[1].clone()) {
                 Ok(attributes) => attributes,
                 Err(error) => {
-                    info!("Could not parse params {}", error);
+                    warn!("Could not parse params {}", error);
                     None
                 }
             };

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -7,7 +7,7 @@ use ethrex_common::{H256, U256};
 use ethrex_p2p::sync::SyncMode;
 use ethrex_rlp::error::RLPDecodeError;
 use serde_json::Value;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::rpc::{RpcApiContext, RpcHandler};
 use crate::types::payload::{
@@ -724,7 +724,7 @@ fn parse_get_payload_request(params: &Option<Vec<Value>>) -> Result<u64, RpcErr>
 }
 
 async fn get_payload(payload_id: u64, context: &RpcApiContext) -> Result<PayloadBundle, RpcErr> {
-    info!("Requested payload with id: {:#018x}", payload_id);
+    debug!("Requested payload with id: {:#018x}", payload_id);
     let Some(payload) = context.storage.get_payload(payload_id).await? else {
         return Err(RpcErr::UnknownPayload(format!(
             "Payload with id {payload_id:#018x} not found",

--- a/crates/networking/rpc/eth/account.rs
+++ b/crates/networking/rpc/eth/account.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use tracing::info;
+use tracing::debug;
 
 use crate::rpc::{RpcApiContext, RpcHandler};
 use crate::types::account_proof::{AccountProof, StorageProof};
@@ -48,7 +48,7 @@ impl RpcHandler for GetBalanceRequest {
         })
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested balance of account {} at block {}",
             self.address, self.block
         );
@@ -84,7 +84,7 @@ impl RpcHandler for GetCodeRequest {
         })
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested code of account {} at block {}",
             self.address, self.block
         );
@@ -121,7 +121,7 @@ impl RpcHandler for GetStorageAtRequest {
         })
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested storage sot {} of account {} at block {}",
             self.storage_slot, self.address, self.block
         );
@@ -157,7 +157,7 @@ impl RpcHandler for GetTransactionCountRequest {
         })
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested nonce of account {} at block {}",
             self.address, self.block
         );
@@ -210,7 +210,7 @@ impl RpcHandler for GetProofRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!(
+        debug!(
             "Requested proof for account {} at block {} with storage keys: {:?}",
             self.address, self.block, self.storage_keys
         );

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -1,7 +1,7 @@
 use ethrex_blockchain::find_parent_header;
 use ethrex_rlp::encode::RLPEncode;
 use serde_json::Value;
-use tracing::info;
+use tracing::debug;
 
 use crate::{
     rpc::{RpcApiContext, RpcHandler},
@@ -71,7 +71,7 @@ impl RpcHandler for GetBlockByNumberRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!("Requested block with number: {}", self.block);
+        debug!("Requested block with number: {}", self.block);
         let block_number = match self.block.resolve_block_number(storage).await? {
             Some(block_number) => block_number,
             _ => return Ok(Value::Null),
@@ -105,7 +105,7 @@ impl RpcHandler for GetBlockByHashRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!("Requested block with hash: {:#x}", self.block);
+        debug!("Requested block with hash: {:#x}", self.block);
         let block_number = match storage.get_block_number(self.block).await? {
             Some(number) => number,
             _ => return Ok(Value::Null),
@@ -137,7 +137,7 @@ impl RpcHandler for GetBlockTransactionCountRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested transaction count for block with number: {}",
             self.block
         );
@@ -171,7 +171,7 @@ impl RpcHandler for GetBlockReceiptsRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!("Requested receipts for block with number: {}", self.block);
+        debug!("Requested receipts for block with number: {}", self.block);
         let block_number = match self.block.resolve_block_number(storage).await? {
             Some(block_number) => block_number,
             _ => return Ok(Value::Null),
@@ -203,7 +203,7 @@ impl RpcHandler for GetRawHeaderRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested raw header for block with identifier: {}",
             self.block
         );
@@ -236,7 +236,7 @@ impl RpcHandler for GetRawBlockRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!("Requested raw block: {}", self.block);
+        debug!("Requested raw block: {}", self.block);
         let block_number = match self.block.resolve_block_number(&context.storage).await? {
             Some(block_number) => block_number,
             _ => return Ok(Value::Null),
@@ -295,7 +295,7 @@ impl RpcHandler for BlockNumberRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!("Requested latest block number");
+        debug!("Requested latest block number");
         serde_json::to_value(format!(
             "{:#x}",
             context.storage.get_latest_block_number().await?
@@ -310,7 +310,7 @@ impl RpcHandler for GetBlobBaseFee {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!("Requested blob gas price");
+        debug!("Requested blob gas price");
         let block_number = context.storage.get_latest_block_number().await?;
         let header = match context.storage.get_block_header(block_number)? {
             Some(header) => header,
@@ -382,11 +382,11 @@ impl RpcHandler for ExecutionWitness {
         }
 
         if self.to.is_some() {
-            info!(
+            debug!(
                 "Requested execution witness from block: {from_block_number} to {to_block_number}",
             );
         } else {
-            info!("Requested execution witness for block: {from_block_number}",);
+            debug!("Requested execution witness for block: {from_block_number}",);
         }
 
         let mut blocks = Vec::new();

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -1,7 +1,7 @@
 use ethrex_common::serde_utils;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::info;
+use tracing::debug;
 
 use crate::{
     rpc::{RpcApiContext, RpcHandler},
@@ -15,7 +15,7 @@ impl RpcHandler for ChainId {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!("Requested chain id");
+        debug!("Requested chain id");
         let chain_spec = context
             .storage
             .get_chain_config()

--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -8,7 +8,7 @@ use ethrex_common::{
 };
 use serde::Serialize;
 use serde_json::Value;
-use tracing::info;
+use tracing::debug;
 
 use crate::{
     rpc::{RpcApiContext, RpcHandler},
@@ -87,7 +87,7 @@ impl RpcHandler for FeeHistoryRequest {
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
         let config = storage.get_chain_config()?;
-        info!(
+        debug!(
             "Requested fee history for {} blocks starting from {}",
             self.block_count, self.newest_block
         );

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -24,7 +24,7 @@ use ethrex_vm::ExecutionResult;
 use serde::Serialize;
 
 use serde_json::Value;
-use tracing::info;
+use tracing::debug;
 
 pub const ESTIMATE_ERROR_RATIO: f64 = 0.015;
 pub const CALL_STIPEND: u64 = 2_300; // Free gas given at beginning of call.
@@ -102,7 +102,7 @@ impl RpcHandler for CallRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let block = self.block.clone().unwrap_or_default();
-        info!("Requested call on block: {}", block);
+        debug!("Requested call on block: {}", block);
         let header = match block.resolve_block_header(&context.storage).await? {
             Some(header) => header,
             // Block not found
@@ -145,7 +145,7 @@ impl RpcHandler for GetTransactionByBlockNumberAndIndexRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested transaction at index: {} of block with number: {}",
             self.transaction_index, self.block,
         );
@@ -196,7 +196,7 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
         })
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        info!(
+        debug!(
             "Requested transaction at index: {} of block with hash: {:#x}",
             self.transaction_index, self.block,
         );
@@ -239,7 +239,7 @@ impl RpcHandler for GetTransactionByHashRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!(
+        debug!(
             "Requested transaction with hash: {:#x}",
             self.transaction_hash,
         );
@@ -286,7 +286,7 @@ impl RpcHandler for GetTransactionReceiptRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!(
+        debug!(
             "Requested receipt for transaction {:#x}",
             self.transaction_hash,
         );
@@ -336,7 +336,7 @@ impl RpcHandler for CreateAccessListRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let block = self.block.clone().unwrap_or_default();
-        info!("Requested access list creation for tx on block: {}", block);
+        debug!("Requested access list creation for tx on block: {}", block);
         let block_number = match block.resolve_block_number(&context.storage).await? {
             Some(block_number) => block_number,
             _ => return Ok(Value::Null),
@@ -437,7 +437,7 @@ impl RpcHandler for EstimateGasRequest {
         let storage = &context.storage;
         let blockchain = &context.blockchain;
         let block = self.block.clone().unwrap_or_default();
-        info!("Requested estimate on block: {}", block);
+        debug!("Requested estimate on block: {}", block);
         let block_header = match block.resolve_block_header(storage).await? {
             Some(header) => header,
             // Block not found

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -64,7 +64,7 @@ use std::{
 };
 use tokio::{net::TcpListener, sync::Mutex as TokioMutex};
 use tower_http::cors::CorsLayer;
-use tracing::info;
+use tracing::{error, info};
 
 #[derive(Deserialize)]
 #[serde(untagged)]
@@ -149,9 +149,9 @@ pub async fn start_api(
         let filters = active_filters.clone();
         loop {
             interval.tick().await;
-            tracing::info!("Running filter clean task");
+            tracing::debug!("Running filter clean task");
             filter::clean_outdated_filters(filters.clone(), FILTER_DURATION);
-            tracing::info!("Filter clean task complete");
+            tracing::debug!("Filter clean task complete");
         }
     });
 
@@ -186,7 +186,7 @@ pub async fn start_api(
     info!("Starting Auth-RPC server at {authrpc_addr}");
 
     let _ = tokio::try_join!(authrpc_server, http_server)
-        .inspect_err(|e| info!("Error shutting down servers: {e:?}"));
+        .inspect_err(|e| error!("Error shutting down servers: {e:?}"));
 
     Ok(())
 }


### PR DESCRIPTION
**Motivation**
We don't want to spam the logs with getters. Only relevant things should be logged with info or above.

**Description**
- Downgraded read RPC requests to `debug`.
- Changed some log levels that were inappropriate


