### PR TITLE
perf(l1,l2): avoid unnecessary Arc::make_mut in trie iterator

### DIFF
--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -51,7 +51,7 @@ impl TrieIterator {
             };
             match next_node.as_ref() {
                 Node::Branch(branch_node) => {
-                    // Add all children to the stack (in reverse order so we process first child frist)
+                    // Add all children to the stack (in reverse order so we process first child first)
                     let Some(choice) = target_nibbles.next_choice() else {
                         return Ok(());
                     };

--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, sync::Arc};
+use std::cmp::Ordering;
 
 use crate::{
     PathRLP, Trie, TrieDB, TrieError, ValueRLP,

--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -42,14 +42,14 @@ impl TrieIterator {
             node: NodeRef,
             new_stack: &mut Vec<(Nibbles, NodeRef)>,
         ) -> Result<(), TrieError> {
-            let Some(mut next_node) = node
+            let Some(next_node) = node
                 .get_node_checked(db, prefix_nibbles.clone())
                 .ok()
                 .flatten()
             else {
                 return Ok(());
             };
-            match Arc::make_mut(&mut next_node) {
+            match next_node.as_ref() {
                 Node::Branch(branch_node) => {
                     // Add all children to the stack (in reverse order so we process first child frist)
                     let Some(choice) = target_nibbles.next_choice() else {


### PR DESCRIPTION
**Motivation**

The code only reads the node and never mutates it, so Arc::make_mut could trigger deep clones when the node is shared.

**Description**

Replace Arc::make_mut in TrieIterator::advance’s first_ge helper with a match on &Node and drop the mutable binding.