### PR TITLE
ci(l1,l2): fix apt trigger.

### DIFF
--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -79,6 +79,6 @@ jobs:
       contents: write
       actions: write
     secrets:
-      APT_SIGNING_KEY: ${{ secrets.APT_SIGNING_KEY }}
-      APT_SIGNING_PASSPHRASE: ${{ secrets.APT_SIGNING_PASSPHRASE }}
-      APT_SSH_BOT_COMMIT_KEY: ${{ secrets.APT_SSH_BOT_COMMIT_KEY }}
+      APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+      APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
+      APT_SSH_COMMIT_KEY: ${{ secrets.APT_SSH_COMMIT_KEY }}


### PR DESCRIPTION
**Motivation**

This PR fixes a CI issue that broke the `tag_latest` workflow due to a syntax error that triggered the following error:

> The workflow is requesting 'actions: write, contents: write', but is only allowed 'actions: none, contents: read'.


Now the `ethrex-apt` workflow get's triggered properly