### PR TITLE
style(l2): remove unused collections

### DIFF
--- a/crates/l2/prover/src/guest_program/src/execution.rs
+++ b/crates/l2/prover/src/guest_program/src/execution.rs
@@ -179,7 +179,6 @@ pub fn stateless_validation_l1(
     // Execute blocks
     let mut parent_block_header = &parent_block_header;
     let mut acc_account_updates: BTreeMap<Address, AccountUpdate> = BTreeMap::new();
-    let mut acc_receipts = Vec::new();
     let mut non_privileged_count = 0;
 
     for block in blocks.iter() {
@@ -242,7 +241,6 @@ pub fn stateless_validation_l1(
         })?;
 
         non_privileged_count += block.body.transactions.len();
-        acc_receipts.push(result.receipts);
         parent_block_header = &block.header;
     }
 

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -619,7 +619,6 @@ impl L1Committer {
         let first_block_of_batch = last_added_block_number + 1;
         let mut blobs_bundle = BlobsBundle::default();
 
-        let mut acc_messages = vec![];
         let mut acc_privileged_txs = vec![];
         let mut message_hashes = vec![];
         let mut privileged_transactions_hashes = vec![];
@@ -768,7 +767,6 @@ impl L1Committer {
             }
 
             // Accumulate block data with the rest of the batch.
-            acc_messages.extend(messages.clone());
             acc_privileged_txs.extend(privileged_transactions.clone());
 
             let acc_privileged_txs_len: u64 = acc_privileged_txs.len().try_into()?;

--- a/crates/l2/utils/state_reconstruct.rs
+++ b/crates/l2/utils/state_reconstruct.rs
@@ -93,9 +93,8 @@ async fn extract_block_messages(
         )));
     };
 
-    let mut txs = vec![];
     let mut receipts = vec![];
-    for (index, tx) in block_body.transactions.iter().enumerate() {
+    for index in 0..block_body.transactions.len() {
         let receipt = store
             .get_receipt(
                 block_number,
@@ -107,7 +106,6 @@ async fn extract_block_messages(
             .ok_or(UtilsError::RetrievalError(
                 "Transactions in a block should have a receipt".to_owned(),
             ))?;
-        txs.push(tx.clone());
         receipts.push(receipt);
     }
     Ok(get_block_l1_messages(&receipts))


### PR DESCRIPTION
**Motivation**

There are vectors we push to, but do not use.

**Description**

Uses the `clippy::collection_is_never_read` experimental lint to find these cases.

