### PR TITLE
fix(l1,l2): eth client support 4 byte signatures, return decoded error in `RpcErr::Revert`

### DIFF
--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         block_identifier::{BlockIdentifier, BlockTag},
         receipt::{RpcLog, RpcReceipt},
     },
-    utils::{RpcErrorResponse, RpcRequest, RpcSuccessResponse},
+    utils::{RpcErrorResponse, RpcRequest, RpcSuccessResponse, get_message_from_revert_data},
 };
 use bytes::Bytes;
 use errors::{
@@ -296,59 +296,14 @@ impl EthClient {
             }
             .map_err(EstimateGasError::ParseIntError)
             .map_err(EthClientError::from),
-            RpcResponse::Error(error_response) => {
-                let error_data = if let Some(error_data) = error_response.error.data {
-                    if &error_data == "0x" {
-                        "unknown error".to_owned()
-                    } else {
-                        let abi_decoded_error_data = hex::decode(
-                            error_data.strip_prefix("0x").ok_or(EthClientError::Custom(
-                                "Failed to strip_prefix in estimate_gas".to_owned(),
-                            ))?,
-                        )
-                        .map_err(|_| {
-                            EthClientError::Custom(
-                                "Failed to hex::decode in estimate_gas".to_owned(),
-                            )
-                        })?;
-                        let string_length = U256::from_big_endian(
-                            abi_decoded_error_data
-                                .get(36..68)
-                                .ok_or(EthClientError::Custom(
-                                    "Failed to slice index abi_decoded_error_data in estimate_gas"
-                                        .to_owned(),
-                                ))?,
-                        );
-
-                        let string_len = if string_length > usize::MAX.into() {
-                            return Err(EthClientError::Custom(
-                                "Failed to convert string_length to usize in estimate_gas"
-                                    .to_owned(),
-                            ));
-                        } else {
-                            string_length.as_usize()
-                        };
-                        let string_data = abi_decoded_error_data.get(68..68 + string_len).ok_or(
-                            EthClientError::Custom(
-                                "Failed to slice index abi_decoded_error_data in estimate_gas"
-                                    .to_owned(),
-                            ),
-                        )?;
-                        String::from_utf8(string_data.to_vec()).map_err(|_| {
-                            EthClientError::Custom(
-                                "Failed to String::from_utf8 in estimate_gas".to_owned(),
-                            )
-                        })?
-                    }
-                } else {
-                    "unknown error".to_owned()
-                };
-                Err(EstimateGasError::RPCError(format!(
-                    "{}: {}",
-                    error_response.error.message, error_data
-                ))
-                .into())
-            }
+            RpcResponse::Error(error_response) => Err(EstimateGasError::RPCError(format!(
+                "{}: {}",
+                error_response.error.message,
+                get_message_from_revert_data(
+                    &error_response.error.data.unwrap_or("0x".to_string())
+                )?
+            ))
+            .into()),
         }
     }
 

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         block_identifier::{BlockIdentifier, BlockTag},
         receipt::{RpcLog, RpcReceipt},
     },
-    utils::{RpcErrorResponse, RpcRequest, RpcSuccessResponse, get_message_from_revert_data},
+    utils::{RpcErrorResponse, RpcRequest, RpcSuccessResponse},
 };
 use bytes::Bytes;
 use errors::{
@@ -296,14 +296,9 @@ impl EthClient {
             }
             .map_err(EstimateGasError::ParseIntError)
             .map_err(EthClientError::from),
-            RpcResponse::Error(error_response) => Err(EstimateGasError::RPCError(format!(
-                "{}: {}",
-                error_response.error.message,
-                get_message_from_revert_data(
-                    &error_response.error.data.unwrap_or("0x".to_string())
-                )?
-            ))
-            .into()),
+            RpcResponse::Error(error_response) => {
+                Err(EstimateGasError::RPCError(error_response.error.message.to_string()).into())
+            }
         }
     }
 

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -1,9 +1,10 @@
+use ethrex_common::U256;
 use ethrex_storage::error::StoreError;
 use ethrex_vm::EvmError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::authentication::AuthenticationError;
+use crate::{authentication::AuthenticationError, clients::EthClientError};
 use ethrex_blockchain::error::MempoolError;
 
 #[derive(Debug, thiserror::Error)]
@@ -95,7 +96,7 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: Some(data.clone()),
                 message: format!(
                     "execution reverted: {}",
-                    get_message_from_revert_data(&data)
+                    get_message_from_revert_data(&data).unwrap_or("unknown error".to_string())
                 ),
             },
             RpcErr::Halt { reason, gas_used } => RpcErrorMetadata {
@@ -268,12 +269,47 @@ impl From<EvmError> for RpcErr {
     }
 }
 
-fn get_message_from_revert_data(_data: &str) -> String {
-    // TODO
-    // Hive tests are not failing when revert message does not match, but currently it is not matching
-    // It should be fixed
-    // See https://github.com/ethereum/go-ethereum/blob/8fd43c80132434dca896d8ae5004ae2aac1450d3/accounts/abi/abi.go#L275
-    "".to_owned()
+pub fn get_message_from_revert_data(data: &str) -> Result<String, EthClientError> {
+    if data == "0x" {
+        Ok("unknown error".to_owned())
+    // 4 byte function signature 0xXXXXXXXX
+    } else if data.len() == 10 {
+        Ok(data.to_owned())
+    } else {
+        let abi_decoded_error_data =
+            hex::decode(data.strip_prefix("0x").ok_or(EthClientError::Custom(
+                "Failed to strip_prefix when getting message from revert data".to_owned(),
+            ))?)
+            .map_err(|_| {
+                EthClientError::Custom(
+                    "Failed to hex::decode when getting message from revert data".to_owned(),
+                )
+            })?;
+        let string_length = U256::from_big_endian(abi_decoded_error_data.get(36..68).ok_or(
+            EthClientError::Custom(
+                "Failed to slice index abi_decoded_error_data when getting message from revert data".to_owned(),
+            ),
+        )?);
+        let string_len = if string_length > usize::MAX.into() {
+            return Err(EthClientError::Custom(
+                "Failed to convert string_length to usize when getting message from revert data"
+                    .to_owned(),
+            ));
+        } else {
+            string_length.as_usize()
+        };
+        let string_data = abi_decoded_error_data
+            .get(68..68 + string_len)
+            .ok_or(EthClientError::Custom(
+            "Failed to slice index abi_decoded_error_data when getting message from revert data"
+                .to_owned(),
+        ))?;
+        String::from_utf8(string_data.to_vec()).map_err(|_| {
+            EthClientError::Custom(
+                "Failed to String::from_utf8 when getting message from revert data".to_owned(),
+            )
+        })
+    }
 }
 
 pub fn parse_json_hex(hex: &serde_json::Value) -> Result<u64, String> {

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -96,7 +96,9 @@ impl From<RpcErr> for RpcErrorMetadata {
                 data: Some(data.clone()),
                 message: format!(
                     "execution reverted: {}",
-                    get_message_from_revert_data(&data).unwrap_or("unknown error".to_string())
+                    get_message_from_revert_data(&data).unwrap_or_else(|err| format!(
+                        "tried to decode error from abi but failed: {err}"
+                    ))
                 ),
             },
             RpcErr::Halt { reason, gas_used } => RpcErrorMetadata {


### PR DESCRIPTION
**Motivation**

When calling contracts with `eth_call` or `eth_estimateGas` ethrex rpc was returning an empty message from `get_message_from_revert_data`, we had some code that decoded the error from the revert data but it was only used when calling `eth_estimateGas` from our EthClient.

**Description**

- Move the code used to decode error from `EthClient::estimate_gas` to `get_message_from_revert_data`
  - Add logic to check for 4 byte function signatures, instead of trying to decode this as string, we just return the selector so that the user can look it up in existing databases
- Now that the `RpcErrorMetadata` has a message with content in it use `error_response.error.message.to_string()` in `EthClient::estimate_gas` when an error occurs

Closes #4021 

