### PR TITLE
fix(l2): remove duplicate Following log in determine_new_status

### DIFF
--- a/crates/l2/based/state_updater.rs
+++ b/crates/l2/based/state_updater.rs
@@ -280,7 +280,6 @@ fn determine_new_status(
         }
         // If the node is up to date but not the lead sequencer, it follows the lead sequencer.
         (true, false) => {
-            info!("Node is up to date and following the lead sequencer.");
             SequencerStatus::Following
         }
         // If the node is not up to date, it should sync.


### PR DESCRIPTION
Remove info! log from determine_new_status for the (true, false) branch.

Why: 1) The log inside determine_new_status caused two issues:
2) Duplicate message on transition to Following (logged both in determine_new_status and update_state).
3) Log spam every tick while staying in Following, since determine_new_status is called periodically even without state changes.