### PR TITLE
feat(replay): endless replay & only eth proofs blocks

### DIFF
--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -447,6 +447,8 @@ impl EthrexReplayCommand {
                 loop {
                     let block_identifier = or_latest(block)?;
 
+                    let start = Instant::now();
+
                     get_blockdata(
                         eth_client.clone(),
                         network.clone(),
@@ -454,6 +456,8 @@ impl EthrexReplayCommand {
                         only_eth_proofs_blocks,
                     )
                     .await?;
+
+                    let elapsed = start.elapsed();
 
                     if let Some(block_number) = block {
                         info!("Block {block_number} data cached successfully.");
@@ -463,6 +467,11 @@ impl EthrexReplayCommand {
 
                     if !endless {
                         break;
+                    }
+
+                    // Sleep until the next block time (12 seconds)
+                    if elapsed < Duration::from_secs(12) {
+                        tokio::time::sleep(Duration::from_secs(12) - elapsed).await;
                     }
                 }
             }

--- a/cmd/ethrex_replay/src/cli.rs
+++ b/cmd/ethrex_replay/src/cli.rs
@@ -261,6 +261,20 @@ pub struct BlockOptions {
         help_heading = "Command Options"
     )]
     pub block: Option<u64>,
+    #[arg(
+        long,
+        help = "Run blocks endlessly, starting from the specified block or the latest if not specified.",
+        help_heading = "Replay Options",
+        conflicts_with = "block"
+    )]
+    pub endless: bool,
+    #[arg(
+        long,
+        help = "Only fetch Ethereum proofs blocks (i.e., no L2 blocks).",
+        help_heading = "Replay Options",
+        requires = "rpc_url"
+    )]
+    pub only_eth_proofs_blocks: bool,
     #[command(flatten)]
     pub opts: EthrexReplayOptions,
 }
@@ -327,7 +341,13 @@ impl EthrexReplayCommand {
     pub async fn run(self) -> eyre::Result<()> {
         match self {
             #[cfg(not(feature = "l2"))]
-            Self::Block(block_opts) => replay_block(block_opts).await?,
+            Self::Block(mut block_opts) => loop {
+                let _ = replay_block(block_opts).await;
+
+                if !block_opts.endless {
+                    break;
+                }
+            },
             #[cfg(not(feature = "l2"))]
             Self::Blocks(BlocksOptions {
                 blocks,
@@ -355,18 +375,31 @@ impl EthrexReplayCommand {
 
                     replay_block(BlockOptions {
                         block: Some(*block_number),
+                        endless: false,
+                        only_eth_proofs_blocks: false,
                         opts: opts.clone(),
                     })
                     .await?;
                 }
             }
             #[cfg(not(feature = "l2"))]
-            Self::Cache(CacheSubcommand::Block(BlockOptions { block, opts })) => {
+            Self::Cache(CacheSubcommand::Block(BlockOptions {
+                block,
+                endless,
+                only_eth_proofs_blocks,
+                opts,
+            })) => {
                 let (eth_client, network) = setup(&opts).await?;
 
                 let block_identifier = or_latest(block)?;
 
-                get_blockdata(eth_client, network.clone(), block_identifier).await?;
+                get_blockdata(
+                    eth_client,
+                    network.clone(),
+                    block_identifier,
+                    only_eth_proofs_blocks,
+                )
+                .await?;
 
                 if let Some(block_number) = block {
                     info!("Block {block_number} data cached successfully.");
@@ -390,6 +423,7 @@ impl EthrexReplayCommand {
                         eth_client.clone(),
                         network.clone(),
                         BlockIdentifier::Number(block_number),
+                        opts.only_eth_proofs_blocks,
                     )
                     .await?;
                 }
@@ -687,6 +721,7 @@ async fn replay_transaction(tx_opts: TransactionOpts) -> eyre::Result<()> {
         eth_client,
         network,
         BlockIdentifier::Number(tx.block_number.as_u64()),
+        tx_opts.opts.only_eth_proofs_blocks,
     )
     .await?;
 
@@ -712,7 +747,13 @@ async fn replay_block(block_opts: BlockOptions) -> eyre::Result<()> {
 
     let (eth_client, network) = setup(&opts).await?;
 
-    let cache = get_blockdata(eth_client, network.clone(), or_latest(block)?).await?;
+    let cache = get_blockdata(
+        eth_client,
+        network.clone(),
+        or_latest(block)?,
+        opts.only_eth_proofs_blocks,
+    )
+    .await?;
 
     // Always write the cache after fetching from RPC.
     // It will be deleted later if not needed.

--- a/cmd/ethrex_replay/src/fetcher.rs
+++ b/cmd/ethrex_replay/src/fetcher.rs
@@ -42,7 +42,7 @@ pub async fn get_blockdata(
             format_duration(time_for_next_eth_proofs_block)
         );
 
-        tokio::time::sleep(Duration::from_secs(time_for_next_eth_proofs_block)).await;
+        tokio::time::sleep(time_for_next_eth_proofs_block).await;
 
         latest_block_number = eth_client.get_block_number().await?.as_u64();
     }


### PR DESCRIPTION
**Motivation**

We want to remove the `ethrex-replayer` internal tool. This is the first step; we still need to support requesting multiple RPCs.

**Description**

- Adds the flag `--endless` to `BlockOptions`. This allows replaying blocks endlessly (once it finishes replaying one block, it fetches the latest and starts replaying it, and so on).
- Adds the flag `--endless` to `BlocksOptions`. Similar to the above, but only works if `--from <BLOCK>` is set, replaying endlessly from `BLOCK`.
- Adds the flag `--only-eth-proofs-blocks` to `BlockOptions` and `BlocksOptions`. If set, it constrains which blocks are executed.
- Adds the above to the cache commands (the same but skips execution).

