### PR TITLE
feat(l1): use descriptive error when we fail to replace a mempool tx

### DIFF
--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -132,7 +132,7 @@ pub enum MempoolError {
     RequestedPooledTxNotFound,
     #[error("Transaction sender is invalid {0}")]
     InvalidTxSender(#[from] secp256k1::Error),
-    #[error("Attempted to replace transaction with underpriced transaction")]
+    #[error("Attempted to replace a pooled transaction with an underpriced transaction")]
     UnderpricedReplacement,
 }
 

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -132,6 +132,8 @@ pub enum MempoolError {
     RequestedPooledTxNotFound,
     #[error("Transaction sender is invalid {0}")]
     InvalidTxSender(#[from] secp256k1::Error),
+    #[error("Attempted to replace transaction with underpriced transaction")]
+    UnderpricedReplacement,
 }
 
 #[derive(Debug)]

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -435,7 +435,7 @@ impl Mempool {
         };
 
         if !is_a_replacement_tx {
-            return Err(MempoolError::NonceTooLow);
+            return Err(MempoolError::UnderpricedReplacement);
         }
 
         Ok(Some(tx_in_pool.hash()))


### PR DESCRIPTION
**Motivation**
We currently return a "NonceTooLow" error when we fail to replace a mempool transaction (aka we receive a transaction with the same sender and nonce as an existing one but without a higher fee value). This doesn't make any sense and can be quite confusing. This PR adds a MempoolError enum variant for this specific case.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Use a specific error variant when we fail to replace a mempool transaction
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes None

