### PR TITLE
fix(l2): log message typo

### DIFF
--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -611,7 +611,7 @@ impl Command {
                 info!("Pausing contract {}", opts.contract_address);
                 opts.call_contract(PAUSE_CONTRACT_SELECTOR, vec![])
                     .await
-                    .inspect(|_| info!("Succesfully paused contract"))?;
+                    .inspect(|_| info!("Successfully paused contract"))?;
             }
             Command::Unpause {
                 contract_call_options: opts,
@@ -619,7 +619,7 @@ impl Command {
                 info!("Unpausing contract {}", opts.contract_address);
                 opts.call_contract(UNPAUSE_CONTRACT_SELECTOR, vec![])
                     .await
-                    .inspect(|_| info!("Succesfully unpaused contract"))?;
+                    .inspect(|_| info!("Successfully unpaused contract"))?;
             }
             Command::Deploy { options } => {
                 deploy_l1_contracts(options).await?;
@@ -686,7 +686,7 @@ async fn delete_batch_from_rollup_store(batch: u64, rollup_store_dir: &Path) -> 
         .and_then(|kept_blocks| kept_blocks.iter().max().cloned())
         .unwrap_or(0);
     rollup_store.revert_to_batch(batch).await?;
-    info!("Succesfully deleted batch from rollup store");
+    info!("Successfully deleted batch from rollup store");
     Ok(last_kept_block)
 }
 

--- a/crates/common/trie/trie.rs
+++ b/crates/common/trie/trie.rs
@@ -152,7 +152,7 @@ impl Trie {
     }
 
     /// Remove a value from the trie given its RLP-encoded path.
-    /// Returns the value if it was succesfully removed or None if it wasn't part of the trie
+    /// Returns the value if it was successfully removed or None if it wasn't part of the trie
     pub fn remove(&mut self, path: &[u8]) -> Result<Option<ValueRLP>, TrieError> {
         self.dirty.insert(Nibbles::from_bytes(path));
         if !self.root.is_valid() {

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -672,7 +672,7 @@ pub async fn update_pivot(
 
         // Reward peer
         peers.peer_table.record_success(&peer_id).await?;
-        info!("Succesfully updated pivot");
+        info!("Successfully updated pivot");
         let block_headers = peers
             .request_block_headers(block_number + 1, pivot.hash())
             .await?
@@ -705,7 +705,7 @@ pub async fn validate_state_root(store: Store, state_root: H256) -> bool {
     .expect("We should be able to create threads");
 
     if validated.is_ok() {
-        info!("Succesfully validated tree, {state_root} found");
+        info!("Successfully validated tree, {state_root} found");
     } else {
         error!("We have failed the validation of the state tree");
         std::process::exit(1);

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -1700,7 +1700,7 @@ pub fn generic_system_contract_levm(
         ..Default::default()
     };
 
-    // This check is not necessary in practice, since contract deployment has succesfully happened in all relevant testnets and mainnet
+    // This check is not necessary in practice, since contract deployment has successfully happened in all relevant testnets and mainnet
     // However, it's necessary to pass some of the Hive tests related to system contract deployment, which is why we have it
     // The error that should be returned for the relevant contracts is indicated in the following:
     // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7002.md#empty-code-failure

--- a/tooling/sync/docker_monitor.py
+++ b/tooling/sync/docker_monitor.py
@@ -215,7 +215,7 @@ VALIDATION_PROGRESS_PATTERNS = [
     ("Starting validate_storage_root", "validating storage roots"),
     ("Starting validate_bytecodes", "validating bytecodes"),
     ("Finished validate_storage_root", "storage validation complete"),
-    ("Succesfully validated tree", "state validation complete"),
+    ("Successfully validated tree", "state validation complete"),
 ]
 
 


### PR DESCRIPTION
**Motivation**

I just switched to running Ethrex and noticed a recurring typo in the logs

**Description**

This PR fixes the spelling of "successfully" in a few of the log messages. I noticed it specifically in the `Block with hash 0x... executed and added to storage succesfully` log message, but did a ctrl+f and found a few more instances.

