### PR TITLE
feat(l1): don't log an error if we have no node config file when reading known peers

### DIFF
--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -148,13 +148,21 @@ pub async fn store_node_config_file(config: NodeConfigFile, file_path: PathBuf) 
     };
 }
 
+
 #[allow(dead_code)]
-pub fn read_node_config_file(file_path: PathBuf) -> Result<NodeConfigFile, String> {
-    match std::fs::File::open(file_path) {
-        Ok(file) => {
-            serde_json::from_reader(file).map_err(|e| format!("Invalid node config file {e}"))
-        }
-        Err(e) => Err(format!("No config file found: {e}")),
+pub fn read_node_config_file(data_dir: &str) -> Result<Option<NodeConfigFile>, String> {
+    const NODE_CONFIG_FILENAME: &str = "/node_config.json";
+    let file_path = PathBuf::from(data_dir.to_owned() + NODE_CONFIG_FILENAME);
+    if file_path.exists() {
+        Ok(match std::fs::File::open(file_path) {
+            Ok(file) => Some(
+                serde_json::from_reader(file)
+                    .map_err(|e| format!("Invalid node config file {e}"))?,
+            ),
+            Err(e) => return Err(format!("No config file found: {e}")),
+        })
+    } else {
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
**Motivation**
We shouldn't emit a warning if we have no node config files where to read known peers from. We should log an error if we get an actual error while reading from an existing node config file
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Don't emit a warning if we have no node config file when reading known peers
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #3908

