### PR TITLE
feat(l1): warn when using same port for WS and HTTP

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -372,6 +372,12 @@ pub async fn start_api(
     info!("Starting Auth-RPC server at {authrpc_addr}");
 
     if let Some(address) = ws_addr {
+        if address.port() == http_addr.port() {
+            warn!(
+                "WebSocket server port is the same as HTTP server port: {}. This may cause conflicts.",
+                address.port()
+            );
+        }
         let ws_handler = |ws: WebSocketUpgrade, ctx| async {
             ws.on_upgrade(|socket| handle_websocket(socket, ctx))
         };


### PR DESCRIPTION
**Motivation**

We recently had a problem where RPC requests were failing. It was caused due to WS overriding the HTTP API when they were mapped to the same port.

**Description**

This PR adds a warning when this happens.

This should be removed once #4761 is done
