### PR TITLE
chore(l1): remove massive branch debug log spam

### DIFF
--- a/crates/common/trie/trie_sorted.rs
+++ b/crates/common/trie/trie_sorted.rs
@@ -6,7 +6,6 @@ use crossbeam::channel::{Receiver, Sender, bounded};
 use ethereum_types::H256;
 use ethrex_threadpool::ThreadPool;
 use std::{sync::Arc, thread::scope};
-use tracing::debug;
 
 /// The elements of the stack represent the branch node that is the parent of the current
 /// parent element. When the current parent is no longer valid (is not the parent of
@@ -139,16 +138,6 @@ fn add_current_to_parent_and_write_queue(
     };
     parent_element.element.choices[index as usize] =
         node.compute_hash_no_alloc(&mut nodehash_buffer).into();
-    debug!(
-        "branch {:x?}",
-        parent_element
-            .element
-            .choices
-            .iter()
-            .enumerate()
-            .filter_map(|(index, child)| child.is_valid().then_some(index))
-            .collect::<Vec<_>>()
-    );
     nodes_to_write.push((target_path, node));
     Ok(())
 }


### PR DESCRIPTION
**Motivation**

This log provides no useful info and it spams so much my terminal couldnt keep up with the output, so much that i had to SIGINT ethrex to stop it, since ctrl-c didnt work

<img width="1036" height="893" alt="image" src="https://github.com/user-attachments/assets/ef97614f-a1c5-421d-b45b-63d3e4007fa6" />

