### PR TITLE
ci(l1): use same configuration for daily hive jobs as in the hive page.

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -110,8 +110,8 @@ jobs:
         run: |
           FLAGS='--sim.parallelism 4 --sim.loglevel 1'
           if [[ "$SIMULATION" == "ethereum/eest/consume-engine" || "$SIMULATION" == "ethereum/eest/consume-rlp" ]]; then
-            FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.1.0/fixtures_develop.tar.gz"
-            FLAGS+=" --sim.buildarg branch=v5.1.0"
+            FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.1.0/fixtures_stable.tar.gz"
+            FLAGS+=" --sim.buildarg branch=main"
             FLAGS+=" --client.checktimelimit=180s"
           fi
           if [[ -n "$SIM_LIMIT" ]]; then


### PR DESCRIPTION
**Motivation**
See https://hive.ethpandaops.io/#/test/generic/1759816110-3c40a86453dd88c40b16a6375749f35e

**Description**
- Changes the fixtures to use stable instead of develop and the branch to main.


