### PR TITLE
ci(l1,l2): free disk in build docker job

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -293,6 +293,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk
+
       - name: Format name
         run: |
           # For branch builds (main) we want docker images tagged as 'main'. For tag pushes


### PR DESCRIPTION
**Motivation**

This job has failed some times in `main` due to no more space left on device error (see [this](https://github.com/lambdaclass/ethrex/actions/runs/19351089268/job/55362819152)).
