### PR TITLE
perf(levm): avoid initial account clone

### DIFF
--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -75,7 +75,7 @@ pub fn restore_cache_state(
 ) -> Result<(), VMError> {
     for (address, account) in callframe_backup.original_accounts_info {
         if let Some(current_account) = db.current_accounts_state.get_mut(&address) {
-            current_account.info = account.info;
+            current_account.to_mut().info = account.info;
         }
     }
 
@@ -89,7 +89,7 @@ pub fn restore_cache_state(
             .ok_or(InternalError::AccountNotFound)?;
 
         for (key, value) in storage {
-            account.storage.insert(key, value);
+            account.to_mut().storage.insert(key, value);
         }
     }
 


### PR DESCRIPTION
**Motivation**

<img width="1507" height="584" alt="image" src="https://github.com/user-attachments/assets/0ff41c83-33f3-4e9c-b7fd-ba1b5db740fd" />

### Improvements
- `RETURN` / `REVERT` with 1 KiB data: **~1.33–1.45× faster**
- `CODECOPY` (0.75× max code size, fixed src/dst): **~1.52× faster**
- Additional `CODECOPY` path (fixed src/dst disabled): **~1.23× faster**
- `LOG*` opcodes (various fixed-offset, non-zero topic cases): **~1.18–1.19× faster**
- `MSIZE` (large memory): **~1.18× faster**
- `CALLDATACOPY` (10 KiB, non-zero data): **~1.16× faster**

### Regressions
- `block_full_of_ether_transfers`: **~1.19–1.30× slower**
- `CALLDATALOAD` (zero-loop): **~1.16× slower**
- `CODECOPY` (0.5× max code size): **~1.10× slower**  
- `LOG*` opcodes (large zeroed topic/data cases): **~1.07–1.09× slower**
- Large memory expansion (one path): **~1.08× slower**
- `CALLVALUE`: **~1.07× slower**


Closes https://github.com/lambdaclass/ethrex/issues/5753

