### PR TITLE
chore(l1): Improve logging on the `import` subcommand.

### DIFF
--- a/cmd/ethrex/bench/build_block_benchmark.rs
+++ b/cmd/ethrex/bench/build_block_benchmark.rs
@@ -256,6 +256,7 @@ pub fn build_block_benchmark(c: &mut Criterion<GasMeasurement>) {
                         EvmEngine::LEVM,
                         store_with_genesis.clone(),
                         BlockchainType::L1, // TODO: Should we support L2?
+                        false
                     );
                     fill_mempool(&block_chain, accounts).await;
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -115,9 +115,10 @@ pub fn init_blockchain(
     evm_engine: EvmEngine,
     store: Store,
     blockchain_type: BlockchainType,
+    perf_logs_endabled: bool,
 ) -> Arc<Blockchain> {
-    info!("Initiating blockchain with EVM: {}", evm_engine);
-    Blockchain::new(evm_engine, store, blockchain_type).into()
+    info!("Initiating blockchain: evm={}", evm_engine);
+    Blockchain::new(evm_engine, store, blockchain_type, perf_logs_endabled).into()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -384,7 +385,7 @@ pub async fn init_l1(
     #[cfg(feature = "sync-test")]
     set_sync_block(&store).await;
 
-    let blockchain = init_blockchain(opts.evm, store.clone(), BlockchainType::L1);
+    let blockchain = init_blockchain(opts.evm, store.clone(), BlockchainType::L1, true);
 
     let signer = get_signer(&data_dir);
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -35,7 +35,7 @@ use std::{
 };
 use tokio::sync::Mutex;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::{error, info, warn};
+use tracing::{debug, info, warn};
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, filter::Directive, fmt, layer::SubscriberExt,
 };
@@ -115,10 +115,10 @@ pub fn init_blockchain(
     evm_engine: EvmEngine,
     store: Store,
     blockchain_type: BlockchainType,
-    perf_logs_endabled: bool,
+    perf_logs_enabled: bool,
 ) -> Arc<Blockchain> {
-    info!("Initiating blockchain: evm={}", evm_engine);
-    Blockchain::new(evm_engine, store, blockchain_type, perf_logs_endabled).into()
+    info!(evm = %evm_engine, "Initiating blockchain");
+    Blockchain::new(evm_engine, store, blockchain_type, perf_logs_enabled).into()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -251,7 +251,7 @@ pub fn get_bootnodes(opts: &Options, network: &Network, data_dir: &str) -> Vec<N
 
     bootnodes.extend(network.get_bootnodes());
 
-    info!("Reading known peers from config file");
+    debug!("Loading known peers from config");
 
     match read_node_config_file(data_dir) {
         Ok(Some(ref mut config)) => bootnodes.append(&mut config.known_peers),
@@ -313,7 +313,7 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> Node {
     // TODO Find a proper place to show node information
     // https://github.com/lambdaclass/ethrex/issues/836
     let enode = node.enode_url();
-    info!("Node: {enode}");
+    info!(enode = %enode, "Local node initialized");
 
     node
 }

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -157,7 +157,7 @@ pub async fn init_l2(opts: L2Options) -> eyre::Result<()> {
     let store = init_store(&data_dir, genesis).await;
     let rollup_store = init_rollup_store(&rollup_store_dir).await;
 
-    let blockchain = init_blockchain(opts.node_opts.evm, store.clone(), BlockchainType::L2);
+    let blockchain = init_blockchain(opts.node_opts.evm, store.clone(), BlockchainType::L2, true);
 
     let signer = get_signer(&data_dir);
 

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -264,7 +264,7 @@ pub async fn init_l2(opts: L2Options) -> eyre::Result<()> {
     }
     info!("Server shut down started...");
     let node_config_path = PathBuf::from(data_dir + "/node_config.json");
-    info!("Storing config at {:?}...", node_config_path);
+    info!(path = %node_config_path.display(), "Storing node config");
     cancel_token.cancel();
     let node_config = NodeConfigFile::new(peer_table, local_node_record.lock().await.clone()).await;
     store_node_config_file(node_config, node_config_path).await;

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -64,6 +64,8 @@ pub struct Blockchain {
     /// This will be set to true once the initial sync has taken place and wont be set to false after
     /// This does not reflect whether there is an ongoing sync process
     is_synced: AtomicBool,
+    /// Whether performance logs should be emitted
+    pub perf_logs_enabled: bool,
     pub r#type: BlockchainType,
 }
 
@@ -86,13 +88,19 @@ fn log_batch_progress(batch_size: u32, current_block: u32) {
 }
 
 impl Blockchain {
-    pub fn new(evm_engine: EvmEngine, store: Store, blockchain_type: BlockchainType) -> Self {
+    pub fn new(
+        evm_engine: EvmEngine,
+        store: Store,
+        blockchain_type: BlockchainType,
+        perf_logs_enabled: bool,
+    ) -> Self {
         Self {
             evm_engine,
             storage: store,
             mempool: Mempool::new(),
             is_synced: AtomicBool::new(false),
             r#type: blockchain_type,
+            perf_logs_enabled: perf_logs_enabled,
         }
     }
 
@@ -103,6 +111,7 @@ impl Blockchain {
             mempool: Mempool::new(),
             is_synced: AtomicBool::new(false),
             r#type: BlockchainType::default(),
+            perf_logs_enabled: false,
         }
     }
 
@@ -400,7 +409,10 @@ impl Blockchain {
         let merkleized = Instant::now();
         let result = self.store_block(block, account_updates_list, res).await;
         let stored = Instant::now();
-        Self::print_add_block_logs(block, since, executed, merkleized, stored);
+
+        if self.perf_logs_enabled {
+            Self::print_add_block_logs(block, since, executed, merkleized, stored);
+        }
         result
     }
 
@@ -448,7 +460,7 @@ impl Blockchain {
                 "".to_string()
             };
 
-            info!("{}{}", base_log, extra_log);
+            debug!("{}{}", base_log, extra_log);
         }
     }
 
@@ -589,15 +601,17 @@ impl Blockchain {
             METRICS_BLOCKS.set_latest_gigagas(throughput);
         );
 
-        info!(
-            "[METRICS] Executed and stored: Range: {}, Last block num: {}, Last block gas limit: {}, Total transactions: {}, Total Gas: {}, Throughput: {} Gigagas/s",
-            blocks_len,
-            last_block_number,
-            last_block_gas_limit,
-            transactions_count,
-            total_gas_used,
-            throughput
-        );
+        if self.perf_logs_enabled {
+            info!(
+                "[METRICS] Executed and stored: Range: {}, Last block num: {}, Last block gas limit: {}, Total transactions: {}, Total Gas: {}, Throughput: {} Gigagas/s",
+                blocks_len,
+                last_block_number,
+                last_block_gas_limit,
+                transactions_count,
+                total_gas_used,
+                throughput
+            );
+        }
 
         Ok(())
     }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -24,7 +24,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::RwLock,
 };
-use tracing::{error, info, instrument};
+use tracing::{debug, error, info, instrument};
 /// Number of state trie segments to fetch concurrently during state sync
 pub const STATE_TRIE_SEGMENTS: usize = 2;
 /// Maximum amount of reads from the snapshot in a single transaction to avoid performance hits due to long-living reads
@@ -73,12 +73,12 @@ impl Store {
         self.engine.apply_updates(update_batch).await
     }
 
-    pub fn new(_path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
-        info!("Starting storage engine ({engine_type:?})");
+    pub fn new(path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
+        info!("Opening storage engine: engine={engine_type:?}, path={path}");
         let store = match engine_type {
             #[cfg(feature = "libmdbx")]
             EngineType::Libmdbx => Self {
-                engine: Arc::new(LibmdbxStore::new(_path)?),
+                engine: Arc::new(LibmdbxStore::new(path)?),
                 chain_config: Default::default(),
                 latest_block_header: Arc::new(RwLock::new(BlockHeader::default())),
             },
@@ -89,7 +89,6 @@ impl Store {
             },
         };
 
-        info!("Started store engine");
         Ok(store)
     }
 
@@ -569,7 +568,7 @@ impl Store {
     }
 
     pub async fn add_initial_state(&self, genesis: Genesis) -> Result<(), StoreError> {
-        info!("Storing initial state from genesis");
+        debug!("Storing initial state from genesis");
 
         // Obtain genesis block
         let genesis_block = genesis.get_block();
@@ -613,10 +612,7 @@ impl Store {
         debug_assert_eq!(genesis_state_root, genesis_block.header.state_root);
 
         // Store genesis block
-        info!(
-            "Storing genesis block with number {} and hash {}",
-            genesis_block_number, genesis_hash
-        );
+        info!("Storing genesis block: hash={}", genesis_hash);
 
         self.add_block(genesis_block).await?;
         self.update_earliest_block_number(genesis_block_number)

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -74,7 +74,7 @@ impl Store {
     }
 
     pub fn new(path: &str, engine_type: EngineType) -> Result<Self, StoreError> {
-        info!("Opening storage engine: engine={engine_type:?}, path={path}");
+        info!(engine = ?engine_type, path = %path, "Opening storage engine");
         let store = match engine_type {
             #[cfg(feature = "libmdbx")]
             EngineType::Libmdbx => Self {
@@ -612,7 +612,7 @@ impl Store {
         debug_assert_eq!(genesis_state_root, genesis_block.header.state_root);
 
         // Store genesis block
-        info!("Storing genesis block: hash={}", genesis_hash);
+        info!(hash = %genesis_hash, "Storing genesis block");
 
         self.add_block(genesis_block).await?;
         self.update_earliest_block_number(genesis_block_number)

--- a/fixtures/network/hoodi.yaml
+++ b/fixtures/network/hoodi.yaml
@@ -1,6 +1,6 @@
 participants:
   - el_type: ethrex
-    el_image: ethrex:latest
+    el_image: ethrex:local
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v7.0.1
     count: 1

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -79,7 +79,7 @@ pub async fn run_ef_test(
     check_prestate_against_db(test_key, test, &store);
 
     // Blockchain EF tests are meant for L1.
-    let blockchain = Blockchain::new(evm, store.clone(), BlockchainType::L1);
+    let blockchain = Blockchain::new(evm, store.clone(), BlockchainType::L1, false);
 
     // Early return if the exception is in the rlp decoding of the block
     for bf in &test.blocks {


### PR DESCRIPTION
**Motivation**
Logging in general, and specifically in the `import` subcommand is quite messy.

**Description**
- Improves the logging phrasing
- Instead of logging for each block, logs a summary every 10 seconds
- Logs the total time that it took.
- Some misc log additions and downgrades

This is how it looks:
```
2025-08-28T17:27:12.121079Z  INFO ethrex_storage::store: Opening storage engine engine=Libmdbx path=/Users/mpaulucci/Library/Application-Support/ethrex
2025-08-28T17:27:12.158692Z  INFO ethrex_storage::store: Storing genesis block hash=0xbbe3…971b
2025-08-28T17:27:12.159567Z  INFO ethrex::initializers: Initiating blockchain evm=levm
2025-08-28T17:27:12.159726Z  INFO ethrex::cli: Importing blocks from file path=./hoodi-1k.rlp
2025-08-28T17:27:22.415021Z  INFO ethrex::cli: Import progress processed=151 total=1000 percent=15.1
2025-08-28T17:27:32.602179Z  INFO ethrex::cli: Import progress processed=180 total=1000 percent=18.0
```

