### PR TITLE
Add extra data to block header

### DIFF
--- a/cmd/ethrex/bench/build_block_benchmark.rs
+++ b/cmd/ethrex/bench/build_block_benchmark.rs
@@ -151,7 +151,7 @@ async fn create_payload_block(genesis_block: &Block, store: &Store) -> (Block, u
         gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
     };
     let id = payload_args.id();
-    let block = create_payload(&payload_args, store).unwrap();
+    let block = create_payload(&payload_args, store, Bytes::new()).unwrap();
     (block, id.unwrap())
 }
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -138,6 +138,7 @@ pub async fn init_rpc_api(
     tracker: TaskTracker,
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     gas_ceil: Option<u64>,
+    extra_data: String,
 ) {
     init_datadir(&opts.datadir);
     // Create SyncManager
@@ -164,6 +165,7 @@ pub async fn init_rpc_api(
         get_client_version(),
         log_filter_handler,
         gas_ceil,
+        extra_data,
     );
 
     tracker.spawn(rpc_api);
@@ -419,6 +421,8 @@ pub async fn init_l1(
         log_filter_handler,
         // TODO (#4482): Make this configurable.
         None,
+        // TODO: Make this configurable.
+        "ethrex/0.2.0".into(),
     )
     .await;
 

--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use ethrex_blockchain::{
     Blockchain, BlockchainType,
@@ -900,7 +901,7 @@ pub async fn produce_l1_block(
 
     let payload_id = build_payload_args.id()?;
 
-    let payload = create_payload(&build_payload_args, store)?;
+    let payload = create_payload(&build_payload_args, store, Bytes::new())?;
 
     blockchain
         .clone()

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -117,7 +117,11 @@ impl BuildPayloadArgs {
 
 /// Creates a new payload based on the payload arguments
 // Basic payload block building, can and should be improved
-pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block, ChainError> {
+pub fn create_payload(
+    args: &BuildPayloadArgs,
+    storage: &Store,
+    extra_data: Bytes,
+) -> Result<Block, ChainError> {
     let parent_block = storage
         .get_block_header_by_hash(args.parent)?
         .ok_or_else(|| ChainError::ParentNotFound)?;
@@ -141,8 +145,7 @@ pub fn create_payload(args: &BuildPayloadArgs, storage: &Store) -> Result<Block,
         gas_limit,
         gas_used: 0,
         timestamp: args.timestamp,
-        // TODO: should use builder config's extra_data
-        extra_data: Bytes::new(),
+        extra_data,
         prev_randao: args.random,
         nonce: 0,
         base_fee_per_gas: calculate_base_fee_per_gas(

--- a/crates/blockchain/smoke_test.rs
+++ b/crates/blockchain/smoke_test.rs
@@ -10,6 +10,7 @@ mod blockchain_integration_test {
         payload::{BuildPayloadArgs, create_payload},
     };
 
+    use bytes::Bytes;
     use ethrex_common::{
         H160, H256,
         types::{Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, ELASTICITY_MULTIPLIER},
@@ -311,7 +312,7 @@ mod blockchain_integration_test {
         // Create blockchain
         let blockchain = Blockchain::default_with_store(store.clone().clone());
 
-        let block = create_payload(&args, store).unwrap();
+        let block = create_payload(&args, store, Bytes::new()).unwrap();
         let result = blockchain.build_payload(block).await.unwrap();
         result.payload
     }

--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -95,6 +95,7 @@ pub async fn start_api(
                 local_p2p_node,
                 local_node_record,
                 client_version,
+                extra_data: Bytes::new(),
             },
             gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
             log_filter_handler,

--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use bytes::Bytes;
 use ethrex_blockchain::{
     Blockchain,
     error::ChainError,
@@ -150,7 +151,7 @@ impl BlockProducer {
             elasticity_multiplier: self.elasticity_multiplier,
             gas_ceil: self.block_gas_limit,
         };
-        let payload = create_payload(&args, &self.store)?;
+        let payload = create_payload(&args, &self.store, Bytes::new())?;
 
         // Blockchain builds the payload from mempool txs and executes them
         let payload_build_result = build_payload(

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -379,7 +379,7 @@ async fn build_payload(
     let payload_id = args
         .id()
         .map_err(|error| RpcErr::Internal(error.to_string()))?;
-    let payload = match create_payload(&args, &context.storage) {
+    let payload = match create_payload(&args, &context.storage, context.node_data.extra_data) {
         Ok(payload) => payload,
         Err(ChainError::EvmError(error)) => return Err(error.into()),
         // Parent block is guaranteed to be present at this point,

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -169,6 +169,7 @@ pub struct NodeData {
     pub local_p2p_node: Node,
     pub local_node_record: NodeRecord,
     pub client_version: String,
+    pub extra_data: Bytes,
 }
 
 #[allow(async_fn_in_trait)]
@@ -205,6 +206,7 @@ pub async fn start_api(
     client_version: String,
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     gas_ceil: Option<u64>,
+    extra_data: String,
 ) -> Result<(), RpcErr> {
     // TODO: Refactor how filters are handled,
     // filters are used by the filters endpoints (eth_newFilter, eth_getFilterChanges, ...etc)
@@ -220,6 +222,7 @@ pub async fn start_api(
             local_p2p_node,
             local_node_record,
             client_version,
+            extra_data: extra_data.into(),
         },
         gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
         log_filter_handler,

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -328,6 +328,7 @@ pub fn parse_json_hex(hex: &serde_json::Value) -> Result<u64, String> {
 pub mod test_utils {
     use std::{net::SocketAddr, str::FromStr, sync::Arc};
 
+    use bytes::Bytes;
     use ethrex_blockchain::Blockchain;
     use ethrex_common::{H512, types::DEFAULT_BUILDER_GAS_CEIL};
     use ethrex_p2p::{
@@ -395,6 +396,7 @@ pub mod test_utils {
             "ethrex/test".to_string(),
             None,
             None,
+            String::new(),
         )
         .await
         .unwrap();
@@ -414,6 +416,7 @@ pub mod test_utils {
                 local_p2p_node: example_p2p_node(),
                 local_node_record,
                 client_version: "ethrex/test".to_string(),
+                extra_data: Bytes::new(),
             },
             gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
             log_filter_handler: None,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We don't set the `extra_data` field in the block header.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Use a CLI provided `extra_data` string or a default one.

<!-- Link to issues: Resolves #111, Resolves #222 -->

