### PR TITLE
fix(l2): compile contracts on releases

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -83,6 +83,19 @@ jobs:
           method: "network"
           sub-packages: '["nvcc"]'
 
+      - name: Install solc
+        if: ${{ matrix.platform != 'ubuntu-22.04-arm' }}
+        uses: pontem-network/get-solc@master
+        with:
+          version: v0.8.29
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install solc
+        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
+        run: |
+          sudo curl -L -o /usr/local/bin/solc https://github.com/nikitastupin/solc/raw/refs/heads/main/linux/aarch64/solc-v0.8.29
+          sudo chmod +x /usr/local/bin/solc
+
       - name: Set compiler envs
         if: ${{ matrix.os == 'linux' }}
         run: |
@@ -90,7 +103,7 @@ jobs:
 
       - name: Build ethrex
         run: |
-          ${{ env.COMPILE_FLAGS }} cargo build --release --features "${{ matrix.prover_features }}" --bin ethrex
+          COMPILE_CONTRACTS=true ${{ env.COMPILE_FLAGS }} cargo build --release --features "${{ matrix.prover_features }}" --bin ethrex
           mv target/release/ethrex ethrex-${{ matrix.os }}_${{ matrix.arch }}
 
       - name: Copy verification keys

--- a/cmd/ethrex/l2/deployer.rs
+++ b/cmd/ethrex/l2/deployer.rs
@@ -343,7 +343,7 @@ impl Default for DeployerOptions {
                 .as_bytes(),
             )
             .unwrap(),
-            env_file_path: None,
+            env_file_path: Some(PathBuf::from(".env")),
             deposit_rich: true,
             private_keys_file_path: Some("../../fixtures/keys/private_keys_l1.txt".into()),
             genesis_l1_path: Some("../../fixtures/genesis/l1-dev.json".into()),


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Without compiling contracts, `ethrex l2 --dev` doesn't work.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Add `COMPILE_CONTRACTS` env var to compilation. Also default `.env` file to cwd instead of cargo manifest path

<!-- Link to issues: Resolves #111, Resolves #222 -->


