### PR TITLE
chore(l1): make `get_receipts_for_block async`

### DIFF
--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -831,7 +831,7 @@ async fn handle_peer_message(state: &mut Established, message: Message) -> Resul
             if let Some(eth) = &state.negotiated_eth_capability {
                 let mut receipts = Vec::new();
                 for hash in block_hashes.iter() {
-                    receipts.push(state.storage.get_receipts_for_block(hash)?);
+                    receipts.push(state.storage.get_receipts_for_block(hash).await?);
                 }
                 let response = match eth.version {
                     68 => Message::Receipts68(Receipts68::new(id, receipts)),

--- a/crates/storage/api.rs
+++ b/crates/storage/api.rs
@@ -254,7 +254,10 @@ pub trait StoreEngine: Debug + Send + Sync + RefUnwindSafe {
         finalized: Option<BlockNumber>,
     ) -> Result<(), StoreError>;
 
-    fn get_receipts_for_block(&self, block_hash: &BlockHash) -> Result<Vec<Receipt>, StoreError>;
+    async fn get_receipts_for_block(
+        &self,
+        block_hash: &BlockHash,
+    ) -> Result<Vec<Receipt>, StoreError>;
 
     // Snap State methods
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1047,11 +1047,11 @@ impl Store {
         Ok(nodes)
     }
 
-    pub fn get_receipts_for_block(
+    pub async fn get_receipts_for_block(
         &self,
         block_hash: &BlockHash,
     ) -> Result<Vec<Receipt>, StoreError> {
-        self.engine.get_receipts_for_block(block_hash)
+        self.engine.get_receipts_for_block(block_hash).await
     }
 
     /// Creates a new state trie with an empty state root, for testing purposes only

--- a/crates/storage/store_db/in_memory.rs
+++ b/crates/storage/store_db/in_memory.rs
@@ -466,7 +466,10 @@ impl StoreEngine for Store {
         Ok(())
     }
 
-    fn get_receipts_for_block(&self, block_hash: &BlockHash) -> Result<Vec<Receipt>, StoreError> {
+    async fn get_receipts_for_block(
+        &self,
+        block_hash: &BlockHash,
+    ) -> Result<Vec<Receipt>, StoreError> {
         let store = self.inner()?;
         let Some(receipts_for_block) = store.receipts.get(block_hash) else {
             return Ok(vec![]);

--- a/crates/storage/store_db/rocksdb.rs
+++ b/crates/storage/store_db/rocksdb.rs
@@ -1167,14 +1167,16 @@ impl StoreEngine for Store {
         .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?
     }
 
-    fn get_receipts_for_block(&self, block_hash: &BlockHash) -> Result<Vec<Receipt>, StoreError> {
-        let cf = self.cf_handle(CF_RECEIPTS)?;
+    async fn get_receipts_for_block(
+        &self,
+        block_hash: &BlockHash,
+    ) -> Result<Vec<Receipt>, StoreError> {
         let mut receipts = Vec::new();
         let mut index = 0u64;
 
         loop {
             let key = (*block_hash, index).encode_to_vec();
-            match self.db.get_cf(&cf, key)? {
+            match self.read_async(CF_RECEIPTS, key).await? {
                 Some(receipt_bytes) => {
                     let receipt = Receipt::decode(receipt_bytes.as_slice())?;
                     receipts.push(receipt);


### PR DESCRIPTION
Closes #4614

resuming from closed pr 4660 (with last approved changes) due to conflicts.