### PR TITLE
fix(l1): record new inbound peers as new discoveries

### DIFF
--- a/crates/networking/p2p/discv4/peer_table.rs
+++ b/crates/networking/p2p/discv4/peer_table.rs
@@ -1032,6 +1032,7 @@ impl GenServer for PeerTableServer {
                 match self.contacts.entry(node.node_id()) {
                     Entry::Occupied(_) => false,
                     Entry::Vacant(entry) => {
+                        METRICS.record_new_discovery().await;
                         entry.insert(Contact::from(node));
                         true
                     }


### PR DESCRIPTION
**Motivation**

I saw that contacts seem to only be recorded when received in a `Neighbors` message, but not when we receive a PING from a new peer.

**Description**

This PR calls `record_new_discovery` when inserting new peers into the peer table.