### PR TITLE
fix(l1): use transactional database with RocksDB

### DIFF
--- a/crates/storage/trie_db/rocksdb.rs
+++ b/crates/storage/trie_db/rocksdb.rs
@@ -1,12 +1,12 @@
 use ethrex_common::H256;
 use ethrex_trie::{NodeHash, TrieDB, error::TrieError};
-use rocksdb::{DBWithThreadMode, MultiThreaded};
+use rocksdb::{MultiThreaded, OptimisticTransactionDB};
 use std::sync::Arc;
 
 /// RocksDB implementation for the TrieDB trait, with get and put operations.
 pub struct RocksDBTrieDB {
     /// RocksDB database
-    db: Arc<DBWithThreadMode<MultiThreaded>>,
+    db: Arc<OptimisticTransactionDB<MultiThreaded>>,
     /// Column family name
     cf_name: String,
     /// Storage trie address prefix
@@ -15,7 +15,7 @@ pub struct RocksDBTrieDB {
 
 impl RocksDBTrieDB {
     pub fn new(
-        db: Arc<DBWithThreadMode<MultiThreaded>>,
+        db: Arc<OptimisticTransactionDB<MultiThreaded>>,
         cf_name: &str,
         address_prefix: Option<H256>,
     ) -> Result<Self, TrieError> {
@@ -68,7 +68,7 @@ impl TrieDB for RocksDBTrieDB {
 
     fn put_batch(&self, key_values: Vec<(NodeHash, Vec<u8>)>) -> Result<(), TrieError> {
         let cf = self.cf_handle()?;
-        let mut batch = rocksdb::WriteBatch::default();
+        let mut batch = rocksdb::WriteBatchWithTransaction::default();
 
         for (key, value) in key_values {
             let db_key = self.make_key(key);
@@ -85,7 +85,7 @@ impl TrieDB for RocksDBTrieDB {
 mod tests {
     use super::*;
     use ethrex_trie::NodeHash;
-    use rocksdb::{ColumnFamilyDescriptor, DBWithThreadMode, MultiThreaded, Options};
+    use rocksdb::{ColumnFamilyDescriptor, MultiThreaded, Options};
     use tempfile::TempDir;
 
     #[test]
@@ -99,7 +99,7 @@ mod tests {
         db_options.create_missing_column_families(true);
 
         let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", Options::default());
-        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+        let db = OptimisticTransactionDB::<MultiThreaded>::open_cf_descriptors(
             &db_options,
             db_path,
             vec![cf_descriptor],
@@ -139,7 +139,7 @@ mod tests {
         db_options.create_missing_column_families(true);
 
         let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", Options::default());
-        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+        let db = OptimisticTransactionDB::<MultiThreaded>::open_cf_descriptors(
             &db_options,
             db_path,
             vec![cf_descriptor],
@@ -176,7 +176,7 @@ mod tests {
         db_options.create_missing_column_families(true);
 
         let cf_descriptor = ColumnFamilyDescriptor::new("test_cf", Options::default());
-        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+        let db = OptimisticTransactionDB::<MultiThreaded>::open_cf_descriptors(
             &db_options,
             db_path,
             vec![cf_descriptor],


### PR DESCRIPTION
RocksDB is non-transactional by default, meaning writes logically
interleave rather than behaving as a unit, which is prone to errors.
The optimistic transaction mode implements ACID behavior, with conflict
resolution at commit time to improve parallelism.
