### PR TITLE
fix(l1): change default script branch in sync tool

### DIFF
--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -185,7 +185,7 @@ start-ethrex: ## Start ethrex for the network given by NETWORK.
     		--authrpc.jwtsecret $(DATA_PATH)/${NETWORK}_data/jwt.hex \
     		$(BOOTNODES_FLAG) \
 
-SERVER_SYNC_BRANCH ?= snap_sync
+SERVER_SYNC_BRANCH ?= main
 SERVER_SYNC_NETWORK ?= hoodi
 
 ifeq ($(SERVER_SYNC_NETWORK),hoodi)

--- a/tooling/sync/server_runner.py
+++ b/tooling/sync/server_runner.py
@@ -29,8 +29,8 @@ def parse_args():
     parser.add_argument(
         "--branch",
         type=str,
-        default="snap_sync",
-        help="Branch variable (default: snap_sync)",
+        default="main",
+        help="Branch variable (default: main)",
     )
     parser.add_argument(
         "--logs_file",


### PR DESCRIPTION
**Motivation**
The default server script is snap_sync which is no longer valid
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Changed default script branch to main
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

