### PR TITLE
fix(l1): do not use `secp256k1` SP1 patch for the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,8 +123,5 @@ rocksdb = { version = "0.24.0", default-features = false, features = [
   "lz4",
 ] }
 
-[patch.crates-io]
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.30.0-sp1-5.0.0" }
-
 [workspace.lints.clippy]
 redundant_clone = "warn"


### PR DESCRIPTION
**Motivation**

This patch is being applied to the whole workspace when it shouldn't, because SP1 patches should be applied in the corresponding guest program instead.

