### PR TITLE
fix(blockchain): avoid awaiting under payloads mutex in get_payload

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -39,6 +39,9 @@ use std::time::Instant;
 use tokio::sync::Mutex as TokioMutex;
 use tokio_util::sync::CancellationToken;
 
+type PayloadEntry = Arc<TokioMutex<PayloadOrTask>>;
+type PayloadTable = Vec<(u64, PayloadEntry)>;
+
 use vm::StoreVmDatabase;
 
 #[cfg(feature = "metrics")]
@@ -69,9 +72,9 @@ pub struct Blockchain {
     /// This does not reflect whether there is an ongoing sync process
     is_synced: AtomicBool,
     pub options: BlockchainOptions,
-    /// Mapping from a payload id to either a complete payload or a payload build task
-    /// We need to keep completed payloads around in case consensus requests them twice
-    pub payloads: Arc<TokioMutex<Vec<(u64, PayloadOrTask)>>>,
+    /// Mapping from a payload id to a shareable payload entry (either a complete payload or a build task)
+    /// We keep completed payloads around in case consensus requests them twice
+    pub payloads: Arc<TokioMutex<PayloadTable>>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Refactor get_payload to avoid awaiting while holding the payloads mutex. Previously, the code held the tokio::Mutex across an async join (finishing a payload build task), which could serialize concurrent engine_getPayload calls and cause avoidable stalls. The new flow removes the entry under lock, drops the lock, finishes the task, then re-acquires the lock to reinsert the finished payload at a clamped index. This preserves eviction/order semantics as much as possible while eliminating the await-under-lock hotspot.