### PR TITLE
fix(l2): grafana for macos

### DIFF
--- a/metrics/docker-compose-metrics-l2.overrides.yaml
+++ b/metrics/docker-compose-metrics-l2.overrides.yaml
@@ -5,7 +5,7 @@ services:
     ports:
       - "9092:9090"
     extra_hosts:
-      - "host.docker.internal:172.17.0.1"
+      - "host.docker.internal:host-gateway"
   grafana:
     ports:
       - "3802:3000"


### PR DESCRIPTION
**Motivation**

Our Grafana dashboards are not showing data when running the node on macos because the Linux bridge address is hardcoded in the Prometheus container.
 
**Description**

- Use the `host-gateway` feature instead.

Closes None

