### PR TITLE
fix(l1): remove incorrect debug_assert on trie iteration

### DIFF
--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -28,7 +28,6 @@ impl TrieIterator {
     /// Manually push the correct nodes to the stack so iteration doesn't rewind back
     /// to left children of a traversed branch node.
     pub fn advance(&mut self, key: PathRLP) -> Result<(), TrieError> {
-        debug_assert!(!self.stack.is_empty());
         let Some((root_path, root_ref)) = self.stack.pop() else {
             return Ok(());
         };


### PR DESCRIPTION
**Motivation**

When adding support for trie iteration from a given starting point, we added a `debug_assert!` that checks that the internal stack isn't empty, but this is incorrect; it is entirely possible that the stack is empty if the trie is empty, in that case we simply return an empty iterator, which is fine.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

