### PR TITLE
chore(l2): skip L2 Dev workflow in the merge queue

### DIFF
--- a/.github/workflows/pr-main_l1_l2_dev.yaml
+++ b/.github/workflows/pr-main_l1_l2_dev.yaml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   integration-test-l1-l2-dev:
+    if: ${{ github.event_name != 'merge_group' }}
     name: Integration Test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Motivation**

This workflow is currently flaky, and it could take up to 5 hours to fail because of a timeout.

**Description**

Skip running this workflow in the queue until we fix the flakiness.
