### PR TITLE
test(l1): add reorg case with multiple storage trie branches

### DIFF
--- a/tooling/reorgs/src/main.rs
+++ b/tooling/reorgs/src/main.rs
@@ -44,6 +44,7 @@ async fn main() {
     // run_test(&cmd_path, test_one_block_reorg_and_back).await;
     // run_test(&cmd_path, test_reorg_back_to_base_with_common_ancestor).await;
     // run_test(&cmd_path, test_storage_slots_reorg).await;
+    run_test(&cmd_path, test_storage_tree_with_branches).await;
 
     // run_test(&cmd_path, test_many_blocks_reorg).await;
 }
@@ -343,15 +344,18 @@ async fn test_storage_slots_reorg(simulator: Arc<Mutex<Simulator>>) {
         .send_contract_deploy(&signer, contract_deploy_bytecode)
         .await;
 
-    for _ in 0..10 {
-        let extended_base_chain = node0.build_payload(base_chain).await;
-        node0.notify_new_payload(&extended_base_chain).await;
-        node0.update_forkchoice(&extended_base_chain).await;
+    base_chain = node0.extend_chain(base_chain, 10).await;
+    // for _ in 0..10 {
+    //     let extended_base_chain = node0.build_payload(base_chain).await;
+    //     node0.notify_new_payload(&extended_base_chain).await;
+    //     node0.update_forkchoice(&extended_base_chain).await;
 
-        node1.notify_new_payload(&extended_base_chain).await;
-        node1.update_forkchoice(&extended_base_chain).await;
-        base_chain = extended_base_chain;
-    }
+    //     node1.notify_new_payload(&extended_base_chain).await;
+    //     node1.update_forkchoice(&extended_base_chain).await;
+    //     base_chain = extended_base_chain;
+    // }
+
+    node1.update_forkchoice(&base_chain).await;
 
     // Sanity check: storage slots are initially empty
     let initial_value = node0.get_storage_at(contract_address, slot_key0).await;
@@ -418,4 +422,16 @@ async fn test_storage_slots_reorg(simulator: Arc<Mutex<Simulator>>) {
     assert_eq!(value_slot0, U256::zero());
     let value_slot1 = node0.get_storage_at(contract_address, slot_key1).await;
     assert_eq!(value_slot1, slot_value1);
+}
+
+async fn test_storage_tree_with_branches(simulator: Arc<Mutex<Simulator>>) {
+    let mut simulator = simulator.lock().await;
+
+    // These hash to the same 0x2b prefix, causing a branch in the storage trie
+    let slot0A = 15865164872778812924_u64;
+    let slot0B = 11566337052255443646_u64;
+
+    // These hash to the same 0x83 prefix, causing a branch in the storage trie
+    let slot1A = 5800641681667202032_u64;
+    let slot1B = 8343558256908705664_u64;
 }


### PR DESCRIPTION
**Motivation**

Reth had a [recent incident](https://laced-king-de5.notion.site/Incident-Post-Mortem-Reth-Mainnet-State-Root-Mismatch-26732f2c348480dea8b8c2a8753696dc#26732f2c3484809489d0c249a67b1acd) when following the chain on mainnet, where one of the storages wasn't reorged out correctly. We want to have a test for this kind of cases.

**Description**

This PR adds a test case for an account with multiple branches in its storage.