### PR TITLE
chore(l1, l2): remove levm substate backups

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -313,7 +313,6 @@ pub struct VM<'a> {
     pub db: &'a mut GeneralizedDatabase,
     pub tx: Transaction,
     pub hooks: Vec<Rc<RefCell<dyn Hook>>>,
-    pub substate_backups: Vec<Substate>,
     /// Original storage values before the transaction. Used for gas calculations in SSTORE.
     pub storage_original_values: BTreeMap<(Address, H256), U256>,
     /// When enabled, it "logs" relevant information during execution
@@ -351,7 +350,6 @@ impl<'a> VM<'a> {
             db,
             tx: tx.clone(),
             hooks: get_hooks(&vm_type),
-            substate_backups: Vec::new(),
             storage_original_values: BTreeMap::new(),
             tracer,
             debug_mode: DebugMode::disabled(),


### PR DESCRIPTION
**Motivation**

Substate backups are no longer used by the vm; they can be removed.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.


