### PR TITLE
chore(l1): add a message related to a snapsync edge case

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -786,7 +786,7 @@ impl Syncer {
                     }
 
                     warn!("Storage could not be downloaded after multiple attempts. Marking for healing.
-                        This could severely impact snap sync time, please consider stopping the node and resyncing.");
+                        This could impact snap sync time (healing may take a while).");
 
                     storage_accounts.accounts_with_storage_root.clear();
                 }


### PR DESCRIPTION
**Motivation**

If we cant get storages after some retries we just mark everything for healing. This could take a really long time, we want to make it clear.

**Description**

Add a warn log related to this edge case