### PR TITLE
fix(l1): port 30303 still used after stopping the node 

### DIFF
--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -162,9 +162,10 @@ fn listener(tcp_addr: SocketAddr) -> Result<TcpListener, io::Error> {
         SocketAddr::V4(_) => TcpSocket::new_v4(),
         SocketAddr::V6(_) => TcpSocket::new_v6(),
     }?;
-    tcp_socket.bind(tcp_addr)?;
     tcp_socket.set_reuseport(true).ok();
     tcp_socket.set_reuseaddr(true).ok();
+    tcp_socket.bind(tcp_addr)?;
+
     tcp_socket.listen(50)
 }
 


### PR DESCRIPTION
**Motivation**

Closes https://github.com/lambdaclass/ethrex/issues/4895

