### PR TITLE
feat(p2p): add snap sync checkpoint types and progress logging [5/7]

### DIFF
--- a/crates/networking/p2p/p2p.rs
+++ b/crates/networking/p2p/p2p.rs
@@ -74,6 +74,7 @@ pub mod network;
 pub mod peer_handler;
 pub mod rlpx;
 pub(crate) mod snap;
+pub mod snap_sync_progress;
 pub mod sync;
 pub mod sync_manager;
 pub mod tx_broadcaster;

--- a/crates/networking/p2p/snap_sync_progress.rs
+++ b/crates/networking/p2p/snap_sync_progress.rs
@@ -1,0 +1,601 @@
+//! Snap sync progress tracking and logging.
+//!
+//! Provides clear, consistent progress logging for snap sync with:
+//! - Phase indicators (e.g., "[SNAP SYNC] Phase 3/9: Downloading Accounts")
+//! - Progress within phases (e.g., "12.5M / 18M accounts (69%)")
+//! - Download rates and ETA calculations
+//! - Summary statistics at phase completion
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tracing::info;
+
+/// Total number of phases in snap sync (excluding NotStarted and Completed)
+pub const TOTAL_PHASES: u8 = 8;
+
+/// Phase names for display
+const PHASE_NAMES: [&str; 10] = [
+    "Not Started",
+    "Downloading Headers",
+    "Downloading Accounts",
+    "Inserting Accounts",
+    "Downloading Storage",
+    "Inserting Storage",
+    "Healing State",
+    "Healing Storage",
+    "Downloading Bytecodes",
+    "Completed",
+];
+
+/// Get the display phase number (1-8 for active phases)
+fn get_phase_number(phase: u8) -> u8 {
+    match phase {
+        0 => 0,  // NotStarted
+        1 => 1,  // HeaderDownload
+        2 => 2,  // AccountDownload
+        3 => 3,  // AccountInsertion
+        4 => 4,  // StorageDownload
+        5 => 5,  // StorageInsertion
+        6 => 6,  // StateHealing
+        7 => 7,  // StorageHealing (shown as part of healing)
+        8 => 8,  // BytecodeDownload
+        9 => 8,  // Completed (same as last phase)
+        _ => 0,
+    }
+}
+
+/// Format a large number with appropriate suffix (K, M, B)
+pub fn format_count(count: u64) -> String {
+    if count >= 1_000_000_000 {
+        format!("{:.2}B", count as f64 / 1_000_000_000.0)
+    } else if count >= 1_000_000 {
+        format!("{:.2}M", count as f64 / 1_000_000.0)
+    } else if count >= 1_000 {
+        format!("{:.1}K", count as f64 / 1_000.0)
+    } else {
+        format!("{}", count)
+    }
+}
+
+/// Format duration in human-readable form
+pub fn format_duration(duration: Duration) -> String {
+    let total_secs = duration.as_secs();
+    if total_secs >= 3600 {
+        let hours = total_secs / 3600;
+        let mins = (total_secs % 3600) / 60;
+        format!("{}h {}m", hours, mins)
+    } else if total_secs >= 60 {
+        let mins = total_secs / 60;
+        let secs = total_secs % 60;
+        format!("{}m {}s", mins, secs)
+    } else {
+        format!("{}s", total_secs)
+    }
+}
+
+/// Format rate per second
+pub fn format_rate(rate: f64) -> String {
+    if rate >= 1_000_000.0 {
+        format!("{:.1}M/s", rate / 1_000_000.0)
+    } else if rate >= 1_000.0 {
+        format!("{:.1}K/s", rate / 1_000.0)
+    } else {
+        format!("{:.0}/s", rate)
+    }
+}
+
+/// Calculate ETA based on current progress
+pub fn calculate_eta(current: u64, total: u64, elapsed: Duration) -> Option<Duration> {
+    if current == 0 || total == 0 || current >= total {
+        return None;
+    }
+    let rate = current as f64 / elapsed.as_secs_f64();
+    if rate <= 0.0 {
+        return None;
+    }
+    let remaining = total - current;
+    let eta_secs = remaining as f64 / rate;
+    if eta_secs.is_finite() && eta_secs > 0.0 {
+        Some(Duration::from_secs_f64(eta_secs))
+    } else {
+        None
+    }
+}
+
+/// Progress tracker for a single phase
+#[derive(Debug)]
+pub struct PhaseProgress {
+    pub current: AtomicU64,
+    pub total: AtomicU64,
+    pub start_time: Mutex<Option<Instant>>,
+    pub last_log_time: Mutex<Option<Instant>>,
+}
+
+impl Default for PhaseProgress {
+    fn default() -> Self {
+        Self {
+            current: AtomicU64::new(0),
+            total: AtomicU64::new(0),
+            start_time: Mutex::new(None),
+            last_log_time: Mutex::new(None),
+        }
+    }
+}
+
+impl PhaseProgress {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn start(&self, total: u64) {
+        self.current.store(0, Ordering::Relaxed);
+        self.total.store(total, Ordering::Relaxed);
+        *self.start_time.lock().await = Some(Instant::now());
+        *self.last_log_time.lock().await = None;
+    }
+
+    pub async fn reset(&self) {
+        self.current.store(0, Ordering::Relaxed);
+        self.total.store(0, Ordering::Relaxed);
+        *self.start_time.lock().await = None;
+        *self.last_log_time.lock().await = None;
+    }
+
+    pub fn increment(&self, amount: u64) {
+        self.current.fetch_add(amount, Ordering::Relaxed);
+    }
+
+    pub fn set_current(&self, value: u64) {
+        self.current.store(value, Ordering::Relaxed);
+    }
+
+    pub fn set_total(&self, value: u64) {
+        self.total.store(value, Ordering::Relaxed);
+    }
+
+    pub fn get_current(&self) -> u64 {
+        self.current.load(Ordering::Relaxed)
+    }
+
+    pub fn get_total(&self) -> u64 {
+        self.total.load(Ordering::Relaxed)
+    }
+
+    pub async fn elapsed(&self) -> Duration {
+        self.start_time
+            .lock()
+            .await
+            .map(|t| t.elapsed())
+            .unwrap_or_default()
+    }
+
+    pub async fn rate(&self) -> f64 {
+        let elapsed = self.elapsed().await;
+        let current = self.get_current();
+        if elapsed.as_secs_f64() > 0.0 {
+            current as f64 / elapsed.as_secs_f64()
+        } else {
+            0.0
+        }
+    }
+
+    pub async fn eta(&self) -> Option<Duration> {
+        let elapsed = self.elapsed().await;
+        calculate_eta(self.get_current(), self.get_total(), elapsed)
+    }
+
+    pub fn percentage(&self) -> f64 {
+        let total = self.get_total();
+        if total == 0 {
+            0.0
+        } else {
+            (self.get_current() as f64 / total as f64) * 100.0
+        }
+    }
+}
+
+/// Central progress tracker for the entire snap sync process
+#[derive(Debug)]
+pub struct SnapSyncProgress {
+    /// Overall sync start time
+    pub sync_start: Mutex<Option<Instant>>,
+    /// Current phase (as u8 matching SnapSyncPhase)
+    pub current_phase: AtomicU64,
+    /// Pivot block number
+    pub pivot_block: AtomicU64,
+    /// Progress for headers
+    pub headers: PhaseProgress,
+    /// Progress for accounts
+    pub accounts: PhaseProgress,
+    /// Progress for storage slots
+    pub storage: PhaseProgress,
+    /// Progress for bytecodes
+    pub bytecodes: PhaseProgress,
+    /// Progress for healing (nodes healed)
+    pub healing: PhaseProgress,
+    /// Minimum interval between progress logs
+    pub log_interval: Duration,
+}
+
+impl Default for SnapSyncProgress {
+    fn default() -> Self {
+        Self {
+            sync_start: Mutex::new(None),
+            current_phase: AtomicU64::new(0),
+            pivot_block: AtomicU64::new(0),
+            headers: PhaseProgress::new(),
+            accounts: PhaseProgress::new(),
+            storage: PhaseProgress::new(),
+            bytecodes: PhaseProgress::new(),
+            healing: PhaseProgress::new(),
+            log_interval: Duration::from_secs(5),
+        }
+    }
+}
+
+impl SnapSyncProgress {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start the overall sync
+    pub async fn start_sync(&self, pivot_block: u64) {
+        *self.sync_start.lock().await = Some(Instant::now());
+        self.pivot_block.store(pivot_block, Ordering::Relaxed);
+        self.current_phase.store(0, Ordering::Relaxed);
+        info!(
+            "================================================================================\n\
+             [SNAP SYNC] Starting snap sync to pivot block #{}\n\
+             ================================================================================",
+            pivot_block
+        );
+    }
+
+    /// Log entry into a new phase
+    pub async fn enter_phase(&self, phase: u8) {
+        self.current_phase.store(phase as u64, Ordering::Relaxed);
+        let phase_num = get_phase_number(phase);
+        let phase_name = PHASE_NAMES.get(phase as usize).unwrap_or(&"Unknown");
+
+        info!(
+            "--------------------------------------------------------------------------------\n\
+             [SNAP SYNC] Phase {}/{}: {}\n\
+             --------------------------------------------------------------------------------",
+            phase_num, TOTAL_PHASES, phase_name
+        );
+    }
+
+    /// Log completion of a phase with summary
+    pub async fn complete_phase(&self, phase: u8) {
+        let phase_num = get_phase_number(phase);
+        let phase_name = PHASE_NAMES.get(phase as usize).unwrap_or(&"Unknown");
+
+        // Get the appropriate progress tracker for this phase
+        let (elapsed, processed, rate) = match phase {
+            1 => {
+                // Headers
+                let elapsed = self.headers.elapsed().await;
+                let processed = self.headers.get_current();
+                let rate = self.headers.rate().await;
+                (elapsed, processed, rate)
+            }
+            2 | 3 => {
+                // Account download/insertion
+                let elapsed = self.accounts.elapsed().await;
+                let processed = self.accounts.get_current();
+                let rate = self.accounts.rate().await;
+                (elapsed, processed, rate)
+            }
+            4 | 5 => {
+                // Storage download/insertion
+                let elapsed = self.storage.elapsed().await;
+                let processed = self.storage.get_current();
+                let rate = self.storage.rate().await;
+                (elapsed, processed, rate)
+            }
+            6 | 7 => {
+                // Healing
+                let elapsed = self.healing.elapsed().await;
+                let processed = self.healing.get_current();
+                let rate = self.healing.rate().await;
+                (elapsed, processed, rate)
+            }
+            8 => {
+                // Bytecodes
+                let elapsed = self.bytecodes.elapsed().await;
+                let processed = self.bytecodes.get_current();
+                let rate = self.bytecodes.rate().await;
+                (elapsed, processed, rate)
+            }
+            _ => (Duration::ZERO, 0, 0.0),
+        };
+
+        info!(
+            "[SNAP SYNC] Phase {}/{} complete: {} | Processed: {} | Rate: {} | Duration: {}",
+            phase_num,
+            TOTAL_PHASES,
+            phase_name,
+            format_count(processed),
+            format_rate(rate),
+            format_duration(elapsed)
+        );
+    }
+
+    /// Log overall sync completion
+    pub async fn complete_sync(&self) {
+        let total_elapsed = self
+            .sync_start
+            .lock()
+            .await
+            .map(|t| t.elapsed())
+            .unwrap_or_default();
+
+        let pivot = self.pivot_block.load(Ordering::Relaxed);
+        let headers = self.headers.get_current();
+        let accounts = self.accounts.get_current();
+        let storage = self.storage.get_current();
+        let bytecodes = self.bytecodes.get_current();
+
+        info!(
+            "================================================================================\n\
+             [SNAP SYNC] COMPLETED SUCCESSFULLY\n\
+             ================================================================================\n\
+             Pivot Block:    #{}\n\
+             Total Duration: {}\n\
+             \n\
+             Summary:\n\
+             - Headers:    {}\n\
+             - Accounts:   {}\n\
+             - Storage:    {} slots\n\
+             - Bytecodes:  {}\n\
+             ================================================================================",
+            pivot,
+            format_duration(total_elapsed),
+            format_count(headers),
+            format_count(accounts),
+            format_count(storage),
+            format_count(bytecodes),
+        );
+    }
+
+    /// Log progress for headers download
+    pub async fn log_headers_progress(&self, downloaded: u64, total: u64) {
+        self.headers.set_current(downloaded);
+        self.headers.set_total(total);
+
+        if !self.should_log(&self.headers).await {
+            return;
+        }
+
+        let rate = self.headers.rate().await;
+        let eta = self.headers.eta().await;
+        let pct = self.headers.percentage();
+
+        let eta_str = eta.map(format_duration).unwrap_or_else(|| "calculating...".to_string());
+
+        info!(
+            "[SNAP SYNC] Phase 1/{}: Headers: {} / {} ({:.1}%) | Rate: {} | ETA: {}",
+            TOTAL_PHASES,
+            format_count(downloaded),
+            format_count(total),
+            pct,
+            format_rate(rate),
+            eta_str
+        );
+
+        self.mark_logged(&self.headers).await;
+    }
+
+    /// Log progress for account download
+    pub async fn log_accounts_download_progress(&self, downloaded: u64, rate_per_sec: Option<f64>) {
+        self.accounts.set_current(downloaded);
+
+        if !self.should_log(&self.accounts).await {
+            return;
+        }
+
+        let elapsed = self.accounts.elapsed().await;
+        let rate = rate_per_sec.unwrap_or_else(|| {
+            if elapsed.as_secs_f64() > 0.0 {
+                downloaded as f64 / elapsed.as_secs_f64()
+            } else {
+                0.0
+            }
+        });
+
+        info!(
+            "[SNAP SYNC] Phase 2/{}: Downloading accounts: {} | Rate: {} | Elapsed: {}",
+            TOTAL_PHASES,
+            format_count(downloaded),
+            format_rate(rate),
+            format_duration(elapsed)
+        );
+
+        self.mark_logged(&self.accounts).await;
+    }
+
+    /// Log progress for account insertion
+    pub async fn log_accounts_insertion_progress(&self, inserted: u64, total: u64) {
+        self.accounts.set_current(inserted);
+        self.accounts.set_total(total);
+
+        if !self.should_log(&self.accounts).await {
+            return;
+        }
+
+        let rate = self.accounts.rate().await;
+        let eta = self.accounts.eta().await;
+        let pct = self.accounts.percentage();
+
+        let eta_str = eta.map(format_duration).unwrap_or_else(|| "calculating...".to_string());
+
+        info!(
+            "[SNAP SYNC] Phase 3/{}: Inserting accounts: {} / {} ({:.1}%) | Rate: {} | ETA: {}",
+            TOTAL_PHASES,
+            format_count(inserted),
+            format_count(total),
+            pct,
+            format_rate(rate),
+            eta_str
+        );
+
+        self.mark_logged(&self.accounts).await;
+    }
+
+    /// Log progress for storage download
+    pub async fn log_storage_download_progress(&self, downloaded_slots: u64, accounts_remaining: u64) {
+        self.storage.set_current(downloaded_slots);
+
+        if !self.should_log(&self.storage).await {
+            return;
+        }
+
+        let elapsed = self.storage.elapsed().await;
+        let rate = self.storage.rate().await;
+
+        info!(
+            "[SNAP SYNC] Phase 4/{}: Downloading storage: {} slots | {} accounts remaining | Rate: {} | Elapsed: {}",
+            TOTAL_PHASES,
+            format_count(downloaded_slots),
+            format_count(accounts_remaining),
+            format_rate(rate),
+            format_duration(elapsed)
+        );
+
+        self.mark_logged(&self.storage).await;
+    }
+
+    /// Log progress for storage insertion
+    pub async fn log_storage_insertion_progress(&self, inserted: u64, total: u64) {
+        self.storage.set_current(inserted);
+        self.storage.set_total(total);
+
+        if !self.should_log(&self.storage).await {
+            return;
+        }
+
+        let rate = self.storage.rate().await;
+        let eta = self.storage.eta().await;
+        let pct = self.storage.percentage();
+
+        let eta_str = eta.map(format_duration).unwrap_or_else(|| "calculating...".to_string());
+
+        info!(
+            "[SNAP SYNC] Phase 5/{}: Inserting storage: {} / {} slots ({:.1}%) | Rate: {} | ETA: {}",
+            TOTAL_PHASES,
+            format_count(inserted),
+            format_count(total),
+            pct,
+            format_rate(rate),
+            eta_str
+        );
+
+        self.mark_logged(&self.storage).await;
+    }
+
+    /// Log progress for healing
+    pub async fn log_healing_progress(&self, nodes_healed: u64, phase_name: &str) {
+        self.healing.set_current(nodes_healed);
+
+        if !self.should_log(&self.healing).await {
+            return;
+        }
+
+        let elapsed = self.healing.elapsed().await;
+        let rate = self.healing.rate().await;
+
+        info!(
+            "[SNAP SYNC] Phase 6/{}: {}: {} nodes healed | Rate: {} | Elapsed: {}",
+            TOTAL_PHASES,
+            phase_name,
+            format_count(nodes_healed),
+            format_rate(rate),
+            format_duration(elapsed)
+        );
+
+        self.mark_logged(&self.healing).await;
+    }
+
+    /// Log progress for bytecode download
+    pub async fn log_bytecodes_progress(&self, downloaded: u64, total: u64) {
+        self.bytecodes.set_current(downloaded);
+        self.bytecodes.set_total(total);
+
+        if !self.should_log(&self.bytecodes).await {
+            return;
+        }
+
+        let rate = self.bytecodes.rate().await;
+        let eta = self.bytecodes.eta().await;
+        let pct = self.bytecodes.percentage();
+
+        let eta_str = eta.map(format_duration).unwrap_or_else(|| "calculating...".to_string());
+
+        info!(
+            "[SNAP SYNC] Phase 8/{}: Downloading bytecodes: {} / {} ({:.1}%) | Rate: {} | ETA: {}",
+            TOTAL_PHASES,
+            format_count(downloaded),
+            format_count(total),
+            pct,
+            format_rate(rate),
+            eta_str
+        );
+
+        self.mark_logged(&self.bytecodes).await;
+    }
+
+    /// Check if we should log (respecting minimum interval)
+    async fn should_log(&self, progress: &PhaseProgress) -> bool {
+        let last_log = *progress.last_log_time.lock().await;
+        match last_log {
+            None => true,
+            Some(t) => t.elapsed() >= self.log_interval,
+        }
+    }
+
+    /// Mark that we just logged
+    async fn mark_logged(&self, progress: &PhaseProgress) {
+        *progress.last_log_time.lock().await = Some(Instant::now());
+    }
+}
+
+/// Global progress tracker instance
+pub static SNAP_PROGRESS: std::sync::LazyLock<Arc<SnapSyncProgress>> =
+    std::sync::LazyLock::new(|| Arc::new(SnapSyncProgress::new()));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_count() {
+        assert_eq!(format_count(500), "500");
+        assert_eq!(format_count(1500), "1.5K");
+        assert_eq!(format_count(1_500_000), "1.50M");
+        assert_eq!(format_count(1_500_000_000), "1.50B");
+    }
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration(Duration::from_secs(30)), "30s");
+        assert_eq!(format_duration(Duration::from_secs(90)), "1m 30s");
+        assert_eq!(format_duration(Duration::from_secs(3700)), "1h 1m");
+    }
+
+    #[test]
+    fn test_format_rate() {
+        assert_eq!(format_rate(500.0), "500/s");
+        assert_eq!(format_rate(1500.0), "1.5K/s");
+        assert_eq!(format_rate(1_500_000.0), "1.5M/s");
+    }
+
+    #[test]
+    fn test_calculate_eta() {
+        let eta = calculate_eta(50, 100, Duration::from_secs(10));
+        assert!(eta.is_some());
+        // 50 items in 10 seconds = 5/s, 50 remaining = 10 seconds ETA
+        assert_eq!(eta.unwrap().as_secs(), 10);
+    }
+}

--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -75,6 +75,7 @@ pub mod utils;
 
 pub use layering::apply_prefix;
 pub use store::{AccountUpdatesList, EngineType, Store, UpdateBatch, hash_address, hash_key};
+pub use utils::{SnapSyncCheckpoint, SnapSyncPhase};
 
 /// Store Schema Version, must be updated on any breaking change.
 ///

--- a/crates/storage/utils.rs
+++ b/crates/storage/utils.rs
@@ -45,6 +45,12 @@ pub enum SnapStateIndex {
     StateTrieRebuildCheckpoint = 3,
     // Storage tries awaiting rebuild (AccountHash, ExpectedRoot)
     StorageTrieRebuildPending = 4,
+    // Current snap sync phase
+    CurrentPhase = 5,
+    // Full checkpoint data (serialized SnapSyncCheckpoint)
+    FullCheckpoint = 6,
+    // Pivot block info (number, hash, state_root)
+    PivotBlockInfo = 7,
 }
 
 impl From<u8> for SnapStateIndex {
@@ -55,7 +61,252 @@ impl From<u8> for SnapStateIndex {
             2 => SnapStateIndex::StateHealPaths,
             3 => SnapStateIndex::StateTrieRebuildCheckpoint,
             4 => SnapStateIndex::StorageTrieRebuildPending,
+            5 => SnapStateIndex::CurrentPhase,
+            6 => SnapStateIndex::FullCheckpoint,
+            7 => SnapStateIndex::PivotBlockInfo,
             _ => panic!("Invalid value when casting to SnapDataIndex: {value}"),
         }
+    }
+}
+
+/// Represents the current phase of snap sync.
+/// Used for checkpointing to enable resume from any phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+pub enum SnapSyncPhase {
+    /// Snap sync has not started yet
+    #[default]
+    NotStarted = 0,
+    /// Downloading block headers
+    HeaderDownload = 1,
+    /// Downloading account ranges from peers
+    AccountDownload = 2,
+    /// Inserting downloaded accounts into the trie
+    AccountInsertion = 3,
+    /// Downloading storage ranges from peers
+    StorageDownload = 4,
+    /// Inserting downloaded storage into the trie
+    StorageInsertion = 5,
+    /// Healing the state trie
+    StateHealing = 6,
+    /// Healing storage tries
+    StorageHealing = 7,
+    /// Downloading bytecode
+    BytecodeDownload = 8,
+    /// Snap sync completed successfully
+    Completed = 9,
+}
+
+impl From<u8> for SnapSyncPhase {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => SnapSyncPhase::NotStarted,
+            1 => SnapSyncPhase::HeaderDownload,
+            2 => SnapSyncPhase::AccountDownload,
+            3 => SnapSyncPhase::AccountInsertion,
+            4 => SnapSyncPhase::StorageDownload,
+            5 => SnapSyncPhase::StorageInsertion,
+            6 => SnapSyncPhase::StateHealing,
+            7 => SnapSyncPhase::StorageHealing,
+            8 => SnapSyncPhase::BytecodeDownload,
+            9 => SnapSyncPhase::Completed,
+            _ => panic!("Invalid value when casting to SnapSyncPhase: {value}"),
+        }
+    }
+}
+
+impl std::fmt::Display for SnapSyncPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SnapSyncPhase::NotStarted => write!(f, "NotStarted"),
+            SnapSyncPhase::HeaderDownload => write!(f, "HeaderDownload"),
+            SnapSyncPhase::AccountDownload => write!(f, "AccountDownload"),
+            SnapSyncPhase::AccountInsertion => write!(f, "AccountInsertion"),
+            SnapSyncPhase::StorageDownload => write!(f, "StorageDownload"),
+            SnapSyncPhase::StorageInsertion => write!(f, "StorageInsertion"),
+            SnapSyncPhase::StateHealing => write!(f, "StateHealing"),
+            SnapSyncPhase::StorageHealing => write!(f, "StorageHealing"),
+            SnapSyncPhase::BytecodeDownload => write!(f, "BytecodeDownload"),
+            SnapSyncPhase::Completed => write!(f, "Completed"),
+        }
+    }
+}
+
+/// Checkpoint for snap sync progress that can be persisted to disk.
+/// Enables resuming snap sync from any phase after a restart.
+#[derive(Debug, Clone, Default)]
+pub struct SnapSyncCheckpoint {
+    /// Current phase of snap sync
+    pub phase: SnapSyncPhase,
+    /// Pivot block number
+    pub pivot_block_number: u64,
+    /// Pivot block hash
+    pub pivot_block_hash: ethrex_common::H256,
+    /// Pivot state root
+    pub pivot_state_root: ethrex_common::H256,
+    /// Number of account snapshot files processed
+    pub account_files_processed: usize,
+    /// Number of storage snapshot files processed
+    pub storage_files_processed: usize,
+    /// Number of nodes healed during state healing
+    pub state_nodes_healed: u64,
+    /// Number of nodes healed during storage healing
+    pub storage_nodes_healed: u64,
+    /// Number of bytecodes downloaded
+    pub bytecodes_downloaded: usize,
+    /// Timestamp when checkpoint was created
+    pub checkpoint_timestamp: u64,
+}
+
+impl SnapSyncCheckpoint {
+    /// Creates a new checkpoint at the given phase
+    pub fn new(phase: SnapSyncPhase) -> Self {
+        Self {
+            phase,
+            checkpoint_timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            ..Default::default()
+        }
+    }
+
+    /// Sets the pivot block information
+    pub fn with_pivot(
+        mut self,
+        block_number: u64,
+        block_hash: ethrex_common::H256,
+        state_root: ethrex_common::H256,
+    ) -> Self {
+        self.pivot_block_number = block_number;
+        self.pivot_block_hash = block_hash;
+        self.pivot_state_root = state_root;
+        self
+    }
+
+    /// Updates the checkpoint timestamp to now
+    pub fn touch(&mut self) {
+        self.checkpoint_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+    }
+
+    /// Returns true if the checkpoint is stale (older than max_age_secs)
+    pub fn is_stale(&self, max_age_secs: u64) -> bool {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        now.saturating_sub(self.checkpoint_timestamp) > max_age_secs
+    }
+
+    /// RLP encode the checkpoint for storage
+    pub fn encode_to_vec(&self) -> Vec<u8> {
+        use ethrex_rlp::encode::RLPEncode;
+        let mut encoded = Vec::new();
+        let group1 = (
+            self.phase as u8,
+            self.pivot_block_number,
+            self.pivot_block_hash,
+            self.pivot_state_root,
+        );
+        let group2 = (
+            self.account_files_processed as u64,
+            self.storage_files_processed as u64,
+            self.state_nodes_healed,
+            self.storage_nodes_healed,
+        );
+        let group3 = (
+            self.bytecodes_downloaded as u64,
+            self.checkpoint_timestamp,
+        );
+        (group1, group2, group3).encode(&mut encoded);
+        encoded
+    }
+
+    /// RLP decode the checkpoint from storage
+    pub fn decode(bytes: &[u8]) -> Result<Self, ethrex_rlp::error::RLPDecodeError> {
+        use ethrex_rlp::decode::RLPDecode;
+        let (group1, group2, group3): (
+            (u8, u64, ethrex_common::H256, ethrex_common::H256),
+            (u64, u64, u64, u64),
+            (u64, u64),
+        ) = RLPDecode::decode(bytes)?;
+
+        let (phase_u8, pivot_block_number, pivot_block_hash, pivot_state_root) = group1;
+        let (account_files_processed, storage_files_processed, state_nodes_healed, storage_nodes_healed) = group2;
+        let (bytecodes_downloaded, checkpoint_timestamp) = group3;
+
+        Ok(Self {
+            phase: SnapSyncPhase::from(phase_u8),
+            pivot_block_number,
+            pivot_block_hash,
+            pivot_state_root,
+            account_files_processed: account_files_processed as usize,
+            storage_files_processed: storage_files_processed as usize,
+            state_nodes_healed,
+            storage_nodes_healed,
+            bytecodes_downloaded: bytecodes_downloaded as usize,
+            checkpoint_timestamp,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snap_sync_checkpoint_roundtrip() {
+        let checkpoint = SnapSyncCheckpoint {
+            phase: SnapSyncPhase::AccountInsertion,
+            pivot_block_number: 12345678,
+            pivot_block_hash: ethrex_common::H256::repeat_byte(0xab),
+            pivot_state_root: ethrex_common::H256::repeat_byte(0xcd),
+            account_files_processed: 42,
+            storage_files_processed: 17,
+            state_nodes_healed: 1000,
+            storage_nodes_healed: 2000,
+            bytecodes_downloaded: 500,
+            checkpoint_timestamp: 1700000000,
+        };
+
+        let encoded = checkpoint.encode_to_vec();
+        let decoded = SnapSyncCheckpoint::decode(&encoded).expect("decode should succeed");
+
+        assert_eq!(decoded.phase, SnapSyncPhase::AccountInsertion);
+        assert_eq!(decoded.pivot_block_number, 12345678);
+        assert_eq!(decoded.pivot_block_hash, ethrex_common::H256::repeat_byte(0xab));
+        assert_eq!(decoded.pivot_state_root, ethrex_common::H256::repeat_byte(0xcd));
+        assert_eq!(decoded.account_files_processed, 42);
+        assert_eq!(decoded.storage_files_processed, 17);
+        assert_eq!(decoded.state_nodes_healed, 1000);
+        assert_eq!(decoded.storage_nodes_healed, 2000);
+        assert_eq!(decoded.bytecodes_downloaded, 500);
+        assert_eq!(decoded.checkpoint_timestamp, 1700000000);
+    }
+
+    #[test]
+    fn test_snap_sync_phase_roundtrip() {
+        for phase_val in 0..=9u8 {
+            let phase = SnapSyncPhase::from(phase_val);
+            assert_eq!(phase as u8, phase_val);
+        }
+    }
+
+    #[test]
+    fn test_checkpoint_staleness() {
+        let mut checkpoint = SnapSyncCheckpoint::new(SnapSyncPhase::AccountDownload);
+        assert!(!checkpoint.is_stale(60));
+
+        checkpoint.checkpoint_timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 7200;
+
+        assert!(checkpoint.is_stale(3600));
+        assert!(!checkpoint.is_stale(10800));
     }
 }


### PR DESCRIPTION
## Stats
| Lines | Files |
|-------|-------|
| **+854** | 4 |

## Summary
Adds infrastructure for snap sync progress tracking and checkpointing:
- `SnapSyncPhase` enum: Tracks sync phases (HeaderDownload → Completed)
- `SnapSyncCheckpoint` struct: Persists sync progress to disk with RLP encoding
- `snap_sync_progress` module: Human-readable progress logging with phases/ETA
- Format utilities for counts (K/M/B), durations, and rates

This enables resumable snap sync and provides clear progress indication.

## Part of snap sync improvements series
- [1/7] Trie batch operations (#5892)
- [2/7] P2P discovery improvements (#5893)
- [3/7] Bytecode parallel downloads (#5894)
- [4/7] Healing cache infrastructure (#5895)
- **[5/7] Snap sync checkpoint + progress (this PR)**
- [6/7] ethrex_db + state manager (#5898)
- [7/7] Sync refactoring + healing (#5899)

## Test plan
- [x] Compile check passes
- [ ] Run tests: `cargo test -p ethrex-storage utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)