### PR TITLE
fix(l1): fix overlapping chunk ids

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1949,7 +1949,7 @@ impl PeerHandler {
         let total_slots = all_account_storages.iter().map(|s| s.len()).sum::<usize>();
         info!("Finished downloading account ranges, total storage slots: {total_slots}");
 
-        chunk_index
+        chunk_index + 1
     }
 
     /// Requests state trie nodes given the root of the trie where they are contained and their path (be them full or partial)


### PR DESCRIPTION
**Motivation**

As part of snap sync, we download accounts which generates several batches.

For each of these batches, storage download requests are made. Those are numbered with a chunk_id.

For the last chunk of each storage download, the chunk_id isn't incremented This causes the first chunk of the next batch to overwrite the last chunk of the previous one.

This causes some storage ranges to be lost when more than one chunk is generated.

**Description**

Fixes the off-by-one error.
