### PR TITLE
fix(l2): return None when branch becomes empty in remove

### DIFF
--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -214,6 +214,9 @@ impl BranchNode {
             .enumerate()
             .filter(|(_, child)| child.is_valid())
             .collect::<Vec<_>>();
+        if children.is_empty() && self.value.is_empty() {
+            return Ok((None, value));
+        }
         let new_node = match (children.len(), !self.value.is_empty()) {
             // If this node still has a value but no longer has children, convert it into a leaf node
             (0, true) => NodeRemoveResult::New(


### PR DESCRIPTION
In BranchNode::remove() return None when the branch has zero children and no value after removal, instead of returning Mutated. Node::remove() relies on new_root.is_none() to mark the subtree as empty, and Trie::remove() uses that signal to reset the root to the empty trie (keccak(RLP_NULL)). LeafNode::remove() and ExtensionNode::remove() already adhere to this contract, so this change aligns BranchNode with the established semantics and prevents persisting a structurally empty branch at the root which would otherwise break the empty trie invariant.