### PR TITLE
chore(l2): rename `ETHREX_MONITOR` to `ETHREX_NO_MONITOR`

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -97,7 +97,7 @@ pub struct SequencerOptions {
         long,
         default_value = "false",
         value_name = "BOOLEAN",
-        env = "ETHREX_MONITOR",
+        env = "ETHREX_NO_MONITOR",
         help_heading = "Monitor options"
     )]
     pub no_monitor: bool,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -444,7 +444,7 @@ L2 options:
 
 Monitor options:
       --no-monitor
-          [env: ETHREX_MONITOR=]
+          [env: ETHREX_NO_MONITOR=]
 ```
 
 ## ethrex l2 prover


### PR DESCRIPTION
the boolean is a negation
