### PR TITLE
refactor(l1,l2): remove keccak-hash crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,7 +581,6 @@ dependencies = [
  "ethrex-storage",
  "eyre",
  "hex",
- "keccak-hash",
  "lazy_static",
  "reqwest 0.12.23",
  "serde",
@@ -3391,7 +3390,6 @@ dependencies = [
  "ethrex-vm",
  "hex",
  "itertools 0.13.0",
- "keccak-hash",
  "rayon",
  "revm 19.7.0",
  "serde",
@@ -3419,7 +3417,6 @@ dependencies = [
  "ethrex-storage",
  "ethrex-vm",
  "hex",
- "keccak-hash",
  "secp256k1",
  "serde",
  "serde_json",
@@ -4030,7 +4027,6 @@ dependencies = [
  "genesis-tool",
  "hex",
  "itertools 0.14.0",
- "keccak-hash",
  "lazy_static",
  "local-ip-address",
  "rand 0.8.5",
@@ -4082,7 +4078,6 @@ dependencies = [
  "ethrex-trie",
  "hex",
  "hex-literal",
- "keccak-hash",
  "kzg-rs",
  "lazy_static",
  "once_cell",
@@ -4106,7 +4101,6 @@ dependencies = [
  "ethrex-common",
  "ethrex-p2p",
  "hex",
- "keccak-hash",
  "serde",
  "serde_json",
 ]
@@ -4125,7 +4119,6 @@ dependencies = [
  "ethrex-rpc",
  "hex",
  "jsonwebtoken 9.3.1",
- "keccak-hash",
  "reqwest 0.12.23",
  "serde",
  "serde_json",
@@ -4173,7 +4166,6 @@ dependencies = [
  "guest_program",
  "hex",
  "jsonwebtoken 9.3.1",
- "keccak-hash",
  "lazy_static",
  "rand 0.8.5",
  "ratatui",
@@ -4206,7 +4198,6 @@ dependencies = [
  "ethrex-storage",
  "ethrex-trie",
  "ethrex-vm",
- "keccak-hash",
  "lambdaworks-crypto 0.11.0",
  "secp256k1",
  "serde",
@@ -4230,7 +4221,6 @@ dependencies = [
  "ethrex-storage",
  "ethrex-storage-rollup",
  "hex",
- "keccak-hash",
  "reqwest 0.12.23",
  "rustc-hex",
  "secp256k1",
@@ -4261,7 +4251,6 @@ dependencies = [
  "ethrex-rlp",
  "hex",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hash",
  "lambdaworks-math 0.11.0",
  "lazy_static",
  "malachite 0.6.1",
@@ -4313,7 +4302,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
- "keccak-hash",
  "lazy_static",
  "prometheus 0.14.0",
  "rand 0.8.5",
@@ -4467,7 +4455,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "jsonwebtoken 9.3.1",
- "keccak-hash",
  "rand 0.8.5",
  "reqwest 0.12.23",
  "secp256k1",
@@ -4499,7 +4486,6 @@ dependencies = [
  "eyre",
  "hex",
  "itertools 0.13.0",
- "keccak-hash",
  "lazy_static",
  "reqwest 0.12.23",
  "secp256k1",
@@ -5332,7 +5318,6 @@ dependencies = [
  "ethrex-trie",
  "ethrex-vm",
  "hex",
- "keccak-hash",
  "risc0-build",
  "risc0-zkvm",
  "rkyv",
@@ -6509,16 +6494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-hash"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1b8590eb6148af2ea2d75f38e7d29f5ca970d5a4df456b3ef19b8b415d0264"
-dependencies = [
- "primitive-types 0.13.1",
- "tiny-keccak",
-]
-
-[[package]]
 name = "kurbo"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6961,7 +6936,6 @@ dependencies = [
  "eyre",
  "futures",
  "hex",
- "keccak-hash",
  "secp256k1",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ secp256k1 = { version = "0.29.1", default-features = false, features = [
   "recovery",
   "rand",
 ] }
-keccak-hash = "0.11.0"
 axum = "0.8.1"
 clap = { version = "4.3", features = ["derive", "env"] }
 clap_complete = "4.5.17"

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -38,7 +38,6 @@ local-ip-address = "0.6"
 tokio-util.workspace = true
 lazy_static.workspace = true
 secp256k1.workspace = true
-keccak-hash.workspace = true
 reqwest.workspace = true
 thiserror.workspace = true
 itertools = "0.14.0"

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -9,6 +9,7 @@ use crate::{
     utils::{self, default_datadir, init_datadir, parse_private_key},
 };
 use clap::{FromArgMatches, Parser, Subcommand};
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address, H256, U256,
     types::{BYTES_PER_BLOB, BlobsBundle, BlockHeader, batch::Batch, bytes_from_blob},
@@ -23,7 +24,6 @@ use ethrex_storage::{EngineType, Store, UpdateBatch};
 use ethrex_storage_rollup::StoreRollup;
 use eyre::OptionExt;
 use itertools::Itertools;
-use keccak_hash::keccak;
 use reqwest::Url;
 use secp256k1::{PublicKey, SecretKey};
 use std::{

--- a/cmd/ethrex/l2/deployer.rs
+++ b/cmd/ethrex/l2/deployer.rs
@@ -8,6 +8,7 @@ use std::{
 
 use bytes::Bytes;
 use clap::Parser;
+use ethrex_common::H256;
 use ethrex_common::{
     Address, U256,
     types::{Genesis, TxType},
@@ -25,7 +26,6 @@ use ethrex_rpc::{
     clients::Overrides,
     types::block_identifier::{BlockIdentifier, BlockTag},
 };
-use keccak_hash::H256;
 use tracing::{debug, error, info, trace, warn};
 
 use ethrex_l2_sdk::DeployError;

--- a/crates/blockchain/dev/Cargo.toml
+++ b/crates/blockchain/dev/Cargo.toml
@@ -19,7 +19,6 @@ ethereum-types.workspace = true
 hex.workspace = true
 reqwest = { version = "0.12.7", features = ["json"] }
 envy = "0.4.2"
-keccak-hash.workspace = true
 sha2 = "0.10.8"
 
 [lib]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -19,7 +19,6 @@ sha2.workspace = true
 # TODO(#1102): Move to Lambdaworks in the future
 c-kzg = { version = "^1.0.3", optional = true }
 kzg-rs.workspace = true
-keccak-hash.workspace = true
 sha3.workspace = true
 secp256k1.workspace = true
 once_cell = "1.20.2"

--- a/crates/common/config/Cargo.toml
+++ b/crates/common/config/Cargo.toml
@@ -8,7 +8,6 @@ ethrex-p2p.workspace = true
 ethrex-common.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-keccak-hash.workspace = true
 hex.workspace = true
 
 [lib]

--- a/crates/common/config/networks.rs
+++ b/crates/common/config/networks.rs
@@ -142,7 +142,7 @@ fn get_genesis_contents(network: PublicNetwork) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use keccak_hash::H256;
+    use crate::H256;
 
     use super::*;
 

--- a/crates/common/constants.rs
+++ b/crates/common/constants.rs
@@ -1,5 +1,5 @@
+use crate::H256;
 use ethrex_rlp::constants::RLP_NULL;
-use keccak_hash::H256;
 use sha3::{Digest as _, Keccak256};
 use std::{str::FromStr, sync::LazyLock};
 

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, HashMap};
 use bytes::Bytes;
 use ethereum_types::{H256, U256};
 use ethrex_trie::Trie;
-use keccak_hash::keccak;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest as _, Keccak256};
 
@@ -15,7 +14,10 @@ use ethrex_rlp::{
 };
 
 use super::GenesisAccount;
-use crate::constants::{EMPTY_KECCACK_HASH, EMPTY_TRIE_HASH};
+use crate::{
+    constants::{EMPTY_KECCACK_HASH, EMPTY_TRIE_HASH},
+    utils::keccak,
+};
 
 #[allow(unused)]
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,7 +82,7 @@ impl From<GenesisAccount> for Account {
 }
 
 pub fn code_hash(code: &Bytes) -> H256 {
-    keccak_hash::keccak(code.as_ref())
+    keccak(code.as_ref())
 }
 
 impl RLPEncode for AccountInfo {

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -2,6 +2,7 @@ use super::{
     BASE_FEE_MAX_CHANGE_DENOMINATOR, ChainConfig, Fork, ForkBlobSchedule,
     GAS_LIMIT_ADJUSTMENT_FACTOR, GAS_LIMIT_MINIMUM, INITIAL_BASE_FEE,
 };
+use crate::utils::keccak;
 use crate::{
     Address, H256, U256,
     constants::{
@@ -19,7 +20,6 @@ use ethrex_rlp::{
     structs::{Decoder, Encoder},
 };
 use ethrex_trie::Trie;
-use keccak_hash::keccak;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rkyv::{Archive, Deserialize as RDeserialize, Serialize as RSerialize};
 use serde::{Deserialize, Serialize};

--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -7,13 +7,12 @@ use crate::{
     H160,
     constants::EMPTY_KECCACK_HASH,
     types::{AccountInfo, AccountState, AccountUpdate, BlockHeader, ChainConfig},
-    utils::decode_hex,
+    utils::{decode_hex, keccak},
 };
 use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_trie::{NodeHash, NodeRLP, Trie};
-use keccak_hash::keccak;
 use rkyv::{Archive, Deserialize as RDeserialize, Serialize as RSerialize};
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::SerializeSeq;

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -1,7 +1,7 @@
+use crate::H256;
 use bytes::Bytes;
 use ethereum_types::Address;
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, error::RLPDecodeError};
-use keccak_hash::H256;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::error;

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1,8 +1,8 @@
 use std::{cmp::min, fmt::Display};
 
+use crate::utils::keccak;
 use bytes::Bytes;
 use ethereum_types::{Address, H256, Signature, U256};
-use keccak_hash::keccak;
 pub use mempool::MempoolTransaction;
 use rkyv::{Archive, Deserialize as RDeserialize, Serialize as RSerialize};
 use secp256k1::{Message, ecdsa::RecoveryId};
@@ -1214,7 +1214,7 @@ impl Transaction {
         if let Transaction::PrivilegedL2Transaction(tx) = self {
             return tx.get_privileged_hash().unwrap_or_default();
         }
-        keccak_hash::keccak(self.encode_canonical_to_vec())
+        crate::utils::keccak(self.encode_canonical_to_vec())
     }
 
     pub fn hash(&self) -> H256 {
@@ -1327,7 +1327,7 @@ impl PrivilegedL2Transaction {
         let u256_nonce = U256::from(self.nonce);
         let nonce = u256_nonce.to_big_endian();
 
-        Some(keccak_hash::keccak(
+        Some(crate::utils::keccak(
             [
                 self.from.as_bytes(),
                 to.as_bytes(),

--- a/crates/common/utils.rs
+++ b/crates/common/utils.rs
@@ -1,6 +1,8 @@
+use crate::H256;
 use ethereum_types::U256;
 use hex::FromHexError;
-use keccak_hash::H256;
+use sha3::Digest;
+use sha3::Keccak256;
 
 /// Converts a big endian slice to a u256, faster than `u256::from_big_endian`.
 pub fn u256_from_big_endian(slice: &[u8]) -> U256 {
@@ -59,6 +61,10 @@ pub fn u256_to_h256(value: U256) -> H256 {
 pub fn decode_hex(hex: &str) -> Result<Vec<u8>, FromHexError> {
     let trimmed = hex.strip_prefix("0x").unwrap_or(hex);
     hex::decode(trimmed)
+}
+
+pub fn keccak(data: impl AsRef<[u8]>) -> H256 {
+    H256(Keccak256::digest(data.as_ref()).into())
 }
 
 #[cfg(test)]

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -33,7 +33,6 @@ hex.workspace = true
 bytes.workspace = true
 jsonwebtoken.workspace = true
 secp256k1.workspace = true
-keccak-hash.workspace = true
 envy = "0.4.2"
 rand.workspace = true
 thiserror.workspace = true

--- a/crates/l2/based/block_fetcher.rs
+++ b/crates/l2/based/block_fetcher.rs
@@ -1,6 +1,7 @@
 use std::{cmp::min, collections::HashMap, sync::Arc, time::Duration};
 
 use ethrex_blockchain::{Blockchain, fork_choice::apply_fork_choice, vm::StoreVmDatabase};
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address, H160, H256, U256,
     types::{
@@ -17,7 +18,6 @@ use ethrex_rlp::decode::RLPDecode;
 use ethrex_rpc::{EthClient, types::receipt::RpcLog};
 use ethrex_storage::Store;
 use ethrex_storage_rollup::{RollupStoreError, StoreRollup};
-use keccak_hash::keccak;
 use spawned_concurrency::{
     error::GenServerError,
     messages::Unused,

--- a/crates/l2/common/Cargo.toml
+++ b/crates/l2/common/Cargo.toml
@@ -12,7 +12,6 @@ ethrex-trie.workspace = true
 ethrex-vm.workspace = true
 bytes.workspace = true
 thiserror.workspace = true
-keccak-hash.workspace = true
 serde.workspace = true
 lambdaworks-crypto.workspace = true
 sha3.workspace = true

--- a/crates/l2/common/src/l1_messages.rs
+++ b/crates/l2/common/src/l1_messages.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
 use ethereum_types::{Address, H256};
+use ethrex_common::utils::keccak;
 use ethrex_common::{H160, U256, types::Receipt};
-use keccak_hash::keccak;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/l2/common/src/merkle_tree.rs
+++ b/crates/l2/common/src/merkle_tree.rs
@@ -1,4 +1,4 @@
-use keccak_hash::H256;
+use ethrex_common::H256;
 use lambdaworks_crypto::merkle_tree::{merkle::MerkleTree, traits::IsMerkleTreeBackend};
 use sha3::{Digest, Keccak256};
 

--- a/crates/l2/common/src/privileged_transactions.rs
+++ b/crates/l2/common/src/privileged_transactions.rs
@@ -1,6 +1,6 @@
 use ethereum_types::{Address, H256, U256};
 use ethrex_common::types::{PrivilegedL2Transaction, Transaction};
-use keccak_hash::keccak;
+use ethrex_common::utils::keccak;
 use serde::{Deserialize, Serialize};
 
 /// Max privileged tx to allow per batch

--- a/crates/l2/common/src/utils.rs
+++ b/crates/l2/common/src/utils.rs
@@ -1,5 +1,5 @@
 use ethrex_common::Address;
-use keccak_hash::keccak;
+use ethrex_common::utils::keccak;
 use secp256k1::SecretKey;
 
 pub fn get_address_from_secret_key(secret_key: &SecretKey) -> Result<Address, String> {

--- a/crates/l2/monitor/utils.rs
+++ b/crates/l2/monitor/utils.rs
@@ -1,8 +1,8 @@
 use std::cmp::min;
 
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, U256};
 use ethrex_rpc::{EthClient, types::receipt::RpcLog};
-use keccak_hash::keccak;
 
 use crate::sequencer::errors::MonitorError;
 

--- a/crates/l2/monitor/widget/l1_to_l2_messages.rs
+++ b/crates/l2/monitor/widget/l1_to_l2_messages.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, H256, U256};
 use ethrex_l2_sdk::{COMMON_BRIDGE_L2_ADDRESS, get_pending_privileged_transactions};
 use ethrex_rpc::{EthClient, types::receipt::RpcLog};
 use ethrex_storage::Store;
-use keccak_hash::keccak;
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Rect},

--- a/crates/l2/monitor/widget/l2_to_l1_messages.rs
+++ b/crates/l2/monitor/widget/l2_to_l1_messages.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, H256, U256};
 use ethrex_l2_common::{calldata::Value, l1_messages::L1MESSENGER_ADDRESS};
 use ethrex_l2_sdk::{COMMON_BRIDGE_L2_ADDRESS, calldata::encode_calldata};
 use ethrex_rpc::{EthClient, clients::Overrides, types::receipt::RpcLog};
-use keccak_hash::keccak;
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Rect},

--- a/crates/l2/networking/rpc/Cargo.toml
+++ b/crates/l2/networking/rpc/Cargo.toml
@@ -25,7 +25,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 thiserror.workspace = true
 secp256k1.workspace = true
-keccak-hash.workspace = true
 reqwest.workspace = true
 ethereum-types.workspace = true
 hex.workspace = true

--- a/crates/l2/networking/rpc/clients.rs
+++ b/crates/l2/networking/rpc/clients.rs
@@ -1,4 +1,5 @@
 use crate::l2::batch::RpcBatch;
+use ethrex_common::H256;
 use ethrex_l2_common::l1_messages::L1MessageProof;
 use ethrex_rpc::{
     EthClient,
@@ -11,7 +12,6 @@ use ethrex_rpc::{
     },
     utils::RpcRequest,
 };
-use keccak_hash::H256;
 use serde_json::json;
 
 pub async fn get_message_proof(

--- a/crates/l2/networking/rpc/l2/l1_message.rs
+++ b/crates/l2/networking/rpc/l2/l1_message.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use keccak_hash::H256;
+use ethrex_common::H256;
 use serde_json::Value;
 use tracing::info;
 

--- a/crates/l2/networking/rpc/signer.rs
+++ b/crates/l2/networking/rpc/signer.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use ethereum_types::{Address, Signature};
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     U256,
     types::{
@@ -8,7 +9,6 @@ use ethrex_common::{
     },
 };
 use ethrex_rlp::encode::PayloadRLPEncode;
-use keccak_hash::keccak;
 use reqwest::{Client, StatusCode, Url};
 use rustc_hex::FromHexError;
 use secp256k1::{Message, PublicKey, SECP256K1, SecretKey};

--- a/crates/l2/prover/src/guest_program/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/Cargo.toml
@@ -9,7 +9,6 @@ serde_with.workspace = true
 serde_json = "1.0.117"
 thiserror = "2.0.9"
 rkyv.workspace = true
-keccak-hash.workspace = true
 bytes.workspace = true
 
 ethrex-common = { path = "../../../../common/", default-features = false }

--- a/crates/l2/sdk/Cargo.toml
+++ b/crates/l2/sdk/Cargo.toml
@@ -13,7 +13,6 @@ ethrex-sdk-contract-utils = { path = "contract_utils" }
 ethereum-types.workspace = true
 tokio.workspace = true
 hex.workspace = true
-keccak-hash.workspace = true
 secp256k1.workspace = true
 itertools = "0.13.0"
 thiserror.workspace = true

--- a/crates/l2/sdk/src/calldata.rs
+++ b/crates/l2/sdk/src/calldata.rs
@@ -1,9 +1,10 @@
 use ethrex_common::Bytes;
+use ethrex_common::H256;
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, H32, U256};
 use ethrex_l2_common::calldata::Value;
 use ethrex_rpc::clients::EthClientError;
 use ethrex_rpc::clients::eth::errors::CalldataEncodeError;
-use keccak_hash::{H256, keccak};
 
 use crate::address_to_word;
 

--- a/crates/l2/sdk/src/l1_to_l2_tx_data.rs
+++ b/crates/l2/sdk/src/l1_to_l2_tx_data.rs
@@ -4,6 +4,7 @@ use crate::{
     send_generic_transaction,
 };
 use bytes::Bytes;
+use ethrex_common::H256;
 use ethrex_common::{Address, U256, types::TxType};
 use ethrex_l2_common::calldata::Value;
 use ethrex_l2_rpc::signer::LocalSigner;
@@ -11,7 +12,6 @@ use ethrex_rpc::{
     EthClient,
     clients::{EthClientError, Overrides, eth::errors::CalldataEncodeError},
 };
-use keccak_hash::H256;
 use secp256k1::SecretKey;
 
 #[derive(Debug)]

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use calldata::encode_calldata;
 use ethereum_types::{H160, H256, U256};
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address,
     types::{
@@ -17,7 +18,6 @@ use ethrex_rlp::encode::RLPEncode;
 use ethrex_rpc::clients::eth::{EthClient, Overrides, errors::EthClientError};
 use ethrex_rpc::types::block_identifier::{BlockIdentifier, BlockTag};
 use ethrex_rpc::types::receipt::RpcReceipt;
-use keccak_hash::keccak;
 use secp256k1::SecretKey;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::ops::{Add, Div};

--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -12,10 +12,10 @@ use ethrex_blockchain::{
     validate_block,
 };
 use ethrex_common::Address;
+use ethrex_common::H256;
 use ethrex_storage::Store;
 use ethrex_storage_rollup::StoreRollup;
 use ethrex_vm::BlockExecutionResult;
-use keccak_hash::H256;
 use payload_builder::build_payload;
 use serde::Serialize;
 use spawned_concurrency::tasks::{

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use ethereum_types::{Address, H256, U256};
 use ethrex_blockchain::Blockchain;
 use ethrex_common::types::{PrivilegedL2Transaction, TxType};
+use ethrex_common::utils::keccak;
 use ethrex_common::{H160, types::Transaction};
 use ethrex_l2_sdk::{
     build_generic_tx, get_last_fetched_l1_block, get_pending_privileged_transactions,
@@ -17,7 +18,6 @@ use ethrex_rpc::{
     types::receipt::RpcLogInfo,
 };
 use ethrex_storage::Store;
-use keccak_hash::keccak;
 use serde::Serialize;
 use spawned_concurrency::tasks::{
     CallResponse, CastResponse, GenServer, GenServerHandle, InitResult, Success, send_after,

--- a/crates/l2/sequencer/setup.rs
+++ b/crates/l2/sequencer/setup.rs
@@ -1,5 +1,6 @@
 use crate::sequencer::errors::ProofCoordinatorError;
 use ethrex_common::types::TxType;
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, Bytes};
 use ethrex_l2_common::calldata::Value;
 use ethrex_l2_common::utils::get_address_from_secret_key;
@@ -7,7 +8,6 @@ use ethrex_l2_rpc::signer::{LocalSigner, Signer};
 use ethrex_l2_sdk::calldata::encode_calldata;
 use ethrex_l2_sdk::{build_generic_tx, send_tx_bump_gas_exponential_backoff};
 use ethrex_rpc::clients::{Overrides, eth::EthClient};
-use keccak_hash::keccak;
 use secp256k1::SecretKey;
 use std::str::FromStr;
 

--- a/crates/l2/sequencer/utils.rs
+++ b/crates/l2/sequencer/utils.rs
@@ -1,4 +1,5 @@
 use aligned_sdk::common::types::Network;
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, H160, H256, types::TxType};
 use ethrex_l2_common::prover::ProverType;
 use ethrex_l2_rpc::signer::Signer;
@@ -11,7 +12,6 @@ use ethrex_rpc::{
     clients::{EthClientError, Overrides},
 };
 use ethrex_storage_rollup::{RollupStoreError, StoreRollup};
-use keccak_hash::keccak;
 use rand::Rng;
 use std::time::{Duration, SystemTime};
 use std::{str::FromStr, time::UNIX_EPOCH};

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 configfs-tsm = "0.0.1"
 tokio = { version = "1.41.1", features = ["full"] }
-keccak-hash = "0.11"
 hex = "0.4"
 zerocopy = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/l2/tee/quote-gen/src/main.rs
+++ b/crates/l2/tee/quote-gen/src/main.rs
@@ -9,7 +9,7 @@ use ethrex_l2_common::{
     utils::get_address_from_secret_key,
 };
 use guest_program::input::ProgramInput;
-use keccak_hash::keccak;
+use ethrex_common::utils::keccak;
 use secp256k1::{Message, SecretKey, generate_keypair, rand};
 use sender::{get_batch, submit_proof, submit_quote};
 use std::time::Duration;

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use ethrex_common::types::TxType;
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, H160, H256, U256};
 use ethrex_l2::monitor::widget::l2_to_l1_messages::{L2ToL1MessageKind, L2ToL1MessageStatus};
 use ethrex_l2::monitor::widget::{L2ToL1MessagesTable, l2_to_l1_messages::L2ToL1MessageRow};
@@ -28,7 +29,6 @@ use ethrex_rpc::{
     },
 };
 use hex::FromHexError;
-use keccak_hash::keccak;
 use secp256k1::SecretKey;
 use std::{
     fs::{File, read_to_string},

--- a/crates/l2/utils/error.rs
+++ b/crates/l2/utils/error.rs
@@ -1,6 +1,6 @@
 use ethrex_blockchain::error::ChainError;
+use ethrex_common::H256;
 use ethrex_storage::error::StoreError;
-use keccak_hash::H256;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProverInputError {

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -28,7 +28,6 @@ secp256k1.workspace = true
 spawned-rt.workspace = true
 spawned-concurrency.workspace = true
 sha2.workspace = true
-keccak-hash.workspace = true
 futures.workspace = true
 prometheus = "0.14.0"
 

--- a/crates/networking/p2p/discv4/server.rs
+++ b/crates/networking/p2p/discv4/server.rs
@@ -5,9 +5,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+use ethrex_common::H256;
 use ethrex_common::{H512, U256};
 use futures::{SinkExt as _, StreamExt, stream::SplitSink};
-use keccak_hash::H256;
 use rand::rngs::OsRng;
 use secp256k1::SecretKey;
 use spawned_concurrency::{

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1236,7 +1236,7 @@ impl PeerHandler {
                     let validated_codes: Vec<Bytes> = codes
                         .into_iter()
                         .zip(hashes_to_request)
-                        .take_while(|(b, hash)| keccak_hash::keccak(b) == *hash)
+                        .take_while(|(b, hash)| ethrex_common::utils::keccak(b) == *hash)
                         .map(|(b, _hash)| b)
                         .collect();
                     let result = TaskResult {

--- a/crates/networking/p2p/rlpx/l2/messages.rs
+++ b/crates/networking/p2p/rlpx/l2/messages.rs
@@ -4,13 +4,13 @@ use crate::rlpx::{
     utils::{snappy_compress, snappy_decompress},
 };
 use bytes::BufMut;
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     H256, Signature,
     types::{Block, batch::Batch},
 };
 use ethrex_rlp::error::{RLPDecodeError, RLPEncodeError};
 use ethrex_rlp::structs::{Decoder, Encoder};
-use keccak_hash::keccak;
 use secp256k1::{Message as SecpMessage, SecretKey};
 use std::{ops::Deref as _, sync::Arc};
 

--- a/crates/networking/p2p/tx_broadcaster.rs
+++ b/crates/networking/p2p/tx_broadcaster.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use ethrex_blockchain::Blockchain;
+use ethrex_common::H256;
 use ethrex_common::types::{MempoolTransaction, Transaction};
 use ethrex_storage::error::StoreError;
-use keccak_hash::H256;
 use rand::{seq::SliceRandom, thread_rng};
 use spawned_concurrency::{
     messages::Unused,

--- a/crates/networking/p2p/utils.rs
+++ b/crates/networking/p2p/utils.rs
@@ -3,10 +3,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use ethrex_common::utils::keccak;
 use ethrex_common::{H256, H512};
 use ethrex_rlp::error::RLPDecodeError;
 use ethrex_trie::Node;
-use keccak_hash::keccak;
 use secp256k1::{PublicKey, SecretKey};
 use spawned_concurrency::error::GenServerError;
 

--- a/crates/networking/rpc/Cargo.toml
+++ b/crates/networking/rpc/Cargo.toml
@@ -37,7 +37,6 @@ sha2.workspace = true
 envy = "0.4.2"
 thiserror.workspace = true
 secp256k1.workspace = true
-keccak-hash.workspace = true
 uuid.workspace = true
 
 cfg-if.workspace = true

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
+use ethrex_common::H256;
 use ethrex_common::{serde_utils, tracing::CallTrace, types::BlockNumber};
-use keccak_hash::H256;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -11,7 +11,6 @@ ethrex-rlp.workspace = true
 derive_more = { version = "1.0.0", features = ["full"] }
 
 bytes.workspace = true
-keccak-hash.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true

--- a/crates/vm/levm/src/account.rs
+++ b/crates/vm/levm/src/account.rs
@@ -1,9 +1,9 @@
+use ethrex_common::{H256, utils::keccak};
 use ethrex_common::{
     U256,
     constants::EMPTY_KECCACK_HASH,
     types::{AccountInfo, GenesisAccount},
 };
-use keccak_hash::{H256, keccak};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -7,8 +7,8 @@ use crate::{
     vm::VM,
 };
 use bytes::Bytes;
+use ethrex_common::H256;
 use ethrex_common::{Address, U256};
-use keccak_hash::H256;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use ethrex_common::Address;
+use ethrex_common::H256;
 use ethrex_common::U256;
 use ethrex_common::types::Account;
-use keccak_hash::H256;
-use keccak_hash::keccak;
+use ethrex_common::utils::keccak;
 
 use super::Database;
 use crate::account::LevmAccount;

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -6,7 +6,7 @@ use bls12_381::{
     hash_to_curve::MapToCurve, multi_miller_loop,
 };
 use bytes::{Buf, Bytes};
-use ethrex_common::utils::u256_from_big_endian_const;
+use ethrex_common::utils::{keccak, u256_from_big_endian_const};
 use ethrex_common::{
     Address, H160, H256, U256, kzg::verify_kzg_proof, serde_utils::bool, types::Fork,
     utils::u256_from_big_endian,
@@ -14,7 +14,6 @@ use ethrex_common::{
 use ethrex_crypto::blake2f::blake2b_f;
 use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 use k256::elliptic_curve::Field;
-use keccak_hash::keccak256;
 use lambdaworks_math::{
     elliptic_curve::{
         short_weierstrass::{
@@ -356,7 +355,7 @@ pub fn ecrecover(calldata: &Bytes, gas_remaining: &mut u64, _fork: Fork) -> Resu
     let xy = &mut uncompressed[1..65];
 
     // keccak256(X||Y).
-    keccak256(xy);
+    let xy = keccak(xy);
 
     // Address is the last 20 bytes of the hash.
     let mut out = [0u8; 32];

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -19,12 +19,11 @@ use ethrex_common::{
     Address, H256, U256,
     evm::calculate_create_address,
     types::{Account, Fork, Transaction, tx_fields::*},
-    utils::u256_to_big_endian,
+    utils::{keccak, u256_to_big_endian},
 };
 use ethrex_common::{types::TxKind, utils::u256_from_big_endian_const};
 use ethrex_rlp;
 use ethrex_rlp::encode::RLPEncode;
-use keccak_hash::keccak;
 use secp256k1::{
     Message,
     ecdsa::{RecoverableSignature, RecoveryId},

--- a/tooling/archive_sync/Cargo.toml
+++ b/tooling/archive_sync/Cargo.toml
@@ -9,7 +9,6 @@ ethrex-common.workspace = true
 ethrex-storage.workspace = true
 ethrex-rlp.workspace = true
 ethrex-rpc.workspace = true
-keccak-hash.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/tooling/archive_sync/src/main.rs
+++ b/tooling/archive_sync/src/main.rs
@@ -6,6 +6,7 @@ use clap::{ArgGroup, Parser};
 use ethrex::initializers::open_store;
 use ethrex::utils::{default_datadir, init_datadir};
 use ethrex_common::types::BlockHash;
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, serde_utils};
 use ethrex_common::{BigEndianHash, Bytes, H256, U256, types::BlockNumber};
 use ethrex_common::{
@@ -16,7 +17,6 @@ use ethrex_rlp::decode::RLPDecode;
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_rpc::clients::auth::RpcResponse;
 use ethrex_storage::Store;
-use keccak_hash::keccak;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::HashMap;

--- a/tooling/ef_tests/state/Cargo.toml
+++ b/tooling/ef_tests/state/Cargo.toml
@@ -17,7 +17,6 @@ serde_json.workspace = true
 simd-json = "0.15.1"
 bytes.workspace = true
 hex.workspace = true
-keccak-hash.workspace = true
 colored = "2.1.0"
 spinoff = "0.8.0"
 thiserror.workspace = true

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -4,6 +4,7 @@ use crate::{
     types::{EFTest, TransactionExpectedException},
     utils::{self, effective_gas_price},
 };
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     H256, U256,
     types::{
@@ -20,7 +21,6 @@ use ethrex_levm::{
 };
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_vm::backends;
-use keccak_hash::keccak;
 
 pub async fn run_ef_test(test: &EFTest) -> Result<EFTestReport, EFTestRunnerError> {
     // There are some tests that don't have a hash, unwrap will panic

--- a/tooling/ef_tests/state/runner/revm_runner.rs
+++ b/tooling/ef_tests/state/runner/revm_runner.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloy_rlp::Encodable;
 use bytes::Bytes;
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address, H256,
     types::{Account, AccountUpdate, Fork, TxKind},
@@ -22,7 +23,6 @@ use ethrex_vm::{
         revm::{db::EvmState, helpers::fork_to_spec_id},
     },
 };
-use keccak_hash::keccak;
 pub use revm::primitives::{Address as RevmAddress, SpecId, U256 as RevmU256};
 use revm::{
     Evm as Revm,

--- a/tooling/ef_tests/state_v2/Cargo.toml
+++ b/tooling/ef_tests/state_v2/Cargo.toml
@@ -17,7 +17,6 @@ serde.workspace = true
 serde_json.workspace = true
 bytes.workspace = true
 hex.workspace = true
-keccak-hash.workspace = true
 thiserror.workspace = true
 clap.workspace = true
 clap_complete.workspace = true

--- a/tooling/ef_tests/state_v2/src/modules/result_check.rs
+++ b/tooling/ef_tests/state_v2/src/modules/result_check.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use ethrex_common::H256;
+use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address, U256,
     types::{AccountUpdate, Fork, Genesis, code_hash},
@@ -13,7 +15,6 @@ use ethrex_levm::{
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::Store;
 use ethrex_vm::backends;
-use keccak_hash::{H256, keccak};
 
 use crate::modules::{
     error::RunnerError,

--- a/tooling/ef_tests/state_v2/src/modules/utils.rs
+++ b/tooling/ef_tests/state_v2/src/modules/utils.rs
@@ -1,4 +1,5 @@
 use ethrex_blockchain::vm::StoreVmDatabase;
+use ethrex_common::H256;
 use ethrex_common::{
     U256,
     types::{Fork, Genesis},
@@ -6,7 +7,6 @@ use ethrex_common::{
 use ethrex_levm::db::gen_db::GeneralizedDatabase;
 use ethrex_storage::{EngineType, Store};
 use ethrex_vm::DynVmDatabase;
-use keccak_hash::H256;
 
 use std::sync::Arc;
 

--- a/tooling/load_test/Cargo.toml
+++ b/tooling/load_test/Cargo.toml
@@ -15,6 +15,5 @@ ethrex-common.workspace = true
 ethrex-l2-common.workspace = true
 ethrex-l2-rpc.workspace = true
 eyre.workspace = true
-keccak-hash.workspace = true
 tokio = { workspace = true, features = ["full"] }
 futures = "0.3"


### PR DESCRIPTION
**Motivation**
We want to stop using the keccak-hash crate and implement it with sha3.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Removed the keccak-hash crate and implemented it with sha3
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes https://github.com/lambdaclass/ethrex/issues/4535

