### PR TITLE
fix(l2): make tdx private key an optional argument

### DIFF
--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -88,6 +88,7 @@ jobs:
           ETHREX_PROOF_COORDINATOR_DEV_MODE=false \
           ETHREX_WATCHER_BLOCK_DELAY=0 \
           PROOF_COORDINATOR_ADDRESS=0.0.0.0 \
+          ETHREX_PROOF_COORDINATOR_TDX_PRIVATE_KEY=0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
           make init-l2 &
           sleep 30
           cd tee/quote-gen/

--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -466,7 +466,7 @@ pub struct ProofCoordinatorOptions {
         help_heading = "Proof coordinator options",
         long_help = "Private key of of a funded account that the TDX tool that will use to send the tdx attestation to L1.",
     )]
-    pub proof_coordinator_tdx_private_key: SecretKey,
+    pub proof_coordinator_tdx_private_key: Option<SecretKey>,
     #[arg(
         long = "proof-coordinator.remote-signer-url",
         value_name = "URL",
@@ -537,10 +537,11 @@ impl Default for ProofCoordinatorOptions {
             listen_port: 3900,
             proof_send_interval_ms: 5000,
             dev_mode: false,
-            proof_coordinator_tdx_private_key:
+            proof_coordinator_tdx_private_key: Some(
                 "0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d"
                     .parse()
                     .unwrap(),
+            ),
         }
     }
 }

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -135,8 +135,7 @@ init-l2: ## 🚀 Initializes an L2 Lambda ethrex Client
 	--block-producer.coinbase-address 0x0007a881CD95B1484fca47615B64803dad620C8d \
 	--committer.l1-private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924 \
 	--proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
-	--proof-coordinator.addr ${PROOF_COORDINATOR_ADDRESS} \
-	--proof-coordinator.tdx-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d
+	--proof-coordinator.addr ${PROOF_COORDINATOR_ADDRESS}
 
 update-system-contracts:
 	COMPILE_CONTRACTS=true \

--- a/crates/l2/based/README.md
+++ b/crates/l2/based/README.md
@@ -178,7 +178,6 @@ cargo run --release --manifest-path ../../Cargo.toml --bin ethrex -- l2 \
   --block-producer.coinbase-address 0xacb3bb54d7c5295c158184044bdeedd9aa426607 \
   --committer.l1-private-key <SEQUENCER_PRIVATE_KEY> \
   --proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
-  --proof-coordinator.tdx-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
   --network ../../fixtures/genesis/l2.json \
   --datadir ethrex_l2 \
   --proof-coordinator.addr 127.0.0.1 \

--- a/crates/l2/docker-compose-l2-store.overrides.yaml
+++ b/crates/l2/docker-compose-l2-store.overrides.yaml
@@ -16,4 +16,3 @@ services:
       --block-producer.coinbase-address 0x0007a881CD95B1484fca47615B64803dad620C8d
       --committer.l1-private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924
       --proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d
-      --proof-coordinator.tdx-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d

--- a/crates/l2/docker-compose-l2-web3signer.yaml
+++ b/crates/l2/docker-compose-l2-web3signer.yaml
@@ -27,4 +27,3 @@ services:
       --committer.remote-signer-public-key 02eadbea0cdb17fda8d56fc9c51df8a6158c2ab157aabf2ca57c3a32cd69f98bbc 
       --proof-coordinator.remote-signer-url http://web3signer:9000 
       --proof-coordinator.remote-signer-public-key 029a87812d21330c485e2ab11fbbcc875fd3ecda9e74c3964d8de9a95560b64f21 
-      --proof-coordinator.tdx-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d

--- a/crates/l2/docker-compose-l2.yaml
+++ b/crates/l2/docker-compose-l2.yaml
@@ -91,4 +91,3 @@ services:
       --block-producer.coinbase-address 0x0007a881CD95B1484fca47615B64803dad620C8d
       --committer.l1-private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924
       --proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d
-      --proof-coordinator.tdx-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -61,7 +61,7 @@ pub struct ProofCoordinatorConfig {
     pub dev_mode: bool,
     pub signer: Signer,
     pub validium: bool,
-    pub tdx_private_key: SecretKey,
+    pub tdx_private_key: Option<SecretKey>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -115,6 +115,8 @@ pub enum ProofCoordinatorError {
     ProverDBError(#[from] ProverDBError),
     #[error("Missing blob for batch {0}")]
     MissingBlob(u64),
+    #[error("Missing TDX private key")]
+    MissingTDXPrivateKey,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -67,6 +67,14 @@ pub async fn start_l2(
         );
         return Ok(());
     }
+    if needed_proof_types.contains(&ProverType::TDX)
+        && cfg.proof_coordinator.tdx_private_key.is_none()
+    {
+        error!(
+            "A private key for TDX is required. Please set the flag `--proof-coordinator.tdx-private-key <KEY>` or use the `ETHREX_PROOF_COORDINATOR_TDX_PRIVATE_KEY` environment variable to set the private key"
+        );
+        return Ok(());
+    }
 
     let _ = L1Watcher::spawn(
         store.clone(),


### PR DESCRIPTION
**Motivation**

The `proof-coordinator.tdx-private-key` flag was always required even when not actively used

**Description**

- Make the flag optional and handle the Option type in the required places

Closes #3750 

