### PR TITLE
docs(levm): align LEVM database docs with implementation

### DIFF
--- a/docs/vm/levm/database.md
+++ b/docs/vm/levm/database.md
@@ -2,8 +2,8 @@
 
 ## Database
 
-`Database` is a trait in LEVM. Any execution client that wants to use LEVM as its EVM should implement this trait on the struct they use for accessing the state trie. It has methods for interacting with it like `get_account_info(address)` and `get_storage_slot(address, key)`.\
-Even though in LEVM we can abstract from the actual implementation, it’s useful to know that the Database is actually a [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/).
+`Database` is a trait in LEVM. Any execution client that wants to use LEVM as its EVM should implement this trait on the struct they use for accessing the state trie. It defines methods such as `get_account_state(address)`, `get_storage_value(address, key)`, `get_block_hash(block_number)`, `get_chain_config()` and `get_account_code(code_hash)` for interacting with the underlying state.\
+Even though in LEVM we can abstract from the actual implementation, it’s useful to know that the Database is typically backed by a [Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/).
 The database can be either on-disk or in-memory. In a real case scenario it is usually the former one.
 
 ## CacheDB
@@ -12,7 +12,7 @@ LEVM exposes an `execute()` method just for executing transactions. Every time t
 
 For example, imagine that in the first transaction of a block an account sends all its Ether to another account, and after that, there is another transaction in which that same account wants to call a contract. That last transaction should fail because the account has no Ether left for paying for the execution of that contract. The thing is, if we look at the Database we'll see that the account still has balance because it hasn't been updated yet!
 
-The current solution to this is persisting the uncommitted storage in memory. In LEVM, this is done using the `CacheDB` struct, which is simply a `HashMap<Address, Account>`. Therefore, after executing any transaction we mutate this struct over and over again, storing all the accounts that have been gathered from the `Database` and that have potentially been updated! So that if we want to access information of an account or a storage slot we first check if it's in the `CacheDB`, and if it's not then we query the `Database` and insert the data into our cache. This is useful for tracking changes within and across transactions and it also reduces queries to the database, which impacts performance.
+The current solution to this is persisting the uncommitted storage in memory. In LEVM, this is done using the `CacheDB` struct, which is an in-memory map from `Address` to `LevmAccount` (a LEVM-specific account representation). Therefore, after executing any transaction we mutate this struct over and over again, storing all the accounts that have been gathered from the `Database` and that have potentially been updated! So that if we want to access information of an account or a storage slot we first check if it's in the `CacheDB`, and if it's not then we query the `Database` and insert the data into our cache. This is useful for tracking changes within and across transactions and it also reduces queries to the database, which impacts performance.
 
 ## Generalized Database
 


### PR DESCRIPTION
**Description**

Updated the LEVM database documentation to match the current Database trait and CacheDB type. The text now references the actual method set (get_account_state, get_storage_value, get_block_hash, get_chain_config, get_account_code) and describes CacheDB as a map from Address to LevmAccount instead of a generic Account map.

