### PR TITLE
fix(l1): auto-switch from snap to full sync when node has synced state

### DIFF
--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -43,31 +43,32 @@ impl SyncManager {
     ) -> Self {
         let snap_enabled = Arc::new(AtomicBool::new(matches!(sync_mode, SyncMode::Snap)));
 
+        // Fetch checkpoint once to avoid duplicate DB reads
+        let has_checkpoint = store
+            .get_header_download_checkpoint()
+            .await
+            .unwrap_or_else(|e| {
+                warn!("Failed to read header download checkpoint: {e}");
+                None
+            })
+            .is_some();
+
         // Auto-switch from snap to full sync if node already has synced state.
-        // A node is considered "synced" if:
-        // 1. It has blocks beyond the merge fork (post-merge state exists)
-        // 2. AND there's no ongoing snap sync (no header_download_checkpoint)
-        //
-        // The merge_netsplit_block threshold is used to avoid false positives in
-        // hive tests that start with pre-merge blocks. For post-merge networks
+        // A node is considered "synced" if it has blocks beyond the merge fork AND
+        // there's no ongoing snap sync. The merge_netsplit_block threshold avoids
+        // false positives in hive tests with pre-merge blocks. For post-merge networks
         // where merge_netsplit_block is 0, any block > 0 indicates prior sync.
-        if snap_enabled.load(Ordering::Relaxed) {
-            let has_checkpoint = store
-                .get_header_download_checkpoint()
-                .await
-                .is_ok_and(|res| res.is_some());
-
-            if !has_checkpoint {
-                let latest_block = store.get_latest_block_number().await.unwrap_or(0);
-                let merge_block = store.get_chain_config().merge_netsplit_block.unwrap_or(0);
-
-                if latest_block > merge_block {
-                    info!(
-                        "Node has synced state (block {} > merge block {}), switching to full sync",
-                        latest_block, merge_block
-                    );
-                    snap_enabled.store(false, Ordering::Relaxed);
-                }
+        // Skip auto-switch if merge_netsplit_block is None (custom genesis).
+        if snap_enabled.load(Ordering::Relaxed)
+            && !has_checkpoint
+            && let Some(merge_block) = store.get_chain_config().merge_netsplit_block
+        {
+            let latest_block = store.get_latest_block_number().await.unwrap_or(0);
+            if latest_block > merge_block {
+                info!(
+                    "Node has synced state (block {latest_block} > merge block {merge_block}), switching to full sync"
+                );
+                snap_enabled.store(false, Ordering::Relaxed);
             }
         }
 
@@ -86,11 +87,7 @@ impl SyncManager {
         };
         // If the node was in the middle of a sync and then re-started we must resume syncing
         // Otherwise we will incorreclty assume the node is already synced and work on invalid state
-        if store
-            .get_header_download_checkpoint()
-            .await
-            .is_ok_and(|res| res.is_some())
-        {
+        if has_checkpoint {
             sync_manager.start_sync();
         }
         sync_manager


### PR DESCRIPTION
## Motivation

The node starts snap sync regardless of existing state when using `--syncmode snap` (the default). The check for existing blocks only happened **inside** the snap sync cycle, causing the node to incorrectly report `SYNCING` to the CL before realizing it should use full sync.

## Description

Add state detection at startup in `SyncManager::new()` that automatically switches from snap to full sync when the node already has synced state.

A node is considered "synced" if:
1. It has blocks beyond the merge fork (post-merge state exists)
2. AND there's no ongoing snap sync (no `header_download_checkpoint`)

The `merge_netsplit_block` threshold is used to avoid false positives in hive tests that start with pre-merge blocks. For post-merge networks where `merge_netsplit_block` is 0, any block > 0 indicates prior sync.

### Network behavior

| Network | `merge_netsplit_block` | Behavior |
|---------|------------------------|----------|
| Mainnet | 15,537,394 | Pre-merge blocks allow snap sync, post-merge triggers full sync |
| Sepolia | ~1,450,409 | Same as mainnet |
| Holesky | 0 (post-merge genesis) | Any block > 0 triggers full sync |
| Devnets | Often 0 | Same as Holesky |

## How to Test

1. Run hive sync tests: `make run-hive SIMULATION=ethereum/sync`
2. Manual test scenarios:
   - Fresh node with `--syncmode snap` → should use snap sync
   - Node with existing blocks + `--syncmode snap` → should auto-switch to full sync
   - Node mid-snap-sync (has checkpoint) → should resume snap sync