### PR TITLE
fix(levm): accumulate EIP-7702 gas refunds instead of overwriting

### DIFF
--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -431,7 +431,11 @@ impl<'a> VM<'a> {
                 .map_err(|_| TxValidationError::NonceIsMax)?;
         }
 
-        self.substate.refunded_gas = refunded_gas;
+        self.substate.refunded_gas = self
+            .substate
+            .refunded_gas
+            .checked_add(refunded_gas)
+            .ok_or(InternalError::Overflow)?;
 
         Ok(())
     }


### PR DESCRIPTION
**Motivation**

In `eip7702_set_access_code()`, the `refunded_gas` was being assigned directly to `self.substate.refunded_gas` rather than accumulated. While this doesn't cause issues currently (the function runs during validation before execution, when `refunded_gas` is 0), it's a latent bug that could silently discard previously accumulated refunds if the execution order changed during a refactor.

This was identified during an external audit review.

**Description**

Changed line 434 in `utils.rs` from direct assignment to checked addition:

```rust
// Before
self.substate.refunded_gas = refunded_gas;

// After
self.substate.refunded_gas = self
    .substate
    .refunded_gas
    .checked_add(refunded_gas)
    .ok_or(InternalError::Overflow)?;
```

This makes the code semantically correct and prevents future bugs during refactoring.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.