### PR TITLE
chore(l1): improve engine API logs

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -335,7 +335,7 @@ impl Syncer {
         loop {
             debug!("Sync Log 1: In Full Sync");
             debug!(
-                "Sync Log 3: State current headears len {}",
+                "Sync Log 3: State current headers len {}",
                 block_sync_state.current_headers.len()
             );
             debug!(

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -602,7 +602,8 @@ fn get_block_from_payload(
     requests_hash: Option<H256>,
 ) -> Result<Block, RLPDecodeError> {
     let block_hash = payload.block_hash;
-    info!("Received new payload with block hash: {block_hash:#x}");
+    let block_number = payload.block_number;
+    info!(%block_hash, %block_number, "Received new payload");
 
     payload
         .clone()
@@ -626,6 +627,7 @@ async fn try_execute_payload(
     latest_valid_hash: H256,
 ) -> Result<PayloadStatus, RpcErr> {
     let block_hash = block.hash();
+    let block_number = block.header.number;
     let storage = &context.storage;
     // Return the valid message directly if we have it.
     if storage.get_block_by_hash(block_hash).await?.is_some() {
@@ -633,7 +635,7 @@ async fn try_execute_payload(
     }
 
     // Execute and store the block
-    info!("Executing payload with block hash: {block_hash:#x}");
+    info!(%block_hash, %block_number, "Executing payload");
 
     match context.blockchain.add_block(block).await {
         Err(ChainError::ParentNotFound) => {

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -22,7 +22,7 @@ pub struct ExecutionPayload {
     logs_bloom: Bloom,
     prev_randao: H256,
     #[serde(with = "serde_utils::u64::hex_str")]
-    block_number: u64,
+    pub block_number: u64,
     #[serde(with = "serde_utils::u64::hex_str")]
     gas_limit: u64,
     #[serde(with = "serde_utils::u64::hex_str")]


### PR DESCRIPTION
**Motivation**

`engine_newPayload` logs don't include the block number, which is an important part of a block's context.

**Description**

This PR changes `engine_newPayload`-related logs to include both the hash and number, as log attributes instead of being embedded, which is more idiomatic.

