### PR TITLE
chore(l1): update Amsterdam ef_tests to v5.1.0

### DIFF
--- a/tooling/ef_tests/blockchain/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/blockchain/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v4.0.0/fixtures_bal.tar.gz
+https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v5.1.0/fixtures_bal.tar.gz

--- a/tooling/ef_tests/state/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/state/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v4.0.0/fixtures_bal.tar.gz
+https://github.com/ethereum/execution-spec-tests/releases/download/bal%40v5.1.0/fixtures_bal.tar.gz


### PR DESCRIPTION
**Motivation**

These tests are currently inactive as we are currently implementing Amsterdam, so this change doesn't require fixing any tests.

"Spec-alignment release for [bal-devnet-2](https://notes.ethereum.org/@ethpandaops/bal-devnet-2), updating test cases to match recent EIP specification changes."

https://github.com/ethereum/execution-spec-tests/releases/tag/bal%40v5.1.0


