### PR TITLE
chore(levm): avoid duplicate BackupHook in L2 stateless_execute

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -507,7 +507,9 @@ impl<'a> VM<'a> {
     /// Executes without making changes to the cache.
     pub fn stateless_execute(&mut self) -> Result<ExecutionReport, VMError> {
         // Add backup hook to restore state after execution.
-        self.add_hook(BackupHook::default());
+        if matches!(self.vm_type, VMType::L1) {
+            self.add_hook(BackupHook::default());
+        }
         let report = self.execute()?;
         // Restore cache to the state before execution.
         self.db.undo_last_transaction()?;


### PR DESCRIPTION
**Motivation**

Redundant BackupHook in L2 when using stateless_execute.

**Description**

This change prevents adding a second BackupHook during stateless_execute when running in L2 mode. L2 already installs BackupHook via its default hook set, so adding another caused redundant finalize_execution work and a second identical tx_backup write. Restricting the injection to VMType::L1 preserves stateless behavior for L1 while removing unnecessary duplication for L2, with no functional change to execution semantics.