### PR TITLE
ci(l1,l2): free unused packages on github runners

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -42,6 +42,12 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Setup Rust Environment

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -17,6 +17,12 @@ jobs:
       matrix:
         backend: ["sp1", "risc0"]
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Add Rust Cache


### PR DESCRIPTION
**Motivation**

The CI is broken due to not having space left to run the jobs

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

