### PR TITLE
ci(l1,l2): publish performance docker tag with final release

### DIFF
--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -59,10 +59,12 @@ jobs:
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEW_TAG }} \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:performance \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREV_TAG }}
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEW_TAG }}-l2 \
             -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:l2 \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:performance-l2 \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREV_TAG }}-l2
 
   publish-apt:


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->
Add `performance` to the published docker tags when a release is set to latest

<!-- Link to issues: Resolves #111, Resolves #222 -->

