### PR TITLE
fix(replay): replace unwrap with proper error handling for empty URLs

### DIFF
--- a/cmd/ethrex_replay/src/fetcher.rs
+++ b/cmd/ethrex_replay/src/fetcher.rs
@@ -8,7 +8,7 @@ use ethrex_rpc::{
     clients::{EthClientError, eth::errors::GetWitnessError},
     types::block_identifier::{BlockIdentifier, BlockTag},
 };
-use eyre::WrapErr;
+use eyre::{OptionExt, WrapErr};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -103,7 +103,11 @@ pub async fn get_blockdata(
                 requested_block_number - 1
             );
             let rpc_db = RpcDB::with_cache(
-                eth_client.urls.first().unwrap().as_str(),
+                eth_client
+                    .urls
+                    .first()
+                    .ok_or_eyre("No RPC URLs configured")?
+                    .as_str(),
                 chain_config,
                 (requested_block_number - 1).try_into()?,
                 &block,


### PR DESCRIPTION
Replace `unwrap()` with `ok_or_eyre()` when accessing the first URL from eth_client.urls to prevent potential panics when the URLs vector is empty.