### PR TITLE
chore(l1,l2): ignore L1 and L2 dev mode database directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,5 @@ hive/
 ethereum-package/
 tooling/ef_tests/blockchain/vectors
 tooling/ef_tests/state/vectors
+dev_ethrex_l1/
+dev_ethrex_l2/

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ GEMINI.md
 
 # Documentation Graphs
 !docs/internal/l1/healing/*.svg
+
+# Default database directories for Ethrex in Dev mode
+dev_ethrex_l1/
+dev_ethrex_l2/


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- When running L1 and L2 in dev mode these directories are created and we weren't ignoring them.


