### PR TITLE
ci(l2): show L1 logs in sp1 backend workflow

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -116,10 +116,12 @@ jobs:
         run: |
           cd crates/l2
           make init-prover-sp1 GPU=true &
-          docker logs --follow ethrex_l2 & DOCKER_LOGS_PID=$!
+          docker logs --follow ethrex_l2 & DOCKER_LOGS_L2_PID=$!
+          docker logs --follow ethrex_l1 & DOCKER_LOGS_L1_PID=$!
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test l2 --release -- --nocapture --test-threads=1
           killall ethrex -s SIGINT
-          kill $DOCKER_LOGS_PID || true
+          kill $DOCKER_LOGS_L2_PID || true
+          kill $DOCKER_LOGS_L1_PID || true
 
       - name: Destroy Docker containers
         if: always()


### PR DESCRIPTION
**Motivation**

Our SP1 backend workflow failed because the L1 RPC stopped responding:

```
WARN Could not request RPC server endpoint=http://ethrex_l1:8545/ error=reqwest error: error sending request for url (http://ethrex_l1:8545/)
ERROR L1 Proof Sender: Failed because of an EthClient error: reqwest error: error sending request for url (http://ethrex_l1:8545/)
WARN Could not request RPC server endpoint=http://ethrex_l1:8545/ error=reqwest error: error sending request for url (http://ethrex_l1:8545/)
ERROR L1 Watcher Error: L1Watcher error: reqwest error: error sending request for url (http://ethrex_l1:8545/)
WARN Could not request RPC server endpoint=http://ethrex_l1:8545/ error=reqwest error: error sending request for url (http://ethrex_l1:8545/)
ERROR Metrics Gatherer Error: MetricsGatherer failed because of an EthClient error: reqwest error: error sending request for url (http://ethrex_l1:8545/)
WARN Could not request RPC server endpoint=http://ethrex_l1:8545/ error=reqwest error: error sending request for url (http://ethrex_l1:8545/)
```

As we don't have the L1 logs, we can't know what happened.

**Description**

- Follows `ethrex_l1` logs as well.

Closes None

