### PR TITLE
feat(l1): improve syncing helper function update_pivot

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1023,9 +1023,14 @@ impl PeerHandler {
 
             if block_is_stale(pivot_header) {
                 info!("request_account_range became stale, updating pivot");
-                *pivot_header = update_pivot(pivot_header.clone(), self, block_sync_state)
-                    .await
-                    .expect("Should be able to update pivot")
+                *pivot_header = update_pivot(
+                    pivot_header.number,
+                    pivot_header.timestamp,
+                    self,
+                    block_sync_state,
+                )
+                .await
+                .expect("Should be able to update pivot")
             }
 
             tokio::spawn(PeerHandler::request_account_range_worker(


### PR DESCRIPTION
**Motivation**
The current update_pivot funciton in crates/networking/p2p/sync.rs has several room for improvement, primarily in the logic.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
The function now estimates the new block number based on the block timestamp
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/4261

