### PR TITLE
perf: remove redundant clone in smoke_test

### DIFF
--- a/crates/blockchain/smoke_test.rs
+++ b/crates/blockchain/smoke_test.rs
@@ -308,7 +308,7 @@ mod blockchain_integration_test {
         };
 
         // Create blockchain
-        let blockchain = Blockchain::default_with_store(store.clone().clone());
+        let blockchain = Blockchain::default_with_store(store.clone());
 
         let block = create_payload(&args, store).unwrap();
         let result = blockchain.build_payload(block).await.unwrap();


### PR DESCRIPTION
Removes unnecessary double clone in `new_block` function.

`Blockchain::default_with_store` takes ownership of `Store`, so only one clone is needed.
