### PR TITLE
ci(l1): login with docker before running hive

### DIFF
--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -120,6 +120,12 @@ jobs:
           fi
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run Hive Simulation
         id: run-hive-action
         uses: ethpandaops/hive-github-action@v0.5.0

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -251,6 +251,12 @@ jobs:
           fi
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run Hive Simulation
         id: run-hive-action
         uses: ethpandaops/hive-github-action@v0.5.0


### PR DESCRIPTION
**Motivation**

We have workflows failing due to rate limits on dockerhub. This is because hive runs pull images without authenticating with dockerhub.

**Description**

This PR adds a call to `docker/login-action` to authenticate before running any hive simulation.

Closes #5495