### PR TITLE
fix: redb feature

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -100,10 +100,10 @@ pub fn open_store(data_dir: &str) -> Store {
         Store::new(data_dir, EngineType::InMemory).expect("Failed to create Store")
     } else {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "libmdbx")] {
-                let engine_type = EngineType::Libmdbx;
-            } else if #[cfg(feature = "redb")] {
+          if #[cfg(feature = "redb")] {
                 let engine_type = EngineType::RedB;
+          } else if #[cfg(feature = "libmdbx")] {
+                let engine_type = EngineType::Libmdbx;
             } else {
                 error!("No database specified. The feature flag `redb` or `libmdbx` should've been set while building.");
                 panic!("Specify the desired database engine.");


### PR DESCRIPTION
**Motivation**

Since libmdbx is a default feature, it should be afterwards in the if than redb, because redb is not enabled by default, so if a user enables it it, it probably wants to use it. in this case the user would need to disable all features and enable redb and other features. Changing the order allows the user to simply enable the redb feature without disabling all features

**Description**

the code now first checks if `redb` is enabled and as a result user does not have to disable other defaults like `libmdbx`

Closes #4038 


