### PR TITLE
fix(l1,l2): add sed filter to remove server's name on telegram

### DIFF
--- a/.github/scripts/publish_telegram.sh
+++ b/.github/scripts/publish_telegram.sh
@@ -6,4 +6,4 @@ REPORT_FILE="$1"
 curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/sendMessage" \
   -d chat_id="$TELEGRAM_ETHREX_CHAT_ID" \
   -d parse_mode=HTML \
-  --data-urlencode text="$(cat "$REPORT_FILE" | sed '/```/d' | sed '1s/^# \(.*\)$/<b>\1<\/b>/' | sed 's/^\* /• /')"
+  --data-urlencode text="$(cat "$REPORT_FILE" | sed '/```/d' | sed '1s/^# \(.*\)$/<b>\1<\/b>/' | sed 's/^\* /• /' | sed '/^  /d')"


### PR DESCRIPTION
**Description**

Hotfix to remove server's name on telegram's report

Before vs after:
<img width="351" height="378" alt="image" src="https://github.com/user-attachments/assets/c85f9aaa-9929-4e52-a8a3-2dd16aa2e2b6" />

