### PR TITLE
feat(core): add a new manual docker publish for performance tag

### DIFF
--- a/.github/workflows/manual_docker_performance_publish.yaml
+++ b/.github/workflows/manual_docker_performance_publish.yaml
@@ -1,0 +1,40 @@
+name: Publish Docker
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pushes to ghcr.io/lambdaclass/ethrex
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:performance


### PR DESCRIPTION
**Motivation**

Have a manually triggered docker publish of our latest changes in performance.

**Description**

This PR adds a workflow which cpy our current docker publish but instead of be triggered by push to main it can be just triggered manually.

