### PR TITLE
fix(l2): committer wake up delay

### DIFF
--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -831,7 +831,7 @@ impl GenServer for L1Committer {
                 last_committed_batch_at = self.last_committed_batch_timestamp,
                 will_send_commitment = should_send_commitment,
                 last_committed_batch = self.last_committed_batch,
-                "Committer waked up"
+                "Committer woke up"
             );
 
             #[expect(clippy::collapsible_if)]


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Committer is not always waking up after `committer_wake_up_ms` but `commit_time_ms`

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Change the delay time to wake up again

<!-- Link to issues: Resolves #111, Resolves #222 -->


