### PR TITLE
feat(l1): add max blobs per tx check (Osaka EIP-7594)

### DIFF
--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -55,6 +55,8 @@ pub const BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE: u64 = 5007716; // Defined in [EI
 // is. Use the `max_blobs_per_block` function instead
 pub const MAX_BLOB_COUNT: u32 = 6;
 pub const MAX_BLOB_COUNT_ELECTRA: u32 = 9;
+// Max blob count per tx (introduced by Osaka fork)
+pub const MAX_BLOB_COUNT_TX: usize = 6;
 
 pub const VALID_BLOB_PREFIXES: [u8; 2] = [0x01, 0x02];
 

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -91,7 +91,7 @@ impl EVMConfig {
     }
 
     fn max_blobs_per_block(fork: Fork) -> u32 {
-        if fork == Fork::Prague {
+        if fork >= Fork::Prague {
             MAX_BLOB_COUNT_ELECTRA
         } else {
             MAX_BLOB_COUNT

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -91,7 +91,7 @@ impl EVMConfig {
     }
 
     fn max_blobs_per_block(fork: Fork) -> u32 {
-        if fork >= Fork::Prague {
+        if fork == Fork::Prague {
             MAX_BLOB_COUNT_ELECTRA
         } else {
             MAX_BLOB_COUNT

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -317,20 +317,15 @@ pub fn validate_4844_tx(vm: &mut VM<'_>) -> Result<(), VMError> {
     }
 
     // (14) TYPE_3_TX_BLOB_COUNT_EXCEEDED
-    let max_blob_count = vm
-        .env
-        .config
-        .blob_schedule
-        .max
-        .try_into()
-        .map_err(|_| InternalError::TypeConversion)?;
-    let blob_count = blob_hashes.len();
-    if blob_count > max_blob_count {
-        return Err(TxValidationError::Type3TxBlobCountExceeded {
-            max_blob_count,
-            actual_blob_count: blob_count,
+    if vm.env.config.fork >= Fork::Osaka {
+        let blob_count = blob_hashes.len();
+        if blob_count > MAX_BLOB_COUNT as usize {
+            return Err(TxValidationError::Type3TxBlobCountExceeded {
+                max_blob_count: MAX_BLOB_COUNT as usize,
+                actual_blob_count: blob_count,
+            }
+            .into());
         }
-        .into());
     }
 
     // (15) TYPE_3_TX_CONTRACT_CREATION

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -319,9 +319,9 @@ pub fn validate_4844_tx(vm: &mut VM<'_>) -> Result<(), VMError> {
     // (14) TYPE_3_TX_BLOB_COUNT_EXCEEDED
     if vm.env.config.fork >= Fork::Osaka {
         let blob_count = blob_hashes.len();
-        if blob_count > MAX_BLOB_COUNT as usize {
+        if blob_count > MAX_BLOB_COUNT_TX {
             return Err(TxValidationError::Type3TxBlobCountExceeded {
-                max_blob_count: MAX_BLOB_COUNT as usize,
+                max_blob_count: MAX_BLOB_COUNT_TX,
                 actual_blob_count: blob_count,
             }
             .into());

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -34,7 +34,7 @@ pub fn parse_and_execute(
     let tests = parse_tests(path);
     //Test with the Fusaka tests that should pass. TODO: Once we've implemented all the Fusaka EIPs this should be removed
     //EIPs should be added as strings in the format 'eip-XXXX'
-    let fusaka_eips_to_test: Vec<&str> = vec!["eip-7883", "eip-7939"];
+    let fusaka_eips_to_test: Vec<&str> = vec!["eip-7594", "eip-7883", "eip-7939"];
 
     //Hashes of any other tests to run, that don't correspond to an especific EIP (for examples, some integration tests)
     //We should really remove this once we're finished with implementing Fusaka, but it's a good-enough workaround to run specific tests for now

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -39,7 +39,7 @@ pub async fn run_ef_test(test: &EFTest) -> Result<EFTestReport, EFTestRunnerErro
 
     //Test with the Fusaka tests that should pass. TODO: Once we've implemented all the Fusaka EIPs this should be removed
     //EIPs should be added as strings in the format 'eip-XXXX'
-    let fusaka_eips_to_test: Vec<&str> = vec!["eip-7883", "eip-7939"];
+    let fusaka_eips_to_test: Vec<&str> = vec!["eip-7594", "eip-7883", "eip-7939"];
 
     //Names of any other tests to run, that don't correspond to an especific EIP (for examples, some integration tests)
     //We should really remove this once we're finished with implementing Fusaka, but it's a good-enough workaround to run specific tests for now

--- a/tooling/ef_tests/state_v2/src/modules/runner.rs
+++ b/tooling/ef_tests/state_v2/src/modules/runner.rs
@@ -45,7 +45,7 @@ pub async fn run_tests(tests: Vec<Test>) -> Result<(), RunnerError> {
 
     //Test with the Fusaka tests that should pass. TODO: Once we've implemented all the Fusaka EIPs this should be removed
     //EIPs should be added as strings in the format 'eip-XXXX'
-    let fusaka_eips_to_test: Vec<&str> = vec!["eip-7939", "eip-7883"];
+    let fusaka_eips_to_test: Vec<&str> = vec!["eip-7594", "eip-7939", "eip-7883"];
 
     for test in tests {
         let test_eip = test._info.clone().reference_spec.unwrap_or_default();


### PR DESCRIPTION
**Motivation**
Add the max blobs per tx check introduced by [EIP-7594](https://eips.ethereum.org/EIPS/eip-7594)
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add max blobs per tx check to levm pre check sequence
* Enable ef tests for eip-7594
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #4152 

