### PR TITLE
fix(l1): enable SOCKS5(h) proxy support in Reqwest so RPC calls work behind SOCKS proxies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ tokio-util = { version = "0.7.15", features = ["rt"] }
 jsonwebtoken = "9.3.0"
 rand = "0.8.5"
 cfg-if = "1.0.0"
-reqwest = { version = "0.12.7", features = ["json"] }
+reqwest = { version = "0.12.7", features = ["socks", "json"] }
 snap = "1.1.1"
 secp256k1 = { version = "0.29.1", default-features = false, features = [
   "global-context",


### PR DESCRIPTION
**Description**

Some environments (e.g. SSH dynamic port forwarding via ssh -D) expose an outbound SOCKS5 proxy. Our binaries were built with `reqwest = { features = ["json"] }`, which does not include SOCKS support. As a result, when users set ALL_PROXY=socks5h://…, Reqwest read the env var but could not speak SOCKS, leading to connection failures and misleading errors (e.g. “incompatible SOCKS version”, local DNS failures).

