### PR TITLE
feat(l1): add `engine_newPayloadWithWitnessV3`/`V4` endpoints

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -297,6 +297,14 @@ pub struct Options {
         help_heading = "Node options"
     )]
     pub precompute_witnesses: bool,
+    #[arg(
+        long = "new-payload-with-witness",
+        action = ArgAction::SetTrue,
+        default_value = "false",
+        help = "Enable engine_newPayloadWithWitness endpoints (experimental)",
+        help_heading = "RPC options"
+    )]
+    pub new_payload_with_witness: bool,
 }
 
 impl Options {
@@ -374,6 +382,7 @@ impl Default for Options {
             gas_limit: DEFAULT_BUILDER_GAS_CEIL,
             max_blobs_per_block: None,
             precompute_witnesses: false,
+            new_payload_with_witness: false,
         }
     }
 }

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -227,6 +227,7 @@ pub async fn init_rpc_api(
         log_filter_handler,
         opts.gas_limit,
         opts.extra_data.clone(),
+        opts.new_payload_with_witness,
     );
 
     tracker.spawn(rpc_api);

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -1,7 +1,11 @@
 use bytes::Bytes;
 use ethereum_types::{Address, Bloom, H256, U256};
 use ethrex_crypto::keccak::keccak_hash;
-use ethrex_rlp::encode::RLPEncode;
+use ethrex_rlp::{
+    decode::RLPDecode,
+    encode::RLPEncode,
+    structs::{Decoder, Encoder},
+};
 use ethrex_trie::Trie;
 use rkyv::{Archive, Deserialize as RDeserialize, Serialize as RSerialize};
 use serde::{Deserialize, Serialize};
@@ -269,6 +273,199 @@ pub struct ChainConfig {
 
     #[serde(default)]
     pub enable_verkle_at_genesis: bool,
+}
+
+impl RLPEncode for ForkBlobSchedule {
+    fn encode(&self, buf: &mut dyn bytes::BufMut) {
+        Encoder::new(buf)
+            .encode_field(&self.base_fee_update_fraction)
+            .encode_field(&(self.max as u64))
+            .encode_field(&(self.target as u64))
+            .finish();
+    }
+}
+
+impl RLPDecode for ForkBlobSchedule {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), ethrex_rlp::error::RLPDecodeError> {
+        let decoder = Decoder::new(rlp)?;
+        let (base_fee_update_fraction, decoder) =
+            decoder.decode_field("base_fee_update_fraction")?;
+        let (max, decoder): (u64, _) = decoder.decode_field("max")?;
+        let (target, decoder): (u64, _) = decoder.decode_field("target")?;
+        Ok((
+            Self {
+                base_fee_update_fraction,
+                max: max as u32,
+                target: target as u32,
+            },
+            decoder.finish()?,
+        ))
+    }
+}
+
+impl RLPEncode for BlobSchedule {
+    fn encode(&self, buf: &mut dyn bytes::BufMut) {
+        Encoder::new(buf)
+            .encode_field(&self.cancun)
+            .encode_field(&self.prague)
+            .encode_field(&self.osaka)
+            .encode_field(&self.bpo1)
+            .encode_field(&self.bpo2)
+            .encode_optional_field(&self.bpo3)
+            .encode_optional_field(&self.bpo4)
+            .encode_optional_field(&self.bpo5)
+            .encode_optional_field(&self.amsterdam)
+            .finish();
+    }
+}
+
+impl RLPDecode for BlobSchedule {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), ethrex_rlp::error::RLPDecodeError> {
+        let decoder = Decoder::new(rlp)?;
+        let (cancun, decoder) = decoder.decode_field("cancun")?;
+        let (prague, decoder) = decoder.decode_field("prague")?;
+        let (osaka, decoder) = decoder.decode_field("osaka")?;
+        let (bpo1, decoder) = decoder.decode_field("bpo1")?;
+        let (bpo2, decoder) = decoder.decode_field("bpo2")?;
+        let (bpo3, decoder) = decoder.decode_optional_field();
+        let (bpo4, decoder) = decoder.decode_optional_field();
+        let (bpo5, decoder) = decoder.decode_optional_field();
+        let (amsterdam, decoder) = decoder.decode_optional_field();
+        Ok((
+            Self {
+                cancun,
+                prague,
+                osaka,
+                bpo1,
+                bpo2,
+                bpo3,
+                bpo4,
+                bpo5,
+                amsterdam,
+            },
+            decoder.finish()?,
+        ))
+    }
+}
+
+impl RLPEncode for ChainConfig {
+    fn encode(&self, buf: &mut dyn bytes::BufMut) {
+        Encoder::new(buf)
+            .encode_field(&self.chain_id)
+            .encode_optional_field(&self.homestead_block)
+            .encode_optional_field(&self.dao_fork_block)
+            .encode_field(&self.dao_fork_support)
+            .encode_optional_field(&self.eip150_block)
+            .encode_optional_field(&self.eip155_block)
+            .encode_optional_field(&self.eip158_block)
+            .encode_optional_field(&self.byzantium_block)
+            .encode_optional_field(&self.constantinople_block)
+            .encode_optional_field(&self.petersburg_block)
+            .encode_optional_field(&self.istanbul_block)
+            .encode_optional_field(&self.muir_glacier_block)
+            .encode_optional_field(&self.berlin_block)
+            .encode_optional_field(&self.london_block)
+            .encode_optional_field(&self.arrow_glacier_block)
+            .encode_optional_field(&self.gray_glacier_block)
+            .encode_optional_field(&self.merge_netsplit_block)
+            .encode_optional_field(&self.shanghai_time)
+            .encode_optional_field(&self.cancun_time)
+            .encode_optional_field(&self.prague_time)
+            .encode_optional_field(&self.verkle_time)
+            .encode_optional_field(&self.osaka_time)
+            .encode_optional_field(&self.bpo1_time)
+            .encode_optional_field(&self.bpo2_time)
+            .encode_optional_field(&self.bpo3_time)
+            .encode_optional_field(&self.bpo4_time)
+            .encode_optional_field(&self.bpo5_time)
+            .encode_optional_field(&self.amsterdam_time)
+            .encode_optional_field(&self.terminal_total_difficulty)
+            .encode_field(&self.terminal_total_difficulty_passed)
+            .encode_field(&self.blob_schedule)
+            .encode_field(&self.deposit_contract_address)
+            .encode_field(&self.enable_verkle_at_genesis)
+            .finish();
+    }
+}
+
+impl RLPDecode for ChainConfig {
+    fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), ethrex_rlp::error::RLPDecodeError> {
+        let decoder = Decoder::new(rlp)?;
+        let (chain_id, decoder) = decoder.decode_field("chain_id")?;
+        let (homestead_block, decoder) = decoder.decode_optional_field();
+        let (dao_fork_block, decoder) = decoder.decode_optional_field();
+        let (dao_fork_support, decoder) = decoder.decode_field("dao_fork_support")?;
+        let (eip150_block, decoder) = decoder.decode_optional_field();
+        let (eip155_block, decoder) = decoder.decode_optional_field();
+        let (eip158_block, decoder) = decoder.decode_optional_field();
+        let (byzantium_block, decoder) = decoder.decode_optional_field();
+        let (constantinople_block, decoder) = decoder.decode_optional_field();
+        let (petersburg_block, decoder) = decoder.decode_optional_field();
+        let (istanbul_block, decoder) = decoder.decode_optional_field();
+        let (muir_glacier_block, decoder) = decoder.decode_optional_field();
+        let (berlin_block, decoder) = decoder.decode_optional_field();
+        let (london_block, decoder) = decoder.decode_optional_field();
+        let (arrow_glacier_block, decoder) = decoder.decode_optional_field();
+        let (gray_glacier_block, decoder) = decoder.decode_optional_field();
+        let (merge_netsplit_block, decoder) = decoder.decode_optional_field();
+        let (shanghai_time, decoder) = decoder.decode_optional_field();
+        let (cancun_time, decoder) = decoder.decode_optional_field();
+        let (prague_time, decoder) = decoder.decode_optional_field();
+        let (verkle_time, decoder) = decoder.decode_optional_field();
+        let (osaka_time, decoder) = decoder.decode_optional_field();
+        let (bpo1_time, decoder) = decoder.decode_optional_field();
+        let (bpo2_time, decoder) = decoder.decode_optional_field();
+        let (bpo3_time, decoder) = decoder.decode_optional_field();
+        let (bpo4_time, decoder) = decoder.decode_optional_field();
+        let (bpo5_time, decoder) = decoder.decode_optional_field();
+        let (amsterdam_time, decoder) = decoder.decode_optional_field();
+        let (terminal_total_difficulty, decoder) = decoder.decode_optional_field();
+        let (terminal_total_difficulty_passed, decoder) =
+            decoder.decode_field("terminal_total_difficulty_passed")?;
+        let (blob_schedule, decoder) = decoder.decode_field("blob_schedule")?;
+        let (deposit_contract_address, decoder) =
+            decoder.decode_field("deposit_contract_address")?;
+        let (enable_verkle_at_genesis, decoder) =
+            decoder.decode_field("enable_verkle_at_genesis")?;
+        Ok((
+            Self {
+                chain_id,
+                homestead_block,
+                dao_fork_block,
+                dao_fork_support,
+                eip150_block,
+                eip155_block,
+                eip158_block,
+                byzantium_block,
+                constantinople_block,
+                petersburg_block,
+                istanbul_block,
+                muir_glacier_block,
+                berlin_block,
+                london_block,
+                arrow_glacier_block,
+                gray_glacier_block,
+                merge_netsplit_block,
+                shanghai_time,
+                cancun_time,
+                prague_time,
+                verkle_time,
+                osaka_time,
+                bpo1_time,
+                bpo2_time,
+                bpo3_time,
+                bpo4_time,
+                bpo5_time,
+                amsterdam_time,
+                terminal_total_difficulty,
+                terminal_total_difficulty_passed,
+                blob_schedule,
+                deposit_contract_address,
+                enable_verkle_at_genesis,
+            },
+            decoder.finish()?,
+        ))
+    }
 }
 
 lazy_static::lazy_static! {

--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -110,6 +110,7 @@ pub async fn start_api(
             log_filter_handler,
             gas_ceil,
             block_worker_channel,
+            new_payload_with_witness: false,
         },
         valid_delegation_addresses,
         sponsor_pk,

--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -15,7 +15,7 @@ pub type ExchangeCapabilitiesRequest = Vec<String>;
 
 /// List of capabilities that the execution layer client supports. Add new capabilities here.
 /// More info: https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities
-pub const CAPABILITIES: [&str; 19] = [
+pub const CAPABILITIES: [&str; 21] = [
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",
@@ -23,6 +23,8 @@ pub const CAPABILITIES: [&str; 19] = [
     "engine_newPayloadV2",
     "engine_newPayloadV3",
     "engine_newPayloadV4",
+    "engine_newPayloadWithWitnessV3",
+    "engine_newPayloadWithWitnessV4",
     "engine_getPayloadV1",
     "engine_getPayloadV2",
     "engine_getPayloadV3",

--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -23,8 +23,6 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_newPayloadV2",
     "engine_newPayloadV3",
     "engine_newPayloadV4",
-    "engine_newPayloadWithWitnessV3",
-    "engine_newPayloadWithWitnessV4",
     "engine_getPayloadV1",
     "engine_getPayloadV2",
     "engine_getPayloadV3",
@@ -37,6 +35,12 @@ pub const CAPABILITIES: &[&str] = &[
     "engine_getBlobsV2",
     "engine_getBlobsV3",
     "engine_getClientVersionV1",
+];
+
+/// Additional capabilities enabled with --new-payload-with-witness flag (experimental).
+pub const WITNESS_CAPABILITIES: &[&str] = &[
+    "engine_newPayloadWithWitnessV3",
+    "engine_newPayloadWithWitnessV4",
 ];
 
 impl From<ExchangeCapabilitiesRequest> for RpcRequest {
@@ -62,7 +66,13 @@ impl RpcHandler for ExchangeCapabilitiesRequest {
             })
     }
 
-    async fn handle(&self, _context: RpcApiContext) -> Result<Value, RpcErr> {
-        Ok(json!(CAPABILITIES))
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        if context.new_payload_with_witness {
+            let mut capabilities: Vec<&str> = CAPABILITIES.to_vec();
+            capabilities.extend_from_slice(WITNESS_CAPABILITIES);
+            Ok(json!(capabilities))
+        } else {
+            Ok(json!(CAPABILITIES))
+        }
     }
 }

--- a/crates/networking/rpc/engine/mod.rs
+++ b/crates/networking/rpc/engine/mod.rs
@@ -15,7 +15,7 @@ pub type ExchangeCapabilitiesRequest = Vec<String>;
 
 /// List of capabilities that the execution layer client supports. Add new capabilities here.
 /// More info: https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities
-pub const CAPABILITIES: [&str; 21] = [
+pub const CAPABILITIES: &[&str] = &[
     "engine_forkchoiceUpdatedV1",
     "engine_forkchoiceUpdatedV2",
     "engine_forkchoiceUpdatedV3",

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -225,6 +225,123 @@ impl RpcHandler for NewPayloadV4Request {
     }
 }
 
+// NewPayloadWithWitness V3-V4 implementations (experimental)
+pub struct NewPayloadWithWitnessV3Request {
+    pub payload: ExecutionPayload,
+    pub expected_blob_versioned_hashes: Vec<H256>,
+    pub parent_beacon_block_root: H256,
+}
+
+impl RpcHandler for NewPayloadWithWitnessV3Request {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 3 {
+            return Err(RpcErr::BadParams("Expected 3 params".to_owned()));
+        }
+        Ok(NewPayloadWithWitnessV3Request {
+            payload: serde_json::from_value(params[0].clone())
+                .map_err(|_| RpcErr::WrongParam("payload".to_string()))?,
+            expected_blob_versioned_hashes: serde_json::from_value(params[1].clone())
+                .map_err(|_| RpcErr::WrongParam("expected_blob_versioned_hashes".to_string()))?,
+            parent_beacon_block_root: serde_json::from_value(params[2].clone())
+                .map_err(|_| RpcErr::WrongParam("parent_beacon_block_root".to_string()))?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let block = match get_block_from_payload(
+            &self.payload,
+            Some(self.parent_beacon_block_root),
+            None,
+        ) {
+            Ok(block) => block,
+            Err(err) => {
+                return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                    &err.to_string(),
+                ))?);
+            }
+        };
+        validate_fork(&block, Fork::Cancun, &context)?;
+        validate_execution_payload_v3(&self.payload)?;
+        let payload_status = handle_new_payload_with_witness_v3(
+            &self.payload,
+            context,
+            block,
+            self.expected_blob_versioned_hashes.clone(),
+        )
+        .await?;
+        serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+pub struct NewPayloadWithWitnessV4Request {
+    pub payload: ExecutionPayload,
+    pub expected_blob_versioned_hashes: Vec<H256>,
+    pub parent_beacon_block_root: H256,
+    pub execution_requests: Vec<EncodedRequests>,
+}
+
+impl RpcHandler for NewPayloadWithWitnessV4Request {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 4 {
+            return Err(RpcErr::BadParams("Expected 4 params".to_owned()));
+        }
+        Ok(NewPayloadWithWitnessV4Request {
+            payload: serde_json::from_value(params[0].clone())
+                .map_err(|_| RpcErr::WrongParam("payload".to_string()))?,
+            expected_blob_versioned_hashes: serde_json::from_value(params[1].clone())
+                .map_err(|_| RpcErr::WrongParam("expected_blob_versioned_hashes".to_string()))?,
+            parent_beacon_block_root: serde_json::from_value(params[2].clone())
+                .map_err(|_| RpcErr::WrongParam("parent_beacon_block_root".to_string()))?,
+            execution_requests: serde_json::from_value(params[3].clone())
+                .map_err(|_| RpcErr::WrongParam("execution_requests".to_string()))?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        // validate the received requests
+        validate_execution_requests(&self.execution_requests)?;
+
+        let requests_hash = compute_requests_hash(&self.execution_requests);
+        let block = match get_block_from_payload(
+            &self.payload,
+            Some(self.parent_beacon_block_root),
+            Some(requests_hash),
+        ) {
+            Ok(block) => block,
+            Err(err) => {
+                return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                    &err.to_string(),
+                ))?);
+            }
+        };
+
+        let chain_config = context.storage.get_chain_config();
+
+        if !chain_config.is_prague_activated(block.header.timestamp) {
+            return Err(RpcErr::UnsuportedFork(format!(
+                "{:?}",
+                chain_config.get_fork(block.header.timestamp)
+            )));
+        }
+        // We use v3 since the execution payload remains the same.
+        validate_execution_payload_v3(&self.payload)?;
+        let payload_status = handle_new_payload_with_witness_v3(
+            &self.payload,
+            context,
+            block,
+            self.expected_blob_versioned_hashes.clone(),
+        )
+        .await?;
+        serde_json::to_value(payload_status).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
 // GetPayload V1-V2-V3 implementations
 pub struct GetPayloadV1Request {
     pub payload_id: u64,
@@ -642,6 +759,147 @@ async fn handle_new_payload_v3(
     }
 
     handle_new_payload_v1_v2(payload, block, context).await
+}
+
+async fn handle_new_payload_with_witness_v3(
+    payload: &ExecutionPayload,
+    context: RpcApiContext,
+    block: Block,
+    expected_blob_versioned_hashes: Vec<H256>,
+) -> Result<PayloadStatus, RpcErr> {
+    let Some(syncer) = &context.syncer else {
+        return Err(RpcErr::Internal(
+            "New payload requested but syncer is not initialized".to_string(),
+        ));
+    };
+
+    // V3 specific: validate blob hashes
+    let blob_versioned_hashes: Vec<H256> = block
+        .body
+        .transactions
+        .iter()
+        .flat_map(|tx| tx.blob_versioned_hashes())
+        .collect();
+
+    if expected_blob_versioned_hashes != blob_versioned_hashes {
+        return Ok(PayloadStatus::invalid_with_err(
+            "Invalid blob_versioned_hashes",
+        ));
+    }
+
+    // Validate block hash
+    if let Err(RpcErr::Internal(error_msg)) = validate_block_hash(payload, &block) {
+        return Ok(PayloadStatus::invalid_with_err(&error_msg));
+    }
+
+    // Check for invalid ancestors
+    if let Some(status) = validate_ancestors(&block, &context).await? {
+        return Ok(status);
+    }
+
+    // We have validated ancestors, the parent is correct
+    let latest_valid_hash = block.header.parent_hash;
+
+    if syncer.sync_mode() == SyncMode::Snap {
+        debug!("Snap sync in progress, skipping new payload validation");
+        return Ok(PayloadStatus::syncing());
+    }
+
+    // Execute payload with witness generation
+    let payload_status =
+        try_execute_payload_with_witness(block, &context, latest_valid_hash).await?;
+    Ok(payload_status)
+}
+
+async fn try_execute_payload_with_witness(
+    block: Block,
+    context: &RpcApiContext,
+    latest_valid_hash: H256,
+) -> Result<PayloadStatus, RpcErr> {
+    let Some(syncer) = &context.syncer else {
+        return Err(RpcErr::Internal(
+            "New payload requested but syncer is not initialized".to_string(),
+        ));
+    };
+    let block_hash = block.hash();
+    let block_number = block.header.number;
+    let storage = &context.storage;
+
+    // Return the valid message directly if we already have it.
+    // For cached blocks, we try to get the witness from storage
+    if storage.get_block_header_by_hash(block_hash)?.is_some() {
+        // Block already exists, try to get witness from storage
+        if let Ok(Some(witness)) = storage.get_witness_by_number_and_hash(block_number, block_hash)
+        {
+            let witness_bytes =
+                serde_json::to_vec(&witness).map_err(|e| RpcErr::Internal(e.to_string()))?;
+            return Ok(PayloadStatus::valid_with_hash_and_witness(
+                block_hash,
+                witness_bytes.into(),
+            ));
+        }
+        // No witness stored, return valid without witness
+        return Ok(PayloadStatus::valid_with_hash(block_hash));
+    }
+
+    // Execute and store the block with witness generation
+    debug!(%block_hash, %block_number, "Executing payload with witness");
+
+    match context.blockchain.add_block_pipeline_with_witness(block) {
+        Err(ChainError::ParentNotFound) => {
+            // Start sync
+            syncer.sync_to_head(block_hash);
+            Ok(PayloadStatus::syncing())
+        }
+        Err(ChainError::ParentStateNotFound) => {
+            let e = "Failed to obtain parent state";
+            error!("{e} for block {block_hash}");
+            Err(RpcErr::Internal(e.to_string()))
+        }
+        Err(ChainError::InvalidBlock(error)) => {
+            warn!("Error executing block: {error}");
+            context
+                .storage
+                .set_latest_valid_ancestor(block_hash, latest_valid_hash)
+                .await?;
+            Ok(PayloadStatus::invalid_with(
+                latest_valid_hash,
+                error.to_string(),
+            ))
+        }
+        Err(ChainError::EvmError(error)) => {
+            warn!("Error executing block: {error}");
+            context
+                .storage
+                .set_latest_valid_ancestor(block_hash, latest_valid_hash)
+                .await?;
+            Ok(PayloadStatus::invalid_with(
+                latest_valid_hash,
+                error.to_string(),
+            ))
+        }
+        Err(ChainError::StoreError(error)) => {
+            warn!("Error storing block: {error}");
+            Err(RpcErr::Internal(error.to_string()))
+        }
+        Err(e) => {
+            error!("{e} for block {block_hash}");
+            Err(RpcErr::Internal(e.to_string()))
+        }
+        Ok(witness) => {
+            debug!("Block with hash {block_hash} executed and added to storage successfully");
+            if let Some(witness) = witness {
+                let witness_bytes =
+                    serde_json::to_vec(&witness).map_err(|e| RpcErr::Internal(e.to_string()))?;
+                Ok(PayloadStatus::valid_with_hash_and_witness(
+                    block_hash,
+                    witness_bytes.into(),
+                ))
+            } else {
+                Ok(PayloadStatus::valid_with_hash(block_hash))
+            }
+        }
+    }
 }
 
 // Elements of the list MUST be ordered by request_type in ascending order.

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -5,6 +5,7 @@ use ethrex_common::types::requests::{EncodedRequests, compute_requests_hash};
 use ethrex_common::types::{Block, BlockBody, BlockHash, BlockNumber, Fork};
 use ethrex_common::{H256, U256};
 use ethrex_p2p::sync::SyncMode;
+use ethrex_rlp::encode::RLPEncode;
 use ethrex_rlp::error::RLPDecodeError;
 use serde_json::Value;
 use tokio::sync::oneshot;
@@ -831,8 +832,7 @@ async fn try_execute_payload_with_witness(
         // Block already exists, try to get witness from storage
         if let Ok(Some(witness)) = storage.get_witness_by_number_and_hash(block_number, block_hash)
         {
-            let witness_bytes =
-                serde_json::to_vec(&witness).map_err(|e| RpcErr::Internal(e.to_string()))?;
+            let witness_bytes = witness.encode_to_vec();
             return Ok(PayloadStatus::valid_with_hash_and_witness(
                 block_hash,
                 witness_bytes.into(),
@@ -889,8 +889,7 @@ async fn try_execute_payload_with_witness(
         Ok(witness) => {
             debug!("Block with hash {block_hash} executed and added to storage successfully");
             if let Some(witness) = witness {
-                let witness_bytes =
-                    serde_json::to_vec(&witness).map_err(|e| RpcErr::Internal(e.to_string()))?;
+                let witness_bytes = witness.encode_to_vec();
                 Ok(PayloadStatus::valid_with_hash_and_witness(
                     block_hash,
                     witness_bytes.into(),

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -832,7 +832,9 @@ async fn try_execute_payload_with_witness(
         // Block already exists, try to get witness from storage
         if let Ok(Some(witness)) = storage.get_witness_by_number_and_hash(block_number, block_hash)
         {
-            let witness_bytes = witness.encode_to_vec();
+            let rpc_witness = crate::debug::execution_witness::RpcExecutionWitness::try_from(witness)
+                .map_err(|e| RpcErr::Internal(format!("Failed to convert witness: {e}")))?;
+            let witness_bytes = rpc_witness.encode_to_vec();
             return Ok(PayloadStatus::valid_with_hash_and_witness(
                 block_hash,
                 witness_bytes.into(),
@@ -889,7 +891,10 @@ async fn try_execute_payload_with_witness(
         Ok(witness) => {
             debug!("Block with hash {block_hash} executed and added to storage successfully");
             if let Some(witness) = witness {
-                let witness_bytes = witness.encode_to_vec();
+                let rpc_witness =
+                    crate::debug::execution_witness::RpcExecutionWitness::try_from(witness)
+                        .map_err(|e| RpcErr::Internal(format!("Failed to convert witness: {e}")))?;
+                let witness_bytes = rpc_witness.encode_to_vec();
                 Ok(PayloadStatus::valid_with_hash_and_witness(
                     block_hash,
                     witness_bytes.into(),

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -260,6 +260,7 @@ pub async fn start_test_api() -> tokio::task::JoinHandle<()> {
             None,
             DEFAULT_BUILDER_GAS_CEIL,
             String::new(),
+            false,
         )
         .await
         .unwrap()
@@ -294,6 +295,7 @@ pub async fn default_context_with_storage(storage: Store) -> RpcApiContext {
         log_filter_handler: None,
         gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
         block_worker_channel,
+        new_payload_with_witness: false,
     }
 }
 

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -172,6 +172,9 @@ pub struct PayloadStatus {
     pub status: PayloadValidationStatus,
     pub latest_valid_hash: Option<H256>,
     pub validation_error: Option<String>,
+    /// RLP-encoded execution witness (only present on VALID status when requested).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub witness: Option<Bytes>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -191,6 +194,7 @@ impl PayloadStatus {
             status: PayloadValidationStatus::Invalid,
             latest_valid_hash: Some(latest_valid_hash),
             validation_error: Some(error),
+            witness: None,
         }
     }
 
@@ -200,6 +204,7 @@ impl PayloadStatus {
             status: PayloadValidationStatus::Invalid,
             latest_valid_hash: None,
             validation_error: Some(error.to_string()),
+            witness: None,
         }
     }
 
@@ -209,6 +214,7 @@ impl PayloadStatus {
             status: PayloadValidationStatus::Invalid,
             latest_valid_hash: Some(hash),
             validation_error: None,
+            witness: None,
         }
     }
 
@@ -218,6 +224,7 @@ impl PayloadStatus {
             status: PayloadValidationStatus::Syncing,
             latest_valid_hash: None,
             validation_error: None,
+            witness: None,
         }
     }
 
@@ -227,14 +234,27 @@ impl PayloadStatus {
             status: PayloadValidationStatus::Valid,
             latest_valid_hash: Some(hash),
             validation_error: None,
+            witness: None,
         }
     }
+
     /// Creates a PayloadStatus with valid status and latest valid hash
     pub fn valid() -> Self {
         PayloadStatus {
             status: PayloadValidationStatus::Valid,
             latest_valid_hash: None,
             validation_error: None,
+            witness: None,
+        }
+    }
+
+    /// Creates a PayloadStatus with valid status, latest valid hash, and witness
+    pub fn valid_with_hash_and_witness(hash: BlockHash, witness: Bytes) -> Self {
+        PayloadStatus {
+            status: PayloadValidationStatus::Valid,
+            latest_valid_hash: Some(hash),
+            validation_error: None,
+            witness: Some(witness),
         }
     }
 }


### PR DESCRIPTION
## Motivation

Consensus clients may need execution witnesses for stateless validation. Geth provides `engine_newPayloadWithWitnessV3` and `engine_newPayloadWithWitnessV4` endpoints that return the execution witness alongside the payload status. This PR implements these experimental endpoints in ethrex.

## Description

Implements `engine_newPayloadWithWitnessV3` and `engine_newPayloadWithWitnessV4` following [Geth's implementation](https://github.com/ethereum/go-ethereum/blob/master/eth/catalyst/api.go).

### Key changes:

1. **CLI flag**: Added `--new-payload-with-witness` flag (disabled by default) to enable the experimental endpoints

2. **Blockchain refactoring**: 
   - Extracted `add_block_pipeline_inner(block, generate_witness: bool)` from existing `add_block_pipeline`
   - `add_block_pipeline` now calls inner with `false` (API unchanged)
   - Added `add_block_pipeline_with_witness` that calls inner with `true` and returns `Option<ExecutionWitness>`

3. **PayloadStatus**: Added optional `witness` field (JSON-encoded bytes, only present on VALID status when requested)

4. **Handlers**: Implemented `NewPayloadWithWitnessV3Request` and `NewPayloadWithWitnessV4Request` with same signatures as their non-witness counterparts

5. **Conditional registration**: Endpoints are only registered when `--new-payload-with-witness` is passed

### Response format (matches Geth):

```json
{
  "status": "VALID",
  "latestValidHash": "0x...",
  "validationError": null,
  "witness": "0x..."
}
```

Note: The witness is currently JSON-encoded (matching ethrex's internal storage format). Full RLP encoding to match Geth exactly can be added in a follow-up if needed.

## How to Test

1. Build ethrex:
   ```bash
   cargo build -p ethrex
   ```

2. Verify CLI flag:
   ```bash
   ./target/debug/ethrex --help | grep new-payload-with-witness
   ```

3. Test without flag (endpoints should return method not found):
   ```bash
   ./target/debug/ethrex --network sepolia
   # Call engine_newPayloadWithWitnessV3 -> should get "method not found"
   ```

4. Test with flag (endpoints should be available):
   ```bash
   ./target/debug/ethrex --network sepolia --new-payload-with-witness
   # Call engine_newPayloadWithWitnessV3 -> should work
   ```

## Checklist

- [x] Lint passes (`cargo clippy -p ethrex-rpc -p ethrex-blockchain -- -D warnings`)
- [x] Build passes (`cargo build -p ethrex`)
- [x] Tests pass (`cargo test -p ethrex-rpc --lib`)
- [ ] Real-world testing against mainnet node (pending)