### PR TITLE
feat(l1): bump libmdbx max size to 8TB

### DIFF
--- a/crates/storage/store_db/libmdbx.rs
+++ b/crates/storage/store_db/libmdbx.rs
@@ -1376,8 +1376,8 @@ impl Encodable for SnapStateIndex {
 const DB_PAGE_SIZE: usize = 4096;
 /// For a default page size of 4096, the max value size is roughly 1/2 page size.
 const DB_MAX_VALUE_SIZE: usize = 2022;
-// Maximum DB size, set to 2 TB
-const MAX_MAP_SIZE: isize = 1024_isize.pow(4) * 2; // 2 TB
+// Maximum DB size, set to 8 TB
+const MAX_MAP_SIZE: isize = 1024_isize.pow(4) * 8; // 8 TB
 
 /// Initializes a new database with the provided path. If the path is `None`, the database
 /// will be temporary.


### PR DESCRIPTION
**Motivation**
Recently, we ran out of map space while full syncing on sepolia testnet at 2.1TB. This PR increases the max size of the DB so we don't run into this problem again in the near future
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Increase `MAX_MAP_SIZE` constant from 2TB to 8TB
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed for #1676 

