### PR TITLE
feat(l1): add `datadir` size metric and panel

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -110,6 +110,8 @@ pub fn open_store(datadir: &Path) -> Store {
                 panic!("Specify the desired database engine.");
             }
         };
+        #[cfg(feature = "metrics")]
+        ethrex_metrics::metrics_process::set_datadir_path(datadir.to_path_buf());
         Store::new(datadir, engine_type).expect("Failed to create Store")
     }
 }

--- a/crates/blockchain/metrics/metrics_process.rs
+++ b/crates/blockchain/metrics/metrics_process.rs
@@ -1,9 +1,14 @@
-use prometheus::{Encoder, Registry, TextEncoder};
-use std::sync::LazyLock;
+use prometheus::{Encoder, IntGauge, Registry, TextEncoder};
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::{LazyLock, OnceLock},
+};
 
 use crate::MetricsError;
 
 pub static METRICS_PROCESS: LazyLock<MetricsProcess> = LazyLock::new(MetricsProcess::default);
+static DATADIR_PATH: OnceLock<PathBuf> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct MetricsProcess;
@@ -37,6 +42,20 @@ impl MetricsProcess {
                 })?;
         }
 
+        if let Some(path) = DATADIR_PATH.get() {
+            if let Ok(size) = directory_size(path) {
+                let gauge = IntGauge::new(
+                    "datadir_size_bytes",
+                    "Total size in bytes consumed by the configured datadir.",
+                )
+                .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+                let clamped = size.min(i64::MAX as u64);
+                gauge.set(clamped as i64);
+                r.register(Box::new(gauge))
+                    .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+            }
+        }
+
         let encoder = TextEncoder::new();
         let metric_families = r.gather();
 
@@ -48,4 +67,38 @@ impl MetricsProcess {
         let res = String::from_utf8(buffer)?;
         Ok(res)
     }
+}
+
+pub fn set_datadir_path(path: PathBuf) {
+    let _ = DATADIR_PATH.set(path);
+}
+
+fn directory_size(root: &Path) -> io::Result<u64> {
+    let mut total = 0;
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(path) = stack.pop() {
+        let entries = match fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err),
+        };
+
+        for entry in entries {
+            let entry = entry?;
+            let metadata = match entry.metadata() {
+                Ok(metadata) => metadata,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(err),
+            };
+
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else {
+                total += metadata.len();
+            }
+        }
+    }
+
+    Ok(total)
 }

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -1329,6 +1329,109 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "This calculates the size in bytes of the datadir path where the DB is stored.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "mean",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "datadir_size_bytes{job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "Datadir Size",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Datadir Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "This is the CPU utilization % of the host machine where the node is running. This was extracted from node_exporter.",
       "fieldConfig": {
         "defaults": {
@@ -1391,7 +1494,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 37
       },
       "id": 45,
       "options": {
@@ -1529,7 +1632,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 37
       },
       "id": 42,
       "options": {
@@ -1638,7 +1741,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 45
       },
       "id": 30,
       "options": {
@@ -1765,7 +1868,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 45
       },
       "id": 31,
       "options": {
@@ -1799,105 +1902,6 @@
         }
       ],
       "title": "Node Memory (RSS)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "This calculates the size in bytes of the datadir path where the DB is stored.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 46,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0-16636675413",
-      "targets": [
-        {
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "datadir_size_bytes{job=\"$job\"}",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Datadir Size",
       "type": "timeseries"
     }
   ],
@@ -1981,5 +1985,5 @@
   "timezone": "browser",
   "title": "Ethrex L1 - Perf Dashboard",
   "uid": "beoru4vp59yiof",
-  "version": 7
+  "version": 8
 }

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -1418,7 +1418,7 @@
           "expr": "datadir_size_bytes{job=\"$job\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "Datadir Size",
+          "legendFormat": "Datadir Size (GB)",
           "range": true,
           "refId": "A",
           "useBackend": false

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -1800,6 +1800,105 @@
       ],
       "title": "Node Memory (RSS)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This calculates the size in bytes of the datadir path where the DB is stored.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-16636675413",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "datadir_size_bytes{job=\"$job\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Datadir Size",
+      "type": "timeseries"
     }
   ],
   "preload": false,


### PR DESCRIPTION
**Motivation**

We want to have an initial way to know how much is taking our DB

**Description**

This PR is an initial iteration over the addition of DB related metrics to our dashboards, in this case we add a metric and corresponding panel with the datadir size.

Closes #4174