### PR TITLE
ci(l1): fix daily hive job

### DIFF
--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -188,7 +188,7 @@ jobs:
           fi
 
       - name: Generate the hive report
-        run: cargo run -p hive_report > results.md
+        run: cargo run --manifest-path tooling/Cargo.toml -p hive_report > results.md
 
       - name: Upload daily result
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
**Description**
- Since tooling has been moved to another workspace, no we need to reference it when calling a crate from tooling
