### PR TITLE
fix(l2): revert breaking when budget is reached for privileged txs

### DIFF
--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -163,9 +163,6 @@ pub async fn fill_transactions(
         if head_tx.is_privileged() {
             if privileged_tx_count >= PRIVILEGED_TX_BUDGET {
                 debug!("Ran out of space for privileged transactions");
-                // We break here because if we have expired privileged transactions
-                // in the contract, our batch will be rejected if non-privileged txs
-                // are included.
                 txs.pop();
                 continue;
             }


### PR DESCRIPTION
**Motivation**
[This](https://github.com/lambdaclass/ethrex/pull/5135#discussion_r2518482596) change made the integration tests took longer, having to amp the amount of retries.
<!-- Why does this pull request exist? What are its goals? -->

**Description**
Reverts this change and adds an [issue](https://github.com/lambdaclass/ethrex/issues/5325) for solving it.
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


