### PR TITLE
chore(l1): reduce log spam when building blocks

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -401,7 +401,10 @@ impl Blockchain {
         self.finalize_payload(&mut context).await?;
 
         let interval = Instant::now().duration_since(since).as_millis();
-        tracing::info!(
+        // TODO: expose as a proper metric
+        // Commented out because we build multiple blocks per request
+        // each one printing this metric can be spammy
+        tracing::debug!(
             "[METRIC] BUILDING PAYLOAD TOOK: {interval} ms, base fee {}",
             base_fee
         );
@@ -410,7 +413,10 @@ impl Blockchain {
 
             if interval != 0 {
                 let throughput = (as_gigas) / (interval as f64) * 1000_f64;
-                tracing::info!(
+                // TODO: expose as a proper metric
+                // Commented out because we build multiple blocks per request
+                // each one printing this metric can be spammy
+                tracing::debug!(
                     "[METRIC] BLOCK BUILDING THROUGHPUT: {throughput} Gigagas/s TIME SPENT: {interval} msecs"
                 );
             }
@@ -543,7 +549,7 @@ impl Blockchain {
                 }
                 // Ignore following txs from sender
                 Err(e) => {
-                    error!("Failed to execute transaction: {tx_hash:x}, {e}");
+                    debug!("Failed to execute transaction: {tx_hash:x}, {e}");
                     metrics!(METRICS_TX.inc_tx_errors(e.to_metric()));
                     txs.pop();
                     continue;

--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -58,6 +58,7 @@ pub async fn build_payload(
     blockchain.finalize_payload(&mut context).await?;
 
     let interval = Instant::now().duration_since(since).as_millis();
+    // TODO: expose as a proper metric
     tracing::info!("[METRIC] BUILDING PAYLOAD TOOK: {interval} ms");
     #[allow(clippy::as_conversions)]
     if let Some(gas_used) = gas_limit.checked_sub(context.remaining_gas) {
@@ -65,6 +66,7 @@ pub async fn build_payload(
 
         if interval != 0 {
             let throughput = (as_gigas) / (interval as f64) * 1000_f64;
+            // TODO: expose as a proper metric
             tracing::info!(
                 "[METRIC] BLOCK BUILDING THROUGHPUT: {throughput} Gigagas/s TIME SPENT: {interval} msecs"
             );


### PR DESCRIPTION
**Motivation**

When we changed block building to be done asynchronously and multiple times per slot, we kept metrics logs, which ended up being too spammy.

**Description**

This PR reduces the logs to `debug` level.

Closes #4719

