### PR TITLE
revert(l1, l2): revert revert of build empty block

### DIFF
--- a/tooling/reorgs/src/simulator.rs
+++ b/tooling/reorgs/src/simulator.rs
@@ -277,6 +277,11 @@ impl Node {
         );
         let payload_id = fork_choice_response.payload_id.unwrap();
 
+        // We need this sleep so the get_payload call doesn't return an empty block
+        // As of #5205 we build an empty block first before building a payload with the transactions to avoid missing slots
+        // This can cause issues in these tests if the payload is requested too early, the sleep is there to avoid it
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
         let payload_response = self
             .engine_client
             .engine_get_payload_v5(payload_id)


### PR DESCRIPTION
**Description**

This commit reverts the revert of #5205 done in #5257. 
As of #5310, the dev mode block producer now waits for the configured amount of time after initiating the payload build process and before retrieving the built payload, rather than after payload validation. This solves the issue we were having after merging #5205 where empty payloads were retrieved because the `engine_getPayload` call was immediately done after the `engine_forkChoiceUpdate`. 


