### PR TITLE
perf(levm): use a distinct opcode table per fork to avoid runtime checks

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/block.rs
+++ b/crates/vm/levm/src/opcode_handlers/block.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::*,
     vm::VM,
 };
-use ethrex_common::{U256, types::Fork, utils::u256_from_big_endian_const};
+use ethrex_common::{U256, utils::u256_from_big_endian_const};
 
 // Block Information (11)
 // Opcodes: BLOCKHASH, COINBASE, TIMESTAMP, NUMBER, PREVRANDAO, GASLIMIT, CHAINID, SELFBALANCE, BASEFEE, BLOBHASH, BLOBBASEFEE
@@ -138,10 +138,6 @@ impl<'a> VM<'a> {
     // BLOBHASH operation
     /// Currently not tested
     pub fn op_blobhash(&mut self) -> Result<OpcodeResult, VMError> {
-        // [EIP-4844] - BLOBHASH is only available from CANCUN
-        if self.env.config.fork < Fork::Cancun {
-            return Err(ExceptionalHalt::InvalidOpcode.into());
-        }
         self.current_call_frame
             .increase_consumed_gas(gas_cost::BLOBHASH)?;
         let index = self.current_call_frame.stack.pop1()?;
@@ -167,11 +163,6 @@ impl<'a> VM<'a> {
 
     // BLOBBASEFEE operation
     pub fn op_blobbasefee(&mut self) -> Result<OpcodeResult, VMError> {
-        // [EIP-7516] - BLOBBASEFEE is only available from CANCUN
-        if self.env.config.fork < Fork::Cancun {
-            return Err(ExceptionalHalt::InvalidOpcode.into());
-        }
-
         self.current_call_frame
             .increase_consumed_gas(gas_cost::BLOBBASEFEE)?;
 

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -1,9 +1,9 @@
 use crate::{
-    errors::{ExceptionalHalt, InternalError, OpcodeResult, VMError},
+    errors::{InternalError, OpcodeResult, VMError},
     gas_cost,
     vm::VM,
 };
-use ethrex_common::{U256, types::Fork, utils::u256_from_big_endian_const};
+use ethrex_common::{U256, utils::u256_from_big_endian_const};
 
 // Push Operations
 // Opcodes: PUSH0, PUSH1 ... PUSH32
@@ -55,10 +55,6 @@ impl<'a> VM<'a> {
 
     // PUSH0
     pub fn op_push0(&mut self) -> Result<OpcodeResult, VMError> {
-        // [EIP-3855] - PUSH0 is only available from SHANGHAI
-        if self.env.config.fork < Fork::Shanghai {
-            return Err(ExceptionalHalt::InvalidOpcode.into());
-        }
         let current_call_frame = &mut self.current_call_frame;
 
         current_call_frame.increase_consumed_gas(gas_cost::PUSH0)?;

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use ethrex_common::{
     U256,
-    types::Fork,
     utils::{u256_to_big_endian, u256_to_h256},
 };
 
@@ -30,11 +29,6 @@ impl<'a> VM<'a> {
 
     // TLOAD operation
     pub fn op_tload(&mut self) -> Result<OpcodeResult, VMError> {
-        // [EIP-1153] - TLOAD is only available from CANCUN
-        if self.env.config.fork < Fork::Cancun {
-            return Err(ExceptionalHalt::InvalidOpcode.into());
-        }
-
         let key = self.current_call_frame.stack.pop1()?;
         let to = self.current_call_frame.to;
         let value = self.substate.get_transient(&to, &key);
@@ -49,10 +43,6 @@ impl<'a> VM<'a> {
 
     // TSTORE operation
     pub fn op_tstore(&mut self) -> Result<OpcodeResult, VMError> {
-        // [EIP-1153] - TLOAD is only available from CANCUN
-        if self.env.config.fork < Fork::Cancun {
-            return Err(ExceptionalHalt::InvalidOpcode.into());
-        }
         let (key, value, to) = {
             let current_call_frame = &mut self.current_call_frame;
 
@@ -262,10 +252,6 @@ impl<'a> VM<'a> {
 
     // MCOPY operation
     pub fn op_mcopy(&mut self) -> Result<OpcodeResult, VMError> {
-        // [EIP-5656] - MCOPY is only available from CANCUN
-        if self.env.config.fork < Fork::Cancun {
-            return Err(ExceptionalHalt::InvalidOpcode.into());
-        }
         let current_call_frame = &mut self.current_call_frame;
         let [dest_offset, src_offset, size] = *current_call_frame.stack.pop()?;
         let size: usize = u256_to_usize(size)?;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -442,6 +442,7 @@ impl<'a> VM<'a> {
                 self.env.config.fork,
             );
         }
+        let opcode_table = &VM::OPCODE_TABLES[self.env.config.fork as usize];
 
         loop {
             let opcode = self.current_call_frame.next_opcode();
@@ -449,7 +450,7 @@ impl<'a> VM<'a> {
             // Call the opcode, using the opcode function lookup table.
             // Indexing will not panic as all the opcode values fit within the table.
             #[allow(clippy::indexing_slicing, clippy::as_conversions)]
-            let op_result = VM::OPCODE_TABLE[opcode as usize].call(self);
+            let op_result = opcode_table[opcode as usize].call(self);
 
             let result = match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

