### PR TITLE
fix(l1): close db before removing datadir

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -1495,6 +1495,8 @@ async fn insert_accounts(
     )
     .map_err(SyncError::TrieGenerationError)?;
 
+    drop(db); // close db before removing directory
+
     std::fs::remove_dir_all(account_state_snapshots_dir)
         .map_err(|_| SyncError::AccountStateSnapshotsDirNotFound)?;
     std::fs::remove_dir_all(get_rocksdb_temp_accounts_dir(datadir))
@@ -1633,6 +1635,10 @@ async fn insert_storages(
             pool.execute(task);
         }
     });
+
+    // close db before removing directory
+    drop(snapshot);
+    drop(db);
 
     std::fs::remove_dir_all(account_storages_snapshots_dir)
         .map_err(|_| SyncError::AccountStoragesSnapshotsDirNotFound)?;


### PR DESCRIPTION
**Motivation**

Currently for the temporary database used in account/storage insertions, we delete the directory before closing the database. This might lead to the directory deletion failing.

**Description**

This PR closes the database first.
