### PR TITLE
fix(l1): fetch transactions from mempool on `GetTransactionByHash` & `GetRawTransaction` rpc endpoints

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -239,7 +239,7 @@ impl RpcHandler for GetTransactionByHashRequest {
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let storage = &context.storage;
-        info!(
+        debug!(
             "Requested transaction with hash: {:#x}",
             self.transaction_hash,
         );
@@ -264,10 +264,6 @@ impl RpcHandler for GetTransactionByHashRequest {
             };
             RpcTransaction::build(tx, Some(0), BlockHash::default(), Some(0))?
         };
-        info!(
-            "Supplying transaction with hash {:#x}",
-            self.transaction_hash
-        );
         serde_json::to_value(transaction).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }


### PR DESCRIPTION
**Motivation**
`GetTransactionByHash` & `GetRawTransaction` should fetch pooled transactions from the mempool if they are not yet finalized.

<!-- Why does this pull request exist? What are its goals? -->

**Description**
* When handling `GetTransactionByHash` & `GetRawTransaction` we should fetch transactions from the mempool if they are not in the store
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, needed for #3844

