### PR TITLE
fix(l2): use `spawned::start_blocking` for block_producer

### DIFF
--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -92,7 +92,7 @@ impl BlockProducer {
             blockchain,
             sequencer_state,
         )
-        .start();
+        .start_blocking();
         block_producer
             .cast(InMessage::Produce)
             .await


### PR DESCRIPTION
**Motivation**

To prevent blocking other async tasks.

**Description**

- Uses [spawned::start_blocking](https://github.com/lambdaclass/spawned/blob/aa47f8277b058737e351cf75a0926bd580d0f4e4/concurrency/src/tasks/gen_server.rs#L146) for the  L2 `BlockProducer` `GenServer`.

Closes None

