### PR TITLE
test(l1): add reorg case with multiple storage trie branches

### DIFF
--- a/tooling/reorgs/src/simulator.rs
+++ b/tooling/reorgs/src/simulator.rs
@@ -279,6 +279,14 @@ impl Node {
         chain
     }
 
+    pub async fn extend_chain(&self, mut chain: Chain, num_blocks: usize) -> Chain {
+        for _ in 0..num_blocks {
+            chain = self.build_payload(chain).await;
+            self.notify_new_payload(&chain).await;
+        }
+        chain
+    }
+
     pub async fn notify_new_payload(&self, chain: &Chain) {
         let head = chain.blocks.last().unwrap();
         let execution_payload = ExecutionPayload::from_block(head.clone());


### PR DESCRIPTION
**Motivation**

Reth had a [recent incident](https://laced-king-de5.notion.site/Incident-Post-Mortem-Reth-Mainnet-State-Root-Mismatch-26732f2c348480dea8b8c2a8753696dc#26732f2c3484809489d0c249a67b1acd) when following the chain on mainnet, where one of the storages wasn't reorged out correctly. We want to have a test for this kind of cases.

**Description**

This PR adds a test case for an account with multiple branches in its storage.