### PR TITLE
feat(l2): revert batch subcommand with web3signer

### DIFF
--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -169,7 +169,7 @@ pub enum Command {
             env = "ETHREX_REMOTE_SIGNER_URL",
             help = "URL of a Web3Signer-compatible server to remote sign instead of a local private key.",
             requires = "remote_signer_public_key",
-            required_unless_present = "private_key"
+            conflicts_with = "private_key"
         )]
         remote_signer_url: Option<Url>,
         #[arg(
@@ -179,6 +179,7 @@ pub enum Command {
             env = "ETHREX_REMOTE_SIGNER_PUBLIC_KEY",
             help = "Public key to request the remote signature from.",
             requires = "remote_signer_url",
+            conflicts_with = "private_key"
         )]
         remote_signer_public_key: Option<PublicKey>,
     },

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -4,7 +4,7 @@ use crate::{
     l2::{
         self,
         deployer::{DeployerOptions, deploy_l1_contracts},
-        options::{Options, ProverClientOptions},
+        options::{Options, ProverClientOptions, parse_signer},
     },
     utils::{self, default_datadir, init_datadir, parse_private_key},
 };
@@ -473,21 +473,21 @@ impl Command {
                 private_key,
                 datadir,
                 network,
-                remote_signer_public_key: _,
-                remote_signer_url: _,
+                remote_signer_public_key,
+                remote_signer_url,
             } => {
                 let data_dir = init_datadir(&datadir);
                 let rollup_store_dir = data_dir.clone() + "/rollup_store";
+                let signer = parse_signer(private_key, remote_signer_url, remote_signer_public_key);
 
                 let client = EthClient::new(rpc_url.as_str())?;
-                if let Some(private_key) = private_key {
+                if let Ok(signer) = signer.as_ref() {
                     info!("Pausing OnChainProposer...");
-                    call_contract(&client, &private_key, contract_address, "pause()", vec![])
-                        .await?;
+                    call_contract(&client, signer, contract_address, "pause()", vec![]).await?;
                     info!("Doing revert on OnChainProposer...");
                     call_contract(
                         &client,
-                        &private_key,
+                        signer,
                         contract_address,
                         "revertBatch(uint256)",
                         vec![Value::Uint(batch.into())],
@@ -525,10 +525,9 @@ impl Command {
                     .forkchoice_update(None, last_kept_block, last_kept_header.hash(), None, None)
                     .await?;
 
-                if let Some(private_key) = private_key {
+                if let Ok(signer) = signer.as_ref() {
                     info!("Unpausing OnChainProposer...");
-                    call_contract(&client, &private_key, contract_address, "unpause()", vec![])
-                        .await?;
+                    call_contract(&client, signer, contract_address, "unpause()", vec![]).await?;
                 }
             }
             Command::Deploy { options } => {

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -569,19 +569,18 @@ pub async fn initialize_contract(
 
 pub async fn call_contract(
     client: &EthClient,
-    private_key: &SecretKey,
+    signer: &Signer,
     to: Address,
     signature: &str,
     parameters: Vec<Value>,
 ) -> Result<H256, EthClientError> {
     let calldata = encode_calldata(signature, &parameters)?.into();
-    let signer: Signer = Signer::Local(LocalSigner::new(*private_key));
     let from = signer.address();
     let tx = client
         .build_generic_tx(TxType::EIP1559, to, from, calldata, Default::default())
         .await?;
 
-    let tx_hash = send_generic_transaction(client, tx, &signer).await?;
+    let tx_hash = send_generic_transaction(client, tx, signer).await?;
 
     wait_for_transaction_receipt(tx_hash, client, 100).await?;
     Ok(tx_hash)


### PR DESCRIPTION
**Motivation**

Most L2 chains are deployed with the private keys hidden under a web3signer, we want the `ethrex l2 revert-batch` subcommand to support web3signer

**Description**

- Add 2 flags
   - `remote-signer-url`: the url of the web3signer server
   - `remote-signer-public-key`: the public key to send to the web3server to ask for a signature
- Modify `call_contract` to get a `Signer` as an argument instead of only a private key
- Modify `revert-batch` subcommand to parse either a `RemoteSigner` or a `LocalSigner` then use that value when calling `call_contract`

Closes #4189 

