### PR TITLE
fix(l1): wrong home path in sync tool makefile

### DIFF
--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -14,9 +14,9 @@ CURRENT_DATETIME = $(shell date +'%y.%m.%d-%H.%M.%S')
 BATCH_SIZE ?= 1024
 OS = $(shell uname)
 ifeq ($(OS), Darwin)
-	DATA_PATH = ~/Library/Application\ Support
-else 
-	DATA_PATH = ~/.local/share
+	DATA_PATH = $(HOME)/Library/Application\ Support
+else
+	DATA_PATH = $(HOME)/.local/share
 endif
 
 # Set checkpoint sync url based on network


### PR DESCRIPTION
The Makefile was creating a '~' directory by trying to use the shell
idiom for HOME. Replace it by the proper environent variable.
