### PR TITLE
feat(l1): add --p2p.bind-addr to separate bind and advertised addresses

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -218,10 +218,18 @@ pub struct Options {
     #[arg(
         long = "p2p.addr",
         value_name = "ADDRESS",
-        help = "Listening address for the P2P protocol.",
+        help = "Advertised address for the P2P protocol (Node Record). Defaults to local IP if not set.",
         help_heading = "P2P options"
     )]
     pub p2p_addr: Option<String>,
+    #[arg(
+        long = "p2p.bind-addr",
+        default_value = "0.0.0.0",
+        value_name = "ADDRESS",
+        help = "Bind address for the P2P protocol.",
+        help_heading = "P2P options"
+    )]
+    pub p2p_bind_addr: String,
     #[arg(
         long = "p2p.port",
         default_value = "30303",
@@ -308,6 +316,7 @@ impl Options {
             metrics_port: "9090".to_string(),
             authrpc_addr: "localhost".to_string(),
             authrpc_jwtsecret: "jwt.hex".to_string(),
+            p2p_bind_addr: "0.0.0.0".to_owned(),
             p2p_port: "30303".into(),
             discovery_port: "30303".into(),
             mempool_max_size: 10_000,
@@ -328,6 +337,7 @@ impl Options {
             authrpc_addr: "localhost".into(),
             authrpc_port: "8551".into(),
             authrpc_jwtsecret: "jwt.hex".into(),
+            p2p_bind_addr: "0.0.0.0".into(),
             p2p_port: "30303".into(),
             discovery_port: "30303".into(),
             mempool_max_size: 10_000,
@@ -352,6 +362,7 @@ impl Default for Options {
             authrpc_jwtsecret: Default::default(),
             p2p_disabled: Default::default(),
             p2p_addr: None,
+            p2p_bind_addr: "0.0.0.0".to_owned(),
             p2p_port: Default::default(),
             discovery_port: Default::default(),
             network: Default::default(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -495,8 +495,14 @@ pub async fn init_l1(
 
     let cancel_token = tokio_util::sync::CancellationToken::new();
 
+    let p2p_bind_addr: IpAddr = opts
+        .p2p_bind_addr
+        .parse()
+        .expect("Failed to parse p2p bind address");
+
     let p2p_context = P2PContext::new(
         local_p2p_node.clone(),
+        p2p_bind_addr,
         tracker.clone(),
         signer,
         peer_table.clone(),

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -26,7 +26,7 @@ use ethrex_storage_rollup::{EngineTypeRollup, StoreRollup};
 use eyre::OptionExt;
 use secp256k1::SecretKey;
 use spawned_concurrency::tasks::GenServerHandle;
-use std::{fs::read_to_string, path::Path, sync::Arc, time::Duration};
+use std::{fs::read_to_string, net::IpAddr, path::Path, sync::Arc, time::Duration};
 use tokio::task::JoinSet;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{info, warn};
@@ -239,8 +239,14 @@ pub async fn init_l2(
             blockchain.set_synced();
         }
         let peer_table = PeerTable::spawn(opts.node_opts.target_peers);
+        let p2p_bind_addr: IpAddr = opts
+            .node_opts
+            .p2p_bind_addr
+            .parse()
+            .expect("Failed to parse p2p bind address");
         let p2p_context = P2PContext::new(
             local_p2p_node.clone(),
+            p2p_bind_addr,
             tracker.clone(),
             signer,
             peer_table.clone(),

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -25,7 +25,11 @@ use ethrex_storage::{EngineType, Store};
 use hex_literal::hex;
 use secp256k1::SecretKey;
 use spawned_concurrency::tasks::{GenServer, GenServerHandle};
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+    sync::Arc,
+};
 use tokio::sync::Mutex as TokioMutex;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::info;
@@ -318,6 +322,7 @@ pub async fn dummy_p2p_context(peer_table: PeerTable) -> P2PContext {
 
     P2PContext::new(
         local_node,
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         TaskTracker::default(),
         SecretKey::from_byte_array(&[0xcd; 32]).expect("32 bytes, within curve order"),
         peer_table,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,7 +87,12 @@ P2P options:
 
 
       --p2p.addr <ADDRESS>
-          Listening address for the P2P protocol.
+          Advertised address for the P2P protocol (Node Record). Defaults to local IP if not set.
+
+      --p2p.bind-addr <ADDRESS>
+          Bind address for the P2P protocol.
+
+          [default: 0.0.0.0]
 
       --p2p.port <PORT>
           TCP port for the P2P protocol.


### PR DESCRIPTION
**Motivation**

ethrex uses the local-ip-address crate to find the IP address to advertise on the p2p layer. Inside Docker or in a NAT environment, none of the interfaces have the correct IP address, so using netlink calls won't find the correct IP.

While `--p2p.addr` can be used to set the IP address explicitly, setting that option also causes a `bind` call to that IP. This `bind` call panics because as said before there is no interface inside a Docker or NAT-ed environment with this IP address. 

<!-- Why does this pull request exist? What are its goals? -->

**Description**

Introduced --p2p.bind-addr (defaulting to 0.0.0.0) to allow specifying the local interface to bind to, while keeping --p2p.addr for the advertised address in the Node Record (ENR). This enables running the node in Docker environments where the bind and advertised addresses may differ.

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

