### PR TITLE
fix(l1): fix off-by-one in update_pivot

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -957,7 +957,10 @@ impl Syncer {
 
                         maybe_big_account_storage_state_roots_clone.lock().expect("Failed to acquire lock").insert(account_hash, computed_state_root);
 
-                        METRICS.storage_tries_state_roots_computed.inc();
+                        let account_state = store.get_account_state_by_acc_hash(pivot_hash, account_hash).unwrap().unwrap();
+                        if computed_state_root == account_state.storage_root {
+                            METRICS.storage_tries_state_roots_computed.inc();
+                        }
 
                         sender.send((account_hash, changes)).expect("Failed to send changes");
                     });


### PR DESCRIPTION
**Motivation**

When snap syncing, we may update the pivot. This function fetches the extra block headers between the old and new pivot position.

However, it fetches an extra block (the old pivot, that we already have). This causes the list of block hashes to have a duplicate item, which causes errors when calculating the block numbers (numbers_and_hashes).

**Description**

Fixes the off-by-one, uncomments the update_pivot call and ensures the updated block hash list is passed to into_fullsync.
