### PR TITLE
perf(l1): use secondary instances for reading in RocksDB

### DIFF
--- a/crates/storage/store_db/rocksdb.rs
+++ b/crates/storage/store_db/rocksdb.rs
@@ -281,10 +281,11 @@ impl Store {
         )
         .map_err(|e| StoreError::Custom(format!("Failed to open RocksDB: {}", e)))?;
 
-        let secondary = DBWithThreadMode::<MultiThreaded>::open_as_secondary(
+        let secondary = DBWithThreadMode::<MultiThreaded>::open_cf_as_secondary(
             &db_options,
             path,
             &path.join(".secondary"),
+            &expected_column_families,
         )
         .map_err(|e| StoreError::Custom(format!("Failed to open RocksDB: {}", e)))?;
 

--- a/crates/storage/trie_db/rocksdb.rs
+++ b/crates/storage/trie_db/rocksdb.rs
@@ -90,7 +90,13 @@ impl TrieDB for RocksDBTrieDB {
 
         self.primary
             .write(batch)
-            .map_err(|e| TrieError::DbError(anyhow::anyhow!("RocksDB batch write error: {}", e)))
+            .map_err(|e| TrieError::DbError(anyhow::anyhow!("RocksDB batch write error: {}", e)))?;
+        self.secondary.try_catch_up_with_primary().map_err(|e| {
+            TrieError::DbError(anyhow::anyhow!(
+                "Secondary RocksDB instance failed to catch up with primary: {}",
+                e
+            ))
+        })
     }
 }
 


### PR DESCRIPTION
- **perf(l1): use secondary replica for reading in RocksDB**
- **catch up on apply_account_updates and put_batch**
- **test: catch up on every write**
- **open column families**

**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

