### PR TITLE
fix(l2): revert substrate-bn patched `ecadd` precompile for SP1

### DIFF
--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -743,7 +743,7 @@ pub fn ecadd(calldata: &Bytes, gas_remaining: &mut u64, _fork: Fork) -> Result<B
     bn254_g1_add(first_point, second_point)
 }
 
-#[cfg(not(any(feature = "zisk")))]
+#[cfg(not(feature = "zisk"))]
 #[inline]
 pub fn bn254_g1_add(first_point: G1, second_point: G1) -> Result<Bytes, VMError> {
     let first_point_x = ark_bn254::Fq::from_be_bytes_mod_order(&first_point.0.to_big_endian());
@@ -799,7 +799,7 @@ pub fn bn254_g1_add(first_point: G1, second_point: G1) -> Result<Bytes, VMError>
     Ok(Bytes::from(out))
 }
 
-#[cfg(any(feature = "zisk"))]
+#[cfg(feature = "zisk")]
 #[inline]
 pub fn bn254_g1_add(first_point: G1, second_point: G1) -> Result<Bytes, VMError> {
     // SP1 patches the substrate-bn crate too, but some Ethereum Mainnet blocks fail to execute with it with a GasMismatch error


### PR DESCRIPTION
**Motivation**

https://github.com/lambdaclass/ethrex/pull/5535 introduced a version of ecadd that uses substrate-bn, because both ZisK and SP1 patch this crate to use zkVM accelerators for the operation.

After merging, we found an Ethereum Mainnet block failing to execute with a gas mismatch error, which does not happen one commit before merging that PR.

This PR reverts the usage of substrate-bn for SP1 only.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

