### PR TITLE
chore(l1): add instance filter for loki logs panel

### DIFF
--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -264,7 +264,7 @@
               },
               "direction": "backward",
               "editorMode": "builder",
-              "expr": "{job=\"ethrex\"} |= ``",
+              "expr": "{job=\"ethrex\", instance=~\"$instance.*\"} |= ``",
               "queryType": "range",
               "refId": "A"
             }


### PR DESCRIPTION
**Motivation**

We have an issue showing the same instance for all loki panels

**Description**

It just add the instance as a filter as part of the panels repeated for logs
