### PR TITLE
ci(l2): add workflow to check l2.json is up-to-date

### DIFF
--- a/.github/workflows/pr_check_l2_genesis.yml
+++ b/.github/workflows/pr_check_l2_genesis.yml
@@ -3,6 +3,12 @@ name: Check L2 Genesis
 on:
   pull_request:
     branches: ["**"]
+    paths:
+      - "crates/l2/contracts/src/**"
+      - "cmd/ethrex/build.rs"
+      - "cmd/ethrex/build_l2.rs"
+      - "fixtures/genesis/l2.json"
+      - "crates/common/types/genesis.rs"
 
 permissions:
   contents: read


### PR DESCRIPTION
**Motivation**

To prevent us from forgetting to commit the `l2.json` genesis file when changes are made to the L2 contracts.

**Description**

Adds a workflow that checks whether the `l2.json` genesis file is up-to-date.

[Here](https://github.com/lambdaclass/ethrex/actions/runs/20971587169/job/60276073094?pr=5831) is an example of a run using an outdated `l2.json` genesis file.


**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.


