### PR TITLE
remove `choose_multiple` from the `FindNode` handler

### DIFF
--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -1,8 +1,11 @@
-use std::{collections::btree_map::Entry, net::SocketAddr, sync::Arc};
+use std::{
+    collections::{BTreeMap, btree_map::Entry},
+    net::SocketAddr,
+    sync::Arc,
+};
 
-use ethrex_common::H512;
+use ethrex_common::{H512, U256};
 use keccak_hash::H256;
-use rand::{rngs::OsRng, seq::IteratorRandom};
 use secp256k1::SecretKey;
 use spawned_concurrency::{
     messages::Unused,
@@ -493,10 +496,7 @@ impl GenServer for ConnectionHandler {
                     return CastResponse::Stop;
                 }
 
-                let neighbors = table
-                    .iter()
-                    .map(|(_, c)| c.node.clone())
-                    .choose_multiple(&mut OsRng, 16);
+                let neighbors = get_closest_nodes(node_id, table.clone());
 
                 drop(table);
 
@@ -591,3 +591,29 @@ impl GenServer for ConnectionHandler {
 }
 
 // TODO: SNAP SYNC: REIMPL TESTS
+
+/// Returns the closest nodes to `node_id`.
+pub fn get_closest_nodes(node_id: H256, table: BTreeMap<H256, Contact>) -> Vec<Node> {
+    let mut nodes: Vec<(Node, usize)> = vec![];
+
+    for (neighbor_id, neighbor) in &table {
+        let distance = distance(&node_id, neighbor_id);
+        if nodes.len() < 16 {
+            nodes.push((neighbor.node.clone(), distance));
+        } else {
+            for (i, (_, dis)) in &mut nodes.iter().enumerate() {
+                if distance < *dis {
+                    nodes[i] = (neighbor.node.clone(), distance);
+                    break;
+                }
+            }
+        }
+    }
+    nodes.into_iter().map(|(node, _distance)| node).collect()
+}
+
+pub fn distance(node_id_1: &H256, node_id_2: &H256) -> usize {
+    let xor = node_id_1 ^ node_id_2;
+    let distance = U256::from_big_endian(xor.as_bytes());
+    distance.bits().saturating_sub(1)
+}

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -592,18 +592,18 @@ impl GenServer for ConnectionHandler {
 
 // TODO: SNAP SYNC: REIMPL TESTS
 
-/// Returns the closest nodes to `node_id`.
+/// Returns the nodes closest to the given `node_id`.
 pub fn get_closest_nodes(node_id: H256, table: BTreeMap<H256, Contact>) -> Vec<Node> {
     let mut nodes: Vec<(Node, usize)> = vec![];
 
-    for (neighbor_id, neighbor) in &table {
-        let distance = distance(&node_id, neighbor_id);
+    for (contact_id, contact) in &table {
+        let distance = distance(&node_id, contact_id);
         if nodes.len() < 16 {
-            nodes.push((neighbor.node.clone(), distance));
+            nodes.push((contact.node.clone(), distance));
         } else {
             for (i, (_, dis)) in &mut nodes.iter().enumerate() {
                 if distance < *dis {
-                    nodes[i] = (neighbor.node.clone(), distance);
+                    nodes[i] = (contact.node.clone(), distance);
                     break;
                 }
             }

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 const MAX_DISC_PACKET_SIZE: usize = 1280;
+const MAX_NODES_IN_NEIGHBORS_PACKET: usize = 16;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DiscoveryServerError {
@@ -598,7 +599,7 @@ pub fn get_closest_nodes(node_id: H256, table: BTreeMap<H256, Contact>) -> Vec<N
 
     for (contact_id, contact) in &table {
         let distance = distance(&node_id, contact_id);
-        if nodes.len() < 16 {
+        if nodes.len() < MAX_NODES_IN_NEIGHBORS_PACKET {
             nodes.push((contact.node.clone(), distance));
         } else {
             for (i, (_, dis)) in &mut nodes.iter().enumerate() {


### PR DESCRIPTION
**Motivation**

The `FindNode` message handler calls the `choose_multiple` function to select random nodes.
This is quite expensive since each call makes several syscalls to generate random numbers.

**Description**
Removes the call to `choose_multiple` by replacing it with the `get_closest_nodes` function (inspired by the [`main` implementation](https://github.com/lambdaclass/ethrex/blob/66d3e7dcec4d7628a6fe34762251fc5106e3a589/crates/networking/p2p/kademlia.rs#L148)) which returns the nodes that are closest to the given node id.

