### PR TITLE
fix(l2): fix default vk paths of deployer

### DIFF
--- a/cmd/ethrex/l2/deployer.rs
+++ b/cmd/ethrex/l2/deployer.rs
@@ -270,7 +270,7 @@ pub struct DeployerOptions {
     pub on_chain_proposer_owner_pk: Option<SecretKey>,
     #[arg(
         long,
-        default_value_t = format!("{}/../prover/zkvm/interface/sp1/out/riscv32im-succinct-zkvm-vk", env!("CARGO_MANIFEST_DIR")),
+        default_value_t = format!("{}/../../crates/l2/prover/zkvm/interface/sp1/out/riscv32im-succinct-zkvm-vk", env!("CARGO_MANIFEST_DIR")),
         value_name = "PATH",
         env = "ETHREX_SP1_VERIFICATION_KEY_PATH",
         help_heading = "Deployer options",
@@ -279,7 +279,7 @@ pub struct DeployerOptions {
     pub sp1_vk_path: String,
     #[arg(
         long,
-        default_value_t = format!("{}/../prover/zkvm/interface/risc0/out/riscv32im-risc0-vk", env!("CARGO_MANIFEST_DIR")),
+        default_value_t = format!("{}/../../crates/l2/prover/zkvm/interface/risc0/out/riscv32im-risc0-vk", env!("CARGO_MANIFEST_DIR")),
         value_name = "PATH",
         env = "ETHREX_RISC0_VERIFICATION_KEY_PATH",
         help_heading = "Deployer options",


### PR DESCRIPTION
**Motivation**

Paths were invalid because now the L2 is run from the `cmd/ethrex` binary crate.

Integration tests were passing because the vk paths are overwritten in the L2 config, to point into the vk file that's on the container's volume root dir.
