### PR TITLE
fix(l1): avoid blocking during fullsync

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -31,7 +31,6 @@ use ethrex_trie::trie_sorted::TrieGenerationError;
 use ethrex_trie::{Trie, TrieError};
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::fmt::format;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use std::{


### PR DESCRIPTION
**Motivation**

In fullsync, when in the final (head found) stage, we execute blocks individually. However, because we execute (sync) inside an async function, this blocks the runtime.

**Description**

Uses spawn_blocking to avoid blocking the runtime.

