### PR TITLE
chore(l1): revert "fixed branch for daily engine test until hive merges the solution in main"

### DIFF
--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -125,10 +125,6 @@ jobs:
             FLAGS+=" --sim.buildarg branch=d08382ae5c808680e976fce4b73f4ba91647199b"
           fi
 
-          if [[ "$SIMULATION" == "ethereum/engine" ]]; then
-            FLAGS+=" --sim.buildarg branch=73fb4440b1fe4b362bf66e6278ec7d46b254f362"
-          fi
-
           if [[ -n "$SIM_LIMIT" ]]; then
             FLAGS+=" --sim.limit \"$SIM_LIMIT\""
           fi


### PR DESCRIPTION
Reverts lambdaclass/ethrex#5721, as commented there this was a temporal fix waiting for hive to merge: https://github.com/ethereum/hive/pull/1377, now that's merged it shouldn't be needed.