### PR TITLE
fix(l1,l2): fix encoding of nodes in witness

### DIFF
--- a/crates/networking/rpc/debug/execution_witness.rs
+++ b/crates/networking/rpc/debug/execution_witness.rs
@@ -9,7 +9,7 @@ use ethrex_common::{
     },
     utils::keccak,
 };
-use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode, error::RLPDecodeError};
+use ethrex_rlp::{decode::RLPDecode, error::RLPDecodeError};
 use ethrex_storage::hash_address;
 use ethrex_trie::{EMPTY_TRIE_HASH, Node, NodeRef, Trie, TrieError};
 use serde::{Deserialize, Serialize};
@@ -53,10 +53,7 @@ impl TryFrom<ExecutionWitness> for RpcExecutionWitness {
             node.encode_subtrie(&mut nodes)?;
         }
         Ok(Self {
-            state: nodes
-                .into_iter()
-                .map(Bytes::from)
-                .collect(),
+            state: nodes.into_iter().map(Bytes::from).collect(),
             keys: value.keys.into_iter().map(Bytes::from).collect(),
             codes: value.codes.into_iter().map(Bytes::from).collect(),
             headers: value


### PR DESCRIPTION
**Motivation**

- Fix `debug_executionWitness` endpoint

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
- When asking for the witness of a block the trie nodes were being encoded 2 times (double encoding). This just removes the additional encoding.

This has been tested with ethrex-replay and now it works perfectly fine with ethrex nodes. We were getting errors decoding RLP before.


How to test it?
- Run L1 in dev mode
- Request witness with debug_executionWitness

See the response both in main and in this branch, you'll see that the nodes are "the same" but in main they are encoded one more time. Basically in main: `RLP(RLP(node))`, but here: `RLP(node)`. We want the latter.