### PR TITLE
chore(l1): improve log message when trying to run incompatible configs

### DIFF
--- a/crates/storage/error.rs
+++ b/crates/storage/error.rs
@@ -53,5 +53,5 @@ pub enum StoreError {
     #[error("Failed to lock database for writing")]
     LockError,
     #[error("Incompatible chain configuration")]
-    IncompatibleChainConfig(),
+    IncompatibleChainConfig,
 }

--- a/crates/storage/error.rs
+++ b/crates/storage/error.rs
@@ -52,4 +52,6 @@ pub enum StoreError {
     MempoolReadLock(String),
     #[error("Failed to lock database for writing")]
     LockError,
+    #[error("Incompatible chain configuration")]
+    IncompatibleChainConfig(),
 }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -604,7 +604,7 @@ impl Store {
             }
             Some(_) => {
                 error!(
-                    "The chain configuration stored in the database is incompatible with the provided configuration. If you intended to switch networks, clear the database (e.g., run `ethrex removedb`) and try again."
+                    "The chain configuration stored in the database is incompatible with the provided configuration. If you intended to switch networks, choose another datadir or clear the database (e.g., run `ethrex removedb`) and try again."
                 );
                 return Err(StoreError::IncompatibleChainConfig);
             }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -606,7 +606,7 @@ impl Store {
                 error!(
                     "The chain configuration stored in the database is incompatible with the provided configuration. If you intended to switch networks, clear the database (e.g., run `ethrex removedb`) and try again."
                 );
-                return Err(StoreError::IncompatibleChainConfig());
+                return Err(StoreError::IncompatibleChainConfig);
             }
             None => {
                 self.engine
@@ -1439,11 +1439,9 @@ mod tests {
             .add_initial_state(genesis_kurtosis)
             .await
             .expect("second genesis with same block");
-        let add_initial_state_handle =
-            tokio::task::spawn(async move { store.add_initial_state(genesis_hive).await });
-        let result = add_initial_state_handle.await.unwrap();
+        let result = store.add_initial_state(genesis_hive).await;
         assert!(result.is_err());
-        assert!(matches!(result, Err(StoreError::IncompatibleChainConfig())));
+        assert!(matches!(result, Err(StoreError::IncompatibleChainConfig)));
     }
 
     fn remove_test_dbs(path: &str) {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -32,8 +32,6 @@ pub const STATE_TRIE_SEGMENTS: usize = 2;
 /// Maximum amount of reads from the snapshot in a single transaction to avoid performance hits due to long-living reads
 /// This will always be the amount yielded by snapshot reads unless there are less elements left
 pub const MAX_SNAPSHOT_READS: usize = 100;
-/// Panic message shown when the Store is initialized with a genesis that differs from the one already stored
-pub const GENESIS_DIFF_PANIC_MESSAGE: &str = "Tried to run genesis twice with different blocks. Try again after clearing the database. If you're running ethrex as an Ethereum client, run cargo run --release --bin ethrex -- removedb; if you're running ethrex as an L2 run make rm-db-l1 rm-db-l2";
 
 #[derive(Debug, Clone)]
 pub struct Store {
@@ -604,7 +602,9 @@ impl Store {
                 info!("Received genesis file matching a previously stored one, nothing to do");
                 return Ok(());
             }
-            Some(_) => panic!("{GENESIS_DIFF_PANIC_MESSAGE}"),
+            Some(_) => {
+                return Err(StoreError::Custom("The chain configuration stored in the database is incompatible with the provided configuration. If you intended to switch networks or configs, clear the database (e.g., run `ethrex removedb`) and try again.".to_string()))
+            },
             None => {
                 self.engine
                     .add_block_header(genesis_hash, genesis_block.header.clone())
@@ -1436,15 +1436,15 @@ mod tests {
             .add_initial_state(genesis_kurtosis)
             .await
             .expect("second genesis with same block");
-        // The task panic will still be shown via stderr, but rest assured that it will also be caught and read by the test assertion
         let add_initial_state_handle =
             tokio::task::spawn(async move { store.add_initial_state(genesis_hive).await });
-        let panic = add_initial_state_handle.await.unwrap_err().into_panic();
-        assert_eq!(
-            panic
-                .downcast_ref::<String>()
-                .expect("Failed to downcast panic message"),
-            &GENESIS_DIFF_PANIC_MESSAGE
+        let result = add_initial_state_handle.await.unwrap();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Tried to run genesis twice with different blocks"),
         );
     }
 


### PR DESCRIPTION
**Motivation**
Current error message was confusing.
