### PR TITLE
fix(l1): add RLP_INVALID_VALUE exception support

### DIFF
--- a/tooling/ef_tests/state/deserialize.rs
+++ b/tooling/ef_tests/state/deserialize.rs
@@ -56,6 +56,9 @@ where
                     "TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS" => {
                         TransactionExpectedException::InsufficientMaxFeePerGas
                     }
+                    "TransactionException.RLP_INVALID_VALUE" => {
+                        TransactionExpectedException::RlpInvalidValue
+                    }
                     "TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW" => {
                         TransactionExpectedException::GasLimitPriceProductOverflow
                     }

--- a/tooling/ef_tests/state_v2/src/modules/deserialize.rs
+++ b/tooling/ef_tests/state_v2/src/modules/deserialize.rs
@@ -53,6 +53,9 @@ where
                     "TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS" => {
                         TransactionExpectedException::InsufficientMaxFeePerGas
                     }
+                    "TransactionException.RLP_INVALID_VALUE" => {
+                        TransactionExpectedException::RlpInvalidValue
+                    }
                     "TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW" => {
                         TransactionExpectedException::GasLimitPriceProductOverflow
                     }


### PR DESCRIPTION
Add missing TransactionException.RLP_INVALID_VALUE case to deserialize_transaction_expected_exception function.

The RlpInvalidValue enum variant was already defined but not handled in the deserializer, causing these exceptions to fall through to the _other case.

reopen #3941 