### PR TITLE
fix(l1): filter empty tries in storage healing

### DIFF
--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -532,6 +532,9 @@ fn get_initial_downloads(
                     .expect("We should be able to open the store")
                     .expect("This account should exist in the trie");
                 let account = AccountState::decode(&rlp).expect("We should have a valid account");
+                if account.storage_root == *EMPTY_TRIE_HASH {
+                    return None;
+                }
                 if store
                     .contains_storage_node(*acc_path, account.storage_root)
                     .expect("We should be able to open the store")


### PR DESCRIPTION
**Motivation**

Currently, we don't filter accounts that go from having storage to having an empty trie. This causes storage healing to get stuck with a log like:

```
2025-09-03T12:47:36.412558Z  INFO ethrex_p2p::sync::storage_healing: this peer 0x062b…6972 request NodeRequest { acc_path: Nibbles { data: [1, 8, 11, 9, 5, 12, 15, 10, 0, 5, 15, 2, 12, 9, 14, 12, 0, 6, 2, 0, 11, 11, 8, 6, 2, 6, 15, 3, 6, 9, 4, 12, 0, 2, 9, 5, 10, 4, 6, 10, 3, 3, 15, 12, 0, 5, 9, 2, 9, 0, 10, 11, 14, 0, 15, 1, 4, 2, 6, 15, 10, 11, 12, 13, 16] }, storage_path: Nibbles { data: [] }, parent: Nibbles { data: [] }, hash: 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421 }, had this error InvalidLength, and the raw node was b""
```

(0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421 is the empty trie hash)

**Description**

This filters accounts with an empty trie as the storage root.
