### PR TITLE
pef(levm): improve instruction fetching and callerpop

### DIFF
--- a/crates/storage/store_db/libmdbx.rs
+++ b/crates/storage/store_db/libmdbx.rs
@@ -3,7 +3,6 @@ use crate::api::StoreEngine;
 use crate::error::StoreError;
 use crate::rlp::{
     AccountCodeHashRLP, AccountCodeRLP, BlockBodyRLP, BlockHashRLP, BlockHeaderRLP, BlockRLP, Rlp,
-    TransactionHashRLP, TupleRLP,
 };
 use crate::store::STATE_TRIE_SEGMENTS;
 use crate::trie_db::libmdbx::LibmdbxTrieDB;

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -10,6 +10,7 @@ use bytes::Bytes;
 use ethrex_common::{Address, U256};
 use keccak_hash::H256;
 use std::{
+    cell::OnceCell,
     collections::{BTreeMap, HashMap},
     fmt,
 };
@@ -209,6 +210,7 @@ pub struct CallFrame {
     pub pc: usize,
     /// Address of the account that sent the message
     pub msg_sender: Address,
+    pub msg_sender_u256: OnceCell<U256>,
     /// Address of the recipient of the message
     pub to: Address,
     /// Address of the code to execute. Usually the same as `to`, but can be different
@@ -307,6 +309,7 @@ impl CallFrame {
             gas_limit,
             gas_remaining: gas_limit,
             msg_sender,
+            msg_sender_u256: OnceCell::new(),
             to,
             code_address,
             bytecode: bytecode.clone(),

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -224,6 +224,7 @@ pub enum DatabaseError {
 /// "Stop" is an Opcode
 pub enum OpcodeResult {
     Continue { pc_increment: usize },
+    SetPc { new_pc: usize },
     Halt,
 }
 

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -59,10 +59,10 @@ impl<'a> VM<'a> {
         let current_call_frame = &mut self.current_call_frame;
         current_call_frame.increase_consumed_gas(gas_cost::CALLER)?;
 
-        let caller = current_call_frame.msg_sender;
-        current_call_frame
-            .stack
-            .push(&[u256_from_big_endian_const(caller.to_fixed_bytes())])?;
+        let caller = *current_call_frame.msg_sender_u256.get_or_init(|| {
+            u256_from_big_endian_const(current_call_frame.msg_sender.to_fixed_bytes())
+        });
+        current_call_frame.stack.push1(caller)?;
 
         Ok(OpcodeResult::Continue { pc_increment: 1 })
     }

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -329,9 +329,7 @@ impl<'a> VM<'a> {
         if Self::target_address_is_valid(call_frame, jump_address_usize) {
             call_frame.increase_consumed_gas(gas_cost::JUMPDEST)?;
 
-            let new_pc = jump_address_usize
-                .checked_add(1)
-                .ok_or(InternalError::Overflow)?;
+            let new_pc = jump_address_usize + 1;
             Ok(new_pc)
         } else {
             Err(ExceptionalHalt::InvalidJump.into())

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -798,15 +798,14 @@ impl<'a> VM<'a> {
                 TxResult::Revert(_) => FAIL,
             })?;
 
-            // Increment PC of the parent callframe after execution of the child.
-            call_frame.increment_pc_by(1)?;
-
             // Transfer value from caller to callee.
             if should_transfer_value && ctx_result.is_success() {
                 self.transfer(msg_sender, to, value)?;
             }
 
             self.tracer.exit_context(&ctx_result, false)?;
+
+            return Ok(OpcodeResult::Continue { pc_increment: 1 });
         } else {
             let mut stack = self.stack_pool.pop().unwrap_or_default();
             stack.clear();
@@ -856,7 +855,7 @@ impl<'a> VM<'a> {
     }
 
     /// Handles case in which callframe was initiated by another callframe (with CALL or CREATE family opcodes)
-    pub fn handle_return(&mut self, ctx_result: &ContextResult) -> Result<(), VMError> {
+    pub fn handle_return(&mut self, ctx_result: &ContextResult) -> Result<usize, VMError> {
         self.handle_state_backup(ctx_result)?;
         let executed_call_frame = self.pop_call_frame()?;
 
@@ -867,10 +866,8 @@ impl<'a> VM<'a> {
             self.handle_return_call(executed_call_frame, ctx_result)?;
         }
 
-        // Increment PC of the parent callframe after execution of the child.
-        self.increment_pc_by(1)?;
-
-        Ok(())
+        // Parent callframe should advance past the CALL/CREATE opcode now that the child completed.
+        Ok(1)
     }
 
     pub fn handle_return_call(

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -453,10 +453,13 @@ impl<'a> VM<'a> {
 
             let result = match op_result {
                 Ok(OpcodeResult::Continue { pc_increment }) => {
-                    self.increment_pc_by(pc_increment)?;
+                    self.advance_pc(pc_increment)?;
                     continue;
                 }
-
+                Ok(OpcodeResult::SetPc { new_pc }) => {
+                    self.set_pc(new_pc);
+                    continue;
+                }
                 Ok(OpcodeResult::Halt) => self.handle_opcode_result()?,
                 Err(error) => self.handle_opcode_error(error)?,
             };
@@ -468,7 +471,8 @@ impl<'a> VM<'a> {
             }
 
             // Handle interaction between child and parent callframe.
-            self.handle_return(&result)?;
+            let pc_increment = self.handle_return(&result)?;
+            self.advance_pc(pc_increment)?;
         }
     }
 


### PR DESCRIPTION
**Motivation**

On the old gas bench callerpop improves by 100 mgas from 820 to 920~ locally on linux.

EEST benches:

<img width="2560" height="19272" alt="image" src="https://github.com/user-attachments/assets/00744563-be86-4015-9d15-395839919068" />


Closes #issue_number

