### PR TITLE
fix(l1): remove duplicate span.entered() call in apply_updates

### DIFF
--- a/crates/storage/store_db/rocksdb.rs
+++ b/crates/storage/store_db/rocksdb.rs
@@ -659,7 +659,6 @@ impl StoreEngine for Store {
                 ],
             )?;
 
-            let _span = tracing::trace_span!("Block DB update").entered();
             let mut batch = WriteBatch::default();
 
             let mut updated_trie = false;


### PR DESCRIPTION
**Motivation**

Some of the numbers we get from grafana seem to be weird. This might have been caused by a duplicate span that was created in `apply_updates`. I suspect it was from a git conflict that was solved erroneously.

**Description**

This PR removes a duplicate span `entered()` call.