### PR TITLE
fix(l1): request storage peer leak

### DIFF
--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -254,6 +254,21 @@ impl Kademlia {
             .and_modify(|peer_data| peer_data.in_use = false);
     }
 
+    pub async fn free_peers(&self) -> u64 {
+        let mut free_count = 0;
+        self.peers
+            .lock()
+            .await
+            .iter_mut()
+            .for_each(|(_, peer_data)| {
+                if peer_data.in_use {
+                    free_count += 1;
+                }
+                peer_data.in_use = false;
+            });
+        free_count
+    }
+
     /// Returns the peer with the highest score and its peer channel.
     pub async fn get_peer_channel_with_highest_score(
         &self,

--- a/crates/networking/p2p/kademlia.rs
+++ b/crates/networking/p2p/kademlia.rs
@@ -255,18 +255,19 @@ impl Kademlia {
     }
 
     pub async fn free_peers(&self) -> u64 {
-        let mut free_count = 0;
         self.peers
             .lock()
             .await
             .iter_mut()
-            .for_each(|(_, peer_data)| {
+            .filter_map(|(_, peer_data)| {
                 if peer_data.in_use {
-                    free_count += 1;
+                    peer_data.in_use = false;
+                    Some(peer_data)
+                } else {
+                    None
                 }
-                peer_data.in_use = false;
-            });
-        free_count
+            })
+            .count() as u64
     }
 
     /// Returns the peer with the highest score and its peer channel.

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1595,6 +1595,16 @@ impl PeerHandler {
                 .remove(&account_done);
         }
 
+        while completed_tasks < task_count {
+            match task_receiver.recv().await {
+                None => break,
+                Some(result) => {
+                    completed_tasks += 1;
+                    self.peer_table.free_peer(result.peer_id).await;
+                }
+            }
+        }
+
         Ok(chunk_index + 1)
     }
 

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1604,13 +1604,8 @@ impl PeerHandler {
         // Dropping the task sender so that the recv returns None
         drop(task_sender);
 
-        loop {
-            match task_receiver.recv().await {
-                None => break,
-                Some(result) => {
-                    self.peer_table.free_peer(result.peer_id).await;
-                }
-            }
+        while let Some(result) = task_receiver.recv().await {
+            self.peer_table.free_peer(result.peer_id).await;
         }
 
         Ok(chunk_index + 1)

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1595,11 +1595,13 @@ impl PeerHandler {
                 .remove(&account_done);
         }
 
-        while completed_tasks < task_count {
+        // Dropping the task sender so that the recv returns None
+        drop(task_sender);
+
+        loop {
             match task_receiver.recv().await {
                 None => break,
                 Some(result) => {
-                    completed_tasks += 1;
                     self.peer_table.free_peer(result.peer_id).await;
                 }
             }

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -794,8 +794,9 @@ impl SnapBlockSyncState {
     }
 }
 
-/// Debug function, frees all peer and logs an error if we found freed peers when not expectig to
-/// step is a string indicating where did we lose the peers
+/// Safety function that frees all peer and logs an error if we found freed peers when not expectig to
+/// Logs with where the function was when it found this error
+/// TODO: remove this function once peer table has moved to spawned implementation
 async fn free_peers_and_log_if_not_empty(peer_handler: &PeerHandler) {
     if peer_handler.peer_table.free_peers().await != 0 {
         let step = METRICS.current_step.lock().await.clone();


### PR DESCRIPTION
**Motivation**

Whenever a step of snap sync is completed, the peers should be marked as free. When requesting storage ranges, the function was ending without clearing the peers if the block was stale.

**Description**

- Changes the request_storage_ranges function to wait until all spawned tasks end and frees those peers before continuing.
- Adds utility function that frees the peers when they're supposed to be free and logs an error if it finds peers in that inconsistent state.

This pr shouldn't be merged before thorough testing on Sepolia!