### PR TITLE
feat(l1,l2): make tuple encoders single-pass to avoid double-encoding

### DIFF
--- a/crates/common/rlp/encode.rs
+++ b/crates/common/rlp/encode.rs
@@ -222,31 +222,31 @@ pub fn encode_length(total_len: usize, buf: &mut dyn BufMut) {
 
 impl<S: RLPEncode, T: RLPEncode> RLPEncode for (S, T) {
     fn encode(&self, buf: &mut dyn BufMut) {
-        let total_len = self.0.length() + self.1.length();
-        encode_length(total_len, buf);
-        self.0.encode(buf);
-        self.1.encode(buf);
+        super::structs::Encoder::new(buf)
+            .encode_field(&self.0)
+            .encode_field(&self.1)
+            .finish();
     }
 }
 
 impl<S: RLPEncode, T: RLPEncode, U: RLPEncode> RLPEncode for (S, T, U) {
     fn encode(&self, buf: &mut dyn BufMut) {
-        let total_len = self.0.length() + self.1.length() + self.2.length();
-        encode_length(total_len, buf);
-        self.0.encode(buf);
-        self.1.encode(buf);
-        self.2.encode(buf);
+        super::structs::Encoder::new(buf)
+            .encode_field(&self.0)
+            .encode_field(&self.1)
+            .encode_field(&self.2)
+            .finish();
     }
 }
 
 impl<S: RLPEncode, T: RLPEncode, U: RLPEncode, V: RLPEncode> RLPEncode for (S, T, U, V) {
     fn encode(&self, buf: &mut dyn BufMut) {
-        let total_len = self.0.length() + self.1.length() + self.2.length() + self.3.length();
-        encode_length(total_len, buf);
-        self.0.encode(buf);
-        self.1.encode(buf);
-        self.2.encode(buf);
-        self.3.encode(buf);
+        super::structs::Encoder::new(buf)
+            .encode_field(&self.0)
+            .encode_field(&self.1)
+            .encode_field(&self.2)
+            .encode_field(&self.3)
+            .finish();
     }
 }
 
@@ -254,14 +254,13 @@ impl<S: RLPEncode, T: RLPEncode, U: RLPEncode, V: RLPEncode, W: RLPEncode> RLPEn
     for (S, T, U, V, W)
 {
     fn encode(&self, buf: &mut dyn BufMut) {
-        let total_len =
-            self.0.length() + self.1.length() + self.2.length() + self.3.length() + self.4.length();
-        encode_length(total_len, buf);
-        self.0.encode(buf);
-        self.1.encode(buf);
-        self.2.encode(buf);
-        self.3.encode(buf);
-        self.4.encode(buf);
+        super::structs::Encoder::new(buf)
+            .encode_field(&self.0)
+            .encode_field(&self.1)
+            .encode_field(&self.2)
+            .encode_field(&self.3)
+            .encode_field(&self.4)
+            .finish();
     }
 }
 


### PR DESCRIPTION
This change replaces the tuple RLP encoders in crates/common/rlp/encode.rs to use structs::Encoder instead of summing element lengths via .length() and then re-encoding each element, which previously caused every tuple element to be encoded into a temporary Vec just to determine its size and then encoded again into the output buffer. The new approach pre-encodes all tuple elements into a single temporary buffer and writes the list prefix and payload once, matching the pattern already used by Vec::encode and structs::Encoder elsewhere in the codebase. This removes avoidable allocations and CPU overhead while preserving identical RLP output and API behavior.