### PR TITLE
feat(l2): add verification key upgrade functions

### DIFF
--- a/crates/l2/contracts/src/l1/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/OnChainProposer.sol
@@ -182,11 +182,13 @@ contract OnChainProposer is
     /// @inheritdoc IOnChainProposer
     function upgradeSP1VerificationKey(bytes32 new_vk) public onlyOwner {
         SP1_VERIFICATION_KEY = new_vk;
+        emit VerificationKeyUpgraded("SP1", new_vk);
     }
 
     /// @inheritdoc IOnChainProposer
     function upgradeRISC0VerificationKey(bytes32 new_vk) public onlyOwner {
         RISC0_VERIFICATION_KEY = new_vk;
+        emit VerificationKeyUpgraded("RISC0", new_vk);
     }
 
     /// @inheritdoc IOnChainProposer

--- a/crates/l2/contracts/src/l1/based/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/based/OnChainProposer.sol
@@ -230,11 +230,13 @@ contract OnChainProposer is
     /// @inheritdoc IOnChainProposer
     function upgradeSP1VerificationKey(bytes32 new_vk) public onlyOwner {
         SP1_VERIFICATION_KEY = new_vk;
+        emit VerificationKeyUpgraded("SP1", new_vk);
     }
 
     /// @inheritdoc IOnChainProposer
     function upgradeRISC0VerificationKey(bytes32 new_vk) public onlyOwner {
         RISC0_VERIFICATION_KEY = new_vk;
+        emit VerificationKeyUpgraded("RISC0", new_vk);
     }
 
     /// @inheritdoc IOnChainProposer

--- a/crates/l2/contracts/src/l1/based/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/based/interfaces/IOnChainProposer.sol
@@ -23,6 +23,12 @@ interface IOnChainProposer {
     /// @dev Event emitted when a batch is verified.
     event BatchVerified(uint256 indexed lastVerifiedBatch);
 
+    /// @notice A verification key has been upgraded.
+    /// @dev Event emitted when a verification key is upgraded.
+    /// @param verifier The name of the verifier whose key was upgraded.
+    /// @param newVerificationKey The new verification key.
+    event VerificationKeyUpgraded(string verifier, bytes32 newVerificationKey);
+
     /// @notice Set the bridge address for the first time.
     /// @dev This method is separated from initialize because both the CommonBridge
     /// and the OnChainProposer need to know the address of the other. This solves

--- a/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
@@ -27,6 +27,12 @@ interface IOnChainProposer {
     /// @dev Event emitted when a batch is reverted.
     event BatchReverted(bytes32 indexed newStateRoot);
 
+    /// @notice A verification key has been upgraded.
+    /// @dev Event emitted when a verification key is upgraded.
+    /// @param verifier The name of the verifier whose key was upgraded.
+    /// @param newVerificationKey The new verification key.
+    event VerificationKeyUpgraded(string verifier, bytes32 newVerificationKey);
+
     /// @notice Set the bridge address for the first time.
     /// @dev This method is separated from initialize because both the CommonBridge
     /// and the OnChainProposer need to know the address of the other. This solves


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Currently when someone wants to upgrade the ethrex version of an L2, they have to perform an UUPS upgrade to the contract in order to upgrade the verification keys.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Add a function to upgrade SP1 and RISC0 VKs without the need of a full upgrade to the contract

<!-- Link to issues: Resolves #111, Resolves #222 -->
