### PR TITLE
chore(l1): fix benchmark lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,9 +3995,14 @@ name = "ethrex-rlp"
 version = "9.0.0"
 dependencies = [
  "bytes",
+ "criterion",
  "ethereum-types 0.15.1",
+ "ethrex-common",
+ "ethrex-p2p",
+ "ethrex-trie",
  "hex",
  "lazy_static",
+ "rand 0.8.5",
  "snap",
  "thiserror 2.0.17",
  "tinyvec",

--- a/crates/common/rlp/Cargo.toml
+++ b/crates/common/rlp/Cargo.toml
@@ -14,6 +14,13 @@ lazy_static.workspace = true
 ethereum-types.workspace = true
 snap.workspace = true
 
+[dev-dependencies]
+criterion = "0.5.1"
+rand = "0.8.5"
+ethrex-common = { workspace = true }
+ethrex-p2p = { workspace = true }
+ethrex-trie = { workspace = true }
+
 [lib]
 path = "./rlp.rs"
 


### PR DESCRIPTION
**Motivation**

`make lint` was broken due to a missing dev-dep in a benchmark.

**Description**

Add the dep and update the Cargo.lock.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

