### PR TITLE
docs(l1): discv4 send neighbors chunk size comment

### DIFF
--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -456,8 +456,10 @@ impl DiscoveryServer {
 
         drop(table);
 
-        // we are sending the neighbors in 2 different messages to avoid exceeding the
-        // maximum packet size
+        // A single node encodes to at most 89B, so 8 of them are at most 712B plus
+        // recursive length and expiration time, well within bound of 1280B per packet.
+        // Sending all in one packet would exceed bounds with the nodes only, weighing
+        // up to 1424B.
         for chunk in neighbors.chunks(8) {
             let _ = self
                 .send_neighbors(chunk.to_vec(), &node)


### PR DESCRIPTION
**Motivation**
We send batches of 8 neighbors to avoid exceeding the package max length, this is not properly explained.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Adds a better explanation
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/4493

