### PR TITLE
perf(l1): remove metric current_step string lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2025-10-06
+
+- Refactor current_step sync metric from a `Mutex<String>` to a simple atomic. [#4772](https://github.com/lambdaclass/ethrex/pull/4772)
+
 ### 2025-10-01
 
 - Change remaining_gas to i64, improving performance in gas cost calculations [#4684](https://github.com/lambdaclass/ethrex/pull/4684)

--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -1,14 +1,18 @@
+use core::fmt;
 use std::{
     collections::{BTreeMap, VecDeque},
     sync::{
         Arc, LazyLock,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU8, AtomicU64, Ordering},
     },
     time::{Duration, SystemTime},
 };
 
 use ethrex_common::H256;
-use prometheus::{Gauge, IntCounter, Registry};
+use prometheus::{
+    Gauge, IntCounter, Registry,
+    core::{Atomic, Metric, Number},
+};
 use tokio::sync::Mutex;
 
 use crate::rlpx::{error::RLPxError, p2p::DisconnectReason};
@@ -57,7 +61,7 @@ pub struct Metrics {
     // Common
     pub sync_head_block: AtomicU64,
     pub sync_head_hash: Arc<Mutex<H256>>,
-    pub current_step: Arc<Mutex<String>>,
+    pub current_step: Arc<CurrentStep>,
 
     // Headers
     pub headers_to_download: AtomicU64,
@@ -99,6 +103,89 @@ pub struct Metrics {
     pub bytecode_download_end_time: Arc<Mutex<Option<SystemTime>>>,
 
     start_time: SystemTime,
+}
+
+#[derive(Debug)]
+pub struct CurrentStep(AtomicU8);
+
+impl CurrentStep {
+    pub fn set(&self, value: CurrentStepValue) {
+        self.0.store(value.into(), Ordering::Relaxed);
+    }
+
+    pub fn get(&self) -> CurrentStepValue {
+        self.0.load(Ordering::Relaxed).into()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum CurrentStepValue {
+    None,
+    HealingStorage,
+    HealingState,
+    RequestingBytecodes,
+    RequestingAccountRanges,
+    RequestingStorageRanges,
+    DownloadingHeaders,
+    InsertingStorageRanges,
+    InsertingAccountRanges,
+    InsertingAccountRangesNoDb,
+}
+
+impl From<u8> for CurrentStepValue {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => Self::HealingStorage,
+            2 => Self::HealingState,
+            3 => Self::RequestingBytecodes,
+            4 => Self::RequestingAccountRanges,
+            5 => Self::RequestingStorageRanges,
+            6 => Self::DownloadingHeaders,
+            7 => Self::InsertingStorageRanges,
+            8 => Self::InsertingAccountRanges,
+            9 => Self::InsertingAccountRangesNoDb,
+            _ => Self::None,
+        }
+    }
+}
+
+impl From<CurrentStepValue> for u8 {
+    fn from(value: CurrentStepValue) -> Self {
+        match value {
+            CurrentStepValue::None => 0,
+            CurrentStepValue::HealingStorage => 1,
+            CurrentStepValue::HealingState => 2,
+            CurrentStepValue::RequestingBytecodes => 3,
+            CurrentStepValue::RequestingAccountRanges => 4,
+            CurrentStepValue::RequestingStorageRanges => 5,
+            CurrentStepValue::DownloadingHeaders => 6,
+            CurrentStepValue::InsertingStorageRanges => 7,
+            CurrentStepValue::InsertingAccountRanges => 8,
+            CurrentStepValue::InsertingAccountRangesNoDb => 9,
+        }
+    }
+}
+
+impl fmt::Display for CurrentStepValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CurrentStepValue::None => write!(f, "Unknown"),
+            CurrentStepValue::HealingStorage => write!(f, "Healing Storage"),
+            CurrentStepValue::HealingState => write!(f, "Healing State"),
+            CurrentStepValue::RequestingBytecodes => write!(f, "Requesting Bytecodes"),
+            CurrentStepValue::RequestingAccountRanges => write!(f, "Requesting Account Ranges"),
+            CurrentStepValue::RequestingStorageRanges => write!(f, "Requesting Storage Ranges"),
+            CurrentStepValue::DownloadingHeaders => write!(f, "Downloading Headers"),
+            CurrentStepValue::InsertingStorageRanges => {
+                write!(f, "Inserting Storage Ranges - \x1b[31mWriting to DB\x1b[0m")
+            }
+            CurrentStepValue::InsertingAccountRanges => {
+                write!(f, "Inserting Account Ranges - \x1b[31mWriting to DB\x1b[0m")
+            }
+            CurrentStepValue::InsertingAccountRangesNoDb => write!(f, "Inserting Account Ranges"),
+        }
+    }
 }
 
 impl Metrics {
@@ -559,7 +646,7 @@ impl Default for Metrics {
             // Common
             sync_head_block: AtomicU64::new(0),
             sync_head_hash: Arc::new(Mutex::new(H256::default())),
-            current_step: Arc::new(Mutex::new("".to_string())),
+            current_step: Arc::new(CurrentStep(AtomicU8::new(0))),
 
             // Headers
             headers_to_download: AtomicU64::new(0),

--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -9,10 +9,7 @@ use std::{
 };
 
 use ethrex_common::H256;
-use prometheus::{
-    Gauge, IntCounter, Registry,
-    core::{Atomic, Metric, Number},
-};
+use prometheus::{Gauge, IntCounter, Registry};
 use tokio::sync::Mutex;
 
 use crate::rlpx::{error::RLPxError, p2p::DisconnectReason};

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -186,7 +186,7 @@ pub async fn periodically_show_peer_stats_during_syncing(
             // Common metrics
             let elapsed = format_duration(start.elapsed());
             let peer_number = peer_table.peer_count().await.unwrap_or(0);
-            let current_step = METRICS.current_step.lock().await.clone();
+            let current_step = METRICS.current_step.get();
             let current_header_hash = *METRICS.sync_head_hash.lock().await;
 
             // Headers metrics
@@ -355,7 +355,7 @@ Current Header Hash: {current_header_hash:x}
 headers progress: {headers_download_progress} (total: {headers_to_download}, downloaded: {headers_downloaded}, remaining: {headers_remaining})
 account leaves download: {account_leaves_downloaded}, elapsed: {account_leaves_time}
 account leaves insertion: {account_leaves_inserted_percentage:.2}%, elapsed: {account_leaves_inserted_time}
-storage leaves download: {storage_leaves_downloaded}, elapsed: {storage_leaves_time}, initially accounts with storage {storage_accounts}, healed accounts {storage_accounts_healed} 
+storage leaves download: {storage_leaves_downloaded}, elapsed: {storage_leaves_time}, initially accounts with storage {storage_accounts}, healed accounts {storage_accounts_healed}
 storage leaves insertion: {storage_leaves_inserted_time}
 healing: global accounts healed {healed_accounts} global storage slots healed {healed_storages}, elapsed: {heal_time}, current throttle {heal_current_throttle}
 bytecodes progress: downloaded: {bytecodes_downloaded}, elapsed: {bytecodes_download_time})"

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -17,7 +17,7 @@ use ethrex_trie::{Node, verify_range};
 
 use crate::{
     discv4::peer_table::{PeerChannels, PeerData, PeerTable, PeerTableError, PeerTableHandle},
-    metrics::METRICS,
+    metrics::{CurrentStepValue, METRICS},
     rlpx::{
         connection::server::CastMessage,
         eth::{
@@ -174,7 +174,9 @@ impl PeerHandler {
         sync_head: H256,
     ) -> Result<Option<Vec<BlockHeader>>, PeerHandlerError> {
         let start_time = SystemTime::now();
-        *METRICS.current_step.lock().await = "Downloading Headers".to_string();
+        METRICS
+            .current_step
+            .set(CurrentStepValue::DownloadingHeaders);
 
         let initial_downloaded_headers = METRICS.downloaded_headers.load(Ordering::Relaxed);
 
@@ -740,7 +742,9 @@ impl PeerHandler {
         pivot_header: &mut BlockHeader,
         block_sync_state: &mut BlockSyncState,
     ) -> Result<(), PeerHandlerError> {
-        *METRICS.current_step.lock().await = "Requesting Account Ranges".to_string();
+        METRICS
+            .current_step
+            .set(CurrentStepValue::RequestingAccountRanges);
         // 1) split the range in chunks of same length
         let start_u256 = U256::from_big_endian(&start.0);
         let limit_u256 = U256::from_big_endian(&limit.0);
@@ -1096,7 +1100,9 @@ impl PeerHandler {
         &mut self,
         all_bytecode_hashes: &[H256],
     ) -> Result<Option<Vec<Bytes>>, PeerHandlerError> {
-        *METRICS.current_step.lock().await = "Requesting Bytecodes".to_string();
+        METRICS
+            .current_step
+            .set(CurrentStepValue::RequestingBytecodes);
         const MAX_BYTECODES_REQUEST_SIZE: usize = 100;
         // 1) split the range in chunks of same length
         let chunk_count = 800;
@@ -1295,7 +1301,9 @@ impl PeerHandler {
         mut chunk_index: u64,
         pivot_header: &mut BlockHeader,
     ) -> Result<u64, PeerHandlerError> {
-        *METRICS.current_step.lock().await = "Requesting Storage Ranges".to_string();
+        METRICS
+            .current_step
+            .set(CurrentStepValue::RequestingStorageRanges);
         debug!("Starting request_storage_ranges function");
         // 1) split the range in chunks of same length
         let chunk_size = 300;

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -807,11 +807,8 @@ impl SnapBlockSyncState {
 /// TODO: remove this function once peer table has moved to spawned implementation
 async fn free_peers_and_log_if_not_empty(peer_handler: &mut PeerHandler) -> Result<(), SyncError> {
     if peer_handler.peer_table.free_peers().await? != 0 {
-        let step = METRICS.current_step.lock().await.clone();
-        error!(
-            step = step,
-            "Found peers marked as used even though we just finished this step"
-        );
+        let step = METRICS.current_step.get();
+        error!("Found peers marked as used even though we just finished this step: step = {step}");
     };
     Ok(())
 }
@@ -887,7 +884,10 @@ impl Syncer {
             for entry in std::fs::read_dir(&account_state_snapshots_dir)
                 .map_err(|_| SyncError::AccountStateSnapshotsDirNotFound)?
             {
-                *METRICS.current_step.lock().await = "Inserting Account Ranges".to_string();
+                METRICS
+                    .current_step
+                    .set(crate::metrics::CurrentStepValue::InsertingAccountRangesNoDb);
+
                 let entry = entry.map_err(|err| {
                     SyncError::SnapshotReadError(account_state_snapshots_dir.clone(), err)
                 })?;
@@ -936,8 +936,9 @@ impl Syncer {
                                 .fetch_add(1, Ordering::Relaxed);
                             trie.insert(account_hash.0.to_vec(), account.encode_to_vec())?;
                         }
-                        *METRICS.current_step.blocking_lock() =
-                            "Inserting Account Ranges - \x1b[31mWriting to DB\x1b[0m".to_string();
+                        METRICS
+                            .current_step
+                            .set(crate::metrics::CurrentStepValue::InsertingAccountRanges);
                         let current_state_root = trie.hash()?;
                         Ok(current_state_root)
                     })
@@ -1030,8 +1031,9 @@ impl Syncer {
                 Arc::new(Mutex::new(HashMap::new()));
 
             *METRICS.storage_tries_insert_start_time.lock().await = Some(SystemTime::now());
-            *METRICS.current_step.lock().await =
-                "Inserting Storage Ranges - \x1b[31mWriting to DB\x1b[0m".to_string();
+            METRICS
+                .current_step
+                .set(crate::metrics::CurrentStepValue::InsertingStorageRanges);
             let account_storages_snapshots_dir = get_account_storages_snapshots_dir(&self.datadir);
             for entry in std::fs::read_dir(&account_storages_snapshots_dir)
                 .map_err(|_| SyncError::AccountStoragesSnapshotsDirNotFound)?

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -22,7 +22,7 @@ use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, Node, NodeHash, TrieDB, TrieError};
 use tracing::{debug, error, info};
 
 use crate::{
-    metrics::METRICS,
+    metrics::{CurrentStepValue, METRICS},
     peer_handler::{PeerHandler, RequestMetadata, RequestStateTrieNodesError},
     rlpx::p2p::SUPPORTED_SNAP_CAPABILITIES,
     sync::{AccountStorageRoots, code_collector::CodeHashCollector},
@@ -55,7 +55,7 @@ pub async fn heal_state_trie_wrap(
     code_hash_collector: &mut CodeHashCollector,
 ) -> Result<bool, SyncError> {
     let mut healing_done = false;
-    *METRICS.current_step.lock().await = "Healing State".to_string();
+    METRICS.current_step.set(CurrentStepValue::HealingState);
     info!("Starting state healing");
     while !healing_done {
         healing_done = heal_state_trie(

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    metrics::METRICS,
+    metrics::{CurrentStepValue, METRICS},
     peer_handler::{MAX_RESPONSE_BYTES, PeerHandler, RequestStorageTrieNodes},
     rlpx::{
         p2p::SUPPORTED_SNAP_CAPABILITIES,
@@ -126,7 +126,7 @@ pub async fn heal_storage_trie(
     staleness_timestamp: u64,
     global_leafs_healed: &mut u64,
 ) -> Result<bool, SyncError> {
-    *METRICS.current_step.lock().await = "Healing Storage".to_string();
+    METRICS.current_step.set(CurrentStepValue::HealingStorage);
     let download_queue = get_initial_downloads(&store, state_root, storage_accounts);
     info!(
         "Started Storage Healing with {} accounts",


### PR DESCRIPTION
**Motivation**

The current_step metric currently is a Mutex with a String allocated on every update. This is very inefficient.

**Description**

Changed to a lockless atomic using an enum to handle the step state, avoid string allocations by using the display trait.


