### PR TITLE
chore(l2): implement ecadd with substrate for ZisK and SP1

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -776,7 +776,7 @@ pub fn bn254_g1_add(first_point: G1, second_point: G1) -> Result<Bytes, VMError>
 #[cfg(any(feature = "sp1", feature = "zisk"))]
 #[inline]
 pub fn bn254_g1_add(first_point: G1, second_point: G1) -> Result<Bytes, VMError> {
-    use substrate_bn::{AffineG1, Fq, Group, G1 as SubstrateG1};
+    use substrate_bn::{AffineG1, Fq, G1 as SubstrateG1, Group};
 
     if first_point.is_zero() && second_point.is_zero() {
         return Ok(Bytes::from([0u8; 64].to_vec()));


### PR DESCRIPTION
To use the patched substrate-bn of both zkVMs.

Benchmarks for ZisK:

main (7722c65):
```
| Block    | Gas Used     | Steps         | Duration (s) | TP (Msteps/s) | Freq (MHz) | Clocks/step |
|----------|--------------|---------------|--------------|----------------|------------|--------------|
| 23919400 |   41,075,722 |   668,153,769 |      16.3140 |        40.9557 |  1999.0000 |      48.8088 |
| 23919500 |   40,237,085 |   777,636,222 |      18.2261 |        42.6661 |  1999.0000 |      46.8522 |
| 23919600 |   24,064,259 |   512,450,533 |      12.0544 |        42.5113 |  1999.0000 |      47.0228 |
| 23919700 |   20,862,238 |   445,609,968 |      10.6352 |        41.8996 |  1999.0000 |      47.7093 |
| 23919800 |   31,813,109 |   596,881,989 |      14.2796 |        41.7996 |  1999.0000 |      47.8234 |
| 23919900 |   22,917,739 |   404,876,652 |       9.9049 |        40.8764 |  1999.0000 |      48.9035 |
| 23920000 |   37,256,487 |   649,722,314 |      15.3030 |        42.4573 |  1999.0000 |      47.0826 |
| 23920100 |   33,542,307 |   598,963,230 |      14.1022 |        42.4729 |  1999.0000 |      47.0653 |
| 23920200 |   22,994,047 |   417,072,430 |      10.2212 |        40.8046 |  1999.0000 |      48.9895 |
| 23920300 |   53,950,967 |   966,469,904 |      23.0963 |        41.8452 |  1999.0000 |      47.7713 |
```

zisk_ecadd:
```
| Block    | Gas Used     | Steps         | Duration (s) | TP (Msteps/s) | Freq (MHz) | Clocks/step |
|----------|--------------|---------------|--------------|----------------|------------|--------------|
| 23919400 |   41,075,722 |   664,968,601 |      16.3159 |        40.7560 |  1999.0000 |      49.0480 |
| 23919500 |   40,237,085 |   775,906,640 |      18.2147 |        42.5978 |  1999.0000 |      46.9273 |
| 23919600 |   24,064,259 |   511,611,990 |      12.0984 |        42.2877 |  1999.0000 |      47.2714 |
| 23919700 |   20,862,238 |   444,896,241 |      10.4587 |        42.5382 |  1999.0000 |      46.9930 |
| 23919800 |   31,813,109 |   596,005,571 |      14.2294 |        41.8856 |  1999.0000 |      47.7252 |
| 23919900 |   22,917,739 |   404,355,231 |       9.7270 |        41.5704 |  1999.0000 |      48.0871 |
| 23920000 |   37,256,487 |   648,362,675 |      15.0888 |        42.9699 |  1999.0000 |      46.5209 |
| 23920100 |   33,542,307 |   598,148,173 |      14.2343 |        42.0217 |  1999.0000 |      47.5707 |
| 23920200 |   22,994,047 |   416,341,598 |       9.8153 |        42.4178 |  1999.0000 |      47.1265 |
| 23920300 |   53,950,967 |   964,216,522 |      22.9837 |        41.9521 |  1999.0000 |      47.6495 |
```

diff in steps:
```
23919400: -0.48%
23919500: -0.22%
23919600: -0.16%
23919700: -0.16%
23919800: -0.15% 
3919900: -0.13%
23920000: -0.21%
23920100: -0.14%
23920200: -0.18%
23920300: -0.23%
```