### PR TITLE
feat(replay): allow replay in range from some block to the latest

### DIFF
--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -209,17 +209,7 @@ impl EthrexReplayCommand {
                     unimplemented!("cached mode is not implemented yet");
                 }
 
-                let to = if to.is_none() {
-                    let eth_client = EthClient::new(opts.rpc_url.as_str())?;
-
-                    let latest_block = eth_client.get_block_number().await?;
-
-                    Some(latest_block.as_u64())
-                } else {
-                    to
-                };
-
-                let blocks = resolve_blocks(blocks, from, to)?;
+                let blocks = resolve_blocks(blocks, from, to, opts.rpc_url.clone()).await?;
 
                 for (i, block_number) in blocks.iter().enumerate() {
                     info!(
@@ -257,17 +247,7 @@ impl EthrexReplayCommand {
                 to,
                 opts,
             })) => {
-                let to = if to.is_none() {
-                    let eth_client = EthClient::new(opts.rpc_url.as_str())?;
-
-                    let latest_block = eth_client.get_block_number().await?;
-
-                    Some(latest_block.as_u64())
-                } else {
-                    to
-                };
-
-                let blocks = resolve_blocks(blocks, from, to)?;
+                let blocks = resolve_blocks(blocks, from, to, opts.rpc_url.clone()).await?;
 
                 let (eth_client, network) = setup(&opts).await?;
 
@@ -557,17 +537,15 @@ fn or_latest(maybe_number: Option<u64>) -> eyre::Result<BlockIdentifier> {
     })
 }
 
-fn resolve_blocks(
+async fn resolve_blocks(
     mut blocks: Vec<u64>,
     from: Option<u64>,
     to: Option<u64>,
+    rpc_url: Url,
 ) -> eyre::Result<Vec<u64>> {
-    if let (Some(start), Some(end)) = (from, to) {
-        if start > end {
-            return Err(eyre::Error::msg(
-                "starting point can't be greater than ending point",
-            ));
-        }
+    if let Some(start) = from {
+        let end = to.unwrap_or(fetch_latest_block_number(rpc_url).await?);
+
         for block in start..=end {
             blocks.push(block);
         }
@@ -915,4 +893,10 @@ pub async fn produce_custom_l2_block(
     apply_fork_choice(store, new_block_hash, new_block_hash, new_block_hash).await?;
 
     Ok(new_block)
+}
+
+async fn fetch_latest_block_number(rpc_url: Url) -> eyre::Result<u64> {
+    let eth_client = EthClient::new(rpc_url.as_str())?;
+    let latest_block = eth_client.get_block_number().await?;
+    Ok(latest_block.as_u64())
 }

--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -257,6 +257,16 @@ impl EthrexReplayCommand {
                 to,
                 opts,
             })) => {
+                let to = if to.is_none() {
+                    let eth_client = EthClient::new(opts.rpc_url.as_str())?;
+
+                    let latest_block = eth_client.get_block_number().await?;
+
+                    Some(latest_block.as_u64())
+                } else {
+                    to
+                };
+
                 let blocks = resolve_blocks(blocks, from, to)?;
 
                 let (eth_client, network) = setup(&opts).await?;

--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -154,7 +154,7 @@ pub struct BlockOptions {
 pub struct BlocksOptions {
     #[arg(long, help = "List of blocks to execute.", num_args = 1.., value_delimiter = ',', conflicts_with_all = ["from", "to"])]
     blocks: Vec<u64>,
-    #[arg(long, help = "Starting block. (Inclusive)", requires = "to")]
+    #[arg(long, help = "Starting block. (Inclusive)")]
     from: Option<u64>,
     #[arg(long, help = "Ending block. (Inclusive)", requires = "from")]
     to: Option<u64>,
@@ -208,6 +208,16 @@ impl EthrexReplayCommand {
                 if opts.cached {
                     unimplemented!("cached mode is not implemented yet");
                 }
+
+                let to = if to.is_none() {
+                    let eth_client = EthClient::new(opts.rpc_url.as_str())?;
+
+                    let latest_block = eth_client.get_block_number().await?;
+
+                    Some(latest_block.as_u64())
+                } else {
+                    to
+                };
 
                 let blocks = resolve_blocks(blocks, from, to)?;
 

--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -897,6 +897,8 @@ pub async fn produce_custom_l2_block(
 
 async fn fetch_latest_block_number(rpc_url: Url) -> eyre::Result<u64> {
     let eth_client = EthClient::new(rpc_url.as_str())?;
+
     let latest_block = eth_client.get_block_number().await?;
+
     Ok(latest_block.as_u64())
 }


### PR DESCRIPTION
**Motivation**

https://github.com/lambdaclass/ethrex/pull/4125

**Description**

- `--from` arg doesn't require `--to` anymore.
- If `--from` is passed alone, then the `--to` is set to the latest block.

