### PR TITLE
fix: check first 18 address bytes in execute_precompile

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -262,7 +262,7 @@ pub fn execute_precompile(
         precompiles
     };
 
-    if address[0..17] != [0u8; 17] {
+    if address[0..18] != [0u8; 18] {
         return Err(VMError::Internal(InternalError::InvalidPrecompileAddress));
     }
     let index = u16::from_be_bytes([address[18], address[19]]) as usize;


### PR DESCRIPTION
This PR fixes a check in `execute_precompile`. It isn't triggerable due to it being redundant, but it's still a bug.