### PR TITLE
chore(l1): load c-kzg trusted setup when initializing the node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,7 @@ dependencies = [
  "ethrex-blockchain",
  "ethrex-common 3.0.0",
  "ethrex-config",
+ "ethrex-crypto",
  "ethrex-dev",
  "ethrex-l2",
  "ethrex-l2-common",

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -13,6 +13,7 @@ ethrex-config.workspace = true
 ethrex-blockchain.workspace = true
 ethrex-rpc.workspace = true
 ethrex-common.workspace = true
+ethrex-crypto.workspace = true
 ethrex-p2p.workspace = true
 ethrex-storage.workspace = true
 ethrex-vm.workspace = true
@@ -70,6 +71,7 @@ c-kzg = [
   "ethrex-common/c-kzg",
   "ethrex-blockchain/c-kzg",
   "ethrex-p2p/c-kzg",
+  "ethrex-crypto/c-kzg",
 ]
 metrics = ["ethrex-blockchain/metrics", "ethrex-l2/metrics"]
 rocksdb = ["ethrex-storage/rocksdb", "ethrex-p2p/rocksdb"]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -403,6 +403,8 @@ pub async fn init_l1(
     display_chain_initialization(&genesis);
 
     raise_fd_limit()?;
+    debug!("Preloading KZG trusted setup");
+    ethrex_crypto::kzg::warm_up_trusted_setup();
 
     let store = init_store(datadir, genesis).await;
 

--- a/crates/common/crypto/kzg.rs
+++ b/crates/common/crypto/kzg.rs
@@ -15,6 +15,14 @@ type Blob = [u8; BYTES_PER_BLOB];
 type Commitment = Bytes48;
 type Proof = Bytes48;
 
+/// Ensures the Ethereum trusted setup is loaded so later KZG operations avoid the first-call cost.
+pub fn warm_up_trusted_setup() {
+    #[cfg(feature = "c-kzg")]
+    {
+        let _ = c_kzg::ethereum_kzg_settings(8);
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum KzgError {
     #[cfg(feature = "c-kzg")]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
- First time point evaluation precompile was called inside LEVM it took a long time to execute the block. This was because of the loading of the trusted setup. By doing it when initializing the node we avoid this.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- Add function to warm up trusted setup and use it in the client initialization

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

