### PR TITLE
fix(replay): block number wrongly displayed in RpcDB

### DIFF
--- a/cmd/ethrex_replay/src/fetcher.rs
+++ b/cmd/ethrex_replay/src/fetcher.rs
@@ -100,12 +100,12 @@ pub async fn get_blockdata(
 
             info!(
                 "Caching callers and recipients state for block {}",
-                requested_block_number - 1
+                requested_block_number
             );
             let rpc_db = RpcDB::with_cache(
                 eth_client.urls.first().unwrap().as_str(),
                 chain_config,
-                (requested_block_number - 1).try_into()?,
+                requested_block_number,
                 &block,
                 vm_type,
             )
@@ -114,14 +114,14 @@ pub async fn get_blockdata(
 
             info!(
                 "Pre executing block {}. This may take a while.",
-                requested_block_number - 1
+                requested_block_number
             );
             let rpc_db = rpc_db
                 .to_execution_witness(&block)
                 .wrap_err("failed to build execution db")?;
             info!(
                 "Finished building execution witness for block {}",
-                requested_block_number - 1
+                requested_block_number
             );
             rpc_db
         }

--- a/cmd/ethrex_replay/src/rpc/db.rs
+++ b/cmd/ethrex_replay/src/rpc/db.rs
@@ -41,8 +41,8 @@ static RATE_LIMITER: LazyLock<RateLimiter> =
 pub struct RpcDB {
     /// RPC endpoint URL.
     pub rpc_url: String,
-    /// Block number of the actual block to execute.
-    pub block_number: usize,
+    /// Block number of the block we want to execute.
+    pub block_number: u64,
     /// Cache of already fetched accounts. This includes state, code, storage and proofs.
     /// Accounts in the parent block, i.e. the initial state of the execution.
     pub cache: Arc<Mutex<HashMap<Address, Account>>>,
@@ -63,7 +63,7 @@ impl RpcDB {
     pub fn new(
         rpc_url: &str,
         chain_config: ChainConfig,
-        block_number: usize,
+        block_number: u64,
         vm_type: VMType,
     ) -> Self {
         RpcDB {
@@ -82,7 +82,7 @@ impl RpcDB {
     pub async fn with_cache(
         rpc_url: &str,
         chain_config: ChainConfig,
-        block_number: usize,
+        block_number: u64,
         block: &Block,
         vm_type: VMType,
     ) -> eyre::Result<Self> {
@@ -137,8 +137,8 @@ impl RpcDB {
     ///
     /// # Parameters
     /// * `index` - List of addresses and their storage keys to fetch
-    /// * `from_child` - If true, fetches data for the post-state (block_number + 1),
-    ///   otherwise fetches data for the pre-state (block_number)
+    /// * `from_child` - If true, fetches data for the post-state (block_number),
+    ///   otherwise fetches data for the pre-state (block_number - 1)
     ///
     /// # Implementation details
     /// * Uses rate limiting to avoid surpassing the RPC endpoint limits
@@ -150,10 +150,10 @@ impl RpcDB {
         from_child: bool,
     ) -> eyre::Result<HashMap<Address, Account>> {
         let block_number = if from_child {
-            self.block_number + 1
-        } else {
             self.block_number
-        };
+        } else {
+            self.block_number - 1
+        } as usize;
 
         let mut fetched = HashMap::new();
         let mut counter = 0;


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Block number being displayed on screen was wrong.
We now do store the actual block number to execute and this is used for the post-state proofs, whereas the `block number - 1` is used for the pre-state proofs.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

