### PR TITLE
fix(l1): add `engine_getBlobsV2` to capabilities.

### DIFF
--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -14,7 +14,7 @@ pub type ExchangeCapabilitiesRequest = Vec<String>;
 
 /// List of capabilities that the execution layer client supports. Add new capabilities here.
 /// More info: https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities
-pub const CAPABILITIES: [&str; 15] = [
+pub const CAPABILITIES: [&str; 16] = [
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",
@@ -30,6 +30,7 @@ pub const CAPABILITIES: [&str; 15] = [
     "engine_getPayloadBodiesByHashV1",
     "engine_getPayloadBodiesByRangeV1",
     "engine_getBlobsV1",
+    "engine_getBlobsV2",
 ];
 
 impl From<ExchangeCapabilitiesRequest> for RpcRequest {


### PR DESCRIPTION
**Motivation**
Fixing lighthouse error complaining endpoint is not supported

**Description**
- Add endpoint to capabilities

