### PR TITLE
fix(l1): fixed global storage slot metric

### DIFF
--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -169,7 +169,7 @@ pub async fn heal_storage_trie(
         if state.last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             METRICS
                 .global_storage_tries_leafs_healed
-                .fetch_add(*global_leafs_healed, Ordering::Relaxed);
+                .store(*global_leafs_healed, Ordering::Relaxed);
             METRICS
                 .healing_empty_try_recv
                 .store(state.empty_count as u64, Ordering::Relaxed);


### PR DESCRIPTION
**Motivation**

The global storage slots metrics was displaying a number way larger than expected.

**Description**

- Fixed bug where the global metrics counter was being added to itself multiple times.

