### PR TITLE
fix(l2): properly update message hashes in committer

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -86,9 +86,10 @@ jobs:
         run: |
           cd crates/l2
           RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover &
-          docker logs --follow ethrex_l2 &
+          docker logs --follow ethrex_l2 & DOCKER_LOGS_PID=$!
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex -s SIGINT
+          kill $DOCKER_LOGS_PID || true
 
       - name: Destroy Docker containers
         if: always()

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -3,6 +3,9 @@ name: L2 (SP1 Backend)
 on:
   push:
     branches: ["main"]
+  pull_request:
+    paths:
+      - ".github/workflows/main_prover.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -83,6 +83,7 @@ jobs:
         run: |
           cd crates/l2
           RUST_LOG=info,ethrex_prover_lib=debug SP1_PROVER=cuda make init-prover &
+          docker logs --follow ethrex_l2 &
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex -s SIGINT
 

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -45,7 +45,7 @@ jobs:
       # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.
       - name: Clean .env
         # if: ${{ always() && github.event_name == 'merge_group' }}
-        run: rm -rf crates/l2/.env
+        run: rm -rf cmd/.env
 
       - name: Build prover
         # if: ${{ always() && github.event_name == 'merge_group' }}

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -77,7 +77,7 @@ jobs:
           cd crates/l2
           DOCKER_ETHREX_WORKDIR=/usr/local/bin \
           ETHREX_PROPOSER_BLOCK_TIME=12000 \
-          ETHREX_COMMITTER_COMMIT_TIME=180000 \
+          ETHREX_COMMITTER_COMMIT_TIME=30000 \
           ETHREX_WATCHER_WATCH_INTERVAL=1000 \
           docker compose up --build --detach --no-deps ethrex_l2
 

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -1,8 +1,8 @@
 # TODO: uncomment "if: ${{ always() && github.event_name == 'merge_group' }}" lines when reenabling this workflow in the merge queue
 name: L2 (SP1 Backend)
 on:
-  # push:
-  #   branches: ["main"]
+  push:
+    branches: ["main"]
   pull_request:
     paths:
       - ".github/workflows/main_prover.yaml"

--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -1,7 +1,7 @@
 name: Replay proving
 on:
-  # push:
-  #   branches: ["main"]
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -481,7 +481,7 @@ impl L1Committer {
                     .collect::<Vec<H256>>(),
             );
 
-            message_hashes.extend(acc_messages.iter().map(|msg| get_l1_message_hash(msg)));
+            message_hashes.extend(acc_messages.iter().map(get_l1_message_hash));
 
             new_state_root = self
                 .store

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -481,7 +481,7 @@ impl L1Committer {
                     .collect::<Vec<H256>>(),
             );
 
-            message_hashes.extend(acc_messages.iter().map(get_l1_message_hash));
+            message_hashes.extend(messages.iter().map(get_l1_message_hash));
 
             new_state_root = self
                 .store

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -481,6 +481,8 @@ impl L1Committer {
                     .collect::<Vec<H256>>(),
             );
 
+            message_hashes.extend(acc_messages.iter().map(|msg| get_l1_message_hash(msg)));
+
             new_state_root = self
                 .store
                 .state_trie(block_to_commit.hash())?
@@ -491,7 +493,7 @@ impl L1Committer {
 
             last_added_block_number += 1;
             acc_gas_used += current_block_gas_used;
-        }
+        } // end loop
 
         metrics!(if let (Ok(privileged_transaction_count), Ok(messages_count)) = (
                 privileged_transactions_hashes.len().try_into(),
@@ -523,9 +525,7 @@ impl L1Committer {
 
         let privileged_transactions_hash =
             compute_privileged_transactions_hash(privileged_transactions_hashes)?;
-        for msg in &acc_messages {
-            message_hashes.push(get_l1_message_hash(msg));
-        }
+
         Ok((
             blobs_bundle,
             new_state_root,

--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -198,6 +198,7 @@ impl L1ProofSender {
                 .map(|proof_type| format!("{proof_type:?}"))
                 .collect();
             info!(
+                ?batch_to_send,
                 "Missing {} batch proof(s), will not send",
                 missing_proof_types.join(", ")
             );

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -1333,7 +1333,7 @@ async fn perform_transfer(
     .await?;
 
     let transfer_tx_receipt =
-        ethrex_l2_sdk::wait_for_transaction_receipt(transfer_tx, l2_client, 1000).await?;
+        ethrex_l2_sdk::wait_for_transaction_receipt(transfer_tx, l2_client, 10000).await?;
 
     assert!(
         transfer_tx_receipt.receipt.status,
@@ -1438,7 +1438,7 @@ async fn test_n_withdraws(
 
     for (i, tx) in withdraw_txs.iter().enumerate() {
         println!("test_n_withdraws: Waiting receipt {}/{n} ({tx:x})", i + 1);
-        let r = ethrex_l2_sdk::wait_for_transaction_receipt(*tx, l2_client, 1000)
+        let r = ethrex_l2_sdk::wait_for_transaction_receipt(*tx, l2_client, 10000)
             .await
             .expect("Withdraw tx receipt not found");
         receipts.push(r);
@@ -1847,7 +1847,7 @@ async fn wait_for_l2_deposit_receipt(
         .get_privileged_hash()
         .unwrap();
 
-    Ok(ethrex_l2_sdk::wait_for_transaction_receipt(l2_deposit_tx_hash, l2_client, 1000).await?)
+    Ok(ethrex_l2_sdk::wait_for_transaction_receipt(l2_deposit_tx_hash, l2_client, 10000).await?)
 }
 
 pub fn read_env_file_by_config() {
@@ -2004,7 +2004,7 @@ async fn wait_for_verified_proof(
     l2_client: &EthClient,
     tx: H256,
 ) -> L1MessageProof {
-    let proof = wait_for_message_proof(l2_client, tx, 1000).await;
+    let proof = wait_for_message_proof(l2_client, tx, 10000).await;
     let proof = proof.unwrap().into_iter().next().expect("proof not found");
 
     loop {


### PR DESCRIPTION
**Motivation**

We are prematurely updating the [acc_messages](https://github.com/lambdaclass/ethrex/blob/101a11dce6e86332de330699a54dc549df03f651/crates/l2/sequencer/l1_committer.rs#L316) variable in our committer, even though the block may later be discarded due to `stateDiff` or privileged transaction limits.  
The SP1 workflow is getting stuck in batches 1 or 2 for this reason. We had not seen the error before because we weren’t spamming enough transactions to hit the limit.  
I also noticed that, since we are spamming 3000 privileged transactions in our integration tests, 1000 retries to obtain a privileged receipt falls short.

Successful run [here](https://github.com/lambdaclass/ethrex/actions/runs/17838300648/job/50721020331).

**Description**

- Displays the sequencer logs in the SP1 workflow.  
- Increases the number of retries in `wait_for_transaction_receipt` to 10000.  
- Correctly calculates the message hashes of the batch.  
- Re-enables the prover workflows on pushes to `main`.

Closes #4550 

