### PR TITLE
ci(l2): silent prover slack notifications

### DIFF
--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -4,14 +4,14 @@ on:
   workflow_run:
     workflows:
       - L1
-      # - L2 (SP1 Backend)
+      - L2 (SP1 Backend)
       - L2 (without proving)
       - L2 Prover
       - L2 Prover (TDX)
       - L2 TDX build
       - LEVM
       - Publish Docker
-      # - Replay proving
+      - Replay proving
     branches:
       - main
     types:

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -1,8 +1,11 @@
 # TODO: uncomment "if: ${{ always() && github.event_name == 'merge_group' }}" lines when reenabling this workflow in the merge queue
 name: L2 (SP1 Backend)
 on:
-  push:
-    branches: ["main"]
+  # push:
+  #   branches: ["main"]
+  pull_request:
+    paths:
+      - ".github/workflows/main_prover.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -1,13 +1,12 @@
 name: Replay proving
 on:
-  push:
-    branches: ["main"]
+  # push:
+  #   branches: ["main"]
   pull_request:
     branches: ["**"]
     paths:
       - ".github/workflows/main_prover_l1.yaml"
   workflow_dispatch:
-  
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
**Motivation**

We will be cancelling workflows manually for debugging purposes.

**Description**

- Cancel slack notifications for `Replay proving` and `L2 (SP1 Backend)`.
- #4550 was created to re-enable slack notifications.

Closes None

