### PR TITLE
chore(l1,l2): use IPs instead of localhost as default RPC address

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -109,7 +109,7 @@ pub struct Options {
     pub log_level: Level,
     #[arg(
         long = "http.addr",
-        default_value = "localhost",
+        default_value = "0.0.0.0",
         value_name = "ADDRESS",
         help = "Listening address for the http rpc server.",
         help_heading = "RPC options",
@@ -127,7 +127,7 @@ pub struct Options {
     pub http_port: String,
     #[arg(
         long = "authrpc.addr",
-        default_value = "localhost",
+        default_value = "127.0.0.1",
         value_name = "ADDRESS",
         help = "Listening address for the authenticated rpc server.",
         help_heading = "RPC options"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -84,7 +84,7 @@ RPC options:
           Listening address for the http rpc server.
 
           [env: ETHREX_HTTP_ADDR=]
-          [default: localhost]
+          [default: 0.0.0.0]
 
       --http.port <PORT>
           Listening port for the http rpc server.
@@ -95,7 +95,7 @@ RPC options:
       --authrpc.addr <ADDRESS>
           Listening address for the authenticated rpc server.
 
-          [default: localhost]
+          [default: 127.0.0.1]
 
       --authrpc.port <PORT>
           Listening port for the authenticated rpc server.


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Using "localhost" as default bind address can cause some problems.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Changed default to `0.0.0.0` for ETH RPC and `127.0.0.1` for EngineAPI

<!-- Link to issues: Resolves #111, Resolves #222 -->


