### PR TITLE
ci(l2): free space in lint workflow

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -24,6 +24,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Setup Rust Environment


### PR DESCRIPTION
**Motivation**

Our lint workflow is failing with a `No space left on device` error.

**Description**

Adds the `Free Disk Space` step that we already use in other workflows.

Closes None
