### PR TITLE
fix(l1): fixed error message for gas limit

### DIFF
--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -515,6 +515,8 @@ pub fn calculate_base_fee_per_gas(
 pub enum InvalidBlockHeaderError {
     #[error("Gas used is greater than gas limit")]
     GasUsedGreaterThanGasLimit,
+    #[error("Gas limit changed more than allowed from the parent")]
+    GasLimitTooFarFromParent,
     #[error("Base fee per gas is incorrect")]
     BaseFeePerGasIncorrect,
     #[error("Timestamp is not greater than parent timestamp")]
@@ -582,7 +584,7 @@ pub fn validate_block_header(
     ) {
         base_fee
     } else {
-        return Err(InvalidBlockHeaderError::BaseFeePerGasIncorrect);
+        return Err(InvalidBlockHeaderError::GasLimitTooFarFromParent);
     };
 
     if expected_base_fee_per_gas != header.base_fee_per_gas.unwrap_or(INITIAL_BASE_FEE) {


### PR DESCRIPTION
**Motivation**

When sending blocks to the validation steps, the user may have a block with gas limit too high, and in those cases the wrong error would be showed ("Base fee per gas is incorrect")

**Description**

- Added a new error `GasLimitTooFarFromParent`
- validate_block_header now returns `GasLimitTooFarFromParent` when the gas limit exceeds the limit and the function `calculate_base_fee_per_gas` returns None

