### PR TITLE
fix(2): revert sealed batch if witness generation fails

### DIFF
--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -410,7 +410,10 @@ impl L1Committer {
             batch.number,
         );
 
-        self.generate_and_store_batch_prover_input(&batch).await?;
+        if let Err(e) = self.generate_and_store_batch_prover_input(&batch).await {
+            let _ = self.rollup_store.revert_to_batch(batch.number - 1).await;
+            return Err(e);
+        }
 
         // We need to update the current checkpoint after generating the witness
         // with it, and before sending the commitment.


### PR DESCRIPTION
Fix inconsistent state where a batch was sealed and stored but witness generation failed after #5152; in crates/l2/sequencer/l1_committer.rs wrap generate_and_store_batch_prover_input with error handling and call rollup_store.revert_to_batch(batch.number - 1) on failure to rollback the just-sealed batch, keeping DB and internal checkpoint state consistent; on success behavior is unchanged; consider future improvements like sealing only after witness generation or using a single transactional boundary for batch + witness persistence.

#5154 