### PR TITLE
perf(l1): investigate Arc vs Box for trie deserialization

### DIFF
--- a/crates/common/trie/Cargo.toml
+++ b/crates/common/trie/Cargo.toml
@@ -27,6 +27,8 @@ rkyv.workspace = true
 
 [features]
 default = []
+# Optimize for zkVM execution: uses Box instead of Arc for single-threaded performance
+zkvm = []
 
 
 [dev-dependencies]

--- a/crates/common/trie/trie.rs
+++ b/crates/common/trie/trie.rs
@@ -24,7 +24,7 @@ pub use self::logger::{TrieLogger, TrieWitness};
 pub use self::nibbles::Nibbles;
 pub use self::verify_range::verify_range;
 pub use self::{
-    node::{Node, NodeRef},
+    node::{Node, NodePtr, NodeRef},
     node_hash::NodeHash,
 };
 
@@ -195,7 +195,7 @@ impl Trie {
         }
     }
 
-    pub fn get_root_node(&self, path: Nibbles) -> Result<Arc<Node>, TrieError> {
+    pub fn get_root_node(&self, path: Nibbles) -> Result<NodePtr, TrieError> {
         self.root
             .get_node_checked(self.db.as_ref(), path)?
             .ok_or_else(|| {
@@ -505,7 +505,7 @@ impl Trie {
         }
     }
 
-    pub fn root_node(&self) -> Result<Option<Arc<Node>>, TrieError> {
+    pub fn root_node(&self) -> Result<Option<NodePtr>, TrieError> {
         if self.hash_no_commit() == *EMPTY_TRIE_HASH {
             return Ok(None);
         }

--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, sync::Arc};
+use std::cmp::Ordering;
 
 use crate::{
     PathRLP, Trie, TrieDB, TrieError, ValueRLP,
@@ -42,14 +42,14 @@ impl TrieIterator {
             node: NodeRef,
             new_stack: &mut Vec<(Nibbles, NodeRef)>,
         ) -> Result<(), TrieError> {
-            let Some(mut next_node) = node
+            let Some(next_node) = node
                 .get_node_checked(db, prefix_nibbles.clone())
                 .ok()
                 .flatten()
             else {
                 return Ok(());
             };
-            match Arc::make_mut(&mut next_node) {
+            match &*next_node {
                 Node::Branch(branch_node) => {
                     // Add all children to the stack (in reverse order so we process first child frist)
                     let Some(choice) = target_nibbles.next_choice() else {

--- a/crates/l2/prover/src/guest_program/Cargo.toml
+++ b/crates/l2/prover/src/guest_program/Cargo.toml
@@ -47,6 +47,7 @@ zisk = [
     "ethrex-blockchain/zisk",
     "ethrex-vm/zisk",
     "ethrex-l2-common/zisk",
+    "ethrex-trie/zkvm",
 ]
 openvm = ["dep:openvm-sdk"]
 l2 = []


### PR DESCRIPTION
## Summary

Investigation into reducing rkyv deserialization overhead for the trie data structure in zkVM execution.

- Add `zkvm` feature flag to `ethrex-trie` that uses `Box<Node>` instead of `Arc<Node>` for `NodeRef`
- Hypothesis: rkyv's shared pointer deserialization (`deserialize_shared`) for `Arc` is more expensive than simple `Box` deserialization
- **Result: No measurable improvement** (~0% change in steps)

## Analysis

Profile data showed rkyv deserialization accounts for ~31% of zkVM steps:
- `[NodeRef; 16]` arrays: 10.41% (15,346 calls)
- `Box<BranchNode>`: 10.44% (15,346 calls)  
- `Arc<Node>` shared: 10.11% (18,819 calls)

Switching from Arc to Box did not reduce costs because the overhead comes from:
1. **Heap allocation** - both Box and Arc require allocating memory for each node
2. **Data copying** - rkyv still copies data into allocated memory
3. **Array deserialization** - `[NodeRef; 16]` still requires deserializing 16 elements

## Future Optimization Paths

Achieving meaningful improvement would require more invasive changes:

1. **Arena allocation** - Use a bump allocator for all nodes (single allocation)
2. **Sparse array representation** - Replace `[NodeRef; 16]` with a compact representation for mostly-empty arrays
3. **Zero-copy deserialization** - Use rkyv's archived types directly without full deserialization (blocked by `Arc`/mutable access patterns)

## Benchmark Results

| Block | Baseline | After Change | Δ |
|-------|----------|--------------|---|
| heavy | 1,022,872,948 | 1,022,872,947 | -1 |
| medium_high | 793,470,627 | 793,470,626 | -1 |
| average | 522,680,036 | 522,680,035 | -1 |
| medium_low | 324,696,244 | 324,696,243 | -1 |
| light | 87,678,762 | 87,678,761 | -1 |
| **Total** | **2,751,398,617** | **2,751,398,612** | **-5** (~0%)

## Test plan

- [x] `cargo build -p ethrex-trie` passes
- [x] `cargo build -p ethrex-trie --features zkvm` passes
- [x] `cargo clippy -p ethrex-trie -- -D warnings` passes
- [x] ZisK guest program builds successfully
- [x] Benchmark confirms no regression