### PR TITLE
chore(l1): bump number of storage request attempts

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -755,7 +755,7 @@ impl Syncer {
                     storage_accounts.accounts_with_storage_root.len()
                 );
                 storage_range_request_attempts += 1;
-                if storage_range_request_attempts < 3 {
+                if storage_range_request_attempts < 5 {
                     chunk_index = self
                         .peers
                         .request_storage_ranges(


### PR DESCRIPTION
**Motivation**

We're currently testing #5660 for possible regressions. We already noticed some pretty big sync-time improvements with it, so we're temporarily bumping the number of attempts while we finish testing.

**Description**

This PR bumps the number of attempts before skipping the "request storage ranges" step from 3 (2 pivot changes) to 5 (4 pivot changes).