### PR TITLE
feat(l1): validate bytecodes at snap sync end

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1470,7 +1470,7 @@ pub async fn validate_storage_root(store: Store, state_root: H256) -> bool {
 }
 
 pub async fn validate_bytecodes(store: Store, state_root: H256) -> bool {
-    info!("Starting validate_state_root");
+    info!("Starting validate_bytecodes");
     let mut is_valid = true;
     for (account_hash, account_state) in store
         .iter_accounts(state_root)

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1126,7 +1126,6 @@ impl Syncer {
 
         debug_assert!(validate_state_root(store.clone(), pivot_header.state_root).await);
         debug_assert!(validate_storage_root(store.clone(), pivot_header.state_root).await);
-        debug_assert!(validate_bytecodes(store.clone(), pivot_header.state_root).await);
         info!("Finished healing");
 
         // Finish code hash collection
@@ -1191,6 +1190,8 @@ impl Syncer {
         }
 
         *METRICS.bytecode_download_end_time.lock().await = Some(SystemTime::now());
+
+        debug_assert!(validate_bytecodes(store.clone(), pivot_header.state_root).await);
 
         store_block_bodies(vec![pivot_header.hash()], self.peers.clone(), store.clone()).await?;
 


### PR DESCRIPTION
**Motivation**

We weren't validating the btytecodes in debug assert, added a validation for it.

**Description**

- Adds a validate_bytecodes function and runs it in debug assert at the end of the snap sync.

