### PR TITLE
fix(l1): fix big account download stopping prematurely

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -1310,7 +1310,7 @@ impl PeerHandler {
                         if !accounts_done.contains_key(account) {
                             let (_, old_intervals) = account_storage_roots
                                 .accounts_with_storage_root
-                                .get_mut(&account)
+                                .get_mut(account)
                                 .ok_or(PeerHandlerError::UnrecoverableError("Tried to get the old download intervals for an account but did not find them".to_owned()))?;
 
                             if old_intervals.is_empty() {


### PR DESCRIPTION
**Motivation**

There was a bug that was prematurely marking big accounts as done, causing inconsistent behaviour in the downloads of these accounts. This PR aims to fix the bug

**Description**

- When we receive a "should continue" in `verify_range` the task result will include the account as done in the `remaining_start` field. We changed the logic of marking accounts done to check that no intervals remain.


