### PR TITLE
ci(l1): remove ethrex image cache when running sync hoodi job.

### DIFF
--- a/.github/workflows/manual_snapsync_test.yaml
+++ b/.github/workflows/manual_snapsync_test.yaml
@@ -1,6 +1,9 @@
-name: Sync Ethrex
+name: Snapsync Test
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/manual_snapsync_test.yaml"
   schedule:
     - cron: "0 */2 * * *"
   workflow_dispatch:


### PR DESCRIPTION
**Motivation**
Sync Hoodi job was using a cached version of ethrex.

**Description**
- Remove ethrex docker images from runner to make sure they are always downloaded. Alternative, you can use `--image-download always` in kurtosis, but that would remove the cache of all the images, not just ethrex
- Add the ethrex version to summary.

