### PR TITLE
fix(l1): reset `ctr` variable to 0 once committed

### DIFF
--- a/crates/storage/store_db/rocksdb.rs
+++ b/crates/storage/store_db/rocksdb.rs
@@ -625,6 +625,7 @@ impl Store {
                         .last_computed_flatkeyvalue
                         .lock()
                         .map_err(|_| StoreError::LockError)? = path.as_ref().to_vec();
+                    ctr = 0;
                 }
 
                 let mut iter_inner = self
@@ -648,6 +649,7 @@ impl Store {
                             .last_computed_flatkeyvalue
                             .lock()
                             .map_err(|_| StoreError::LockError)? = key.as_ref().to_vec();
+                        ctr = 0;
                     }
                     if let Ok(value) = control_rx.try_recv() {
                         match value {


### PR DESCRIPTION
**Motivation**

There seems to be a logic error in the flat-key-value generator on the store. A counter wasn't being correctly reset once it reached a threshold, effectively making us commit on each item inserted.

**Description**

This PR resets the counter on each commit. This should make batching work correctly from now on.
