### PR TITLE
fix(l1): fix gas tip estimator base fee sampling

### DIFF
--- a/crates/networking/rpc/eth/gas_tip_estimator.rs
+++ b/crates/networking/rpc/eth/gas_tip_estimator.rs
@@ -86,7 +86,7 @@ impl GasTipEstimator {
             };
 
             let base_fee = storage
-                .get_block_header(latest_block_number)
+                .get_block_header(block_num)
                 .ok()
                 .flatten()
                 .and_then(|header| header.base_fee_per_gas);


### PR DESCRIPTION
`base_fee` was always being sampled from the `latest_block_number` instead of iterating through blocks


