### PR TITLE
chore(l1): remove unused rocksdb feature in ethrex-trie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rkyv",
- "rocksdb",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/crates/common/trie/Cargo.toml
+++ b/crates/common/trie/Cargo.toml
@@ -18,7 +18,6 @@ thiserror.workspace = true
 hex.workspace = true
 serde.workspace = true
 serde_json = "1.0.117"
-rocksdb = { workspace = true, optional = true }
 smallvec = { version = "1.10.0", features = ["const_generics", "union"] }
 digest = "0.10.6"
 lazy_static.workspace = true
@@ -28,7 +27,6 @@ rkyv.workspace = true
 
 [features]
 default = []
-rocksdb = ["dep:rocksdb"]
 
 
 [dev-dependencies]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -32,7 +32,7 @@ lru = "0.16.2"
 
 [features]
 default = []
-rocksdb = ["dep:rocksdb", "ethrex-trie/rocksdb", "dep:tokio"]
+rocksdb = ["dep:rocksdb", "dep:tokio"]
 
 [dev-dependencies]
 hex.workspace = true


### PR DESCRIPTION
**Motivation**

We had an unused "rocksdb" feature in the `ethrex-trie` crate

**Description**

This PR removes the feature.
