### PR TITLE
fix(l2): get gas price error

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -214,6 +214,15 @@ impl Store {
         &self,
         block_number: BlockNumber,
     ) -> Result<Option<BlockBody>, StoreError> {
+        let latest = self
+            .latest_block_header
+            .read()
+            .map_err(|_| StoreError::LockError)?
+            .clone();
+        if block_number == latest.number {
+            // The latest may not be marked as canonical yet
+            return self.engine.get_block_body_by_hash(latest.hash()).await;
+        }
         self.engine.get_block_body(block_number).await
     }
 


### PR DESCRIPTION
**Motivation**

Our CI is sometimes failing with:
```
thread 'l2_integration_test' panicked at crates/l2/tests/tests.rs:1847:10:
called `Result::unwrap()` on an `Err` value: GetGasPriceError(RPCError("Internal Error: Error calculating gas price: missing data"))
```

**Description**

- Modifies `get_block_body()` to check whether the requested body is the latest, and makes the query by hash if so.

Closes #4006 

