### PR TITLE
fix(l1,l2): fix git branch and hash in `ethrex --version`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY cmd ./cmd
 COPY metrics ./metrics
 COPY tooling ./tooling
 COPY fixtures/genesis ./fixtures/genesis
+COPY .git ./.git
 COPY Cargo.* ./
 RUN cargo build --release $BUILD_FLAGS
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
`ethrex --version` is broken in Docker image right now, displaying `VERGEN_IDEMPOTENT_OUTPUT` instead of git branch and hash. This also breaks the commit check between L2 sequencer and prover when running one in Docker and another natively.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Copy `.git` dir into the Docker build stage allowing `cargo build` to calculate the values.
Related: #3848 

<!-- Link to issues: Resolves #111, Resolves #222 -->
