### PR TITLE
fix(l1): fix exponential overflow in fake exponential

### DIFF
--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -25,7 +25,6 @@ use rkyv::{Archive, Deserialize as RDeserialize, Serialize as RSerialize};
 use serde::{Deserialize, Serialize};
 
 use std::cmp::{Ordering, max};
-use std::u64;
 
 pub type BlockNumber = u64;
 pub type BlockHash = H256;


### PR DESCRIPTION
**Motivation**

Fake Exponential defined in `block.rs` can overflow. As such, we need to use the U256 data type to avoid overflows

**Description**

- Added intermediate conversions to U256 to avoid overflows
- Added test for the overflow

