### PR TITLE
ci(l1,l2): avoid running CI tests on docs-only changes

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -3,6 +3,8 @@ name: L2 (SP1 Backend)
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     paths:
       - ".github/workflows/main_prover.yaml"

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -2,9 +2,13 @@ name: L1
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
   merge_group:
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/pr-main_l1_l2_dev.yaml
+++ b/.github/workflows/pr-main_l1_l2_dev.yaml
@@ -2,9 +2,13 @@ name: L2 Dev
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
   merge_group:
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -2,9 +2,13 @@ name: L2 (without proving)
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
   merge_group:
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -2,8 +2,12 @@ name: L2 Prover
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -2,8 +2,12 @@ name: L2 TDX build
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->
Changes to docs are slow because of waiting pointless tests.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Avoid running tests if the changes are only in `docs/`. According to [GH docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths):
> If any path names do not match patterns in paths-ignore, even if some path names match the patterns, the workflow will run.
So we are guaranteed that the tests are going to run if there is at least one non-docs change

<!-- Link to issues: Resolves #111, Resolves #222 -->

Resolves #3323 