### PR TITLE
feat(l2): change the block timestamp precision to ms

### DIFF
--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -110,6 +110,10 @@ impl BlockProducer {
         };
         let head_hash = head_header.hash();
         let head_beacon_block_root = H256::zero();
+        let timestamp: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .try_into()?;
 
         // The proposer leverages the execution payload framework used for the engine API,
         // but avoids calling the API methods and unnecesary re-execution.
@@ -120,7 +124,7 @@ impl BlockProducer {
         // Proposer creates a new payload
         let args = BuildPayloadArgs {
             parent: head_hash,
-            timestamp: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+            timestamp,
             fee_recipient: self.coinbase_address,
             random: H256::zero(),
             withdrawals: Default::default(),


### PR DESCRIPTION
**Motivation**
With the current timestamp precision, we cannot have sub-second block time. We understand that block time on L1 needs to be compatible with Ethereum spec, but in L2 land there are lots of chains aiming for sub-second block time mainly because of interactivity in the applications.

**Description**
Change the block timestamp precision from second to millisecond to allow sub-second block time.

Closes none
