### PR TITLE
fix(l1): unhardcode snapshot paths

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -32,6 +32,10 @@ use crate::{
         },
     },
     snap::encodable_to_proof,
+    utils::{
+        get_account_state_snapshot_file, get_account_state_snapshots_dir,
+        get_account_storages_snapshot_file, get_account_storages_snapshots_dir,
+    },
 };
 use tracing::{debug, error, info, trace, warn};
 pub const PEER_REPLY_TIMEOUT: Duration = Duration::from_secs(15);
@@ -814,6 +818,9 @@ impl PeerHandler {
         let mut scores = self.peer_scores.lock().await;
         let mut chunk_file = 0;
 
+        // TODO: handle this error
+        let account_state_snapshots_dir = get_account_state_snapshots_dir()
+            .expect("Failed to get account_state_snapshots directory");
         loop {
             if all_accounts_state.len() * size_of::<AccountState>() >= 1024 * 1024 * 64 {
                 let current_account_hashes = std::mem::take(&mut all_account_hashes);
@@ -825,21 +832,30 @@ impl PeerHandler {
                     .collect::<Vec<(H256, AccountState)>>()
                     .encode_to_vec();
 
-                if !std::fs::exists("/home/admin/.local/share/ethrex/account_state_snapshots")
-                    .expect("Failed")
-                {
-                    std::fs::create_dir_all(
-                        "/home/admin/.local/share/ethrex/account_state_snapshots",
-                    )
-                    .expect("Failed to create accounts_state_snapshot dir");
+                if !std::fs::exists(&account_state_snapshots_dir).expect("Failed") {
+                    std::fs::create_dir_all(&account_state_snapshots_dir)
+                        .expect("Failed to create accounts_state_snapshot dir");
                 }
 
+                let account_state_snapshots_dir_cloned = account_state_snapshots_dir.clone();
                 let dump_account_result_sender_cloned = dump_account_result_sender.clone();
                 tokio::task::spawn(async move {
-                    let path = format!("/home/admin/.local/share/ethrex/account_state_snapshots/account_state_chunk.rlp.{chunk_file}");
+                    let path = get_account_state_snapshot_file(
+                        account_state_snapshots_dir_cloned,
+                        chunk_file,
+                    );
                     // TODO: check the error type and handle it properly
-                    let result = std::fs::write(path.clone(), account_state_chunk.clone()).map_err(|_| AccountDumpError{path, contents: account_state_chunk});
-                    dump_account_result_sender_cloned.send(result).await.unwrap();
+                    let result =
+                        std::fs::write(path.clone(), account_state_chunk.clone()).map_err(|_| {
+                            AccountDumpError {
+                                path,
+                                contents: account_state_chunk,
+                            }
+                        });
+                    dump_account_result_sender_cloned
+                        .send(result)
+                        .await
+                        .unwrap();
                 })
                 .await
                 .unwrap();
@@ -1095,18 +1111,19 @@ impl PeerHandler {
                 .collect::<Vec<(H256, AccountState)>>()
                 .encode_to_vec();
 
-            if !std::fs::exists("/home/admin/.local/share/ethrex/account_state_snapshots")
-                .expect("Failed")
-            {
-                std::fs::create_dir_all("/home/admin/.local/share/ethrex/account_state_snapshots")
+            if !std::fs::exists(&account_state_snapshots_dir).expect("Failed") {
+                std::fs::create_dir_all(&account_state_snapshots_dir)
                     .expect("Failed to create accounts_state_snapshot dir");
             }
 
             tokio::task::spawn(async move {
-                    std::fs::write(format!("/home/admin/.local/share/ethrex/account_state_snapshots/account_state_chunk.rlp.{chunk_file}"), account_state_chunk).unwrap_or_else(|_| panic!("Failed to write account_state_snapshot chunk {chunk_file}"));
-                })
-                .await
-                .unwrap();
+                let path = get_account_state_snapshot_file(account_state_snapshots_dir, chunk_file);
+                std::fs::write(path, account_state_chunk).unwrap_or_else(|_| {
+                    panic!("Failed to write account_state_snapshot chunk {chunk_file}")
+                });
+            })
+            .await
+            .unwrap();
         }
 
         *METRICS.accounts_downloads_tasks_queued.lock().await =
@@ -1481,6 +1498,7 @@ impl PeerHandler {
 
         let mut scores = self.peer_scores.lock().await;
 
+        let account_storages_snapshots_dir = get_account_storages_snapshots_dir().unwrap();
         loop {
             if all_account_storages.iter().map(Vec::len).sum::<usize>() * 64 > 1024 * 1024 * 64 {
                 let current_account_hashes = account_storage_roots
@@ -1496,17 +1514,19 @@ impl PeerHandler {
                     .collect::<Vec<_>>()
                     .encode_to_vec();
 
-                if !std::fs::exists("/home/admin/.local/share/ethrex/account_storages_snapshots")
-                    .expect("Failed")
-                {
-                    std::fs::create_dir_all(
-                        "/home/admin/.local/share/ethrex/account_storages_snapshots",
-                    )
-                    .expect("Failed to create accounts_state_snapshot dir");
+                if !std::fs::exists(&account_storages_snapshots_dir).expect("Failed") {
+                    std::fs::create_dir_all(&account_storages_snapshots_dir)
+                        .expect("Failed to create accounts_state_snapshot dir");
                 }
-
+                let account_storages_snapshots_dir_cloned = account_storages_snapshots_dir.clone();
                 tokio::task::spawn(async move {
-                    std::fs::write(format!("/home/admin/.local/share/ethrex/account_storages_snapshots/account_storages_chunk.rlp.{chunk_index}"), snapshot).unwrap_or_else(|_| panic!("Failed to write account_storages_snapshot chunk {chunk_index}"));
+                    let path = get_account_storages_snapshot_file(
+                        account_storages_snapshots_dir_cloned,
+                        chunk_index,
+                    );
+                    std::fs::write(path, snapshot).unwrap_or_else(|_| {
+                        panic!("Failed to write account_storages_snapshot chunk {chunk_index}")
+                    });
                 })
                 .await
                 .expect("");
@@ -1904,20 +1924,22 @@ impl PeerHandler {
                 .collect::<Vec<_>>()
                 .encode_to_vec();
 
-            if !std::fs::exists("/home/admin/.local/share/ethrex/account_storages_snapshots")
-                .expect("Failed")
-            {
-                std::fs::create_dir_all(
-                    "/home/admin/.local/share/ethrex/account_storages_snapshots",
-                )
-                .expect("Failed to create accounts_state_snapshot dir");
+            if !std::fs::exists(&account_storages_snapshots_dir).expect("Failed") {
+                std::fs::create_dir_all(&account_storages_snapshots_dir)
+                    .expect("Failed to create accounts_state_snapshot dir");
             }
-
+            let account_storages_snapshots_dir_cloned = account_storages_snapshots_dir.clone();
             tokio::task::spawn(async move {
-                    std::fs::write(format!("/home/admin/.local/share/ethrex/account_storages_snapshots/account_storages_chunk.rlp.{chunk_index}"), snapshot).unwrap_or_else(|_| panic!("Failed to write account_storages_snapshot chunk {chunk_index}"));
-                })
-                .await
-                .expect("");
+                let path = get_account_storages_snapshot_file(
+                    account_storages_snapshots_dir_cloned,
+                    chunk_index,
+                );
+                std::fs::write(path, snapshot).unwrap_or_else(|_| {
+                    panic!("Failed to write account_storages_snapshot chunk {chunk_index}")
+                });
+            })
+            .await
+            .expect("");
         }
 
         *METRICS.storages_downloads_tasks_queued.lock().await =

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1,6 +1,8 @@
 use crate::peer_handler::SNAP_LIMIT;
 use crate::rlpx::p2p::SUPPORTED_ETH_CAPABILITIES;
-use crate::utils::current_unix_time;
+use crate::utils::{
+    current_unix_time, get_account_state_snapshots_dir, get_account_storages_snapshots_dir,
+};
 use crate::{
     metrics::METRICS,
     peer_handler::{HASH_MAX, MAX_BLOCK_BODIES_TO_REQUEST, PeerHandler},
@@ -764,7 +766,10 @@ impl Syncer {
 
         let mut chunk_index = 0;
         let mut downloaded_account_storages = 0;
-        for entry in std::fs::read_dir("/home/admin/.local/share/ethrex/account_state_snapshots/")
+
+        let account_state_snapshots_dir = get_account_state_snapshots_dir()
+            .expect("Failed to get account_state_snapshots directory");
+        for entry in std::fs::read_dir(&account_state_snapshots_dir)
             .expect("Failed to read account_state_snapshots dir")
         {
             let entry = entry.expect("Failed to read dir entry");
@@ -805,7 +810,7 @@ impl Syncer {
         let mut computed_state_root = *EMPTY_TRIE_HASH;
         let mut bytecode_hashes = Vec::new();
 
-        for entry in std::fs::read_dir("/home/admin/.local/share/ethrex/account_state_snapshots/")
+        for entry in std::fs::read_dir(&account_state_snapshots_dir)
             .expect("Failed to read account_state_snapshots dir")
         {
             let entry = entry.expect("Failed to read dir entry");
@@ -867,9 +872,10 @@ impl Syncer {
         let maybe_big_account_storage_state_roots: Arc<Mutex<HashMap<H256, H256>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
-        for entry in
-            std::fs::read_dir("/home/admin/.local/share/ethrex/account_storages_snapshots/")
-                .expect("Failed to read account_storages_snapshots dir")
+        let account_storages_snapshots_dir = get_account_storages_snapshots_dir()
+            .expect("Failed to get account_storages_snapshots directory");
+        for entry in std::fs::read_dir(&account_storages_snapshots_dir)
+            .expect("Failed to read account_storages_snapshots dir")
         {
             let entry = entry.expect("Failed to read dir entry");
 

--- a/crates/networking/p2p/utils.rs
+++ b/crates/networking/p2p/utils.rs
@@ -46,3 +46,27 @@ pub fn unmap_ipv4in6_address(addr: IpAddr) -> IpAddr {
     }
     addr
 }
+
+pub fn get_account_storages_snapshots_dir() -> Option<String> {
+    let home_dir = std::env::home_dir()?;
+    let home_dir = home_dir.to_str()?;
+    let account_storages_snapshots_dir =
+        format!("{home_dir}/.local/share/ethrex/account_storages_snapshots");
+    Some(account_storages_snapshots_dir)
+}
+
+pub fn get_account_state_snapshots_dir() -> Option<String> {
+    let home_dir = std::env::home_dir()?;
+    let home_dir = home_dir.to_str()?;
+    let account_state_snapshots_dir =
+        format!("{home_dir}/.local/share/ethrex/account_state_snapshots");
+    Some(account_state_snapshots_dir)
+}
+
+pub fn get_account_state_snapshot_file(directory: String, chunk_index: u64) -> String {
+    format!("{directory}/account_state_chunk.rlp.{chunk_index}")
+}
+
+pub fn get_account_storages_snapshot_file(directory: String, chunk_index: u64) -> String {
+    format!("{directory}/account_storages_chunk.rlp.{chunk_index}")
+}


### PR DESCRIPTION
**Motivation**
Currently the snapshots are stored in files in the `/home/admin/.local/share` directory. However this does not work in macOS, since directories cannot be created inside `/home`.


**Description**
Unhardcodes the directory in which the snapshots are stored, so that it works both on Linux and macOS.


