### PR TITLE
fix(l2): remote grafana no data from a Linux system

### DIFF
--- a/metrics/docker-compose-metrics-l2.overrides.yaml
+++ b/metrics/docker-compose-metrics-l2.overrides.yaml
@@ -4,6 +4,8 @@ services:
       - ../metrics/provisioning/prometheus/prometheus_l2.yaml:/etc/prometheus/prometheus.yaml
     ports:
       - "9092:9090"
+    extra_hosts:
+      - "host.docker.internal:172.17.0.1"
   grafana:
     ports:
       - "3802:3000"


### PR DESCRIPTION
**Motivation**

The Prometheus server of L2 is initiated in a container, while the L2 itself is a host process. For communication, Prometheus uses the `host.docker.internal` gateway, but this domain doesn't resolve to the gateway address in Linux as it's a macOS only feature.

This results in that we can't see metrics of a L2 running in a remote Linux server.

The fix is to manually add the domain in the docker compose file.
