### PR TITLE
feat(l1,l2): add DB versioning

### DIFF
--- a/crates/storage/error.rs
+++ b/crates/storage/error.rs
@@ -5,6 +5,10 @@ use thiserror::Error;
 // TODO improve errors
 #[derive(Debug, Error)]
 pub enum StoreError {
+    #[error("Unsupported DB version: found {found}, expected {expected}")]
+    UnsupportedDbVersion { found: u64, expected: u64 },
+    #[error("Failed to open file at path: {0}")]
+    OpenFileError(#[from] std::io::Error),
     #[error("DecodeError")]
     DecodeError,
     #[cfg(feature = "rocksdb")]


### PR DESCRIPTION
**Motivation**

We already had some changes that break the DB format. We want to easily detect these cases and tell the user how to handle them.

**Description**

This PR adds a simple versioning scheme with a single numerical version number, stored in a standalone file under `<ethrex datadir>/db.version`.

Closes #5056