### PR TITLE
fix(l1): ef_tests-blockchain ProgramInput for L1

### DIFF
--- a/crates/l2/prover/src/guest_program/src/l1/input.rs
+++ b/crates/l2/prover/src/guest_program/src/l1/input.rs
@@ -10,3 +10,13 @@ pub struct ProgramInput {
     /// Database containing all the data necessary to execute.
     pub execution_witness: ExecutionWitness,
 }
+
+impl ProgramInput {
+    /// Creates a new ProgramInput with the given blocks and execution witness.
+    pub fn new(blocks: Vec<Block>, execution_witness: ExecutionWitness) -> Self {
+        Self {
+            blocks,
+            execution_witness,
+        }
+    }
+}

--- a/crates/l2/prover/src/guest_program/src/l2/input.rs
+++ b/crates/l2/prover/src/guest_program/src/l2/input.rs
@@ -37,3 +37,16 @@ impl Default for ProgramInput {
         }
     }
 }
+
+impl ProgramInput {
+    /// Creates a new ProgramInput with the given blocks and execution witness.
+    /// L2-specific fields are set to default values.
+    pub fn new(blocks: Vec<Block>, execution_witness: ExecutionWitness) -> Self {
+        Self {
+            blocks,
+            execution_witness,
+            elasticity_multiplier: ethrex_common::types::ELASTICITY_MULTIPLIER,
+            ..Default::default()
+        }
+    }
+}

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -3511,7 +3511,6 @@ dependencies = [
  "ethrex-rlp 9.0.0",
  "ethrex-storage 9.0.0",
  "ethrex-storage-rollup",
- "ethrex-threadpool",
  "ethrex-trie 9.0.0",
  "futures",
  "hex",
@@ -3736,13 +3735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethrex-threadpool"
-version = "9.0.0"
-dependencies = [
- "crossbeam 0.8.4",
-]
-
-[[package]]
 name = "ethrex-trie"
 version = "1.0.0"
 source = "git+https://github.com/lambdaclass/ethrex?tag=v1.0.0#a976db3e20acb441b930e1afd156586f222e8f79"
@@ -3774,7 +3766,6 @@ dependencies = [
  "ethereum-types 0.15.1",
  "ethrex-crypto",
  "ethrex-rlp 9.0.0",
- "ethrex-threadpool",
  "hex",
  "lazy_static",
  "rkyv",

--- a/tooling/ef_tests/blockchain/Cargo.toml
+++ b/tooling/ef_tests/blockchain/Cargo.toml
@@ -31,6 +31,7 @@ default = ["c-kzg"]
 c-kzg = ["ethrex-blockchain/c-kzg"]
 sp1 = ["guest_program/sp1", "ethrex-prover/sp1"]
 stateless = []
+l2 = ["guest_program/l2", "ethrex-prover/l2"]
 
 [[test]]
 name = "all"

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -409,12 +409,7 @@ async fn re_run_stateless(
     // At this point witness is guaranteed to be Ok
     let execution_witness = witness.unwrap();
 
-    let program_input = ProgramInput {
-        blocks,
-        execution_witness,
-        elasticity_multiplier: ethrex_common::types::ELASTICITY_MULTIPLIER,
-        ..Default::default()
-    };
+    let program_input = ProgramInput::new(blocks, execution_witness);
 
     let execute_result = match backend_type {
         BackendType::Exec => ExecBackend::new().execute(program_input),


### PR DESCRIPTION
## Summary
- Fix compilation errors in ef_tests-blockchain crate for both standalone and workspace builds

## Description
Due to Cargo's feature unification, when building with `cargo check --workspace --all-targets` in the tooling directory, `guest_program`'s `l2` feature gets enabled through `ethrex-prover`'s default features. This causes `guest_program::input::ProgramInput` to resolve to:
- `guest_program::l2::ProgramInput` in workspace builds
- `guest_program::l1::ProgramInput` in standalone builds

The fix adds a `ProgramInput::new()` constructor to both L1 and L2 input modules that creates the appropriate struct regardless of which features are enabled. The ef_tests-blockchain crate now uses this constructor instead of direct struct initialization.

### Changes:
- Add `ProgramInput::new(blocks, execution_witness)` to L1 input module
- Add `ProgramInput::new(blocks, execution_witness)` to L2 input module (with L2-specific fields set to defaults)
- Update ef_tests-blockchain to use the new constructor
- Add `l2` feature to ef_tests-blockchain for explicit feature control

## How to Test
```bash
# Standalone build
cargo check --manifest-path tooling/ef_tests/blockchain/Cargo.toml

# Workspace build
cd tooling && cargo check --workspace --all-targets

# Run tests
make -C tooling/ef_tests/blockchain test
```

## Related Issues
Fixes build failure after #5818 was merged