### PR TITLE
fix(l1): fix failing eip 7623 hive tests

### DIFF
--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -96,8 +96,10 @@ pub enum TxValidationError {
         priority_fee: U256,
         max_fee_per_gas: U256,
     },
-    #[error("Intrinsic gas too low")]
+    #[error("Transaction gas limit lower than the minimum gas cost to execute the transaction")]
     IntrinsicGasTooLow,
+    #[error("Transaction gas limit lower than the gas cost floor for calldata tokens")]
+    IntrinsicGasBelowFloorGasCost,
     #[error(
         "Gas allowance exceeded. Block gas limit: {block_gas_limit}, transaction gas limit: {tx_gas_limit}"
     )]

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -248,6 +248,10 @@ pub fn validate_min_gas_limit(vm: &mut VM<'_>) -> Result<(), VMError> {
     let calldata = vm.current_call_frame.calldata.clone();
     let intrinsic_gas: u64 = vm.get_intrinsic_gas()?;
 
+    if vm.current_call_frame.gas_limit < intrinsic_gas {
+        return Err(TxValidationError::IntrinsicGasTooLow.into());
+    }
+
     // calldata_cost = tokens_in_calldata * 4
     let calldata_cost: u64 = gas_cost::tx_calldata(&calldata)?;
 
@@ -261,9 +265,8 @@ pub fn validate_min_gas_limit(vm: &mut VM<'_>) -> Result<(), VMError> {
         .checked_add(TX_BASE_COST)
         .ok_or(InternalError::Overflow)?;
 
-    let min_gas_limit = max(intrinsic_gas, floor_cost_by_tokens);
-    if vm.current_call_frame.gas_limit < min_gas_limit {
-        return Err(TxValidationError::IntrinsicGasTooLow.into());
+    if vm.current_call_frame.gas_limit < floor_cost_by_tokens {
+        return Err(TxValidationError::IntrinsicGasBelowFloorGasCost.into());
     }
 
     Ok(())

--- a/tooling/ef_tests/state/deserialize.rs
+++ b/tooling/ef_tests/state/deserialize.rs
@@ -41,6 +41,9 @@ where
                     "TransactionException.INTRINSIC_GAS_TOO_LOW" => {
                         TransactionExpectedException::IntrinsicGasTooLow
                     }
+                    "TransactionException.INTRINSIC_BELOW_FLOOR_GAS_COST" => {
+                        TransactionExpectedException::IntrinsicGasBelowFloorGasCost
+                    }
                     "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" => {
                         TransactionExpectedException::InsufficientAccountFunds
                     }

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -310,6 +310,9 @@ fn exception_is_expected(
                 TransactionExpectedException::IntrinsicGasTooLow,
                 VMError::TxValidation(TxValidationError::IntrinsicGasTooLow)
             ) | (
+                TransactionExpectedException::IntrinsicGasBelowFloorGasCost,
+                VMError::TxValidation(TxValidationError::IntrinsicGasBelowFloorGasCost)
+            ) | (
                 TransactionExpectedException::InsufficientAccountFunds,
                 VMError::TxValidation(TxValidationError::InsufficientAccountFunds)
             ) | (

--- a/tooling/ef_tests/state/types.rs
+++ b/tooling/ef_tests/state/types.rs
@@ -156,6 +156,7 @@ pub enum TransactionExpectedException {
     Type3TxInvalidBlobVersionedHash,
     Type4TxContractCreation,
     IntrinsicGasTooLow,
+    IntrinsicGasBelowFloorGasCost,
     InsufficientAccountFunds,
     SenderNotEoa,
     PriorityGreaterThanMaxFeePerGas,

--- a/tooling/ef_tests/state_v2/src/modules/deserialize.rs
+++ b/tooling/ef_tests/state_v2/src/modules/deserialize.rs
@@ -38,6 +38,9 @@ where
                     "TransactionException.INTRINSIC_GAS_TOO_LOW" => {
                         TransactionExpectedException::IntrinsicGasTooLow
                     }
+                    "TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST" => {
+                        TransactionExpectedException::IntrinsicGasBelowFloorGasCost
+                    }
                     "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" => {
                         TransactionExpectedException::InsufficientAccountFunds
                     }

--- a/tooling/ef_tests/state_v2/src/modules/result_check.rs
+++ b/tooling/ef_tests/state_v2/src/modules/result_check.rs
@@ -161,6 +161,9 @@ fn exception_matches_expected(
                 TransactionExpectedException::IntrinsicGasTooLow,
                 VMError::TxValidation(TxValidationError::IntrinsicGasTooLow)
             ) | (
+                TransactionExpectedException::IntrinsicGasBelowFloorGasCost,
+                VMError::TxValidation(TxValidationError::IntrinsicGasBelowFloorGasCost)
+            ) | (
                 TransactionExpectedException::InsufficientAccountFunds,
                 VMError::TxValidation(TxValidationError::InsufficientAccountFunds)
             ) | (

--- a/tooling/ef_tests/state_v2/src/modules/types.rs
+++ b/tooling/ef_tests/state_v2/src/modules/types.rs
@@ -447,6 +447,7 @@ pub enum TransactionExpectedException {
     Type3TxInvalidBlobVersionedHash,
     Type4TxContractCreation,
     IntrinsicGasTooLow,
+    IntrinsicGasBelowFloorGasCost,
     InsufficientAccountFunds,
     SenderNotEoa,
     PriorityGreaterThanMaxFeePerGas,


### PR DESCRIPTION
**Motivation**

Passing failing Hive tests

**Description**

This PR adds a new error type, that's returned specifically when the gas limit is below floor cost for the tokens. The gas limit is now also checked both against the intrinsic gas and the token gas cost floor because some tests were failing when both were equal (in which case the error returned should be over the intrinsic gas; plus it saves us from doing some extra calculations when the gas limit is below the intrinsic gas anyways). Additionally the error message for the IntrinsicGasTooLow error was improved.

For these changes to work a PR needs to also be merged into the EEST repo, specifically changing [this file](https://github.com/ethereum/execution-spec-tests/blob/main/src/ethereum_clis/clis/ethrex.py) to map the errors correctly. A PR doing so is currently open on our fork of the repo

Closes #4682 

