### PR TITLE
fix(l1): fixed global state slot metric 

### DIFF
--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -127,7 +127,7 @@ async fn heal_state_trie(
 
             METRICS
                 .global_state_trie_leafs_healed
-                .fetch_add(*global_leafs_healed, Ordering::Relaxed);
+                .store(*global_leafs_healed, Ordering::Relaxed);
             METRICS
                 .healing_empty_try_recv
                 .store(empty_try_recv, Ordering::Relaxed);


### PR DESCRIPTION
**Motivation**

The global state account healed metrics was displaying a number way larger than expected.

**Description**

- Fixed bug where the global metrics counter was being added to itself multiple times.