### PR TITLE
chore(l2): use ZisK patched substrate-bn for bn254 G1 mul

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -841,6 +841,10 @@ pub fn bn254_g1_mul(g1: G1, scalar: U256) -> Result<Bytes, VMError> {
     let scalar =
         Fr::from_slice(&scalar.to_big_endian()).map_err(|_| PrecompileError::ParsingInputError)?;
 
+    #[allow(
+        clippy::arithmetic_side_effects,
+        reason = "G1 scalar multiplication doesn't overflow, intermediate operations that could overflow should be handled correctly by the library"
+    )]
     let result = g1 * scalar;
 
     let mut x_bytes = [0u8; 32];


### PR DESCRIPTION
**Motivation**

We were missing a feature attribute so we weren't using the patched crate for this precompile.

before:
```
| Block    | Gas Used    | Steps       | Duration (s) | TP (Msteps/s) | Freq (MHz) | Clocks/step |
|----------|-------------|-------------|--------------|----------------|------------|--------------|
| 23919400 | 41,075,722  | 760,022,264 | 18.4439      | 41.2072        | 1999.0000  | 48.5109      |
| 23919500 | 40,237,085  | 798,604,814 | 18.8685      | 42.3247        | 1999.0000  | 47.2301      |
| 23919600 | 24,064,259  | 512,165,934 | 12.0746      | 42.4168        | 1999.0000  | 47.1276      |
| 23919700 | 20,862,238  | 445,582,906 | 10.5385      | 42.2815        | 1999.0000  | 47.2784      |
| 23919800 | 31,813,109  | 596,446,973 | 14.4148      | 41.3774        | 1999.0000  | 48.3114      |
| 23919900 | 22,917,739  | 428,983,514 | 10.6816      | 40.1612        | 1999.0000  | 49.7745      |
| 23920000 | 37,256,487  | 695,820,714 | 16.3619      | 42.5268        | 1999.0000  | 47.0056      |
| 23920100 | 33,542,307  | 598,535,326 | 14.1889      | 42.1834        | 1999.0000  | 47.3883      |
| 23920200 | 22,994,047  | 416,578,732 | 9.9036       | 42.0633        | 1999.0000  | 47.5236      |
| 23920300 | 53,950,967  | 986,179,450 | 23.7537      | 41.5169        | 1999.0000  | 48.1490      |
```

after:
```
| Block    | Gas Used     | Steps         | Duration (s) | TP (Msteps/s) | Freq (MHz) | Clocks/step |
|----------|--------------|---------------|--------------|----------------|------------|--------------|
| 23919400 |   41,075,722 |   691,101,207 |      17.0141 |        40.6192 |  1999.0000 |      49.2132 |
| 23919500 |   40,237,085 |   779,305,442 |      18.6583 |        41.7672 |  1999.0000 |      47.8606 |
| 23919600 |   24,064,259 |   513,012,780 |      12.0374 |        42.6181 |  1999.0000 |      46.9050 |
| 23919700 |   20,862,238 |   446,302,312 |      10.5317 |        42.3771 |  1999.0000 |      47.1717 |
| 23919800 |   31,813,109 |   597,330,618 |      14.2609 |        41.8859 |  1999.0000 |      47.7249 |
| 23919900 |   22,917,739 |   429,507,357 |      10.2934 |        41.7265 |  1999.0000 |      47.9072 |
| 23920000 |   37,256,487 |   687,119,433 |      16.1958 |        42.4259 |  1999.0000 |      47.1175 |
| 23920100 |   33,542,307 |   599,355,989 |      14.1664 |        42.3083 |  1999.0000 |      47.2485 |
| 23920200 |   22,994,047 |   417,314,063 |       9.8807 |        42.2351 |  1999.0000 |      47.3303 |
| 23920300 |   53,950,967 |   967,119,435 |      23.0891 |        41.8864 |  1999.0000 |      47.7243 |
```

diff in steps:
```
23919400: −9.06%
23919500: −2.42%
23919600: 0.16%
23919700: 0.16%
23919800: 0.15%
23919900: 0.12%
23920000: −1.25%
23920100: 0.14%
23920200: 0.18%
23920300: −1.94%
```