### PR TITLE
fix(l2): Fix EIP-4844 blob fee bump to use percentage scale

### DIFF
--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -813,10 +813,10 @@ fn bump_gas_generic_tx(tx: &mut GenericTransaction, bump_percentage: u64) {
         *max_priority_fee_per_gas = (*max_priority_fee_per_gas * (100 + bump_percentage)) / 100;
     }
     if let Some(max_fee_per_blob_gas) = &mut tx.max_fee_per_blob_gas {
-        let factor = 1 + (bump_percentage / 100) * 10;
+        let factor = 100 + bump_percentage;
         *max_fee_per_blob_gas = max_fee_per_blob_gas
             .saturating_mul(U256::from(factor))
-            .div(10);
+            .div(100);
     }
 }
 


### PR DESCRIPTION
**Motivation**

The bump formula max_fee_per_blob_gas in crates/l2/sdk/src/sdk.rs::bump_gas_generic_tx() is incorrect and decreases the value instead of increasing it.

**Description**

Adjust the bump logic for EIP-4844 max_fee_per_blob_gas in bump_gas_generic_tx() to increase by (100 + bump_percentage)/100, mirroring the existing EIP-1559 fee bump strategy. The previous implementation used a factor with integer division and an extra division by 10, which effectively reduced the blob fee (e.g., with bump_percentage=30 it divided by 10) and conflicted with replacement rules and inclusion probabilities for blob transactions. This change aligns behavior with how max_fee_per_gas and max_priority_fee_per_gas are bumped, respects client-side clamping via maximum_allowed_max_fee_per_blob_gas, and prevents underpriced retries for blob transactions.

