### PR TITLE
fix(l2): handle better when producing an empty batch

### DIFF
--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -659,7 +659,7 @@ impl L1Committer {
             acc_blocks.push((last_added_block_number, potential_batch_block.hash()));
         } // end loop
 
-        if blocks.is_empty() {
+        if acc_blocks.is_empty() {
             debug!("No new blocks were available to build batch {batch_number}, skipping it");
             return Ok(None);
         }


### PR DESCRIPTION
**Motivation**

The L2 was failing when trying to commit the first batch that was empty.
Inside `produce_batch_from_block` when doing the metrics we do:
```rust
let first_block_of_batch = last_added_block_number + 1;
// Rest of the code ...
let batch_size = (last_added_block_number - first_block_of_batch).try_into()?; // batch_size is an `i64`
```
This could end up in `u64::max` and failing the conversion because if there are no blocks in the batch we never do `last_added_block_number += 1;` inside the loop.

**Description**

* Handle the empty batch before doing the metrics
* Change `produce_batch_from_block` to return an `Option<T>`

