### PR TITLE
perf(levm): adjust memory resize

### DIFF
--- a/crates/vm/levm/src/memory.rs
+++ b/crates/vm/levm/src/memory.rs
@@ -92,8 +92,8 @@ impl Memory {
         let real_new_memory_size = new_memory_size + self.current_base;
 
         if real_new_memory_size > buffer.len() {
-            // when resizing, resize by allocating entire pages instead of small memory sizes.
-            let new_size = real_new_memory_size.next_multiple_of(4096);
+            // when resizing, avoid really small resizes.
+            let new_size = real_new_memory_size.next_multiple_of(64);
             buffer.resize(new_size, 0);
         }
 


### PR DESCRIPTION
Current memory resize is overly eager, tune it to resize to multiples of 64 instead, this avoids really small allocations while not over allocating, since we require to zero the allocated bytes, it can be expensive to overallocate

**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

