### PR TITLE
feat: add configurable L2 RPC URL for L1 watcher

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -191,6 +191,7 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
                 check_interval_ms: opts.watcher_opts.watch_interval_ms,
                 max_block_step: opts.watcher_opts.max_block_step.into(),
                 watcher_block_delay: opts.watcher_opts.watcher_block_delay,
+                l2_rpc_url: opts.watcher_opts.l2_rpc_url,
             },
             proof_coordinator: ProofCoordinatorConfig {
                 listen_ip: opts.proof_coordinator_opts.listen_ip,
@@ -348,6 +349,15 @@ pub struct WatcherOptions {
         help_heading = "L1 Watcher options"
     )]
     pub watcher_block_delay: u64,
+    #[arg(
+        long = "watcher.l2-rpc-url",
+        default_value = "http://localhost:1729",
+        value_name = "URL",
+        env = "ETHREX_WATCHER_L2_RPC_URL",
+        help = "L2 RPC URL for the L1 watcher to connect to.",
+        help_heading = "L1 Watcher options"
+    )]
+    pub l2_rpc_url: String,
 }
 
 impl Default for WatcherOptions {
@@ -357,6 +367,7 @@ impl Default for WatcherOptions {
             watch_interval_ms: 1000,
             max_block_step: 5000,
             watcher_block_delay: 0,
+            l2_rpc_url: "http://localhost:1729".to_string(),
         }
     }
 }

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -51,6 +51,7 @@ pub struct L1WatcherConfig {
     pub check_interval_ms: u64,
     pub max_block_step: U256,
     pub watcher_block_delay: u64,
+    pub l2_rpc_url: String,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -57,7 +57,7 @@ impl L1Watcher {
         sequencer_state: SequencerState,
     ) -> Result<Self, L1WatcherError> {
         let eth_client = EthClient::new_with_multiple_urls(eth_config.rpc_url.clone())?;
-        let l2_client = EthClient::new("http://localhost:1729")?;
+        let l2_client = EthClient::new(&watcher_config.l2_rpc_url)?;
         let last_block_fetched = U256::zero();
         Ok(Self {
             store,


### PR DESCRIPTION
**Motivation**

To solve the issue "add L2 rpc url to WatcherConfig instead of using a hardcoded one"

**Description**

This update introduces a new l2_rpc_url option to WatcherOptions, allowing the L1 watcher to connect to a configurable L2 RPC endpoint. Default behavior points to http://localhost:1729, ensuring backward compatibility.

Closes #3696