### PR TITLE
chore(l1): change bytecode fetching log to debug

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1442,7 +1442,7 @@ impl PeerHandler {
                     };
                     tx.send(result).await.ok();
                 } else {
-                    tracing::error!("Failed to get bytecode");
+                    tracing::debug!("Failed to get bytecode");
                     tx.send(empty_task_result).await.ok();
                 }
             });


### PR DESCRIPTION
**Motivation**

The "Failed to get bytecode" log is expected to happen sometimes (the peer might not have the bytecode), we shouldn't log it as an error.

**Description**

Changes the log to debug.
