### PR TITLE
chore(l1, l2): use version, authors, documentation and edition fields from the root cargo toml for all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ default-members = ["cmd/ethrex"]
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+authors = ["LambdaClass"]
+documentation = "https://docs.ethrex.xyz"
 
 [profile.release]
 opt-level = 3

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cmd/ethrex_replay/Cargo.toml
+++ b/cmd/ethrex_replay/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-replay"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [profile.dev]
 debug = 2

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-blockchain"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/blockchain/dev/Cargo.toml
+++ b/crates/blockchain/dev/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-dev"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/blockchain/metrics/Cargo.toml
+++ b/crates/blockchain/metrics/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-metrics"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-common"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/common/config/Cargo.toml
+++ b/crates/common/config/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-config"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-p2p.workspace = true

--- a/crates/common/crypto/Cargo.toml
+++ b/crates/common/crypto/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-crypto"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [lib]
 path = "./lib.rs"

--- a/crates/common/rlp/Cargo.toml
+++ b/crates/common/rlp/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-rlp"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 tinyvec = "1.6.0"

--- a/crates/common/trie/Cargo.toml
+++ b/crates/common/trie/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-trie"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-rlp.workspace = true

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-l2"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/l2/common/Cargo.toml
+++ b/crates/l2/common/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-l2-common"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethereum-types.workspace = true

--- a/crates/l2/networking/rpc/Cargo.toml
+++ b/crates/l2/networking/rpc/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-l2-rpc"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-prover"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 serde_json.workspace = true

--- a/crates/l2/prover/src/guest_program/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "guest_program"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 serde = { version = "1.0.203", features = ["derive"] }

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "zkvm-risc0-program"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [workspace]
 

--- a/crates/l2/prover/src/guest_program/src/sp1/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/sp1/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-version = "0.1.0"
 name = "zkvm-sp1-program"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [workspace]
 

--- a/crates/l2/sdk/Cargo.toml
+++ b/crates/l2/sdk/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-sdk"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-common.workspace = true

--- a/crates/l2/sdk/contract_utils/Cargo.toml
+++ b/crates/l2/sdk/contract_utils/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-sdk-contract-utils"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/l2/storage/Cargo.toml
+++ b/crates/l2/storage/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-storage-rollup"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 
 [dependencies]

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "quote-gen"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 configfs-tsm = "0.0.1"

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-p2p"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/networking/rpc/Cargo.toml
+++ b/crates/networking/rpc/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-rpc"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-storage"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "ethrex-vm"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-common.workspace = true

--- a/crates/vm/levm/Cargo.toml
+++ b/crates/vm/levm/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ethrex-levm"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 lazy_static.workspace = true

--- a/crates/vm/levm/bench/revm_comparison/Cargo.toml
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "revm_comparison"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [lib]
 name = "revm_comparison"

--- a/tooling/archive_sync/Cargo.toml
+++ b/tooling/archive_sync/Cargo.toml
@@ -2,6 +2,8 @@
 name = "archive_sync"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 lazy_static.workspace = true

--- a/tooling/ef_tests/blockchain/Cargo.toml
+++ b/tooling/ef_tests/blockchain/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ef_tests-blockchain"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-blockchain.workspace = true

--- a/tooling/ef_tests/state/Cargo.toml
+++ b/tooling/ef_tests/state/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ef_tests-state"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-blockchain.workspace = true

--- a/tooling/ef_tests/state_v2/Cargo.toml
+++ b/tooling/ef_tests/state_v2/Cargo.toml
@@ -2,6 +2,8 @@
 name = "ef_tests-statev2"
 version.workspace = true
 edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-blockchain.workspace = true

--- a/tooling/genesis/Cargo.toml
+++ b/tooling/genesis/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "genesis-tool"
-edition.workspace = true
 version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 ethrex-common.workspace = true

--- a/tooling/hive_report/Cargo.toml
+++ b/tooling/hive_report/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "hive_report"
-edition.workspace = true
 version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/tooling/load_test/Cargo.toml
+++ b/tooling/load_test/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "load_test"
-edition.workspace = true
 version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 clap.workspace = true

--- a/tooling/loc/Cargo.toml
+++ b/tooling/loc/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "loc"
-edition.workspace = true
 version.workspace = true
+edition.workspace = true
+authors.workspace = true
+documentation.workspace = true
 
 [dependencies]
 tokei = "12.1.2"


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

