### PR TITLE
chore(l1): remove wrong color codes from log

### DIFF
--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -175,10 +175,10 @@ impl fmt::Display for CurrentStepValue {
             CurrentStepValue::RequestingStorageRanges => write!(f, "Requesting Storage Ranges"),
             CurrentStepValue::DownloadingHeaders => write!(f, "Downloading Headers"),
             CurrentStepValue::InsertingStorageRanges => {
-                write!(f, "Inserting Storage Ranges - \x1b[31mWriting to DB\x1b[0m")
+                write!(f, "Inserting Storage Ranges - Writing to DB")
             }
             CurrentStepValue::InsertingAccountRanges => {
-                write!(f, "Inserting Account Ranges - \x1b[31mWriting to DB\x1b[0m")
+                write!(f, "Inserting Account Ranges - Writing to DB")
             }
             CurrentStepValue::InsertingAccountRangesNoDb => write!(f, "Inserting Account Ranges"),
         }

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -352,13 +352,13 @@ pub async fn periodically_show_peer_stats_during_syncing(
                 "P2P Snap Sync:
 elapsed: {elapsed}
 {peer_number} peers.
-\x1b[93mCurrent step:\x1b[0m {current_step}
+Current step: {current_step}
 Current Header Hash: {current_header_hash:x}
 ---
 headers progress: {headers_download_progress} (total: {headers_to_download}, downloaded: {headers_downloaded}, remaining: {headers_remaining})
 account leaves download: {account_leaves_downloaded}, elapsed: {account_leaves_time}
 account leaves insertion: {account_leaves_inserted_percentage:.2}%, elapsed: {account_leaves_inserted_time}
-storage leaves download: {storage_leaves_downloaded}, elapsed: {storage_leaves_time}, initially accounts with storage {storage_accounts}, healed accounts {storage_accounts_healed} 
+storage leaves download: {storage_leaves_downloaded}, elapsed: {storage_leaves_time}, initially accounts with storage {storage_accounts}, healed accounts {storage_accounts_healed}
 storage leaves insertion: {storage_accounts_inserted}, {storage_leaves_inserted_time}
 healing: global accounts healed {healed_accounts} global storage slots healed {healed_storages}, elapsed: {heal_time}, current throttle {heal_current_throttle}
 bytecodes progress: downloaded: {bytecodes_downloaded}, elapsed: {bytecodes_download_time})"


### PR DESCRIPTION
**Motivation**

Fixes the following:
```
\x1b[93mCurrent step:\x1b[0m Inserting Storage Ranges - \x1b[31mWriting to DB\x1b[0m
Current Header Hash: d85dd555dfb85f28c6c639de3b9fc41577115cd02428c3e89e67942417d6ef55
---
```




