### PR TITLE
fix(l2): proof_coordinator genserver locked by tcp listen loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,6 +4131,7 @@ dependencies = [
  "tabwriter",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "tui-big-text",

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -56,6 +56,7 @@ tui-scrollview = "0.5.1"
 tui-logger.workspace = true
 tabwriter = "1.4.1"
 color-eyre = "0.6.5"
+tokio-stream = { version = "0.1.17", features = ["net"] }
 
 guest_program = { path = "./prover/src/guest_program/" }
 


### PR DESCRIPTION
**Motivation**

Currently the proof_coordinator Genserver can only handle a single cast message `Listen { listener: Arc<TcpListener> }` as the handler for this messages starts an infinite loop that prevents other cast messages to be handled.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

