### PR TITLE
ci(l1, l2): add GitHub runner token to Install Protoc step

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install solc (Linux ARM)
         if: ${{ matrix.platform == 'ubuntu-24.04-arm' }}


### PR DESCRIPTION
So we are not rate limited by GitHub when downloading protoc More info: https://github.com/arduino/setup-protoc?tab=readme-ov-file#usage