### PR TITLE
fix(l1): preventing "Address family not supported by protocol" errors on discv4

### DIFF
--- a/crates/common/rlp/decode.rs
+++ b/crates/common/rlp/decode.rs
@@ -254,7 +254,8 @@ impl RLPDecode for IpAddr {
                 let octets: [u8; 16] = ip_bytes
                     .try_into()
                     .map_err(|_| RLPDecodeError::InvalidLength)?;
-                Ok((IpAddr::V6(Ipv6Addr::from(octets)), rest))
+                // Using to_canonical just in case it's an Ipv6-encoded Ipv4 address
+                Ok((IpAddr::V6(Ipv6Addr::from(octets)).to_canonical(), rest))
             }
             _ => Err(RLPDecodeError::InvalidLength),
         }

--- a/crates/networking/p2p/utils.rs
+++ b/crates/networking/p2p/utils.rs
@@ -1,5 +1,4 @@
 use std::{
-    net::IpAddr,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -47,15 +46,6 @@ pub fn public_key_from_signing_key(signer: &SecretKey) -> H512 {
     let public_key = PublicKey::from_secret_key(secp256k1::SECP256K1, signer);
     let encoded = public_key.serialize_uncompressed();
     H512::from_slice(&encoded[1..])
-}
-
-pub fn unmap_ipv4in6_address(addr: IpAddr) -> IpAddr {
-    if let IpAddr::V6(v6_addr) = addr {
-        if let Some(v4_addr) = v6_addr.to_ipv4_mapped() {
-            return IpAddr::V4(v4_addr);
-        }
-    }
-    addr
 }
 
 pub fn get_account_storages_snapshots_dir(datadir: &Path) -> PathBuf {


### PR DESCRIPTION
**Motivation**

Using `UdpFramed` to send messages was causing a problem when a message send failed: A singe error was causing every other message send to fail. (See https://github.com/tokio-rs/tokio/issues/7648)
It was causing the log spam issue described in #4232 

**Description**

Moved back to use `UdpSocket` directly to send messages. It prevents the "Address family not supported by protocol" propagation of errors.

Also fixes some of the issues in #4232 (but still full IPv6 needs to be implemented):
- Comparing canonical IP addresses
- Removes a custom implementation of `to_canonical()`

