### PR TITLE
chore(l1): reduce handling cast message warn spam

### DIFF
--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -428,7 +428,7 @@ impl GenServer for PeerConnectionServer {
                             .version
                             .clone()
                             .unwrap_or("-".to_string());
-                        log_peer_warn(
+                        log_peer_debug(
                             &established_state.node,
                             &format!(
                                 "Error handling cast message: {e}, for client: {} with capabilities {:?}",


### PR DESCRIPTION
Currently this gets spammed all the time:

```
h capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:05.971809Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:06.272159Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:06.351314Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:06.386477Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:06.555773Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:06.715587Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:07.990430Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
2025-10-15T06:04:08.090260Z  WARN ethrex_p2p::rlpx::utils: ethrex/[0xdb10…275f(62.210.198.66:30303)]: Error handling cast message: Request id not present: snap:StorageRanges, for client: ethrex/v1.0.0-HEAD-a976db3/x86_64-unknown-linux-gnu/rustc-v1.87.0 with capabilities [Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 68 }, Capability { protocol: [101, 116, 104, 0, 0, 0, 0, 0], version: 69 }, Capability { protocol: [115, 110, 97, 112, 0, 0, 0, 0], version: 1 }]
```

