### PR TITLE
fix(l1): use fullsync in dev mode

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -16,6 +16,7 @@ use ethrex_p2p::{
     network::P2PContext,
     peer_handler::PeerHandler,
     rlpx::l2::l2_connection::P2PBasedContext,
+    sync::SyncMode,
     sync_manager::SyncManager,
     types::{Node, NodeRecord},
     utils::public_key_from_signing_key,
@@ -135,10 +136,17 @@ pub async fn init_rpc_api(
     extra_data: String,
 ) {
     init_datadir(&opts.datadir);
+
+    let syncmode = if opts.dev {
+        &SyncMode::Full
+    } else {
+        &opts.syncmode
+    };
+
     // Create SyncManager
     let syncer = SyncManager::new(
         peer_handler.clone(),
-        opts.syncmode.clone(),
+        syncmode,
         cancel_token,
         blockchain.clone(),
         store.clone(),

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -49,7 +49,7 @@ async fn init_rpc_api(
     // Create SyncManager
     let syncer = SyncManager::new(
         peer_handler.clone(),
-        opts.syncmode.clone(),
+        &opts.syncmode,
         cancel_token,
         blockchain.clone(),
         store.clone(),

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -35,7 +35,7 @@ pub struct SyncManager {
 impl SyncManager {
     pub async fn new(
         peer_handler: PeerHandler,
-        sync_mode: SyncMode,
+        sync_mode: &SyncMode,
         cancel_token: CancellationToken,
         blockchain: Arc<Blockchain>,
         store: Store,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
`--dev` mode was broken when set `snap` as default syncmode.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
If `--dev` flag is set, use always fullsync.

<!-- Link to issues: Resolves #111, Resolves #222 -->


