### PR TITLE
ci(l1): fix performance report ordering and simplify Slack format

### DIFF
--- a/.github/scripts/generate_performance_report.sh
+++ b/.github/scripts/generate_performance_report.sh
@@ -189,14 +189,12 @@ header_text="Daily performance report (24-hour average)"
         printf "• nethermind: %.3f Ggas/s (mean)\n  %s\n" "$nether_value" "$version_nethermind"
         ;;
     esac
-  done < <(printf '%s\n' "${sort_entries[@]}" | sort -rn)
+  done < <(printf '%s\n' "${sort_entries[@]}" | LC_ALL=C sort -rn)
 } >"${OUTPUT_DIR}/performance_report_github.txt"
 
-# Generate Slack message with code block table (truncated versions)
+# Generate Slack message (simple format, similar to Telegram)
 # Sorted by performance value (descending)
-slack_table='```'$'\n'
-slack_table+='Client       Version                  Performance'$'\n'
-slack_table+='-------------------------------------------------------'$'\n'
+slack_text=""
 
 # Build sortable entries: "value client"
 slack_sort_entries=()
@@ -213,29 +211,27 @@ if [[ -n "$nether_value" ]]; then
   slack_sort_entries+=("$nether_value nethermind")
 fi
 
-# Sort by value and append each client row
+# Sort by value and append each client entry
 while read -r value client; do
   case "$client" in
     ethrex)
-      slack_table+=$(printf "%-12s %-24s %.3f Ggas/s (mean)" "ethrex" "$version_ethrex_short" "$ethrex_value")$'\n'
+      slack_text+=$(printf "• *ethrex*: %.3f Ggas/s (mean)\n  %s" "$ethrex_value" "$version_ethrex")$'\n'
       ;;
     reth)
-      slack_table+=$(printf "%-12s %-24s %.3f Ggas/s (mean)" "reth" "$version_reth_short" "$reth_value")$'\n'
+      slack_text+=$(printf "• *reth*: %.3f Ggas/s (mean)\n  %s" "$reth_value" "$version_reth")$'\n'
       ;;
     geth)
-      slack_table+=$(printf "%-12s %-24s %.3f Ggas/s (p50) / %.3f Ggas/s (p99.9)" "geth" "$version_geth_short" "${geth_p50:-0}" "${geth_p999:-0}")$'\n'
+      slack_text+=$(printf "• *geth*: %.3f Ggas/s (p50) | %.3f Ggas/s (p99.9)\n  %s" "${geth_p50:-0}" "${geth_p999:-0}" "$version_geth")$'\n'
       ;;
     nethermind)
-      slack_table+=$(printf "%-12s %-24s %.3f Ggas/s (mean)" "nethermind" "$version_nethermind_short" "$nether_value")$'\n'
+      slack_text+=$(printf "• *nethermind*: %.3f Ggas/s (mean)\n  %s" "$nether_value" "$version_nethermind")$'\n'
       ;;
   esac
-done < <(printf '%s\n' "${slack_sort_entries[@]}" | sort -rn)
+done < <(printf '%s\n' "${slack_sort_entries[@]}" | LC_ALL=C sort -rn)
 
-slack_table+='```'
-
-jq -n --arg header "$header_text" --arg table "$slack_table" '{
+jq -n --arg header "$header_text" --arg text "$slack_text" '{
   "blocks": [
     { "type": "header", "text": { "type": "plain_text", "text": $header } },
-    { "type": "section", "text": { "type": "mrkdwn", "text": $table } }
+    { "type": "section", "text": { "type": "mrkdwn", "text": $text } }
   ]
 }' >"${OUTPUT_DIR}/performance_report_slack.json"


### PR DESCRIPTION
## Summary

- Fix sorting by adding `LC_ALL=C` to ensure consistent numeric sorting across locales
- Simplify Slack format from table to bullet points (matching Telegram format)
- Results sorted: performance report (highest Ggas/s first), block time (fastest first)

## Example Output

**Slack (new format):**
```
• *nethermind*: 0.700 Ggas/s (mean)
  v1.37.0-unstable+9f78bef2
• *ethrex*: 0.689 Ggas/s (mean)
  v9.0.0-HEAD-e0144a6
• *reth*: 0.574 Ggas/s (mean)
  v1.10.2-e9fe028
• *geth*: 0.507 Ggas/s (p50) | 0.507 Ggas/s (p99.9)
  v1.16.8-stable-abeb78c6
```

## How to test

```bash
# 1. Open tunnel
ssh -NL 9090:localhost:9090 app@ethrex-grafana

# 2. Run performance report
PERF_PROMETHEUS_URL="http://localhost:9090" \
PERF_PROMETHEUS_RANGE=24h \
PERF_PROMETHEUS_QUERY='label_replace(avg_over_time(gigagas{instance=~"ethrex-mainnet-1(:[0-9]+)?"}[24h]), "client", "ethrex", "", "") or label_replace(rate(reth_consensus_engine_beacon_new_payload_gas_per_second_sum{instance=~"reth-mainnet-1(:[0-9]+)?"}[24h]) / rate(reth_consensus_engine_beacon_new_payload_gas_per_second_count{instance=~"reth-mainnet-1(:[0-9]+)?"}[24h]) / 1e9, "client", "reth", "", "") or label_replace(avg_over_time(nethermind_mgas_per_sec{instance=~"nethermind-mainnet-1(:[0-9]+)?"}[24h]) / 1000, "client", "nethermind", "", "") or label_replace(avg_over_time(chain_mgasps{instance=~"geth-mainnet-1(:[0-9]+)?",quantile="0.5"}[24h]) / 1000, "client", "geth", "", "") or label_replace(avg_over_time(chain_mgasps{instance=~"geth-mainnet-1(:[0-9]+)?",quantile="0.999"}[24h]) / 1000, "client", "geth", "", "")' \
bash .github/scripts/generate_performance_report.sh

# 3. Run block time report
BLOCK_TIME_PROMETHEUS_URL="http://localhost:9090" \
BLOCK_TIME_PROMETHEUS_RANGE=24h \
BLOCK_TIME_PROMETHEUS_QUERY='label_replace((sum by (method, instance) (increase(rpc_request_duration_seconds_sum{job="ethrex L1",instance=~"ethrex-mainnet-1:3701",method="engine_newPayloadV4",namespace="engine"}[24h])) / sum by (method, instance) (increase(rpc_request_duration_seconds_count{job="ethrex L1",instance=~"ethrex-mainnet-1:3701",method="engine_newPayloadV4",namespace="engine"}[24h]))) * 10e2,"client","ethrex","","") or label_replace(avg_over_time((max without (BuildTimestamp,Commit,Version) (nethermind_last_block_processing_time_in_ms{instance="nethermind-mainnet-1:6060"}))[24h:]),"client","nethermind","","") or label_replace(avg_over_time(reth_engine_rpc_new_payload_v4{instance="reth-mainnet-1:6060", quantile="0.999"}[24h]) * 10e2,"client","reth","","") or label_replace(avg_over_time(reth_engine_rpc_new_payload_v4{instance="reth-mainnet-1:6060", quantile="0.5"}[24h]) * 10e2,"client","reth","","") or label_replace(avg_over_time(((rpc_duration_engine_newPayloadV4_success{instance="geth-mainnet-1:6060",quantile="0.999"} / 1e6) > 0)[24h:15s]),"client","geth","","") or label_replace(avg_over_time(((rpc_duration_engine_newPayloadV4_success{instance="geth-mainnet-1:6060",quantile="0.5"} / 1e6) > 0)[24h:15s]),"client","geth","","")' \
bash .github/scripts/generate_block_time_report.sh

# 4. Inspect outputs
cat tooling/performance_report/performance_report_github.txt
cat tooling/block_time_report/block_time_report_github.txt
jq -r '.blocks[1].text.text' tooling/performance_report/performance_report_slack.json
jq -r '.blocks[1].text.text' tooling/block_time_report/block_time_report_slack.json
```