### PR TITLE
fix(levm): fix problems related to 32 bit architecture

### DIFF
--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -15,7 +15,7 @@ pub const EMPTY_CODE_HASH: H256 = H256([
     0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70,
 ]);
 
-pub const MEMORY_EXPANSION_QUOTIENT: usize = 512;
+pub const MEMORY_EXPANSION_QUOTIENT: u64 = 512;
 
 // Dedicated gas limit for system calls according to EIPs 2935, 4788, 7002 and 7251
 pub const SYS_CALL_GAS_LIMIT: u64 = 30000000;

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -683,7 +683,8 @@ pub fn account_to_levm_account(account: Account) -> (LevmAccount, Bytes) {
 /// Converts a U256 value into usize, fails if the value is over 64 bytes
 #[expect(clippy::as_conversions)]
 pub fn u256_to_usize(val: U256) -> Result<usize, VMError> {
-    if val.0[1] != 0 || val.0[2] != 0 || val.0[3] != 0 {
+    // Only allow values that fit in 32 bits, otherwise there would be an OOM anyway.
+    if val.0[0] > u32::MAX as u64 || val.0[1] != 0 || val.0[2] != 0 || val.0[3] != 0 {
         return Err(VMError::ExceptionalHalt(ExceptionalHalt::VeryLargeNumber));
     }
     Ok(val.0[0] as usize)

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -680,10 +680,10 @@ pub fn account_to_levm_account(account: Account) -> (LevmAccount, Bytes) {
     )
 }
 
-/// Converts a U256 value into usize, fails if the value is over 64 bytes
+/// Converts a U256 value into usize, returning an error if the value is over 32 bits
+/// This is generally used for memory offsets and sizes, 32 bits is more than enough for this purpose.
 #[expect(clippy::as_conversions)]
 pub fn u256_to_usize(val: U256) -> Result<usize, VMError> {
-    // Only allow values that fit in 32 bits, otherwise there would be an OOM anyway.
     if val.0[0] > u32::MAX as u64 || val.0[1] != 0 || val.0[2] != 0 || val.0[3] != 0 {
         return Err(VMError::ExceptionalHalt(ExceptionalHalt::VeryLargeNumber));
     }


### PR DESCRIPTION
**Motivation**

- Find errors on 32 bit architecture

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- `u256_to_usize` now halts if the number doesn't fit in 32 bits instead of 64.
- Memory size cost is computed using u64 instead of usize. The previous implementation overflowed on 32 bit architectures in some edge cases. Also I made it prettier :D


How this was tested: Adapting ethrex to run on 32 bit x86 in branch [replay_32_bit_x86_testing](https://github.com/lambdaclass/ethrex/tree/replay_32_bit_x86_testing) and running EFTests, both state and blockchain. After these changes they all pass.
<!-- Link to issues: Resolves #111, Resolves #222 -->

Makes progress towards #4081
