### PR TITLE
fix(l2): properly restore context in payload_builder

### DIFF
--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -8,7 +8,7 @@ use ethrex_blockchain::{
     },
 };
 use ethrex_common::{
-    Address,
+    Address, U256,
     types::{Block, Receipt, SAFE_BYTES_PER_BLOB, Transaction, TxType},
 };
 use ethrex_l2_common::l1_messages::get_block_l1_messages;
@@ -190,6 +190,10 @@ pub async fn fill_transactions(
             }
         }
 
+        // Copy remaining gas and block value beforeexecuting the transact ion
+        let previous_remaining_gas = context.remaining_gas;
+        let previous_block_value = context.block_value;
+
         // Execute tx
         let receipt = match apply_plain_transaction(&head_tx, context) {
             Ok(receipt) => receipt,
@@ -218,8 +222,7 @@ pub async fn fill_transactions(
             txs.pop();
 
             // This transaction state change is too big, we need to undo it.
-            context.vm.undo_last_tx()?;
-
+            undo_last_tx(context, previous_remaining_gas, previous_block_value)?;
             continue;
         }
 
@@ -435,4 +438,15 @@ fn calculate_tx_diff_size(
 
 fn is_privileged_tx(tx: &Transaction) -> bool {
     matches!(tx, Transaction::PrivilegedL2Transaction(_tx))
+}
+
+fn undo_last_tx(
+    context: &mut PayloadBuildContext,
+    previous_remaining_gas: u64,
+    previous_block_value: U256,
+) -> Result<(), BlockProducerError> {
+    context.vm.undo_last_tx()?;
+    context.remaining_gas = previous_remaining_gas;
+    context.block_value = previous_block_value;
+    Ok(())
 }

--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -190,7 +190,7 @@ pub async fn fill_transactions(
             }
         }
 
-        // Copy remaining gas and block value beforeexecuting the transact ion
+        // Copy remaining gas and block value before executing the transaction
         let previous_remaining_gas = context.remaining_gas;
         let previous_block_value = context.block_value;
 


### PR DESCRIPTION
**Motivation**

We have a bug in our `payload_builder` when filling transactions into a block, which appears later during the block validation process of the `prover`:


```
2025-09-01T18:27:49.421092Z ERROR ethrex_prover_lib::prover: Gas validation error: Invalid Block: Gas used doesn't match value in header. Used: 46011000, Expected: 50064000 endpoint=tcp://127.0.0.1:3900
```

#### What is it about?

After executing a transaction, if the block’s `stateDiff` size exceeds the maximum allowed, we restore the `vm.context`, reverting the account updates generated by the transaction.  
The problem is that we should also update `context.remaining_gas` and `context.block_value` as well.

#### Why haven’t we seen the error before?

There is an `if` check that prevents the error from appearing in our daily usage:


```Rust
// Check if we have enough space for the StateDiff to run more transactions
if acc_size_without_accounts + size_accounts_diffs + SIMPLE_TX_STATE_DIFF_SIZE
> safe_bytes_per_blob {
	warn!("No more StateDiff space to run transactions");
	break;
};
```

This is an early return that checks if we have enough space for a simple transfer, and stops adding transactions to the block if we don’t.  
However, it can also happen that we have enough space for a simple transfer, but the transaction we are trying to add occupies more space than that, making us restore the previous state.

#### How to trigger the error

The easiest way to trigger the error is to comment out the early return, allowing the `payload_builder` to attempt restoring the previous state.  
Then start the `L2` and `prover` with:

```
make init
make init-prover
```

and run a load test with:
```
cargo run --release --manifest-path ./tooling/load_test/Cargo.toml -- -k ./fixtures/keys/private_keys_l1.txt -t eth-transfers -n "http://localhost:1729"
```


**Description**

This PR updates the `paylaod_builder` to restore the `remaining_gas` and the `block_value` If the `stateDiff` size exceeds the maximum allowed after executing a transaction.

Issue #4243 was created to add an integration test covering this case.

Closes None

