### PR TITLE
perf(levm): change accessed_storage_slots from btree to fxhashmap

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -22,6 +22,7 @@ use ethrex_common::{
     tracing::CallType,
     types::{AccessListEntry, Code, Fork, Log, Transaction, fee_config::FeeConfig},
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -47,7 +48,7 @@ pub struct Substate {
 
     selfdestruct_set: HashSet<Address>,
     accessed_addresses: HashSet<Address>,
-    accessed_storage_slots: BTreeMap<Address, BTreeSet<H256>>,
+    accessed_storage_slots: FxHashMap<Address, FxHashSet<H256>>,
     created_accounts: HashSet<Address>,
     pub refunded_gas: u64,
     transient_storage: TransientStorage,
@@ -57,7 +58,7 @@ pub struct Substate {
 impl Substate {
     pub fn from_accesses(
         accessed_addresses: HashSet<Address>,
-        accessed_storage_slots: BTreeMap<Address, BTreeSet<H256>>,
+        accessed_storage_slots: FxHashMap<Address, FxHashSet<H256>>,
     ) -> Self {
         Self {
             parent: None,
@@ -563,7 +564,7 @@ impl Substate {
     pub fn initialize(env: &Environment, tx: &Transaction) -> Result<Substate, VMError> {
         // Add sender and recipient to accessed accounts [https://www.evm.codes/about#access_list]
         let mut initial_accessed_addresses = HashSet::new();
-        let mut initial_accessed_storage_slots: BTreeMap<Address, BTreeSet<H256>> = BTreeMap::new();
+        let mut initial_accessed_storage_slots: FxHashMap<Address, FxHashSet<H256>> = FxHashMap::default();
 
         // Add Tx sender to accessed accounts
         initial_accessed_addresses.insert(env.origin);


### PR DESCRIPTION
**Motivation**

Perf experiment, change btree to fxhash

Closes #5757

I would say there is no relevant change in performance

<img width="1525" height="613" alt="image" src="https://github.com/user-attachments/assets/f54f565e-b027-46c1-a6cf-2638d2a4808c" />



### Improvements
- Memory access with large memory expansion: **~1.21× faster**
- `CODECOPY` (fixed src/dst, 0.25× max code size): **~1.19× faster**  
- Additional memory expansion paths: **~1.12× faster**
- Arithmetic ops:
  - `MOD` (various bit widths): **~1.08–1.12× faster**
  - `DIV`: **~1.11× faster**
- `CALLDATACOPY` (various non-zero data patterns): **~1.09–1.11× faster**

### Regressions
- `CALLDATACOPY` (other data/layout patterns): **~1.19–1.22× slower**
- Initcode `JUMPDEST` analysis: **~1.17× slower**
- `JUMPDESTS`: **~1.14× slower**
- `RETURNDATACOPY`: **~1.14× slower**
- `CODECOPY` (fixed src/dst, 0.75× max code size): **~1.14× slower**  
- `CALLDATASIZE` (various lengths): **~1.12–1.13× slower**
- `SWAP1`: **~1.12× slower**


