### PR TITLE
chore(l2): remove useless debug-purpose logs in proof coordinator

### DIFF
--- a/crates/l2/sequencer/proof_coordinator.rs
+++ b/crates/l2/sequencer/proof_coordinator.rs
@@ -344,7 +344,6 @@ impl ProofCoordinator {
             );
         } else {
             metrics!(
-                tracing::warn!("getting request timestamp for batch {batch_number}");
                 let mut request_timestamps = self.request_timestamp.lock().await;
                 let request_timestamp = request_timestamps.get(&batch_number).ok_or(
                     ProofCoordinatorError::InternalError(
@@ -357,7 +356,6 @@ impl ProofCoordinator {
                     .as_secs().try_into()
                     .map_err(|_| ProofCoordinatorError::InternalError("failed to convert proving time to i64".to_string()))?;
                 METRICS.set_batch_proving_time(batch_number, proving_time)?;
-                tracing::warn!("removed request timestamp for batch {batch_number}");
                 let _ = request_timestamps.remove(&batch_number);
             );
             // If not, store it


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Warning logs raise quick attention

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Logs were left from a debugging session and are useless

<!-- Link to issues: Resolves #111, Resolves #222 -->


