### PR TITLE
fix(l1): remove weird slash from datadir path on macOS

### DIFF
--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -111,7 +111,7 @@ pub fn default_datadir() -> String {
 
 // TODO: Use PathBuf instead of strings
 pub fn init_datadir(data_dir: &str) -> String {
-    let datadir = if data_dir != &default_datadir() {
+    let datadir = if data_dir != default_datadir() {
         // Prefix the provided datadir with the project directory
         // i.e. ~/.local/share/<data_dir>
         let project_dir =


### PR DESCRIPTION
**Motivation**

On my machine (macOS), the default datadir was `/Users/mega/Library/Application-Support/ethrex/`, which differs from the usual default of `/Users/mega/Library/Application Support/ethrex/`.

**Description**

~This PR fixes this by removing a call to `ProjectDirs` that seems to be misplaced.~

~Note: the removed part was added in #4050~

This PR fixes this by skipping the call to `ProjectDirs` when the path is the default one.

