### PR TITLE
feat(l1, l2): add action button to EthProofs in `BlockRunReport` slack message

### DIFF
--- a/cmd/ethrex_replay/src/block_run_report.rs
+++ b/cmd/ethrex_replay/src/block_run_report.rs
@@ -89,102 +89,100 @@ impl BlockRunReport {
     }
 
     pub fn to_slack_message(&self) -> SlackWebHookRequest {
-        let eth_proofs_button = SlackWebHookBlock::Actions {
-            elements: vec![SlackWebHookActionElement::Button {
-                text: SlackWebHookBlock::PlainText {
-                    text: String::from("View on EthProofs"),
-                    emoji: false,
-                },
-                url: format!("https://ethproofs.org/blocks/{}", self.number),
-            }],
+        let eth_proofs_button = SlackWebHookActionElement::Button {
+            text: SlackWebHookBlock::PlainText {
+                text: String::from("View on EthProofs"),
+                emoji: false,
+            },
+            url: format!("https://ethproofs.org/blocks/{}", self.number),
         };
 
-        let mut slack_webhook_request_blocks = vec![
-            SlackWebHookBlock::Header {
-                text: Box::new(SlackWebHookBlock::PlainText {
-                    text: match (&self.run_result, &self.replayer_mode) {
-                        (Ok(_), ReplayerMode::Execute) => {
-                            String::from("✅ Successfully Executed Block")
-                        }
-                        (Ok(_), ReplayerMode::ExecuteSP1) => {
-                            String::from("✅ Successfully Executed Block with SP1")
-                        }
-                        (Ok(_), ReplayerMode::ExecuteRISC0) => {
-                            String::from("✅ Successfully Executed Block with RISC0")
-                        }
-                        (Ok(_), ReplayerMode::ProveSP1) => {
-                            String::from("✅ Successfully Proved Block with SP1")
-                        }
-                        (Ok(_), ReplayerMode::ProveRISC0) => {
-                            String::from("✅ Successfully Proved Block with RISC0")
-                        }
-                        (Err(_), ReplayerMode::Execute) => {
-                            String::from("⚠️ Failed to Execute Block")
-                        }
-                        (Err(_), ReplayerMode::ExecuteSP1) => {
-                            String::from("⚠️ Failed to Execute Block with SP1")
-                        }
-                        (Err(_), ReplayerMode::ExecuteRISC0) => {
-                            String::from("⚠️ Failed to Execute Block with RISC0")
-                        }
-                        (Err(_), ReplayerMode::ProveSP1) => {
-                            String::from("⚠️ Failed to Prove Block with SP1")
-                        }
-                        (Err(_), ReplayerMode::ProveRISC0) => {
-                            String::from("⚠️ Failed to Prove Block with RISC0")
-                        }
-                    },
-                    emoji: true,
-                }),
+        let mut slack_webhook_actions = vec![SlackWebHookActionElement::Button {
+            text: SlackWebHookBlock::PlainText {
+                text: String::from("View on Etherscan"),
+                emoji: false,
             },
-            SlackWebHookBlock::Section {
-                text: Box::new(SlackWebHookBlock::Markdown {
-                    text: format!(
-                        "*Network:* `{network}`\n*Block:* {number}\n*Gas:* {gas}\n*#Txs:* {txs}\n*Execution Result:* {execution_result}{maybe_gpu}{maybe_cpu}{maybe_ram}\n*Time Taken:* {time_taken}",
-                        network = self.network,
-                        number = self.number,
-                        gas = self.gas,
-                        txs = self.txs,
-                        execution_result = if self.run_result.is_err() {
-                            "Error: ".to_string()
-                                + &self.run_result.as_ref().err().unwrap().to_string()
-                        } else {
-                            "Success".to_string()
-                        },
-                        maybe_gpu = hardware_info_slack_message("GPU"),
-                        maybe_cpu = hardware_info_slack_message("CPU"),
-                        maybe_ram = hardware_info_slack_message("RAM"),
-                        time_taken = format_duration(self.time_taken),
-                    ),
-                }),
+            url: if let Network::PublicNetwork(PublicNetwork::Mainnet) = self.network {
+                format!("https://etherscan.io/block/{}", self.number)
+            } else {
+                format!(
+                    "https://{}.etherscan.io/block/{}",
+                    self.network, self.number
+                )
             },
-            SlackWebHookBlock::Actions {
-                elements: vec![SlackWebHookActionElement::Button {
-                    text: SlackWebHookBlock::PlainText {
-                        text: String::from("View on Etherscan"),
-                        emoji: false,
-                    },
-                    url: if let Network::PublicNetwork(PublicNetwork::Mainnet) = self.network {
-                        format!("https://etherscan.io/block/{}", self.number)
-                    } else {
-                        format!(
-                            "https://{}.etherscan.io/block/{}",
-                            self.network, self.number
-                        )
-                    },
-                }],
-            },
-        ];
+        }];
 
         if let Network::PublicNetwork(_) = self.network {
             // EthProofs only prove block numbers multiples of 100.
             if self.number % 100 == 0 && self.replayer_mode.is_proving_mode() {
-                slack_webhook_request_blocks.push(eth_proofs_button);
+                slack_webhook_actions.push(eth_proofs_button);
             }
         }
 
         SlackWebHookRequest {
-            blocks: slack_webhook_request_blocks,
+            blocks: vec![
+                SlackWebHookBlock::Header {
+                    text: Box::new(SlackWebHookBlock::PlainText {
+                        text: match (&self.run_result, &self.replayer_mode) {
+                            (Ok(_), ReplayerMode::Execute) => {
+                                String::from("✅ Successfully Executed Block")
+                            }
+                            (Ok(_), ReplayerMode::ExecuteSP1) => {
+                                String::from("✅ Successfully Executed Block with SP1")
+                            }
+                            (Ok(_), ReplayerMode::ExecuteRISC0) => {
+                                String::from("✅ Successfully Executed Block with RISC0")
+                            }
+                            (Ok(_), ReplayerMode::ProveSP1) => {
+                                String::from("✅ Successfully Proved Block with SP1")
+                            }
+                            (Ok(_), ReplayerMode::ProveRISC0) => {
+                                String::from("✅ Successfully Proved Block with RISC0")
+                            }
+                            (Err(_), ReplayerMode::Execute) => {
+                                String::from("⚠️ Failed to Execute Block")
+                            }
+                            (Err(_), ReplayerMode::ExecuteSP1) => {
+                                String::from("⚠️ Failed to Execute Block with SP1")
+                            }
+                            (Err(_), ReplayerMode::ExecuteRISC0) => {
+                                String::from("⚠️ Failed to Execute Block with RISC0")
+                            }
+                            (Err(_), ReplayerMode::ProveSP1) => {
+                                String::from("⚠️ Failed to Prove Block with SP1")
+                            }
+                            (Err(_), ReplayerMode::ProveRISC0) => {
+                                String::from("⚠️ Failed to Prove Block with RISC0")
+                            }
+                        },
+                        emoji: true,
+                    }),
+                },
+                SlackWebHookBlock::Section {
+                    text: Box::new(SlackWebHookBlock::Markdown {
+                        text: format!(
+                            "*Network:* `{network}`\n*Block:* {number}\n*Gas:* {gas}\n*#Txs:* {txs}\n*Execution Result:* {execution_result}{maybe_gpu}{maybe_cpu}{maybe_ram}\n*Time Taken:* {time_taken}",
+                            network = self.network,
+                            number = self.number,
+                            gas = self.gas,
+                            txs = self.txs,
+                            execution_result = if self.run_result.is_err() {
+                                "Error: ".to_string()
+                                    + &self.run_result.as_ref().err().unwrap().to_string()
+                            } else {
+                                "Success".to_string()
+                            },
+                            maybe_gpu = hardware_info_slack_message("GPU"),
+                            maybe_cpu = hardware_info_slack_message("CPU"),
+                            maybe_ram = hardware_info_slack_message("RAM"),
+                            time_taken = format_duration(self.time_taken),
+                        ),
+                    }),
+                },
+                SlackWebHookBlock::Actions {
+                    elements: slack_webhook_actions,
+                },
+            ],
         }
     }
 

--- a/cmd/ethrex_replay/src/block_run_report.rs
+++ b/cmd/ethrex_replay/src/block_run_report.rs
@@ -177,7 +177,8 @@ impl BlockRunReport {
         ];
 
         if let Network::PublicNetwork(_) = self.network {
-            if self.replayer_mode.is_proving_mode() {
+            // EthProofs only prove block numbers multiples of 100.
+            if self.number % 100 == 0 && self.replayer_mode.is_proving_mode() {
                 slack_webhook_request_blocks.push(eth_proofs_button);
             }
         }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

Mainnet blocks whose numbers are multiples of 100 are proved in [EthProofs](http://ethproofs.org/). If we happen to prove one of them, it is useful to have a link to more proving stats for that block.

