### PR TITLE
ci(l1,l2): use Ubuntu 24 instead of 22 for Linux ARM runners

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -20,14 +20,14 @@ jobs:
       matrix:
         platform:
           - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
           - macos-latest
         include:
           - platform: ubuntu-22.04
             os: linux
             arch: x86_64
             prover_features: sp1,risc0,gpu
-          - platform: ubuntu-22.04-arm
+          - platform: ubuntu-24.04-arm
             os: linux
             arch: aarch64
             prover_features: sp1,gpu
@@ -61,7 +61,7 @@ jobs:
           ~/.sp1/bin/sp1up --version 5.0.8
 
       - name: Set up QEMU
-        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
+        if: ${{ matrix.platform == 'ubuntu-24.04-arm' }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: amd64
@@ -84,14 +84,14 @@ jobs:
           sub-packages: '["nvcc"]'
 
       - name: Install solc
-        if: ${{ matrix.platform != 'ubuntu-22.04-arm' }}
+        if: ${{ matrix.platform != 'ubuntu-24.04-arm' }}
         uses: pontem-network/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install solc
-        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
+      - name: Install solc (Linux ARM)
+        if: ${{ matrix.platform == 'ubuntu-24.04-arm' }}
         run: |
           sudo curl -L -o /usr/local/bin/solc https://github.com/nikitastupin/solc/raw/refs/heads/main/linux/aarch64/solc-v0.8.29
           sudo chmod +x /usr/local/bin/solc


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Ubuntu 22 has an old version of clang which is not compatible with `solc 0.8.29`.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Bumped to Ubuntu 24.04

<!-- Link to issues: Resolves #111, Resolves #222 -->


