### PR TITLE
refactor(l1,l2): use Url types instead of String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7000,6 +7000,7 @@ dependencies = [
  "keccak-hash",
  "secp256k1",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/cmd/ethrex/build.rs
+++ b/cmd/ethrex/build.rs
@@ -224,7 +224,7 @@ fn download_contract_deps(contracts_path: &Path) {
         &contracts_path
             .join("lib/openzeppelin-contracts-upgradeable")
             .to_string_lossy(),
-        None,
+        Some("release-v5.4"),
         true,
     )
     .expect("Failed to clone openzeppelin-contracts-upgradeable");

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -202,8 +202,8 @@ pub enum Command {
         #[arg(
             long,
             value_parser = parse_private_key,
-            env = "SEQUENCER_PRIVATE_KEY", 
-            help = "The private key of the sequencer", 
+            env = "SEQUENCER_PRIVATE_KEY",
+            help = "The private key of the sequencer",
             help_heading  = "Sequencer account options",
             group = "sequencer_signing",
         )]
@@ -289,7 +289,7 @@ impl Command {
             } => {
                 create_dir_all(datadir.clone())?;
 
-                let eth_client = EthClient::new(l1_eth_rpc.as_str())?;
+                let eth_client = EthClient::new(l1_eth_rpc)?;
                 let beacon_client = BeaconClient::new(l1_beacon_rpc);
 
                 // Keep delay for finality
@@ -671,7 +671,7 @@ pub struct ContractCallOptions {
 
 impl ContractCallOptions {
     async fn call_contract(&self, selector: &str, params: Vec<Value>) -> eyre::Result<()> {
-        let client = EthClient::new(self.rpc_url.as_str())?;
+        let client = EthClient::new(self.rpc_url.clone())?;
         let signer = parse_signer(
             self.private_key,
             self.remote_signer_url.clone(),

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -24,6 +24,7 @@ use tracing::{error, info, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry, reload};
 use tui_logger::{LevelFilter, TuiTracingSubscriberLayer};
+use url::Url;
 
 use crate::cli::Options as L1Options;
 use crate::initializers::{
@@ -261,10 +262,11 @@ pub async fn init_l2(
         l2_sequencer_cfg,
         cancellation_token.clone(),
         #[cfg(feature = "metrics")]
-        format!(
+        Url::parse(&format!(
             "http://{}:{}",
             opts.node_opts.http_addr, opts.node_opts.http_port
-        ),
+        ))
+        .expect("Invalid L2 RPC URL"),
     )
     .into_future();
 

--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -5,8 +5,8 @@ use crate::{
 use clap::Parser;
 use ethrex_common::{Address, types::DEFAULT_BUILDER_GAS_CEIL};
 use ethrex_l2::{
-    BasedConfig, BlockFetcherConfig, BlockProducerConfig, CommitterConfig, EthConfig,
-    L1WatcherConfig, ProofCoordinatorConfig, SequencerConfig, StateUpdaterConfig,
+    BasedConfig, BlockFetcherConfig, BlockProducerConfig, CommitterConfig, L1WatcherConfig,
+    ProofCoordinatorConfig, SequencerConfig, StateUpdaterConfig,
     sequencer::{
         configs::{AdminConfig, AlignedConfig, MonitorConfig},
         utils::resolve_aligned_network,
@@ -15,7 +15,7 @@ use ethrex_l2::{
 use ethrex_l2_rpc::signer::{LocalSigner, RemoteSigner, Signer};
 use ethrex_prover_lib::{backend::Backend, config::ProverConfig};
 use ethrex_rpc::clients::eth::{
-    BACKOFF_FACTOR, MAX_NUMBER_OF_RETRIES, MAX_RETRY_DELAY, MIN_RETRY_DELAY,
+    BACKOFF_FACTOR, EthConfig, MAX_NUMBER_OF_RETRIES, MAX_RETRY_DELAY, MIN_RETRY_DELAY,
 };
 use reqwest::Url;
 use secp256k1::{PublicKey, SecretKey};
@@ -176,15 +176,17 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
                 validium: opts.validium,
             },
             eth: EthConfig {
-                rpc_url: opts.eth_opts.rpc_url,
+                urls: opts.eth_opts.rpc_url,
                 max_number_of_retries: opts.eth_opts.max_number_of_retries,
                 backoff_factor: opts.eth_opts.backoff_factor,
                 min_retry_delay: opts.eth_opts.min_retry_delay,
                 max_retry_delay: opts.eth_opts.max_retry_delay,
-                maximum_allowed_max_fee_per_gas: opts.eth_opts.maximum_allowed_max_fee_per_gas,
-                maximum_allowed_max_fee_per_blob_gas: opts
-                    .eth_opts
-                    .maximum_allowed_max_fee_per_blob_gas,
+                maximum_allowed_max_fee_per_gas: Some(
+                    opts.eth_opts.maximum_allowed_max_fee_per_gas,
+                ),
+                maximum_allowed_max_fee_per_blob_gas: Some(
+                    opts.eth_opts.maximum_allowed_max_fee_per_blob_gas,
+                ),
                 safe_block_delay: opts.eth_opts.safe_block_delay,
             },
             l1_watcher: L1WatcherConfig {
@@ -253,7 +255,7 @@ pub struct EthOptions {
         help_heading = "Eth options",
         num_args = 1..
     )]
-    pub rpc_url: Vec<String>,
+    pub rpc_url: Vec<Url>,
     #[arg(
         long = "eth.maximum-allowed-max-fee-per-gas",
         default_value = "10000000000",
@@ -316,7 +318,7 @@ pub struct EthOptions {
 impl Default for EthOptions {
     fn default() -> Self {
         Self {
-            rpc_url: vec!["http://localhost:8545".to_string()],
+            rpc_url: vec![Url::parse("http://localhost:8545").expect("Failed to parse L1 RPC URL")],
             maximum_allowed_max_fee_per_gas: 10000000000,
             maximum_allowed_max_fee_per_blob_gas: 10000000000,
             max_number_of_retries: MAX_NUMBER_OF_RETRIES,

--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -80,7 +80,7 @@ pub enum EthrexReplayCommand {
         #[arg(help = "Ending block. (Inclusive)")]
         end: u64,
         #[arg(long, env = "RPC_URL", required = true)]
-        rpc_url: String,
+        rpc_url: Url,
         #[arg(
             long,
             help = "Name of the network or genesis file. Supported: mainnet, holesky, sepolia, hoodi. Default: mainnet",
@@ -346,7 +346,7 @@ impl EthrexReplayCommand {
                     ));
                 }
 
-                let eth_client = EthClient::new(&rpc_url)?;
+                let eth_client = EthClient::new(rpc_url)?;
 
                 let cache = get_rangedata(eth_client, network, start, end).await?;
 
@@ -413,7 +413,7 @@ impl EthrexReplayCommand {
 }
 
 async fn setup(opts: &EthrexReplayOptions) -> eyre::Result<(EthClient, Network)> {
-    let eth_client = EthClient::new(opts.rpc_url.as_str())?;
+    let eth_client = EthClient::new(opts.rpc_url.clone())?;
     let chain_id = eth_client.get_chain_id().await?.as_u64();
     let network = network_from_chain_id(chain_id);
     Ok((eth_client, network))
@@ -1109,7 +1109,7 @@ pub async fn produce_custom_l2_block(
 }
 
 async fn fetch_latest_block_number(rpc_url: Url) -> eyre::Result<u64> {
-    let eth_client = EthClient::new(rpc_url.as_str())?;
+    let eth_client = EthClient::new(rpc_url)?;
 
     let latest_block = eth_client.get_block_number().await?;
 

--- a/cmd/ethrex_replay/src/fetcher.rs
+++ b/cmd/ethrex_replay/src/fetcher.rs
@@ -103,7 +103,7 @@ pub async fn get_blockdata(
                 requested_block_number - 1
             );
             let rpc_db = RpcDB::with_cache(
-                eth_client.urls.first().unwrap().as_str(),
+                eth_client.config.urls.first().unwrap().as_str(),
                 chain_config,
                 (requested_block_number - 1).try_into()?,
                 &block,

--- a/crates/l2/based/block_fetcher.rs
+++ b/crates/l2/based/block_fetcher.rs
@@ -103,7 +103,7 @@ impl BlockFetcher {
         blockchain: Arc<Blockchain>,
         sequencer_state: SequencerState,
     ) -> Result<Self, BlockFetcherError> {
-        let eth_client = EthClient::new_with_multiple_urls(cfg.eth.rpc_url.clone())?;
+        let eth_client = EthClient::new_with_multiple_urls(cfg.eth.urls.clone())?;
         let last_l1_block_fetched =
             get_last_fetched_l1_block(&eth_client, cfg.l1_watcher.bridge_address)
                 .await?

--- a/crates/l2/based/state_updater.rs
+++ b/crates/l2/based/state_updater.rs
@@ -75,7 +75,7 @@ impl StateUpdater {
             sequencer_registry_address: sequencer_cfg.based.state_updater.sequencer_registry,
             sequencer_address: sequencer_cfg.l1_committer.signer.address(),
             eth_client: Arc::new(EthClient::new_with_multiple_urls(
-                sequencer_cfg.eth.rpc_url.clone(),
+                sequencer_cfg.eth.urls.clone(),
             )?),
             store,
             rollup_store,

--- a/crates/l2/l2.rs
+++ b/crates/l2/l2.rs
@@ -6,7 +6,7 @@ pub mod utils;
 
 pub use based::{block_fetcher::BlockFetcher, state_updater::StateUpdater};
 pub use sequencer::configs::{
-    BasedConfig, BlockFetcherConfig, BlockProducerConfig, CommitterConfig, EthConfig,
-    L1WatcherConfig, ProofCoordinatorConfig, SequencerConfig, StateUpdaterConfig,
+    BasedConfig, BlockFetcherConfig, BlockProducerConfig, CommitterConfig, L1WatcherConfig,
+    ProofCoordinatorConfig, SequencerConfig, StateUpdaterConfig,
 };
 pub use sequencer::start_l2;

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -1,6 +1,7 @@
 use aligned_sdk::common::types::Network;
 use ethrex_common::{Address, U256};
 use ethrex_l2_rpc::signer::Signer;
+use ethrex_rpc::clients::eth::EthConfig;
 use reqwest::Url;
 use secp256k1::SecretKey;
 use std::net::IpAddr;
@@ -36,18 +37,6 @@ pub struct CommitterConfig {
     pub arbitrary_base_blob_gas_price: u64,
     pub validium: bool,
     pub signer: Signer,
-}
-
-#[derive(Clone, Debug)]
-pub struct EthConfig {
-    pub rpc_url: Vec<String>,
-    pub maximum_allowed_max_fee_per_gas: u64,
-    pub maximum_allowed_max_fee_per_blob_gas: u64,
-    pub max_number_of_retries: u64,
-    pub backoff_factor: u64,
-    pub min_retry_delay: u64,
-    pub max_retry_delay: u64,
-    pub safe_block_delay: u64,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CommitterConfig, EthConfig, SequencerConfig,
+    CommitterConfig, SequencerConfig,
     based::sequencer_state::{SequencerState, SequencerStatus},
     sequencer::{
         errors::CommitterError,
@@ -36,7 +36,7 @@ use ethrex_metrics::l2::metrics::{METRICS, MetricsBlockType};
 use ethrex_metrics::metrics;
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_rpc::{
-    clients::eth::{EthClient, Overrides},
+    clients::eth::{EthClient, EthConfig, Overrides},
     types::block_identifier::{BlockIdentifier, BlockTag},
 };
 use ethrex_storage::Store;
@@ -132,20 +132,7 @@ impl L1Committer {
         based: bool,
         sequencer_state: SequencerState,
     ) -> Result<Self, CommitterError> {
-        let eth_client = EthClient::new_with_config(
-            eth_config.rpc_url.clone(),
-            ethrex_rpc::clients::eth::EthConfig {
-                max_number_of_retries: eth_config.max_number_of_retries,
-                backoff_factor: eth_config.backoff_factor,
-                min_retry_delay: eth_config.min_retry_delay,
-                max_retry_delay: eth_config.max_retry_delay,
-                maximum_allowed_max_fee_per_gas: Some(eth_config.maximum_allowed_max_fee_per_gas),
-                maximum_allowed_max_fee_per_blob_gas: Some(
-                    eth_config.maximum_allowed_max_fee_per_blob_gas,
-                ),
-                safe_block_delay: eth_config.safe_block_delay,
-            },
-        )?;
+        let eth_client = EthClient::new_with_config(eth_config.clone())?;
         let last_committed_batch =
             get_last_committed_batch(&eth_client, committer_config.on_chain_proposer_address)
                 .await?;

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -17,6 +17,8 @@ use l1_watcher::L1Watcher;
 #[cfg(feature = "metrics")]
 use metrics::MetricsGatherer;
 use proof_coordinator::ProofCoordinator;
+#[cfg(feature = "metrics")]
+use reqwest::Url;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use utils::get_needed_proof_types;
@@ -42,7 +44,7 @@ pub async fn start_l2(
     blockchain: Arc<Blockchain>,
     cfg: SequencerConfig,
     cancellation_token: CancellationToken,
-    #[cfg(feature = "metrics")] l2_url: String,
+    #[cfg(feature = "metrics")] l2_url: Url,
 ) -> Result<(), errors::SequencerError> {
     let initial_status = if cfg.based.enabled {
         SequencerStatus::default()
@@ -65,7 +67,7 @@ pub async fn start_l2(
     let shared_state = SequencerState::from(initial_status);
 
     let Ok(needed_proof_types) = get_needed_proof_types(
-        cfg.eth.rpc_url.clone(),
+        cfg.eth.urls.clone(),
         cfg.l1_committer.on_chain_proposer_address,
     )
     .await

--- a/crates/l2/sequencer/utils.rs
+++ b/crates/l2/sequencer/utils.rs
@@ -13,6 +13,7 @@ use ethrex_rpc::{
 use ethrex_storage_rollup::{RollupStoreError, StoreRollup};
 use keccak_hash::keccak;
 use rand::Rng;
+use reqwest::Url;
 use std::time::{Duration, SystemTime};
 use std::{str::FromStr, time::UNIX_EPOCH};
 use tokio::time::sleep;
@@ -81,7 +82,7 @@ pub async fn send_verify_tx(
 }
 
 pub async fn get_needed_proof_types(
-    rpc_urls: Vec<String>,
+    rpc_urls: Vec<Url>,
     on_chain_proposer_address: Address,
 ) -> Result<Vec<ProverType>, EthClientError> {
     let eth_client = EthClient::new_with_multiple_urls(rpc_urls)?;

--- a/crates/l2/tests/state_reconstruct.rs
+++ b/crates/l2/tests/state_reconstruct.rs
@@ -7,6 +7,7 @@ use ethrex_common::{Address, U256};
 use ethrex_l2_common::utils::get_address_from_secret_key;
 use ethrex_rpc::{EthClient, types::block_identifier::BlockIdentifier};
 
+use reqwest::Url;
 use secp256k1::SecretKey;
 
 const ETH_RPC_URL: &str = "http://localhost:1729";
@@ -77,7 +78,8 @@ async fn test_state_block(addresses: &[Address], block_number: u64, rich_account
 }
 
 async fn connect() -> EthClient {
-    let client = EthClient::new(ETH_RPC_URL).unwrap();
+    let url = Url::parse(ETH_RPC_URL).unwrap();
+    let client = EthClient::new(url).unwrap();
 
     let mut retries = 0;
     while retries < 20 {

--- a/crates/l2/tests/tests.rs
+++ b/crates/l2/tests/tests.rs
@@ -29,6 +29,7 @@ use ethrex_rpc::{
 };
 use hex::FromHexError;
 use keccak_hash::keccak;
+use reqwest::Url;
 use secp256k1::SecretKey;
 use std::{
     fs::{File, read_to_string},
@@ -1800,13 +1801,17 @@ async fn get_fees_details_l2(tx_receipt: &RpcReceipt, l2_client: &EthClient) -> 
 }
 
 fn l1_client() -> EthClient {
-    EthClient::new(&std::env::var("INTEGRATION_TEST_L1_RPC").unwrap_or(DEFAULT_L1_RPC.to_string()))
-        .unwrap()
+    let url =
+        Url::parse(&std::env::var("INTEGRATION_TEST_L1_RPC").unwrap_or(DEFAULT_L1_RPC.to_string()))
+            .expect("Invalid L1 RPC URL");
+    EthClient::new(url).unwrap()
 }
 
 fn l2_client() -> EthClient {
-    EthClient::new(&std::env::var("INTEGRATION_TEST_L2_RPC").unwrap_or(DEFAULT_L2_RPC.to_string()))
-        .unwrap()
+    let url =
+        Url::parse(&std::env::var("INTEGRATION_TEST_L1_RPC").unwrap_or(DEFAULT_L2_RPC.to_string()))
+            .expect("Invalid L1 RPC URL");
+    EthClient::new(url).unwrap()
 }
 
 fn fees_vault() -> Address {

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -40,6 +40,7 @@ pub enum RpcResponse {
 
 #[derive(Debug, Clone)]
 pub struct EthConfig {
+    pub urls: Vec<Url>,
     pub max_number_of_retries: u64,
     pub backoff_factor: u64,
     pub min_retry_delay: u64,
@@ -52,7 +53,6 @@ pub struct EthConfig {
 #[derive(Debug, Clone)]
 pub struct EthClient {
     client: Client,
-    pub urls: Vec<Url>,
     pub config: EthConfig,
 }
 
@@ -82,42 +82,35 @@ pub const MAX_RETRY_DELAY: u64 = 1800;
 pub const ERROR_FUNCTION_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
 
 impl EthClient {
-    pub fn new(url: &str) -> Result<EthClient, EthClientError> {
-        Self::new_with_multiple_urls(vec![url.to_string()])
+    pub fn new(url: Url) -> Result<EthClient, EthClientError> {
+        Self::new_with_multiple_urls(vec![url])
     }
 
-    pub fn new_with_config(urls: Vec<String>, config: EthConfig) -> Result<Self, EthClientError> {
-        let urls = urls
-            .iter()
-            .map(|url| Url::parse(url).map_err(|_| EthClientError::ParseUrlError(url.clone())))
-            .collect::<Result<Vec<_>, _>>()?;
+    pub fn new_with_config(config: EthConfig) -> Result<Self, EthClientError> {
         Ok(Self {
             client: Client::new(),
-            urls,
             config,
         })
     }
 
-    pub fn new_with_multiple_urls(urls: Vec<String>) -> Result<EthClient, EthClientError> {
-        Self::new_with_config(
+    pub fn new_with_multiple_urls(urls: Vec<Url>) -> Result<EthClient, EthClientError> {
+        Self::new_with_config(EthConfig {
             urls,
-            EthConfig {
-                max_number_of_retries: MAX_NUMBER_OF_RETRIES,
-                backoff_factor: BACKOFF_FACTOR,
-                min_retry_delay: MIN_RETRY_DELAY,
-                max_retry_delay: MAX_RETRY_DELAY,
-                maximum_allowed_max_fee_per_gas: None,
-                maximum_allowed_max_fee_per_blob_gas: None,
-                safe_block_delay: 0,
-            },
-        )
+            max_number_of_retries: MAX_NUMBER_OF_RETRIES,
+            backoff_factor: BACKOFF_FACTOR,
+            min_retry_delay: MIN_RETRY_DELAY,
+            max_retry_delay: MAX_RETRY_DELAY,
+            maximum_allowed_max_fee_per_gas: None,
+            maximum_allowed_max_fee_per_blob_gas: None,
+            safe_block_delay: 0,
+        })
     }
 
     /// Send a request to the RPC. Tries each URL until one succeeds.
     pub async fn send_request(&self, request: RpcRequest) -> Result<RpcResponse, EthClientError> {
         let mut response = Err(EthClientError::FailedAllRPC);
 
-        for url in self.urls.iter() {
+        for url in self.config.urls.iter() {
             response = self.send_request_to_url(url, &request).await;
             // Some RPC servers don't implement all the endpoints or don't implement them completely/correctly
             // so if the server returns Ok(RpcResponse::Error) we retry with the others
@@ -147,7 +140,7 @@ impl EthClient {
     ) -> Result<RpcResponse, EthClientError> {
         let mut response = Err(EthClientError::FailedAllRPC);
 
-        for url in self.urls.iter() {
+        for url in self.config.urls.iter() {
             let maybe_response = self.send_request_to_url(url, &request).await;
 
             match &maybe_response {
@@ -650,7 +643,7 @@ impl EthClient {
     /// Smoke test the all the urls by calling eth_blockNumber
     pub async fn test_urls(&self) -> BTreeMap<String, serde_json::Value> {
         let mut map = BTreeMap::new();
-        for url in self.urls.iter() {
+        for url in self.config.urls.iter() {
             let response = match self
                 .send_request_to_url(url, &RpcRequest::new("eth_blockNumber", None))
                 .await

--- a/tooling/load_test/Cargo.toml
+++ b/tooling/load_test/Cargo.toml
@@ -18,3 +18,4 @@ eyre.workspace = true
 keccak-hash.workspace = true
 tokio = { workspace = true, features = ["full"] }
 futures = "0.3"
+url.workspace = true

--- a/tooling/load_test/src/main.rs
+++ b/tooling/load_test/src/main.rs
@@ -20,6 +20,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 use tokio::{task::JoinSet, time::sleep};
+use url::Url;
 
 // ERC20 compiled artifact generated from this tutorial:
 // https://medium.com/@kaishinaw/erc20-using-hardhat-a-comprehensive-guide-3211efba98d4
@@ -47,7 +48,7 @@ struct Cli {
         default_value = "http://localhost:8545",
         help = "URL of the node being tested."
     )]
-    node: String,
+    node: Url,
 
     #[arg(long, short = 'k', help = "Path to the file containing private keys.")]
     pkeys: String,
@@ -334,7 +335,7 @@ async fn main() {
     let pkeys_path = Path::new(&cli.pkeys);
     let accounts = parse_pk_file(pkeys_path)
         .unwrap_or_else(|_| panic!("Failed to parse private keys file {}", pkeys_path.display()));
-    let client = EthClient::new(&cli.node).expect("Failed to create EthClient");
+    let client = EthClient::new(cli.node).expect("Failed to create EthClient");
 
     // We ask the client for the chain id.
     let chain_id = client

--- a/tooling/replayer/src/main.rs
+++ b/tooling/replayer/src/main.rs
@@ -224,7 +224,7 @@ async fn replay_execution(
 ) -> Result<(), EthClientError> {
     tracing::info!("Starting execution replayer for network: {network} with RPC URL: {rpc_url}");
 
-    let eth_client = EthClient::new(rpc_url.as_str()).unwrap();
+    let eth_client = EthClient::new(rpc_url.clone()).unwrap();
 
     loop {
         let elapsed = replay_latest_block(
@@ -258,7 +258,7 @@ async fn replay_proving(
             } else {
                 continue;
             };
-            let eth_client = EthClient::new(rpc_url.as_str()).unwrap();
+            let eth_client = EthClient::new(rpc_url.clone()).unwrap();
 
             replay_latest_block(
                 replayer_mode.clone(),
@@ -382,7 +382,7 @@ async fn replay_latest_block(
 }
 
 async fn revalidate_rpc(rpc_url: Url) -> Result<(), EthClientError> {
-    let eth_client = EthClient::new(rpc_url.as_str()).unwrap();
+    let eth_client = EthClient::new(rpc_url).unwrap();
 
     loop {
         let mut interval = tokio::time::interval(Duration::from_secs(10));


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We are using `String` and `&str` for URLs instead of the more specific `Url`.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Replace CLI and occurrences, primarly in `EthClient` to use `Url` instead.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Related: #2673

