### PR TITLE
perf(l1,l2): avoid redundant hashing with Code::from_hashed_bytecode and update call sites

### DIFF
--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -29,12 +29,20 @@ pub struct Code {
 }
 
 impl Code {
-    // TODO: also add `from_hashed_bytecode` to optimize the download pipeline,
-    // where hash is already known and checked.
     pub fn from_bytecode(code: Bytes) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
         Self {
             hash: keccak(code.as_ref()),
+            bytecode: code,
+            jump_targets,
+        }
+    }
+
+    pub fn from_hashed_bytecode(hash: H256, code: Bytes) -> Self {
+        debug_assert_eq!(hash, keccak(code.as_ref()));
+        let jump_targets = Self::compute_jump_targets(&code);
+        Self {
+            hash,
             bytecode: code,
             jump_targets,
         }
@@ -125,13 +133,15 @@ impl Default for Code {
 
 impl From<GenesisAccount> for Account {
     fn from(genesis: GenesisAccount) -> Self {
+        let hash = code_hash(&genesis.code);
+        let code = Code::from_hashed_bytecode(hash, genesis.code);
         Self {
             info: AccountInfo {
-                code_hash: code_hash(&genesis.code),
+                code_hash: hash,
                 balance: genesis.balance,
                 nonce: genesis.nonce,
             },
-            code: Code::from_bytecode(genesis.code),
+            code,
             storage: genesis
                 .storage
                 .iter()

--- a/crates/l2/prover/src/guest_program/src/execution.rs
+++ b/crates/l2/prover/src/guest_program/src/execution.rs
@@ -93,6 +93,9 @@ pub enum StatelessExecutionError {
     InvalidParentBlockHeader,
     #[error("Failed to calculate privileged transaction hash")]
     InvalidPrivilegedTransaction,
+    #[cfg(feature = "l2")]
+    #[error("Invalid code hash: expected {0:?}, got {1:?}")]
+    InvalidCodeHash(H256, H256),
     #[error("Internal error: {0}")]
     Internal(String),
 }

--- a/crates/l2/prover/src/guest_program/src/execution.rs
+++ b/crates/l2/prover/src/guest_program/src/execution.rs
@@ -205,7 +205,7 @@ pub fn stateless_validation_l2(
         let mut guest_program_state = GuestProgramState {
             codes_hashed: codes_hashed
                 .into_iter()
-                .map(|(h, c)| (h, Code::from_bytecode(Bytes::from_owner(c))))
+                .map(|(h, c)| (h, Code::from_hashed_bytecode(h, Bytes::from_owner(c))))
                 .collect(),
             parent_block_header,
             first_block_number: initial_db.first_block_number,

--- a/crates/l2/prover/src/guest_program/src/execution.rs
+++ b/crates/l2/prover/src/guest_program/src/execution.rs
@@ -11,6 +11,7 @@ use ethrex_common::types::fee_config::FeeConfig;
 use ethrex_common::types::{
     block_execution_witness::GuestProgramState, block_execution_witness::GuestProgramStateError,
 };
+use ethrex_common::utils::keccak;
 use ethrex_common::{Address, U256};
 use ethrex_common::{
     H256,
@@ -202,11 +203,20 @@ pub fn stateless_validation_l2(
         use bytes::Bytes;
         use ethrex_common::types::Code;
 
+        let codes_hashed_verified: BTreeMap<H256, Code> = codes_hashed
+            .into_iter()
+            .map(|(h, c)| {
+                let bytes = Bytes::from_owner(c);
+                let got = keccak(bytes.as_ref());
+                if got != h {
+                    return Err(StatelessExecutionError::InvalidCodeHash(h, got));
+                }
+                Ok((h, Code::from_hashed_bytecode(h, bytes)))
+            })
+            .collect::<Result<_, _>>()?;
+
         let mut guest_program_state = GuestProgramState {
-            codes_hashed: codes_hashed
-                .into_iter()
-                .map(|(h, c)| (h, Code::from_hashed_bytecode(h, Bytes::from_owner(c))))
-                .collect(),
+            codes_hashed: codes_hashed_verified,
             parent_block_header,
             first_block_number: initial_db.first_block_number,
             chain_config: initial_db.chain_config,

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -952,7 +952,8 @@ impl Syncer {
                             .write_account_code_batch(
                                 code_hashes_to_download
                                     .drain(..)
-                                    .zip(bytecodes.into_iter().map(Code::from_bytecode))
+                                    .zip(bytecodes.into_iter())
+                                    .map(|(h, b)| (h, Code::from_hashed_bytecode(h, b)))
                                     .collect(),
                             )
                             .await?;
@@ -973,7 +974,8 @@ impl Syncer {
                 .write_account_code_batch(
                     code_hashes_to_download
                         .drain(..)
-                        .zip(bytecodes.into_iter().map(Code::from_bytecode))
+                        .zip(bytecodes.into_iter())
+                        .map(|(h, b)| (h, Code::from_hashed_bytecode(h, b)))
                         .collect(),
                 )
                 .await?;

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -948,15 +948,15 @@ impl Syncer {
                             .map_err(SyncError::PeerHandler)?
                             .ok_or(SyncError::BytecodesNotFound)?;
 
-                        store
-                            .write_account_code_batch(
-                                code_hashes_to_download
-                                    .drain(..)
-                                    .zip(bytecodes.into_iter())
-                                    .map(|(h, b)| (h, Code::from_hashed_bytecode(h, b)))
-                                    .collect(),
-                            )
-                            .await?;
+                        // Download side validates bytecode hashes; here we rely on that
+                        // and construct Code using the known hash without rehashing.
+                        let account_codes: Vec<(H256, Code)> = code_hashes_to_download
+                            .drain(..)
+                            .zip(bytecodes.into_iter())
+                            .map(|(h, b)| (h, Code::from_hashed_bytecode(h, b)))
+                            .collect();
+
+                        store.write_account_code_batch(account_codes).await?;
                     }
                 }
             }
@@ -970,15 +970,15 @@ impl Syncer {
                 .await
                 .map_err(SyncError::PeerHandler)?
                 .ok_or(SyncError::BytecodesNotFound)?;
-            store
-                .write_account_code_batch(
-                    code_hashes_to_download
-                        .drain(..)
-                        .zip(bytecodes.into_iter())
-                        .map(|(h, b)| (h, Code::from_hashed_bytecode(h, b)))
-                        .collect(),
-                )
-                .await?;
+            // Download side validates bytecode hashes; here we rely on that
+            // and construct Code using the known hash without rehashing.
+            let account_codes: Vec<(H256, Code)> = code_hashes_to_download
+                .drain(..)
+                .zip(bytecodes.into_iter())
+                .map(|(h, b)| (h, Code::from_hashed_bytecode(h, b)))
+                .collect();
+
+            store.write_account_code_batch(account_codes).await?;
         }
 
         std::fs::remove_dir_all(code_hashes_dir)

--- a/crates/vm/levm/runner/src/input.rs
+++ b/crates/vm/levm/runner/src/input.rs
@@ -35,13 +35,14 @@ pub struct InputAccount {
 
 impl From<InputAccount> for Account {
     fn from(account: InputAccount) -> Self {
+        let hash = code_hash(&account.code);
         Account {
             info: AccountInfo {
-                code_hash: code_hash(&account.code),
+                code_hash: hash,
                 balance: account.balance,
                 nonce: 0,
             },
-            code: Code::from_bytecode(account.code),
+            code: Code::from_hashed_bytecode(hash, account.code),
             storage: account
                 .storage
                 .into_iter()

--- a/tooling/archive_sync/src/main.rs
+++ b/tooling/archive_sync/src/main.rs
@@ -147,7 +147,10 @@ async fn process_dump(dump: Dump, store: Store, current_root: H256) -> eyre::Res
         // Add code to DB if it is not empty
         if dump_account.code_hash != *EMPTY_KECCACK_HASH {
             store
-                .add_account_code(Code::from_bytecode(dump_account.code.clone()))
+                .add_account_code(Code::from_hashed_bytecode(
+                    dump_account.code_hash,
+                    dump_account.code.clone(),
+                ))
                 .await?;
         }
         // Process storage trie if it is not empty

--- a/tooling/archive_sync/src/main.rs
+++ b/tooling/archive_sync/src/main.rs
@@ -146,6 +146,15 @@ async fn process_dump(dump: Dump, store: Store, current_root: H256) -> eyre::Res
         )?;
         // Add code to DB if it is not empty
         if dump_account.code_hash != *EMPTY_KECCACK_HASH {
+            let got = keccak(dump_account.code.as_ref());
+            if got != dump_account.code_hash {
+                return Err(eyre::ErrReport::msg(
+                    format!(
+                        "Bytecode hash mismatch during archive sync: expected {:#x}, got {:#x}",
+                        dump_account.code_hash, got
+                    ),
+                ));
+            }
             store
                 .add_account_code(Code::from_hashed_bytecode(
                     dump_account.code_hash,

--- a/tooling/ef_tests/blockchain/types.rs
+++ b/tooling/ef_tests/blockchain/types.rs
@@ -561,13 +561,14 @@ impl From<Transaction> for EIP2930Transaction {
 
 impl From<Account> for ethrexAccount {
     fn from(val: Account) -> Self {
+        let hash = code_hash(&val.code);
         ethrexAccount {
             info: AccountInfo {
-                code_hash: code_hash(&val.code),
+                code_hash: hash,
                 balance: val.balance,
                 nonce: val.nonce.as_u64(),
             },
-            code: Code::from_bytecode(val.code),
+            code: Code::from_hashed_bytecode(hash, val.code),
             storage: val
                 .storage
                 .into_iter()

--- a/tooling/ef_tests/state/runner/revm_db.rs
+++ b/tooling/ef_tests/state/runner/revm_db.rs
@@ -225,7 +225,10 @@ impl RevmState {
                 if account.is_contract_changed()
                     && let Some(code) = new_acc_info.code
                 {
-                    account_update.code = Some(Code::from_bytecode(code.original_bytes().0));
+                    account_update.code = Some(Code::from_hashed_bytecode(
+                        code_hash,
+                        code.original_bytes().0,
+                    ));
                 }
             }
             // Update account storage in DB


### PR DESCRIPTION
**Motivation**

Unnecessary hashing work on genesis load path; noted by the file’s own TODO to add from_hashed_bytecode.

**Description**

Adds a new constructor Code::from_hashed_bytecode(hash, code) to construct Code without recomputing the keccak hash when the hash is already known and trusted. Includes a debug_assert! to validate the provided hash in debug builds.

Refactors From<GenesisAccount> for Account to avoid double hashing.

Updates call sites to use the new constructor where the hash is available:
- P2P sync bytecode download batching
- Archive sync loading
- L2 prover guest program state construction
- Test utilities (VM runner input, EF blockchain types, REVM DB runner)

This reduces unnecessary hashing on hot paths (e.g., bytecode download and witness preparation) without changing behavior.

