### PR TITLE
fix(l1): properly set p2p flag as disabled

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -202,7 +202,7 @@ pub struct Options {
         help_heading = "RPC options"
     )]
     pub authrpc_jwtsecret: String,
-    #[arg(long = "p2p.disabled", default_value = "false", value_name = "P2P_DISABLED", action = ArgAction::SetFalse, help_heading = "P2P options")]
+    #[arg(long = "p2p.disabled", default_value = "false", value_name = "P2P_DISABLED", action = ArgAction::SetTrue, help_heading = "P2P options")]
     pub p2p_disabled: bool,
     #[arg(
         long = "p2p.addr",


### PR DESCRIPTION
**Motivation**

The p2p disabled flag in the cli did nothing, as the default value was false and the action was setting it false.

**Description**

- Changed SetFalse for SetTrue
