### PR TITLE
perf(l1): avoid cloning the mempool keys when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2025-08-29
+
+- Improve P2P mempool gossip performance [#4205](https://github.com/lambdaclass/ethrex/pull/4205)
+
 ### 2025-08-28
 
 - Improve precompiles further: modexp, ecrecover [#4168](https://github.com/lambdaclass/ethrex/pull/4168)

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -168,10 +168,9 @@ impl Mempool {
             .read()
             .map_err(|error| StoreError::MempoolReadLock(error.to_string()))?;
 
-        let tx_set: HashSet<_> = tx_pool.keys().collect();
         Ok(possible_hashes
             .iter()
-            .filter(|hash| !tx_set.contains(hash))
+            .filter(|hash| !tx_pool.contains_key(hash))
             .copied()
             .collect())
     }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     sync::{Mutex, RwLock},
 };
 


### PR DESCRIPTION
**Motivation**

Currently, on larger networks the CPU usage is very high and increases until the node can't keep up with execution.

**Description**

Currently, filter_unknown_transactions makes a copy of the mempool keys (known transaction hashes).

This cloning is not necessary, we can query the mempool directly.