### PR TITLE
fix(l1): use correct block_num for base_fee in gas_tip_estimator

### DIFF
--- a/crates/networking/rpc/eth/gas_tip_estimator.rs
+++ b/crates/networking/rpc/eth/gas_tip_estimator.rs
@@ -86,7 +86,7 @@ impl GasTipEstimator {
             };
 
             let base_fee = storage
-                .get_block_header(latest_block_number)
+                .get_block_header(block_num)
                 .ok()
                 .flatten()
                 .and_then(|header| header.base_fee_per_gas);


### PR DESCRIPTION
we were using `latest_block_number` to sample `base_fee` instead of iterating through `block_num`. this PR fixes that problem.

