### PR TITLE
feat(l2): optimize RISC0's guest program input read

### DIFF
--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -54,7 +54,7 @@ pub fn prove(
     let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
     let env = ExecutorEnv::builder()
         .stdout(&mut stdout)
-        .write(&bytes.as_slice())?
+        .write_slice(bytes.as_slice())
         .build()?;
 
     let prover = default_prover();

--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -31,7 +31,9 @@ pub enum Error {
 
 pub fn execute(input: ProgramInput) -> Result<(), Box<dyn std::error::Error>> {
     let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
-    let env = ExecutorEnv::builder().write(&bytes.as_slice())?.build()?;
+    let env = ExecutorEnv::builder()
+        .write_slice(bytes.as_slice())
+        .build()?;
 
     let executor = default_executor();
 

--- a/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
+++ b/crates/l2/prover/src/guest_program/src/risc0/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use guest_program::{execution::execution_program, input::ProgramInput};
 use risc0_zkvm::guest::env;
 use rkyv::rancor::Error;
@@ -5,7 +7,8 @@ use rkyv::rancor::Error;
 fn main() {
     println!("start reading input");
     let start = env::cycle_count();
-    let input = env::read::<Vec<u8>>();
+    let mut input = Vec::new();
+    env::stdin().read_to_end(&mut input).unwrap();
     let input = rkyv::from_bytes::<ProgramInput, Error>(&input).unwrap();
     let end = env::cycle_count();
     println!("end reading input, cycles: {}", end - start);


### PR DESCRIPTION
**Description**

RISC0's official documentation suggests using `env::stdin().read_to_end` when we need to read the input as raw bytes, because that method doesn't do (de)serialization and so does not need to copy or reinterpret the input data. This is the case because we then serialize using `rkyv`.

On the host side, `ExecutorEnvBuilder::write_slice` is used to pass in the bytes.

**Execution Times Comparison**

> Command: `cargo r -r -p ethrex-replay -F risc0 -- block --zkvm risc0 --resource cpu --action execute --rpc-url http://157.180.1.98:8545 <BLOCK>`

| Block | `main` (`1ef53cc`) |  `optimize_risc0_guest_program_input_read ` | Speedup |
| --- | --- | --- | --- |
| 23451000 | 57s | 42s | 1.37x |
| 23451100 | 36s | 25s | 1.44x |
| 23451200 | 19s | 13s | 1.46x |
| 23451300 | 43s | 30s | 1.43x |
| 23451400 | 43s | 31s | 1.39x |

**Input Reading Cycles Comparison**

> Command: `cargo r -r -p ethrex-replay -F risc0 -- block --zkvm risc0 --resource cpu --action execute --rpc-url http://157.180.1.98:8545 <BLOCK>`

| Block | `main` (`1ef53cc`) |  `optimize_risc0_guest_program_input_read ` | Diff |
| --- | --- | --- | --- |
| 23451000 | 980048869 | 21048307 | -46.56x |
| 23451100 | 755479461 | 17713531 | -42.65x |
| 23451200 | 390695293 | 9137304 | -42.76x |
| 23451300 | 865096745 | 19224750 | -45x |
| 23451400 | 832784361 | 18776551 | -44.35x |