### PR TITLE
fix(l2): avoid updating last_block_fetched when getLogs fails

### DIFF
--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -167,13 +167,7 @@ impl L1Watcher {
                 self.address,
                 vec![topic],
             )
-            .await
-            .inspect_err(|error| {
-                // We may get an error if the RPC doesn't has the logs for the requested
-                // block interval. For example, Light Nodes.
-                warn!("Error when getting logs from L1: {}", error);
-            })
-            .unwrap_or_default();
+            .await?;
 
         debug!("Logs: {:#?}", logs);
 


### PR DESCRIPTION
**Motivation**

We are encountering the following error in our L2 integration tests:

```
2025-08-29T19:17:04.573865Z  WARN ethrex_l2::sequencer::l1_watcher: Error when getting logs from L1: eth_getLogs request error: Internal Error: Could not get receipt
```

Although this error is being addressed in #4346, our `l1_watcher` shouldn't simply log the error and update `last_block_fetched` as if it were already reviewed. We should retry since we might be missing some `privilegedTransactions`.

**Description**

- If `getLogs()` fails, return without updating `last_block_fetched`.


Closes None

