### PR TITLE
perf(levm): improve calldatacopy further

### DIFF
--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -255,6 +255,29 @@ impl Memory {
 
         Ok(())
     }
+
+    #[inline(always)]
+    pub fn store_zeros(&mut self, offset: usize, size: usize) -> Result<(), VMError> {
+        if size == 0 {
+            return Ok(());
+        }
+
+        let new_size = offset.checked_add(size).ok_or(OutOfBounds)?;
+        self.resize(new_size)?;
+
+        let real_offset = self.current_base.wrapping_add(offset);
+        let mut buffer = self.buffer.borrow_mut();
+
+        // resize ensures bounds are correct
+        #[allow(unsafe_code)]
+        unsafe {
+            buffer
+                .get_unchecked_mut(real_offset..(real_offset.wrapping_add(size)))
+                .fill(0);
+        }
+
+        Ok(())
+    }
 }
 
 impl Default for Memory {

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -181,15 +181,16 @@ impl<'a> VM<'a> {
                     .memory
                     .store_data(dest_offset, src_slice)?;
             } else {
-                let mut data = Vec::with_capacity(size);
+                let mut data = vec![0u8; size];
+
+                let available_data = calldata_len - calldata_offset;
+                let copy_size = size.min(available_data);
 
                 if copy_size > 0 {
-                    data.extend_from_slice(
+                    data[..copy_size].copy_from_slice(
                         &current_call_frame.calldata[calldata_offset..calldata_offset + copy_size],
                     );
                 }
-
-                data.resize(size, 0);
 
                 current_call_frame.memory.store_data(dest_offset, &data)?;
             }

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -152,43 +152,50 @@ impl<'a> VM<'a> {
             return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
-        // Happiest fast path, copy without an intermediate buffer because there is no need to pad 0s and also size doesn't overflow.
-        if let Some(calldata_offset_end) = calldata_offset.checked_add(size) {
-            if calldata_offset_end <= current_call_frame.calldata.len() {
-                #[expect(unsafe_code, reason = "bounds checked beforehand")]
-                let slice = unsafe {
-                    current_call_frame
-                        .calldata
-                        .get_unchecked(calldata_offset..calldata_offset_end)
-                };
-                current_call_frame.memory.store_data(dest_offset, slice)?;
+        let calldata_len = current_call_frame.calldata.len();
 
-                return Ok(OpcodeResult::Continue { pc_increment: 1 });
-            }
+        // offset is out of bounds, so fill zeroes
+        if calldata_offset >= calldata_len {
+            current_call_frame.memory.store_zeros(dest_offset, size)?;
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         }
 
-        let mut data = vec![0u8; size];
-        if calldata_offset < current_call_frame.calldata.len() {
-            let diff = current_call_frame
-                .calldata
-                .len()
-                .wrapping_sub(calldata_offset);
-            let final_size = size.min(diff);
-            let end = calldata_offset.wrapping_add(final_size);
+        #[expect(
+            clippy::arithmetic_side_effects,
+            clippy::indexing_slicing,
+            reason = "bounds checked"
+        )]
+        {
+            // we already verified calldata_len >= calldata_offset
+            let available_data = calldata_len - calldata_offset;
+            let copy_size = size.min(available_data);
+            let zero_fill_size = size - copy_size;
 
-            #[expect(unsafe_code, reason = "bounds checked beforehand")]
-            unsafe {
-                data.get_unchecked_mut(..final_size).copy_from_slice(
-                    current_call_frame
-                        .calldata
-                        .get_unchecked(calldata_offset..end),
-                );
+            if zero_fill_size == 0 {
+                // no zero padding needed
+
+                // calldata_offset + copy_size can't overflow because its the min of size and (calldata_len - calldata_offset).
+                let src_slice =
+                    &current_call_frame.calldata[calldata_offset..calldata_offset + copy_size];
+                current_call_frame
+                    .memory
+                    .store_data(dest_offset, src_slice)?;
+            } else {
+                let mut data = Vec::with_capacity(size);
+
+                if copy_size > 0 {
+                    data.extend_from_slice(
+                        &current_call_frame.calldata[calldata_offset..calldata_offset + copy_size],
+                    );
+                }
+
+                data.resize(size, 0);
+
+                current_call_frame.memory.store_data(dest_offset, &data)?;
             }
+
+            Ok(OpcodeResult::Continue { pc_increment: 1 })
         }
-
-        current_call_frame.memory.store_data(dest_offset, &data)?;
-
-        Ok(OpcodeResult::Continue { pc_increment: 1 })
     }
 
     // CODESIZE operation


### PR DESCRIPTION
**Motivation**

Added a specific memory function to zero fill, also simplified the code + removed some unnecesary checked arithmetic.

<img width="1350" height="294" alt="image" src="https://github.com/user-attachments/assets/8747be0a-1c96-4fbc-b0a9-e9875b46058b" />


