### PR TITLE
feat(l1): print client version at bootup

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use ethrex::{
     cli::CLI,
     initializers::{init_l1, init_tracing},
-    utils::{NodeConfigFile, store_node_config_file},
+    utils::{NodeConfigFile, get_client_version, store_node_config_file},
 };
 use ethrex_p2p::{discv4::peer_table::PeerTableHandle, types::NodeRecord};
 use std::{path::Path, sync::Arc, time::Duration};
@@ -57,6 +57,8 @@ async fn main() -> eyre::Result<()> {
     }
 
     let log_filter_handler = init_tracing(&opts);
+
+    info!("ethrex version: {}", get_client_version());
 
     let (datadir, cancel_token, peer_table, local_node_record) =
         init_l1(opts, Some(log_filter_handler)).await?;


### PR DESCRIPTION
**Motivation**

When reviewing logs, it's useful to know exactly was was run. This PR adds a log at boot for the version

**Description**

- Add an info log at boot indicating the version

Example output: `INFO ethrex: ethrex version: ethrex/v0.1.0-main-9a03e4c/aarch64-apple-darwin/rustc-v1.90.0`


