### PR TITLE
chore(l1): only validate trie in debug mode

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1069,7 +1069,7 @@ impl Syncer {
             )
             .await;
         }
-        
+
         debug_assert!(validate_state_root(store.clone(), pivot_header.state_root).await);
         debug_assert!(validate_storage_root(store.clone(), pivot_header.state_root).await);
         info!("Finished healing");


### PR DESCRIPTION
**Motivation**

Currently, we reconstruct the whole state and storage tries as a validation. This is very expensive, taking several hours on mainnet.

**Description**

This moves the validations to a debug_assert, so they are only executed in debug mode.


