### PR TITLE
fix(levm): ignore offset value when size is zero

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -145,7 +145,7 @@ impl<'a> VM<'a> {
         self.current_call_frame
             .increase_consumed_gas(gas_cost::BLOBHASH)?;
 
-        let index = u256_into_usize(self.current_call_frame.stack.pop1()?);
+        let index = u256_to_usize(self.current_call_frame.stack.pop1()?)?;
         let blob_hashes = &self.env.tx_blob_hashes;
 
         if index >= blob_hashes.len() {

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -152,7 +152,7 @@ impl<'a> VM<'a> {
             _ => {
                 self.current_call_frame.stack.push1(U256::zero())?;
                 return Ok(OpcodeResult::Continue { pc_increment: 1 });
-            },
+            }
         };
 
         //This should never fail because we check if the index fits above

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -145,17 +145,8 @@ impl<'a> VM<'a> {
         self.current_call_frame
             .increase_consumed_gas(gas_cost::BLOBHASH)?;
 
-        let index = self.current_call_frame.stack.pop1()?;
-
+        let index = u256_into_usize(self.current_call_frame.stack.pop1()?);
         let blob_hashes = &self.env.tx_blob_hashes;
-
-        let index: usize = match index.try_into() {
-            Ok(index) => index,
-            Err(_) => {
-                self.current_call_frame.stack.push1(U256::zero())?;
-                return Ok(OpcodeResult::Continue { pc_increment: 1 });
-            }
-        };
 
         if index >= blob_hashes.len() {
             self.current_call_frame.stack.push1(U256::zero())?;

--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -144,14 +144,16 @@ impl<'a> VM<'a> {
         }
         self.current_call_frame
             .increase_consumed_gas(gas_cost::BLOBHASH)?;
-
-        let index = u256_to_usize(self.current_call_frame.stack.pop1()?)?;
+        let index = self.current_call_frame.stack.pop1()?;
         let blob_hashes = &self.env.tx_blob_hashes;
 
-        if index >= blob_hashes.len() {
-            self.current_call_frame.stack.push1(U256::zero())?;
-            return Ok(OpcodeResult::Continue { pc_increment: 1 });
-        }
+        let index = match u256_to_usize(index) {
+            Ok(index) if index < blob_hashes.len() => index,
+            _ => {
+                self.current_call_frame.stack.push1(U256::zero())?;
+                return Ok(OpcodeResult::Continue { pc_increment: 1 });
+            },
+        };
 
         //This should never fail because we check if the index fits above
         #[expect(unsafe_code, reason = "bounds checked beforehand already")]

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -137,7 +137,7 @@ impl<'a> VM<'a> {
 
         let size = u256_into_usize(size);
         let dest_offset = u256_into_usize(dest_offset);
-        let calldata_offset = calldata_offset.try_into().unwrap_or(u64::MAX as usize);
+        let calldata_offset = calldata_offset.try_into().unwrap_or(usize::MAX);
 
         let new_memory_size = calculate_memory_size(dest_offset, size)?;
 
@@ -192,7 +192,7 @@ impl<'a> VM<'a> {
 
         let size = u256_into_usize(size);
         let destination_offset = u256_into_usize(destination_offset);
-        let code_offset = code_offset.try_into().unwrap_or(u64::MAX as usize);
+        let code_offset = code_offset.try_into().unwrap_or(usize::MAX);
 
         let new_memory_size = calculate_memory_size(destination_offset, size)?;
 
@@ -277,7 +277,7 @@ impl<'a> VM<'a> {
         let address = word_to_address(address);
         let size = u256_into_usize(size);
         let dest_offset = u256_into_usize(dest_offset);
-        let offset = offset.try_into().unwrap_or(u64::MAX as usize);
+        let offset = offset.try_into().unwrap_or(usize::MAX);
 
         let current_memory_size = call_frame.memory.len();
         let address_was_cold = self.substate.accessed_addresses.insert(address);
@@ -334,7 +334,7 @@ impl<'a> VM<'a> {
 
         let size = u256_into_usize(size);
         let dest_offset = u256_into_usize(dest_offset);
-        let returndata_offset = returndata_offset.try_into().unwrap_or(u64::MAX as usize);
+        let returndata_offset = returndata_offset.try_into().unwrap_or(usize::MAX);
 
         let new_memory_size = calculate_memory_size(dest_offset, size)?;
 

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -1,7 +1,8 @@
 use crate::{
-    errors::{ExceptionalHalt, OpcodeResult, VMError},
+    errors::{OpcodeResult, VMError},
     gas_cost,
     memory::calculate_memory_size,
+    utils::u256_into_usize,
     vm::VM,
 };
 use ethrex_common::utils::u256_from_big_endian;
@@ -14,13 +15,9 @@ impl<'a> VM<'a> {
     pub fn op_keccak256(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = &mut self.current_call_frame;
         let [offset, size] = *current_call_frame.stack.pop()?;
-        let size: usize = size
-            .try_into()
-            .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-        let offset: usize = match offset.try_into() {
-            Ok(x) => x,
-            Err(_) => usize::MAX,
-        };
+
+        let size = u256_into_usize(size);
+        let offset = u256_into_usize(offset);
 
         let new_memory_size = calculate_memory_size(offset, size)?;
 

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::{OpcodeResult, VMError},
     gas_cost,
     memory::calculate_memory_size,
-    utils::u256_into_usize,
+    utils::size_offset_to_usize,
     vm::VM,
 };
 use ethrex_common::utils::u256_from_big_endian;
@@ -15,9 +15,7 @@ impl<'a> VM<'a> {
     pub fn op_keccak256(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = &mut self.current_call_frame;
         let [offset, size] = *current_call_frame.stack.pop()?;
-
-        let size = u256_into_usize(size);
-        let offset = u256_into_usize(offset);
+        let (size, offset) = size_offset_to_usize(size, offset)?;
 
         let new_memory_size = calculate_memory_size(offset, size)?;
 

--- a/crates/vm/levm/src/opcode_handlers/logging.rs
+++ b/crates/vm/levm/src/opcode_handlers/logging.rs
@@ -2,6 +2,7 @@ use crate::{
     errors::{ExceptionalHalt, OpcodeResult, VMError},
     gas_cost,
     memory::calculate_memory_size,
+    utils::u256_into_usize,
     vm::VM,
 };
 use bytes::Bytes;
@@ -19,13 +20,9 @@ impl<'a> VM<'a> {
         }
 
         let [offset, size] = *current_call_frame.stack.pop()?;
-        let size = size
-            .try_into()
-            .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-        let offset = match offset.try_into() {
-            Ok(x) => x,
-            Err(_) => usize::MAX,
-        };
+        let offset = u256_into_usize(offset);
+        let size = u256_into_usize(size);
+
         let topics = current_call_frame
             .stack
             .pop::<N_TOPICS>()?

--- a/crates/vm/levm/src/opcode_handlers/logging.rs
+++ b/crates/vm/levm/src/opcode_handlers/logging.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::{ExceptionalHalt, OpcodeResult, VMError},
     gas_cost,
     memory::calculate_memory_size,
-    utils::u256_into_usize,
+    utils::size_offset_to_usize,
     vm::VM,
 };
 use bytes::Bytes;
@@ -20,8 +20,7 @@ impl<'a> VM<'a> {
         }
 
         let [offset, size] = *current_call_frame.stack.pop()?;
-        let offset = u256_into_usize(offset);
-        let size = u256_into_usize(size);
+        let (size, offset) = size_offset_to_usize(size, offset)?;
 
         let topics = current_call_frame
             .stack

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -5,6 +5,7 @@ use crate::{
     gas_cost::{self, SSTORE_STIPEND},
     memory::calculate_memory_size,
     opcodes::Opcode,
+    utils::u256_into_usize,
     vm::VM,
 };
 use ethrex_common::{
@@ -77,11 +78,7 @@ impl<'a> VM<'a> {
     // MLOAD operation
     pub fn op_mload(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = &mut self.current_call_frame;
-        let offset = current_call_frame.stack.pop1()?;
-
-        let offset: usize = offset
-            .try_into()
-            .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
+        let offset = u256_into_usize(current_call_frame.stack.pop1()?);
 
         let new_memory_size = calculate_memory_size(offset, WORD_SIZE_IN_BYTES_USIZE)?;
 
@@ -106,9 +103,7 @@ impl<'a> VM<'a> {
             return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
-        let offset: usize = offset
-            .try_into()
-            .map_err(|_err| ExceptionalHalt::OutOfGas)?;
+        let offset = u256_into_usize(offset);
 
         let current_call_frame = &mut self.current_call_frame;
 
@@ -128,11 +123,7 @@ impl<'a> VM<'a> {
     pub fn op_mstore8(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = &mut self.current_call_frame;
 
-        let offset = current_call_frame.stack.pop1()?;
-
-        let offset: usize = offset
-            .try_into()
-            .map_err(|_err| ExceptionalHalt::OutOfGas)?;
+        let offset = u256_into_usize(current_call_frame.stack.pop1()?);
 
         let new_memory_size = calculate_memory_size(offset, 1)?;
 
@@ -283,24 +274,11 @@ impl<'a> VM<'a> {
         let current_call_frame = &mut self.current_call_frame;
         let [dest_offset, src_offset, size] = *current_call_frame.stack.pop()?;
 
-        let size: usize = size
-            .try_into()
-            .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-
-        let dest_offset: usize = match dest_offset.try_into() {
-            Ok(x) => x,
-            Err(_) if size == 0 => 0,
-            Err(_) => return Err(ExceptionalHalt::VeryLargeNumber.into()),
-        };
-
-        let src_offset: usize = match src_offset.try_into() {
-            Ok(x) => x,
-            Err(_) if size == 0 => 0,
-            Err(_) => return Err(ExceptionalHalt::VeryLargeNumber.into()),
-        };
+        let size: usize = u256_into_usize(size);
+        let dest_offset: usize = u256_into_usize(dest_offset);
+        let src_offset: usize = u256_into_usize(src_offset);
 
         let new_memory_size_for_dest = calculate_memory_size(dest_offset, size)?;
-
         let new_memory_size_for_src = calculate_memory_size(src_offset, size)?;
 
         current_call_frame.increase_consumed_gas(gas_cost::mcopy(

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -273,19 +273,18 @@ impl<'a> VM<'a> {
         }
         let current_call_frame = &mut self.current_call_frame;
         let [dest_offset, src_offset, size] = *current_call_frame.stack.pop()?;
-
         let size: usize = u256_to_usize(size)?;
+
         let (dest_offset, src_offset) = if size == 0 {
             (0, 0)
         } else {
             (u256_to_usize(dest_offset)?, u256_to_usize(src_offset)?)
         };
 
-        let new_memory_size_for_dest = calculate_memory_size(dest_offset, size)?;
-        let new_memory_size_for_src = calculate_memory_size(src_offset, size)?;
+        let new_memory_size = calculate_memory_size(dest_offset.max(src_offset), size)?;
 
         current_call_frame.increase_consumed_gas(gas_cost::mcopy(
-            new_memory_size_for_dest.max(new_memory_size_for_src),
+            new_memory_size,
             current_call_frame.memory.len(),
             size,
         )?)?;

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -40,18 +40,10 @@ impl<'a> VM<'a> {
                 return_data_size,
             ] = *current_call_frame.stack.pop()?;
             let callee: Address = word_to_address(callee);
-            let args_start_offset = args_start_offset
-                .try_into()
-                .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-            let args_size = args_size
-                .try_into()
-                .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset: usize = return_data_start_offset
-                .try_into()
-                .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_size: usize = return_data_size
-                .try_into()
-                .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
+            let args_start_offset = u256_into_usize(args_start_offset);
+            let args_size = u256_into_usize(args_size);
+            let return_data_start_offset = u256_into_usize(return_data_start_offset);
+            let return_data_size = u256_into_usize(return_data_size);
             let current_memory_size = current_call_frame.memory.len();
             (
                 gas,
@@ -153,19 +145,10 @@ impl<'a> VM<'a> {
                 return_data_size,
             ] = *current_call_frame.stack.pop()?;
             let address = word_to_address(address);
-            let args_size = args_size
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let args_start_offset = match args_start_offset.try_into() {
-                Ok(x) => x,
-                Err(_) => usize::MAX,
-            };
-            let return_data_start_offset = return_data_start_offset
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_size = return_data_size
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
+            let args_start_offset = u256_into_usize(args_start_offset);
+            let args_size = u256_into_usize(args_size);
+            let return_data_start_offset = u256_into_usize(return_data_start_offset);
+            let return_data_size = u256_into_usize(return_data_size);
             let current_memory_size = current_call_frame.memory.len();
             (
                 gas,
@@ -241,18 +224,13 @@ impl<'a> VM<'a> {
     pub fn op_return(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = &mut self.current_call_frame;
         let [offset, size] = *current_call_frame.stack.pop()?;
-        let size = size
-            .try_into()
-            .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
+        let size = u256_into_usize(size);
 
         if size == 0 {
             return Ok(OpcodeResult::Halt);
         }
 
-        let offset: usize = match offset.try_into() {
-            Ok(x) => x,
-            Err(_) => usize::MAX,
-        };
+        let offset: usize = u256_into_usize(offset);
 
         let new_memory_size = calculate_memory_size(offset, size)?;
         let current_memory_size = current_call_frame.memory.len();
@@ -287,18 +265,10 @@ impl<'a> VM<'a> {
                 return_data_size,
             ] = *current_call_frame.stack.pop()?;
             let address = word_to_address(address);
-            let args_start_offset = args_start_offset
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let args_size = args_size
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset = return_data_start_offset
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_size = return_data_size
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
+            let args_start_offset = u256_into_usize(args_start_offset);
+            let args_size = u256_into_usize(args_size);
+            let return_data_start_offset = u256_into_usize(return_data_start_offset);
+            let return_data_size = u256_into_usize(return_data_size);
             let current_memory_size = current_call_frame.memory.len();
             (
                 gas,
@@ -392,18 +362,10 @@ impl<'a> VM<'a> {
                 return_data_size,
             ] = *current_call_frame.stack.pop()?;
             let address = word_to_address(address);
-            let args_start_offset = args_start_offset
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let args_size = args_size
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_start_offset = return_data_start_offset
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-            let return_data_size = return_data_size
-                .try_into()
-                .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
+            let args_start_offset = u256_into_usize(args_start_offset);
+            let args_size = u256_into_usize(args_size);
+            let return_data_start_offset = u256_into_usize(return_data_start_offset);
+            let return_data_size = u256_into_usize(return_data_size);
             let current_memory_size = current_call_frame.memory.len();
             (
                 gas,
@@ -483,13 +445,8 @@ impl<'a> VM<'a> {
             code_offset_in_memory,
             code_size_in_memory,
         ] = *current_call_frame.stack.pop()?;
-        let code_size_in_memory: usize = code_size_in_memory
-            .try_into()
-            .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-        let code_offset_in_memory: usize = match code_offset_in_memory.try_into() {
-            Ok(x) => x,
-            Err(_) => usize::MAX,
-        };
+        let code_size_in_memory: usize = u256_into_usize(code_size_in_memory);
+        let code_offset_in_memory: usize = u256_into_usize(code_offset_in_memory);
 
         let new_size = calculate_memory_size(code_offset_in_memory, code_size_in_memory)?;
 
@@ -518,13 +475,8 @@ impl<'a> VM<'a> {
             code_size_in_memory,
             salt,
         ] = *current_call_frame.stack.pop()?;
-        let code_size_in_memory: usize = code_size_in_memory
-            .try_into()
-            .map_err(|_err| ExceptionalHalt::VeryLargeNumber)?;
-        let code_offset_in_memory: usize = match code_offset_in_memory.try_into() {
-            Ok(x) => x,
-            Err(_) => usize::MAX,
-        };
+        let code_size_in_memory: usize = u256_into_usize(code_size_in_memory);
+        let code_offset_in_memory: usize = u256_into_usize(code_offset_in_memory);
 
         let new_size = calculate_memory_size(code_offset_in_memory, code_size_in_memory)?;
 
@@ -553,14 +505,8 @@ impl<'a> VM<'a> {
 
         let [offset, size] = *current_call_frame.stack.pop()?;
 
-        let offset = match offset.try_into() {
-            Ok(x) => x,
-            Err(_) => usize::MAX,
-        };
-
-        let size = size
-            .try_into()
-            .map_err(|_| ExceptionalHalt::VeryLargeNumber)?;
+        let offset = u256_into_usize(offset);
+        let size = u256_into_usize(size);
 
         let new_memory_size = calculate_memory_size(offset, size)?;
         let current_memory_size = current_call_frame.memory.len();

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -222,14 +222,12 @@ impl<'a> VM<'a> {
     pub fn op_return(&mut self) -> Result<OpcodeResult, VMError> {
         let current_call_frame = &mut self.current_call_frame;
         let [offset, size] = *current_call_frame.stack.pop()?;
-        let size = u256_to_usize(size)?;
 
-        if size == 0 {
+        if size.is_zero() {
             return Ok(OpcodeResult::Halt);
         }
 
-        let offset: usize = u256_to_usize(offset)?;
-
+        let (size, offset) = size_offset_to_usize(size, offset)?;
         let new_memory_size = calculate_memory_size(offset, size)?;
         let current_memory_size = current_call_frame.memory.len();
 

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -681,6 +681,7 @@ impl<'a> VM<'a> {
 }
 
 /// Converts U256 value into usize by taking the first 64 bytes and discarding the rest
+#[expect(clippy::as_conversions)]
 pub fn u256_into_usize(val: U256) -> usize {
     val.0[0] as usize
 }

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -679,3 +679,8 @@ impl<'a> VM<'a> {
         }
     }
 }
+
+/// Converts U256 value into usize by taking the first 64 bytes and discarding the rest
+pub fn u256_into_usize(val: U256) -> usize {
+    val.0[0] as usize
+}

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -680,8 +680,22 @@ impl<'a> VM<'a> {
     }
 }
 
-/// Converts U256 value into usize by taking the first 64 bytes and discarding the rest
+/// Converts a U256 value into usize, fails if the value is over 64 bytes
 #[expect(clippy::as_conversions)]
-pub fn u256_into_usize(val: U256) -> usize {
-    val.0[0] as usize
+pub fn u256_to_usize(val: U256) -> Result<usize, VMError> {
+    if val.0[1] != 0 || val.0[2] != 0 || val.0[3] != 0 {
+        return Err(VMError::ExceptionalHalt(ExceptionalHalt::VeryLargeNumber));
+    }
+    Ok(val.0[0] as usize)
+}
+
+/// Converts U256 size and offset to usize.
+/// If the size is zero, the offset will be zero regardless of its original value as it is not relevant
+pub fn size_offset_to_usize(size: U256, offset: U256) -> Result<(usize, usize), VMError> {
+    if size.is_zero() {
+        // Offset is irrelevant
+        Ok((0, 0))
+    } else {
+        Ok((u256_to_usize(size)?, u256_to_usize(offset)?))
+    }
 }


### PR DESCRIPTION
**Motivation**
We recently ran into a gas mismatch when running full sync in sepolia testnet. The problem was that we were reverting earlier due to an `ExceptionHalt::VeryLargeNumber`. This happened during a `STATICCALL` opcode execution where the `arg_offset` value taken from the stack was a very large number. Upon comparing our implementation with geth we realized that the difference lies in that we do ignore the value of the offset when calculating the memory size If the size is zero, but by that time we have already converted the offset into a usize value, and failed if we couldn't do so. 
The transaction where this bug was discovered is https://sepolia.etherscan.io/tx/0x0495f636d6d69c91e40afc44d3bd12800831d848391666cf23325720fd9ebfd4
This PR solves this problem and aims to solve future related problems by adding a utility function `size_offset_to_usize` which first converts the size into a size value and if it is not zero then converts the offset into a size value, if the size is zero, offset will be ignored and given a default value as it won't be used.
It also gets rid of some explicit error handling by adding utility function `u256_to_usize` to checkedly convert U256 to usize. Some tweaks have also been performed while checking against geth handling.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add util  function `u256_to_usize` which converts a U256 to usize.
* Add util  function `size_offset_to_usize` which converts U256 size and offset to usize, ignoring the offset value if size is zero.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed in order to progress through #1676 