### PR TITLE
perf(l1): reduce allocations in account range verification

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -873,15 +873,11 @@ impl PeerHandler {
             }
             // Unzip & validate response
             let proof = encodable_to_proof(&proof);
-            let (account_hashes, account_states): (Vec<_>, Vec<_>) = accounts
-                .clone()
-                .into_iter()
-                .map(|unit| (unit.hash, unit.account))
-                .unzip();
-            let encoded_accounts = account_states
+            let account_hashes: Vec<H256> = accounts.iter().map(|unit| unit.hash).collect();
+            let encoded_accounts: Vec<Vec<u8>> = accounts
                 .iter()
-                .map(|acc| acc.encode_to_vec())
-                .collect::<Vec<_>>();
+                .map(|unit| unit.account.encode_to_vec())
+                .collect();
 
             let Ok(should_continue) = verify_range(
                 state_root,


### PR DESCRIPTION
**Motivation**

`request_account_range_worker` was cloning the entire accounts vector and building an intermediate `Vec<AccountState>` just to feed verify_range, even though verify_range only needs slices of hashes and encoded values. This caused unnecessary allocations and copies on a hot path without providing any semantic benefits.

**Description**

Removed the clone and intermediate `Vec<AccountState>` by deriving account hashes and encoded account values directly from `&accounts` via iterators. The behavior of account range verification and the worker’s external API remain unchanged; only memory usage and CPU overhead are reduced.

