### PR TITLE
feat(l1): make `jemalloc` the default global allocator

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -61,7 +61,7 @@ path = "./lib.rs"
 
 [features]
 debug = ["ethrex-vm/debug"]
-default = ["rocksdb", "c-kzg", "rollup_storage_sql", "dev", "metrics"]
+default = ["rocksdb", "c-kzg", "rollup_storage_sql", "dev", "metrics", "jemalloc"]
 dev = ["dep:ethrex-dev"]
 c-kzg = [
   "ethrex-vm/c-kzg",


### PR DESCRIPTION
**Motivation**

`jemalloc` reduce RAM usage in ~80% during snapsync

**Description**

This PR adds the `jemalloc` feature flag to the default cmd features.

