### PR TITLE
feat(l1): keep downloading big storage leaves on pivot jump during snap sync

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1491,6 +1491,7 @@ impl PeerHandler {
                                     task_count += 1;
                                 }
                             } else {
+                                // TODO: DRY
                                 account_storage_roots.accounts_with_storage_root.insert(
                                     current_account_hashes[remaining_start],
                                     (None, vec![]),

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1436,16 +1436,10 @@ impl PeerHandler {
                             let old_intervals = accounts_done
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
-                            // dbg!(&old_intervals);
-                            // dbg!(&current_account_hashes[remaining_start]);
-                            // dbg!(&hash_end);
                             old_intervals.remove(
                                 old_intervals
                                     .iter()
-                                    .position(|(_old_start, end)| {
-                                        // dbg!(&end);
-                                        end == &hash_end
-                                    })
+                                    .position(|(_old_start, end)| end == &hash_end)
                                     .unwrap(),
                             );
                         }
@@ -1478,10 +1472,11 @@ impl PeerHandler {
 
                         let chunk_count = (missing_storage_range / chunk_size).as_usize().max(1);
 
-                        let maybe_old_intervals =
-                            accounts_done.get(&current_account_hashes[remaining_start]);
+                        let maybe_old_intervals = account_storage_roots
+                            .accounts_with_storage_root
+                            .get(&current_account_hashes[remaining_start]);
 
-                        if let Some(old_intervals) = maybe_old_intervals {
+                        if let Some((_, old_intervals)) = maybe_old_intervals {
                             for (start_hash, end_hash) in old_intervals {
                                 let task = StorageTask {
                                     start_index: remaining_start,

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1395,7 +1395,7 @@ impl PeerHandler {
                     // If this is not a big account, insert it as done.
                     // If it's a big account, its logic will be handled below
 
-                    if index + 1 < remaining_start {
+                    if start_index + index + 1 < remaining_start {
                         accounts_done.insert(*account, vec![]);
                     } else {
                         if hash_start.is_zero() {

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1283,7 +1283,7 @@ impl PeerHandler {
         *METRICS.current_step.lock().await = "Requesting Storage Ranges".to_string();
         debug!("Starting request_storage_ranges function");
         // 1) split the range in chunks of same length
-        let chunk_size = 300;
+        let chunk_size = 1600;
         let chunk_count = (account_storage_roots.accounts_with_storage_root.len() / chunk_size) + 1;
 
         // list of tasks to be executed

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1443,10 +1443,15 @@ impl PeerHandler {
                             let old_intervals = accounts_done
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
+                            dbg!(&current_account_hashes[remaining_start]);
                             old_intervals.remove(
                                 old_intervals
                                     .iter()
-                                    .position(|(_old_start, end)| end == &hash_end)
+                                    .position(|(_old_start, end)| {
+                                        dbg!(&end);
+                                        dbg!(&hash_end);
+                                        end == &hash_end
+                                    })
                                     .unwrap(),
                             );
                         }

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -55,7 +55,7 @@ pub const MAX_HEADER_CHUNK: u64 = 500_000;
 // before we dump it into the file. This tunes how much memory ethrex uses during
 // the first steps of snap sync
 pub const RANGE_FILE_CHUNK_SIZE: usize = 1024 * 1024 * 512; // 512MB
-pub const SNAP_LIMIT: usize = 128;
+pub const SNAP_LIMIT: usize = 30;
 
 // Request as many as 128 block bodies per request
 // this magic number is not part of the protocol and is taken from geth, see:

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1421,7 +1421,8 @@ impl PeerHandler {
                             tasks_queue_not_started.push_back(task);
                             task_count += 1;
                             // accounts_done.push(current_account_hashes[remaining_start]);
-                            let old_intervals = accounts_done
+                            let (_, old_intervals) = account_storage_roots
+                                .accounts_with_storage_root
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
                             for (old_start, end) in old_intervals {
@@ -1433,7 +1434,8 @@ impl PeerHandler {
                                 .healed_accounts
                                 .insert(current_account_hashes[start_index]);
                         } else {
-                            let old_intervals = accounts_done
+                            let (_, old_intervals) = account_storage_roots
+                                .accounts_with_storage_root
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
                             old_intervals.remove(
@@ -1442,6 +1444,10 @@ impl PeerHandler {
                                     .position(|(_old_start, end)| end == &hash_end)
                                     .unwrap(),
                             );
+                            if old_intervals.is_empty() {
+                                accounts_done
+                                    .insert(current_account_hashes[remaining_start], vec![]);
+                            }
                         }
                     } else {
                         if remaining_start + 1 < remaining_end {
@@ -1489,8 +1495,11 @@ impl PeerHandler {
                                 task_count += 1;
                             }
                         } else {
-                            accounts_done.insert(current_account_hashes[remaining_start], vec![]);
-                            let intervals = accounts_done
+                            account_storage_roots
+                                .accounts_with_storage_root
+                                .insert(current_account_hashes[remaining_start], (None, vec![]));
+                            let (_, intervals) = account_storage_roots
+                                .accounts_with_storage_root
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
 

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1390,7 +1390,9 @@ impl PeerHandler {
                 for account in current_account_hashes[start_index..remaining_start].iter() {
                     // If this is not a big account, insert it as done.
                     // If it's a big account, its logic will be handled below
-                    accounts_done.insert(*account, vec![]);
+                    if !accounts_done.contains_key(account) {
+                        accounts_done.insert(*account, vec![]);
+                    }
                 }
 
                 if remaining_start < remaining_end {

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1387,21 +1387,10 @@ impl PeerHandler {
 
                 self.peer_table.free_peer(peer_id).await;
 
-                for (index, account) in current_account_hashes[start_index..remaining_start]
-                    .iter()
-                    .enumerate()
-                {
-                    // accounts_done.push((*account, vec![]));
+                for account in current_account_hashes[start_index..remaining_start].iter() {
                     // If this is not a big account, insert it as done.
                     // If it's a big account, its logic will be handled below
-
-                    if start_index + index + 1 < remaining_start {
-                        accounts_done.insert(*account, vec![]);
-                    } else {
-                        if hash_start.is_zero() {
-                            accounts_done.insert(*account, vec![]);
-                        }
-                    }
+                    accounts_done.insert(*account, vec![]);
                 }
 
                 if remaining_start < remaining_end {

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1443,13 +1443,14 @@ impl PeerHandler {
                             let old_intervals = accounts_done
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
+                            dbg!(&old_intervals);
                             dbg!(&current_account_hashes[remaining_start]);
+                            dbg!(&hash_end);
                             old_intervals.remove(
                                 old_intervals
                                     .iter()
                                     .position(|(_old_start, end)| {
                                         dbg!(&end);
-                                        dbg!(&hash_end);
                                         end == &hash_end
                                     })
                                     .unwrap(),

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1434,14 +1434,14 @@ impl PeerHandler {
                             let old_intervals = accounts_done
                                 .get_mut(&current_account_hashes[remaining_start])
                                 .unwrap();
-                            dbg!(&old_intervals);
-                            dbg!(&current_account_hashes[remaining_start]);
-                            dbg!(&hash_end);
+                            // dbg!(&old_intervals);
+                            // dbg!(&current_account_hashes[remaining_start]);
+                            // dbg!(&hash_end);
                             old_intervals.remove(
                                 old_intervals
                                     .iter()
                                     .position(|(_old_start, end)| {
-                                        dbg!(&end);
+                                        // dbg!(&end);
                                         end == &hash_end
                                     })
                                     .unwrap(),

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1343,18 +1343,11 @@ pub fn calculate_staleness_timestamp(timestamp: u64) -> u64 {
 pub struct AccountStorageRoots {
     /// The accounts that have not been healed are guaranteed to have the original storage root
     /// we can read this storage root
-    // pub accounts_with_storage_root: BTreeMap<H256, H256>,
     pub accounts_with_storage_root: BTreeMap<H256, (Option<H256>, Vec<(H256, H256)>)>,
     /// If an account has been healed, it may return to a previous state, so we just store the account
     /// in a hashset
     pub healed_accounts: HashSet<H256>,
 }
-
-// accounts_with_storage_root tracks accounts to download storage ranges by
-// setting account_hash -> storage_root (root for verify_range)
-
-// We need to track the following: (storage_root, Vec<start_hash, end_hash>) with the vec having the start and
-// end of each task to resume on a big account. The storage root needs to be modified each time the pivot jumps.
 
 #[derive(thiserror::Error, Debug)]
 pub enum SyncError {

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -905,7 +905,7 @@ impl Syncer {
                         .zip(account_states.iter())
                         .filter_map(|(hash, state)| {
                             (state.storage_root != *EMPTY_TRIE_HASH)
-                                .then_some((*hash, (state.storage_root, vec![])))
+                                .then_some((*hash, (Some(state.storage_root), vec![])))
                         }),
                 );
 
@@ -999,6 +999,7 @@ impl Syncer {
                         account_storages_snapshots_dir.as_ref(),
                         chunk_index,
                         &mut pivot_header,
+                        store.clone(),
                     )
                     .await
                     .map_err(SyncError::PeerHandler)?;
@@ -1343,7 +1344,7 @@ pub struct AccountStorageRoots {
     /// The accounts that have not been healed are guaranteed to have the original storage root
     /// we can read this storage root
     // pub accounts_with_storage_root: BTreeMap<H256, H256>,
-    pub accounts_with_storage_root: BTreeMap<H256, (H256, Vec<(H256, H256)>)>,
+    pub accounts_with_storage_root: BTreeMap<H256, (Option<H256>, Vec<(H256, H256)>)>,
     /// If an account has been healed, it may return to a previous state, so we just store the account
     /// in a hashset
     pub healed_accounts: HashSet<H256>,

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -905,7 +905,7 @@ impl Syncer {
                         .zip(account_states.iter())
                         .filter_map(|(hash, state)| {
                             (state.storage_root != *EMPTY_TRIE_HASH)
-                                .then_some((*hash, state.storage_root))
+                                .then_some((*hash, (state.storage_root, vec![])))
                         }),
                 );
 
@@ -1342,11 +1342,18 @@ pub fn calculate_staleness_timestamp(timestamp: u64) -> u64 {
 pub struct AccountStorageRoots {
     /// The accounts that have not been healed are guaranteed to have the original storage root
     /// we can read this storage root
-    pub accounts_with_storage_root: BTreeMap<H256, H256>,
+    // pub accounts_with_storage_root: BTreeMap<H256, H256>,
+    pub accounts_with_storage_root: BTreeMap<H256, (H256, Vec<(H256, H256)>)>,
     /// If an account has been healed, it may return to a previous state, so we just store the account
     /// in a hashset
     pub healed_accounts: HashSet<H256>,
 }
+
+// accounts_with_storage_root tracks accounts to download storage ranges by
+// setting account_hash -> storage_root (root for verify_range)
+
+// We need to track the following: (storage_root, Vec<start_hash, end_hash>) with the vec having the start and
+// end of each task to resume on a big account. The storage root needs to be modified each time the pivot jumps.
 
 #[derive(thiserror::Error, Debug)]
 pub enum SyncError {

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1339,6 +1339,7 @@ pub fn calculate_staleness_timestamp(timestamp: u64) -> u64 {
     timestamp + (SNAP_LIMIT as u64 * 12)
 }
 #[derive(Debug, Default)]
+#[allow(clippy::type_complexity)]
 /// We store for optimization the accounts that need to heal storage
 pub struct AccountStorageRoots {
     /// The accounts that have not been healed are guaranteed to have the original storage root

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -181,9 +181,18 @@ async fn heal_state_trie(
                             }
 
                             storage_accounts.healed_accounts.insert(account_hash);
-                            storage_accounts
+                            // Instead of removing, here we should set its new storage root value while
+                            // keeping its vec of stuff intact. That way request storage ranges can resume
+                            // with the new storage root.
+                            let old_value = storage_accounts
                                 .accounts_with_storage_root
-                                .remove(&account_hash);
+                                .get_mut(&account_hash);
+                            if let Some((old_root, _)) = old_value {
+                                *old_root = account.storage_root;
+                            }
+                            // storage_accounts
+                            //     .accounts_with_storage_root
+                            //     .remove(&account_hash);
                         }
                     }
                     leafs_healed += nodes

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -188,7 +188,7 @@ async fn heal_state_trie(
                                 .accounts_with_storage_root
                                 .get_mut(&account_hash);
                             if let Some((old_root, _)) = old_value {
-                                *old_root = account.storage_root;
+                                *old_root = None;
                             }
                             // storage_accounts
                             //     .accounts_with_storage_root

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -181,18 +181,12 @@ async fn heal_state_trie(
                             }
 
                             storage_accounts.healed_accounts.insert(account_hash);
-                            // Instead of removing, here we should set its new storage root value while
-                            // keeping its vec of stuff intact. That way request storage ranges can resume
-                            // with the new storage root.
                             let old_value = storage_accounts
                                 .accounts_with_storage_root
                                 .get_mut(&account_hash);
                             if let Some((old_root, _)) = old_value {
                                 *old_root = None;
                             }
-                            // storage_accounts
-                            //     .accounts_with_storage_root
-                            //     .remove(&account_hash);
                         }
                     }
                     leafs_healed += nodes

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -547,7 +547,7 @@ fn get_initial_downloads(
         account_paths
             .accounts_with_storage_root
             .par_iter()
-            .filter_map(|(acc_path, storage_root)| {
+            .filter_map(|(acc_path, (storage_root, _))| {
                 if store
                     .contains_storage_node(*acc_path, *storage_root)
                     .expect("We should be able to open the store")

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -543,26 +543,26 @@ fn get_initial_downloads(
             })
             .collect::<VecDeque<_>>(),
     );
-    initial_requests.extend(
-        account_paths
-            .accounts_with_storage_root
-            .par_iter()
-            .filter_map(|(acc_path, (storage_root, _))| {
-                if store
-                    .contains_storage_node(*acc_path, *storage_root)
-                    .expect("We should be able to open the store")
-                {
-                    return None;
-                }
-                Some(NodeRequest {
-                    acc_path: Nibbles::from_bytes(&acc_path.0),
-                    storage_path: Nibbles::default(), // We need to be careful, the root parent is a special case
-                    parent: Nibbles::default(),
-                    hash: *storage_root,
-                })
-            })
-            .collect::<VecDeque<_>>(),
-    );
+    // initial_requests.extend(
+    //     account_paths
+    //         .accounts_with_storage_root
+    //         .par_iter()
+    //         .filter_map(|(acc_path, (storage_root, _))| {
+    //             if store
+    //                 .contains_storage_node(*acc_path, *storage_root)
+    //                 .expect("We should be able to open the store")
+    //             {
+    //                 return None;
+    //             }
+    //             Some(NodeRequest {
+    //                 acc_path: Nibbles::from_bytes(&acc_path.0),
+    //                 storage_path: Nibbles::default(), // We need to be careful, the root parent is a special case
+    //                 parent: Nibbles::default(),
+    //                 hash: *storage_root,
+    //             })
+    //         })
+    //         .collect::<VecDeque<_>>(),
+    // );
     initial_requests
 }
 

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -543,26 +543,6 @@ fn get_initial_downloads(
             })
             .collect::<VecDeque<_>>(),
     );
-    // initial_requests.extend(
-    //     account_paths
-    //         .accounts_with_storage_root
-    //         .par_iter()
-    //         .filter_map(|(acc_path, (storage_root, _))| {
-    //             if store
-    //                 .contains_storage_node(*acc_path, *storage_root)
-    //                 .expect("We should be able to open the store")
-    //             {
-    //                 return None;
-    //             }
-    //             Some(NodeRequest {
-    //                 acc_path: Nibbles::from_bytes(&acc_path.0),
-    //                 storage_path: Nibbles::default(), // We need to be careful, the root parent is a special case
-    //                 parent: Nibbles::default(),
-    //                 hash: *storage_root,
-    //             })
-    //         })
-    //         .collect::<VecDeque<_>>(),
-    // );
     initial_requests
 }
 


### PR DESCRIPTION
**Motivation**

Our current snap sync implementation stops downloading an account's storage leaves if there's a pivot jump. This is a big deal because in every network there are very few contracts that have almost all of the storage; this means in big networks like Sepolia or Mainnet we currently heal most of the storage tries in their entirety.

This PR makes it so the snap sync step that downloads storage leaves keeps track of big accounts to resume their download when a pivot jump occurs.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

