### PR TITLE
fix(l1): remove deprecated lighthouse flag 

### DIFF
--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -169,7 +169,7 @@ start-lighthouse: ## Start lighthouse for the network given by NETWORK.
 		--metrics-address 0.0.0.0 \
 		--metrics-port 5054 \
 		--datadir $(DATA_PATH)/${NETWORK}_data/lighthouse_${NODE_NAME}_$(EVM) \
-		--disable-deposit-contract-sync --port $(LIGHTHOUSE_PORT) --discovery-port $(LIGHTHOUSE_DISCOVERY_PORT)
+		--port $(LIGHTHOUSE_PORT) --discovery-port $(LIGHTHOUSE_DISCOVERY_PORT)
 
 start-ethrex: ## Start ethrex for the network given by NETWORK.
 	cd $(ETHREX_DIR) && RUST_LOG=3 cargo run --release --features "rocksdb sync-test metrics" --bin ethrex -- \


### PR DESCRIPTION
**Motivation**
The flag `--disable-deposit-contract-sync` no longer exists on the latest lighthouse version (v8.0.0)
<!-- Why does this pull request exist? What are its goals? -->

**Description**
* Remove `--disable-deposit-contract-sync` flag from `start-lighthouse` target on `tooling/sync/Makefile`
<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

