### PR TITLE
refactor(l2): improve error handling in `EthClient`'s `send_request_to_all`

### DIFF
--- a/crates/networking/rpc/clients/eth/errors.rs
+++ b/crates/networking/rpc/clients/eth/errors.rs
@@ -62,6 +62,8 @@ pub enum EthClientError {
     FailedToGetTxPool(#[from] TxPoolContentError),
     #[error("ethrex_getBatchByNumber request error: {0}")]
     GetBatchByNumberError(#[from] GetBatchByNumberError),
+    #[error("All RPC calls failed. Last RPC response: {0}")]
+    FailedAllRPC(String),
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
When sending a transaction, the `EthClient` returns the last `Ok()` result, if there is one, but it doesn't take into account `Ok(RpcResponse::Error)` cases, resulting in confusing errors.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Improve the way responses are handled.

<!-- Link to issues: Resolves #111, Resolves #222 -->


