### PR TITLE
build(l1, l2): tag `ethrex:main` instead of `ethrex:unstable`.

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -64,8 +64,8 @@ jobs:
         if: ${{ inputs.job_type == 'main' }}
         run: |
           docker pull ghcr.io/lambdaclass/ethrex:main
-          # Tests use ethrex:latest so we retag it
-          docker tag ghcr.io/lambdaclass/ ethrex:ci
+          # Tests use ethrex:ci so we retag it
+          docker tag ghcr.io/lambdaclass/ethrex:main ethrex:ci
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -63,9 +63,9 @@ jobs:
       - name: Pull image
         if: ${{ inputs.job_type == 'main' }}
         run: |
-          docker pull ghcr.io/lambdaclass/ethrex:unstable
+          docker pull ghcr.io/lambdaclass/ethrex:main
           # Tests use ethrex:latest so we retag it
-          docker tag ghcr.io/lambdaclass/ethrex:unstable ethrex:ci
+          docker tag ghcr.io/lambdaclass/ ethrex:ci
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/main_docker_publish.yaml
+++ b/.github/workflows/main_docker_publish.yaml
@@ -34,4 +34,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:unstable
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          tags: ethrex:unstable
+          tags: ethrex:main
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(STAMP_FILE): $(shell find crates cmd -type f -name '*.rs') Cargo.toml Dockerfi
 build-image: $(STAMP_FILE) ## 🐳 Build the Docker image
 
 run-image: build-image ## 🏃 Run the Docker image
-	docker run --rm -p 127.0.0.1:8545:8545 ethrex:unstable --http.addr 0.0.0.0
+	docker run --rm -p 127.0.0.1:8545:8545 ethrex:main --http.addr 0.0.0.0
 
 dev: ## 🏃 Run the ethrex client in DEV_MODE with the InMemory Engine
 	cargo run --bin ethrex -- \

--- a/crates/l2/docker-compose.yaml
+++ b/crates/l2/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   ethrex_l1:
     container_name: ethrex_l1
-    image: "ethrex:unstable"
+    image: "ethrex:main"
     build: ../../
     ports:
       - 127.0.0.1:8545:8545
@@ -11,7 +11,7 @@ services:
 
   contract_deployer:
     container_name: contract_deployer
-    image: "ethrex:unstable"
+    image: "ethrex:main"
     build: ../../
     volumes:
       # NOTE: DOCKER_ETHREX_WORKDIR is defined in crates/l2/Makefile
@@ -58,7 +58,7 @@ services:
 
   ethrex_l2:
     container_name: ethrex_l2
-    image: "ethrex:unstable"
+    image: "ethrex:main"
     build: ../../
     ports:
       # RPC
@@ -100,7 +100,7 @@ services:
 
   ethrex_prover:
     container_name: ethrex_prover
-    image: "ethrex:unstable"
+    image: "ethrex:main"
     build: ../../
     command: >
       l2 prover

--- a/docs/getting-started/installation/docker_images.md
+++ b/docs/getting-started/installation/docker_images.md
@@ -15,7 +15,7 @@ docker pull ghcr.io/lambdaclass/ethrex:latest
 To pull the latest development docker image, run:
 
 ```
-docker pull ghcr.io/lambdaclass/ethrex:unstable
+docker pull ghcr.io/lambdaclass/ethrex:main
 ```
 
 To pull the image for a specific version, run:
@@ -63,7 +63,7 @@ The command also mounts the docker volume `ethrex` to persist data.
 
 If you want to follow the logs run
 ```
-docker logs -f ethrex 
+docker logs -f ethrex
 ```
 
 To stop the container run


### PR DESCRIPTION
**Motivation**
the term `unstable` is confusing. `main` is much clearer imo and it's the default other clients use

**Description**
- Changed the docker tag on merge from `unstable` to `main`
- Updated references to `unstable` across the codebase.


