### PR TITLE
feat!(l1): change `--datadir` to be relative to current working directory

### DIFF
--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -111,12 +111,6 @@ pub fn default_datadir() -> String {
 
 // TODO: Use PathBuf instead of strings
 pub fn init_datadir(data_dir: &str) -> String {
-    let project_dir = ProjectDirs::from("", "", data_dir).expect("Couldn't find home directory");
-    let data_dir = project_dir
-        .data_local_dir()
-        .to_str()
-        .expect("invalid data directory")
-        .to_owned();
     let datadir = PathBuf::from(data_dir);
     if datadir.exists() {
         if !datadir.is_dir() {


### PR DESCRIPTION
May supersede https://github.com/lambdaclass/ethrex/pull/4514

**Motivation**

Currently, the datadir is specified relative to the application directory (i.e. `/home/<user>/Application Support/` in macOS). This behavior is confusing, since usually path args are relative to the current working directory.

**Description**

This PR changes this behavior by removing the path-prefixing behavior. It also fixes the issue found in #4514, where any spaces in the path are replaced by slashes (even if the path is the default path).