### PR TITLE
fix(l2): make `down-l2` kill only the L2 process, not the prover

### DIFF
--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -153,7 +153,7 @@ down-metrics: ## 🛑 Shuts down the metrics' containers
 restart-metrics: down-metrics init-metrics ## 🔄 Restarts the metrics' containers
 
 down-l2: ## 🛑 Shuts down the L2 Lambda ethrex Client
-	pkill -x ethrex || exit 0
+	pgrep -a -f "ethrex l2" | awk '!/prover/ {print $1}' | xargs -r kill -s SIGINT
 
 rm-db-l2: ## 🛑 Removes the DB used by the L2
 	cargo run --release --manifest-path ../../Cargo.toml --bin ethrex -- l2 removedb --datadir ${ethrex_L2_DEV_DB} --force


### PR DESCRIPTION
**Motivation**

When running `make restart-l2`, the `down-l2` rule kills the prover if it's already running. This filters out the `ethrex l2 prover ...` process.

