### PR TITLE
refactor(levm): remove unused variants from enum

### DIFF
--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -195,12 +195,8 @@ pub enum PrecompileError {
     ParsingInputError,
     #[error("There is not enough gas to execute precompiled contract")]
     NotEnoughGas,
-    #[error("Kzg error: {0}")]
-    KzgError(String),
     #[error("Invalid point")]
     InvalidPoint,
-    #[error("The point is not in the curve")]
-    PointNotInTheCurve,
     #[error("The point is not in the subgroup")]
     PointNotInSubgroup,
     #[error("The G1 point is not in the curve")]


### PR DESCRIPTION
**Motivation**

The `PrecompileError` enum had two variants that were not in use. One of them, `KzgError`, contained a string which caused the size of the `PrecompileError` enum to increase.

**Description**

This PR removes the unused variants, causing both `PrecompileError` and `ExceptionalHalt` (which used PrecompileError) to shrink from 24 bytes to just one.
