### PR TITLE
fix(l1): subtract DB read times from block execution.

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -73,7 +73,6 @@ pub struct AccountUpdatesList {
 }
 
 impl Store {
-    #[instrument(level = "trace", name = "Block DB update", skip_all)]
     pub async fn store_block_updates(&self, update_batch: UpdateBatch) -> Result<(), StoreError> {
         self.engine.apply_updates(update_batch).await
     }

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -944,7 +944,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "(\n  sum by (function_name) (\n    function_duration_seconds_sum{function_name!=\"Block execution\"}\n  )\n)\nor\nlabel_replace(\n  sum(function_duration_seconds_sum{function_name=\"Block execution\"})\n  - sum(function_duration_seconds_sum{function_name=~\"Storage read|Account read|Account Read|Account code Account code read|Block Block hash read\"}),\n  \"function_name\",\"Block execution (excl DB reads)\",\"__name__\",\".*\"\n)",
+          "expr": "(\n  sum by (function_name) (\n    increase(function_duration_seconds_sum{function_name!=\"Block execution\"}[$__range])\n  )\n)\nor\nlabel_replace(\n  sum( increase(function_duration_seconds_sum{function_name=\"Block execution\"}[$__range]) )\n  - sum( increase(function_duration_seconds_sum{function_name=~\"Storage read|Account read|Account Read\"}[$__range]) ),\n  \"function_name\",\"Block execution (without db)\",\"__name__\",\".*\"\n)",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "legendFormat": "__auto",

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -943,8 +943,8 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(function_name) (function_duration_seconds_sum)",
+          "editorMode": "code",
+          "expr": "(\n  sum by (function_name) (\n    function_duration_seconds_sum{function_name!=\"Block execution\"}\n  )\n)\nor\nlabel_replace(\n  sum(function_duration_seconds_sum{function_name=\"Block execution\"})\n  - sum(function_duration_seconds_sum{function_name=~\"Storage read|Account read|Account Read|Account code Account code read|Block Block hash read\"}),\n  \"function_name\",\"Block execution (excl DB reads)\",\"__name__\",\".*\"\n)",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "legendFormat": "__auto",


### PR DESCRIPTION
**Motivation**
Be able to get the _net_ block execution, substracting the DB reads in Grafana.

**Description**
This is how it looks:
<img width="577" height="297" alt="Screenshot 2025-08-14 at 13 24 56" src="https://github.com/user-attachments/assets/feb5d9fd-3dce-426e-8705-4049e5c2b98e" />


