### PR TITLE
perf(levm): remove unnecessary calldata clone

### DIFF
--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -245,7 +245,6 @@ pub fn delete_self_destruct_accounts(vm: &mut VM<'_>) -> Result<(), VMError> {
 
 pub fn validate_min_gas_limit(vm: &mut VM<'_>) -> Result<(), VMError> {
     // check for gas limit is grater or equal than the minimum required
-    let calldata = vm.current_call_frame.calldata.clone();
     let intrinsic_gas: u64 = vm.get_intrinsic_gas()?;
 
     if vm.current_call_frame.gas_limit < intrinsic_gas {
@@ -253,7 +252,7 @@ pub fn validate_min_gas_limit(vm: &mut VM<'_>) -> Result<(), VMError> {
     }
 
     // calldata_cost = tokens_in_calldata * 4
-    let calldata_cost: u64 = gas_cost::tx_calldata(&calldata)?;
+    let calldata_cost: u64 = gas_cost::tx_calldata(&vm.current_call_frame.calldata)?;
 
     // same as calculated in gas_used()
     let tokens_in_calldata: u64 = calldata_cost / STANDARD_TOKEN_COST;


### PR DESCRIPTION
**Motivation**

`let calldata = vm.current_call_frame.calldata.clone();` followed by `gas_cost::tx_calldata(&calldata)?`.
`gas_cost::tx_calldata` appears to consume by reference; cloning Bytes here is unnecessary.

**Description**


Replace a redundant clone of bytes::Bytes in validate_min_gas_limit by borrowing vm.current_call_frame.calldata directly when calling gas_cost::tx_calldata. The function only needs an immutable reference, and this matches existing patterns in get_intrinsic_gas and get_min_gas_used, so cloning was not required.
