### PR TITLE
fix(l2): add EthClient config to proof_sender and proof_verifier

### DIFF
--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -99,7 +99,15 @@ impl L1ProofSender {
         rollup_store: StoreRollup,
         needed_proof_types: Vec<ProverType>,
     ) -> Result<Self, ProofSenderError> {
-        let eth_client = EthClient::new_with_multiple_urls(eth_cfg.rpc_url.clone())?;
+        let eth_client = EthClient::new_with_config(
+            eth_cfg.rpc_url.iter().map(AsRef::as_ref).collect(),
+            eth_cfg.max_number_of_retries,
+            eth_cfg.backoff_factor,
+            eth_cfg.min_retry_delay,
+            eth_cfg.max_retry_delay,
+            Some(eth_cfg.maximum_allowed_max_fee_per_gas),
+            Some(eth_cfg.maximum_allowed_max_fee_per_blob_gas),
+        )?;
         let l1_chain_id = eth_client.get_chain_id().await?.try_into().map_err(|_| {
             ProofSenderError::UnexpectedError("Failed to convert chain ID to U256".to_owned())
         })?;

--- a/crates/l2/sequencer/l1_proof_verifier.rs
+++ b/crates/l2/sequencer/l1_proof_verifier.rs
@@ -68,7 +68,15 @@ impl L1ProofVerifier {
         aligned_cfg: &AlignedConfig,
         rollup_store: StoreRollup,
     ) -> Result<Self, ProofVerifierError> {
-        let eth_client = EthClient::new_with_multiple_urls(eth_cfg.rpc_url.clone())?;
+        let eth_client = EthClient::new_with_config(
+            eth_cfg.rpc_url.iter().map(AsRef::as_ref).collect(),
+            eth_cfg.max_number_of_retries,
+            eth_cfg.backoff_factor,
+            eth_cfg.min_retry_delay,
+            eth_cfg.max_retry_delay,
+            Some(eth_cfg.maximum_allowed_max_fee_per_gas),
+            Some(eth_cfg.maximum_allowed_max_fee_per_blob_gas),
+        )?;
         let beacon_urls = parse_beacon_urls(&aligned_cfg.beacon_urls);
 
         let sp1_vk = get_sp1_vk(&eth_client, committer_cfg.on_chain_proposer_address).await?;


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Currently, proof sender and proof verifier doesn't have control over max gas price, retries and so.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Replace the simple `EthClient::new_with_multiple_urls` with `EthClient::new_with_config`

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #4562


