### PR TITLE
docs(l1): fix broken link

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -9,7 +9,7 @@ The client supports running in two different modes:
 ## Quickstart L1
 
 > [!CAUTION]
-> Before starting, ensure your hardware meets the [hardware requirements](./hardware_requirements.md).
+> Before starting, ensure your hardware meets the [hardware requirements](../getting-started/hardware_requirements.md).
 
 Follow these steps to sync an ethrex node on the Hoodi testnet.
 


### PR DESCRIPTION
**Motivation**

Currently if you go to [the docs](https://docs.ethrex.xyz/), the "hardware requirements" link inside the caution box will point to the wrong address.

**Description**

This is caused by [a bug in mdbook](https://github.com/rust-lang/mdBook/issues/2060)

We can't use absolute links since those would break local viewing, so a workaround is to go back to the root and then back up again.
