### PR TITLE
feat(l2): Remove redundant L2 Lint workflow

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -5,8 +5,6 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
-    paths-ignore:
-      - "crates/l2/**" # Behind a feature flag not used in this workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -19,49 +19,6 @@ env:
   DOCKER_ETHREX_WORKDIR: /usr/local/bin
 
 jobs:
-  lint:
-    # "Lint" is a required check, don't change the name
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Setup Rust Environment
-        uses: ./.github/actions/setup-rust
-        with:
-          components: rustfmt, clippy
-
-      - name: Install RISC0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl -L https://risczero.com/install | bash
-          ~/.risc0/bin/rzup install cargo-risczero 3.0.3
-          ~/.risc0/bin/rzup install risc0-groth16
-          ~/.risc0/bin/rzup install rust
-
-      - name: Create placeholder SP1 ELF
-        run: |
-          mkdir -p crates/l2/prover/src/guest_program/src/sp1/out
-          touch crates/l2/prover/src/guest_program/src/sp1/out/riscv32im-succinct-zkvm-elf
-
-      - name: Run cargo check
-        run: cargo check --workspace
-
-      - name: Run cargo clippy
-        run: |
-          cargo clippy --workspace -- -D warnings
-          make lint
-
-      - name: Run cargo fmt
-        run: |
-          cargo fmt --all -- --check
-
   build-docker:
     name: Build docker image
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #3973. 

After #3826 merged the prover binary into ethrex, the L1 workflow now uses `--all-features --workspace` for linting which checks the entire codebase including L2 code, making the separate L2 lint job redundant. 

removes the duplicate L2 lint job and the outdated `paths-ignore: crates/l2/**` from L1 workflow to ensure all PRs receive consistent lint coverage while eliminating duplicate CI executions and saving resources.