### PR TITLE
refactor(l1): avoid extra allocations in RLPx handshake

### DIFF
--- a/crates/networking/p2p/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p/rlpx/connection/handshake.rs
@@ -261,7 +261,6 @@ async fn receive_handshake_msg<S: AsyncRead + std::marker::Unpin>(
 
     // Read the rest of the message
     stream.read_exact(&mut buf[2..]).await?;
-    buf.truncate(msg_size + 2);
     Ok(buf)
 }
 


### PR DESCRIPTION
Remove unnecessary allocations on the handshake path. 
receive_handshake_msg() now returns the owned buffer instead of cloning a slice, and receive_auth()/receive_ack() move msg_bytes into init_message instead of cloning. This keeps behavior unchanged while reducing copies and heap traffic during auth/ack processing.