### PR TITLE
ci(l1): Fix typo in Docker Login CI.

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -71,6 +71,9 @@ jobs:
           if [ -z "$DOCKER_USERNAME" ] || [ -z "$DOCKER_PASSWORD" ]; then
             echo "DOCKER_CREDS_EXISTS=false" >> $GITHUB_ENV
             echo "No credentials provided. Skipping DockerHub login..."
+          else
+            echo "DOCKER_CREDS_EXISTS=true" >> $GITHUB_ENV
+            echo "Credentials were provided!"
           fi
 
       - name: Login to Docker Hub


### PR DESCRIPTION
**Motivation**
When credentials were present, `DOCKER_CREDS_EXISTS` was never set to true, meaning the Docker login step was always skipped, even when creds were there. This PR fixes this.
