### PR TITLE
ci(l1): on workflow failure notification, name the job(s) that failed.

### DIFF
--- a/.github/scripts/notify_workflow_failure.sh
+++ b/.github/scripts/notify_workflow_failure.sh
@@ -17,6 +17,7 @@ CONCLUSION=${CONCLUSION:-}
 RUN_HTML_URL=${RUN_HTML_URL:-}
 RUN_ID=${RUN_ID:-}
 HEAD_SHA=${HEAD_SHA:-}
+FAILED_JOBS=${FAILED_JOBS:-Unknown job}
 
 RUN_URL="$RUN_HTML_URL"
 if [[ -z "$RUN_URL" ]]; then
@@ -34,6 +35,7 @@ PAYLOAD=$(jq -n \
   --arg sha "$SHORT_SHA" \
   --arg commit_url "$COMMIT_URL" \
   --arg url "$RUN_URL" \
+  --arg failed_jobs "$FAILED_JOBS" \
   '{
     blocks: [
       {
@@ -49,7 +51,8 @@ PAYLOAD=$(jq -n \
           { type: "mrkdwn", text: "*Workflow*\n\($workflow)" },
           { type: "mrkdwn", text: "*Conclusion*\n\($conclusion)" },
           { type: "mrkdwn", text: "*Commit*\n<\($commit_url)|\($sha)>" },
-          { type: "mrkdwn", text: "*Run*\n<\($url)|Open in GitHub>" }
+          { type: "mrkdwn", text: "*Run*\n<\($url)|Open in GitHub>" },
+          { type: "mrkdwn", text: "*Failed job(s)*\n\($failed_jobs)" }
         ]
       }
     ]

--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -45,6 +45,34 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Collect failed job names
+        id: failed_jobs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const { owner, repo } = context.repo;
+            const failingConclusions = new Set(['failure', 'timed_out', 'action_required']);
+            const failedJobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id: runId,
+                per_page: 100,
+              },
+              response =>
+                response.data.jobs.filter(
+                  job => job.conclusion && failingConclusions.has(job.conclusion)
+                )
+            );
+            const ignoredJobs = new Set(['Integration Test']);
+            const relevantJobs = failedJobs
+              .map(job => job.name)
+              .filter(name => !ignoredJobs.has(name));
+            const names = relevantJobs.length > 0 ? relevantJobs.join('\n- ') : 'Unknown job';
+            core.setOutput('names', relevantJobs.length > 0 ? `- ${names}` : names);
+
       - name: Post failure to Slack
         env:
           REPO: ${{ github.repository }}
@@ -53,5 +81,6 @@ jobs:
           RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          FAILED_JOBS: ${{ steps.failed_jobs.outputs.names }}
         run: |
           bash .github/scripts/notify_workflow_failure.sh "${{ steps.select_webhook.outputs.webhook }}"


### PR DESCRIPTION
**Motivation**
Be able to easily see which job failed in a workflow

**Description**
- Adds the name of failed jobs to the notification.
- Skips notifying the job "Integration test", since it's a special job that just fails if other job fail

