### PR TITLE
ci(l2): disable replay proving with risc0

### DIFF
--- a/.github/workflows/main_prover_l1.yaml
+++ b/.github/workflows/main_prover_l1.yaml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        # TODO (#4669): re-enable risc0
         # backend: ["sp1", "risc0"]
         backend: ["sp1"]
     steps:


### PR DESCRIPTION
**Motivation**

Running the `Replay proving` workflow with both backends takes too much time on our self-hosted runner.

**Description**

Temporarily disable replay proving with Risc0.

Closes None

