### PR TITLE
chore(l1): increased MISSING_SLOTS_PERCENTAGE to avoid reorgs

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -51,7 +51,10 @@ const SECONDS_PER_BLOCK: u64 = 12;
 /// Bytecodes to downloader per batch
 const BYTECODE_CHUNK_SIZE: usize = 50_000;
 
-const MISSING_SLOTS_PERCENTAGE: f64 = 0.9;
+/// We assume this amount of slots are missing a block to adjust our timestamp
+/// based update pivot algorithm. This is also used to try to find "safe" blocks in the chain
+/// that are unlikely to be re-orged.
+const MISSING_SLOTS_PERCENTAGE: f64 = 0.8;
 
 #[cfg(feature = "sync-test")]
 lazy_static::lazy_static! {


### PR DESCRIPTION
**Motivation**

Currently, when testing snapsync, we aren't prepared to handle a reorg. To try to avoid snasyncing to blocks that can be reorged, we lowered the amount of blocks we advanced in `update_pivot`.

**Description**

- Lowered `MISSING_SLOTS_PERCENTAGE` to 0.8 from 0.9
