### PR TITLE
ci(l1): fix make docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -84,6 +84,7 @@
   - [Based sequencing](./l2/fundamentals/based.md)
   - [Transaction fees](./l2/fundamentals/transaction_fees.md)
   - [Exit Window](./l2/fundamentals/exit_window.md)
+  - [Timelock](./l2/fundamentals/timelock.md)
   - [Fee token](./l2/fundamentals/fee_token.md)
   - [Shared Bridge](./l2/fundamentals/shared_bridge.md)
   - [Aligned Layer Integration](./l2/fundamentals/ethrex_l2_aligned_integration.md)


### PR DESCRIPTION
**Motivation**

`make docs` command is failing because `docs/l2/fundamentals/timelock.md` wasn't included in SUMMARY.md.

Successful run [here](https://github.com/lambdaclass/ethrex/actions/runs/21007246950/job/60392688150?pr=5846).

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

