### PR TITLE
ci(l1,l2): run release workflow on each push to main

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -8,7 +8,6 @@ on:
     # On pushes to main, this silently builds and pushes docker images tagged as 'main'
     branches:
       - main
-      - release-workflow-smoke
 
 permissions:
   contents: write


### PR DESCRIPTION
**Motivation**

We recently had some problems in our release workflow that our CI didn't catch.

**Description**

This PR changes the release workflow to run on each push to main, generating release artifacts, but without making a release:

- docker images are tagged with `main` instead of a version number
- GH release isn't generated

A try run was done here: https://github.com/lambdaclass/ethrex/actions/runs/19274089089 (it fails due to the aforementioned problems)
