### PR TITLE
chore(l1): put all discv5 behind a feature flag

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -101,6 +101,8 @@ jemalloc_profiling = [
   "ethrex-rpc/jemalloc_profiling",
 ]
 sync-test = ["ethrex-p2p/sync-test"]
+# discv5 is currently experimental and should only be enabled for development purposes
+discv5 = ["ethrex-p2p/discv5"]
 
 l2 = [
   "ethrex-l2",

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -66,6 +66,8 @@ sync-test = []
 l2 = ["dep:ethrex-storage-rollup"]
 test-utils = []
 metrics = ["dep:ethrex-metrics"]
+# discv5 is currently experimental and should only be enabled for development purposes
+discv5 = []
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/crates/networking/p2p/p2p.rs
+++ b/crates/networking/p2p/p2p.rs
@@ -1,4 +1,5 @@
 pub mod discv4;
+#[cfg(feature = "discv5")]
 pub mod discv5;
 pub(crate) mod metrics;
 pub mod network;


### PR DESCRIPTION
**Motivation**

In order to start merging discv5 code into main, to avoid having a huge PR at the end of the development, we should create a feature flag disabled by default.

Closes #5639

