### PR TITLE
fix(l2): use deserialization error in decode path

### DIFF
--- a/crates/l2/common/src/state_diff.rs
+++ b/crates/l2/common/src/state_diff.rs
@@ -31,8 +31,6 @@ pub const SIMPLE_TX_STATE_DIFF_SIZE: u64 = 108;
 pub enum StateDiffError {
     #[error("StateDiff failed to deserialize: {0}")]
     FailedToDeserializeStateDiff(String),
-    #[error("StateDiff failed to serialize: {0}")]
-    FailedToSerializeStateDiff(String),
     #[error("StateDiff invalid account state diff type: {0}")]
     InvalidAccountStateDiffType(u8),
     #[error("StateDiff unsupported version: {0}")]


### PR DESCRIPTION
Replace FailedToSerializeStateDiff with FailedToDeserializeStateDiff in StateDiff::decode() when validating remaining bytes before AccountStateDiff::decode(). This aligns with error semantics used throughout Decoder methods and ensures consistent error reporting during deserialization.