### PR TITLE
feat(l1): log warning if no CL messages are received in a while

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -308,7 +308,7 @@ pub async fn start_api(
         }
     });
 
-    let authrpc_handler = async move |ctx, auth, body| {
+    let authrpc_handler = move |ctx, auth, body| async move {
         let _ = timer_sender.send(());
         handle_authrpc_request(ctx, auth, body).await
     };


### PR DESCRIPTION
**Motivation**

Making it clearer when the client isn't working properly

**Description**

This PR adds an extra thread which keeps track of whether a message from the consensus layer hasn't been received in the past 30 seconds. This is done by having the auth RPC handler communicate with it when a new message is received to reset the countdown. If no messages have been received after 30 seconds, a message is printed to warn the user, along with some hints as to possible reasons why Ethrex isn't detecting the consensus client.

Closes [#5234](https://github.com/lambdaclass/ethrex/issues/5234)

