### PR TITLE
feat(l1): [EIP-7825] Set gas limit cap for txt and block validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ run-hive-debug: build-image setup-hive ## 🐞 Run Hive testing suite in debug m
 	cd hive && ./hive --sim $(SIMULATION) --client-file $(HIVE_CLIENT_FILE)  --client ethrex --sim.loglevel 4 --sim.limit "$(TEST_PATTERN)" --sim.parallelism "$(SIM_PARALLELISM)" --docker.output
 
 # EEST Hive
-TEST_PATTERN_EEST ?= .*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*
+TEST_PATTERN_EEST ?= .*fork_Paris.*|.*fork_Shanghai.*|.*fork_Cancun.*|.*fork_Prague.*|.*fork_Osaka.*
 run-hive-eest: build-image setup-hive ## 🧪 Generic command for running Hive EEST tests. Specify EEST_SIM
 	- cd hive && ./hive --client-file $(HIVE_CLIENT_FILE) --client ethrex --sim $(EEST_SIM) --sim.limit "$(TEST_PATTERN_EEST)" --sim.parallelism $(SIM_PARALLELISM) --sim.loglevel $(SIM_LOG_LEVEL) --sim.buildarg fixtures=$(shell cat tooling/ef_tests/blockchain/.fixtures_url)
 

--- a/crates/blockchain/constants.rs
+++ b/crates/blockchain/constants.rs
@@ -44,3 +44,5 @@ pub const TX_DATA_NON_ZERO_GAS_EIP2028: u64 = 16;
 pub const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 
 pub const MIN_GAS_LIMIT: u64 = 5000;
+
+pub const OSAKA_MAX_GAS_LIMIT: u64 = 16777216;

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -80,6 +80,8 @@ pub enum MempoolError {
     TxMaxDataSizeError,
     #[error("Transaction gas limit exceeded")]
     TxGasLimitExceededError,
+    #[error("Transaction gas max limit exceeded for Osaka")]
+    TxMaxGasLimitExceededError,
     #[error("Transaction priority fee above gas fee")]
     TxGasOverflowError,
     #[error("Transaction intrinsic gas overflow")]


### PR DESCRIPTION
**Motivation**

Implement EIP-7825 for Osaka fork.

**Description**

This pr introduces the limit cap of 16,777,216 gas (2^24) for individual transactions, as indicated in the [EIP-7825](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7825.md).

Closes #4154 

