### PR TITLE
fix(l1,l2): forbid hash override on empty-path insert in branch/leaf

### DIFF
--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -137,7 +137,9 @@ impl BranchNode {
             self.update(value);
         } else {
             // Value in branches don't happen in our use-case.
-            todo!("handle override case (error?)")
+            return Err(TrieError::Verify(
+                "attempt to override proof node with external hash".to_string(),
+            ));
         }
 
         Ok(())

--- a/crates/common/trie/node/leaf.rs
+++ b/crates/common/trie/node/leaf.rs
@@ -88,14 +88,14 @@ impl LeafNode {
                 let mut choices = BranchNode::EMPTY_CHOICES;
                 let child: Node = self.take().into();
                 choices[self_choice_idx] = child.into();
-                BranchNode::new_with_value(
-                    choices,
-                    match value {
-                        ValueOrHash::Value(value) => value,
-                        // Value in branches don't happen in our use-case.
-                        ValueOrHash::Hash(_) => todo!("handle override case (error?)"),
-                    },
-                )
+                match value {
+                    ValueOrHash::Value(value) => BranchNode::new_with_value(choices, value),
+                    ValueOrHash::Hash(_) => {
+                        return Err(TrieError::Verify(
+                            "attempt to set value in branch node with external hash".to_string(),
+                        ));
+                    }
+                }
             } else {
                 // Create a new leaf node and store the path and value in it
                 // Create a new branch node with the leaf and self as children


### PR DESCRIPTION
Replace unresolved todo!() with explicit verification errors when inserting an external hash at the exact target path. In 
BranchNode::insert() (empty path) and the analogous case in LeafNode::insert() (attempt to set branch value from a hash), return TrieError::Verify instead of allowing override or panicking. This aligns with existing safeguards that allow hashes only in empty child slots and prevents replacing existing nodes/values at the target path.