### PR TITLE
fix(ci): pin rex version in TDX workflow

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -309,6 +309,7 @@ jobs:
           cd /tmp
           git clone https://github.com/lambdaclass/rex
           cd rex
+          git checkout 18466ec1c3dbcbbf22a68fc1f850d660cb2fbf1f
           cargo build --release
           cp target/release/rex /usr/local/bin
 


### PR DESCRIPTION
**Motivation**

The latest Rex commit broke the CI. We should pin a commit to prevent further breaking changes.

**Description**

- Pins a Rex commit in the TDX workflow.

Closes None

