### PR TITLE
add first possible fix

### DIFF
--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -366,9 +366,16 @@ impl ExecutionWitnessResult {
         }
         match self.codes.get(&code_hash) {
             Some(code) => Ok(code.clone()),
-            None => Err(ExecutionWitnessError::Database(format!(
-                "Could not find code for hash {code_hash}"
-            ))),
+            None => {
+                // We do this because what usually happens is that the Witness doesn't have the code we asked for but it is because it isn't relevant for that particular case.
+                // In client implementations there are differences and it's natural for some clients to access more/less information in some edge cases.
+                // Sidenote: logger doesn't work inside SP1, that's why we use println!
+                println!(
+                    "Missing bytecode for hash {} in witness. Defaulting to empty code.", // If there's a state root mismatch and this prints we have to see if it's the cause or not.
+                    hex::encode(code_hash)
+                );
+                Ok(Bytes::new())
+            }
         }
     }
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Different execution clients access state at different times, one can access code of an account before a particular validation and the other one can access it later. In the case in which the validation failed, the latter client will generate a witness without the code whereas the former will actually need that code.
  - A possible fix would be to access data ONLY when we are 100% sure that we are going to use it. But this would mean making the code uglier in order to fix this, which is probably not worth it.
  - The fix that I propose here is to assume that the witness is correct and return a default value when it wasn't found in it, because it would mean that it isn't relevant for execution. We also print a warning alongside this for debugging purposes if there's a state root mismatch.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

