### PR TITLE
chore(l1, l2): enable `clippy::unused_async` lint

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run cargo clippy
         run: |
-          cargo clippy -- -D warnings
+          make lint-l1
 
       - name: Run cargo fmt
         run: |

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run cargo clippy
         run: |
-          cargo clippy --workspace --features l2,l2-sql -- -D warnings
+          make lint-l2
           make lint
 
       - name: Run cargo fmt

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ help: ## 📚 Show help for each of the Makefile recipes
 # Frame pointers for profiling (default off, set FRAME_POINTERS=1 to enable)
 FRAME_POINTERS ?= 0
 
+CLIPPY_DENY := -D warnings -D clippy::unused_async
+
 ifeq ($(FRAME_POINTERS),1)
 PROFILING_CFG := --config .cargo/profiling.toml
 endif
@@ -17,17 +19,17 @@ build: ## 🔨 Build the client
 
 lint-l1:
 	cargo clippy --lib --bins -F debug,sync-test \
-		--release -- -D warnings -D clippy::unused_async
+		--release -- $(CLIPPY_DENY)
 
 lint-l2:
 	cargo clippy --all-targets -F debug,sync-test,l2,l2-sql \
 		--workspace --exclude ethrex-prover --exclude ethrex-guest-program \
-		--release -- -D warnings -D clippy::unused_async
+		--release -- $(CLIPPY_DENY)
 
 lint-gpu:
 	cargo clippy --all-targets -F debug,sync-test,l2,l2-sql,,sp1,risc0,gpu \
 		--workspace --exclude ethrex-prover --exclude ethrex-guest-program \
-		--release -- -D warnings -D clippy::unused_async
+		--release -- $(CLIPPY_DENY)
 
 lint: lint-l1 lint-l2 ## 🧹 Linter check
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint-l1:
 lint-l2:
 	cargo clippy --all-targets -F debug,sync-test,l2,l2-sql \
 		--workspace --exclude ethrex-prover --exclude ethrex-guest-program \
-		--release -- -D warnings
+		--release -- -D warnings -D clippy::unused_async
 
 lint-gpu:
 	cargo clippy --all-targets -F debug,sync-test,l2,l2-sql,,sp1,risc0,gpu \

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: ## 🔨 Build the client
 
 lint-l1:
 	cargo clippy --lib --bins -F debug,sync-test \
-		--release -- -D warnings
+		--release -- -D warnings -D clippy::unused_async
 
 lint-l2:
 	cargo clippy --all-targets -F debug,sync-test,l2,l2-sql \
@@ -27,7 +27,7 @@ lint-l2:
 lint-gpu:
 	cargo clippy --all-targets -F debug,sync-test,l2,l2-sql,,sp1,risc0,gpu \
 		--workspace --exclude ethrex-prover --exclude ethrex-guest-program \
-		--release -- -D warnings
+		--release -- -D warnings -D clippy::unused_async
 
 lint: lint-l1 lint-l2 ## 🧹 Linter check
 


### PR DESCRIPTION
**Motivation**

**Description**

This PR enables the `clippy::unused_async` lint in CI to prevent functions from being marked async without awaiting, which can unintentionally block the Tokio runtime.

Resolves #5662

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #5662

