### PR TITLE
chore(l1): speedup import bench

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -751,7 +751,7 @@ pub async fn import_blocks_bench(
             // Because this wants to compare against running a real node in terms of reported performance
             // It takes less than 500ms, so this is good enough, but we should report the performance
             // without taking into account that wait.
-            tokio::time::sleep(Duration::from_millis(500)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
         // Make head canonical and label all special blocks correctly.


### PR DESCRIPTION
**Motivation**

The import bench added in #5215 had a 500 ms sleep to wait for the the commiting of the last layer of the trie. The speed of that step has been improved in #5266. We should lower the sleep to speedup testing.

**Description**

- Lowers ImportBench sleep to 100 ms

