### PR TITLE
chore(l1): remove hardcoded platform for ethrex in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,6 @@ services:
     container_name: ethrex
     image: "ghcr.io/lambdaclass/ethrex:main"
     pull_policy: always
-    platform: linux/amd64
     ports:
       - 127.0.0.1:8545:8545
     volumes:


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
We don't need to specify the `platform` for the docker image anymore, as we now build it for both `amd64` and `arm64`. Also, `amd64` images are not working anymore on arm machines due to AVX.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Remove the platform specified in the root's docker compose so it auto-detects which to use.

<!-- Link to issues: Resolves #111, Resolves #222 -->

