### PR TITLE
fix(l1,l2): inaccurate block execution metrics

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -579,8 +579,8 @@ impl Blockchain {
                 METRICS_BLOCKS.set_latest_block_gas_limit(gas_limit as f64);
                 METRICS_BLOCKS.set_latest_gigagas(throughput);
                 METRICS_BLOCKS.set_execution_ms(executed.duration_since(since).as_millis() as i64);
-                METRICS_BLOCKS.set_store_ms(stored.duration_since(since).as_millis() as i64);
-                METRICS_BLOCKS.set_merkle_ms(merkleized.duration_since(since).as_millis() as i64);
+                METRICS_BLOCKS.set_merkle_ms(merkleized.duration_since(executed).as_millis() as i64);
+                METRICS_BLOCKS.set_store_ms(stored.duration_since(merkleized).as_millis() as i64);
                 METRICS_BLOCKS.set_transaction_count(transactions_count as i64);
             );
 


### PR DESCRIPTION
**Motivation**

Disaggregated block execution metrics are off because they count accumulate rather than each process' times. 
Given we treat them as parts of a single thing, e.g. later making a pie chart of them, they should be counted as difference from the end of the previous step, like we do in logs.

**Description**

Fix the subtractions.
