### PR TITLE
chore(l1): rename the manual performance tag docker publish

### DIFF
--- a/.github/workflows/manual_docker_performance_publish.yaml
+++ b/.github/workflows/manual_docker_performance_publish.yaml
@@ -1,4 +1,4 @@
-name: Publish Docker
+name: Publish Performance tag Docker
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
**Motivation**

We had the same name on both the main triggered one and the performance one

**Description**

This PR changes correctly the name to identify the performance one that is ran manually

