### PR TITLE
fix(l1): remove second log level override from `init_tracing`

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -42,8 +42,7 @@ use tracing_subscriber::{
 pub fn init_tracing(opts: &Options) -> reload::Handle<EnvFilter, Registry> {
     let log_filter = EnvFilter::builder()
         .with_default_directive(Directive::from(opts.log_level))
-        .from_env_lossy()
-        .add_directive(Directive::from(opts.log_level));
+        .from_env_lossy();
 
     let (filter, filter_handle) = reload::Layer::new(log_filter);
 


### PR DESCRIPTION
**Motivation**

`RUST_LOG` is the common way to specify the log level for a Rust program. Currently, any global level specified by the envvar is being overriden by the value of the CLI flag `--log.level`, which defaults to `INFO`.

**Description**

This PR removes an `add_directive` call from the filter in `init_tracing`, which was causing the override. The CLI flag value will be set by the `with_default_directive` call, unless the user sets the `RUST_LOG` variable.
