### PR TITLE
fix(levm): remove unneeded clone of transaction log

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -57,9 +57,9 @@ impl LEVM {
             cumulative_gas_used += report.gas_used;
             let receipt = Receipt::new(
                 tx.tx_type(),
-                matches!(report.result.clone(), TxResult::Success),
+                matches!(report.result, TxResult::Success),
                 cumulative_gas_used,
-                report.logs.clone(),
+                report.logs,
             );
 
             receipts.push(receipt);


### PR DESCRIPTION
**Motivation**

Cloning the transaction log can be expensive (blocks may contain thousands of logs) and this clone isn't needed.

**Description**

Removes a clone of the transaction logs and a nearby (but much less impactful) unneeded clone.

