### PR TITLE
perf(l2): reduce allocations in blob reconstruction and blob utils

### DIFF
--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -8,14 +8,13 @@ use crate::{
     },
     utils::{self, default_datadir, init_datadir, parse_private_key},
 };
-use bytes::Bytes;
 use clap::{FromArgMatches, Parser, Subcommand};
 use ethrex_blockchain::{
     Blockchain, BlockchainOptions, BlockchainType, L2Config, fork_choice::apply_fork_choice,
 };
 use ethrex_common::{
     Address, U256,
-    types::{BYTES_PER_BLOB, Block, blobs_bundle, bytes_from_blob, fee_config::FeeConfig},
+    types::{BYTES_PER_BLOB, Block, bytes_from_blob, fee_config::FeeConfig},
 };
 use ethrex_common::{types::BlobsBundle, utils::keccak};
 use ethrex_config::networks::Network;

--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -44,26 +44,35 @@ pub fn blob_from_bytes(bytes: Bytes) -> Result<Blob, BlobsBundleError> {
     }
 
     let mut buf = [0u8; BYTES_PER_BLOB];
-    buf[..(bytes.len() * 32).div_ceil(31)].copy_from_slice(
-        &bytes
-            .chunks(31)
-            .map(|x| [&[0x00], x].concat())
-            .collect::<Vec<_>>()
-            .concat(),
-    );
+    let mut dst = 0usize;
+
+    for chunk in bytes.chunks(31) {
+        let needed = 1 + chunk.len();
+        if dst + needed > BYTES_PER_BLOB {
+            return Err(BlobsBundleError::BlobDataInvalidBytesLength);
+        }
+
+        buf[dst] = 0x00;
+        dst += 1;
+
+        buf[dst..dst + chunk.len()].copy_from_slice(chunk);
+        dst += chunk.len();
+    }
 
     Ok(buf)
 }
 
 pub fn bytes_from_blob(blob: Bytes) -> [u8; SAFE_BYTES_PER_BLOB] {
     let mut buf = [0u8; SAFE_BYTES_PER_BLOB];
-    buf.copy_from_slice(
-        &blob
-            .chunks(32)
-            .map(|x| x[1..].to_vec())
-            .collect::<Vec<_>>()
-            .concat(),
-    );
+    let mut dst = 0usize;
+
+    for chunk in blob.chunks(32) {
+        let payload = &chunk[1..];
+        let len = payload.len();
+
+        buf[dst..dst + len].copy_from_slice(payload);
+        dst += len;
+    }
 
     buf
 }

--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -47,7 +47,8 @@ pub fn blob_from_bytes(bytes: Bytes) -> Result<Blob, BlobsBundleError> {
     let mut dst = 0usize;
 
     for chunk in bytes.chunks(31) {
-        let needed = 1 + chunk.len();
+        let len = chunk.len();
+        let needed = 1 + len;
         if dst + needed > BYTES_PER_BLOB {
             return Err(BlobsBundleError::BlobDataInvalidBytesLength);
         }
@@ -55,8 +56,8 @@ pub fn blob_from_bytes(bytes: Bytes) -> Result<Blob, BlobsBundleError> {
         buf[dst] = 0x00;
         dst += 1;
 
-        buf[dst..dst + chunk.len()].copy_from_slice(chunk);
-        dst += chunk.len();
+        buf[dst..dst + len].copy_from_slice(chunk);
+        dst += len;
     }
 
     Ok(buf)


### PR DESCRIPTION
**Motivation**

Expensive allocations in Reconstruct when working with blobs. First, `std::fs::read` returns `Vec<u8>`, then it is converted to `Bytes` inside `bytes_from_blob(blob.into())`, then back to `Vec<u8>` and then another copy is created via `Bytes::copy_from_slice(&blob)` for `blob_from_bytes`.

**Description**

Removed redundant blob re-encoding in the L2 Reconstruct command by reusing the raw blob bytes read from disk when sealing batches, while still decoding block and fee data via bytes_from_blob. Also rewrited blob_from_bytes and bytes_from_blob to operate in a single pass without intermediate Vec allocations, preserving the existing encoding format but significantly reducing heap usage across committer, prover and reconstruction paths that work with blobs.

