### PR TITLE
Use simd-json for faster JSON-RPC request parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,11 +4046,13 @@ dependencies = [
  "jemalloc_pprof",
  "jsonwebtoken 9.3.1",
  "rand 0.8.5",
+ "rayon",
  "reqwest 0.12.24",
  "secp256k1",
  "serde",
  "serde_json",
  "sha2",
+ "simd-json",
  "spawned-concurrency",
  "spawned-rt",
  "thiserror 2.0.17",
@@ -4383,6 +4385,15 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4866,6 +4877,16 @@ dependencies = [
  "cfg-if 1.0.4",
  "crunchy",
  "zerocopy 0.8.30",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -11863,6 +11884,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd-json"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+dependencies = [
+ "getrandom 0.2.16",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13937,6 +13973,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-trait"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ lambdaworks-crypto = "0.13.0"
 tui-logger = { version = "0.17.3", features = ["tracing-support"] }
 crossbeam = "0.8.4"
 rayon = "1.10.0"
+simd-json = "0.14"
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 tempfile = "3.8"
 uuid = { version = "1.18.1", features = ["v4"] }

--- a/crates/networking/rpc/Cargo.toml
+++ b/crates/networking/rpc/Cargo.toml
@@ -17,6 +17,7 @@ bytes.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 ethrex-common.workspace = true
+simd-json.workspace = true
 ethrex-storage.workspace = true
 ethrex-vm.workspace = true
 ethrex-blockchain.workspace = true


### PR DESCRIPTION
## Motivation

Improve RPC performance by using SIMD-accelerated JSON parsing. The `engine_newPayloadV4` RPC call processes large payloads containing block data and transactions, making JSON parsing a significant portion of request handling time.

## Description

Replace `serde_json::from_str` with `simd_json::from_slice` for parsing incoming HTTP and Auth RPC requests. simd-json uses SIMD CPU instructions for vectorized JSON parsing, which is particularly beneficial for large payloads like those in `engine_newPayloadV4`.

### Changes
- Add `simd-json` dependency to workspace and RPC crate
- Update `handle_http_request` to use `simd_json::from_slice`
- Update `handle_authrpc_request` to use `simd_json::from_slice`

## How to Test

1. Build and run ethrex with this branch
2. Monitor `rpc_request_duration_seconds` metric for `engine_newPayloadV4`
3. Compare against baseline on synchronized nodes processing the same blocks