### PR TITLE
revert(l1): remove eth/69 as supported until it is more stable.

### DIFF
--- a/crates/networking/p2p/rlpx/p2p.rs
+++ b/crates/networking/p2p/rlpx/p2p.rs
@@ -14,7 +14,7 @@ use ethrex_rlp::{
 use secp256k1::PublicKey;
 use serde::Serialize;
 
-pub const SUPPORTED_ETH_CAPABILITIES: [Capability; 2] = [Capability::eth(68)];
+pub const SUPPORTED_ETH_CAPABILITIES: [Capability; 1] = [Capability::eth(68)];
 pub const SUPPORTED_SNAP_CAPABILITIES: [Capability; 1] = [Capability::snap(1)];
 
 /// The version of the base P2P protocol we support.


### PR DESCRIPTION
**Description**
Apparently, the inclusion of eth/69 as a supported capability had a negative effect in the number of peers that users see in the network. Let's remove the support for now until we have made sure that it works properly, and that we have the same or more peers compared to only supporting eth/68

