### PR TITLE
fix(l2): use dummy peer handler

### DIFF
--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -17,7 +17,7 @@ use ethrex_p2p::{
     discv4::peer_table::PeerTable,
     network::P2PContext,
     peer_handler::PeerHandler,
-    rlpx::{initiator::RLPxInitiator, l2::l2_connection::P2PBasedContext},
+    rlpx::l2::l2_connection::P2PBasedContext,
     sync_manager::SyncManager,
     types::{Node, NodeRecord},
 };
@@ -233,8 +233,8 @@ pub async fn init_l2(
     .await
     .expect("P2P context could not be created");
 
-    let initiator = RLPxInitiator::spawn(p2p_context.clone()).await;
-    let peer_handler = PeerHandler::new(PeerTable::spawn(opts.node_opts.target_peers), initiator);
+    // We don't need the peer_handler in L2.
+    let peer_handler = PeerHandler::dummy().await;
 
     let cancel_token = tokio_util::sync::CancellationToken::new();
 

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -154,9 +154,9 @@ impl PeerHandler {
         }
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(any(test, feature = "test-utils", feature = "l2"))]
     /// Creates a dummy PeerHandler for tests where interacting with peers is not needed
-    /// This should only be used in tests as it won't be able to interact with the node's connected peers
+    /// This should only be used in tests or L2 as it won't be able to interact with the node's connected peers
     pub async fn dummy() -> PeerHandler {
         let peer_table = PeerTable::spawn(TARGET_PEERS);
         PeerHandler::new(peer_table.clone(), RLPxInitiator::dummy(peer_table).await)

--- a/crates/networking/p2p/rlpx/initiator.rs
+++ b/crates/networking/p2p/rlpx/initiator.rs
@@ -79,9 +79,9 @@ impl RLPxInitiator {
         }
     }
 
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(any(test, feature = "test-utils", feature = "l2"))]
     /// Creates a dummy GenServer for tests
-    /// This should only be used in tests
+    /// This should only be used in tests or L2
     pub async fn dummy(peer_table: PeerTable) -> GenServerHandle<RLPxInitiator> {
         info!("Starting RLPx Initiator");
         let state = RLPxInitiator::new(P2PContext::dummy(peer_table).await);


### PR DESCRIPTION
**Motivation**

In #5004 , the `PeerHandler` was modified to receive the `Initiator` GenServer handle. As a result, our L2 initializer was updated to spawn the `Initiator` GenServer,  which led to the following log being repeatedly printed in our L2 node:

```
2025-11-06T14:57:09.120191Z  INFO ethrex_p2p::discv4::peer_table: Resetting list of tried peers.
```

**Description**

- Since we don't have P2P in L2, this PR updates the L2 initializer to use the `PeerHandler::dummy()` method instead.
- Even though this works for now, we should review our `init_rpc_api`, as we should be able to start the `RPC API` without using a `PeerHandler` at all. #5222 was created to review this.



Closes None
