### PR TITLE
chore(l2): fix prover timing

### DIFF
--- a/crates/l2/prover/src/backend/exec.rs
+++ b/crates/l2/prover/src/backend/exec.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{info, warn};
 
 use ethrex_l2_common::{
@@ -16,6 +16,14 @@ pub fn execute(input: ProgramInput) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+pub fn execute_timed(input: ProgramInput) -> Result<Duration, Box<dyn std::error::Error>> {
+    let now = Instant::now();
+    execution_program(input)?;
+    let duration = now.elapsed();
+
+    Ok(duration)
+}
+
 pub fn prove(
     input: ProgramInput,
     _format: ProofFormat,
@@ -23,6 +31,18 @@ pub fn prove(
     warn!("\"exec\" prover backend generates no proof, only executes");
     let output = execution_program(input)?;
     Ok(output)
+}
+
+pub fn prove_timed(
+    input: ProgramInput,
+    _format: ProofFormat,
+) -> Result<(ProgramOutput, Duration), Box<dyn std::error::Error>> {
+    warn!("\"exec\" prover backend generates no proof, only executes");
+    let now = Instant::now();
+    let output = execution_program(input)?;
+    let duration = now.elapsed();
+
+    Ok((output, duration))
 }
 
 pub fn verify(_proof: &ProgramOutput) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/l2/prover/src/backend/risc0.rs
+++ b/crates/l2/prover/src/backend/risc0.rs
@@ -12,7 +12,7 @@ use risc0_zkvm::{
     serde::Error as Risc0SerdeError,
 };
 use rkyv::rancor::Error as RkyvError;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 #[derive(thiserror::Error, Debug)]
@@ -39,13 +39,24 @@ pub fn execute(input: ProgramInput) -> Result<(), Box<dyn std::error::Error>> {
 
     let executor = default_executor();
 
-    let now = Instant::now();
     let _session_info = executor.execute(env, ZKVM_RISC0_PROGRAM_ELF)?;
-    let elapsed = now.elapsed();
-
-    info!("Successfully executed RISC0 program in {elapsed:.2?}");
 
     Ok(())
+}
+
+pub fn execute_timed(input: ProgramInput) -> Result<Duration, Box<dyn std::error::Error>> {
+    let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
+    let env = ExecutorEnv::builder()
+        .write_slice(bytes.as_slice())
+        .build()?;
+
+    let executor = default_executor();
+
+    let start = Instant::now();
+    let _session_info = executor.execute(env, ZKVM_RISC0_PROGRAM_ELF)?;
+    let duration = start.elapsed();
+
+    Ok(duration)
 }
 
 pub fn prove(
@@ -67,13 +78,35 @@ pub fn prove(
         ProofFormat::Groth16 => ProverOpts::groth16(),
     };
 
-    let now = Instant::now();
     let prove_info = prover.prove_with_opts(env, ZKVM_RISC0_PROGRAM_ELF, &prover_opts)?;
-    let elapsed = now.elapsed();
-
-    info!("Successfully proved RISC0 program in {elapsed:.2?}");
 
     Ok(prove_info.receipt)
+}
+
+pub fn prove_timed(
+    input: ProgramInput,
+    format: ProofFormat,
+) -> Result<(Receipt, Duration), Box<dyn std::error::Error>> {
+    let mut stdout = Vec::new();
+
+    let bytes = rkyv::to_bytes::<RkyvError>(&input)?;
+    let env = ExecutorEnv::builder()
+        .stdout(&mut stdout)
+        .write_slice(bytes.as_slice())
+        .build()?;
+
+    let prover = default_prover();
+
+    let prover_opts = match format {
+        ProofFormat::Compressed => ProverOpts::succinct(),
+        ProofFormat::Groth16 => ProverOpts::groth16(),
+    };
+
+    let start = Instant::now();
+    let prove_info = prover.prove_with_opts(env, ZKVM_RISC0_PROGRAM_ELF, &prover_opts)?;
+    let duration = start.elapsed();
+
+    Ok((prove_info.receipt, duration))
 }
 
 pub fn verify(receipt: &Receipt) -> Result<(), Error> {

--- a/crates/l2/prover/src/lib.rs
+++ b/crates/l2/prover/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 use config::ProverConfig;
 use ethrex_l2_common::prover::{BatchProof, ProofFormat};
 use guest_program::input::ProgramInput;
+use std::time::Duration;
 use tracing::warn;
 
 use crate::backend::{Backend, ProveOutput};
@@ -29,6 +30,24 @@ pub fn execute(backend: Backend, input: ProgramInput) -> Result<(), Box<dyn std:
     }
 }
 
+/// Execute a program using the specified backend and measure the duration.
+pub fn execute_timed(
+    backend: Backend,
+    input: ProgramInput,
+) -> Result<Duration, Box<dyn std::error::Error>> {
+    match backend {
+        Backend::Exec => backend::exec::execute_timed(input),
+        #[cfg(feature = "sp1")]
+        Backend::SP1 => backend::sp1::execute_timed(input),
+        #[cfg(feature = "risc0")]
+        Backend::RISC0 => backend::risc0::execute_timed(input),
+        #[cfg(feature = "zisk")]
+        Backend::ZisK => backend::zisk::execute_timed(input),
+        #[cfg(feature = "openvm")]
+        Backend::OpenVM => backend::openvm::execute_timed(input),
+    }
+}
+
 /// Generate a proof using the specified backend.
 pub fn prove(
     backend: Backend,
@@ -45,6 +64,30 @@ pub fn prove(
         Backend::ZisK => backend::zisk::prove(input, format).map(ProveOutput::ZisK),
         #[cfg(feature = "openvm")]
         Backend::OpenVM => backend::openvm::prove(input, format).map(ProveOutput::OpenVM),
+    }
+}
+
+/// Generate a proof using the specified backend and measure the duration.
+pub fn prove_timed(
+    backend: Backend,
+    input: ProgramInput,
+    format: ProofFormat,
+) -> Result<(ProveOutput, Duration), Box<dyn std::error::Error>> {
+    match backend {
+        Backend::Exec => backend::exec::prove_timed(input, format)
+            .map(|(output, duration)| (ProveOutput::Exec(output), duration)),
+        #[cfg(feature = "sp1")]
+        Backend::SP1 => backend::sp1::prove_timed(input, format)
+            .map(|(output, duration)| (ProveOutput::SP1(output), duration)),
+        #[cfg(feature = "risc0")]
+        Backend::RISC0 => backend::risc0::prove_timed(input, format)
+            .map(|(receipt, duration)| (ProveOutput::RISC0(receipt), duration)),
+        #[cfg(feature = "zisk")]
+        Backend::ZisK => backend::zisk::prove_timed(input, format)
+            .map(|(proof, duration)| (ProveOutput::ZisK(proof), duration)),
+        #[cfg(feature = "openvm")]
+        Backend::OpenVM => backend::openvm::prove_timed(input, format)
+            .map(|(proof, duration)| (ProveOutput::OpenVM(proof), duration)),
     }
 }
 


### PR DESCRIPTION
**Motivation**

To measure execution and proving time correctly. This means removing the client initialization from the equation. In the case of ZisK, we use it's own timing exposed via a JSON file generated after proving.

