### PR TITLE
ci(l1): run snapsync job every 3 hours and set log as debug.

### DIFF
--- a/.github/actions/snapsync-run/action.yml
+++ b/.github/actions/snapsync-run/action.yml
@@ -40,8 +40,9 @@ runs:
             el_image: ${ETHREX_IMAGE}:${ETHREX_TAG}
             el_extra_params:
               - "--syncmode=snap"
+              - "--log.level=debug"
             cl_type: lighthouse
-            cl_image: sigp/lighthouse:v8.0.0-rc.1
+            cl_image: sigp/lighthouse:v8.0.1
             count: 1
 
         network_params:

--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -6,8 +6,8 @@ on:
     paths:
       - ".github/workflows/daily_snapsync.yaml"
   schedule:
-    # Every day at UTC 03:00
-    - cron: "0 3 * * 1,2,3,4,5"
+    # Every 3 hours
+    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
       network:
@@ -32,7 +32,7 @@ jobs:
         run: |
           event_name="${GITHUB_EVENT_NAME}"
           if [[ "$event_name" == "schedule" ]]; then
-            json='[{"network":"hoodi","timeout":"30m"},{"network":"sepolia","timeout":"10h"}]'
+            json='[{"network":"hoodi","timeout":"30m"},{"network":"sepolia","timeout":"2h"}]'
           elif [[ "$event_name" == "pull_request" ]]; then
             json='[{"network":"hoodi","timeout":"30m"}]'
           else
@@ -43,7 +43,7 @@ jobs:
                 json='[{"network":"hoodi","timeout":"30m"}]'
                 ;;
               sepolia)
-                json='[{"network":"sepolia","timeout":"10h"}]'
+                json='[{"network":"sepolia","timeout":"2h"}]'
                 ;;
               *)
                 echo "::error::Unsupported network value '$network'. Allowed values: hoodi, sepolia."


### PR DESCRIPTION
**Motivation**
To make it easier to debug if something goes badly

**Description**
- Sets the job to be run every 3 hours
- Makes a more strict timeout of 2hrs for Sepolia to it's easier to catch regressions
- Sets the default log level to debug
