### PR TITLE
feat(l2): deposit rich accounts by default

### DIFF
--- a/cmd/ethrex/l2/deployer.rs
+++ b/cmd/ethrex/l2/deployer.rs
@@ -38,7 +38,9 @@ use ethrex_common::H160;
 use hex::FromHexError;
 use secp256k1::SecretKey;
 
-use ethrex_config::networks::{LOCAL_DEVNET_GENESIS_CONTENTS, LOCAL_DEVNETL2_GENESIS_CONTENTS};
+use ethrex_config::networks::{
+    LOCAL_DEVNET_GENESIS_CONTENTS, LOCAL_DEVNET_PRIVATE_KEYS, LOCAL_DEVNETL2_GENESIS_CONTENTS,
+};
 
 #[derive(Parser)]
 pub struct DeployerOptions {
@@ -348,7 +350,7 @@ impl Default for DeployerOptions {
             .unwrap(),
             env_file_path: Some(PathBuf::from(".env")),
             deposit_rich: true,
-            private_keys_file_path: Some("../../fixtures/keys/private_keys_l1.txt".into()),
+            private_keys_file_path: None,
             genesis_l1_path: Some("../../fixtures/genesis/l1-dev.json".into()),
             genesis_l2_path: "../../fixtures/genesis/l2.json".into(),
             // 0x3d1e15a1a55578f7c920884a9943b3b35d0d885b
@@ -948,10 +950,13 @@ async fn make_deposits(
                 .ok_or(DeployerError::FailedToGetStringFromPath)?,
         )
     };
-    let pks = read_to_string(opts.private_keys_file_path.clone().ok_or(
-        DeployerError::ConfigValueNotSet("--private-keys-file-path".to_string()),
-    )?)
-    .map_err(|_| DeployerError::FailedToGetStringFromPath)?;
+
+    let pks = if let Some(path) = &opts.private_keys_file_path {
+        read_to_string(path).map_err(|_| DeployerError::FailedToGetStringFromPath)?
+    } else {
+        LOCAL_DEVNET_PRIVATE_KEYS.to_string()
+    };
+
     let private_keys: Vec<String> = pks
         .lines()
         .filter(|line| !line.trim().is_empty())

--- a/crates/common/config/networks.rs
+++ b/crates/common/config/networks.rs
@@ -24,6 +24,9 @@ pub const LOCAL_DEVNET_GENESIS_CONTENTS: &str =
     include_str!("../../../fixtures/genesis/l1-dev.json");
 pub const LOCAL_DEVNETL2_GENESIS_CONTENTS: &str = include_str!("../../../fixtures/genesis/l2.json");
 
+pub const LOCAL_DEVNET_PRIVATE_KEYS: &str =
+    include_str!("../../../fixtures/keys/private_keys_l1.txt");
+
 #[derive(Debug, Clone)]
 pub enum Network {
     PublicNetwork(PublicNetwork),


### PR DESCRIPTION
**Motivation**

Currently, running `ethrex l2 --dev` doesn't make deposits because `../../fixtures/keys/private_keys_l1.txt` can't be found at runtime.

**Description**

Embeds the contents of `private_keys_l1.txt` into the binary and uses them when the `deposit_rich` flag is set without a private key path specified.

Closes None

