### PR TITLE
fix(l1): only ask for block header to check whether an incoming payload is already known

### DIFF
--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -681,8 +681,11 @@ async fn try_execute_payload(
     let block_hash = block.hash();
     let block_number = block.header.number;
     let storage = &context.storage;
-    // Return the valid message directly if we have it.
-    if storage.get_block_by_hash(block_hash).await?.is_some() {
+    // Return the valid message directly if we already have it.
+    // We check for header only as we do not download the block bodies before the pivot during snap sync
+    // The only other cases where we would have a body-less block are during snap sync (in which case we wouldn't be attempting to execute a payload)
+    // or during a fullsync, where the received paylaod matches a soon-to-be-executed block
+    if storage.get_block_header_by_hash(block_hash)?.is_some() {
         return Ok(PayloadStatus::valid_with_hash(block_hash));
     }
 


### PR DESCRIPTION
**Motivation**
As reported by #4790 if we have finished our initial snap sync upon node startup and a consensus node is outdated and sends an old `NewPaylaod` request with a block below our snap sync pivot we will return an invalid state trie error (as we attempt to execute a block on top of a non-existent state). Instead, the node should recognize the block in the payload as already known and return a valid status without attempting to execute it.
We do check if a block is known before attempting to execute it when handling a new payload but our criteria for it is that the full block must exist in our Store. This doesn't happen after a snap sync as we currently only download the headers for the blocks between our current head and the snap sync pivot (#1766). Therefore this PR proposes to solve this problem by only checking if the header is known instead of requesting the full block. The reasoning for this is that the only other case (besides after concluding a snap sync) where we would have a "bodiless" block are during an active snap sync, where we wouldn't attempt to handle an incoming payload.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Only check if the block header is present when deciding if a block is already known when handling a `NewPayload` request
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #4790 

