### PR TITLE
fix(l1): add `RLP_INVALID_VALUE` exception support

### DIFF
--- a/cmd/ef_tests/state/deserialize.rs
+++ b/cmd/ef_tests/state/deserialize.rs
@@ -56,6 +56,9 @@ where
                     "TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS" => {
                         TransactionExpectedException::InsufficientMaxFeePerGas
                     }
+                    "TransactionException.RLP_INVALID_VALUE" => {
+                        TransactionExpectedException::RlpInvalidValue
+                    }
                     "TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW" => {
                         TransactionExpectedException::GasLimitPriceProductOverflow
                     }
@@ -68,7 +71,7 @@ where
                     "TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS" => {
                         TransactionExpectedException::InsufficientMaxFeePerBlobGas
                     }
-                    _other => TransactionExpectedException::Other, //TODO: Support exceptions that enter here.
+                    _other => TransactionExpectedException::Other, //TODO: Support additional exceptions that may enter here.
                 }
             })
             .collect();


### PR DESCRIPTION
Add missing TransactionException.RLP_INVALID_VALUE case to deserialize_transaction_expected_exception function.

The RlpInvalidValue enum variant was already defined but not handled in the deserializer, causing these exceptions to fall through to the _other case.