### PR TITLE
fix(l1): revert "reduce spammy trace-level logs during snap-sync (#5492)"

### DIFF
--- a/crates/common/trie/trie_sorted.rs
+++ b/crates/common/trie/trie_sorted.rs
@@ -6,6 +6,7 @@ use crossbeam::channel::{Receiver, Sender, bounded};
 use ethereum_types::H256;
 use ethrex_threadpool::ThreadPool;
 use std::{sync::Arc, thread::scope};
+use tracing::debug;
 
 /// The elements of the stack represent the branch node that is the parent of the current
 /// parent element. When the current parent is no longer valid (is not the parent of
@@ -138,6 +139,16 @@ fn add_current_to_parent_and_write_queue(
     };
     parent_element.element.choices[index as usize] =
         node.compute_hash_no_alloc(&mut nodehash_buffer).into();
+    debug!(
+        "branch {:x?}",
+        parent_element
+            .element
+            .choices
+            .iter()
+            .enumerate()
+            .filter_map(|(index, child)| child.is_valid().then_some(index))
+            .collect::<Vec<_>>()
+    );
     nodes_to_write.push((target_path, node));
     Ok(())
 }

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -330,7 +330,7 @@ impl GenServer for PeerConnectionServer {
                     trace!(
                         peer=%established_state.node,
                         %message,
-                        "Received incoming message",
+                        "Received incomming message",
                     );
                     handle_incoming_message(established_state, message).await
                 }

--- a/crates/networking/p2p/sync/state_healing.rs
+++ b/crates/networking/p2p/sync/state_healing.rs
@@ -19,7 +19,7 @@ use ethrex_common::{H256, constants::EMPTY_KECCACK_HASH, types::AccountState};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_storage::Store;
 use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, Node, TrieDB, TrieError};
-use tracing::{debug, trace};
+use tracing::debug;
 
 use crate::{
     metrics::{CurrentStepValue, METRICS},
@@ -119,9 +119,6 @@ async fn heal_state_trie(
     )>(1000);
     // Contains both nodes and their corresponding paths to heal
     let mut nodes_to_heal = Vec::new();
-
-    let mut logged_no_free_peers_count = 0;
-
     loop {
         if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             let num_peers = peers
@@ -235,16 +232,6 @@ async fn heal_state_trie(
                 else {
                     // If there are no peers available, re-add the batch to the paths vector, and continue
                     paths.extend(batch);
-
-                    // Log ~ once every 10 seconds
-                    if logged_no_free_peers_count == 0 {
-                        trace!("We are missing peers in heal_state_trie");
-                        logged_no_free_peers_count = 1000;
-                    }
-                    logged_no_free_peers_count -= 1;
-
-                    // Sleep a bit to avoid busy polling
-                    tokio::time::sleep(Duration::from_millis(10)).await;
                     continue;
                 };
 

--- a/crates/networking/p2p/sync/storage_healing.rs
+++ b/crates/networking/p2p/sync/storage_healing.rs
@@ -164,8 +164,6 @@ pub async fn heal_storage_trie(
     let (task_sender, mut task_receiver) =
         tokio::sync::mpsc::channel::<Result<TrieNodes, RequestStorageTrieNodes>>(1000);
 
-    let mut logged_no_free_peers_count = 0;
-
     loop {
         yield_now().await;
         if state.last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
@@ -249,7 +247,6 @@ pub async fn heal_storage_trie(
             peers,
             state.state_root,
             &task_sender,
-            &mut logged_no_free_peers_count,
         )
         .await;
 
@@ -320,24 +317,20 @@ async fn ask_peers_for_nodes(
     peers: &mut PeerHandler,
     state_root: H256,
     task_sender: &Sender<Result<TrieNodes, RequestStorageTrieNodes>>,
-    logged_no_free_peers_count: &mut u32,
 ) {
     if (requests.len() as u32) < MAX_IN_FLIGHT_REQUESTS && !download_queue.is_empty() {
         let Some((peer_id, connection)) = peers
             .peer_table
             .get_best_peer(&SUPPORTED_SNAP_CAPABILITIES)
             .await
-            .inspect_err(|err| debug!(?err, "Error requesting a peer to perform storage healing"))
+            .inspect_err(
+                |err| debug!(err= ?err, "Error requesting a peer to perform storage healing"),
+            )
             .unwrap_or(None)
         else {
-            // Log ~ once every 10 seconds
-            if *logged_no_free_peers_count == 0 {
-                trace!("We are missing peers in heal_storage_trie");
-                *logged_no_free_peers_count = 1000;
-            }
-            *logged_no_free_peers_count -= 1;
-            // Sleep for a bit to avoid busy polling
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            // warn!("We have no free peers for storage healing!"); way too spammy, moving to trace
+            // If we have no peers we shrug our shoulders and wait until next free peer
+            trace!("We have no free peers for storage healing!");
             return;
         };
         let at = download_queue.len().saturating_sub(STORAGE_BATCH_SIZE);


### PR DESCRIPTION
This reverts commit 610df53674f307c7d9e2259e45cb52cc1c2bcbf9.

**Motivation**

The reverted PR appear to have produced a regression in sepolia snapsyncing.

**Description**

Probably due to the added sleep, this PR appears to be causing a regresion during snapsync in sepolia. We are right now testing this and will open this PR for review when confirmed.
