### PR TITLE
docs(l1,l2): document libclang requirement

### DIFF
--- a/docs/getting-started/installation/building_from_source.md
+++ b/docs/getting-started/installation/building_from_source.md
@@ -5,6 +5,7 @@ Build ethrex yourself for maximum flexibility and experimental features.
 ## Prerequisites
 
 - [Rust toolchain](https://www.rust-lang.org/tools/install) (use `rustup` for easiest setup)
+- [libclang](https://clang.llvm.org/docs/index.html) (for RocksDB)
 - [Git](https://git-scm.com/downloads)
 - [solc](https://docs.soliditylang.org/en/v0.8.30/installing-solidity.html) (for L2 development)
 


### PR DESCRIPTION
Due to use of `bindgen`, RocksDB requires `libclang` to compile.
This was previously undocumented.
