### PR TITLE
chore(l1, l2): remove `cfg-if` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "cfg-if 1.0.3",
  "clap 4.5.47",
  "clap_complete",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,7 +3688,6 @@ name = "ethrex-blockchain"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "cfg-if 1.0.3",
  "ethrex-common",
  "ethrex-metrics",
  "ethrex-rlp",
@@ -3781,7 +3780,6 @@ dependencies = [
  "axum 0.8.4",
  "bincode",
  "bytes",
- "cfg-if 1.0.3",
  "chrono",
  "clap 4.5.47",
  "color-eyre",
@@ -3972,7 +3970,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
- "cfg-if 1.0.3",
  "clap 4.5.47",
  "ethereum-types 0.15.1",
  "ethrex-blockchain",
@@ -4064,7 +4061,6 @@ dependencies = [
  "axum 0.8.4",
  "axum-extra",
  "bytes",
- "cfg-if 1.0.3",
  "envy",
  "ethereum-types 0.15.1",
  "ethrex-blockchain",
@@ -4208,7 +4204,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytes",
- "cfg-if 1.0.3",
  "derive_more 1.0.0",
  "dyn-clone",
  "ethereum-types 0.15.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ sha3 = "0.10.8"
 tokio-util = { version = "0.7.15", features = ["rt"] }
 jsonwebtoken = "9.3.0"
 rand = "0.8.5"
-cfg-if = "1.0.0"
 reqwest = { version = "0.12.7", features = ["socks", "json"] }
 snap = "1.1.1"
 secp256k1 = { version = "0.30.0", default-features = false, features = [

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -45,8 +45,6 @@ thiserror.workspace = true
 itertools = "0.14.0"
 tui-logger.workspace = true
 
-cfg-if = "1.0.0"
-
 ethrex-dev = { path = "../../crates/blockchain/dev", optional = true }
 ethrex-metrics = { path = "../../crates/blockchain/metrics" }
 url.workspace = true

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -41,7 +41,10 @@ use tracing_subscriber::{
 
 // Compile-time check to ensure that at least one of the database features is enabled.
 const _: () = {
-    #[cfg(not(any(feature = "rocksdb", feature = "libmdbx")))]
+    #[cfg(any(
+        not(any(feature = "rocksdb", feature = "libmdbx")),
+        all(feature = "rocksdb", feature = "libmdbx")
+    ))]
     compile_error!("Either the `rocksdb` or `libmdbx` feature must be enabled.");
 };
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -39,6 +39,12 @@ use tracing_subscriber::{
     EnvFilter, Layer, Registry, filter::Directive, fmt, layer::SubscriberExt, reload,
 };
 
+// Compile-time check to ensure that at least one of the database features is enabled.
+const _: () = {
+    #[cfg(not(any(feature = "rocksdb", feature = "libmdbx")))]
+    compile_error!("Either the `rocksdb` or `libmdbx` feature must be enabled.");
+};
+
 pub fn init_tracing(opts: &Options) -> reload::Handle<EnvFilter, Registry> {
     let log_filter = EnvFilter::builder()
         .with_default_directive(Directive::from(opts.log_level))
@@ -100,16 +106,10 @@ pub fn open_store(datadir: &Path) -> Store {
     if datadir.ends_with("memory") {
         Store::new(datadir, EngineType::InMemory).expect("Failed to create Store")
     } else {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "rocksdb")] {
-                let engine_type = EngineType::RocksDB;
-            } else if #[cfg(feature = "libmdbx")] {
-                let engine_type = EngineType::Libmdbx;
-            } else {
-                error!("No database specified. The feature flag `rocksdb` or `libmdbx` should've been set while building.");
-                panic!("Specify the desired database engine.");
-            }
-        };
+        #[cfg(feature = "rocksdb")]
+        let engine_type = EngineType::RocksDB;
+        #[cfg(feature = "libmdbx")]
+        let engine_type = EngineType::Libmdbx;
         #[cfg(feature = "metrics")]
         ethrex_metrics::metrics_process::set_datadir_path(datadir.to_path_buf());
         Store::new(datadir, engine_type).expect("Failed to create Store")

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -40,11 +40,11 @@ use tracing_subscriber::{
 };
 
 // Compile-time check to ensure that at least one of the database features is enabled.
+#[cfg(any(
+    not(any(feature = "rocksdb", feature = "libmdbx")),
+    all(feature = "rocksdb", feature = "libmdbx")
+))]
 const _: () = {
-    #[cfg(any(
-        not(any(feature = "rocksdb", feature = "libmdbx")),
-        all(feature = "rocksdb", feature = "libmdbx")
-    ))]
     compile_error!("Either the `rocksdb` or `libmdbx` feature must be enabled.");
 };
 

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -34,11 +34,11 @@ use std::{
 use tracing::{debug, info};
 
 // Compile-time check to ensure that at least one of the database features is enabled.
+#[cfg(any(
+    not(any(feature = "rocksdb", feature = "libmdbx")),
+    all(feature = "rocksdb", feature = "libmdbx")
+))]
 const _: () = {
-    #[cfg(any(
-        not(any(feature = "rocksdb", feature = "libmdbx")),
-        all(feature = "rocksdb", feature = "libmdbx")
-    ))]
     compile_error!("Either the `rocksdb` or `libmdbx` feature must be enabled.");
 };
 

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -33,6 +33,12 @@ use std::{
 };
 use tracing::{debug, info};
 
+// Compile-time check to ensure that at least one of the database features is enabled.
+const _: () = {
+    #[cfg(not(any(feature = "rocksdb", feature = "libmdbx")))]
+    compile_error!("Either the `rocksdb` or `libmdbx` feature must be enabled.");
+};
+
 pub const DB_ETHREX_DEV_L1: &str = "dev_ethrex_l1";
 pub const DB_ETHREX_DEV_L2: &str = "dev_ethrex_l2";
 
@@ -375,25 +381,14 @@ impl Command {
                 store_path,
                 coinbase,
             } => {
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "libmdbx")] {
-                        let store_type = EngineType::Libmdbx;
-                    }
-                };
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "rocksdb")] {
-                        let store_type = EngineType::RocksDB;
-                    } else {
-                        eyre::bail!("Expected rocksdb or libmdbx store engine");
-                    }
-                };
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "rollup_storage_sql")] {
-                        let rollup_store_type = ethrex_storage_rollup::EngineTypeRollup::SQL;
-                    } else {
-                        eyre::bail!("Expected sql rollup store engine");
-                    }
-                };
+                #[cfg(feature = "libmdbx")]
+                let store_type = EngineType::Libmdbx;
+
+                #[cfg(feature = "rocksdb")]
+                let store_type = EngineType::RocksDB;
+
+                #[cfg(feature = "rollup_storage_sql")]
+                let rollup_store_type = ethrex_storage_rollup::EngineTypeRollup::SQL;
 
                 // Init stores
                 let store = Store::new_from_genesis(

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -35,7 +35,10 @@ use tracing::{debug, info};
 
 // Compile-time check to ensure that at least one of the database features is enabled.
 const _: () = {
-    #[cfg(not(any(feature = "rocksdb", feature = "libmdbx")))]
+    #[cfg(any(
+        not(any(feature = "rocksdb", feature = "libmdbx")),
+        all(feature = "rocksdb", feature = "libmdbx")
+    ))]
     compile_error!("Either the `rocksdb` or `libmdbx` feature must be enabled.");
 };
 

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -105,14 +105,10 @@ fn get_valid_delegation_addresses(l2_opts: &L2Options) -> Vec<Address> {
 }
 
 pub async fn init_rollup_store(datadir: &Path) -> StoreRollup {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "rollup_storage_sql")] {
-            let engine_type = EngineTypeRollup::SQL;
-        }
-        else {
-            let engine_type = EngineTypeRollup::InMemory;
-        }
-    }
+    #[cfg(feature = "rollup_storage_sql")]
+    let engine_type = EngineTypeRollup::SQL;
+    #[cfg(not(feature = "rollup_storage_sql"))]
+    let engine_type = EngineTypeRollup::InMemory;
     let rollup_store =
         StoreRollup::new(datadir, engine_type).expect("Failed to create StoreRollup");
     rollup_store

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -18,7 +18,6 @@ thiserror.workspace = true
 sha3.workspace = true
 tracing.workspace = true
 bytes.workspace = true
-cfg-if = "1.0.0"
 tokio = { workspace = true, features = ["time", "rt"] }
 tokio-util.workspace = true
 

--- a/crates/l2/Cargo.toml
+++ b/crates/l2/Cargo.toml
@@ -47,7 +47,6 @@ serde_with.workspace = true
 lazy_static.workspace = true
 aligned-sdk = { git = "https://github.com/yetanotherco/aligned_layer", tag = "v0.16.1" }
 ethers = "2.0"
-cfg-if.workspace = true
 chrono = "0.4.41"
 clap.workspace = true
 crossterm = { version = "0.29.0", features = ["event-stream"] }

--- a/crates/l2/prover/Cargo.toml
+++ b/crates/l2/prover/Cargo.toml
@@ -18,7 +18,6 @@ hex.workspace = true
 thiserror.workspace = true
 clap.workspace = true
 kzg-rs.workspace = true
-cfg-if.workspace = true
 rkyv.workspace = true
 bincode = "1.3.3"
 anyhow = "1.0.86"

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
@@ -1155,7 +1155,6 @@ name = "ethrex-blockchain"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "cfg-if",
  "ethrex-common",
  "ethrex-metrics",
  "ethrex-rlp",
@@ -1323,7 +1322,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytes",
- "cfg-if",
  "derive_more 1.0.0",
  "dyn-clone",
  "ethereum-types",

--- a/crates/l2/prover/src/guest_program/src/sp1/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/sp1/Cargo.lock
@@ -622,28 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,15 +636,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -951,7 +920,6 @@ name = "ethrex-blockchain"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "cfg-if",
  "ethrex-common",
  "ethrex-metrics",
  "ethrex-rlp",
@@ -1093,23 +1061,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethrex-threadpool"
-version = "0.1.0"
-dependencies = [
- "crossbeam",
-]
-
-[[package]]
 name = "ethrex-trie"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crossbeam",
  "digest",
  "ethereum-types",
  "ethrex-rlp",
- "ethrex-threadpool",
  "hex",
  "lazy_static",
  "serde",
@@ -1126,7 +1085,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytes",
- "cfg-if",
  "derive_more",
  "dyn-clone",
  "ethereum-types",

--- a/crates/networking/rpc/Cargo.toml
+++ b/crates/networking/rpc/Cargo.toml
@@ -42,8 +42,6 @@ thiserror.workspace = true
 secp256k1.workspace = true
 uuid.workspace = true
 
-cfg-if.workspace = true
-
 [dev-dependencies]
 hex-literal = "0.4.1"
 

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -16,7 +16,6 @@ bytes.workspace = true
 thiserror.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
-cfg-if.workspace = true
 tracing.workspace = true
 serde.workspace = true
 sha3.workspace = true


### PR DESCRIPTION
**Description**

Removes `cfg-if` usage and adds compile-time checks to ensure that at least one DB feature is enabled.

