### PR TITLE
feat(l2): serialize RISC0's guest program input using `rkyv`

### DIFF
--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -11,7 +11,7 @@ use risc0_zkvm::{
     ExecutorEnv, InnerReceipt, ProverOpts, Receipt, default_executor, default_prover,
     serde::Error as Risc0SerdeError,
 };
-use rkyv::rancor::Error;
+use rkyv::rancor::Error as RkyvError;
 use std::time::Instant;
 use tracing::info;
 
@@ -30,7 +30,7 @@ pub enum Error {
 }
 
 pub fn execute(input: ProgramInput) -> Result<(), Box<dyn std::error::Error>> {
-    let bytes = rkyv::to_bytes::<Error>(&input)?;
+    let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
     let env = ExecutorEnv::builder().write(&execute)?.build()?;
 
     let executor = default_executor();
@@ -49,7 +49,7 @@ pub fn prove(
 ) -> Result<Receipt, Box<dyn std::error::Error>> {
     let mut stdout = Vec::new();
 
-    let bytes = rkyv::to_bytes::<Error>(&input)?;
+    let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
     let env = ExecutorEnv::builder()
         .stdout(&mut stdout)
         .write(&bytes)?

--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -31,7 +31,7 @@ pub enum Error {
 
 pub fn execute(input: ProgramInput) -> Result<(), Box<dyn std::error::Error>> {
     let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
-    let env = ExecutorEnv::builder().write(&bytes)?.build()?;
+    let env = ExecutorEnv::builder().write(&bytes.as_slice())?.build()?;
 
     let executor = default_executor();
 
@@ -52,7 +52,7 @@ pub fn prove(
     let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
     let env = ExecutorEnv::builder()
         .stdout(&mut stdout)
-        .write(&bytes)?
+        .write(&bytes.as_slice())?
         .build()?;
 
     let prover = default_prover();

--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -3,7 +3,7 @@ use ethrex_l2_common::{
     prover::{BatchProof, ProofCalldata, ProverType},
 };
 use guest_program::{
-    input::{JSONProgramInput, ProgramInput},
+    input::ProgramInput,
     methods::{ZKVM_RISC0_PROGRAM_ELF, ZKVM_RISC0_PROGRAM_ID},
 };
 use risc0_zkp::verify::VerificationError;

--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -31,7 +31,7 @@ pub enum Error {
 
 pub fn execute(input: ProgramInput) -> Result<(), Box<dyn std::error::Error>> {
     let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
-    let env = ExecutorEnv::builder().write(&execute)?.build()?;
+    let env = ExecutorEnv::builder().write(&bytes)?.build()?;
 
     let executor = default_executor();
 

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
@@ -4196,6 +4196,7 @@ dependencies = [
  "guest_program",
  "risc0-zkvm",
  "risc0-zkvm-platform",
+ "rkyv",
 ]
 
 [[patch.unused]]

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 [dependencies]
 risc0-zkvm = { version = "=3.0.3", default-features = false, features = [
     "std",
+    "unstable",
 ] }
 risc0-zkvm-platform = { version = "=2.2.1", default-features = false, features = [
     "sys-getenv",

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 [dependencies]
 risc0-zkvm = { version = "=3.0.3", default-features = false, features = [
     "std",
-    "unstable",
 ] }
 risc0-zkvm-platform = { version = "=2.2.1", default-features = false, features = [
     "sys-getenv",
@@ -16,7 +15,7 @@ risc0-zkvm-platform = { version = "=2.2.1", default-features = false, features =
 guest_program = { path = "../../", default-features = false, features = [
     "c-kzg",
 ] }
-rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
+rkyv = { version = "0.8.10", features = ["unaligned"] }
 
 
 ethrex-common = { path = "../../../../../../common", default-features = false }

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
@@ -15,6 +15,7 @@ risc0-zkvm-platform = { version = "=2.2.1", default-features = false, features =
 guest_program = { path = "../../", default-features = false, features = [
     "c-kzg",
 ] }
+rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 
 
 ethrex-common = { path = "../../../../../../common", default-features = false }

--- a/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
+++ b/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
@@ -1,4 +1,4 @@
-use guest_program::execution::execution_program;
+use guest_program::{execution::execution_program, input::ProgramInput};
 use risc0_zkvm::guest::env;
 use rkyv::rancor::Error;
 

--- a/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
+++ b/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
@@ -1,15 +1,17 @@
-use guest_program::{execution::execution_program, input::JSONProgramInput};
+use guest_program::execution::execution_program;
 use risc0_zkvm::guest::env;
+use rkyv::rancor::Error;
 
 fn main() {
     println!("start reading input");
     let start = env::cycle_count();
-    let input: JSONProgramInput = env::read();
+    let input = env::read_frame();
+    let input = rkyv::from_bytes::<ProgramInput, Error>(&input).unwrap();
     let end = env::cycle_count();
     println!("end reading input, cycles: {}", end - start);
 
     println!("start execution");
-    let output = execution_program(input.0).unwrap();
+    let output = execution_program(input).unwrap();
     let end_exec = env::cycle_count();
     println!("end execution, cycles: {}", end_exec - end);
 

--- a/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
+++ b/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
@@ -5,7 +5,7 @@ use rkyv::rancor::Error;
 fn main() {
     println!("start reading input");
     let start = env::cycle_count();
-    let input = env::read_frame();
+    let input = env::read::<Vec<u8>>();
     let input = rkyv::from_bytes::<ProgramInput, Error>(&input).unwrap();
     let end = env::cycle_count();
     println!("end reading input, cycles: {}", end - start);


### PR DESCRIPTION
**Motivation**

JSON deserializations are slow and take too many zkVM cycles.

**Description**

Serialize RISC0's guest program input with `rkyv`.

**Results**

zkVM cycles to read RISC0's guest program takes half the cycles now. 

*Before*

> [!NOTE]
> See the logs below, it takes 1.122.344.791 cycles to read the input

```
2025-09-13T00:52:28.376524Z  INFO ethrex_replay::fetcher: Retrieving execution data for block 23350480 (205 block behind latest)
2025-09-13T00:52:28.381127Z  INFO ethrex_replay::fetcher: Getting block 23350480 data from cache
2025-09-13T00:52:28.381827Z  INFO ethrex_replay::bench: Starting prover program
start reading input
end reading input, cycles: 1122344791
start execution
end execution, cycles: 1929020069
start committing public inputs
end committing public inputs, cycles: 2648
total cycles: 3051367508
2025-09-13T00:52:58.019699Z  INFO ethrex_prover_lib::backend::risc0: Successfully generated session info in 29.62s
2025-09-13T00:52:58.019749Z  INFO ethrex_replay::block_run_report: [mainnet] Block #23350480, Gas Used: 10932281, Tx Count: 114, execute_risc0 Result: Success, Time Taken: 29s 637ms | https://etherscan.io/block/23350480
```

*After*

> [!NOTE]
> See the logs below, it takes 623.283.163 cycles to read the input (almost half of the cycles)

```
admin@ethrex-office-2:~/ethrex$ ./ethrex-replay-risc0 block --block 23350480 --execute --rpc-url http://157.180.1.98:8545
2025-09-13T00:49:59.531233Z  INFO ethrex_replay::fetcher: Retrieving execution data for block 23350480 (192 block behind latest)
2025-09-13T00:49:59.535781Z  INFO ethrex_replay::fetcher: Getting block 23350480 data from cache
2025-09-13T00:49:59.536302Z  INFO ethrex_replay::bench: Starting prover program
start reading input
end reading input, cycles: 623283163
start execution
end execution, cycles: 1929032701
start committing public inputs
end committing public inputs, cycles: 2645
total cycles: 2552318509
2025-09-13T00:50:28.021984Z  INFO ethrex_prover_lib::backend::risc0: Successfully generated session info in 28.48s
2025-09-13T00:50:28.022693Z  INFO ethrex_replay::block_run_report: [mainnet] Block #23350480, Gas Used: 10932281, Tx Count: 114, execute_risc0 Result: Success, Time Taken: 28s 486ms | https://etherscan.io/block/23350480
```