### PR TITLE
fix(l2): remove l2 subcommand from tdx override

### DIFF
--- a/crates/l2/docker-compose-l2-tdx.yaml
+++ b/crates/l2/docker-compose-l2-tdx.yaml
@@ -3,6 +3,7 @@ services:
   ethrex_l2:
     volumes:
       - ./tee/contracts/automata-dcap-qpl/automata-dcap-qpl-tool/target/release/automata-dcap-qpl-tool:/automata-dcap-qpl-tool:ro,exec
+      - ../../cmd/.env:/env/.env
     environment:
       - ETHREX_PROOF_COORDINATOR_TDX_PRIVATE_KEY=${ETHREX_PROOF_COORDINATOR_TDX_PRIVATE_KEY:-0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d}
     command: >
@@ -16,3 +17,6 @@ services:
       --proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d
       --proof-coordinator.qpl-tool-path /automata-dcap-qpl-tool
       --no-monitor
+
+volumes:
+  env: null


### PR DESCRIPTION
**Motivation**

The `TDX` workflow is currently failing: https://github.com/lambdaclass/ethrex/actions/runs/18141426891/job/51633435845.

**Description**

- Removes the extra `L2` subcommand from the `TDX` override.



Closes None

