### PR TITLE
fix(l2): update operator fee flag on makefile

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -453,7 +453,7 @@ pub struct BlockProducerOptions {
     )]
     pub operator_fee_vault_address: Option<Address>,
     #[arg(
-        long,
+        long = "block-producer.operator-fee-per-gas",
         value_name = "UINT64",
         env = "ETHREX_BLOCK_PRODUCER_OPERATOR_FEE_PER_GAS",
         requires = "operator_fee_vault_address",

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -135,7 +135,7 @@ init-l2: ## 🚀 Initializes an L2 Lambda ethrex Client
 	--block-producer.coinbase-address 0x0007a881CD95B1484fca47615B64803dad620C8d \
 	--block-producer.base-fee-vault-address 0x000c0d6b7c4516a5b274c51ea331a9410fe69127 \
 	--block-producer.operator-fee-vault-address 0xd5d2a85751b6F158e5b9B8cD509206A865672362 \
-	--block-producer.operator-fee ${ETHREX_BLOCK_PRODUCER_OPERATOR_FEE_PER_GAS} \
+	--block-producer.operator-fee-per-gas ${ETHREX_BLOCK_PRODUCER_OPERATOR_FEE_PER_GAS} \
 	--committer.l1-private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924 \
 	--proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
 	--proof-coordinator.addr ${PROOF_COORDINATOR_ADDRESS}

--- a/docs/l2/fundamentals/transaction_fees.md
+++ b/docs/l2/fundamentals/transaction_fees.md
@@ -34,7 +34,7 @@ All collected operator fees are deposited into a dedicated `operator fee vault` 
 To set the operator fee amount:
 
 ```sh
-ethrex l2 --block-producer.operator-fee <amount-in-wei>
+ethrex l2 --block-producer.operator-fee-per-gas <amount-in-wei>
 ```
 
 To set the operator fee vault address:


### PR DESCRIPTION
**Motivation**

The main change is Rename the cli argument and references from `operator-fee` to `operator-fee-per-gas`.


