### PR TITLE
perf(l2): avoid redundant String allocations in BlocksTable::render

### DIFF
--- a/crates/l2/monitor/widget/blocks.rs
+++ b/crates/l2/monitor/widget/blocks.rs
@@ -148,12 +148,12 @@ impl StatefulWidget for &mut BlocksTable {
             .map(|(number, n_txs, hash, coinbase, gas, blob_bas, size)| {
                 Row::new(vec![
                     Span::styled(number, Style::default()),
-                    Span::styled(n_txs.to_string(), Style::default()),
+                    Span::styled(n_txs, Style::default()),
                     Span::styled(hash, Style::default()),
                     Span::styled(coinbase, Style::default()),
-                    Span::styled(gas.to_string(), Style::default()),
-                    Span::styled(blob_bas.to_string(), Style::default()),
-                    Span::styled(size.to_string(), Style::default()),
+                    Span::styled(gas, Style::default()),
+                    Span::styled(blob_bas, Style::default()),
+                    Span::styled(size, Style::default()),
                 ])
             });
         let latest_blocks_table = Table::new(rows, constraints)


### PR DESCRIPTION
**Motivation**

In blocks.rs::render(), there are unnecessary allocations due to .to_string()on existing String.

**Description**

Replaced .to_string() calls on existing String values with borrowed references when building Spans in 
BlocksTable::render() (crates/l2/monitor/widget/blocks.rs).
This avoids unnecessary allocations and copies at render time. ratatui’s Span::styled takes Into<Cow<'_, str>>, so &String/&str can be used directly. Aligned with existing usage in mempool.rs.

