### PR TITLE
test(l1): full Sync re org test

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -676,7 +676,7 @@ impl FullBlockSyncState {
         if let Err((err, batch_failure)) = Syncer::add_blocks(
             blockchain.clone(),
             block_batch,
-            sync_head_found,
+            sync_head_found || finished,
             cancel_token.clone(),
         )
         .await

--- a/tooling/reorgs/src/main.rs
+++ b/tooling/reorgs/src/main.rs
@@ -33,7 +33,10 @@ async fn main() {
     info!("");
 
     run_test(&cmd_path, no_reorgs_full_sync_smoke_test).await;
-    run_test(&cmd_path, reorgs_full_sync_smoke_test).await;
+    // This test is flaky 50% of the time, check that it runs correctly 30 times in a row
+    for _ in 0..30 {
+        run_test(&cmd_path, reorgs_full_sync_smoke_test).await;
+    }
     run_test(&cmd_path, test_one_block_reorg_and_back).await;
     run_test(&cmd_path, test_storage_slots_reorg).await;
 


### PR DESCRIPTION
Blocked by https://github.com/lambdaclass/ethrex/pull/4658]
**Motivation**
We want to test a reorg where we have 3 nodes. One with the base chain, one with a side chain and a third one where we want to full sync the base chain.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Adds a test for that scenario, this test is currently flaky, since 50% of the times it will choose the peer with the base chain, working fine, but the other 50% it will choose the peer with the side chain, where it currently fails.
Since there is always a 50% chance of failing, we run the test 30 times to make sure the probability of failure is small enough.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes 

