### PR TITLE
fix: treat missing storage slot in pruned trie as absent instead of DB error

### DIFF
--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -346,17 +346,15 @@ impl ExecutionWitnessResult {
             return Ok(None);
         };
         let hashed_key = hash_key(&key);
-        if let Some(encoded_key) = storage_trie
-            .get(&hashed_key)
-            .map_err(|e| ExecutionWitnessError::Database(e.to_string()))?
-        {
-            U256::decode(&encoded_key)
+        match storage_trie.get(&hashed_key) {
+            Ok(Some(encoded_key)) => U256::decode(&encoded_key)
                 .map_err(|_| {
                     ExecutionWitnessError::Database("failed to read storage from trie".to_string())
                 })
-                .map(Some)
-        } else {
-            Ok(None)
+                .map(Some),
+            Ok(None) => Ok(None),
+            // If the pruned trie does not contain nodes for this key path, treat it as absent
+            Err(_e) => Ok(None),
         }
     }
 


### PR DESCRIPTION
**Motivation**

#4088 

**Description**

in crates/common/types/block_execution_witness.rs, ExecutionWitnessResult::get_storage_slot now returns Ok(None) when storage_trie.get(hashed_key) errors (pruned trie gaps), rather than propagating a DB error.

- Still returns Err(Database(...)) on decode failures for existing nodes.
- Aligns SP1 replay/proving behavior with LEVM expectations without altering public APIs.

Closes #4088 
