### PR TITLE
revert(l1): increase timeout on daily hive jobs.

### DIFF
--- a/.github/workflows/common_hive_reports.yaml
+++ b/.github/workflows/common_hive_reports.yaml
@@ -16,10 +16,7 @@ jobs:
   run-hive:
     name: Hive - ${{ matrix.test.name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 1200 # allow up to 20 hours for long-running simulations
-    continue-on-error: true
     strategy:
-      fail-fast: false
       matrix:
         test:
           - {
@@ -130,7 +127,6 @@ jobs:
   hive-report:
     name: Generate and Save report
     needs: run-hive
-    if: ${{ always() }}
     runs-on: ubuntu-latest
     outputs:
       artifact_name: results_${{ inputs.job_type }}.md
@@ -141,7 +137,6 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Download all results
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           path: hive/workspace/logs


### PR DESCRIPTION
Reverts lambdaclass/ethrex#4940

Github runners don't allow to extend the timeout past 6hs. Reverting to avoid confusion.