### PR TITLE
ci(l1): set --docker.output for running hive tests in ci

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -213,7 +213,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Run Hive Simulation
-        run: chmod +x hive && ./hive --client-file .github/config/hive/clients.yaml --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 16 --sim.loglevel 1
+        run: chmod +x hive && ./hive --client-file .github/config/hive/clients.yaml --client ethrex --sim ${{ matrix.simulation }} --sim.limit "${{ matrix.test_pattern }}" --sim.parallelism 16 --sim.loglevel 1 --docker.output
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -667,6 +667,11 @@ impl FullBlockSyncState {
             .cloned()
             .ok_or(SyncError::InvalidRangeReceived)?;
 
+        let block_batch_hashes = block_batch
+            .iter()
+            .map(|block| block.hash())
+            .collect::<Vec<_>>();
+
         // Run the batch
         if let Err((err, batch_failure)) = Syncer::add_blocks(
             blockchain.clone(),
@@ -680,12 +685,25 @@ impl FullBlockSyncState {
                 warn!("Failed to add block during FullSync: {err}");
                 // Since running the batch failed we set the failing block and it's descendants with having an invalid ancestor on the following cases.
                 if let ChainError::InvalidBlock(_) = err {
-                    self.store
-                        .set_latest_valid_ancestor(
-                            batch_failure.failed_block_hash,
-                            batch_failure.last_valid_hash,
-                        )
-                        .await?;
+                    let mut block_hashes_with_invalid_ancestor: Vec<H256> = vec![];
+                    if let Some(index) = block_batch_hashes
+                        .iter()
+                        .position(|x| x == &batch_failure.failed_block_hash)
+                    {
+                        block_hashes_with_invalid_ancestor = block_batch_hashes[index..].to_vec();
+                    }
+
+                    for hash in block_hashes_with_invalid_ancestor {
+                        self.store
+                            .set_latest_valid_ancestor(hash, batch_failure.last_valid_hash)
+                            .await?;
+                    }
+                    // We also set with having an invalid ancestor all the hashes remaining which are descendants as well.
+                    for header in &self.current_headers {
+                        self.store
+                            .set_latest_valid_ancestor(header.hash(), batch_failure.last_valid_hash)
+                            .await?;
+                    }
                 }
             }
             return Err(err.into());

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -667,11 +667,6 @@ impl FullBlockSyncState {
             .cloned()
             .ok_or(SyncError::InvalidRangeReceived)?;
 
-        let block_batch_hashes = block_batch
-            .iter()
-            .map(|block| block.hash())
-            .collect::<Vec<_>>();
-
         // Run the batch
         if let Err((err, batch_failure)) = Syncer::add_blocks(
             blockchain.clone(),
@@ -685,25 +680,12 @@ impl FullBlockSyncState {
                 warn!("Failed to add block during FullSync: {err}");
                 // Since running the batch failed we set the failing block and it's descendants with having an invalid ancestor on the following cases.
                 if let ChainError::InvalidBlock(_) = err {
-                    let mut block_hashes_with_invalid_ancestor: Vec<H256> = vec![];
-                    if let Some(index) = block_batch_hashes
-                        .iter()
-                        .position(|x| x == &batch_failure.failed_block_hash)
-                    {
-                        block_hashes_with_invalid_ancestor = block_batch_hashes[index..].to_vec();
-                    }
-
-                    for hash in block_hashes_with_invalid_ancestor {
-                        self.store
-                            .set_latest_valid_ancestor(hash, batch_failure.last_valid_hash)
-                            .await?;
-                    }
-                    // We also set with having an invalid ancestor all the hashes remaining which are descendants as well.
-                    for header in &self.current_headers {
-                        self.store
-                            .set_latest_valid_ancestor(header.hash(), batch_failure.last_valid_hash)
-                            .await?;
-                    }
+                    self.store
+                        .set_latest_valid_ancestor(
+                            batch_failure.failed_block_hash,
+                            batch_failure.last_valid_hash,
+                        )
+                        .await?;
                 }
             }
             return Err(err.into());


### PR DESCRIPTION
**Motivation**

Hive test _Invalid Missing Ancestor Syncing ReOrg, Transaction Nonce, EmptyTxs=False, CanonicalReOrg=True, Invalid P9 (Cancun)_ has been detected as flaky in different prs ([here](https://github.com/lambdaclass/ethrex/actions/runs/17778855183/job/50533720000?pr=4402) and [here](https://github.com/lambdaclass/ethrex/actions/runs/17919605582/job/50953659676?pr=4576)) but logs aren't specific on why the test failed. In this [pr](https://github.com/lambdaclass/ethrex/pull/4528) I had the test in question run several times but it never failed, so there was no way to figure out why it is flaky. Having the ci show more specific logs should be useful to have more information on flaky tests for any pr and any test.

**Description**

Set `--docker.output` for running the hive tests on the ci.

Closes no issue but it's related to #3105

