### PR TITLE
fix(l2): common bridge dependencies

### DIFF
--- a/cmd/ethrex/build.rs
+++ b/cmd/ethrex/build.rs
@@ -224,7 +224,7 @@ fn download_contract_deps(contracts_path: &Path) {
         &contracts_path
             .join("lib/openzeppelin-contracts-upgradeable")
             .to_string_lossy(),
-        None,
+        Some("release-v5.4"),
         true,
     )
     .expect("Failed to clone openzeppelin-contracts-upgradeable");

--- a/crates/l2/sdk/build.rs
+++ b/crates/l2/sdk/build.rs
@@ -30,7 +30,7 @@ fn main() {
             .join("lib/openzeppelin-contracts-upgradeable")
             .to_str()
             .expect("Failed to convert path to str"),
-        None,
+        Some("release-v5.4"),
         true,
     )
     .unwrap();

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -1954,7 +1954,7 @@ fn get_contract_dependencies(contracts_path: &Path) {
             .join("lib/openzeppelin-contracts-upgradeable")
             .to_str()
             .expect("Failed to convert path to str"),
-        None,
+        Some("release-v5.4"),
         true,
     )
     .unwrap();


### PR DESCRIPTION
**Motivation**

ReentrancyGuard was removed from the `openzeppelin/contracts-upgradable`. See [this](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/commit/4a073ac393f1c1495391b810b2c7b6b96de28137#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)

For now we pin the commit to the one we were using until we decide what to do.

**Description**

Add to the `git_clone` an optional commit to checkout

Closes #issue_number

