### PR TITLE
fix(l1): fix big storage accounts bug during snap sync

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1493,6 +1493,11 @@ impl PeerHandler {
                         let start_hash_u256 = U256::from_big_endian(&hash_start.0);
                         let missing_storage_range = U256::MAX - start_hash_u256;
 
+                        // Big accounts need to be marked for storage healing unconditionally
+                        for account in accounts_by_root_hash[remaining_start].1.iter() {
+                            account_storage_roots.healed_accounts.insert(*account);
+                        }
+
                         let slot_count = account_storages
                             .last()
                             .map(|v| v.len())


### PR DESCRIPTION
**Motivation**

This PR makes it so that big accounts are **unconditionally** marked for storage healing during download. The current `request_storage_ranges` code has a very specific edge case where we think a big account has been downloaded in its entirety when it hasn't yet, and we don't mark it for storage healing because of that. If a pivot jump occurs after that and before we actually download all of the account, we end up with an incomplete state. This was spotted on a mainnet snap sync. The fix is to immediately mark big accounts for healing when we first encounter them.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

