### PR TITLE
chore(l1): remove old comments and code

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -128,11 +128,6 @@ async fn ask_peer_head_number(
                 Ok(sync_head_number)
             } else {
                 Err(PeerHandlerError::UnexpectedResponseFromPeer(peer_id))
-                // TODO merge:
-                //Err(format!(
-                //    "Received unexpected response from peer {peer_id}. We expected id {request_id}, and we got {id} and we received {} block headers",
-                //    block_headers.len()
-                //))
             }
         }
         Ok(None) => Err(PeerHandlerError::ReceiveMessageFromPeer(peer_id)),
@@ -1132,8 +1127,6 @@ impl PeerHandler {
                 tx.send((Vec::new(), free_peer_id, Some((chunk_start, chunk_end))))
                     .await
                     .ok();
-                // Too spammy
-                // tracing::error!("Received empty account range");
                 return Ok(());
             }
             // Unzip & validate response
@@ -1347,17 +1340,6 @@ impl PeerHandler {
                     free_peer_id = *peer_id;
                 }
             }
-
-            // let peer_id_score = scores.get(&free_peer_id).unwrap_or(&0);
-
-            // let mut score_values : Vec<i64> = Vec::from_iter(scores.values().cloned());
-            // score_values.sort();
-
-            // let middle_value = score_values.get(score_values.len() / 2).unwrap_or(&0);
-
-            // if (*peer_id_score < 0) && (*peer_id_score < *middle_value) {
-            //     continue;
-            // }
 
             let Some(free_downloader_channels) =
                 peer_channels.iter().find_map(|(peer_id, peer_channels)| {
@@ -1602,13 +1584,6 @@ impl PeerHandler {
                 .elapsed()
                 .unwrap_or(Duration::from_secs(1));
 
-            /*             if new_last_metrics_update >= Duration::from_secs(1) {
-                *METRICS.storages_downloads_tasks_queued.lock().await =
-                    tasks_queue_not_started.len() as u64;
-                *METRICS.total_storages_downloaders.lock().await = downloaders.len() as u64;
-                *METRICS.downloaded_storage_tries.lock().await = *downloaded_count;
-            } */
-
             if let Ok(result) = task_receiver.try_recv() {
                 let StorageTaskResult {
                     start_index,
@@ -1725,12 +1700,6 @@ impl PeerHandler {
                 if *peer_score < 10 {
                     *peer_score += 1;
                 }
-
-                /*                 *downloaded_count += account_storages.len() as u64;
-                // If we didn't finish downloading the account, don't count it
-                if !hash_start.is_zero() {
-                    *downloaded_count -= 1;
-                } */
 
                 let n_storages = account_storages.len();
                 let n_slots = account_storages
@@ -1886,12 +1855,6 @@ impl PeerHandler {
             std::fs::write(path, snapshot)
                 .map_err(|_| PeerHandlerError::WriteStorageSnapshotsDir(chunk_index))?;
         }
-
-        /*         *METRICS.storages_downloads_tasks_queued.lock().await =
-            tasks_queue_not_started.len() as u64;
-        *METRICS.total_storages_downloaders.lock().await = downloaders.len() as u64;
-        *METRICS.downloaded_storage_tries.lock().await = *downloaded_count;
-        *METRICS.free_storages_downloaders.lock().await = downloaders.len() as u64; */
         disk_joinset
             .join_all()
             .await

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -811,16 +811,6 @@ impl Syncer {
                 .await?;
             info!("Finish downloading account ranges from peers");
 
-            /*             let storage_tries_to_download = get_number_of_storage_tries_to_download().await?;
-            *METRICS.storage_tries_to_download.lock().await = storage_tries_to_download;
-            let mut downloaded_account_storages = 0;
-
-            METRICS
-                .storage_tries_download_start_time
-                .lock()
-                .await
-                .replace(SystemTime::now()); */
-
             // We read the account leafs from the files in account_state_snapshots_dir, write it into
             // the trie to compute the nodes and stores the accounts with storages for later use
             let mut computed_state_root = *EMPTY_TRIE_HASH;
@@ -873,19 +863,6 @@ impl Syncer {
                 "Finished inserting account ranges, total storage accounts: {}",
                 storage_accounts.accounts_with_storage_root.len()
             );
-
-            /*             METRICS
-                .storage_tries_download_end_time
-                .lock()
-                .await
-                .replace(SystemTime::now());
-            info!("Starting to compute the state root...");
-
-            let account_store_start = Instant::now(); */
-
-            /*             *METRICS.account_tries_state_root.lock().await = Some(computed_state_root);
-
-            let account_store_time = Instant::now().saturating_duration_since(account_store_start); */
 
             info!("Original state root: {state_root:?}");
             info!("Computed state root after request_account_rages: {computed_state_root:?}");
@@ -943,17 +920,6 @@ impl Syncer {
             }
             info!("Finished request_storage_ranges");
 
-            /*             let storages_store_start = Instant::now();
-
-            METRICS
-                .storage_tries_state_roots_start_time
-                .lock()
-                .await
-                .replace(SystemTime::now());
-
-            *METRICS.storage_tries_state_roots_to_compute.lock().await =
-                downloaded_account_storages; */
-
             let maybe_big_account_storage_state_roots: Arc<Mutex<HashMap<H256, H256>>> =
                 Arc::new(Mutex::new(HashMap::new()));
 
@@ -1006,33 +972,7 @@ impl Syncer {
                     .write_storage_trie_nodes_batch(storage_trie_node_changes)
                     .await?;
             }
-            info!("Finished writing to db");
 
-            for (account_hash, computed_storage_root) in maybe_big_account_storage_state_roots
-                .lock()
-                .map_err(|_| SyncError::MaybeBigAccount)?
-                .iter()
-            {
-                let account_state = store
-                    .get_account_state_by_acc_hash(pivot_header.hash(), *account_hash)?
-                    .ok_or(SyncError::AccountState(pivot_header.hash(), *account_hash))?;
-
-                if *computed_storage_root != account_state.storage_root {
-                    debug!(
-                        "Incomplete or incorrect download for account hash {:?}, expected: {:?}, computed: {:?}",
-                        *account_hash, account_state.storage_root, *computed_storage_root,
-                    );
-                }
-            }
-            /*
-            METRICS
-                .storage_tries_state_roots_end_time
-                .lock()
-                .await
-                .replace(SystemTime::now());
-
-            let storages_store_time =
-                Instant::now().saturating_duration_since(storages_store_start); */
             info!("Finished storing storage tries");
         }
 
@@ -1351,9 +1291,7 @@ pub async fn validate_storage_root(store: Store, state_root: H256) {
             );
 
         let tree_validated = account_state.storage_root == computed_storage_root;
-        if tree_validated {
-            //info!("Succesfully validated tree, {computed_storage_root} found");
-        } else {
+        if !tree_validated {
             error!(
                 "We have failed the validation of the storage tree {} expected but {computed_storage_root} found",
                 account_state.storage_root

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -88,14 +88,6 @@ async fn heal_state_trie(
     mut membatch: HashMap<Nibbles, MembatchEntryValue>,
     storage_accounts: &mut AccountStorageRoots,
 ) -> Result<bool, SyncError> {
-    // TODO:
-    // Spawn a bytecode fetcher for this block
-    // let (bytecode_sender, bytecode_receiver) = channel::<Vec<H256>>(MAX_CHANNEL_MESSAGES);
-    // let bytecode_fetcher_handle = tokio::spawn(bytecode_fetcher(
-    //     bytecode_receiver,
-    //     peers.clone(),
-    //     store.clone(),
-    // ));
     // Add the current state trie root to the pending paths
     let mut paths: Vec<RequestMetadata> = vec![RequestMetadata {
         hash: state_root,


### PR DESCRIPTION
**Motivation**

During snapsync development we left old code and comments.

**Description**

Removes old comments and a useless "validation" on big accounts, which is pointless because errors are expected (hence why healing is needed).

