### PR TITLE
revert(l1): parallelize storage trie merkelization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,6 @@
 - Make HashSet use fxhash in discv4 peer_table [#5688](https://github.com/lambdaclass/ethrex/pull/5688)
 - Validate tx blobs after checking if it's already in the mempool [#5686](https://github.com/lambdaclass/ethrex/pull/5686)
 
-### 2025-12-15
-
-- Parallelize storage merkelization [#5497](https://github.com/lambdaclass/ethrex/pull/5497)
-
 ### 2025-12-02
 
 - Avoid unnecessary hashing of init codes and already hashed codes [#5397](https://github.com/lambdaclass/ethrex/pull/5397)

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -50,7 +50,7 @@ pub mod payload;
 pub mod tracing;
 pub mod vm;
 
-use ::tracing::{debug, info, instrument, warn};
+use ::tracing::{debug, info, instrument, trace, warn};
 use constants::{MAX_INITCODE_SIZE, MAX_TRANSACTION_DATA_SIZE, POST_OSAKA_GAS_LIMIT_CAP};
 use error::MempoolError;
 use error::{ChainError, InvalidBlockError};
@@ -62,13 +62,13 @@ use ethrex_common::types::EIP4844Transaction;
 use ethrex_common::types::block_execution_witness::ExecutionWitness;
 use ethrex_common::types::fee_config::FeeConfig;
 use ethrex_common::types::{
-    AccountInfo, AccountState, AccountUpdate, Block, BlockHash, BlockHeader, BlockNumber,
-    ChainConfig, Code, Receipt, Transaction, WrappedEIP4844Transaction,
+    AccountState, AccountUpdate, Block, BlockHash, BlockHeader, BlockNumber, ChainConfig, Code,
+    Receipt, Transaction, WrappedEIP4844Transaction,
 };
 use ethrex_common::types::{ELASTICITY_MULTIPLIER, P2PTransaction};
 use ethrex_common::types::{Fork, MempoolTransaction};
 use ethrex_common::utils::keccak;
-use ethrex_common::{Address, H256, TrieLogger, U256};
+use ethrex_common::{Address, H160, H256, TrieLogger};
 pub use ethrex_common::{
     get_total_blob_gas, validate_block, validate_gas_used, validate_receipts_root,
     validate_requests_hash,
@@ -80,8 +80,8 @@ use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::{
     AccountUpdatesList, Store, UpdateBatch, error::StoreError, hash_address, hash_key,
 };
-use ethrex_trie::node::{BranchNode, ExtensionNode, LeafNode};
-use ethrex_trie::{Nibbles, Node, NodeRef, Trie, TrieError, TrieNode};
+use ethrex_trie::node::{BranchNode, ExtensionNode};
+use ethrex_trie::{Nibbles, Node, NodeRef, Trie};
 use ethrex_vm::backends::CachingDatabase;
 use ethrex_vm::backends::levm::LEVM;
 use ethrex_vm::backends::levm::db::DatabaseLogger;
@@ -91,7 +91,6 @@ use payload::PayloadOrTask;
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::mpsc::Sender;
 use std::sync::{
     Arc, RwLock,
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -111,6 +110,8 @@ use ethrex_common::types::BlobsBundle;
 
 const MAX_PAYLOADS: usize = 10;
 const MAX_MEMPOOL_SIZE_DEFAULT: usize = 10_000;
+
+type StoreUpdatesMap = FxHashMap<H256, (Result<Trie, StoreError>, FxHashMap<Nibbles, Vec<u8>>)>;
 
 // Result type for execute_block_pipeline
 type BlockExecutionPipelineResult = (
@@ -218,6 +219,12 @@ impl Default for BlockchainOptions {
     }
 }
 
+struct PartialMerkleizationResults {
+    state_updates: FxHashMap<Nibbles, Vec<u8>>,
+    storage_updates: StoreUpdatesMap,
+    code_updates: FxHashMap<H256, Code>,
+}
+
 #[derive(Debug, Clone)]
 pub struct BatchBlockProcessingFailure {
     pub last_valid_hash: H256,
@@ -234,47 +241,6 @@ fn log_batch_progress(batch_size: u32, current_block: u32) {
             }
         });
     }
-}
-
-enum MerklizationRequest {
-    LoadAccount(H256),
-    Delete(H256),
-    MerklizeStorage {
-        prefix: H256,
-        key: H256,
-        value: U256,
-    },
-    MerklizeAccount {
-        hashed_account: H256,
-        state: PreMerkelizedAccountState,
-    },
-    CollectStorages {
-        tx: Sender<CollectedStorageMsg>,
-    },
-    CollectState {
-        tx: Sender<CollectedStateMsg>,
-    },
-}
-
-struct CollectedStateMsg {
-    index: u8,
-    subroot: Box<BranchNode>,
-    state_nodes: Vec<TrieNode>,
-    storage_nodes: Vec<(H256, Vec<TrieNode>)>,
-}
-
-struct CollectedStorageMsg {
-    index: u8,
-    prefix: H256,
-    subroot: Box<BranchNode>,
-    nodes: Vec<TrieNode>,
-}
-
-#[derive(Default)]
-struct PreMerkelizedAccountState {
-    info: Option<AccountInfo>,
-    storage_root: Option<Box<BranchNode>>,
-    nodes: Vec<TrieNode>,
 }
 
 impl Blockchain {
@@ -454,6 +420,39 @@ impl Blockchain {
         ))
     }
 
+    fn handle_merkleization_subtrie(
+        &self,
+        rx: Receiver<Vec<(H256, AccountUpdate)>>,
+        parent_header: &BlockHeader,
+    ) -> Result<PartialMerkleizationResults, StoreError> {
+        let mut state_trie = self
+            .storage
+            .state_trie(parent_header.hash())?
+            .ok_or(StoreError::MissingStore)?;
+        let mut state_updates_map: FxHashMap<Nibbles, Vec<u8>> = Default::default();
+        let mut storage_updates_map: StoreUpdatesMap = Default::default();
+        let mut code_updates: FxHashMap<H256, Code> = Default::default();
+        let mut account_states: FxHashMap<H256, AccountState> = Default::default();
+        for updates in rx {
+            Self::process_incoming_update_message(
+                &self.storage,
+                &mut state_trie,
+                updates,
+                &mut storage_updates_map,
+                parent_header,
+                &mut state_updates_map,
+                &mut code_updates,
+                &mut account_states,
+            )?;
+        }
+
+        Ok(PartialMerkleizationResults {
+            state_updates: state_updates_map,
+            storage_updates: storage_updates_map,
+            code_updates,
+        })
+    }
+
     #[instrument(
         level = "trace",
         name = "Trie update",
@@ -472,6 +471,35 @@ impl Blockchain {
         'a: 's,
         'b: 's,
     {
+        // Fetch the old root from the DB and decode it
+        let old_root_opt = self
+            .storage
+            .state_trie(parent_header.hash())?
+            .ok_or(StoreError::MissingStore)?
+            .db()
+            .get(Nibbles::default())?
+            .map(|v| Node::decode(&v))
+            .transpose()?;
+
+        // If there's no root, or it's not a branch node, we fallback to sequential processing.
+        let Some(Node::Branch(old_root)) = old_root_opt else {
+            return self.handle_merkleization_sequential(
+                rx,
+                parent_header,
+                queue_length,
+                max_queue_length,
+            );
+        };
+        // If there are less than 3 subtries, we fallback to sequential processing.
+        // This simplifies the handling of shard results.
+        if old_root.choices.iter().filter(|c| c.is_valid()).count() < 3 {
+            return self.handle_merkleization_sequential(
+                rx,
+                parent_header,
+                queue_length,
+                max_queue_length,
+            );
+        }
         let mut workers_tx = Vec::with_capacity(16);
         let mut workers_handles = Vec::with_capacity(16);
         for i in 0..16 {
@@ -479,16 +507,16 @@ impl Blockchain {
             let handle = std::thread::Builder::new()
                 .name(format!("block_executor_merkleization_shard_worker_{i}"))
                 .spawn_scoped(scope, move || {
-                    self.handle_merkleization_subtrie(rx, parent_header, i)
+                    self.handle_merkleization_subtrie(rx, parent_header)
                 })
                 .map_err(|e| StoreError::Custom(format!("spawn failed: {e:?}",)))?;
             workers_handles.push(handle);
             workers_tx.push(tx);
         }
-
-        let mut account_state: FxHashMap<H256, PreMerkelizedAccountState> = Default::default();
-        let mut code_updates: Vec<(H256, Code)> = vec![];
-        let mut hashed_address_cache: FxHashMap<Address, H256> = Default::default();
+        let mut state_updates_map: FxHashMap<Nibbles, Vec<u8>> = Default::default();
+        let mut storage_updates_map: StoreUpdatesMap = Default::default();
+        let mut code_updates: FxHashMap<H256, Code> = Default::default();
+        let mut hashed_address_cache: FxHashMap<H160, H256> = Default::default();
 
         // Accumulator for witness generation (only used if precompute_witnesses is true)
         let mut accumulator: Option<FxHashMap<Address, AccountUpdate>> =
@@ -501,7 +529,9 @@ impl Blockchain {
         for updates in rx {
             let current_length = queue_length.fetch_sub(1, Ordering::Acquire);
             *max_queue_length = current_length.max(*max_queue_length);
+
             // Accumulate updates for witness generation if enabled
+            // We clone here only when witness generation is needed
             if let Some(acc) = &mut accumulator {
                 for update in updates.clone() {
                     match acc.entry(update.address) {
@@ -515,120 +545,79 @@ impl Blockchain {
                 }
             }
 
-            for update in updates {
-                let hashed_address = *hashed_address_cache
-                    .entry(update.address)
-                    .or_insert_with(|| keccak(update.address));
-                let account_bucket = hashed_address.as_fixed_bytes()[0] >> 4;
-                workers_tx[account_bucket as usize]
-                    .send(MerklizationRequest::LoadAccount(hashed_address))
-                    .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
-                if update.removed_storage | update.removed {
-                    for tx in &workers_tx {
-                        tx.send(MerklizationRequest::Delete(hashed_address))
-                            .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
-                    }
-                }
-                for (key, value) in update.added_storage {
-                    let hashed_key = keccak(key);
-                    let bucket = hashed_key.as_fixed_bytes()[0] >> 4;
-                    workers_tx[bucket as usize]
-                        .send(MerklizationRequest::MerklizeStorage {
-                            prefix: hashed_address,
-                            key: hashed_key,
-                            value,
-                        })
-                        .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
-                }
-                let state = account_state.entry(hashed_address).or_default();
-                if let Some(info) = update.info {
-                    if let Some(code) = update.code {
-                        code_updates.push((info.code_hash, code));
-                    }
-                    state.info = Some(info);
-                }
-
-                if update.removed {
-                    *state = PreMerkelizedAccountState {
-                        info: Some(Default::default()),
-                        ..Default::default()
-                    };
-                }
-            }
-        }
-
-        let (gatherer_tx, gatherer_rx) = channel();
-        for tx in &workers_tx {
-            tx.send(MerklizationRequest::CollectStorages {
-                tx: gatherer_tx.clone(),
-            })
-            .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
-        }
-        drop(gatherer_tx);
-
-        for CollectedStorageMsg {
-            index,
-            prefix,
-            mut subroot,
-            nodes,
-        } in gatherer_rx
-        {
-            let state = account_state.entry(prefix).or_default();
-            match &mut state.storage_root {
-                Some(root) => {
-                    root.choices[index as usize] =
-                        std::mem::take(&mut subroot.choices[index as usize]);
-                }
-                rootptr => {
-                    *rootptr = Some(subroot);
-                }
-            }
-            state.nodes.extend(nodes);
-        }
-
-        let mut storage_updates: Vec<(H256, Vec<TrieNode>)> = Default::default();
-
-        for (hashed_account, state) in account_state {
-            let bucket = hashed_account.as_fixed_bytes()[0] >> 4;
-            workers_tx[bucket as usize]
-                .send(MerklizationRequest::MerklizeAccount {
-                    hashed_account,
-                    state,
+            let mut hashed_updates: Vec<_> = updates
+                .into_iter()
+                .map(|u| {
+                    let hashed_address = hashed_address_cache
+                        .entry(u.address)
+                        .or_insert_with(|| keccak(u.address));
+                    (*hashed_address, u)
                 })
-                .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
+                .collect();
+            hashed_updates.sort_by_key(|(h, _)| h.0[0]);
+            for sharded_update in hashed_updates.chunk_by(|l, r| l.0.0[0] & 0xf0 == r.0.0[0] & 0xf0)
+            {
+                let shard_message = sharded_update.to_vec();
+                workers_tx[(shard_message[0].0.0[0] >> 4) as usize]
+                    .send(shard_message)
+                    .map_err(|e| StoreError::Custom(format!("send failed: {e}")))?;
+            }
         }
-
-        let (gatherer_tx, gatherer_rx) = channel();
-        for tx in &workers_tx {
-            tx.send(MerklizationRequest::CollectState {
-                tx: gatherer_tx.clone(),
-            })
-            .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
-        }
-        drop(gatherer_tx);
-
-        let mut root = BranchNode::default();
-        let mut state_updates = Vec::new();
-        for CollectedStateMsg {
-            index,
-            subroot,
-            state_nodes,
-            storage_nodes,
-        } in gatherer_rx
-        {
-            storage_updates.extend(storage_nodes);
-            state_updates.extend(state_nodes);
-            root.choices[index as usize] = subroot.choices[index as usize].clone();
-        }
-        let state_trie_hash =
-            if let Some(root) = self.collapse_root_node(parent_header, None, root)? {
-                let mut root = NodeRef::from(root);
-                let hash = root.commit(Nibbles::default(), &mut state_updates);
-                hash.finalize()
-            } else {
-                state_updates.push((Nibbles::default(), vec![RLP_NULL]));
-                *EMPTY_TRIE_HASH
+        drop(workers_tx);
+        let mut real_root = old_root;
+        for (choice, worker) in workers_handles.into_iter().enumerate() {
+            let worker_result = worker
+                .join()
+                .map_err(|e| StoreError::Custom(format!("join failed: {e:?}",)))??;
+            let Some(root_node) = worker_result.state_updates.get(&Nibbles::default()) else {
+                continue;
             };
+            let root_node = Node::decode(root_node)?;
+            let Node::Branch(mut subtrie_branch) = root_node else {
+                unreachable!("the result can only remove one of the >2 subtries we had")
+            };
+            real_root.choices[choice] = std::mem::take(&mut subtrie_branch.choices[choice]);
+
+            code_updates.extend(worker_result.code_updates);
+            storage_updates_map.extend(worker_result.storage_updates);
+            state_updates_map.extend(worker_result.state_updates);
+        }
+
+        // Turn the root back into an extension or leaf if applicable
+        let root_node_opt = {
+            let children = real_root
+                .choices
+                .iter()
+                .filter(|child| child.is_valid())
+                // No need to check all of them
+                .take(2)
+                .count();
+
+            match children {
+                0 | 1 => collapse_root_node(
+                    real_root,
+                    &mut state_updates_map,
+                    &self.storage,
+                    parent_header,
+                )?,
+                // More than one child. Keep as branch
+                _ => Some(Node::Branch(real_root)),
+            }
+        };
+
+        let (state_trie_hash, root_node) = if let Some(root_node) = &root_node_opt {
+            let encoded_root_node = root_node.encode_to_vec();
+            (keccak(&encoded_root_node), encoded_root_node)
+        } else {
+            (*EMPTY_TRIE_HASH, vec![RLP_NULL])
+        };
+        state_updates_map.insert(Nibbles::default(), root_node);
+        let state_updates = state_updates_map.into_iter().collect();
+        let storage_updates = storage_updates_map
+            .into_iter()
+            .map(|(a, (_, s))| (a, s.into_iter().collect()))
+            .collect();
+        let code_updates = code_updates.into_iter().collect();
 
         let accumulated_updates = accumulator.map(|acc| acc.into_values().collect());
 
@@ -643,194 +632,219 @@ impl Blockchain {
         ))
     }
 
-    fn load_trie(
+    fn handle_merkleization_sequential(
         &self,
+        rx: Receiver<Vec<AccountUpdate>>,
         parent_header: &BlockHeader,
-        prefix: Option<H256>,
-    ) -> Result<Trie, StoreError> {
-        Ok(match prefix {
-            Some(account_hash) => {
-                let trie = self.storage.open_storage_trie(
-                    account_hash,
-                    parent_header.state_root,
-                    *EMPTY_TRIE_HASH,
-                )?;
-                let root = trie
-                    .db()
-                    .get(Nibbles::default())?
-                    .filter(|rlp| !rlp.is_empty())
-                    .map(keccak)
-                    .unwrap_or(*EMPTY_TRIE_HASH);
-                self.storage
-                    .open_storage_trie(account_hash, parent_header.state_root, root)?
-            }
-            None => self.storage.open_state_trie(parent_header.state_root)?,
-        })
-    }
+        queue_length: &AtomicUsize,
+        max_queue_length: &mut usize,
+    ) -> Result<(AccountUpdatesList, Option<Vec<AccountUpdate>>), StoreError> {
+        let mut state_trie = self
+            .storage
+            .state_trie(parent_header.hash())?
+            .ok_or(StoreError::MissingStore)?;
+        let mut state_trie_hash = H256::default();
+        let mut state_updates_map: FxHashMap<Nibbles, Vec<u8>> = Default::default();
+        let mut storage_updates_map: StoreUpdatesMap = Default::default();
+        let mut code_updates: FxHashMap<H256, Code> = Default::default();
+        let mut account_states: FxHashMap<H256, AccountState> = Default::default();
 
-    /// Collapses a root branch node into an extension or leaf node if it has only one valid child.
-    /// Returns None if there are no valid children.
-    fn collapse_root_node(
-        &self,
-        parent_header: &BlockHeader,
-        prefix: Option<H256>,
-        mut root: BranchNode,
-    ) -> Result<Option<Node>, StoreError> {
-        // Ensures the children are included in the final commit
-        root.choices.iter_mut().for_each(NodeRef::clear_hash);
-        let children: Vec<(usize, &NodeRef)> = root
-            .choices
-            .iter()
-            .enumerate()
-            .filter(|(_, choice)| choice.is_valid())
-            .take(2)
+        let mut hashed_address_cache: FxHashMap<H160, H256> = Default::default();
+
+        // Accumulator for witness generation (only used if precompute_witnesses is true)
+        let mut accumulator: Option<FxHashMap<Address, AccountUpdate>> =
+            if self.options.precompute_witnesses {
+                Some(FxHashMap::default())
+            } else {
+                None
+            };
+
+        for updates in rx {
+            let current_length = queue_length.fetch_sub(1, Ordering::Acquire);
+            *max_queue_length = current_length.max(*max_queue_length);
+
+            // Accumulate updates for witness generation if enabled
+            // We clone here only when witness generation is needed
+            if let Some(acc) = &mut accumulator {
+                for update in updates.clone() {
+                    match acc.entry(update.address) {
+                        Entry::Vacant(e) => {
+                            e.insert(update);
+                        }
+                        Entry::Occupied(mut e) => {
+                            e.get_mut().merge(update);
+                        }
+                    }
+                }
+            }
+
+            let hashed_updates: Vec<_> = updates
+                .into_iter()
+                .map(|u| {
+                    let hashed_address = hashed_address_cache
+                        .entry(u.address)
+                        .or_insert_with(|| keccak(u.address));
+                    (*hashed_address, u)
+                })
+                .collect();
+            state_trie_hash = Self::process_incoming_update_message(
+                &self.storage,
+                &mut state_trie,
+                hashed_updates,
+                &mut storage_updates_map,
+                parent_header,
+                &mut state_updates_map,
+                &mut code_updates,
+                &mut account_states,
+            )?;
+        }
+        let state_updates = state_updates_map.into_iter().collect();
+        let storage_updates = storage_updates_map
+            .into_iter()
+            .map(|(a, (_, s))| (a, s.into_iter().collect()))
             .collect();
-        if children.len() > 1 {
-            return Ok(Some(Node::Branch(Box::from(root))));
-        }
-        let Some((choice, only_child)) = children.first() else {
-            return Ok(None);
-        };
-        let only_child = Arc::unwrap_or_clone(match only_child {
-            NodeRef::Node(node, _) => node.clone(),
-            noderef @ NodeRef::Hash(_) => {
-                let trie = self.load_trie(parent_header, prefix)?;
-                let Some(node) =
-                    noderef.get_node(trie.db(), Nibbles::from_hex(vec![*choice as u8]))?
-                else {
-                    return Ok(None);
-                };
-                node
-            }
-        });
-        Ok(Some(match only_child {
-            Node::Branch(_) => {
-                ExtensionNode::new(Nibbles::from_hex(vec![*choice as u8]), only_child.into()).into()
-            }
-            Node::Extension(mut extension_node) => {
-                extension_node.prefix.prepend(*choice as u8);
-                extension_node.into()
-            }
-            Node::Leaf(mut leaf) => {
-                leaf.partial.prepend(*choice as u8);
-                leaf.into()
-            }
-        }))
+        let code_updates = code_updates.into_iter().collect();
+
+        let accumulated_updates = accumulator.map(|acc| acc.into_values().collect());
+
+        Ok((
+            AccountUpdatesList {
+                state_trie_hash,
+                state_updates,
+                storage_updates,
+                code_updates,
+            },
+            accumulated_updates,
+        ))
     }
 
-    fn handle_merkleization_subtrie(
-        &self,
-        rx: Receiver<MerklizationRequest>,
+    /// Processes a batch of account updates, applying them to the state trie and storage tries,
+    /// and returns the new state root.
+    #[allow(clippy::too_many_arguments)]
+    fn process_incoming_update_message(
+        storage: &Store,
+        state_trie: &mut Trie,
+        updates: Vec<(H256, AccountUpdate)>,
+        storage_updates_map: &mut StoreUpdatesMap,
         parent_header: &BlockHeader,
-        index: u8,
-    ) -> Result<(), StoreError> {
-        let mut tree: FxHashMap<H256, Trie> = Default::default();
-        let mut state_trie = self.storage.open_state_trie(parent_header.state_root)?;
-        let mut storage_nodes = vec![];
-        let mut accounts: FxHashMap<H256, AccountState> = Default::default();
-        for msg in rx {
-            match msg {
-                MerklizationRequest::LoadAccount(prefix) => match accounts.entry(prefix) {
-                    Entry::Occupied(_) => {}
-                    Entry::Vacant(vacant_entry) => {
-                        let account_state = match state_trie.get(prefix.as_bytes())? {
-                            Some(rlp) => {
-                                let state = AccountState::decode(&rlp)?;
-                                state_trie.insert(prefix.as_bytes().to_vec(), rlp)?;
-                                state
-                            }
-                            None => AccountState::default(),
-                        };
-                        vacant_entry.insert(account_state);
-                    }
-                },
-                MerklizationRequest::Delete(prefix) => {
-                    tree.insert(prefix, Trie::new_temp());
+        state_updates_map: &mut FxHashMap<Nibbles, Vec<u8>>,
+        code_updates: &mut FxHashMap<H256, Code>,
+        account_states: &mut FxHashMap<H256, AccountState>,
+    ) -> Result<H256, StoreError> {
+        trace!("Execute block pipeline: Received {} updates", updates.len());
+        // Apply the account updates over the last block's state and compute the new state root
+        for (hashed_address_h256, update) in updates {
+            let hashed_address = hashed_address_h256.0.to_vec();
+            trace!(
+                "Execute block pipeline: Update cycle for {}",
+                hex::encode(&hashed_address)
+            );
+            if update.removed {
+                // Remove account from trie
+                state_trie.remove(&hashed_address)?;
+                account_states.remove(&hashed_address_h256);
+                continue;
+            }
+            // Add or update AccountState in the trie
+            // Fetch current state or create a new state to be inserted
+            let account_state = match account_states.entry(hashed_address_h256) {
+                Entry::Occupied(occupied_entry) => {
+                    trace!(
+                        "Found account state in cache for {}",
+                        hex::encode(&hashed_address)
+                    );
+                    occupied_entry.into_mut()
                 }
-                MerklizationRequest::MerklizeStorage { prefix, key, value } => {
-                    let trie = match tree.entry(prefix) {
-                        Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
-                        Entry::Vacant(vacant_entry) => {
-                            vacant_entry.insert(self.load_trie(parent_header, Some(prefix))?)
+                Entry::Vacant(vacant_entry) => {
+                    let account_state = match state_trie.get(&hashed_address)? {
+                        Some(encoded_state) => {
+                            trace!(
+                                "Found account state in trie for {}",
+                                hex::encode(&hashed_address)
+                            );
+                            AccountState::decode(&encoded_state)?
+                        }
+                        None => {
+                            trace!(
+                                "Created account state in trie for {}",
+                                hex::encode(&hashed_address)
+                            );
+                            AccountState::default()
                         }
                     };
-                    if value.is_zero() {
-                        trie.remove(key.as_bytes())?;
-                    } else {
-                        trie.insert(key.as_bytes().to_vec(), value.encode_to_vec())?;
-                    }
+                    vacant_entry.insert(account_state)
                 }
-                MerklizationRequest::MerklizeAccount {
-                    hashed_account,
-                    mut state,
-                } => {
-                    let mut storage_root = None;
-                    if let Some(root) = state.storage_root {
-                        if let Some(root) =
-                            self.collapse_root_node(parent_header, Some(hashed_account), *root)?
-                        {
-                            let mut root = NodeRef::from(root);
-                            let hash = root.commit(Nibbles::default(), &mut state.nodes);
-                            storage_root = Some(hash.finalize());
-                        } else {
-                            state.nodes.push((Nibbles::default(), vec![RLP_NULL]));
-                            storage_root = Some(*EMPTY_TRIE_HASH);
-                        }
-                    }
-                    storage_nodes.push((hashed_account, state.nodes));
-
-                    let path = hashed_account.as_bytes();
-                    let old_state = match accounts.entry(hashed_account) {
-                        Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
-                        Entry::Vacant(vacant_entry) => {
-                            let account_state = match state_trie.get(path)? {
-                                Some(rlp) => AccountState::decode(&rlp)?,
-                                None => AccountState::default(),
-                            };
-                            vacant_entry.insert(account_state)
-                        }
-                    };
-
-                    if let Some(storage_root) = storage_root {
-                        old_state.storage_root = storage_root;
-                    }
-                    if let Some(info) = state.info {
-                        old_state.nonce = info.nonce;
-                        old_state.balance = info.balance;
-                        old_state.code_hash = info.code_hash;
-                    }
-                    if *old_state != AccountState::default() {
-                        state_trie.insert(path.to_vec(), old_state.encode_to_vec())?;
-                    } else {
-                        state_trie.remove(path)?;
-                    }
-                }
-                MerklizationRequest::CollectStorages { tx } => {
-                    for (prefix, trie) in tree.drain() {
-                        let (root, nodes) = collect_trie(index, trie)?;
-                        tx.send(CollectedStorageMsg {
-                            index,
-                            prefix,
-                            subroot: root,
-                            nodes,
-                        })
-                        .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
-                    }
-                }
-                MerklizationRequest::CollectState { tx } => {
-                    let (subroot, state_nodes) =
-                        collect_trie(index, std::mem::take(&mut state_trie))?;
-                    tx.send(CollectedStateMsg {
-                        index,
-                        subroot,
-                        state_nodes,
-                        storage_nodes: std::mem::take(&mut storage_nodes),
-                    })
-                    .map_err(|e| StoreError::Custom(format!("send error: {e}")))?;
+            };
+            if update.removed_storage {
+                account_state.storage_root = *EMPTY_TRIE_HASH;
+                storage_updates_map.remove(&hashed_address_h256);
+            }
+            if let Some(info) = &update.info {
+                trace!(
+                    nonce = info.nonce,
+                    balance = hex::encode(info.balance.to_big_endian()),
+                    code_hash = hex::encode(info.code_hash),
+                    "With info"
+                );
+                account_state.nonce = info.nonce;
+                account_state.balance = info.balance;
+                account_state.code_hash = info.code_hash;
+                // Store updated code in DB
+                if let Some(code) = &update.code {
+                    trace!("Updated code");
+                    code_updates.insert(info.code_hash, code.clone());
                 }
             }
+            // Store the added storage in the account's storage trie and compute its new root
+            if !update.added_storage.is_empty() {
+                trace!(count = update.added_storage.len(), "Update storages");
+                let (storage_trie, storage_updates_map) = storage_updates_map
+                    .entry(hashed_address_h256)
+                    .or_insert_with(|| {
+                        (
+                            storage.open_storage_trie(
+                                hashed_address_h256,
+                                parent_header.state_root,
+                                account_state.storage_root,
+                            ),
+                            Default::default(),
+                        )
+                    });
+                let Ok(storage_trie) = storage_trie else {
+                    debug!(
+                        "Failed to open storage trie for account {}",
+                        hex::encode(&hashed_address)
+                    );
+                    return Err(StoreError::Custom("Error opening storage trie".to_string()));
+                };
+                for (storage_key, storage_value) in &update.added_storage {
+                    let hashed_key = hash_key(storage_key);
+                    if storage_value.is_zero() {
+                        trace!(slot = hex::encode(&hashed_key), "Removing");
+                        storage_trie.remove(&hashed_key)?;
+                    } else {
+                        trace!(slot = hex::encode(&hashed_key), "Inserting");
+                        storage_trie.insert(hashed_key, storage_value.encode_to_vec())?;
+                    }
+                }
+                trace!(
+                    "Collecting storage changes for account {}",
+                    hex::encode(&hashed_address)
+                );
+                let (storage_hash, storage_updates) =
+                    storage_trie.collect_changes_since_last_hash();
+                trace!(
+                    "Storage changes collected for account {}",
+                    hex::encode(&hashed_address)
+                );
+                storage_updates_map.extend(storage_updates);
+                account_state.storage_root = storage_hash;
+            }
+            state_trie.insert(hashed_address, account_state.encode_to_vec())?;
         }
-        Ok(())
+        let (state_trie_hash, state_updates) = state_trie.collect_changes_since_last_hash();
+        state_updates_map.extend(state_updates);
+        Ok(state_trie_hash)
     }
 
     /// Executes a block from a given vm instance an does not clear its state
@@ -2305,44 +2319,54 @@ pub async fn is_canonical(
     }
 }
 
-fn branchify(node: Node) -> Box<BranchNode> {
-    match node {
-        Node::Branch(branch_node) => branch_node,
-        Node::Extension(extension_node) => {
-            let index = extension_node.prefix.as_ref()[0];
-            let noderef = if extension_node.prefix.len() == 1 {
-                extension_node.child
-            } else {
-                let prefix = extension_node.prefix.offset(1);
-                let node = ExtensionNode::new(prefix, extension_node.child);
-                NodeRef::from(Arc::new(node.into()))
-            };
-            let mut choices = BranchNode::EMPTY_CHOICES;
-            choices[index as usize] = noderef;
-            Box::new(BranchNode::new(choices))
-        }
-        Node::Leaf(leaf_node) => {
-            let index = leaf_node.partial.as_ref()[0];
-            let node = LeafNode::new(leaf_node.partial.offset(1), leaf_node.value);
-            let mut choices = BranchNode::EMPTY_CHOICES;
-            choices[index as usize] = NodeRef::from(Arc::new(node.into()));
-            Box::new(BranchNode::new(choices))
-        }
-    }
-}
-
-fn collect_trie(index: u8, mut trie: Trie) -> Result<(Box<BranchNode>, Vec<TrieNode>), TrieError> {
-    let root = branchify(
-        trie.root_node()?
-            .map(Arc::unwrap_or_clone)
-            .unwrap_or_else(|| Node::Branch(Box::default())),
-    );
-    trie.root = Node::Branch(root).into();
-    let (_, mut nodes) = trie.collect_changes_since_last_hash();
-    nodes.retain(|(nib, _)| nib.as_ref().first() == Some(&index));
-
-    let Some(Node::Branch(root)) = trie.root_node()?.map(Arc::unwrap_or_clone) else {
-        return Err(TrieError::InvalidInput);
+/// Collapses a root branch node into an extension or leaf node if it has only one valid child.
+/// Returns None if there are no valid children.
+///
+/// NOTE: this assumes the branch has 0 or 1 children. If there are more than 1,
+/// it will discard all but the first valid child found.
+#[cold]
+fn collapse_root_node(
+    real_root: Box<BranchNode>,
+    state_updates_map: &mut FxHashMap<Nibbles, Vec<u8>>,
+    storage: &Store,
+    parent_header: &BlockHeader,
+) -> Result<Option<Node>, StoreError> {
+    // Collapse the branch into an extension or leaf
+    let Some((choice, only_child)) = real_root
+        .choices
+        .into_iter()
+        .enumerate()
+        .find(|(_, c)| c.is_valid())
+    else {
+        return Ok(None);
     };
-    Ok((root, nodes))
+    let path = Nibbles::from_hex(vec![choice as u8]);
+    let child_bytes = match state_updates_map.get(&path) {
+        Some(v) => v.clone(),
+        None => storage
+            .state_trie(parent_header.hash())?
+            .ok_or(StoreError::MissingStore)?
+            .db()
+            .get(path)?
+            .ok_or_else(|| StoreError::Custom("Missing child node during root collapse".into()))?,
+    };
+    // Same match as in [`BranchNode::remove`]
+    let child = match Node::decode(&child_bytes)? {
+        // Replace root with an extension node leading to the child
+        Node::Branch(_) => {
+            ExtensionNode::new(Nibbles::from_hex(vec![choice as u8]), only_child).into()
+        }
+        // Replace root with the child extension node, updating its path in the process
+        Node::Extension(mut extension_node) => {
+            let mut extension_node = extension_node.take();
+            extension_node.prefix.prepend(choice as u8);
+            extension_node.into()
+        }
+        Node::Leaf(mut leaf) => {
+            let mut leaf = leaf.take();
+            leaf.partial.prepend(choice as u8);
+            leaf.into()
+        }
+    };
+    Ok(Some(child))
 }

--- a/crates/common/trie/node.rs
+++ b/crates/common/trie/node.rs
@@ -191,7 +191,7 @@ impl NodeRef {
     ///
     /// This is used when mutating a node in place, in which case the memoized hash
     /// is not valid anymore.
-    pub fn clear_hash(&mut self) {
+    pub(crate) fn clear_hash(&mut self) {
         if let NodeRef::Node(_, hash) = self {
             hash.take();
         }

--- a/crates/common/trie/trie.rs
+++ b/crates/common/trie/trie.rs
@@ -508,11 +508,11 @@ impl Trie {
     }
 
     pub fn root_node(&self) -> Result<Option<Arc<Node>>, TrieError> {
-        if self.root.is_valid() {
-            self.root.get_node(self.db.as_ref(), Nibbles::default())
-        } else {
-            Ok(None)
+        if self.hash_no_commit() == *EMPTY_TRIE_HASH {
+            return Ok(None);
         }
+        self.root
+            .get_node_checked(self.db.as_ref(), Nibbles::default())
     }
 
     /// Creates a new Trie based on a temporary InMemory DB

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -119,7 +119,7 @@ async fn run(
         let hash = block.hash();
 
         // Attempt to add the block as the head of the chain
-        let chain_result = blockchain.add_block_pipeline(block);
+        let chain_result = blockchain.add_block(block);
 
         match chain_result {
             Err(error) => {


### PR DESCRIPTION
**Motivation**

Reverting PR #5497 due to issues discovered after merge.

**Description**

This reverts commit 2ef5b3001b7cfda4e225c1e2191995ded32448d9 which introduced parallel storage trie merkelization.

Original PR: #5497

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.