### PR TITLE
perf(levm): improve call and related opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2026-01-19
+
+- Improve call and related opcodes [#5856](https://github.com/lambdaclass/ethrex/pull/5856)
+
 ### 2026-01-15
 
 - Reduce state iterated when calculating partial state transitions [#5864](https://github.com/lambdaclass/ethrex/pull/5864)

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -109,7 +109,11 @@ impl<'a> VM<'a> {
         let to = callee; // In this case code_address and the sub-context account are the same. Unlike CALLCODE or DELEGATECODE.
         let is_static = callframe.is_static;
         let is_tracing = self.tracer.active;
-        if !is_tracing && self.precheck_message_call(gas_limit, from, true, value)?.is_none() {
+        if !is_tracing
+            && self
+                .precheck_message_call(gas_limit, from, true, value)?
+                .is_none()
+        {
             return Ok(OpcodeResult::Continue);
         }
 
@@ -211,7 +215,11 @@ impl<'a> VM<'a> {
         let to = callframe.to;
         let is_static = callframe.is_static;
         let is_tracing = self.tracer.active;
-        if !is_tracing && self.precheck_message_call(gas_limit, from, true, value)?.is_none() {
+        if !is_tracing
+            && self
+                .precheck_message_call(gas_limit, from, true, value)?
+                .is_none()
+        {
             return Ok(OpcodeResult::Continue);
         }
 
@@ -333,7 +341,11 @@ impl<'a> VM<'a> {
         let to = callframe.to;
         let is_static = callframe.is_static;
         let is_tracing = self.tracer.active;
-        if !is_tracing && self.precheck_message_call(gas_limit, from, false, value)?.is_none() {
+        if !is_tracing
+            && self
+                .precheck_message_call(gas_limit, from, false, value)?
+                .is_none()
+        {
             return Ok(OpcodeResult::Continue);
         }
 
@@ -435,7 +447,11 @@ impl<'a> VM<'a> {
         let to = address; // In this case address and the sub-context account are the same. Unlike CALLCODE or DELEGATECODE.
 
         let is_tracing = self.tracer.active;
-        if !is_tracing && self.precheck_message_call(gas_limit, from, false, value)?.is_none() {
+        if !is_tracing
+            && self
+                .precheck_message_call(gas_limit, from, false, value)?
+                .is_none()
+        {
             return Ok(OpcodeResult::Continue);
         }
 


### PR DESCRIPTION
**Motivation**

- Skip empty account checks when CALL value is zero to avoid DB reads.
- Avoid copying calldata on early revert CALLs when tracing is off.
- Reduce precompile output clones when tracing is off.

Closes #issue_number

<img width="1283" height="663" alt="image" src="https://github.com/user-attachments/assets/8fa4cb30-58b5-40bb-9e40-32e81bf61b77" />
