### PR TITLE
refactor(l1): `ethrex_replay` use rkyv for encoding caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4253,6 +4253,7 @@ dependencies = [
  "hex",
  "jemallocator",
  "reqwest 0.12.20",
+ "rkyv",
  "serde",
  "serde_json",
  "serde_with",

--- a/cmd/ethrex_replay/Cargo.toml
+++ b/cmd/ethrex_replay/Cargo.toml
@@ -30,6 +30,7 @@ eyre.workspace = true
 tokio = { workspace = true, features = ["full"] }
 clap.workspace = true
 charming = { version = "0.4.0", features = ["ssr"] }
+rkyv.workspace = true
 
 jemallocator = { version = "0.5.4", optional = true }
 

--- a/cmd/ethrex_replay/src/cache.rs
+++ b/cmd/ethrex_replay/src/cache.rs
@@ -1,14 +1,15 @@
 use ethrex_common::types::blobs_bundle;
 use ethrex_common::types::{Block, block_execution_witness::ExecutionWitnessResult};
+use eyre::Context;
+use rkyv::rancor::Error;
+use rkyv::{Archive, Deserialize as RDeserialize, Serialize as RSerialize};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::{
-    fs::File,
-    io::{BufReader, BufWriter},
-};
+use std::io::Write;
+use std::{fs::File, io::BufWriter};
 
 #[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, RSerialize, RDeserialize, Archive)]
 pub struct L2Fields {
     #[serde_as(as = "[_; 48]")]
     pub blob_commitment: blobs_bundle::Commitment,
@@ -16,7 +17,7 @@ pub struct L2Fields {
     pub blob_proof: blobs_bundle::Proof,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, RSerialize, RDeserialize, Archive)]
 pub struct Cache {
     pub blocks: Vec<Block>,
     pub witness: ExecutionWitnessResult,
@@ -36,14 +37,18 @@ impl Cache {
 }
 
 pub fn load_cache(file_name: &str) -> eyre::Result<Cache> {
-    let file = BufReader::new(File::open(file_name)?);
-    Ok(serde_json::from_reader(file)?)
+    let file_data = std::fs::read(file_name)?;
+    let cache =
+        rkyv::from_bytes::<Cache, Error>(&file_data).wrap_err("Failed to deserialize with rkyv")?;
+    Ok(cache)
 }
 
 pub fn write_cache(cache: &Cache, file_name: &str) -> eyre::Result<()> {
     if cache.blocks.is_empty() {
         return Err(eyre::Error::msg("cache can't be empty"));
     }
-    let file = BufWriter::new(File::create(file_name)?);
-    Ok(serde_json::to_writer_pretty(file, cache)?)
+    let mut file = BufWriter::new(File::create(file_name)?);
+    let bytes = rkyv::to_bytes::<Error>(cache).wrap_err("Failed to serialize with rkyv")?;
+    file.write_all(&bytes)
+        .wrap_err("Failed to write binary data")
 }

--- a/cmd/ethrex_replay/src/fetcher.rs
+++ b/cmd/ethrex_replay/src/fetcher.rs
@@ -32,7 +32,7 @@ pub async fn get_blockdata(
 
     let chain_config = network.get_genesis()?.config;
 
-    let file_name = format!("cache_{network}_{requested_block_number}.json");
+    let file_name = format!("cache_{network}_{requested_block_number}.bin");
 
     if let Ok(cache) = load_cache(&file_name).inspect_err(|e| warn!("Failed to load cache: {e}")) {
         info!("Getting block {requested_block_number} data from cache");
@@ -194,7 +194,7 @@ pub async fn get_rangedata(
 ) -> eyre::Result<Cache> {
     let chain_config = network.get_genesis()?.config;
 
-    let file_name = format!("cache_{network}_{from}-{to}.json");
+    let file_name = format!("cache_{network}_{from}-{to}.bin");
 
     if let Ok(cache) = load_cache(&file_name) {
         info!("Getting block range data from cache");
@@ -215,7 +215,7 @@ pub async fn get_batchdata(
     chain_config: ChainConfig,
     batch_number: u64,
 ) -> eyre::Result<Cache> {
-    let file_name = format!("cache_batch_{batch_number}.json");
+    let file_name = format!("cache_batch_{batch_number}.bin");
     if let Ok(cache) = load_cache(&file_name) {
         info!("Getting batch data from cache");
         return Ok(cache);

--- a/cmd/ethrex_replay/src/run.rs
+++ b/cmd/ethrex_replay/src/run.rs
@@ -70,7 +70,7 @@ pub async fn run_tx(
 
 /// Returns the input based on whether the feature "l2" is enabled or not.
 /// If the feature is enabled, it includes L2 fields (blob commitment and proof).
-pub fn get_input(cache: Cache) -> eyre::Result<ProgramInput> {
+fn get_input(cache: Cache) -> eyre::Result<ProgramInput> {
     let Cache {
         blocks,
         witness: db,

--- a/cmd/ethrex_replay/src/run.rs
+++ b/cmd/ethrex_replay/src/run.rs
@@ -70,7 +70,7 @@ pub async fn run_tx(
 
 /// Returns the input based on whether the feature "l2" is enabled or not.
 /// If the feature is enabled, it includes L2 fields (blob commitment and proof).
-fn get_input(cache: Cache) -> eyre::Result<ProgramInput> {
+pub fn get_input(cache: Cache) -> eyre::Result<ProgramInput> {
     let Cache {
         blocks,
         witness: db,


### PR DESCRIPTION
**Motivation**

We want to change the encoding for the caches that the replay generates when executing or proving a block from a JSON pretty formatted to one serialized using `rkyv`.

**Description**

* Switched cache serialization from JSON to binary using the `rkyv` library , including changes to `load_cache` and `write_cache` to use `rkyv` for reading and writing cache files
* Updated `Cache` and `L2Fields` structs to derive `Archive`, `RSerialize`, and `RDeserialize` traits for compatibility with `rkyv`.
* Changed cache file extensions from `.json` to `.bin` in all relevant cache-related functions.
* Added `rkyv.workspace = true` to `cmd/ethrex_replay/Cargo.toml` to manage the `rkyv` dependency at the workspace level.
