### PR TITLE
chore(l2): remove unwanted error log on L2

### DIFF
--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -112,9 +112,9 @@ impl TrieLayerCache {
         if parent == state_root && key_values.is_empty() {
             return;
         } else if parent == state_root {
-            // L1 always changes the state root (system contracts run even on empty blocks), so this
-            // is inconsistent there. L2 can legitimately keep the same root on empty blocks because
-            // it has no system contract calls.
+            // L1 always changes the state root (system contracts run even on empty blocks), so
+            // this should not happen there. L2 can legitimately keep the same root on empty blocks
+            // because it has no system contract calls.
             tracing::trace!("parent == state_root but key_values not empty");
             return;
         }


### PR DESCRIPTION
**Motivation**

This error is not useful in L2. Empty blocks with same state root is an expected behavior on L2.

On L1 due to calling the system contracts there is always a change in the state. This does not happen on L2, so having a block with no transactions leads to having the same state root.

