### PR TITLE
refactor(l1): throw error on wrong version of eth capaability

### DIFF
--- a/crates/networking/p2p/rlpx/eth/eth68/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth68/status.rs
@@ -48,7 +48,9 @@ impl RLPxMessage for StatusMessage68 {
         let decoder = Decoder::new(&decompressed_data)?;
         let (eth_version, decoder): (u32, _) = decoder.decode_field("protocolVersion")?;
 
-        assert_eq!(eth_version, 68, "only eth version 68 is supported");
+        if eth_version != 68 {
+            return Err(RLPDecodeError::IncompatibleProtocol);
+        }
 
         let (network_id, decoder): (u64, _) = decoder.decode_field("networkId")?;
         let (total_difficulty, decoder): (U256, _) = decoder.decode_field("totalDifficulty")?;

--- a/crates/networking/p2p/rlpx/eth/eth69/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth69/status.rs
@@ -47,7 +47,9 @@ impl RLPxMessage for StatusMessage69 {
         let decoder = Decoder::new(&decompressed_data)?;
         let (eth_version, decoder): (u32, _) = decoder.decode_field("protocolVersion")?;
 
-        assert_eq!(eth_version, 69, "only eth version 69 is supported");
+        if eth_version != 69 {
+            return Err(RLPDecodeError::IncompatibleProtocol);
+        }
 
         let (network_id, decoder): (u64, _) = decoder.decode_field("networkId")?;
         let (genesis, decoder): (BlockHash, _) = decoder.decode_field("genesis")?;


### PR DESCRIPTION
**Motivation**

Stop panicking when decoding a message with a wrong version of capabilities `eth68` and `eth69`.

**Description**

This pr has the `decode` method for both capabilities throw error in case the eth version of the message is wrong.
The only instance where this can happen is if the other peer isn't respecting the negotiated capabilities. This happens as seen in issue #4760. [Here](https://github.com/lambdaclass/ethrex/blob/05e0de5aaa40df9ec7088f7a20a47720c56cd350/crates/networking/p2p/rlpx/connection/server.rs#L676-L677) we can see the eth version negotiated can only be either 68 or 69. 

Closes #4760