### PR TITLE
Update GitHub Actions in CI Workflows 

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -45,11 +45,11 @@ jobs:
     steps:
       - name: Checkout sources
         if: ${{ inputs.job_type != 'main' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout sources
         if: ${{ inputs.job_type == 'main' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
@@ -103,7 +103,7 @@ jobs:
       artifact_name: results_${{ inputs.job_type }}.md
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/daily_loc.yaml
+++ b/.github/workflows/daily_loc.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/daily_reports.yaml
+++ b/.github/workflows/daily_reports.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download hive results
         uses: actions/download-artifact@v4

--- a/.github/workflows/main_docker_publish.yaml
+++ b/.github/workflows/main_docker_publish.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/main_flamegraph_report.yaml
+++ b/.github/workflows/main_flamegraph_report.yaml
@@ -22,7 +22,7 @@ jobs:
         name: ["levm", "revm"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -163,7 +163,7 @@ jobs:
       time: ${{steps.generate-flamegraph-ethrex.outputs.time}}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -200,7 +200,7 @@ jobs:
 
       - name: Checkout gimli addr2line
         if: steps.check-addr2line.outputs.addr2line_exists != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: gimli-rs/addr2line
           path: "addr2line"
@@ -264,7 +264,7 @@ jobs:
       time: ${{steps.generate-flamegraph-reth.outputs.time}}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@master
@@ -273,7 +273,7 @@ jobs:
 
       # We need a reth version that requires a rustc version <= 1.87.0
       - name: Checkout reth
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: paradigmxyz/reth
           path: "reth"
@@ -315,7 +315,7 @@ jobs:
 
       - name: Checkout gimli addr2line
         if: steps.check-addr2line.outputs.addr2line_exists != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: gimli-rs/addr2line
           path: "addr2line"
@@ -379,7 +379,7 @@ jobs:
     needs: [generate-flamegraph-evm, flamegraph-ethrex, flamegraph-reth]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
 

--- a/.github/workflows/main_perf_blocks_exec.yml
+++ b/.github/workflows/main_perf_blocks_exec.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
       - name: Checkout LFS objects

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: gpu
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -26,7 +26,7 @@ jobs:
         backend: ["sp1", "risc0"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -20,7 +20,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -81,7 +81,7 @@ jobs:
     name: Build Docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check for Docker Hub credentials
         shell: bash
@@ -130,7 +130,7 @@ jobs:
     env:
       HIVE_COMMIT_HASH: 115f4d6ef1bdd2bfcabe29ec60424f6327e92f43 # commit from our fork
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Hive
         run: |
           git clone --single-branch --branch update_dockerfile https://github.com/lambdaclass/hive
@@ -149,7 +149,7 @@ jobs:
     env:
       HIVE_COMMIT_HASH: 115f4d6ef1bdd2bfcabe29ec60424f6327e92f43
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Hive
         # TODO: Change repo back to https://github.com/ethereum/hive when
         # https://github.com/ethereum/hive/pull/1325 is merged
@@ -184,7 +184,7 @@ jobs:
             ethereum_package_args: "./.github/config/assertoor/network_params_ethrex_multiple_cl.yaml"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download etherex image artifact
         uses: actions/download-artifact@v4
@@ -248,7 +248,7 @@ jobs:
           #   ethrex_flags: "--syncmode snap"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download ethrex image artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -110,7 +110,7 @@ jobs:
               [docker-compose.yaml, docker-compose-l2-web3signer.yaml]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -182,7 +182,7 @@ jobs:
     needs: build-docker
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -275,7 +275,7 @@ jobs:
     needs: build-docker
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -18,7 +18,7 @@ jobs:
         backend: ["sp1", "risc0"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2
 
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Check tdx

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -26,7 +26,7 @@ jobs:
           large-packages: false
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download main branch ef tests
         uses: actions/download-artifact@v4
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -208,7 +208,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr_github_status_l1.yaml
+++ b/.github/workflows/pr_github_status_l1.yaml
@@ -34,7 +34,7 @@ jobs:
           private-key: ${{ secrets.PROJECT_SYNC_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update PR status
         uses: actions/github-script@v7

--- a/.github/workflows/pr_lint_gha.yaml
+++ b/.github/workflows/pr_lint_gha.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: actionlint
         uses: raven-actions/actionlint@v2

--- a/.github/workflows/pr_lint_readme.yaml
+++ b/.github/workflows/pr_lint_readme.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr_loc.yaml
+++ b/.github/workflows/pr_loc.yaml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout PR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -31,7 +31,7 @@ jobs:
           echo "merge_base=$MERGE_BASE" >> $GITHUB_OUTPUT
       
       - name: Checkout merge base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ steps.find_merge_base.outputs.merge_base }}
@@ -49,7 +49,7 @@ jobs:
         run: mv tooling/loc/current_detailed_loc_report.json tooling/loc/previous_detailed_loc_report.json
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           clean: "false" # Don't clean the workspace, so we can keep the previous report
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr_perf_blocks_exec.yaml
+++ b/.github/workflows/pr_perf_blocks_exec.yaml
@@ -24,7 +24,7 @@ jobs:
           key: binary-${{ github.event.pull_request[matrix.branch].sha }}
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           lfs: true

--- a/.github/workflows/pr_perf_build_block_bench.yml
+++ b/.github/workflows/pr_perf_build_block_bench.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -60,7 +60,7 @@ jobs:
     needs: [benchmark-pr, benchmark-main]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install hyperfine
         uses: taiki-e/install-action@v2

--- a/.github/workflows/pr_perf_trie.yml
+++ b/.github/workflows/pr_perf_trie.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -44,7 +44,7 @@ jobs:
           large-packages: false
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Rustup toolchain install
         uses: dtolnay/rust-toolchain@master
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download verification keys artifacts
         uses: actions/download-artifact@v4
@@ -164,7 +164,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Format name
         run: echo "TAG_VERSION=$(echo ${{ github.ref_name }} | tr -d v)" >> $GITHUB_ENV
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0
