### PR TITLE
ci(l1,l2): enable Lint L1 and Lint L2 jobs in merge queue

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -36,11 +36,18 @@ jobs:
               - '!crates/l2/**'
             non_docs:
               - "!docs/**"
+            code_changed:
+              - "**/*.rs"
+              - "**/*.toml"
+              - "**/*.lock"
       - name: finish
         id: finish
         run: |
           if [[ "${{ steps.filter.outputs.non_docs_count }}" == 0 ]]; then
             echo "run_tests=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+              # In merge queue, only run lint if code files changed
+              echo "run_tests=${{ steps.filter.outputs.code_changed }}" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
               echo "run_tests=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -48,13 +48,18 @@ jobs:
               - "cmd/ethrex/l2/**"
             non_docs:
               - "!docs/**"
+            code_changed:
+              - "**/*.rs"
+              - "**/*.toml"
+              - "**/*.lock"
       - name: finish
         id: finish
         run: |
           if [[ "${{ steps.filter.outputs.non_docs_count }}" == 0 ]]; then
               echo "run_tests=false" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
-              echo "run_tests=false" >> "$GITHUB_OUTPUT"
+              # In merge queue, only run lint if code files changed
+              echo "run_tests=${{ steps.filter.outputs.code_changed }}" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
               echo "run_tests=true" >> "$GITHUB_OUTPUT"
           else
@@ -109,7 +114,7 @@ jobs:
     name: Validate Blob Fixtures
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -126,7 +131,7 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -157,7 +162,7 @@ jobs:
     name: Build docker image L2
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -188,7 +193,7 @@ jobs:
     name: Uniswap Swap Token Flow
     runs-on: ubuntu-latest
     needs: [detect-changes]
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     timeout-minutes: 60
     steps:
       - name: Checkout sources
@@ -299,7 +304,7 @@ jobs:
     name: Integration Test - ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: [detect-changes, build-docker, build-docker-l2]
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     strategy:
       matrix:
         include:
@@ -464,7 +469,7 @@ jobs:
     name: Integration Test - TDX
     runs-on: ubuntu-latest
     needs: [detect-changes, build-docker, build-docker-l2]
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -570,7 +575,7 @@ jobs:
     name: State Reconstruction Tests
     runs-on: ubuntu-latest
     needs: [detect-changes, build-docker, build-docker-l2, validate-blobs]
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -629,7 +634,7 @@ jobs:
     name: Integration Test Shared Bridge - ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: [detect-changes, build-docker, build-docker-l2]
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Motivation

The Lint L1 and Lint L2 jobs were not running in the merge queue, which meant code could enter main without being linted during the final merge queue checks. This PR enables lint jobs to run in the merge queue while keeping heavy integration tests skipped.

## Description

Changes to both `pr-main_l1.yaml` and `pr-main_l2.yaml`:

1. **Added `code_changed` filter** - Detects changes to `.rs`, `.toml`, and `.lock` files
2. **Updated merge_group behavior** - Lint runs when code files change, skips for pure documentation PRs

Additionally for L2 workflow:
- Added `github.event_name != 'merge_group'` condition to heavy jobs (docker builds, integration tests) to keep them skipped in merge queue

**Behavior summary:**

| Event | Code changes | Lint L1 | Lint L2 | Integration tests |
|-------|--------------|---------|---------|-------------------|
| merge_group | Yes | ✓ Run | ✓ Run | Skip |
| merge_group | No (docs only) | Skip | Skip | Skip |
| pull_request | - | Existing behavior | Existing behavior | Existing behavior |

## How to Test

1. Create a PR with only documentation changes → lint should be skipped in merge queue
2. Create a PR with `.rs` or `.toml` changes → lint should run in merge queue