### PR TITLE
ci(l1): make so that the CI job EF Tests Check main properly runs on main

### DIFF
--- a/tooling/ef_tests/state/Makefile
+++ b/tooling/ef_tests/state/Makefile
@@ -59,9 +59,7 @@ run-evm-ef-tests: ## 🏃‍♂️ Run EF Tests
 	fi
 
 run-evm-ef-tests-ci: $(VECTORS_DIR) ## 🏃‍♂️ Run EF Tests only with LEVM and without spinner, for CI.
-#	Adding breaking change to test the ci	
-	ls breaking
-#	time cargo test -p ef_tests-state --test all --profile release-with-debug -- --summary
+	time cargo test -p ef_tests-state --test all --profile release-with-debug -- --summary
 
 test-levm: $(VECTORS_DIR)
 	$(MAKE) run-evm-ef-tests flags="--summary"


### PR DESCRIPTION
**Motivation**

In the PR #3591 the` EF Test check main` ci job lost the reference to main, breaking the purpose of the job. This pr aims to fix this issue.

**Description**

- Reads the `with: ref: main` to the job.

