### PR TITLE
fix(l1): remove await in now sync call in levm_runner

### DIFF
--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -470,7 +470,6 @@ pub async fn post_state_root(account_updates: &[AccountUpdate], test: &EFTest) -
     let (_initial_state, block_hash, store) = utils::load_initial_state_revm(test).await;
     let ret_account_updates_batch = store
         .apply_account_updates_batch(block_hash, account_updates)
-        .await
         .unwrap()
         .unwrap();
     ret_account_updates_batch.state_trie_hash


### PR DESCRIPTION
**Motivation**

`main` recently failed to compile the LEVM runner of state EF tests.

**Description**

This PR fixes the issue by removing an await call on a method that's now sync.
