### PR TITLE
fix(l2): save last committed batch as current checkpoint

### DIFF
--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -748,7 +748,6 @@ impl L1Committer {
             batch.number
         ));
         // We need to create a one-time checkpoint copy because if witness generation fails the checkpoint would be modified
-        info!(batch = batch.number, "WITNESS OTC");
         let (_, one_time_checkpoint_blockchain) = self
             .create_checkpoint(
                 &self.current_checkpoint_store,


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We are saving the latest `Store` as the "current" one. This means the next time a batch is constructed, it might use a latter checkpoint than the needed. This can occur if the batch is sealed with less blocks than the available (e.g., if there's no more available space).

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Save a checkpoint from the batch execution instead

<!-- Link to issues: Resolves #111, Resolves #222 -->


