### PR TITLE
chore(l1): print error on sync error

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -149,7 +149,8 @@ impl Syncer {
                     start_time.elapsed().as_secs()
                 );
             }
-            Err(error) => warn!(
+            // TODO #2767: If the error is irrecoverable, we should exit ethrex
+            Err(error) => error!(
                 "Sync cycle failed due to {error}, time elapsed: {} secs ",
                 start_time.elapsed().as_secs()
             ),


### PR DESCRIPTION
**Motivation**

The error log for failing to sync was a warning, it should be an error.

**Description**

- Changed warn to error in `start_sync`
- Added a comment with the link to issues: #2767

