### PR TITLE
feat(l1): add a way to resume `archive_sync` after a crash

### DIFF
--- a/tooling/archive_sync/README.md
+++ b/tooling/archive_sync/README.md
@@ -78,3 +78,13 @@ If we don't need the node to be synced (for example if we plan to move the state
 ```bash
  cargo run --release BLOCK_NUMBER --input_dir STATE_DUMP_DIR
 ```
+
+## Resuming archive sync after crashes
+
+If the node crashes mid-sync there is little we can (currenlty) do to resume state rebuilding as we would have lost track of the intermediate state root. However, it is possible to resume the file-writing portion of the archive sync from the latest written file by using:
+
+```bash
+ cargo run --release BLOCK_NUMBER --ipc_path IPC_PATH --output_dir STATE_DUMP_DIR --no_sync --continued
+```
+
+This command will continue reading state from an archive node's ipc and dumping it to files from the latest downloaded dump without rebuilding the state in the node's DB. Please ensure you use the same block number as the previously aborted sync to avoid state inconsistencies.

--- a/tooling/archive_sync/src/main.rs
+++ b/tooling/archive_sync/src/main.rs
@@ -532,10 +532,10 @@ impl DumpIpcReader {
 
 /// Set the starting hash for dump reads to the next hash on the latest dump written to a file
 /// Can be used to resume a previously aborted archive sync process.
-/// However, it will only be able to resume state download to file and not state rebuilding for the node
+/// However, it will only be able to resume state download to file and not state rebuilding for the node.
 /// Will only work if the dump processor is a pure file writter and the dump reader is an IPC reader
 /// These conditions should have been checked by the CLI.
-/// Does not ensure in any way that the block used in the previous sync matche sthe current block
+/// Does not ensure in any way that the block used in the previous sync matches the current block
 fn continue_from_latest_file_dump(
     dump_processor: &mut DumpProcessor,
     dump_reader: &mut DumpReader,

--- a/tooling/archive_sync/src/main.rs
+++ b/tooling/archive_sync/src/main.rs
@@ -560,7 +560,7 @@ fn continue_from_latest_file_dump(
         if let Some(dump_number) = filename
             .strip_prefix("dump_")
             .and_then(|filename| filename.strip_suffix(".json"))
-            .and_then(|number_str| usize::from_str_radix(number_str, 10).ok())
+            .and_then(|number_str| number_str.parse::<usize>().ok())
         {
             dump_writer.current_file = max(dump_writer.current_file, dump_number);
         }

--- a/tooling/archive_sync/src/main.rs
+++ b/tooling/archive_sync/src/main.rs
@@ -252,6 +252,7 @@ impl DumpProcessor {
     /// Process incoming state dump by either writing it to a file and/or using it to rebuild the partial state
     /// Will fail if the incoming dump's state root differs from the previously processed dump
     async fn process_dump(&mut self, dump: Dump) -> eyre::Result<bool> {
+        let instant = Instant::now();
         // Sanity check
         if *self.state_root.get_or_insert(dump.state_root) != dump.state_root {
             return Err(eyre::ErrReport::msg(
@@ -265,13 +266,12 @@ impl DumpProcessor {
         }
         // Process dump
         if let Some((current_root, store)) = self.sync_state.as_mut() {
-            let instant = Instant::now();
             *current_root = process_dump(dump, store.clone(), *current_root).await?;
-            info!(
-                "Processed Dump of {MAX_ACCOUNTS} accounts in {}",
-                mseconds_to_readable(instant.elapsed().as_millis())
-            );
         }
+        info!(
+            "Processed Dump of {MAX_ACCOUNTS} accounts in {}",
+            mseconds_to_readable(instant.elapsed().as_millis())
+        );
         Ok(should_continue)
     }
 


### PR DESCRIPTION
**Motivation**
Currently, archive sync always begins downloading state from the very start of the state trie (hash 0x00..). This means that in case of an unexpected crash we have no way of resuming the previous state sync, which can mean losing a lot of precious time. This PR proposes a small solution to this problem, by adding a way to resume the previously aborted archive sync via a `--continued` flag.
However, this solution is very limited, as we are not able to resume the state sync portion of archive sync (aka rebuilding the state locally) as we did not keep track of intermediate roots during the archive sync. It is only able to resume the writing of the archive node's state to files. Hence why `--continued` can only be used in combination with `--ipc_path`, `--output_dir` & `--no_sync` flags
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `--continued` flag to be able to continue a previously aborted archive sync process. (Note: only usable with `--no_sync` as we are not able to resume local state rebuilding)
<!-- A clear and concise general description of the changes this PR introduces -->
* (Misc) Log account processing even with `--no_sync` to avoid silent node

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

