### PR TITLE
fix(l2): set `l2 --dev` mempool size to non zero

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -200,6 +200,7 @@ impl Options {
             p2p_enabled: true,
             p2p_port: "30303".into(),
             discovery_port: "30303".into(),
+            mempool_max_size: 10_000,
             ..Default::default()
         }
     }
@@ -219,6 +220,7 @@ impl Options {
             p2p_enabled: true,
             p2p_port: "30303".into(),
             discovery_port: "30303".into(),
+            mempool_max_size: 10_000,
             ..Default::default()
         }
     }


### PR DESCRIPTION
**Motivation**

The command `ethrex l2 --dev` was broken due to initializing the mempool size to zero value

**Description**

- Set the value to 10000
- Add CI job to check correct functionality

