### PR TITLE
ci(l1): exclude prover packages from L1 tests

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          cargo test --workspace --exclude ethrex-l2
+          cargo test --workspace --exclude 'ethrex-l2*' --exclude ethrex-prover --exclude guest_program
 
       - name: Run Blockchain EF tests
         if: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
L1 tests are compiling L2 packages. We noticed it in [this CI run](https://github.com/lambdaclass/ethrex/actions/runs/20462543412/job/58798420057)

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Exclude `ethrex-prover` and `guest_program` packages from L1 CI tests. Changed `ethrex-l2` with `ethrex-l2*` to also exclude other L2 packages

<!-- Link to issues: Resolves #111, Resolves #222 -->


