### PR TITLE
feat(l1,l2): name rayon threads for easier debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,6 +3306,7 @@ dependencies = [
  "lazy_static",
  "local-ip-address",
  "rand 0.8.5",
+ "rayon",
  "reqwest 0.12.24",
  "secp256k1",
  "serde",

--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -43,6 +43,7 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 anyhow = "1.0.86"
 rand = "0.8.5"
+rayon.workspace = true
 local-ip-address = "0.6"
 tokio-util.workspace = true
 lazy_static.workspace = true

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -49,6 +49,11 @@ async fn server_shutdown(
 async fn main() -> eyre::Result<()> {
     let CLI { opts, command } = CLI::parse();
 
+    rayon::ThreadPoolBuilder::default()
+        .thread_name(|i| format!("rayon-worker-{i}"))
+        .build_global()
+        .expect("failed to build rayon threadpool");
+
     if let Some(subcommand) = command {
         return subcommand.run(&opts).await;
     }


### PR DESCRIPTION
**Motivation**

Rayon currently inherits the name of the thread that calls it first, which creates
confusion when, for example, one tries to see which threads incur the most contention.

**Description**

Initialize the global thread pool on init to ensure the Rayon workers each have a
unique name.
