### PR TITLE
fix(l1): out of bounds on jwt file

### DIFF
--- a/cmd/ethrex/decode.rs
+++ b/cmd/ethrex/decode.rs
@@ -10,10 +10,11 @@ pub fn jwtsecret_file(file: &mut File) -> Bytes {
     let mut contents = String::new();
     file.read_to_string(&mut contents)
         .expect("Failed to read jwt secret file");
-    contents = contents.strip_prefix("0x")
-    	.unwrap_or(&contents)
-    	.trim_end_matches('\n')
-     	.to_string();
+    contents = contents
+        .strip_prefix("0x")
+        .unwrap_or(&contents)
+        .trim_end_matches('\n')
+        .to_string();
     hex::decode(contents)
         .expect("Secret should be hex encoded")
         .into()


### PR DESCRIPTION
**Motivation**

There's a problem when `contents` value has fewer than 2 characters, it panics the program.

**Description**

The program shouldn't panic with out-of-bounds errors. The solution was to replace it with the native check `starts_with()`
