### PR TITLE
fix(l1): sleep between FCU and getPayload calls in dev-mode block producer

### DIFF
--- a/crates/blockchain/dev/block_producer.rs
+++ b/crates/blockchain/dev/block_producer.rs
@@ -16,6 +16,8 @@ pub async fn start_block_producer(
     let engine_client = EngineClient::new(&execution_client_auth_url, jwt_secret);
 
     let mut ticker = tokio::time::interval(Duration::from_millis(block_production_interval_ms));
+
+    // Sleep until the first tick to avoid timestamp collision with the genesis block.
     ticker.tick().await;
 
     let mut head_block_hash: H256 = head_block_hash;


### PR DESCRIPTION
**Motivation**

Our `--dev` block production had a bug where we waited an interval before sending an FCU and called getPayload immediately after, causing inclusion latency to be 1.5x the interval.

**Description**

This PR moves the sleep between the FCU and getPayload calls, fixing the issue. It also switches to `tokio::time::interval` for more precision.
