### PR TITLE
chore: remove unused genesis path constants

### DIFF
--- a/cmd/ethrex/networks.rs
+++ b/cmd/ethrex/networks.rs
@@ -1,30 +1,21 @@
-use std::{
-    fmt::{self},
-    path::{Path, PathBuf},
-};
+use std::{fmt, path::PathBuf};
 
 use ethrex_common::types::{Genesis, GenesisError};
 use ethrex_p2p::types::Node;
 use lazy_static::lazy_static;
 
-pub const HOLESKY_GENESIS_PATH: &str = "cmd/ethrex/networks/holesky/genesis.json";
 pub const HOLESKY_GENESIS_CONTENTS: &str = include_str!("networks/holesky/genesis.json");
 const HOLESKY_BOOTNODES_PATH: &str = "cmd/ethrex/networks/holesky/bootnodes.json";
 
-pub const SEPOLIA_GENESIS_PATH: &str = "cmd/ethrex/networks/sepolia/genesis.json";
 pub const SEPOLIA_GENESIS_CONTENTS: &str = include_str!("networks/sepolia/genesis.json");
 const SEPOLIA_BOOTNODES_PATH: &str = "cmd/ethrex/networks/sepolia/bootnodes.json";
 
-pub const HOODI_GENESIS_PATH: &str = "cmd/ethrex/networks/hoodi/genesis.json";
 pub const HOODI_GENESIS_CONTENTS: &str = include_str!("networks/hoodi/genesis.json");
 const HOODI_BOOTNODES_PATH: &str = "cmd/ethrex/networks/hoodi/bootnodes.json";
 
-pub const MAINNET_GENESIS_PATH: &str = "cmd/ethrex/networks/mainnet/genesis.json";
 pub const MAINNET_GENESIS_CONTENTS: &str = include_str!("networks/mainnet/genesis.json");
 const MAINNET_BOOTNODES_PATH: &str = "cmd/ethrex/networks/mainnet/bootnodes.json";
 
-pub const LOCAL_DEVNET_GENESIS_PATH: &str = "../../fixtures/genesis/l1-dev.json";
-pub const LOCAL_DEVNETL2_GENESIS_PATH: &str = "../../fixtures/genesis/l2.json";
 pub const LOCAL_DEVNET_GENESIS_CONTENTS: &str = include_str!("../../fixtures/genesis/l1-dev.json");
 pub const LOCAL_DEVNETL2_GENESIS_CONTENTS: &str = include_str!("../../fixtures/genesis/l2.json");
 
@@ -105,18 +96,6 @@ impl fmt::Display for Network {
 impl Network {
     pub fn mainnet() -> Self {
         Network::PublicNetwork(PublicNetwork::Mainnet)
-    }
-
-    pub fn get_genesis_path(&self) -> &Path {
-        match self {
-            Network::PublicNetwork(PublicNetwork::Holesky) => Path::new(HOLESKY_GENESIS_PATH),
-            Network::PublicNetwork(PublicNetwork::Hoodi) => Path::new(HOODI_GENESIS_PATH),
-            Network::PublicNetwork(PublicNetwork::Mainnet) => Path::new(MAINNET_GENESIS_PATH),
-            Network::PublicNetwork(PublicNetwork::Sepolia) => Path::new(SEPOLIA_GENESIS_PATH),
-            Network::LocalDevnet => Path::new(LOCAL_DEVNET_GENESIS_PATH),
-            Network::LocalDevnetL2 => Path::new(LOCAL_DEVNETL2_GENESIS_PATH),
-            Network::GenesisPath(s) => s,
-        }
     }
 
     pub fn get_genesis(&self) -> Result<Genesis, GenesisError> {


### PR DESCRIPTION
This PR removes some unused constants and functions related to genesis paths.

