### PR TITLE
fix(l2): peer table duplication

### DIFF
--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -234,7 +234,7 @@ pub async fn init_l2(
     .expect("P2P context could not be created");
 
     let initiator = RLPxInitiator::spawn(p2p_context.clone()).await;
-    let peer_handler = PeerHandler::new(PeerTable::spawn(opts.node_opts.target_peers), initiator);
+    let peer_handler = PeerHandler::new(peer_table, initiator);
 
     let cancel_token = tokio_util::sync::CancellationToken::new();
 

--- a/crates/networking/p2p/rlpx/initiator.rs
+++ b/crates/networking/p2p/rlpx/initiator.rs
@@ -85,7 +85,7 @@ impl RLPxInitiator {
     pub async fn dummy(peer_table: PeerTable) -> GenServerHandle<RLPxInitiator> {
         info!("Starting RLPx Initiator");
         let state = RLPxInitiator::new(P2PContext::dummy(peer_table).await);
-        RLPxInitiator::start_on_thread(state)
+        RLPxInitiator::start(state)
     }
 }
 


### PR DESCRIPTION
**Motivation**

PR #5004 led to changes in `init_l2()` that weren't properly updated, so now when initializing L2 there are 2 Peer Tables.

**Description**

This pr uses the Peer Table created in the first place to initialize the Peer Handler instead of creating a new one.
It also updates the gen server initialization for the gen server dummy.


