### PR TITLE
fix(l1): packet decoding decrease log level

### DIFF
--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -74,7 +74,7 @@ impl DiscoveryServer {
         loop {
             let (read, from) = self.udp_socket.recv_from(&mut buf).await?;
             let Ok(packet) = Packet::decode(&buf[..read])
-                .inspect_err(|e| warn!(err = ?e, "Failed to decode packet"))
+                .inspect_err(|e| debug!(err = ?e, "Failed to decode packet"))
             else {
                 continue;
             };


### PR DESCRIPTION
**Motivation**
There are several warnings of `Failed to decode packet err=InvalidSize` and `Failed to decode packet err=HashMismatch`
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Since we have no control over what we receive on the udp socket, we can only reduce the log level to debug so that it is not spammed.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/4312

