### PR TITLE
fix(l1): cancel background work when DB is dropped

### DIFF
--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -23,11 +23,11 @@ use tracing::{info, warn};
 #[derive(Debug)]
 struct DB(DBWithThreadMode<MultiThreaded>);
 
-impl Drop for RocksDBBackend {
+impl Drop for DB {
     fn drop(&mut self) {
         // Wait for all background work to finish before dropping the DB
         // See #5621 for why this is necessary
-        self.db.0.cancel_all_background_work(true);
+        self.0.cancel_all_background_work(true);
     }
 }
 


### PR DESCRIPTION
**Motivation**

After #5597, we're seeing some pthread errors when running unit tests. [It seems to be related to background workers not being joined with the main thread before the DB is dropped](https://github.com/facebook/rocksdb/issues/11349#issuecomment-2587107605).

**Description**

This PR adds a `Drop` implementation that waits for the background workers to stop before continuing.

The fix can be tested by running `ethrex-storage` unit tests in a loop:

```bash
#!/bin/bash
for i in $(seq 1 1000) ; do
    echo =========== TEST RUN $i ===========
    cargo test -p ethrex-storage -F rocksdb
    if [[ $? -ne 0 ]]; then
        echo
        echo "Failed in run $i"
        exit 1
    fi
done

```

Running it on main fails after ~15 times, but on this branch, it no longer fails with this error.