### PR TITLE
fix(replay): use get block by number instead of get raw block

### DIFF
--- a/cmd/ethrex_replay/src/fetcher.rs
+++ b/cmd/ethrex_replay/src/fetcher.rs
@@ -172,10 +172,12 @@ async fn fetch_rangedata_from_client(
     let block_retrieval_start_time = SystemTime::now();
 
     for block_number in from..=to {
-        let block = eth_client
-            .get_raw_block(BlockIdentifier::Number(block_number))
+        let rpc_block = eth_client
+            .get_block_by_number(BlockIdentifier::Number(block_number), true)
             .await
             .wrap_err(format!("failed to fetch block {block_number}"))?;
+
+        let block = rpc_block.try_into().unwrap();
         blocks.push(block);
     }
 

--- a/tooling/replayer/src/main.rs
+++ b/tooling/replayer/src/main.rs
@@ -304,9 +304,11 @@ async fn replay_latest_block(
         tracing::info!("Replaying block https://{network}.etherscan.io/block/{latest_block}",);
     }
 
-    let block = eth_client
-        .get_raw_block(BlockIdentifier::Number(latest_block))
+    let rpc_block = eth_client
+        .get_block_by_number(BlockIdentifier::Number(latest_block), true)
         .await?;
+
+    let block = rpc_block.try_into().unwrap();
 
     let start = SystemTime::now();
 


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
If the node that we are using as an RPC doesn't expose debug endpoints ethrex replayer won't work because it asks for the raw block. The program got stuck and we didn't know why, we now know.

