### PR TITLE
feat(l2): increase metrics check interval to 5s

### DIFF
--- a/crates/l2/sequencer/metrics.rs
+++ b/crates/l2/sequencer/metrics.rs
@@ -46,7 +46,7 @@ impl MetricsGatherer {
             l2_eth_client,
             rollup_store,
             on_chain_proposer_address: committer_config.on_chain_proposer_address,
-            check_interval: Duration::from_millis(1000),
+            check_interval: Duration::from_millis(5000),
         })
     }
 

--- a/metrics/provisioning/prometheus/prometheus_l2.yaml
+++ b/metrics/provisioning/prometheus/prometheus_l2.yaml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 1s
+  scrape_interval: 5s
 
 scrape_configs:
   - job_name: "ethrex L2"


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Currently the L2 metrics gatherer component scraps data every 1s, including L1 data (gas price and last committed/verified batch). This consumes a lot of unnecessary resources.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Increase the check interval to 5 seconds

<!-- Link to issues: Resolves #111, Resolves #222 -->


