### PR TITLE
perf(l1): optimize BranchNode RLP encoding for hash computation

### DIFF
--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -268,7 +268,7 @@ impl BranchNode {
     /// Computes the node's hash, using the provided buffer
     pub fn compute_hash_no_alloc(&self, buf: &mut Vec<u8>) -> NodeHash {
         buf.clear();
-        self.encode(buf);
+        self.encode_to_buf(buf);
         let hash = NodeHash::from_encoded(buf);
         buf.clear();
         hash


### PR DESCRIPTION
## Summary

- Add specialized `encode_to_buf(&mut Vec<u8>)` method to BranchNode that avoids trait object dispatch
- Use the new method in `compute_hash_no_alloc` for better inlining during hash computation
- Reduces zkVM proving steps by **1.26%** across mainnet blocks

## Details

The existing `BranchNode::encode` uses `&mut dyn BufMut` trait object, which:
1. Prevents inlining of `put_slice` and `push` operations
2. Requires dynamic dispatch for each of the 16+ write operations per node
3. Adds function call overhead in the hot path during MPT hash computation

The new `encode_to_buf` method writes directly to `Vec<u8>`, enabling the compiler to inline vector operations.

## Benchmark Results

| Input | Baseline | After | Δ% |
|-------|----------|-------|-----|
| heavy (24261843) | 1,022,872,948 | 1,010,437,011 | **-1.22%** |
| medium_high (24261905) | 793,470,627 | 782,793,122 | **-1.35%** |
| average (24261865) | 522,680,036 | 517,160,795 | **-1.06%** |
| medium_low (24261892) | 324,696,244 | 320,251,227 | **-1.37%** |
| light (24261838) | 87,678,762 | 86,139,955 | **-1.76%** |
| **Total** | **2,751,398,617** | **2,716,782,110** | **-1.26%** |

Environment: ZisK v0.15.0, ethrex commit ff00c88

## Test plan

- [x] Build succeeds with `cargo-zisk build --release`
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p ethrex-trie -- -D warnings` passes
- [x] Benchmark confirms improvement on 5 mainnet blocks