### PR TITLE
feat(l1): expose fkv progress

### DIFF
--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -74,10 +74,7 @@ pub mod trie;
 pub mod utils;
 
 pub use layering::apply_prefix;
-pub use store::{
-    AccountUpdatesList, EngineType, FKV_COMPLETION_MARKER_LEN, Store, UpdateBatch, hash_address,
-    hash_key,
-};
+pub use store::{AccountUpdatesList, EngineType, Store, UpdateBatch, hash_address, hash_key};
 
 /// Store Schema Version, must be updated on any breaking change.
 ///


### PR DESCRIPTION
**Motivation**

To support the geth2ethrex tool, we want to be able to tell the user when FKV generation is complete and how far we are into the process.

**Description**

This PR exposes that information.



