### PR TITLE
docs(l1): add comment about missing transactions root check

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1744,7 +1744,7 @@ pub fn find_parent_header(
 /// Verifies that blob gas fields in the header are correct in reference to the block's body.
 /// If a block passes this check, execution will still fail with execute_block when a transaction runs out of gas
 ///
-/// Note that this doesn't validate the transactions or withdrawals root of the header match with the body
+/// Note that this doesn't validate that the transactions or withdrawals root of the header matches the body
 /// contents, since we assume the caller already did it. And, in any case, that wouldn't invalidate the block header.
 pub fn validate_block(
     block: &Block,


### PR DESCRIPTION
**Motivation**

We are missing a validation check for the transactions root of a block. This is OK, as explained in #5043, because we compute it ourselves (when it comes from the Engine API), or we validate it elsewhere (P2P).

**Description**

This PR adds an explanation of why we don't validate the header and body match during block execution.

Closes #5043