### PR TITLE
Add scope for `ethrex-replay`

### DIFF
--- a/.github/workflows/pr_lint_pr_title.yml
+++ b/.github/workflows/pr_lint_pr_title.yml
@@ -43,6 +43,7 @@ jobs:
             l1
             l2
             levm
+            replay
 
           # Configure that a scope must always be provided.
           requireScope: true


### PR DESCRIPTION
**Motivation**

`ethrex-replay` has become big enough to have its own scope for PRs, separate from the current ones (`l1`, `l2`, and `levm`).