### PR TITLE
fix(l1,l2): rename CLI arg `--metrics` to `--metrics.enabled` for naming consistency

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -88,7 +88,7 @@ pub struct Options {
     )]
     pub metrics_port: String,
     #[arg(
-        long = "metrics",
+        long = "metrics.enabled",
         action = ArgAction::SetTrue,
         help = "Enable metrics collection and exposition",
         help_heading = "Node options"

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -125,7 +125,7 @@ init-l2: ## 🚀 Initializes an L2 Lambda ethrex Client
 	--network ${L2_GENESIS_FILE_PATH} \
 	--http.port ${L2_PORT} \
 	--http.addr ${L2_RPC_ADDRESS} \
-	--metrics \
+	--metrics.enabled \
 	--metrics.port ${L2_PROMETHEUS_METRICS_PORT} \
 	--datadir ${ethrex_L2_DEV_DB} \
 	--l1.bridge-address ${DEFAULT_BRIDGE_ADDRESS} \

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,7 +45,7 @@ Node options:
           [env: ETHREX_METRICS_PORT=]
           [default: 9090]
 
-      --metrics
+      --metrics.enabled
           Enable metrics collection and exposition
 
       --dev
@@ -198,7 +198,7 @@ Node options:
           [env: ETHREX_METRICS_PORT=]
           [default: 9090]
 
-      --metrics
+      --metrics.enabled
           Enable metrics collection and exposition
 
       --dev

--- a/docs/developers/l1/metrics.md
+++ b/docs/developers/l1/metrics.md
@@ -36,7 +36,7 @@ A consensus node must be running for the syncing to work.
 
 To run the execution node on any network with metrics, the next steps should be followed:
 1. Build the `ethrex` binary for the network you want (see node options in [CLI Commands](../../CLI.md#cli-commands)) with the `metrics` feature enabled.
-2. Enable metrics by using the `--metrics` flag when starting the node.
+2. Enable metrics by using the `--metrics.enabled` flag when starting the node.
 3. Set the `--metrics.port` cli arg of the ethrex binary to match the port defined in `metrics/provisioning/prometheus/prometheus_l1_sync_docker.yaml`
 4. Run the docker containers:
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -5,7 +5,7 @@ If a new dashboard is designed, it can be mounted only in that `*overrides` file
 
 To run the node with metrics, the next steps should be followed:
 1. Build the `ethrex` binary with the `metrics` feature enabled.
-2. Enable metrics by using the `--metrics` flag when starting the node.
+2. Enable metrics by using the `--metrics.enabled` flag when starting the node.
 3. Set the `--metrics.port` cli arg of the ethrex binary to match the port defined in `metrics/provisioning/prometheus/prometheus*.yaml`
 4. Run the docker containers, example with the L2:
 

--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -165,7 +165,7 @@ start-lighthouse: ## Start lighthouse for the network given by NETWORK.
 		--http \
 		--http-address 0.0.0.0 \
 		--http-allow-origin "*" \
-		--metrics.enabled \
+		--metrics \
 		--metrics-address 0.0.0.0 \
 		--metrics-port 5054 \
 		--datadir $(DATA_PATH)/${NETWORK}_data/lighthouse_${NODE_NAME}_$(EVM) \

--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -121,7 +121,7 @@ endif
 	@echo "Starting ethrex..."
 	cd $(ETHREX_DIR) && cargo run --release --features "metrics" --bin ethrex -- \
 	--network $(NETWORK) \
-	--metrics \
+	--metrics.enabled \
 	--metrics.port 3701 \
 	import $(RLP_FILE) \
 	--removedb 
@@ -165,7 +165,7 @@ start-lighthouse: ## Start lighthouse for the network given by NETWORK.
 		--http \
 		--http-address 0.0.0.0 \
 		--http-allow-origin "*" \
-		--metrics \
+		--metrics.enabled \
 		--metrics-address 0.0.0.0 \
 		--metrics-port 5054 \
 		--datadir $(DATA_PATH)/${NETWORK}_data/lighthouse_${NODE_NAME}_$(EVM) \
@@ -178,7 +178,7 @@ start-ethrex: ## Start ethrex for the network given by NETWORK.
     		--authrpc.port 8551 \
     		--p2p.port 30303\
     		--discovery.port 30303 \
-    		--metrics \
+    		--metrics.enabled \
     		--metrics.port 3701 \
     		--network $(NETWORK) \
     		--datadir "$(DATA_PATH)/${NETWORK}_data/ethrex/$(EVM)" \
@@ -219,4 +219,4 @@ server-sync:
 
 	sleep 0.2
 
-	tmux new-window -t sync:2 -n ethrex "cd ../../metrics && docker stop metrics-ethereum-metrics-exporter-1 || true && docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l1.overrides.yaml up -d && cd .. && ulimit -n 1000000 && rm -rf ~/.local/share/ethrex && RUST_LOG=info,ethrex_p2p::sync=debug $(if $(DEBUG_ASSERT),RUSTFLAGS='-C debug-assertions=yes') $(if $(HEALING),SKIP_START_SNAP_SYNC=1) cargo run --release --bin ethrex --features rocksdb --  --http.addr 0.0.0.0 --metrics --metrics.port 3701 --network $(SERVER_SYNC_NETWORK) $(if $(MEMORY),--datadir memory) --authrpc.jwtsecret ~/secrets/jwt.hex $(if $(or $(FULL_SYNC),$(HEALING)),--syncmode full)  2>&1 | tee $(LOGS_FILE)"
+	tmux new-window -t sync:2 -n ethrex "cd ../../metrics && docker stop metrics-ethereum-metrics-exporter-1 || true && docker compose -f docker-compose-metrics.yaml -f docker-compose-metrics-l1.overrides.yaml up -d && cd .. && ulimit -n 1000000 && rm -rf ~/.local/share/ethrex && RUST_LOG=info,ethrex_p2p::sync=debug $(if $(DEBUG_ASSERT),RUSTFLAGS='-C debug-assertions=yes') $(if $(HEALING),SKIP_START_SNAP_SYNC=1) cargo run --release --bin ethrex --features rocksdb --  --http.addr 0.0.0.0 --metrics.enabled --metrics.port 3701 --network $(SERVER_SYNC_NETWORK) $(if $(MEMORY),--datadir memory) --authrpc.jwtsecret ~/secrets/jwt.hex $(if $(or $(FULL_SYNC),$(HEALING)),--syncmode full)  2>&1 | tee $(LOGS_FILE)"


### PR DESCRIPTION
Renames the `--metrics` command line argument to `--metrics.enabled` to maintain consistent dot-notation formatting with other metrics-related parameters (`--metrics.addr` and `--metrics.port`).

Closes #4902