### PR TITLE
chore(l1): remove unused temporary in snap_sync method

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -899,17 +899,11 @@ impl Syncer {
                     RLPDecode::decode(&snapshot_contents)
                         .map_err(|_| SyncError::SnapshotDecodeError(snapshot_path.clone()))?;
 
-                let (account_hashes, account_states): (Vec<H256>, Vec<AccountState>) =
-                    account_states_snapshot.iter().cloned().unzip();
-
                 storage_accounts.accounts_with_storage_root.extend(
-                    account_hashes
-                        .iter()
-                        .zip(account_states.iter())
-                        .filter_map(|(hash, state)| {
-                            (state.storage_root != *EMPTY_TRIE_HASH)
-                                .then_some((*hash, state.storage_root))
-                        }),
+                    account_states_snapshot.iter().filter_map(|(hash, state)| {
+                        (state.storage_root != *EMPTY_TRIE_HASH)
+                            .then_some((*hash, state.storage_root))
+                    }),
                 );
 
                 info!("Inserting accounts into the state trie");


### PR DESCRIPTION
**Motivation**
We were currently unziping a tuple vec to reconstruct it again, doing effectively nothing with it, and if the vec is big it may be noticable if the compiler doesn't optimize it out.

**Description**

Remove the unused unzip

Closes #issue_number

