### PR TITLE
feat(l1): bump secp256k1 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "serde",
  "thiserror 2.0.16",
 ]
@@ -257,7 +257,7 @@ dependencies = [
  "derive_more 0.99.20",
  "hex-literal",
  "itoa",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "keccak-asm",
  "proptest",
  "rand 0.8.5",
@@ -281,7 +281,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.11.0",
  "itoa",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "keccak-asm",
  "paste",
  "proptest",
@@ -306,7 +306,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.11.0",
  "itoa",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "paste",
  "rand 0.9.2",
  "ruint",
@@ -1478,6 +1478,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,7 +2142,7 @@ dependencies = [
  "coins-core",
  "digest 0.10.7",
  "hmac",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "serde",
  "sha2",
  "thiserror 1.0.69",
@@ -3336,21 +3352,8 @@ dependencies = [
  "der",
  "digest 0.10.7",
  "elliptic-curve",
- "rfc6979 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rfc6979",
  "serdect",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979 0.4.0 (git+https://github.com/sp1-patches/signatures?tag=patch-16.9-sp1-4.1.0)",
  "signature",
  "spki",
 ]
@@ -3432,7 +3435,7 @@ dependencies = [
  "ethrex-storage",
  "ethrex-vm",
  "hex",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -3463,7 +3466,6 @@ dependencies = [
  "ff 0.13.1",
  "generic-array 0.14.7",
  "group 0.13.0",
- "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3527,7 +3529,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "hex",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "log",
  "rand 0.8.5",
  "rlp 0.5.2",
@@ -3863,7 +3865,7 @@ dependencies = [
  "elliptic-curve",
  "ethabi",
  "generic-array 0.14.7",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "num_enum 0.7.4",
  "once_cell",
  "open-fastrlp",
@@ -4046,7 +4048,7 @@ dependencies = [
  "local-ip-address",
  "rand 0.8.5",
  "reqwest 0.12.23",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -4073,7 +4075,7 @@ dependencies = [
  "ethrex-storage",
  "ethrex-vm",
  "hex",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_json",
  "sha3",
  "thiserror 2.0.16",
@@ -4099,7 +4101,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "rkyv",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sha2",
@@ -4186,7 +4188,7 @@ dependencies = [
  "rand 0.8.5",
  "ratatui",
  "reqwest 0.12.23",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -4215,7 +4217,7 @@ dependencies = [
  "ethrex-trie",
  "ethrex-vm",
  "lambdaworks-crypto 0.11.0",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "sha3",
  "thiserror 2.0.16",
@@ -4239,7 +4241,7 @@ dependencies = [
  "hex",
  "reqwest 0.12.23",
  "rustc-hex",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4266,13 +4268,13 @@ dependencies = [
  "ethrex-crypto",
  "ethrex-rlp",
  "hex",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "lambdaworks-math 0.11.0",
  "lazy_static",
  "malachite 0.6.1",
  "p256",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sha2",
@@ -4322,7 +4324,7 @@ dependencies = [
  "prometheus 0.14.0",
  "rand 0.8.5",
  "rayon",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sha2",
@@ -4474,7 +4476,7 @@ dependencies = [
  "jsonwebtoken 9.3.1",
  "rand 0.8.5",
  "reqwest 0.12.23",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "sha2",
@@ -4505,7 +4507,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "reqwest 0.12.23",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -5599,6 +5601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5610,15 +5621,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
 ]
 
 [[package]]
@@ -6487,27 +6489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if 1.0.3",
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa",
  "elliptic-curve",
  "once_cell",
  "serdect",
  "sha2",
  "signature",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-5.0.0#f7d8998e05d8cbcbd8e543eba1030a7385011fa8"
-dependencies = [
- "cfg-if 1.0.3",
- "ecdsa 0.16.9 (git+https://github.com/sp1-patches/signatures?tag=patch-16.9-sp1-4.1.0)",
- "elliptic-curve",
- "hex",
- "once_cell",
- "sha2",
- "signature",
- "sp1-lib",
 ]
 
 [[package]]
@@ -6972,7 +6959,7 @@ dependencies = [
  "eyre",
  "futures",
  "hex",
- "secp256k1",
+ "secp256k1 0.30.0",
  "tokio",
 ]
 
@@ -7885,7 +7872,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
  "sha2",
@@ -9434,7 +9421,7 @@ dependencies = [
  "hex",
  "nix",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "sha2",
  "tokio",
  "tokio-util",
@@ -9639,11 +9626,11 @@ dependencies = [
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "once_cell",
  "revm-primitives 4.0.0",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.29.0",
  "sha2",
  "substrate-bn",
 ]
@@ -9658,11 +9645,11 @@ dependencies = [
  "blst",
  "c-kzg",
  "cfg-if 1.0.3",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "once_cell",
  "revm-primitives 15.2.0",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.29.0",
  "sha2",
  "substrate-bn",
 ]
@@ -9728,15 +9715,6 @@ name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "hmac",
  "subtle",
@@ -10817,19 +10795,30 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "cfg-if 1.0.3",
- "k256 0.13.4 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-5.0.0)",
+ "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -11451,7 +11440,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.13.0",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "num",
  "num_cpus",
  "p256",
@@ -11519,7 +11508,7 @@ dependencies = [
  "elliptic-curve",
  "generic-array 1.1.0",
  "itertools 0.13.0",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "num",
  "p256",
  "p3-field",
@@ -11547,7 +11536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1fe81b6f87134f9170cb642f948ae41e0ee1cd3785e0cb665add5b67106d1a"
 dependencies = [
  "bincode",
- "elliptic-curve",
  "serde",
  "sp1-primitives",
 ]
@@ -11772,7 +11760,7 @@ dependencies = [
  "hex",
  "indicatif",
  "itertools 0.13.0",
- "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k256",
  "p3-baby-bear",
  "p3-field",
  "p3-fri",
@@ -14581,3 +14569,8 @@ checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "secp256k1"
+version = "0.29.1"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ rand = "0.8.5"
 cfg-if = "1.0.0"
 reqwest = { version = "0.12.7", features = ["socks", "json"] }
 snap = "1.1.1"
-secp256k1 = { version = "0.29.1", default-features = false, features = [
+secp256k1 = { version = "0.30.0", default-features = false, features = [
   "global-context",
   "recovery",
   "rand",

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1276,7 +1276,7 @@ pub fn recover_address(signature: Signature, payload: H256) -> Result<Address, s
     let signature_bytes = signature.to_fixed_bytes();
     let signature = secp256k1::ecdsa::RecoverableSignature::from_compact(
         &signature_bytes[..64],
-        RecoveryId::from_i32(signature_bytes[64] as i32)?, // cannot fail
+        RecoveryId::try_from(signature_bytes[64] as i32)?, // cannot fail
     )?;
     // Recover public key
     let public = secp256k1::SECP256K1

--- a/crates/l2/networking/rpc/signer.rs
+++ b/crates/l2/networking/rpc/signer.rs
@@ -102,7 +102,13 @@ impl LocalSigner {
             .sign_ecdsa_recoverable(&msg, &self.private_key)
             .serialize_compact();
 
-        Signature::from_slice(&[signature.as_slice(), &[recovery_id.to_i32() as u8]].concat())
+        Signature::from_slice(
+            &[
+                signature.as_slice(),
+                &[Into::<i32>::into(recovery_id) as u8],
+            ]
+            .concat(),
+        )
     }
 }
 

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
@@ -3058,16 +3058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "rand 0.8.5",
- "secp256k1-sys",
-]
-
-[[package]]
 name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/l2/prover/src/guest_program/src/sp1/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/sp1/Cargo.lock
@@ -2452,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.10.0"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.30.0-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"
 dependencies = [
  "cc",
 ]

--- a/crates/l2/prover/src/guest_program/src/sp1/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/sp1/Cargo.lock
@@ -2440,8 +2440,8 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.29.1"
-source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.29.1-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"
+version = "0.30.0"
+source = "git+https://github.com/sp1-patches/rust-secp256k1?tag=patch-0.30.0-sp1-5.0.0#14136bdd2fafe651e3d0ce680f930473e848cf56"
 dependencies = [
  "cfg-if",
  "k256",

--- a/crates/l2/prover/src/guest_program/src/sp1/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/sp1/Cargo.toml
@@ -25,7 +25,7 @@ crypto-bigint = { git = "https://github.com/sp1-patches/RustCrypto-bigint", tag 
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
 
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-5.0.0" }
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-5.0.0" }
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.30.0-sp1-5.0.0" }
 ecdsa = { git = "https://github.com/sp1-patches/signatures", tag = "patch-16.9-sp1-4.1.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-5.0.0" }
 

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -5399,16 +5399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "rand 0.8.5",
- "secp256k1-sys",
-]
-
-[[package]]
 name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -21,7 +21,7 @@ guest_program = { path = "../../prover/src/guest_program", default-features = fa
 ethrex-l2 = { path = "../..", default-features = false }
 ethrex-l2-common = { path = "../../common", default-features = false }
 
-secp256k1 = { version = "0.29.1", default-features = false, features = [
+secp256k1 = { version = "0.30.0", default-features = false, features = [
   "global-context",
   "recovery",
   "rand",

--- a/crates/networking/p2p/discv4/messages.rs
+++ b/crates/networking/p2p/discv4/messages.rs
@@ -73,7 +73,7 @@ impl Packet {
 
         let digest: [u8; 32] = Keccak256::digest(encoded_msg).into();
 
-        let rid = RecoveryId::from_i32(signature_bytes[64].into())
+        let rid = RecoveryId::try_from(Into::<i32>::into(signature_bytes[64]))
             .map_err(|_| PacketDecodeErr::InvalidSignature)?;
 
         let peer_pk = secp256k1::SECP256K1
@@ -160,7 +160,7 @@ impl Message {
             .serialize_compact();
 
         data[..signature_size - 1].copy_from_slice(&signature);
-        data[signature_size - 1] = recovery_id.to_i32() as u8;
+        data[signature_size - 1] = Into::<i32>::into(recovery_id) as u8;
 
         let hash = Keccak256::digest(&data[..]);
         buf.put_slice(&hash);

--- a/crates/networking/p2p/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p/rlpx/connection/handshake.rs
@@ -458,7 +458,7 @@ fn retrieve_remote_ephemeral_key(
 ) -> Result<PublicKey, RLPxError> {
     let signature_prehash = shared_secret ^ remote_nonce;
     let msg = secp256k1::Message::from_digest_slice(signature_prehash.as_bytes())?;
-    let rid = RecoveryId::from_i32(signature[64].into())?;
+    let rid = RecoveryId::try_from(Into::<i32>::into(signature[64]))?;
     let sig = RecoverableSignature::from_compact(&signature[0..64], rid)?;
     Ok(secp256k1::SECP256K1.recover_ecdsa(&msg, &sig)?)
 }
@@ -474,8 +474,7 @@ fn sign_shared_secret(
     let (rid, signature) = sig.serialize_compact();
     let mut signature_bytes = [0; 65];
     signature_bytes[..64].copy_from_slice(&signature);
-    signature_bytes[64] = rid
-        .to_i32()
+    signature_bytes[64] = Into::<i32>::into(rid)
         .try_into()
         .map_err(|_| RLPxError::CryptographyError("Invalid recovery id".into()))?;
     Ok(signature_bytes.into())

--- a/crates/networking/p2p/rlpx/l2/l2_connection.rs
+++ b/crates/networking/p2p/rlpx/l2/l2_connection.rs
@@ -219,11 +219,12 @@ pub(crate) async fn send_new_block(established: &mut Established) -> Result<(), 
                             &l2_state.committer_key,
                         )
                         .serialize_compact();
-                    let recovery_id: u8 = recovery_id.to_i32().try_into().map_err(|e| {
-                        RLPxError::InternalError(format!(
-                            "Failed to convert recovery id to u8: {e}. This is a bug."
-                        ))
-                    })?;
+                    let recovery_id: u8 =
+                        Into::<i32>::into(recovery_id).try_into().map_err(|e| {
+                            RLPxError::InternalError(format!(
+                                "Failed to convert recovery id to u8: {e}. This is a bug."
+                            ))
+                        })?;
                     let mut sig = [0u8; 65];
                     sig[..64].copy_from_slice(&signature);
                     sig[64] = recovery_id;

--- a/crates/networking/p2p/rlpx/l2/messages.rs
+++ b/crates/networking/p2p/rlpx/l2/messages.rs
@@ -65,7 +65,7 @@ impl BatchSealed {
         let (recovery_id, signature) = secp256k1::SECP256K1
             .sign_ecdsa_recoverable(&SecpMessage::from_digest(hash.into()), secret_key)
             .serialize_compact();
-        let recovery_id: u8 = recovery_id.to_i32().try_into().map_err(|e| {
+        let recovery_id: u8 = Into::<i32>::into(recovery_id).try_into().map_err(|e| {
             RLPxError::InternalError(format!(
                 "Failed to convert recovery id to u8: {e}. This is a bug."
             ))

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -288,11 +288,8 @@ pub fn eip7702_recover_address(
     ]
     .concat();
 
-    let Ok(recovery_id) = RecoveryId::from_i32(
-        auth_tuple
-            .y_parity
-            .try_into()
-            .map_err(|_| InternalError::TypeConversion)?,
+    let Ok(recovery_id) = RecoveryId::try_from(
+        TryInto::<i32>::try_into(auth_tuple.y_parity).map_err(|_| InternalError::TypeConversion)?,
     ) else {
         return Ok(None);
     };

--- a/tooling/genesis/Cargo.lock
+++ b/tooling/genesis/Cargo.lock
@@ -741,16 +741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "rand",
- "secp256k1-sys",
-]
-
-[[package]]
 name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
**Motivation**
Bump secp256k1 version to 0.30.0.
This was taken from #4589 
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Bumps secp256k1 version to 0.30.0
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

