### PR TITLE
fix(l1): truncate file contents when printing DumpError

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1932,11 +1932,20 @@ fn format_duration(duration: Duration) -> String {
     format!("{hours:02}h {minutes:02}m {seconds:02}s")
 }
 
-#[derive(Debug)]
 pub struct DumpError {
     pub path: String,
     pub contents: Vec<u8>,
     pub error: ErrorKind,
+}
+
+impl core::fmt::Debug for DumpError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DumpError")
+            .field("path", &self.path)
+            .field("contents_len", &self.contents.len())
+            .field("error", &self.error)
+            .finish()
+    }
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
**Motivation**

Whenever an error causes `DumpError` to be printed, the whole contents of the file that caused the errors may be shown on screen, which can cause crashes due to the sheer amount of data printed.

**Description**

This PR changes `DumpError`'s `Debug` implementation to one that displays the length of `contents` instead of the whole contents of the file.


