### PR TITLE
feat(l1): embed bootnodes for public networks inside binary

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1,6 +1,6 @@
 use crate::{
     cli::Options,
-    networks::{self, Network, PublicNetwork},
+    networks::Network,
     utils::{
         get_client_version, parse_socket_addr, read_jwtsecret_file, read_node_config_file,
         set_datadir,
@@ -227,25 +227,7 @@ pub fn get_network(opts: &Options) -> Network {
 pub fn get_bootnodes(opts: &Options, network: &Network, data_dir: &str) -> Vec<Node> {
     let mut bootnodes: Vec<Node> = opts.bootnodes.clone();
 
-    match network {
-        Network::PublicNetwork(PublicNetwork::Holesky) => {
-            info!("Adding holesky preset bootnodes");
-            bootnodes.extend(networks::HOLESKY_BOOTNODES.clone());
-        }
-        Network::PublicNetwork(PublicNetwork::Hoodi) => {
-            info!("Addig hoodi preset bootnodes");
-            bootnodes.extend(networks::HOODI_BOOTNODES.clone());
-        }
-        Network::PublicNetwork(PublicNetwork::Mainnet) => {
-            info!("Adding mainnet preset bootnodes");
-            bootnodes.extend(networks::MAINNET_BOOTNODES.clone());
-        }
-        Network::PublicNetwork(PublicNetwork::Sepolia) => {
-            info!("Adding sepolia preset bootnodes");
-            bootnodes.extend(networks::SEPOLIA_BOOTNODES.clone());
-        }
-        _ => {}
-    }
+    bootnodes.extend(network.get_bootnodes());
 
     if bootnodes.is_empty() {
         warn!("No bootnodes specified. This node will not be able to connect to the network.");

--- a/cmd/ethrex/networks.rs
+++ b/cmd/ethrex/networks.rs
@@ -5,47 +5,27 @@ use std::{
 
 use ethrex_common::types::{Genesis, GenesisError};
 use ethrex_p2p::types::Node;
-use lazy_static::lazy_static;
 
 pub const HOLESKY_GENESIS_PATH: &str = "cmd/ethrex/networks/holesky/genesis.json";
 pub const HOLESKY_GENESIS_CONTENTS: &str = include_str!("networks/holesky/genesis.json");
-const HOLESKY_BOOTNODES_PATH: &str = "cmd/ethrex/networks/holesky/bootnodes.json";
+const HOLESKY_BOOTNODES: &str = include_str!("networks/holesky/bootnodes.json");
 
 pub const SEPOLIA_GENESIS_PATH: &str = "cmd/ethrex/networks/sepolia/genesis.json";
 pub const SEPOLIA_GENESIS_CONTENTS: &str = include_str!("networks/sepolia/genesis.json");
-const SEPOLIA_BOOTNODES_PATH: &str = "cmd/ethrex/networks/sepolia/bootnodes.json";
+const SEPOLIA_BOOTNODES: &str = include_str!("networks/sepolia/bootnodes.json");
 
 pub const HOODI_GENESIS_PATH: &str = "cmd/ethrex/networks/hoodi/genesis.json";
 pub const HOODI_GENESIS_CONTENTS: &str = include_str!("networks/hoodi/genesis.json");
-const HOODI_BOOTNODES_PATH: &str = "cmd/ethrex/networks/hoodi/bootnodes.json";
+const HOODI_BOOTNODES: &str = include_str!("networks/hoodi/bootnodes.json");
 
 pub const MAINNET_GENESIS_PATH: &str = "cmd/ethrex/networks/mainnet/genesis.json";
 pub const MAINNET_GENESIS_CONTENTS: &str = include_str!("networks/mainnet/genesis.json");
-const MAINNET_BOOTNODES_PATH: &str = "cmd/ethrex/networks/mainnet/bootnodes.json";
+const MAINNET_BOOTNODES: &str = include_str!("networks/mainnet/bootnodes.json");
 
 pub const LOCAL_DEVNET_GENESIS_PATH: &str = "../../fixtures/genesis/l1-dev.json";
 pub const LOCAL_DEVNETL2_GENESIS_PATH: &str = "../../fixtures/genesis/l2.json";
 pub const LOCAL_DEVNET_GENESIS_CONTENTS: &str = include_str!("../../fixtures/genesis/l1-dev.json");
 pub const LOCAL_DEVNETL2_GENESIS_CONTENTS: &str = include_str!("../../fixtures/genesis/l2.json");
-
-lazy_static! {
-    pub static ref HOLESKY_BOOTNODES: Vec<Node> = serde_json::from_reader(
-        std::fs::File::open(HOLESKY_BOOTNODES_PATH).expect("Failed to open holesky bootnodes file")
-    )
-    .expect("Failed to parse holesky bootnodes file");
-    pub static ref SEPOLIA_BOOTNODES: Vec<Node> = serde_json::from_reader(
-        std::fs::File::open(SEPOLIA_BOOTNODES_PATH).expect("Failed to open sepolia bootnodes file")
-    )
-    .expect("Failed to parse sepolia bootnodes file");
-    pub static ref HOODI_BOOTNODES: Vec<Node> = serde_json::from_reader(
-        std::fs::File::open(HOODI_BOOTNODES_PATH).expect("Failed to open hoodi bootnodes file")
-    )
-    .expect("Failed to parse hoodi bootnodes file");
-    pub static ref MAINNET_BOOTNODES: Vec<Node> = serde_json::from_reader(
-        std::fs::File::open(MAINNET_BOOTNODES_PATH).expect("Failed to open mainnet bootnodes file")
-    )
-    .expect("Failed to parse mainnet bootnodes file");
-}
 
 #[derive(Debug, Clone)]
 pub enum Network {
@@ -128,6 +108,17 @@ impl Network {
             Network::LocalDevnetL2 => Ok(serde_json::from_str(LOCAL_DEVNETL2_GENESIS_CONTENTS)?),
             Network::GenesisPath(s) => Genesis::try_from(s.as_path()),
         }
+    }
+
+    pub fn get_bootnodes(&self) -> Vec<Node> {
+        let bootnodes = match self {
+            Network::PublicNetwork(PublicNetwork::Holesky) => HOLESKY_BOOTNODES,
+            Network::PublicNetwork(PublicNetwork::Hoodi) => HOODI_BOOTNODES,
+            Network::PublicNetwork(PublicNetwork::Mainnet) => MAINNET_BOOTNODES,
+            Network::PublicNetwork(PublicNetwork::Sepolia) => SEPOLIA_BOOTNODES,
+            _ => return vec![],
+        };
+        serde_json::from_str(bootnodes).expect("bootnodes file should be valid JSON")
     }
 }
 

--- a/cmd/ethrex/networks.rs
+++ b/cmd/ethrex/networks.rs
@@ -183,4 +183,12 @@ mod tests {
             "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
         );
     }
+
+    #[test]
+    fn test_get_bootnodes_works_for_public_networks() {
+        Network::PublicNetwork(PublicNetwork::Holesky).get_bootnodes();
+        Network::PublicNetwork(PublicNetwork::Hoodi).get_bootnodes();
+        Network::PublicNetwork(PublicNetwork::Mainnet).get_bootnodes();
+        Network::PublicNetwork(PublicNetwork::Sepolia).get_bootnodes();
+    }
 }


### PR DESCRIPTION
**Motivation**

We want users to be able to run the binary without needing to have a file of known bootnodes for each public network.

**Description**

This PR embeds the bootnode files inside the binary.

Closes #3966 

