### PR TITLE
refactor(l1, l2): refactored chain config

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -19,12 +19,12 @@ use ethrex_common::types::fee_config::FeeConfig;
 use ethrex_common::types::requests::{EncodedRequests, Requests, compute_requests_hash};
 use ethrex_common::types::{
     AccountState, AccountUpdate, Block, BlockHash, BlockHeader, BlockNumber, ChainConfig, Code,
-    EIP4844Transaction, Receipt, Transaction, WrappedEIP4844Transaction, compute_receipts_root,
-    validate_block_header, validate_cancun_header_fields, validate_prague_header_fields,
-    validate_pre_cancun_header_fields,
+    EIP4844Transaction, Fork, Receipt, Transaction, WrappedEIP4844Transaction,
+    compute_receipts_root, validate_block_header, validate_cancun_header_fields,
+    validate_prague_header_fields, validate_pre_cancun_header_fields,
 };
 use ethrex_common::types::{ELASTICITY_MULTIPLIER, P2PTransaction};
-use ethrex_common::types::{Fork, MempoolTransaction};
+use ethrex_common::types::{Fork::*, MempoolTransaction};
 use ethrex_common::{Address, H256, TrieLogger};
 use ethrex_metrics::metrics;
 use ethrex_rlp::decode::RLPDecode;
@@ -1263,7 +1263,7 @@ impl Blockchain {
         // NOTE: We could add a tx size limit here, but it's not in the actual spec
 
         // Check init code size
-        if config.is_shanghai_activated(header.timestamp)
+        if config.is_fork_activated(Shanghai, header.timestamp)
             && tx.is_contract_creation()
             && tx.data().len() > MAX_INITCODE_SIZE as usize
         {
@@ -1274,7 +1274,8 @@ impl Blockchain {
             return Err(MempoolError::TxMaxDataSizeError);
         }
 
-        if config.is_osaka_activated(header.timestamp) && tx.gas_limit() > POST_OSAKA_GAS_LIMIT_CAP
+        if config.is_fork_activated(Osaka, header.timestamp)
+            && tx.gas_limit() > POST_OSAKA_GAS_LIMIT_CAP
         {
             // https://eips.ethereum.org/EIPS/eip-7825
             return Err(MempoolError::TxMaxGasLimitExceededError(
@@ -1430,7 +1431,7 @@ pub fn validate_requests_hash(
     chain_config: &ChainConfig,
     requests: &[Requests],
 ) -> Result<(), ChainError> {
-    if !chain_config.is_prague_activated(header.timestamp) {
+    if !chain_config.is_fork_activated(Prague, header.timestamp) {
         return Ok(());
     }
 
@@ -1517,7 +1518,7 @@ pub fn validate_block(
     validate_block_header(&block.header, parent_header, elasticity_multiplier)
         .map_err(InvalidBlockError::from)?;
 
-    if chain_config.is_osaka_activated(block.header.timestamp) {
+    if chain_config.is_fork_activated(Osaka, block.header.timestamp) {
         let block_rlp_size = block.encode_to_vec().len();
         if block_rlp_size > MAX_RLP_BLOCK_SIZE as usize {
             return Err(error::ChainError::InvalidBlock(
@@ -1528,14 +1529,14 @@ pub fn validate_block(
             ));
         }
     }
-    if chain_config.is_prague_activated(block.header.timestamp) {
+    if chain_config.is_fork_activated(Prague, block.header.timestamp) {
         validate_prague_header_fields(&block.header, parent_header, chain_config)
             .map_err(InvalidBlockError::from)?;
         verify_blob_gas_usage(block, chain_config)?;
-        if chain_config.is_osaka_activated(block.header.timestamp) {
+        if chain_config.is_fork_activated(Osaka, block.header.timestamp) {
             verify_transaction_max_gas_limit(block)?;
         }
-    } else if chain_config.is_cancun_activated(block.header.timestamp) {
+    } else if chain_config.is_fork_activated(Cancun, block.header.timestamp) {
         validate_cancun_header_fields(&block.header, parent_header, chain_config)
             .map_err(InvalidBlockError::from)?;
         verify_blob_gas_usage(block, chain_config)?;

--- a/crates/blockchain/constants.rs
+++ b/crates/blockchain/constants.rs
@@ -18,9 +18,6 @@ pub const TX_ACCESS_LIST_ADDRESS_GAS: u64 = 2400;
 // Gas cost for each storage key specified on access lists
 pub const TX_ACCESS_LIST_STORAGE_KEY_GAS: u64 = 1900;
 
-// Gas cost for each non zero byte on transaction data
-pub const TX_DATA_NON_ZERO_GAS: u64 = 68;
-
 // === EIP-170 constants ===
 
 // Max bytecode size
@@ -37,7 +34,7 @@ pub const MAX_TRANSACTION_DATA_SIZE: u32 = 4 * 32 * 1024; // 128 Kb
 // === EIP-2028 constants ===
 
 // Gas cost for each non zero byte on transaction data
-pub const TX_DATA_NON_ZERO_GAS_EIP2028: u64 = 16;
+pub const TX_DATA_NON_ZERO_GAS: u64 = 16;
 
 // === EIP-4844 constants ===
 

--- a/crates/common/config/networks.rs
+++ b/crates/common/config/networks.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
 };
 
-use ethrex_common::types::{ChainConfig, Genesis, GenesisError};
+use ethrex_common::types::{ChainConfig, FORKS, Fork::Prague, Genesis, GenesisError};
 use serde::{Deserialize, Serialize};
 
 //TODO: Look for a better place to move these files
@@ -117,14 +117,19 @@ impl Network {
             }
             Network::LocalDevnet => Ok(serde_json::from_str(LOCAL_DEVNET_GENESIS_CONTENTS)?),
             Network::LocalDevnetL2 => Ok(serde_json::from_str(LOCAL_DEVNETL2_GENESIS_CONTENTS)?),
-            Network::L2Chain(chain_id) => Ok(Genesis {
-                config: ChainConfig {
-                    chain_id: *chain_id,
-                    prague_time: Some(0),
+            Network::L2Chain(chain_id) => {
+                let mut fork_activation_timestamps: [Option<u64>; FORKS.len()] =
+                    [None; FORKS.len()];
+                fork_activation_timestamps[Prague] = Some(0);
+                Ok(Genesis {
+                    config: ChainConfig {
+                        chain_id: *chain_id,
+                        fork_activation_timestamps,
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            }),
+                })
+            }
             Network::GenesisPath(s) => Genesis::try_from(s.as_path()),
         }
     }

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -948,13 +948,13 @@ mod test {
             base_fee_per_gas: Some(30),
             ..Default::default()
         };
+        let fork = Fork::Osaka;
         let schedule = ForkBlobSchedule {
+            fork,
             target: 9,
             max: 14,
             base_fee_update_fraction: 8832827,
         };
-        let fork = Fork::Osaka;
-
         let res = calc_excess_blob_gas(&parent, schedule, fork);
         assert_eq!(res, 5617366)
     }
@@ -967,7 +967,9 @@ mod test {
             base_fee_per_gas: Some(50),
             ..Default::default()
         };
+        let fork = Fork::Osaka;
         let schedule = ForkBlobSchedule {
+            fork,
             target: 21,
             max: 32,
             base_fee_update_fraction: 20609697,
@@ -985,12 +987,14 @@ mod test {
             base_fee_per_gas: Some(0x11),
             ..Default::default()
         };
+        let fork = Fork::Osaka;
+
         let schedule = ForkBlobSchedule {
+            fork,
             target: 9,
             max: 14,
             base_fee_update_fraction: 0x86c73b,
         };
-        let fork = Fork::Osaka;
 
         let res = calc_excess_blob_gas(&parent, schedule, fork);
         assert_eq!(res, 3538944)

--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -114,8 +114,6 @@ pub async fn fill_transactions(
     let safe_bytes_per_blob: u64 = SAFE_BYTES_PER_BLOB.try_into()?;
     let mut privileged_tx_count = 0;
 
-    let chain_config = store.get_chain_config();
-
     debug!("Fetching transactions from mempool");
     // Fetch mempool transactions
     let latest_block_number = store.get_latest_block_number().await?;
@@ -166,16 +164,6 @@ pub async fn fill_transactions(
 
         // TODO: maybe fetch hash too when filtering mempool so we don't have to compute it here (we can do this in the same refactor as adding timestamp)
         let tx_hash = head_tx.tx.hash();
-
-        // Check whether the tx is replay-protected
-        if head_tx.tx.protected() && !chain_config.is_eip155_activated(context.block_number()) {
-            // Ignore replay protected tx & all txs from the sender
-            // Pull transaction from the mempool
-            debug!("Ignoring replay-protected transaction: {}", tx_hash);
-            txs.pop();
-            blockchain.remove_transaction_from_pool(&tx_hash)?;
-            continue;
-        }
 
         let maybe_sender_acc_info = store
             .get_account_info(latest_block_number, head_tx.tx.sender())

--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -1,7 +1,9 @@
 use ethrex_common::{
     H256,
     serde_utils::{self},
-    types::{Blob, CELLS_PER_EXT_BLOB, Proof, blobs_bundle::kzg_commitment_to_versioned_hash},
+    types::{
+        Blob, CELLS_PER_EXT_BLOB, Fork::*, Proof, blobs_bundle::kzg_commitment_to_versioned_hash,
+    },
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -120,7 +122,7 @@ impl RpcHandler for BlobsV2Request {
             && !context
                 .storage
                 .get_chain_config()
-                .is_osaka_activated(current_block_header.timestamp)
+                .is_fork_activated(Osaka, current_block_header.timestamp)
         {
             // validation requested in https://github.com/ethereum/execution-apis/blob/a1d95fb555cd91efb3e0d6555e4ab556d9f5dd06/src/engine/osaka.md?plain=1#L130
             return Err(RpcErr::UnsuportedFork(

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -3,7 +3,7 @@ use ethrex_blockchain::{
     fork_choice::apply_fork_choice,
     payload::{BuildPayloadArgs, create_payload},
 };
-use ethrex_common::types::{BlockHeader, ELASTICITY_MULTIPLIER};
+use ethrex_common::types::{BlockHeader, ELASTICITY_MULTIPLIER, Fork::*};
 use ethrex_p2p::sync::SyncMode;
 use serde_json::Value;
 use tracing::{info, warn};
@@ -38,7 +38,7 @@ impl RpcHandler for ForkChoiceUpdatedV1 {
             handle_forkchoice(&self.fork_choice_state, context.clone(), 1).await?;
         if let (Some(head_block), Some(attributes)) = (head_block_opt, &self.payload_attributes) {
             let chain_config = context.storage.get_chain_config();
-            if chain_config.is_cancun_activated(attributes.timestamp) {
+            if chain_config.is_fork_activated(Cancun, attributes.timestamp) {
                 return Err(RpcErr::UnsuportedFork(
                     "forkChoiceV1 used to build Cancun payload".to_string(),
                 ));
@@ -71,11 +71,11 @@ impl RpcHandler for ForkChoiceUpdatedV2 {
             handle_forkchoice(&self.fork_choice_state, context.clone(), 2).await?;
         if let (Some(head_block), Some(attributes)) = (head_block_opt, &self.payload_attributes) {
             let chain_config = context.storage.get_chain_config();
-            if chain_config.is_cancun_activated(attributes.timestamp) {
+            if chain_config.is_fork_activated(Cancun, attributes.timestamp) {
                 return Err(RpcErr::UnsuportedFork(
                     "forkChoiceV2 used to build Cancun payload".to_string(),
                 ));
-            } else if chain_config.is_shanghai_activated(attributes.timestamp) {
+            } else if chain_config.is_fork_activated(Shanghai, attributes.timestamp) {
                 validate_attributes_v2(attributes, &head_block)?;
             } else {
                 // Behave as a v1
@@ -352,7 +352,7 @@ fn validate_attributes_v3(
             "Attribute parent_beacon_block_root is null".to_string(),
         ));
     }
-    if !chain_config.is_cancun_activated(attributes.timestamp) {
+    if !chain_config.is_fork_activated(Cancun, attributes.timestamp) {
         return Err(RpcErr::UnsuportedFork(
             "forkChoiceV3 used to build pre-Cancun payload".to_string(),
         ));

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -2,7 +2,7 @@ use ethrex_blockchain::error::ChainError;
 use ethrex_blockchain::payload::PayloadBuildResult;
 use ethrex_common::types::payload::PayloadBundle;
 use ethrex_common::types::requests::{EncodedRequests, compute_requests_hash};
-use ethrex_common::types::{Block, BlockBody, BlockHash, BlockNumber, Fork};
+use ethrex_common::types::{Block, BlockBody, BlockHash, BlockNumber, Fork, Fork::*};
 use ethrex_common::{H256, U256};
 use ethrex_p2p::sync::SyncMode;
 use ethrex_rlp::error::RLPDecodeError;
@@ -62,7 +62,7 @@ impl RpcHandler for NewPayloadV2Request {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         let chain_config = &context.storage.get_chain_config();
-        if chain_config.is_shanghai_activated(self.payload.timestamp) {
+        if chain_config.is_fork_activated(Shanghai, self.payload.timestamp) {
             validate_execution_payload_v2(&self.payload)?;
         } else {
             // Behave as a v1
@@ -206,7 +206,7 @@ impl RpcHandler for NewPayloadV4Request {
 
         let chain_config = context.storage.get_chain_config();
 
-        if !chain_config.is_prague_activated(block.header.timestamp) {
+        if !chain_config.is_fork_activated(Prague, block.header.timestamp) {
             return Err(RpcErr::UnsuportedFork(format!(
                 "{:?}",
                 chain_config.get_fork(block.header.timestamp)
@@ -334,13 +334,13 @@ impl RpcHandler for GetPayloadV4Request {
         let payload_bundle = get_payload(self.payload_id, &context).await?;
         let chain_config = &context.storage.get_chain_config();
 
-        if !chain_config.is_prague_activated(payload_bundle.block.header.timestamp) {
+        if !chain_config.is_fork_activated(Prague, payload_bundle.block.header.timestamp) {
             return Err(RpcErr::UnsuportedFork(format!(
                 "{:?}",
                 chain_config.get_fork(payload_bundle.block.header.timestamp)
             )));
         }
-        if chain_config.is_osaka_activated(payload_bundle.block.header.timestamp) {
+        if chain_config.is_fork_activated(Osaka, payload_bundle.block.header.timestamp) {
             return Err(RpcErr::UnsuportedFork(format!("{:?}", Fork::Osaka)));
         }
 
@@ -386,7 +386,7 @@ impl RpcHandler for GetPayloadV5Request {
         let payload_bundle = get_payload(self.payload_id, &context).await?;
         let chain_config = &context.storage.get_chain_config();
 
-        if !chain_config.is_osaka_activated(payload_bundle.block.header.timestamp) {
+        if !chain_config.is_fork_activated(Osaka, payload_bundle.block.header.timestamp) {
             return Err(RpcErr::UnsuportedFork(format!(
                 "{:?}",
                 chain_config.get_fork(payload_bundle.block.header.timestamp)
@@ -541,7 +541,7 @@ fn validate_execution_payload_v3(payload: &ExecutionPayload) -> Result<(), RpcEr
 
 fn validate_payload_v1_v2(block: &Block, context: &RpcApiContext) -> Result<(), RpcErr> {
     let chain_config = &context.storage.get_chain_config();
-    if chain_config.is_cancun_activated(block.header.timestamp) {
+    if chain_config.is_fork_activated(Cancun, block.header.timestamp) {
         return Err(RpcErr::UnsuportedFork(
             "Cancun payload received".to_string(),
         ));

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -610,7 +610,7 @@ mod tests {
     use crate::utils::test_utils::default_context_with_storage;
     use ethrex_common::{
         H160,
-        types::{ChainConfig, Genesis},
+        types::{ChainConfig, FORKS, Fork::*, Genesis, PRE_MERGE_FORKS},
     };
     use ethrex_storage::{EngineType, Store};
     use sha3::{Digest, Keccak256};
@@ -735,22 +735,17 @@ mod tests {
     }
 
     fn example_chain_config() -> ChainConfig {
+        let mut fork_activation_timestamps: [Option<u64>; FORKS.len()] = [None; FORKS.len()];
+        fork_activation_timestamps[Paris] = Some(0);
+        fork_activation_timestamps[Shanghai] = Some(0);
+        fork_activation_timestamps[Cancun] = Some(0);
+        fork_activation_timestamps[Prague] = Some(1718232101);
+
+        let fork_activation_blocks: [Option<u64>; PRE_MERGE_FORKS] = [Some(0); PRE_MERGE_FORKS];
         ChainConfig {
             chain_id: 3151908_u64,
-            homestead_block: Some(0),
-            eip150_block: Some(0),
-            eip155_block: Some(0),
-            eip158_block: Some(0),
-            byzantium_block: Some(0),
-            constantinople_block: Some(0),
-            petersburg_block: Some(0),
-            istanbul_block: Some(0),
-            berlin_block: Some(0),
-            london_block: Some(0),
-            merge_netsplit_block: Some(0),
-            shanghai_time: Some(0),
-            cancun_time: Some(0),
-            prague_time: Some(1718232101),
+            fork_activation_blocks,
+            fork_activation_timestamps,
             terminal_total_difficulty: Some(0),
             terminal_total_difficulty_passed: true,
             deposit_contract_address: H160::from_str("0x00000000219ab540356cbb839cbe05303d7705fa")

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1462,7 +1462,7 @@ mod tests {
     use ethrex_common::{
         Bloom, H160,
         constants::EMPTY_KECCACK_HASH,
-        types::{Transaction, TxType},
+        types::{FORKS, Fork::*, PRE_MERGE_FORKS, Transaction, TxType},
     };
     use ethrex_rlp::decode::RLPDecode;
     use std::{fs, str::FromStr};
@@ -1816,22 +1816,18 @@ mod tests {
     }
 
     fn example_chain_config() -> ChainConfig {
+        let mut fork_activation_timestamps: [Option<u64>; FORKS.len()] = [None; FORKS.len()];
+        fork_activation_timestamps[Paris] = Some(0);
+        fork_activation_timestamps[Shanghai] = Some(0);
+        fork_activation_timestamps[Cancun] = Some(0);
+        fork_activation_timestamps[Prague] = Some(1718232101);
+
+        let fork_activation_blocks: [Option<u64>; PRE_MERGE_FORKS] = [Some(0); PRE_MERGE_FORKS];
+
         ChainConfig {
             chain_id: 3151908_u64,
-            homestead_block: Some(0),
-            eip150_block: Some(0),
-            eip155_block: Some(0),
-            eip158_block: Some(0),
-            byzantium_block: Some(0),
-            constantinople_block: Some(0),
-            petersburg_block: Some(0),
-            istanbul_block: Some(0),
-            berlin_block: Some(0),
-            london_block: Some(0),
-            merge_netsplit_block: Some(0),
-            shanghai_time: Some(0),
-            cancun_time: Some(0),
-            prague_time: Some(1718232101),
+            fork_activation_blocks,
+            fork_activation_timestamps,
             terminal_total_difficulty: Some(58750000000000000000000),
             terminal_total_difficulty_passed: true,
             deposit_contract_address: H160::from_str("0x4242424242424242424242424242424242424242")

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -84,6 +84,7 @@ impl EVMConfig {
         let base_fee_update_fraction: u64 = Self::get_blob_base_fee_update_fraction_value(fork);
 
         ForkBlobSchedule {
+            fork,
             target,
             max: max_blobs_per_block,
             base_fee_update_fraction,


### PR DESCRIPTION
**Motivation**

Improve the maintainability of our code with regards to future forks.

**Description**

The current way we handle activation timestamps and blob schedules is to have a struct field per fork. This creates maintainability issues down the line, since it requires a separate function to check if the fork is activated, a new match arm for its blobschedule, etc. This PR moves the timestamps and blob schedules into arrays, such that all that's required in the future is to modify an array containing the post-merge forks to add a new one.

Closes #issue_number

