### PR TITLE
ci(l1): fix daily hive report.

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Set custom hive flags
         run: |
           if [[ "${{ matrix.test.simulation }}" == "ethereum/eest/consume-engine" || "${{ matrix.test.simulation }}" == "ethereum/eest/consume-rlp" ]]; then
-            EEST_FIXTURES=$(cat tooling/ef_tests/blockchain/.fixtures_url)
+            EEST_FIXTURES="https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_develop.tar.gz"
             EEST_BRANCH=main
             echo 'HIVE_FLAGS=--sim.buildarg fixtures='"$EEST_FIXTURES"' --sim.buildarg branch='"$EEST_BRANCH"' --sim.limit ".*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*"' >> $GITHUB_ENV
           fi

--- a/tooling/hive_report/src/main.rs
+++ b/tooling/hive_report/src/main.rs
@@ -32,9 +32,6 @@ struct HiveResult {
 
 impl HiveResult {
     fn new(suite: String, fork: String, passed_tests: usize, total_tests: usize) -> Self {
-        // Mark as 100% if result is NaN
-        let success_percentage = ((passed_tests as f64 / total_tests as f64) * 100.0).max(100.0);
-
         let (category, display_name) = match suite.as_str() {
             "engine-api" => ("Engine", "Paris"),
             "engine-auth" => ("Engine", "Auth"),
@@ -52,6 +49,12 @@ impl HiveResult {
                 eprintln!("Warn: Unknown suite: {other}. Skipping");
                 ("", "")
             }
+        };
+
+        let success_percentage = if total_tests == 0 {
+            0.0
+        } else {
+            (passed_tests as f64 / total_tests as f64) * 100.0
         };
 
         HiveResult {


### PR DESCRIPTION
**Motivation**
Daily Hive report is broken

**Description**
- Fixes edge case where there are zero tests of a suite
- Revert back to stable Pectra release since the Osaka devnets only have osaka tests.


