### PR TITLE
chore(l1): remove pending logs

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -255,7 +255,6 @@ impl Store {
     }
 
     pub fn add_pending_block(&self, block: Block) -> Result<(), StoreError> {
-        info!("Adding block to pending: {}", block.hash());
         self.engine.add_pending_block(block)
     }
 
@@ -263,7 +262,6 @@ impl Store {
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<Block>, StoreError> {
-        info!("get pending: {}", block_hash);
         self.engine.get_pending_block(block_hash).await
     }
 


### PR DESCRIPTION
**Motivation**

The store has info logs for pending blocks. This is not appropiate level of logging for that info and no other store method has logs.

**Description**

- Removes pending block hash logs

Progress for #4950