### PR TITLE
fix(l1): fix bpo1 validation

### DIFF
--- a/fixtures/networks/default.yaml
+++ b/fixtures/networks/default.yaml
@@ -30,6 +30,13 @@ participants:
 
 ethereum_metrics_exporter_enabled: true
 
+network_params:
+  electra_fork_epoch: 0
+  bpo_1_epoch: 0
+  bpo_1_max_blobs: 15
+  bpo_1_target_blobs: 10
+  bpo_1_base_fee_update_fraction: 8346193
+
 additional_services:
   - dora
   - spamoor


### PR DESCRIPTION
**Motivation**

We received a report that when setting bpo activation to 0 in kurtosis we weren't taking it into account

**Description**

Right now with our current setup, running `make localnet` starts a localnet with kurtosis and bpo1 activated in epoch 0. Unfortunately I'm not seeing the warn sign shown in #5602, instead everything appears to work correctly.

<img width="2388" height="904" alt="image" src="https://github.com/user-attachments/assets/7c502a03-977e-4a5c-89b9-222fc2882071" />

<img width="1384" height="396" alt="image" src="https://github.com/user-attachments/assets/5cb50627-f84c-4647-9d0b-b14da1270022" />

We need to work on reproduce the issue probably moving to ehereum-package main instead of the revision we are using by default and testing with latest from ethrex (7.0.0) instead of main.
