### PR TITLE
fix: retag `ethrex:unstable` as `latest` in Makefile

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -57,8 +57,6 @@ jobs:
         if: ${{ inputs.job_type != 'main' }}
         run: |
           make build-image
-          # Tests use ethrex:latest so we retag it
-          docker tag ethrex:unstable ethrex:latest
 
       - name: Pull image
         if: ${{ inputs.job_type == 'main' }}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ clean: clean-vectors ## 🧹 Remove build artifacts
 STAMP_FILE := .docker_build_stamp
 $(STAMP_FILE): $(shell find crates cmd -type f -name '*.rs') Cargo.toml Dockerfile
 	docker build -t ethrex:unstable .
+	# Tests use ethrex:latest so we retag it
+	docker tag ethrex:unstable ethrex:latest
 	touch $(STAMP_FILE)
 
 build-image: $(STAMP_FILE) ## 🐳 Build the Docker image


### PR DESCRIPTION
**Motivation**

Running hive tests from a new repo causes errors due to the `latest` tag for the `ethrex`

**Description**

This PR fixes this by re-tagging the newly-built "unstable" image as "latest"

