### PR TITLE
refactor(l1,l2): remove unused dependency and import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,6 @@ dependencies = [
  "ethrex-sdk",
  "ethrex-storage 4.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 4.0.0",
  "ethrex-vm",
  "eyre",
  "genesis-tool",

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -26,7 +26,6 @@ ethrex-sdk = { workspace = true, optional = true }
 ethrex-storage.workspace = true
 ethrex-storage-rollup = { workspace = true, optional = true }
 ethrex-vm.workspace = true
-ethrex-trie.workspace = true
 tikv-jemallocator = { version = "0.6.0", optional = true, features = [
   "stats",
   "unprefixed_malloc_on_supported_platforms",

--- a/crates/storage/trie_db/rocksdb.rs
+++ b/crates/storage/trie_db/rocksdb.rs
@@ -141,7 +141,7 @@ impl TrieDB for RocksDBTrieDB {
 mod tests {
     use super::*;
     use ethrex_trie::Nibbles;
-    use rocksdb::{ColumnFamilyDescriptor, DBCommon, MultiThreaded, Options};
+    use rocksdb::{ColumnFamilyDescriptor, MultiThreaded, Options};
     use tempfile::TempDir;
 
     #[test]


### PR DESCRIPTION
**Motivation**

Main was broken due to L2 linting job. Also, and unused dependency was introduced in the latest commit.

**Description**

This PR removes the unused import causing the CI error, along with the unused `ethrex-trie` dependency on the `ethrex` package.