### PR TITLE
fix(l1): restore datadir path 

### DIFF
--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -117,6 +117,12 @@ pub fn default_datadir() -> String {
 
 // TODO: Use PathBuf instead of strings
 pub fn init_datadir(data_dir: &str) -> String {
+    let project_dir = ProjectDirs::from("", "", data_dir).expect("Couldn't find home directory");
+    let data_dir = project_dir
+        .data_local_dir()
+        .to_str()
+        .expect("invalid data directory")
+        .to_owned();
     let datadir = PathBuf::from(data_dir);
     if datadir.exists() {
         if !datadir.is_dir() {


### PR DESCRIPTION
**Motivation**
PR #4024 changed how we initialize the datadir. Instead of looking for the database in a path relative to the home directory (ie: .local/share/datadir on linux) it now looks for it on the path relative to the current directory (ie: ethrex/datadir). This caused problems when updating the ethrex commit on currently running ethrex nodes due to the DB mismatch.
This PR restores the previous behaviour, and has been confirmed to work as usual on the aforementioned ethrex nodes.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Restore where we look for the datadir (relative to home vs current dir)
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed to continue #1676 

