### PR TITLE
feat(l1): added fusaka support for runners

### DIFF
--- a/cmd/ef_tests/blockchain/.fixtures_url
+++ b/cmd/ef_tests/blockchain/.fixtures_url
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz
+https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-5%40v1.1.0/fixtures_fusaka-devnet-5.tar.gz

--- a/cmd/ef_tests/blockchain/network.rs
+++ b/cmd/ef_tests/blockchain/network.rs
@@ -53,6 +53,33 @@ lazy_static! {
         prague_time: Some(0),
         ..*CANCUN_TO_PRAGUE_AT_15K_CONFIG
     };
+
+    pub static ref PRAGUE_TO_OSAKA_AT_15K_CONFIG: ChainConfig = ChainConfig {
+        osaka_time: Some(0x3a98),
+        ..*PRAGUE_CONFIG
+
+    };
+
+    pub static ref OSAKA_CONFIG: ChainConfig = ChainConfig {
+        osaka_time: Some(0),
+        ..*PRAGUE_CONFIG
+    };
+
+    pub static ref OSAKA_TO_BPO1_AT_15K_CONFIG: ChainConfig = ChainConfig {
+        bpo1_time: Some(0x3a98),
+        ..*OSAKA_CONFIG
+    };
+
+    pub static ref BPO1_TO_BPO2_AT_15K_CONFIG: ChainConfig = ChainConfig {
+        bpo2_time: Some(0x3a98),
+        ..*PRAGUE_CONFIG
+    };
+
+    pub static ref BPO2_TO_BPO3_AT_15K_CONFIG: ChainConfig = ChainConfig {
+        bpo3_time: Some(0x3a98),
+        ..*PRAGUE_CONFIG
+    };
+
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -73,6 +100,11 @@ pub enum Network {
     Cancun = 11,
     CancunToPragueAtTime15k = 12,
     Prague = 13,
+    PragueToOsakaAtTime15k = 14,
+    Osaka = 15,
+    OsakaToBPO1AtTime15k = 16,
+    BPO1ToBPO2AtTime15k = 17,
+    BPO2ToBPO3AtTime15k = 18,
 }
 
 impl Network {
@@ -85,6 +117,11 @@ impl Network {
             Network::Cancun => &CANCUN_CONFIG,
             Network::CancunToPragueAtTime15k => &CANCUN_TO_PRAGUE_AT_15K_CONFIG,
             Network::Prague => &PRAGUE_CONFIG,
+            Network::PragueToOsakaAtTime15k => &PRAGUE_TO_OSAKA_AT_15K_CONFIG,
+            Network::Osaka => &OSAKA_CONFIG,
+            Network::OsakaToBPO1AtTime15k => &OSAKA_TO_BPO1_AT_15K_CONFIG,
+            Network::BPO1ToBPO2AtTime15k => &BPO1_TO_BPO2_AT_15K_CONFIG,
+            Network::BPO2ToBPO3AtTime15k => &BPO2_TO_BPO3_AT_15K_CONFIG,
             Network::Frontier
             | Network::Homestead
             | Network::ConstantinopleFix

--- a/cmd/ef_tests/blockchain/test_runner.rs
+++ b/cmd/ef_tests/blockchain/test_runner.rs
@@ -36,6 +36,7 @@ pub fn parse_and_execute(
 
     for (test_key, test) in tests {
         let should_skip_test = test.network < Network::Merge
+            || test.network > Network::Prague
             || skipped_tests
                 .map(|skipped| skipped.iter().any(|s| test_key.contains(s)))
                 .unwrap_or(false);

--- a/cmd/ef_tests/state/.fixtures_url
+++ b/cmd/ef_tests/state/.fixtures_url
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz
+https://github.com/ethereum/execution-spec-tests/releases/download/fusaka-devnet-5%40v1.1.0/fixtures_fusaka-devnet-5.tar.gz

--- a/cmd/ef_tests/state/deserialize.rs
+++ b/cmd/ef_tests/state/deserialize.rs
@@ -303,6 +303,7 @@ where
             "Shanghai" => Fork::Shanghai,
             "Cancun" => Fork::Cancun,
             "Prague" => Fork::Prague,
+            "Osaka" => Fork::Osaka,
             "Byzantium" => Fork::Byzantium,
             "EIP158" => Fork::SpuriousDragon,
             "EIP150" => Fork::Tangerine,

--- a/cmd/ef_tests/state_v2/src/modules/runner.rs
+++ b/cmd/ef_tests/state_v2/src/modules/runner.rs
@@ -39,6 +39,9 @@ pub async fn run_tests(tests: Vec<Test>) -> Result<(), RunnerError> {
     let mut total_run = 0;
 
     for test in tests {
+        if test.path.starts_with("osaka") {
+            continue;
+        }
         run_test(
             &test,
             &mut passing_tests,

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -188,6 +188,12 @@ pub struct ChainConfig {
     pub verkle_time: Option<u64>,
     pub osaka_time: Option<u64>,
 
+    pub bpo1_time: Option<u64>,
+    pub bpo2_time: Option<u64>,
+    pub bpo3_time: Option<u64>,
+    pub bpo4_time: Option<u64>,
+    pub bpo5_time: Option<u64>,
+
     /// Amount of total difficulty reached by the network that triggers the consensus upgrade.
     pub terminal_total_difficulty: Option<u128>,
     /// Network has already passed the terminal total difficult
@@ -198,6 +204,9 @@ pub struct ChainConfig {
     #[rkyv(with = rkyv_utils::H160Wrapper)]
     // Deposits system contract address
     pub deposit_contract_address: Address,
+
+    #[serde(default)]
+    pub enable_verkle_at_genesis: bool,
 }
 
 #[repr(u8)]

--- a/tooling/hive_report/src/main.rs
+++ b/tooling/hive_report/src/main.rs
@@ -137,10 +137,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // Prague
                 let result_prague = create_fork_result(&json_data, "Prague", "fork_Prague");
 
+                let result_osaka = create_fork_result(&json_data, "Osaka", "fork_Osaka");
+
                 results.push(result_paris);
                 results.push(result_shanghai);
                 results.push(result_cancun);
                 results.push(result_prague);
+                results.push(result_osaka);
             } else {
                 let total_tests = json_data.test_cases.len();
                 let passed_tests = json_data


### PR DESCRIPTION
**Motivation**

Adding the boilerplate in the runners to be able to execute the Fusaka tests in the future when we start implementing it

**Description**

This PR changes the fixture URLs to the most recent execution spec tests release that supports Fusaka. Additionally, it adds the parameters needed to the structs the runners use to be able to parse and execute the test; although at the moment they're skipped by default. The Osaka tests were also added to the Hive daily report.

Closes #4114

