### PR TITLE
fix(l1): have block execution stop when block's gas limit is surpassed by executing a transaction

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -54,16 +54,17 @@ impl LEVM {
         for (tx, tx_sender) in block.body.get_transactions_with_sender().map_err(|error| {
             EvmError::Transaction(format!("Couldn't recover addresses with error: {error}"))
         })? {
-            let report = Self::execute_tx(tx, tx_sender, &block.header, db, vm_type)?;
-
-            cumulative_gas_used += report.gas_used;
-            if cumulative_gas_used > block.header.gas_limit {
+            if cumulative_gas_used + tx.gas_limit() > block.header.gas_limit {
                 return Err(EvmError::Transaction(format!(
-                    "Gas allowance exceeded. Block gas limit {} was surpassed by executing transaction with gas used {}",
-                    block.header.gas_limit, report.gas_used
+                    "Gas allowance exceeded. Block gas limit {} can be surpassed by executing transaction with gas limit {}",
+                    block.header.gas_limit,
+                    tx.gas_limit()
                 )));
             }
 
+            let report = Self::execute_tx(tx, tx_sender, &block.header, db, vm_type)?;
+
+            cumulative_gas_used += report.gas_used;
             let receipt = Receipt::new(
                 tx.tx_type(),
                 matches!(report.result, TxResult::Success),
@@ -104,16 +105,18 @@ impl LEVM {
         for (tx, tx_sender) in block.body.get_transactions_with_sender().map_err(|error| {
             EvmError::Transaction(format!("Couldn't recover addresses with error: {error}"))
         })? {
+            if cumulative_gas_used + tx.gas_limit() > block.header.gas_limit {
+                return Err(EvmError::Transaction(format!(
+                    "Gas allowance exceeded. Block gas limit {} can be surpassed by executing transaction with gas limit {}",
+                    block.header.gas_limit,
+                    tx.gas_limit()
+                )));
+            }
+
             let report = Self::execute_tx(tx, tx_sender, &block.header, db, vm_type)?;
             LEVM::send_state_transitions_tx(&merkleizer, db, queue_length)?;
 
             cumulative_gas_used += report.gas_used;
-            if cumulative_gas_used > block.header.gas_limit {
-                return Err(EvmError::Transaction(format!(
-                    "Gas allowance exceeded. Block gas limit {} was surpassed by executing transaction with gas used {}",
-                    block.header.gas_limit, report.gas_used
-                )));
-            }
             let receipt = Receipt::new(
                 tx.tx_type(),
                 matches!(report.result, TxResult::Success),


### PR DESCRIPTION
**Motivation**

The ef test for Osaka that's run in the Hive integration testing site named `osaka/eip7825_transaction_gas_limit_cap/test_tx_gas_limit.py::test_tx_gas_larger_than_block_gas_limit[fork_Osaka-blockchain_test_engine-exceed_block_gas_limit_False]` is failing due to an error message mismatch. See [here](https://hive.ethpandaops.io/#/test/fusaka/1762265312-8631b0f0f5ea8f900a071365137dd155?testnumber=364). 
Besides we don't have any logic implemented when processing a block to stop computing transactions once the block's gas limit was surpassed.

**Description**

This pr adds a conditional to check if the block's gas limit can be potentially surpassed, and in that case stop computing any other transactions. So if tx.gas_limit > gas_available the block's execution must stop with an exception, as the spec says [here](https://github.com/ethereum/execution-specs/blob/69364e2133e1d20f679455fc92680366cb72db37/src/ethereum/forks/osaka/fork.py#L460).

To test it I run:

```
make build-image
cd hive
./hive --sim ethereum/eels/consume-engine --client ethrex --results-root results --client-file=../fixtures/hive/clients.yaml --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz --sim.buildarg branch=forks/osaka --sim.loglevel=3 --sim.limit=".*test_tx_gas_larger_than_block_gas_limit.*"
```

This tx.gas_limit > gas_available check was already implemented for block building, as we can see [here](https://github.com/lambdaclass/ethrex/blob/11fe1c11af394aa8321b26e86babcde387d761d0/crates/blockchain/payload.rs#L531-L537) in [ethrex/crates/blockchain/payload.rs](https://github.com/lambdaclass/ethrex/blob/main/crates/blockchain/payload.rs) The main difference is that instead of throwing an exception when the condition is false we keep searching for a transaction with a smaller gas_limit so it can be included in the block that's being built.
