### PR TITLE
refactor(l1):  remove unneeded usize casts

### DIFF
--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -116,7 +116,7 @@ impl BlobsBundle {
         let max_blobs = max_blobs_per_block(fork);
         let blob_count = self.blobs.len();
 
-        if blob_count > max_blobs as usize {
+        if blob_count > max_blobs {
             return Err(BlobsBundleError::MaxBlobsExceeded);
         }
 
@@ -196,10 +196,10 @@ impl AddAssign for BlobsBundle {
     }
 }
 
-const MAX_BLOB_COUNT: u64 = 6;
-const MAX_BLOB_COUNT_ELECTRA: u64 = 9;
+const MAX_BLOB_COUNT: usize = 6;
+const MAX_BLOB_COUNT_ELECTRA: usize = 9;
 
-fn max_blobs_per_block(fork: Fork) -> u64 {
+fn max_blobs_per_block(fork: Fork) -> usize {
     if fork >= Fork::Prague {
         MAX_BLOB_COUNT_ELECTRA
     } else {

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -51,7 +51,7 @@ pub const MAX_HEADER_CHUNK: u64 = 500_000;
 // How much we store in memory of request_account_range and request_storage_ranges
 // before we dump it into the file. This tunes how much memory ethrex uses during
 // the first steps of snap sync
-pub const RANGE_FILE_CHUNK_SIZE: u64 = 1024 * 1024 * 512; // 512MB
+pub const RANGE_FILE_CHUNK_SIZE: usize = 1024 * 1024 * 512; // 512MB
 pub const SNAP_LIMIT: usize = 128;
 
 // Request as many as 128 block bodies per request
@@ -844,9 +844,7 @@ impl PeerHandler {
         let mut chunk_file = 0;
 
         loop {
-            if all_accounts_state.len() * size_of::<AccountState>()
-                >= RANGE_FILE_CHUNK_SIZE as usize
-            {
+            if all_accounts_state.len() * size_of::<AccountState>() >= RANGE_FILE_CHUNK_SIZE {
                 let current_account_hashes = std::mem::take(&mut all_account_hashes);
                 let current_account_states = std::mem::take(&mut all_accounts_state);
 
@@ -1522,8 +1520,7 @@ impl PeerHandler {
             .collect::<Vec<_>>();
 
         loop {
-            if all_account_storages.iter().map(Vec::len).sum::<usize>() * 64
-                > RANGE_FILE_CHUNK_SIZE as usize
+            if all_account_storages.iter().map(Vec::len).sum::<usize>() * 64 > RANGE_FILE_CHUNK_SIZE
             {
                 let current_account_storages = std::mem::take(&mut all_account_storages);
                 all_account_storages =

--- a/crates/networking/rpc/authentication.rs
+++ b/crates/networking/rpc/authentication.rs
@@ -61,6 +61,6 @@ fn invalid_issued_at_claim(token_data: TokenData<Claims>) -> Result<bool, Authen
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|_| AuthenticationError::InvalidIssuedAtClaim)?
-        .as_secs() as usize;
-    Ok((now as isize - token_data.claims.iat as isize).abs() > 60)
+        .as_secs();
+    Ok((now as i64 - token_data.claims.iat as i64).abs() > 60)
 }

--- a/crates/networking/rpc/clients/auth/mod.rs
+++ b/crates/networking/rpc/clients/auth/mod.rs
@@ -158,7 +158,7 @@ impl EngineClient {
         // Header
         let header = jsonwebtoken::Header::default();
         // Claims
-        let valid_iat = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as usize;
+        let valid_iat = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
         let claims = json!({"iat": valid_iat});
         let encoding_key = jsonwebtoken::EncodingKey::from_secret(&self.secret);
         // JWT Token


### PR DESCRIPTION
**Motivation**
Remove cases where we using `as usize` to cast `u64` values when not needed
<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Contributes to #4081 

