### PR TITLE
fix(l1): use `try_lock` instead of `lock` in state healing

### DIFF
--- a/crates/networking/p2p/utils.rs
+++ b/crates/networking/p2p/utils.rs
@@ -91,7 +91,10 @@ pub async fn send_message_and_wait_for_response(
     message: Message,
     request_id: u64,
 ) -> Result<Vec<Node>, SendMessageError> {
-    let receiver = peer_channel.receiver.lock().await;
+    let receiver = peer_channel
+        .receiver
+        .try_lock()
+        .map_err(|_| SendMessageError::PeerBusy)?;
     peer_channel
         .connection
         .cast(CastMessage::BackendMessage(message))


### PR DESCRIPTION
**Motivation**

This is most likely the source of a deadlock we've been seeing during state healing. Regardless, it's what we should be doing anyways (and what's currently done during storage healing). All this locking should go away once we've properly migrated this part of the codebase to use `spawned`

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

