### PR TITLE
feat(l1,l2): enable log levels update in runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,6 +4138,7 @@ dependencies = [
  "tokio",
  "tower-http 0.6.6",
  "tracing",
+ "tracing-subscriber 0.3.19",
  "url",
 ]
 

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -333,7 +333,9 @@ impl Subcommand {
         // L2 has its own init_tracing because of the ethrex monitor
         match self {
             Self::L2(_) => {}
-            _ => init_tracing(opts),
+            _ => {
+                init_tracing(opts);
+            }
         }
         match self {
             Subcommand::RemoveDB { datadir, force } => {

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -37,9 +37,10 @@ async fn main() -> eyre::Result<()> {
         return subcommand.run(&opts).await;
     }
 
-    init_tracing(&opts);
+    let log_filter_handler = init_tracing(&opts);
 
-    let (data_dir, cancel_token, peer_table, local_node_record) = init_l1(opts).await?;
+    let (data_dir, cancel_token, peer_table, local_node_record) =
+        init_l1(opts, Some(log_filter_handler)).await?;
 
     let mut signal_terminate = signal(SignalKind::terminate())?;
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -135,6 +135,7 @@ pub async fn init_rpc_api(
     blockchain: Arc<Blockchain>,
     cancel_token: CancellationToken,
     tracker: TaskTracker,
+    log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
 ) {
     let peer_handler = PeerHandler::new(peer_table);
 
@@ -160,6 +161,7 @@ pub async fn init_rpc_api(
         syncer,
         peer_handler,
         get_client_version(),
+        log_filter_handler,
     );
 
     tracker.spawn(rpc_api);
@@ -375,6 +377,7 @@ async fn set_sync_block(store: &Store) {
 
 pub async fn init_l1(
     opts: Options,
+    log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
 ) -> eyre::Result<(String, CancellationToken, Kademlia, Arc<Mutex<NodeRecord>>)> {
     let data_dir = init_datadir(&opts.datadir);
 
@@ -415,6 +418,7 @@ pub async fn init_l1(
         blockchain.clone(),
         cancel_token.clone(),
         tracker.clone(),
+        log_filter_handler,
     )
     .await;
 

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -64,7 +64,7 @@ impl L2Command {
 
         let matches = app.try_get_matches_from(args_with_program)?;
         let init_options = Options::from_arg_matches(&matches)?;
-        l2::init_tracing(&init_options);
+        let log_filter_handler = l2::init_tracing(&init_options);
         let mut l2_options = init_options;
 
         if l2_options.node_opts.dev {
@@ -89,7 +89,7 @@ impl L2Command {
                 Some(contract_addresses.bridge_address);
             println!("Initializing L2");
         }
-        l2::init_l2(l2_options).await?;
+        l2::init_l2(l2_options, log_filter_handler).await?;
         Ok(())
     }
 }
@@ -186,7 +186,7 @@ impl Command {
                 ..Default::default()
             }),
             _ => init_tracing(&crate::cli::Options::default()),
-        }
+        };
 
         match self {
             Command::Prover {

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -72,7 +72,11 @@ impl L2Command {
             remove_db(DB_ETHREX_DEV_L1, true);
             remove_db(DB_ETHREX_DEV_L2, true);
             println!("Initializing L1");
-            init_l1(crate::cli::Options::default_l1()).await?;
+            init_l1(
+                crate::cli::Options::default_l1(),
+                log_filter_handler.clone(),
+            )
+            .await?;
             println!("Deploying contracts...");
             let contract_addresses =
                 l2::deployer::deploy_l1_contracts(l2::deployer::DeployerOptions::default()).await?;

--- a/crates/l2/networking/rpc/Cargo.toml
+++ b/crates/l2/networking/rpc/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0.117"
 tokio = { workspace = true, features = ["full"] }
 bytes.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 thiserror.workspace = true
 secp256k1.workspace = true
 keccak-hash.workspace = true

--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -28,6 +28,7 @@ use std::{
 use tokio::{net::TcpListener, sync::Mutex as TokioMutex};
 use tower_http::cors::CorsLayer;
 use tracing::{debug, info};
+use tracing_subscriber::{EnvFilter, Registry, reload};
 
 use crate::l2::transaction::SponsoredTx;
 use ethrex_common::Address;
@@ -76,6 +77,7 @@ pub async fn start_api(
     valid_delegation_addresses: Vec<Address>,
     sponsor_pk: SecretKey,
     rollup_store: StoreRollup,
+    log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
 ) -> Result<(), RpcErr> {
     // TODO: Refactor how filters are handled,
     // filters are used by the filters endpoints (eth_newFilter, eth_getFilterChanges, ...etc)
@@ -94,6 +96,7 @@ pub async fn start_api(
                 client_version,
             },
             gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
+            log_filter_handler,
         },
         valid_delegation_addresses,
         sponsor_pk,

--- a/crates/networking/rpc/admin/mod.rs
+++ b/crates/networking/rpc/admin/mod.rs
@@ -72,7 +72,7 @@ pub async fn set_log_level(
         .clone()
         .ok_or(RpcErr::MissingParam("log level".to_string()))?;
     let log_level = params
-        .get(0)
+        .first()
         .ok_or(RpcErr::MissingParam("log level".to_string()))?
         .as_str()
         .ok_or(RpcErr::WrongParam("Expected string".to_string()))?;

--- a/crates/networking/rpc/admin/mod.rs
+++ b/crates/networking/rpc/admin/mod.rs
@@ -3,8 +3,12 @@ use ethrex_storage::Store;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing_subscriber::{EnvFilter, Registry, reload};
 
-use crate::{rpc::NodeData, utils::RpcErr};
+use crate::{
+    rpc::NodeData,
+    utils::{RpcErr, RpcRequest},
+};
 mod peers;
 pub use peers::peers;
 
@@ -57,4 +61,33 @@ pub fn node_info(storage: Store, node_data: &NodeData) -> Result<Value, RpcErr> 
         protocols,
     };
     serde_json::to_value(node_info).map_err(|error| RpcErr::Internal(error.to_string()))
+}
+
+pub async fn set_log_level(
+    req: &RpcRequest,
+    log_filter_handler: &Option<reload::Handle<EnvFilter, Registry>>,
+) -> Result<Value, RpcErr> {
+    let params = req
+        .params
+        .clone()
+        .ok_or(RpcErr::MissingParam("log level".to_string()))?;
+    let log_level = params
+        .get(0)
+        .ok_or(RpcErr::MissingParam("log level".to_string()))?
+        .as_str()
+        .ok_or(RpcErr::WrongParam("Expected string".to_string()))?;
+
+    let filter = EnvFilter::try_new(log_level)
+        .map_err(|_| RpcErr::BadParams(format!("Cannot parse {log_level} as a log directive")))?;
+
+    if let Some(handle) = log_filter_handler {
+        handle
+            .reload(filter)
+            .map_err(|e| RpcErr::Internal(format!("Failed to reload log filter: {}", e)))?;
+        Ok(Value::Bool(true))
+    } else {
+        Err(RpcErr::Internal(
+            "Log filter handler not available".to_string(),
+        ))
+    }
 }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -127,6 +127,7 @@ pub async fn start_api(
     syncer: SyncManager,
     peer_handler: PeerHandler,
     client_version: String,
+    log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
 ) -> Result<(), RpcErr> {
     // TODO: Refactor how filters are handled,
     // filters are used by the filters endpoints (eth_newFilter, eth_getFilterChanges, ...etc)
@@ -144,8 +145,7 @@ pub async fn start_api(
             client_version,
         },
         gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
-        // TODO: CHANGE
-        log_filter_handler: None,
+        log_filter_handler,
     };
 
     // Periodically clean up the active filters for the filters endpoints.

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -414,6 +414,7 @@ pub mod test_utils {
                 client_version: "ethrex/test".to_string(),
             },
             gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
+            log_filter_handler: None,
         }
     }
 }

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -393,6 +393,7 @@ pub mod test_utils {
             SyncManager::dummy(),
             PeerHandler::dummy(),
             "ethrex/test".to_string(),
+            None,
         )
         .await
         .unwrap();


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Sometimes we want to change the log level, primarly for debugging, and restarting the node would break the case of study.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Add a custom `admin_setLogLevel` endpoint that enables the node operator to specify a new log filter, just like with `RUST_LOG`.

How to test:
1. Run a node (e.g. `ethrex --dev`)
2. Change the log levels:
    ```
    curl localhost:8545 -H 'content-type: application/json' -d '{"jsonrpc": "2.0", "id": "1", "method": "admin_setLogLevel", "params": ["ethrex_dev::block_producer=info"]}'
     ```
3. You should now only see `ethrex_dev::block_producer` logs

> [!WARNING]
> The `admin` namespace is currently unauthenticated and cannot be turned off. Be aware of this in public nodes

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #4299 

