### PR TITLE
feat(l2): rich accounts monitor tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,6 +4030,7 @@ dependencies = [
  "ethers",
  "ethrex-blockchain",
  "ethrex-common",
+ "ethrex-config",
  "ethrex-dev",
  "ethrex-l2-common",
  "ethrex-l2-rpc",

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 serde_json.workspace = true
 ethereum-types.workspace = true
 ethrex-common.workspace = true
+ethrex-config.workspace = true
 ethrex-rlp.workspace = true
 ethrex-rpc.workspace = true
 ethrex-blockchain.workspace = true

--- a/crates/l2/monitor/app.rs
+++ b/crates/l2/monitor/app.rs
@@ -450,7 +450,7 @@ impl EthrexMonitorWidget {
                 );
 
                 let help =
-                    Line::raw("tab: switch tab |  Q: quit | ↑/↓: select table | w/s: scroll table")
+                    Line::raw("↑/↓: select table | w/s: scroll table | tab: switch tab | Q: quit")
                         .centered();
 
                 help.render(*chunks.get(6).ok_or(MonitorError::Chunks)?, buf);
@@ -475,7 +475,7 @@ impl EthrexMonitorWidget {
 
                 log_widget.render(*chunks.first().ok_or(MonitorError::Chunks)?, buf);
 
-                let help = Line::raw("tab: switch tab | Q: quit | ↑/↓: select target | f: focus target | ←/→: display level | +/-: filter level | h: hide target selector").centered();
+                let help = Line::raw("↑/↓: select target | f: focus target | ←/→: display level | +/-: filter level | h: hide target selector | tab: switch tab | Q: quit").centered();
 
                 help.render(*chunks.get(1).ok_or(MonitorError::Chunks)?, buf);
             }
@@ -488,7 +488,7 @@ impl EthrexMonitorWidget {
                     buf,
                     &mut accounts,
                 );
-                let help = Line::raw("tab: switch tab | Q: quit | w/s: scroll table").centered();
+                let help = Line::raw("w/s: scroll table | tab: switch tab | Q: quit").centered();
                 help.render(*chunks.get(1).ok_or(MonitorError::Chunks)?, buf);
             }
         };

--- a/crates/l2/monitor/widget/mod.rs
+++ b/crates/l2/monitor/widget/mod.rs
@@ -5,6 +5,7 @@ pub mod l1_to_l2_messages;
 pub mod l2_to_l1_messages;
 pub mod mempool;
 pub mod node_status;
+pub mod rich_accounts;
 pub mod tabs;
 
 pub use batches::BatchesTable;

--- a/crates/l2/monitor/widget/rich_accounts.rs
+++ b/crates/l2/monitor/widget/rich_accounts.rs
@@ -57,9 +57,8 @@ impl RichAccountsTable {
 
         let mut accounts = Vec::with_capacity(private_keys.len());
         for pk in private_keys.iter() {
-            let secret_key = parse_private_key(pk).map_err(|_| {
-                MonitorError::DecodingError("Error while parsing private key".to_string())
-            })?;
+            let secret_key = SecretKey::from_slice(&parse_hex(pk)?)
+                .map_err(|e| MonitorError::DecodingError(format!("Invalid private key: {e}")))?;
             let address = get_address_from_secret_key(&secret_key)?;
             let get_balance = rollup_client
                 .get_balance(
@@ -88,10 +87,6 @@ impl RichAccountsTable {
         self.last_block_fetched = latest_block;
         Ok(())
     }
-}
-
-pub fn parse_private_key(s: &str) -> Result<SecretKey, MonitorError> {
-    Ok(SecretKey::from_slice(&parse_hex(s)?)?)
 }
 
 pub fn parse_hex(s: &str) -> Result<Bytes, FromHexError> {

--- a/crates/l2/monitor/widget/rich_accounts.rs
+++ b/crates/l2/monitor/widget/rich_accounts.rs
@@ -1,0 +1,146 @@
+use bytes::Bytes;
+use ethrex_common::{Address, U256};
+use ethrex_config::networks::LOCAL_DEVNET_PRIVATE_KEYS;
+use ethrex_l2_sdk::get_address_from_secret_key;
+use ethrex_rpc::{
+    EthClient,
+    types::block_identifier::{BlockIdentifier, BlockTag},
+};
+use hex::FromHexError;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Rect},
+    style::{Color, Modifier, Style},
+    text::Span,
+    widgets::{Block, Row, StatefulWidget, Table, TableState},
+};
+use secp256k1::SecretKey;
+
+use crate::{
+    monitor::{utils::SelectableScroller, widget::HASH_LENGTH_IN_DIGITS},
+    sequencer::errors::MonitorError,
+};
+
+// address | private key | balance
+pub type RichAccountRow = (Address, SecretKey, U256);
+
+#[derive(Clone, Default)]
+pub struct RichAccountsTable {
+    pub state: TableState,
+    pub items: Vec<RichAccountRow>,
+
+    selected: bool,
+}
+
+impl RichAccountsTable {
+    pub async fn new(rollup_client: &EthClient) -> Result<Self, MonitorError> {
+        let items = Self::get_accounts(rollup_client).await?;
+        Ok(Self {
+            items,
+            ..Default::default()
+        })
+    }
+    async fn get_accounts(rollup_client: &EthClient) -> Result<Vec<RichAccountRow>, MonitorError> {
+        // TODO: enable custom private keys
+        let private_keys: Vec<String> = LOCAL_DEVNET_PRIVATE_KEYS
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| line.trim().to_string())
+            .collect();
+
+        let mut accounts = Vec::with_capacity(private_keys.len());
+        for pk in private_keys.iter() {
+            let secret_key = parse_private_key(pk).map_err(|_| {
+                MonitorError::DecodingError("Error while parsing private key".to_string())
+            })?;
+            let address = get_address_from_secret_key(&secret_key)?;
+            let get_balance = rollup_client
+                .get_balance(address, BlockIdentifier::Tag(BlockTag::Latest))
+                .await?;
+            accounts.push((address, secret_key, get_balance));
+        }
+        Ok(accounts)
+    }
+
+    pub async fn on_tick(&mut self, rollup_client: &EthClient) -> Result<(), MonitorError> {
+        for (address, _private_key, balance) in self.items.iter_mut() {
+            *balance = rollup_client
+                .get_balance(*address, BlockIdentifier::Tag(BlockTag::Latest))
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+pub fn parse_private_key(s: &str) -> Result<SecretKey, MonitorError> {
+    Ok(SecretKey::from_slice(&parse_hex(s)?)?)
+}
+
+pub fn parse_hex(s: &str) -> Result<Bytes, FromHexError> {
+    match s.strip_prefix("0x") {
+        Some(s) => hex::decode(s).map(Into::into),
+        None => hex::decode(s).map(Into::into),
+    }
+}
+
+impl StatefulWidget for &mut RichAccountsTable {
+    type State = TableState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State)
+    where
+        Self: Sized,
+    {
+        let constraints = vec![
+            Constraint::Fill(1),
+            Constraint::Length(HASH_LENGTH_IN_DIGITS),
+            Constraint::Fill(1),
+        ];
+
+        let rows = self.items.iter().map(|(address, private_key, balance)| {
+            Row::new(vec![
+                Span::styled(format!("{address}"), Style::default()),
+                Span::styled(
+                    format!("{}", private_key.display_secret()),
+                    Style::default(),
+                ),
+                Span::styled(balance.to_string(), Style::default()),
+            ])
+        });
+
+        let rich_accounts_table = Table::new(rows, constraints)
+            .header(Row::new(vec!["Address", "Private Key", "Balance"]).style(Style::default()))
+            .block(
+                Block::bordered()
+                    .border_style(Style::default().fg(if self.selected {
+                        Color::Magenta
+                    } else {
+                        Color::Cyan
+                    }))
+                    .title(Span::styled(
+                        "L1 to L2 Messages",
+                        Style::default().add_modifier(Modifier::BOLD),
+                    )),
+            );
+
+        rich_accounts_table.render(area, buf, state);
+    }
+}
+
+impl SelectableScroller for RichAccountsTable {
+    fn selected(&mut self, is_selected: bool) {
+        self.selected = is_selected;
+    }
+    fn scroll_up(&mut self) {
+        let selected = self.state.selected_mut();
+        *selected = Some(selected.unwrap_or(0).saturating_sub(1))
+    }
+    fn scroll_down(&mut self) {
+        let selected = self.state.selected_mut();
+        *selected = Some(
+            selected
+                .unwrap_or(0)
+                .saturating_add(1)
+                .min(self.items.len().saturating_sub(1)),
+        )
+    }
+}

--- a/crates/l2/monitor/widget/tabs.rs
+++ b/crates/l2/monitor/widget/tabs.rs
@@ -5,13 +5,15 @@ pub enum TabsState {
     #[default]
     Overview = 0,
     Logs = 1,
+    Accounts = 2,
 }
 
 impl TabsState {
     pub fn next(&mut self) {
         match self {
             TabsState::Overview => *self = TabsState::Logs,
-            TabsState::Logs => *self = TabsState::Overview,
+            TabsState::Logs => *self = TabsState::Accounts,
+            TabsState::Accounts => *self = TabsState::Overview,
         }
     }
 
@@ -19,6 +21,7 @@ impl TabsState {
         match self {
             TabsState::Overview => *self = TabsState::Logs,
             TabsState::Logs => *self = TabsState::Overview,
+            TabsState::Accounts => *self = TabsState::Logs,
         }
     }
 }
@@ -28,6 +31,7 @@ impl Display for TabsState {
         match self {
             TabsState::Overview => write!(f, "Overview"),
             TabsState::Logs => write!(f, "Logs"),
+            TabsState::Accounts => write!(f, "Accounts"),
         }
     }
 }
@@ -37,6 +41,7 @@ impl From<TabsState> for Option<usize> {
         match state {
             TabsState::Overview => Some(0),
             TabsState::Logs => Some(1),
+            TabsState::Accounts => Some(2),
         }
     }
 }

--- a/crates/l2/monitor/widget/tabs.rs
+++ b/crates/l2/monitor/widget/tabs.rs
@@ -5,15 +5,15 @@ pub enum TabsState {
     #[default]
     Overview = 0,
     Logs = 1,
-    Accounts = 2,
+    RichAccounts = 2,
 }
 
 impl TabsState {
     pub fn next(&mut self) {
         match self {
             TabsState::Overview => *self = TabsState::Logs,
-            TabsState::Logs => *self = TabsState::Accounts,
-            TabsState::Accounts => *self = TabsState::Overview,
+            TabsState::Logs => *self = TabsState::RichAccounts,
+            TabsState::RichAccounts => *self = TabsState::Overview,
         }
     }
 
@@ -21,7 +21,7 @@ impl TabsState {
         match self {
             TabsState::Overview => *self = TabsState::Logs,
             TabsState::Logs => *self = TabsState::Overview,
-            TabsState::Accounts => *self = TabsState::Logs,
+            TabsState::RichAccounts => *self = TabsState::Logs,
         }
     }
 }
@@ -31,7 +31,7 @@ impl Display for TabsState {
         match self {
             TabsState::Overview => write!(f, "Overview"),
             TabsState::Logs => write!(f, "Logs"),
-            TabsState::Accounts => write!(f, "Accounts"),
+            TabsState::RichAccounts => write!(f, "Rich Accounts"),
         }
     }
 }
@@ -41,7 +41,7 @@ impl From<TabsState> for Option<usize> {
         match state {
             TabsState::Overview => Some(0),
             TabsState::Logs => Some(1),
-            TabsState::Accounts => Some(2),
+            TabsState::RichAccounts => Some(2),
         }
     }
 }

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -359,6 +359,4 @@ pub enum MonitorError {
     DecodingError(String),
     #[error("Error parsing secret key")]
     FromHexError(#[from] hex::FromHexError),
-    #[error("Error parsing secret key")]
-    SecretKeyError(#[from] secp256k1::Error),
 }

--- a/crates/l2/sequencer/errors.rs
+++ b/crates/l2/sequencer/errors.rs
@@ -355,4 +355,10 @@ pub enum MonitorError {
     RPCListEmpty,
     #[error("Error converting batch window")]
     BatchWindow,
+    #[error("Error while parsing private key")]
+    DecodingError(String),
+    #[error("Error parsing secret key")]
+    FromHexError(#[from] hex::FromHexError),
+    #[error("Error parsing secret key")]
+    SecretKeyError(#[from] secp256k1::Error),
 }


### PR DESCRIPTION
**Motivation**

When launching an L2 with `ethrex l2 --dev`, one of the main things you want to have at hand is the set of rich accounts on the localnet.

**Description**

- Adds a new `Rich Accounts` tab to the ethrex monitor.
- Loads the private keys from `LOCAL_DEVNET_PRIVATE_KEYS` and periodically updates their balances.

<img width="1507" height="946" alt="image" src="https://github.com/user-attachments/assets/ff100d1b-fe61-4b3c-a3f4-d0418d20ea44" />



#4198 and #4200 where created to be addressed in future PRs.

Closes None

