### PR TITLE
revert(l1, l2): revert building initially empty block

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -369,7 +369,8 @@ impl Blockchain {
         let start = Instant::now();
         const SECONDS_PER_SLOT: Duration = Duration::from_secs(12);
         // Attempt to rebuild the payload as many times within the given timeframe to maximize fee revenue
-        let mut res = self.build_empty_payload(payload.clone())?;
+        // TODO(#4997): start with an empty block
+        let mut res = self.build_payload(payload.clone())?;
         while start.elapsed() < SECONDS_PER_SLOT && !cancel_token.is_cancelled() {
             let payload = payload.clone();
             let self_clone = self.clone();
@@ -391,22 +392,8 @@ impl Blockchain {
         Ok(res)
     }
 
-    // We separate this into two functions, so we can build the initial empty payload and then start filling it
-    // TODO: once we implement a mechanism to gradually fill the payload with transactions we won't need this
-    pub fn build_payload(&self, payload: Block) -> Result<PayloadBuildResult, ChainError> {
-        self.build_payload_inner(payload, true)
-    }
-
-    pub fn build_empty_payload(&self, payload: Block) -> Result<PayloadBuildResult, ChainError> {
-        self.build_payload_inner(payload, false)
-    }
-
     /// Completes the payload building process, return the block value
-    pub fn build_payload_inner(
-        &self,
-        payload: Block,
-        fill_transactions: bool,
-    ) -> Result<PayloadBuildResult, ChainError> {
+    pub fn build_payload(&self, payload: Block) -> Result<PayloadBuildResult, ChainError> {
         let since = Instant::now();
         let gas_limit = payload.header.gas_limit;
 
@@ -418,10 +405,8 @@ impl Blockchain {
             self.apply_system_operations(&mut context)?;
         }
         self.apply_withdrawals(&mut context)?;
-        if fill_transactions {
-            self.fill_transactions(&mut context)?;
-            self.extract_requests(&mut context)?;
-        }
+        self.fill_transactions(&mut context)?;
+        self.extract_requests(&mut context)?;
         self.finalize_payload(&mut context)?;
 
         let interval = Instant::now().duration_since(since).as_millis();

--- a/tooling/reorgs/src/simulator.rs
+++ b/tooling/reorgs/src/simulator.rs
@@ -277,11 +277,6 @@ impl Node {
         );
         let payload_id = fork_choice_response.payload_id.unwrap();
 
-        // We need this sleep so the get_payload call doesn't return an empty block
-        // As of #5205 we build an empty block first before building a payload with the transactions to avoid missing slots
-        // This can cause issues in these tests if the payload is requested too early, the sleep is there to avoid it
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
         let payload_response = self
             .engine_client
             .engine_get_payload_v5(payload_id)


### PR DESCRIPTION
**Description**

This reverts #5337. The time between payload building and fetching in devnet turned out to not be enough for some of the L2 test cases, so we'll have to figure out a new approach to building devnet blocks.

