### PR TITLE
chore(l1, l2): fix warning in ethrex-crypto when no feature is included

### DIFF
--- a/crates/common/crypto/kzg.rs
+++ b/crates/common/crypto/kzg.rs
@@ -1,5 +1,3 @@
-use std::iter::repeat_n;
-
 // TODO: Currently, we cannot include the types crate independently of common because the crates are not yet split.
 // After issue #4596 ("Split types crate from common") is resolved, update this to import the types crate directly,
 // so that crypto/kzg.rs does not depend on common for type definitions.
@@ -52,6 +50,7 @@ impl From<kzg_rs::KzgError> for KzgError {
 
 /// Verifies a KZG proof for blob committed data, using a Fiat-Shamir protocol
 /// as defined by EIP-7594.
+#[allow(unused_variables)]
 pub fn verify_cell_kzg_proof_batch(
     blobs: &[Blob],
     commitments: &[Commitment],
@@ -72,9 +71,11 @@ pub fn verify_cell_kzg_proof_batch(
             c_kzg_settings,
             &commitments
                 .iter()
-                .flat_map(|commitment| repeat_n((*commitment).into(), CELLS_PER_EXT_BLOB))
+                .flat_map(|commitment| {
+                    std::iter::repeat_n((*commitment).into(), CELLS_PER_EXT_BLOB)
+                })
                 .collect::<Vec<_>>(),
-            &repeat_n(0..CELLS_PER_EXT_BLOB as u64, blobs.len())
+            &std::iter::repeat_n(0..CELLS_PER_EXT_BLOB as u64, blobs.len())
                 .flatten()
                 .collect::<Vec<_>>(),
             &cells,


### PR DESCRIPTION
**Motivation**

There were compilation warnings while compiling ethrex-crypto with no features.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

