### PR TITLE
fix(l2): l1_watcher don't request logs if latest L1 block is already checked

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -321,7 +321,7 @@ pub struct WatcherOptions {
     pub bridge_address: Option<Address>,
     #[arg(
         long = "watcher.watch-interval",
-        default_value = "1000",
+        default_value = "12000", // One L1 slot
         value_name = "UINT64",
         env = "ETHREX_WATCHER_WATCH_INTERVAL",
         help = "How often the L1 watcher checks for new blocks in milliseconds.",

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -144,6 +144,11 @@ impl L1Watcher {
             latest_block_to_check,
         );
 
+        if self.last_block_fetched == latest_block_to_check {
+            debug!("{:#?} ==  {:#?}", self.last_block_fetched, new_last_block);
+            return Ok(vec![]);
+        }
+
         debug!(
             "Looking logs from block {:#x} to {:#x}",
             self.last_block_fetched, new_last_block


### PR DESCRIPTION
**Motivation**

When getting logs we were constantly getting `Error when getting logs from L1: eth_getLogs request error: end (8944755) < begin (8944756)` errors because the default `watch_interval_ms` for l1_watcher was 1 second and we were not checking that end > begin

**Description**

- change default `watch_interval_ms` to 1 L1 slot (12seconds)
- if `self.last_block_fetched == latest_block_to_check` there are no new blocks to check so we just return
