### PR TITLE
fix: remove unnecessary String clone in CLI import command

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -340,7 +340,7 @@ impl Subcommand {
             }
             Subcommand::Import { path, removedb, l2 } => {
                 if removedb {
-                    remove_db(&opts.datadir.clone(), opts.force);
+                    remove_db(&opts.datadir, opts.force);
                 }
 
                 let network = get_network(opts);


### PR DESCRIPTION
**Description**
Remove redundant .clone() call when passing opts.datadir to remove_db(). String automatically derefs to &str, making the clone unnecessary and inefficient. This eliminates an unnecessary heap allocation
