### PR TITLE
fix(l1): `RpcTransaction` representation for pending transactions

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -168,7 +168,7 @@ impl RpcHandler for GetTransactionByBlockNumberAndIndexRequest {
         let tx = RpcTransaction::build(
             tx.clone(),
             Some(block_number),
-            block_header.hash(),
+            Some(block_header.hash()),
             Some(self.transaction_index),
         )?;
         serde_json::to_value(tx).map_err(|error| RpcErr::Internal(error.to_string()))
@@ -215,7 +215,7 @@ impl RpcHandler for GetTransactionByBlockHashAndIndexRequest {
         let tx = RpcTransaction::build(
             tx.clone(),
             Some(block_number),
-            self.block,
+            Some(self.block),
             Some(self.transaction_index),
         )?;
         serde_json::to_value(tx).map_err(|error| RpcErr::Internal(error.to_string()))

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -253,7 +253,12 @@ impl RpcHandler for GetTransactionByHashRequest {
             else {
                 return Ok(Value::Null);
             };
-            RpcTransaction::build(tx, Some(block_number), block_hash, Some(index as usize))?
+            RpcTransaction::build(
+                tx,
+                Some(block_number),
+                Some(block_hash),
+                Some(index as usize),
+            )?
         } else {
             let Some(tx) = context
                 .blockchain
@@ -262,7 +267,7 @@ impl RpcHandler for GetTransactionByHashRequest {
             else {
                 return Ok(Value::Null);
             };
-            RpcTransaction::build(tx, Some(0), BlockHash::default(), Some(0))?
+            RpcTransaction::build(tx, None, None, None)?
         };
         serde_json::to_value(transaction).map_err(|error| RpcErr::Internal(error.to_string()))
     }

--- a/crates/networking/rpc/mempool.rs
+++ b/crates/networking/rpc/mempool.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ethrex_common::{Address, H256};
+use ethrex_common::Address;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -30,10 +30,7 @@ pub async fn content(context: RpcApiContext) -> Result<Value, RpcErr> {
     let mut mempool_content = MempoolContentEntry::new();
     for tx in transactions {
         let sender_entry = mempool_content.entry(tx.sender()?).or_default();
-        sender_entry.insert(
-            tx.nonce(),
-            RpcTransaction::build(tx, None, H256::zero(), None)?,
-        );
+        sender_entry.insert(tx.nonce(), RpcTransaction::build(tx, None, None, None)?);
     }
     let response = MempoolContent {
         pending: mempool_content,

--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -105,7 +105,7 @@ impl FullBlockBody {
             transactions.push(RpcTransaction::build(
                 tx.clone(),
                 Some(block_number),
-                block_hash,
+                Some(block_hash),
                 Some(index),
             )?);
         }

--- a/crates/networking/rpc/types/transaction.rs
+++ b/crates/networking/rpc/types/transaction.rs
@@ -17,7 +17,7 @@ pub struct RpcTransaction {
     pub tx: Transaction,
     #[serde(with = "serde_utils::u64::hex_str_opt")]
     block_number: Option<BlockNumber>,
-    block_hash: BlockHash,
+    block_hash: Option<BlockHash>,
     from: Address,
     pub hash: H256,
     #[serde(with = "serde_utils::u64::hex_str_opt")]
@@ -28,7 +28,7 @@ impl RpcTransaction {
     pub fn build(
         tx: Transaction,
         block_number: Option<BlockNumber>,
-        block_hash: BlockHash,
+        block_hash: Option<BlockHash>,
         transaction_index: Option<usize>,
     ) -> Result<Self, RpcErr> {
         let from = tx.sender()?;


### PR DESCRIPTION
**Motivation**
PR #4533 Enabled mempool transactions to be fetched by rpc endpoints `GetTransactionByHash` and `GetRawTransaction`, but it used default values instead of null values in the representation for the block hash, block number, and transaction index fields. This doesn't match the spec (geth) and caused problems when running hive tests.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Make `block_hash` field of `RpcTransaction` optional
* Use null values for block hash, number and tx index when building `RpcTransaction`s from pending transactions
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None, but is needed for #3844

Special thanks to @cdiielsi for pointing this out!

