### PR TITLE
fix(l1): multiple connection to the same peer

### DIFF
--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -142,6 +142,12 @@ impl Kademlia {
         self.peers.lock().await.insert(new_peer_id, new_peer);
     }
 
+    /// Checks if a peer is connected.
+    pub async fn is_connected(&self, peer_id: &H256) -> bool {
+        let peers = self.peers.lock().await;
+        peers.contains_key(peer_id)
+    }
+
     pub async fn get_peer_channels(
         &self,
         _capabilities: &[Capability],

--- a/crates/networking/p2p/rlpx/initiator.rs
+++ b/crates/networking/p2p/rlpx/initiator.rs
@@ -68,7 +68,10 @@ impl RLPxInitiator {
 
         for contact in self.context.table.table.lock().await.values() {
             let node_id = contact.node.node_id();
-            if !already_tried_peers.contains(&node_id) && contact.knows_us {
+            if !already_tried_peers.contains(&node_id)
+                && contact.knows_us
+                && !self.context.table.is_connected(&node_id).await
+            {
                 already_tried_peers.insert(node_id);
 
                 RLPxConnection::spawn_as_initiator(self.context.clone(), &contact.node).await;


### PR DESCRIPTION
Signed-off-by: Sacha Froment <sfroment42@gmail.com>

**Motivation**
while trying to understand why I was seeing the same block being added multiple time I found that in look_for_peers we weren't checking if the peer was already connected or not
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Simply add a way to see if we are connected to the peer, and if not we try to connect other wise we do nothing

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

