### PR TITLE
docs(l2): fix ethrex contracts download link

### DIFF
--- a/docs/l2/running.md
+++ b/docs/l2/running.md
@@ -7,7 +7,7 @@ The contract's solidity code can be downloaded from the [GitHub releases](https:
 or by running:
 
 ```
-curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-l1-contracts.tar.gz
+curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-contracts.tar.gz
 ```
 
 ## Starting the sequencer


### PR DESCRIPTION
**Motivation**

The contracts are now bundled in a single file

**Description**

Change the link to use the new name `ethrex-contracts.tar.gz`
