### PR TITLE
fix(l1): handle missing blocks gracefully in export command

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -929,11 +929,13 @@ pub async fn export_blocks(
             }
         };
         block.encode(&mut buffer);
+        file.write_all(&buffer).expect("Failed to write to file");
+        buffer.clear();
+        exported_count += 1;
 
         // Exporting the whole chain can take a while, so we need to show some output in the meantime
         if last_output.elapsed() > Duration::from_secs(5) {
-            let completed = n.saturating_sub(adjusted_start) + 1;
-            let percent = (completed * 100) / denom;
+            let percent = (exported_count * 100) / denom;
             info!(
                 current_block = n,
                 end_block = end,
@@ -943,10 +945,6 @@ pub async fn export_blocks(
             );
             last_output = Instant::now();
         }
-
-        file.write_all(&buffer).expect("Failed to write to file");
-        buffer.clear();
-        exported_count += 1;
     }
 
     info!(


### PR DESCRIPTION
**Motivation**

The `export_blocks` function panics when trying to export blocks that don't exist in the database. This occurs with pruned databases, snapsynced nodes, or databases with gaps. A community member reported this issue when running:

```
ethrex export --first 2126000 --last 2136000 /path/to/export.rlp
```

The panic at `cli.rs:889` with "Failed to read block from DB" provides no actionable information.

**Description**

Add graceful handling for missing blocks in the export command:

- Query `get_earliest_block_number()` to detect pruned blocks
- If requested start block is before earliest available, warn and adjust start
- If a block is missing within the valid range `[earliest..latest]`, log a detailed error and exit gracefully instead of panicking
- Track and report both `blocks_exported` (actual) and `blocks_requested` (original)

Behavior changes:
- Pruned blocks: warn and adjust start → export continues
- Missing blocks in valid range: error with diagnostic info → graceful exit
- Normal operation: unchanged

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. *(N/A - no Store changes)*