### PR TITLE
feat(ef-tests): implement specific BlockExpectedException variants and wire mappings

### DIFF
--- a/cmd/ef_tests/blockchain/deserialize.rs
+++ b/cmd/ef_tests/blockchain/deserialize.rs
@@ -109,6 +109,21 @@ where
                         BlockExpectedException::IncorrectBlockFormat,
                     )
                 }
+                "BlockException.STATE_ROOT_MISMATCH" => BlockChainExpectedException::BlockException(
+                    BlockExpectedException::StateRootMismatch,
+                ),
+                "BlockException.RECEIPTS_ROOT_MISMATCH" => BlockChainExpectedException::BlockException(
+                    BlockExpectedException::ReceiptsRootMismatch,
+                ),
+                "BlockException.EXCEEDED_MAX_BLOB_GAS_PER_BLOCK" => BlockChainExpectedException::BlockException(
+                    BlockExpectedException::ExceededMaxBlobGasPerBlock,
+                ),
+                "BlockException.EXCEEDED_MAX_BLOB_NUMBER_PER_BLOCK" => BlockChainExpectedException::BlockException(
+                    BlockExpectedException::ExceededMaxBlobNumberPerBlock,
+                ),
+                "BlockException.GAS_USED_MISMATCH" => BlockChainExpectedException::BlockException(
+                    BlockExpectedException::GasUsedMismatch,
+                ),
                 "BlockException.INVALID_REQUESTS" => BlockChainExpectedException::BlockException(
                     BlockExpectedException::InvalidRequest,
                 ),

--- a/cmd/ef_tests/blockchain/test_runner.rs
+++ b/cmd/ef_tests/blockchain/test_runner.rs
@@ -171,6 +171,21 @@ fn exception_is_expected(
                 BlockChainExpectedException::BlockException(BlockExpectedException::InvalidRequest),
                 ChainError::InvalidBlock(InvalidBlockError::RequestsHashMismatch)
             ) | (
+                BlockChainExpectedException::BlockException(BlockExpectedException::StateRootMismatch),
+                ChainError::InvalidBlock(InvalidBlockError::StateRootMismatch)
+            ) | (
+                BlockChainExpectedException::BlockException(BlockExpectedException::ReceiptsRootMismatch),
+                ChainError::InvalidBlock(InvalidBlockError::ReceiptsRootMismatch)
+            ) | (
+                BlockChainExpectedException::BlockException(BlockExpectedException::ExceededMaxBlobGasPerBlock),
+                ChainError::InvalidBlock(InvalidBlockError::ExceededMaxBlobGasPerBlock)
+            ) | (
+                BlockChainExpectedException::BlockException(BlockExpectedException::ExceededMaxBlobNumberPerBlock),
+                ChainError::InvalidBlock(InvalidBlockError::ExceededMaxBlobNumberPerBlock)
+            ) | (
+                BlockChainExpectedException::BlockException(BlockExpectedException::GasUsedMismatch),
+                ChainError::InvalidBlock(InvalidBlockError::GasUsedMismatch(_, _))
+            ) | (
                 BlockChainExpectedException::BlockException(
                     BlockExpectedException::SystemContractEmpty
                 ),

--- a/cmd/ef_tests/blockchain/types.rs
+++ b/cmd/ef_tests/blockchain/types.rs
@@ -503,5 +503,9 @@ pub enum BlockExpectedException {
     InvalidRequest,
     SystemContractEmpty,
     SystemContractCallFailed,
-    Other, //TODO: Implement exceptions
+    StateRootMismatch,
+    ReceiptsRootMismatch,
+    ExceededMaxBlobGasPerBlock,
+    ExceededMaxBlobNumberPerBlock,
+    GasUsedMismatch,
 }


### PR DESCRIPTION
- Added explicit BlockExpectedException variants: StateRootMismatch, ReceiptsRootMismatch, ExceededMaxBlobGasPerBlock, ExceededMaxBlobNumberPerBlock, GasUsedMismatch in cmd/ef_tests/blockchain/types.rs.
- Extended deserialize_block_expected_exception to parse corresponding BlockException.* strings into these variants in cmd/ef_tests/blockchain/deserialize.rs.
- Updated exception_is_expected in cmd/ef_tests/blockchain/test_runner.rs to match new variants to InvalidBlockError arms (and existing EVM errors).
- Removed reliance on generic Other for block-level exceptions; aligns EF fixtures with precise error handling and improves determinism.