### PR TITLE
refactor(l1,l2): simplify BranchNode::remove own-value case

### DIFF
--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -200,8 +200,7 @@ impl BranchNode {
         } else {
             // Remove own value (if it has one) and return it
             if !self.value.is_empty() {
-                let value = mem::take(&mut self.value);
-                (!value.is_empty()).then_some(value)
+                Some(mem::take(&mut self.value))
             } else {
                 None
             }


### PR DESCRIPTION
**Motivation**

Internal check `!value.is_empty()` after if `!self.value.is_empty()` is always true, this is an unnecessary branch.

**Description**

Simplify the own-value removal branch in BranchNode::remove by dropping the redundant emptiness check after mem::take. At that point self.value is already known to be non-empty, so the returned value cannot be empty. This keeps the external behavior unchanged while removing dead code and making the control flow clearer.
