### PR TITLE
ci(l1): skip some internal jobs for external contributions.

### DIFF
--- a/.github/workflows/pr_github_metadata.yaml
+++ b/.github/workflows/pr_github_metadata.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   assign-author:
     name: Assign Author
-    if: github.event.action == 'opened'
+    if: github.event.action == 'opened' && github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR author
@@ -32,6 +32,7 @@ jobs:
 
   label-pr:
     name: Set Label
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR already has labels

--- a/.github/workflows/pr_github_status_l1.yaml
+++ b/.github/workflows/pr_github_status_l1.yaml
@@ -1,4 +1,3 @@
-# .github/workflows/set-pr-status.yml
 name: PR Status
 
 on:
@@ -20,7 +19,7 @@ jobs:
     name: Update PR status for ethrex_l1 project
     runs-on: ubuntu-latest
     # sadly pull_request_review doesn't have direct access to labels information so we'll have to check this later.
-    if: github.event_name == 'pull_request_review' || contains(github.event.pull_request.labels.*.name, 'L1')
+    if: github.event.repository.fork == false && (github.event_name == 'pull_request_review' || contains(github.event.pull_request.labels.*.name, 'L1'))
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
**Motivation**
External contributors don't have permissions for some things and the action fails

Closes #3925
