### PR TITLE
feat(l1): pin `execution-apis` version when running `rpc-compat` hive suite in Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ setup-hive: ## 🐝 Set up Hive testing framework
 TEST_PATTERN ?= /
 SIM_LOG_LEVEL ?= 3
 SIM_PARALLELISM ?= 16
+# https://github.com/ethereum/execution-apis/pull/627 changed the simulation to use a pre-merge genesis block, so we need to pin to a commit before that
 ifeq ( $(SIMULATION) , ethereum/rpc-compat )
 SIM_BUILDARG_FLAG = --sim.buildarg "branch=d08382ae5c808680e976fce4b73f4ba91647199b"
 endif


### PR DESCRIPTION
In the hive workflow that runs for each PR, we set the execution-apis version as a building when running `rpc-compat` testing suite, as the latest version uses a pre-merge genesis file. This causes hive tests to pass on the CI but not when developing locally. This PR fixes this by adding the buildarg flag when running rpc-compat testing suite
