### PR TITLE
chore(l1): change default block wait time to 2 minutes instead of 1 on sync tooling script

### DIFF
--- a/tooling/sync/server_runner.py
+++ b/tooling/sync/server_runner.py
@@ -49,7 +49,7 @@ def parse_args():
     parser.add_argument(
         "--block_wait_time",
         type=int,
-        default=60,
+        default=120,
         help="Time to wait until new block in seconds (default: 60)",
     )
     parser.add_argument(


### PR DESCRIPTION
**Motivation**

We have had runs fail simply because there were 5 missed slots in a row on Hoodi, triggering notifications that we were not advancing when in reality the entire network had not advanced in that timeframe. This changes the default time from 1 minute to 2, meaning there would need to be at least 9 missed slots in a row to have this affect us, which should be good enough.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

