### PR TITLE
fix(l1): add `port_publisher` section to kurtosis config file

### DIFF
--- a/fixtures/networks/default.yaml
+++ b/fixtures/networks/default.yaml
@@ -28,6 +28,14 @@ participants:
     validator_count: 32
     # snooper_enabled: true
 
+port_publisher:
+  cl:
+    enabled: true
+    public_port_start: 33000
+  el:
+    enabled: true
+    public_port_start: 32000
+
 ethereum_metrics_exporter_enabled: true
 
 additional_services:


### PR DESCRIPTION
**Motivation**
Currenlt, `make localnet` fails locally with the following error: 
```
  Caused by: An error occurred getting public port spec for private port 'udp-discovery' with spec '9000/UDP' on container '/cl-1-lighthouse-geth--07e5a2e474bf40a5811c2647ec4c9acc'
  Caused by: No host machine port binding was specified for Docker port '9000/udp' which corresponds to port spec with num '9000' and protocol 'UDP'
```
This got fixed by exporting the necessary ports for the consensus and execution clients via `port_publisher`
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Add `port_publisher` section to kurtosis config file (default.yaml)
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

