### PR TITLE
chore(runner): Fix typo in levm_runner.rs comment

### DIFF
--- a/cmd/ef_tests/state/runner/levm_runner.rs
+++ b/cmd/ef_tests/state/runner/levm_runner.rs
@@ -149,7 +149,7 @@ pub fn prepare_vm_for_tx<'a>(
         .map(|arg| (arg.address, arg.storage_keys.clone()))
         .collect();
 
-    // Check if the tx has the authorization_lists field implemented by eip7702.
+    // Check if the tx has the authorization_list field implemented by eip7702.
     let authorization_list = test_tx.authorization_list.clone().map(|list| {
         list.iter()
             .map(|auth_tuple| AuthorizationTuple {


### PR DESCRIPTION
 ## **Motivation**
This change aligns the comment with the actual variable name.

## **Description**
Corrects the word "authorization_lists" to "authorization_list" in a
comment within the `prepare_vm_for_tx` function.


Closes #issue_number

