### PR TITLE
chore(l1): more execution metrics

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -508,6 +508,7 @@ impl Blockchain {
                 METRICS_BLOCKS.set_execution_ms(executed.duration_since(since).as_millis() as i64);
                 METRICS_BLOCKS.set_store_ms(stored.duration_since(since).as_millis() as i64);
                 METRICS_BLOCKS.set_merkle_ms(merkleized.duration_since(since).as_millis() as i64);
+                METRICS_BLOCKS.set_transaction_count(transactions_count as i64);
             );
 
             let base_log = format!(

--- a/crates/blockchain/metrics/metrics_blocks.rs
+++ b/crates/blockchain/metrics/metrics_blocks.rs
@@ -15,6 +15,7 @@ pub struct MetricsBlocks {
     block_building_ms: IntGauge,
     block_building_base_fee: IntGauge,
     gas_used: Gauge,
+    transaction_count: IntGauge,
     execution_ms: IntGauge,
     merkle_ms: IntGauge,
     store_ms: IntGauge,
@@ -86,7 +87,16 @@ impl MetricsBlocks {
                 "Keeps track of the execution time spent in block storage in miliseconds",
             )
             .unwrap(),
+            transaction_count: IntGauge::new(
+                "transaction_count",
+                "Keeps track of transaction count in a block",
+            )
+            .unwrap(),
         }
+    }
+
+    pub fn set_transaction_count(&self, transaction_count: i64) {
+        self.transaction_count.set(transaction_count);
     }
 
     pub fn set_execution_ms(&self, execution_ms: i64) {
@@ -163,6 +173,8 @@ impl MetricsBlocks {
         r.register(Box::new(self.execution_ms.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
         r.register(Box::new(self.merkle_ms.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.transaction_count.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
 
         let encoder = TextEncoder::new();


### PR DESCRIPTION
Adds more execution metrics, this is needed to plot in our ethrex_benchmarks scripts 
<img width="2530" height="1162" alt="image" src="https://github.com/user-attachments/assets/56d43306-25cb-4c59-84ff-dd2a0a46a967" />


Closes https://github.com/lambdaclass/ethrex_benchmarks/issues/47

