### PR TITLE
feat(l1): chunk the download of headers

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -46,6 +46,8 @@ pub const REQUEST_RETRY_ATTEMPTS: u32 = 5;
 pub const MAX_RESPONSE_BYTES: u64 = 512 * 1024;
 pub const HASH_MAX: H256 = H256([0xFF; 32]);
 
+pub const MAX_HEADER_CHUNK: u64 = 500_000;
+
 pub const SNAP_LIMIT: usize = 128;
 
 // Request as many as 128 block bodies per request
@@ -261,6 +263,7 @@ impl PeerHandler {
 
             retries += 1;
         }
+        sync_head_number = sync_head_number.min(start + MAX_HEADER_CHUNK);
 
         let sync_head_number_retrieval_elapsed = sync_head_number_retrieval_start
             .elapsed()

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -167,7 +167,7 @@ impl Syncer {
         // This applies only to snap sync—full sync always starts fetching headers
         // from the canonical block, which updates as new block headers are fetched.
         let mut current_head = block_sync_state.get_current_head().await?;
-        let current_head_number = store
+        let mut current_head_number = store
             .get_block_number(current_head)
             .await?
             .ok_or(SyncError::BlockNumber(current_head))?;
@@ -245,6 +245,7 @@ impl Syncer {
 
             // Update current fetch head
             current_head = last_block_hash;
+            current_head_number = last_block_number;
 
             // If the sync head is less than 64 blocks away from our current head switch to full-sync
             if sync_mode == SyncMode::Snap && sync_head_found {
@@ -310,7 +311,7 @@ impl Syncer {
         // This applies only to snap sync—full sync always starts fetching headers
         // from the canonical block, which updates as new block headers are fetched.
         let mut current_head = block_sync_state.get_current_head().await?;
-        let current_head_number = store
+        let mut current_head_number = store
             .get_block_number(current_head)
             .await?
             .ok_or(SyncError::BlockNumber(current_head))?;
@@ -396,6 +397,7 @@ impl Syncer {
 
             // Update current fetch head
             current_head = last_block_hash;
+            current_head_number = last_block_number;
 
             // Discard the first header as we already have it
             block_headers.remove(0);


### PR DESCRIPTION
**Motivation**

For large networks such as mainnet, downloading all the headers at once causes high RAM usage since the headers are kept in memory until they're all downloaded.

**Description**

We download them in batches (of 500k, should use ~300MB). Since the sync head number is not known in the main sync loop, the cut is made in the header fetching function.
