### PR TITLE
ci(l2): temporarily disable OpenVM linting

### DIFF
--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        backend: ["sp1", "risc0", "zisk", "openvm"]
+        # Note: openvm backend linting is disabled due to a problem in the installation https://github.com/lambdaclass/ethrex/issues/5509
+        backend: ["sp1", "risc0", "zisk"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
**Motivation**

OpenVM toolchain installation started to fail on every workflow in a non-flaky manner.

**Description**

Temporarily disable the OpenVM lint job until solved #5509.

