### PR TITLE
fix(l1): remove volume for CL and EL clients in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,6 @@ services:
       - 127.0.0.1:5052:5052
     volumes:
       - secrets:/secrets
-      - lighthouse:/root/.lighthouse
     command: >
       lighthouse
       --network ${ETHREX_NETWORK:-mainnet}
@@ -39,14 +38,12 @@ services:
       - 127.0.0.1:8545:8545
     volumes:
       - secrets:/secrets
-      - ethrex:/data
     command: >
       --http.addr 0.0.0.0
       --network ${ETHREX_NETWORK:-mainnet}
       --authrpc.addr 0.0.0.0
       --authrpc.jwtsecret /secrets/jwt.hex
       --syncmode snap
-      --datadir /data
     ulimits:
       nofile: 1000000
     depends_on:
@@ -55,5 +52,3 @@ services:
 
 volumes:
   secrets:
-  lighthouse:
-  ethrex:


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Changing the network without deleting the volumes cause an error as the database are not restarted.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
As this is mostly a dev setup (at least for now), removed the volumes. If the container is stopped but not removed, the data will not be lost.

<!-- Link to issues: Resolves #111, Resolves #222 -->


