### PR TITLE
chore(l2): update stable RISC0 patches

### DIFF
--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.lock
@@ -1945,12 +1945,14 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256%2Fv0.13.4-risczero.0#f913b0aa4646e85d4a2095742ce86abf25bb1354"
+source = "git+https://github.com/risc0/RustCrypto-elliptic-curves?tag=k256%2Fv0.13.4-risczero.1#7d4a8d6477e258ce4169ee4669cf92aee0582c39"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "risc0-bigint2",
  "sha2",
  "signature",
 ]

--- a/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/src/risc0/Cargo.toml
@@ -33,7 +33,7 @@ ethrex-l2-common = { path = "../../../../../common", default-features = false }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.4-risczero.1" }
 p256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "p256/v0.13.2-risczero.1" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.0" }


### PR DESCRIPTION
**Motivation**

RISC0's `p256` patch [is not unstable anymore](https://dev.risczero.com/api/zkvm/precompiles#patched-crates) and `k256` patch has a new version.

**Description**

- Enable `p256` patch in RISC0's guest.
- Update `k256` patch version.
- Remove `blst` commented patch because we don't use it anywhere in ethrex.
