### PR TITLE
ci(l2): use updated fork of get-solc action

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -107,7 +107,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install solc
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN || '' }}
@@ -179,7 +179,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install solc
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN || '' }}
@@ -282,7 +282,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Install solc
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN || '' }}

--- a/.github/workflows/pr-main_l2_tdx.yaml
+++ b/.github/workflows/pr-main_l2_tdx.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install solc
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN || '' }}

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -218,7 +218,7 @@ jobs:
           tool: hyperfine@1.16
 
       - name: Install solc
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN || '' }}

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -68,7 +68,7 @@ jobs:
           tool: hyperfine@1.19
 
       - name: Install solc
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN || '' }}

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install solc
         if: ${{ matrix.platform != 'ubuntu-24.04-arm' }}
-        uses: pontem-network/get-solc@master
+        uses: lambdaclass/get-solc@master
         with:
           version: v0.8.29
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
CI is broken due to move of Solidity's GH repositories.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Change the CI to use lambda's fork of `get-solc` GH action, which has updated links

<!-- Link to issues: Resolves #111, Resolves #222 -->


