### PR TITLE
fix(l1,l2): make l2 integration tests and lint required

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -5,8 +5,6 @@ on:
   merge_group:
   pull_request:
     branches: ["**"]
-    paths-ignore:
-      - "crates/l2/**" # Behind a feature flag not used in this workflow
 
 permissions:
   contents: read
@@ -17,10 +15,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+      runs-on: ubuntu-latest
+      outputs:
+        run_tests: ${{ steps.finish.outputs.run_tests }}
+      steps:
+        - uses: actions/checkout@v4
+        - uses: dorny/paths-filter@v3
+          id: filter
+          with:
+            filters: |
+              run_tests:
+                - '!crates/l2/**'
+        - name: finish
+          id: finish
+          run: |
+            if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+                echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            else
+                echo "run_tests=${{ steps.filter.outputs.run_tests }}" >> "$GITHUB_OUTPUT"
+            fi
+        - name: Print result
+          run: echo "run_tests=${{ steps.finish.outputs.run_tests }}"
+
   lint:
     # "Lint" is a required check, don't change the name
     name: Lint
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -61,6 +84,8 @@ jobs:
   test:
     # "Test" is a required check, don't change the name
     name: Test
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -84,6 +109,8 @@ jobs:
   docker_build:
     name: Build Docker
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -105,8 +132,8 @@ jobs:
   run-assertoor:
     name: Assertoor - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [docker_build]
-    if: ${{ github.event_name != 'merge_group' }}
+    needs: [detect-changes, docker_build]
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     strategy:
       fail-fast: true
       matrix:
@@ -147,8 +174,8 @@ jobs:
   run-hive:
     name: Hive - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [docker_build]
-    if: ${{ github.event_name != 'merge_group' }}
+    needs: [detect-changes, docker_build]
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix:
@@ -254,9 +281,9 @@ jobs:
     # "Integration Test" is a required check, don't change the name
     name: Integration Test
     runs-on: ubuntu-latest
-    needs: [run-assertoor, run-hive]
+    needs: [detect-changes, run-assertoor, run-hive]
     # Make sure this job runs even if the previous jobs failed or were skipped
-    if: ${{ always() && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
     steps:
       - name: Check if any job failed
         run: |
@@ -273,7 +300,8 @@ jobs:
   reorg-tests:
     name: Reorg Tests
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' }}
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -4,13 +4,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
-    paths:
-      - "crates/l2/**"
-      - "fixtures/**"
-      - "crates/blockchain/dev/**"
-      - "crates/vm/levm/**"
-      - ".github/workflows/pr-main_l2.yaml"
-      - "cmd/ethrex/l2/**"
 
 permissions:
   contents: read
@@ -24,10 +17,40 @@ env:
   DOCKER_ETHREX_WORKDIR: /usr/local/bin
 
 jobs:
-  lint:
-    # "Lint" is a required check, don't change the name
-    name: Lint
+  detect-changes:
     runs-on: ubuntu-latest
+    outputs:
+      run_tests: ${{ steps.finish.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run_tests:
+              - "crates/l2/**"
+              - "fixtures/**"
+              - "crates/blockchain/dev/**"
+              - "crates/vm/levm/**"
+              - ".github/workflows/pr-main_l2.yaml"
+              - "cmd/ethrex/l2/**"
+      - name: finish
+        id: finish
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "run_tests=${{ steps.filter.outputs.run_tests }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Print result
+        run: echo "run_tests=${{ steps.finish.outputs.run_tests }}"
+
+  lint:
+    # "Lint L2" is a required check, don't change the name
+    name: Lint L2
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -69,6 +92,8 @@ jobs:
   build-docker:
     name: Build docker image
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -94,6 +119,8 @@ jobs:
   build-docker-l2:
     name: Build docker image L2
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -119,7 +146,8 @@ jobs:
   integration-test:
     name: Integration Test - ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [build-docker, build-docker-l2]
+    needs: [detect-changes, build-docker, build-docker-l2]
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     strategy:
       matrix:
         include:
@@ -309,7 +337,8 @@ jobs:
   integration-test-tdx:
     name: Integration Test - TDX
     runs-on: ubuntu-latest
-    needs: [build-docker, build-docker-l2]
+    needs: [detect-changes, build-docker, build-docker-l2]
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -416,7 +445,8 @@ jobs:
   state-diff-test:
     name: State Reconstruction Tests
     runs-on: ubuntu-latest
-    needs: [build-docker, build-docker-l2]
+    needs: [detect-changes, build-docker, build-docker-l2]
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -477,6 +507,8 @@ jobs:
   integration-test-l2-dev:
     name: Integration Test - L2 Dev
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -531,18 +563,19 @@ jobs:
 
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:
-    # "Integration Test" is a required check, don't change the name
-    name: Integration Test
+    # "Integration Test L2" is a required check, don't change the name
+    name: Integration Test L2
     runs-on: ubuntu-latest
     needs:
       [
+        detect-changes,
         integration-test,
         state-diff-test,
         integration-test-tdx,
         integration-test-l2-dev,
       ]
     # Make sure this job runs even if the previous jobs failed or were skipped
-    if: ${{ always() && needs.integration-test.result != 'skipped' && needs.state-diff-test.result != 'skipped' && needs.integration-test-tdx.result != 'skipped' && needs.integration-test-l2-dev.result != 'skipped' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() && needs.integration-test.result != 'skipped' && needs.state-diff-test.result != 'skipped' && needs.integration-test-tdx.result != 'skipped' && needs.integration-test-l2-dev.result != 'skipped' }}
     steps:
       - name: Check if any job failed
         run: |


### PR DESCRIPTION
**Motivation**
The L2 CI is not running on some PRs it should.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
The problem is that the required checks `Integration Test` and `Lint` have the same name for both L1 and L2. So if one of them passes, then the other is not needed to merge. This can be a problem in the case that the L1 CI finishes before the L2 one starts, in that case the L2 CI will not run.

The solution is the following:
- Add `Integration Test L2` and `Lint L2` to the branch protection rules
- Rename the corresponding jobs on the L2 workflow.

With only those changes, we will always require the L2 workflows to run in order to merge, since we want to be able only run the L1 CI in PRs that don't touch the L2, we need a way to skip it.

Note: The current way of not running a workflow doesn't work, since skipping a complete workflow with `paths:` makes the jobs abscent, what we need is for the jobs to be marked as skipped.

To do this, [dorny/paths-filter@v3](https://github.com/dorny/paths-filter) action is used, which performs the same action as the `paths:` option, but as a job itself.
Then with the result of this job we can add ifs to the rest of the jobs to mark if they should be run.

Examples with a fork of ethrex with the branch protection already active (For Integration Test L2)
- [PR with changes only in L1](https://github.com/gianbelinche/ethrex/pull/4): It ran L1 checks and skipped L2 ones.
- [PR with changes only in L2](https://github.com/gianbelinche/ethrex/pull/3): It ran L2 checks and skipped L1 ones.
- [PR with both L1 and L2 changes](https://github.com/gianbelinche/ethrex/pull/5): It ran both L1 and L2 checks.

You can also check that when the PRs were merged to main, all checks ran even though the PRs skipped the checks.
https://github.com/gianbelinche/ethrex/commits/main/

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->



