### PR TITLE
ci(l1): bump hoodi timeout to 1h30m

### DIFF
--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -32,15 +32,15 @@ jobs:
         run: |
           event_name="${GITHUB_EVENT_NAME}"
           if [[ "$event_name" == "schedule" ]]; then
-            json='[{"network":"hoodi","timeout":"1h"},{"network":"sepolia","timeout":"2h30m"}]'
+            json='[{"network":"hoodi","timeout":"1h30m"},{"network":"sepolia","timeout":"2h30m"}]'
           elif [[ "$event_name" == "pull_request" ]]; then
-            json='[{"network":"hoodi","timeout":"1h"}]'
+            json='[{"network":"hoodi","timeout":"1h30m"}]'
           else
             network=$(jq -r '.inputs.network // empty' "$GITHUB_EVENT_PATH")
 
             case "$network" in
               hoodi)
-                json='[{"network":"hoodi","timeout":"1h"}]'
+                json='[{"network":"hoodi","timeout":"1h30m"}]'
                 ;;
               sepolia)
                 json='[{"network":"sepolia","timeout":"2h30m"}]'


### PR DESCRIPTION
**Motivation**

We recently got a failure in the CI due to Hoodi reaching the timeout limit: https://github.com/lambdaclass/ethrex/actions/runs/20176312201/job/57925180164

**Description**

This PR bumps the Hoodi timeout to 1h30m
