### PR TITLE
log `InconsistentTree` as debug while syncing

### DIFF
--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -10,7 +10,6 @@ use ethrex_common::{
     H256,
     types::{MempoolTransaction, Transaction},
 };
-use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::{Store, error::StoreError};
 use ethrex_trie::TrieError;
 use futures::{SinkExt as _, Stream, stream::SplitSink};

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -280,7 +280,7 @@ impl GenServer for RLPxConnection {
     ) -> CastResponse {
         if let InnerState::Established(mut established_state) = self.inner_state.clone() {
             let peer_supports_l2 = established_state.l2_state.connection_state().is_ok();
-            let result = match message.clone() {
+            let result = match message {
                 Self::CastMsg::PeerMessage(message) => {
                     log_peer_debug(
                         &established_state.node,
@@ -353,19 +353,19 @@ impl GenServer for RLPxConnection {
                         if established_state.blockchain.is_synced() {
                             log_peer_error(
                                 &established_state.node,
-                                &format!("Error handling cast message {message:?}. Error: {e}"),
+                                &format!("Error handling cast message: {e}"),
                             );
                         } else {
                             log_peer_debug(
                                 &established_state.node,
-                                &format!("Error handling cast message {message:?}. Error: {e}"),
+                                &format!("Error handling cast message: {e}"),
                             );
                         }
                     }
                     _ => {
                         log_peer_warn(
                             &established_state.node,
-                            &format!("Error handling cast message {e}"),
+                            &format!("Error handling cast message: {e}"),
                         );
                     }
                 }

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -279,6 +279,7 @@ impl GenServer for RLPxConnection {
         _handle: &RLPxConnectionHandle,
     ) -> CastResponse {
         if let InnerState::Established(mut established_state) = self.inner_state.clone() {
+            dbg!(&established_state.blockchain.is_synced());
             let peer_supports_l2 = established_state.l2_state.connection_state().is_ok();
             let result = match message.clone() {
                 Self::CastMsg::PeerMessage(message) => {

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -279,7 +279,6 @@ impl GenServer for RLPxConnection {
         _handle: &RLPxConnectionHandle,
     ) -> CastResponse {
         if let InnerState::Established(mut established_state) = self.inner_state.clone() {
-            dbg!(&established_state.blockchain.is_synced());
             let peer_supports_l2 = established_state.l2_state.connection_state().is_ok();
             let result = match message.clone() {
                 Self::CastMsg::PeerMessage(message) => {
@@ -357,12 +356,9 @@ impl GenServer for RLPxConnection {
                                 &format!("Error handling cast message {message:?}. Error: {e}"),
                             );
                         } else {
-                            // TODO: change this to debug and remove the '[SYNCING]' part
-                            log_peer_warn(
+                            log_peer_debug(
                                 &established_state.node,
-                                &format!(
-                                    "[SYNCING] Error handling cast message {message:?}. Error: {e}"
-                                ),
+                                &format!("Error handling cast message {message:?}. Error: {e}"),
                             );
                         }
                     }

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -278,7 +278,7 @@ impl GenServer for RLPxConnection {
     ) -> CastResponse {
         if let InnerState::Established(mut established_state) = self.inner_state.clone() {
             let peer_supports_l2 = established_state.l2_state.connection_state().is_ok();
-            let result = match message {
+            let result = match message.clone() {
                 Self::CastMsg::PeerMessage(message) => {
                     log_peer_debug(
                         &established_state.node,
@@ -350,7 +350,7 @@ impl GenServer for RLPxConnection {
                     _ => {
                         log_peer_warn(
                             &established_state.node,
-                            &format!("Error handling cast message: {e}"),
+                            &format!("Error handling cast message {message:?}. Error: {e}"),
                         );
                     }
                 }
@@ -467,7 +467,10 @@ where
     Ok(())
 }
 
-async fn send_new_pooled_tx_hashes(state: &mut Established, txs: Vec<MempoolTransaction>) -> Result<(), RLPxError> {
+async fn send_new_pooled_tx_hashes(
+    state: &mut Established,
+    txs: Vec<MempoolTransaction>,
+) -> Result<(), RLPxError> {
     if SUPPORTED_ETH_CAPABILITIES
         .iter()
         .any(|cap| state.capabilities.contains(cap))


### PR DESCRIPTION
**Motivation**
While the node is syncing, we occasionally see warnings with the `InconsistentTree` error.
This occurs because requests may ask for data that has not yet been downloaded during sync.

Since this situation is expected and not truly an error, the log level should be adjusted. However, if the same issue happens once the node is fully synced, it indicates a real problem and should still be logged as an error.

**Description**
This change updates the logging logic:
* When the node is fully synced: log `InconsistentTree` as `error`.
* When the node is syncing: log `InconsistentTree` as `debug`.
