### PR TITLE
docs(l1,l2,levm): mention exclamation mark signals breaking changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ All PR titles must follow the enforced semantic format:
 - `fix(l1,levm): handle edge case in snap sync`
 - `docs(l2): update documentation for L2`
 
-An exclamation mark may be added before the colon to indicate breaking changes.
+An exclamation mark may be added before the colon to indicate breaking changes, for example `perf(l1)!: change database schema`
 
 PRs not following this convention will fail automated checks.
 


### PR DESCRIPTION
**Motivation**

Currently we don't mention PR titles can have an exclamation mark to signal it contains breaking changes.

**Description**

Mentions in CONTRIBUTING.md.
