### PR TITLE
fix(l1): remove `--exclude ef_tests-state` from `test` makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint: ## 🧹 Linter check
 
 CRATE ?= *
 test: ## 🧪 Run each crate's tests
-	cargo test -p '$(CRATE)' --workspace --exclude ethrex-levm --exclude ef_tests-blockchain --exclude ef_tests-state --exclude ethrex-l2 -- --skip test_contract_compilation
+	cargo test -p '$(CRATE)' --workspace --exclude ethrex-levm --exclude ef_tests-blockchain --exclude ethrex-l2 -- --skip test_contract_compilation
 
 clean: clean-vectors ## 🧹 Remove build artifacts
 	cargo clean


### PR DESCRIPTION
**Motivation**
Getting rid of warning that pops up when running `make test`:
```
warning: excluded package(s) `ef_tests-state` not found in workspace `/home/runner/work/ethrex/ethrex
```
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Remove `--exclude ef_tests-state` from `test` makefile target
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

