### PR TITLE
fix(levm): fix access list bug

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -584,7 +584,11 @@ impl Substate {
             for slot in keys {
                 warm_slots.insert(slot);
             }
-            initial_accessed_storage_slots.insert(address, warm_slots);
+            // We don't directly insert because it could happen that an access list has 2 entries for the same address. That's why we extend.
+            initial_accessed_storage_slots
+                .entry(address)
+                .or_insert_with(BTreeSet::new)
+                .extend(warm_slots);
         }
 
         let substate =

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -587,7 +587,7 @@ impl Substate {
             // We don't directly insert because it could happen that an access list has 2 entries for the same address. That's why we extend.
             initial_accessed_storage_slots
                 .entry(address)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .extend(warm_slots);
         }
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -580,15 +580,10 @@ impl Substate {
         // Add access lists contents to accessed accounts and accessed storage slots.
         for (address, keys) in tx.access_list().clone() {
             initial_accessed_addresses.insert(address);
-            let mut warm_slots = BTreeSet::new();
+            let set = initial_accessed_storage_slots.entry(address).or_default();
             for slot in keys {
-                warm_slots.insert(slot);
+                set.insert(slot);
             }
-            // We don't directly insert because it could happen that an access list has 2 entries for the same address. That's why we extend.
-            initial_accessed_storage_slots
-                .entry(address)
-                .or_default()
-                .extend(warm_slots);
         }
 
         let substate =

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -580,9 +580,9 @@ impl Substate {
         // Add access lists contents to accessed accounts and accessed storage slots.
         for (address, keys) in tx.access_list().clone() {
             initial_accessed_addresses.insert(address);
-            let set = initial_accessed_storage_slots.entry(address).or_default();
+            let warm_slots = initial_accessed_storage_slots.entry(address).or_default();
             for slot in keys {
-                set.insert(slot);
+                warm_slots.insert(slot);
             }
         }
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -580,6 +580,7 @@ impl Substate {
         // Add access lists contents to accessed accounts and accessed storage slots.
         for (address, keys) in tx.access_list().clone() {
             initial_accessed_addresses.insert(address);
+            // Access lists can have different entries even for the same address, that's why we check if there's an existing set instead of considering it empty
             let warm_slots = initial_accessed_storage_slots.entry(address).or_default();
             for slot in keys {
                 warm_slots.insert(slot);


### PR DESCRIPTION
**Motivation**

Fix bug when syncing mainnet block 23491026

**Description**

Access list can specify the same address in 2 different entries, this is not common and we weren't contemplating that, so when processing the second entry we were clearing the values inserted during the processing of the first entry
Example
```
"accessList": [
{
	"address": "0x1ac7a0ebf13a996d5915e212900be2d074f94988",
	"storageKeys": [
		"0xb63224678cdc3f930718c5fedb0de566186ebaf61e262a132d8caa6cea32d73b",
	]
},
{
	"address": "0x1ac7a0ebf13a996d5915e212900be2d074f94988",
	"storageKeys": [
		"0x74287e7e7b7a047cfa15f782074b1a8386fb281195cd62d2589ea50ebf2a8331",
	]
},
```

Created issue #4742
