### PR TITLE
fix(l2): remove initial value from CommonBridge's shared bridge variable

### DIFF
--- a/crates/l2/contracts/src/l1/CommonBridge.sol
+++ b/crates/l2/contracts/src/l1/CommonBridge.sol
@@ -110,7 +110,7 @@ contract CommonBridge is
     uint256 private pendingPrivilegedTxIndex;
 
     /// @notice Address of the SharedBridgeRouter contract
-    address public SHARED_BRIDGE_ROUTER = address(0);
+    address public SHARED_BRIDGE_ROUTER;
 
     /// @notice Chain ID of the network
     uint256 public CHAIN_ID;


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Upgradeable contracts cannot have initial values in variable declaration. Instead, they need to be initialized in an initializer.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Remove initial value from `SHARED_BRIDGE_ROUTER`.

<!-- Link to issues: Resolves #111, Resolves #222 -->
