### PR TITLE
feat(l1): add discv5 session structures and remaining official vector tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,6 +3925,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 0.4.1",
+ "hkdf",
  "hmac",
  "indexmap 2.12.1",
  "lazy_static",
@@ -5210,6 +5211,15 @@ name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -2363,6 +2363,7 @@ dependencies = [
  "ethrex-trie",
  "futures",
  "hex",
+ "hkdf",
  "hmac",
  "indexmap 2.11.4",
  "lazy_static",
@@ -3095,6 +3096,15 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -50,6 +50,8 @@ aes-gcm = "0.10.3"
 ctr = "0.9.2"
 rand = "0.8.5"
 
+hkdf = "0.12.4"
+
 rayon = "1.10.0"
 crossbeam.workspace = true
 

--- a/crates/networking/p2p/discv5/codec.rs
+++ b/crates/networking/p2p/discv5/codec.rs
@@ -1,42 +1,68 @@
-use crate::discv5::messages::{Packet, PacketDecodeErr};
+use crate::discv5::messages::{Packet, PacketCodecError};
+use crate::discv5::session::Session;
 
 use bytes::BytesMut;
 use ethrex_common::H256;
+use rand::{RngCore, thread_rng};
 use tokio_util::codec::{Decoder, Encoder};
 
 #[derive(Debug)]
 pub struct Discv5Codec {
     dest_id: H256,
-    nonce: u128,
-    key: Vec<u8>,
+    /// Outgoing message count, used for nonce generation as per the spec.
+    counter: u32,
+    session: Option<Session>,
 }
 
 impl Discv5Codec {
     pub fn new(dest_id: H256) -> Self {
         Self {
             dest_id,
-            nonce: rand::random(),
-            key: vec![],
+            counter: 0,
+            session: None,
         }
     }
 
-    fn new_nonce(&mut self) -> [u8; 12] {
-        self.nonce = self.nonce.wrapping_add(1);
-        let mut bytes = [0u8; 12];
-        bytes.copy_from_slice(&self.nonce.to_be_bytes()[4..]);
-        bytes
+    pub fn with_session(dest_id: H256, session: Session) -> Self {
+        Self {
+            dest_id,
+            counter: 0,
+            session: Some(session),
+        }
+    }
+
+    pub fn set_session(&mut self, session: Session) {
+        self.session = Some(session);
+    }
+
+    /// Generates a 96-bit AES-GCM nonce
+    /// ## Spec Recommendation
+    /// Encode the current outgoing message count into the first 32 bits of the nonce and fill the remaining 64 bits with random data generated
+    /// by a cryptographically secure random number generator.
+    pub fn next_nonce<R: RngCore>(&mut self, rng: &mut R) -> [u8; 12] {
+        let counter = self.counter;
+        self.counter = self.counter.wrapping_add(1);
+
+        let mut nonce = [0u8; 12];
+        nonce[..4].copy_from_slice(&counter.to_be_bytes());
+        rng.fill_bytes(&mut nonce[4..]);
+        nonce
     }
 }
 
 impl Decoder for Discv5Codec {
     type Item = Packet;
-    type Error = PacketDecodeErr;
+    type Error = PacketCodecError;
 
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if !buf.is_empty() {
+            let key: &[u8] = match &self.session {
+                Some(session) => session.inbound_key(),
+                None => &[],
+            };
             Ok(Some(Packet::decode(
                 &self.dest_id,
-                &self.key,
+                key,
                 &buf.split_to(buf.len()),
             )?))
         } else {
@@ -46,11 +72,19 @@ impl Decoder for Discv5Codec {
 }
 
 impl Encoder<Packet> for Discv5Codec {
-    type Error = PacketDecodeErr;
+    type Error = PacketCodecError;
 
-    fn encode(&mut self, package: Packet, buf: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, packet: Packet, buf: &mut BytesMut) -> Result<(), Self::Error> {
         let masking_iv: u128 = rand::random();
-        let nonce = self.new_nonce();
-        package.encode(buf, masking_iv, &nonce, &self.dest_id, &self.key)
+        let mut rng = thread_rng();
+        let nonce = self.next_nonce(&mut rng);
+        // key isnt needed in WHOAREYOU packets
+        let key = match (&packet, &mut self.session) {
+            (Packet::WhoAreYou(_), _) => &[][..],
+            (_, Some(session)) => session.outbound_key(),
+            (_, None) => return Err(PacketCodecError::SessionNotEstablished),
+        };
+
+        packet.encode(buf, masking_iv, &nonce, &self.dest_id, key)
     }
 }

--- a/crates/networking/p2p/discv5/mod.rs
+++ b/crates/networking/p2p/discv5/mod.rs
@@ -1,2 +1,3 @@
 pub mod codec;
 pub mod messages;
+pub mod session;

--- a/crates/networking/p2p/discv5/session.rs
+++ b/crates/networking/p2p/discv5/session.rs
@@ -1,0 +1,196 @@
+use ethrex_common::H256;
+use hkdf::Hkdf;
+use secp256k1::{
+    Message as SecpMessage, PublicKey, SECP256K1, SecretKey, ecdh::shared_secret_point,
+    ecdsa::Signature,
+};
+use sha2::{Digest, Sha256};
+
+/// Role of the local node in the given session
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionRole {
+    Initiator,
+    Recipient,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionKeys {
+    pub initiator_key: [u8; 16],
+    pub recipient_key: [u8; 16],
+}
+
+/// A discv5 session
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Session {
+    pub keys: SessionKeys,
+    pub role: SessionRole,
+}
+
+impl Session {
+    pub fn new(keys: SessionKeys, role: SessionRole) -> Self {
+        Self { keys, role }
+    }
+
+    pub fn outbound_key(&self) -> &[u8; 16] {
+        match self.role {
+            SessionRole::Initiator => &self.keys.initiator_key,
+            SessionRole::Recipient => &self.keys.recipient_key,
+        }
+    }
+
+    pub fn inbound_key(&self) -> &[u8; 16] {
+        match self.role {
+            SessionRole::Initiator => &self.keys.recipient_key,
+            SessionRole::Recipient => &self.keys.initiator_key,
+        }
+    }
+}
+
+/// Builds the challenge-data from a WHOAREYOU packet
+pub fn build_challenge_data(masking_iv: &[u8], static_header: &[u8], authdata: &[u8]) -> Vec<u8> {
+    let mut data = Vec::with_capacity(masking_iv.len() + static_header.len() + authdata.len());
+    data.extend_from_slice(masking_iv);
+    data.extend_from_slice(static_header);
+    data.extend_from_slice(authdata);
+    data
+}
+
+/// Derives initiator/recipient keys from the handshake
+pub fn derive_session_keys(
+    ephemeral_key: &SecretKey,
+    dest_pubkey: &PublicKey,
+    node_id_a: &H256,
+    node_id_b: &H256,
+    challenge_data: &[u8],
+) -> SessionKeys {
+    let shared_secret = compressed_shared_secret(dest_pubkey, ephemeral_key);
+    let hkdf = Hkdf::<Sha256>::new(Some(challenge_data), &shared_secret);
+
+    let mut kdf_info = b"discovery v5 key agreement".to_vec();
+    kdf_info.extend_from_slice(node_id_a.as_bytes());
+    kdf_info.extend_from_slice(node_id_b.as_bytes());
+
+    let mut key_data = [0u8; 32];
+    hkdf.expand(&kdf_info, &mut key_data)
+        .expect("key_data is 32 bytes long, it can never fail");
+
+    SessionKeys {
+        initiator_key: key_data[..16].try_into().expect("sizes always match"),
+        recipient_key: key_data[16..].try_into().expect("sizes always match"),
+    }
+}
+
+/// Signs the id-signature input used in the handshake
+pub fn create_id_signature(
+    static_key: &SecretKey,
+    challenge_data: &[u8],
+    ephemeral_pubkey: &[u8],
+    node_id_b: &H256,
+) -> Signature {
+    /*
+    *  id-signature-text  = "discovery v5 identity proof"
+       id-signature-input = id-signature-text || challenge-data || ephemeral-pubkey || node-id-B
+       id-signature       = id_sign(sha256(id-signature-input))
+    */
+    let mut id_signature_input = b"discovery v5 identity proof".to_vec();
+    id_signature_input.extend_from_slice(challenge_data);
+    id_signature_input.extend_from_slice(ephemeral_pubkey);
+    id_signature_input.extend_from_slice(node_id_b.as_bytes());
+
+    let digest = Sha256::digest(&id_signature_input);
+    let message = SecpMessage::from_digest_slice(&digest).expect("32 byte digest");
+    SECP256K1.sign_ecdsa(&message, static_key)
+}
+
+/// Creates a secret through elliptic-curve Diffie-Hellman key agreement
+///
+/// ecdh(pubkey, privkey) from the spec
+///
+/// https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#identity-specific-cryptography-in-the-handshake
+fn compressed_shared_secret(dest_pubkey: &PublicKey, ephemeral_key: &SecretKey) -> [u8; 33] {
+    let xy_point = shared_secret_point(dest_pubkey, ephemeral_key);
+    let mut compressed = [0u8; 33];
+    let y = &xy_point[32..];
+    compressed[0] = if y[31] & 1 == 0 { 0x02 } else { 0x03 };
+    compressed[1..].copy_from_slice(&xy_point[..32]);
+    compressed
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::discv5::codec::Discv5Codec;
+
+    use super::*;
+    use hex_literal::hex;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    #[test]
+    fn derivation_matches_vector() {
+        let ephemeral_key = SecretKey::from_byte_array(&hex!(
+            "fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+        ))
+        .unwrap();
+        let dest_pubkey = PublicKey::from_slice(&hex!(
+            "0317931e6e0840220642f230037d285d122bc59063221ef3226b1f403ddc69ca91"
+        ))
+        .unwrap();
+        let node_id_a = H256::from_slice(&hex!(
+            "aaaa8419e9f49d0083561b48287df592939a8d19947d8c0ef88f2a4856a69fbb"
+        ));
+        let node_id_b = H256::from_slice(&hex!(
+            "bbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
+        ));
+        let challenge_data = hex!(
+            "000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000"
+        );
+
+        let keys = derive_session_keys(
+            &ephemeral_key,
+            &dest_pubkey,
+            &node_id_a,
+            &node_id_b,
+            &challenge_data,
+        );
+        assert_eq!(keys.initiator_key, hex!("dccc82d81bd610f4f76d3ebe97a40571"));
+        assert_eq!(keys.recipient_key, hex!("ac74bb8773749920b0d3a8881c173ec5"));
+    }
+
+    #[test]
+    fn id_signature_matches_vector() {
+        let static_key = SecretKey::from_byte_array(&hex!(
+            "fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"
+        ))
+        .unwrap();
+        let challenge_data = hex!(
+            "000000000000000000000000000000006469736376350001010102030405060708090a0b0c00180102030405060708090a0b0c0d0e0f100000000000000000"
+        );
+        let ephemeral_pubkey =
+            hex!("039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231");
+        let node_id_b = H256::from_slice(&hex!(
+            "bbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9"
+        ));
+
+        let signature =
+            create_id_signature(&static_key, &challenge_data, &ephemeral_pubkey, &node_id_b);
+        assert_eq!(
+            signature.serialize_compact(),
+            hex!(
+                "94852a1e2318c4e5e9d422c98eaf19d1d90d876b29cd06ca7cb7546d0fff7b484fe86c09a064fe72bdbef73ba8e9c34df0cd2b53e9d65528c2c7f336d5dfc6e6"
+            )
+        );
+    }
+
+    #[test]
+    fn test_next_nonce_counter() {
+        let mut codec = Discv5Codec::new(H256::zero());
+
+        let mut rng = StdRng::seed_from_u64(7);
+
+        let n1 = codec.next_nonce(&mut rng);
+        let n2 = codec.next_nonce(&mut rng);
+
+        assert_eq!(&n1[..4], &[0, 0, 0, 0]);
+        assert_eq!(&n2[..4], &[0, 0, 0, 1]);
+        assert_ne!(&n1[4..], &n2[4..]);
+    }
+}


### PR DESCRIPTION
**Motivation**

Adds a Session struct and related functions to the discv5 module, this represents a session established from a handshake. This PR does not implement the handshake protocol, but it lays a path to doing so easily.

This is based on reading https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md#sessions

This allows us to add the remaining test vectors related to cryptography, which is done now.

Also renamed the PacketDecodeErr to PacketCodecError, since the error was also used when encoding and for other things.

Fixed nonce generation to be secure according to the spec

