### PR TITLE
fix(l2): correctly update in-memory operations counts

### DIFF
--- a/crates/l2/storage/src/store_db/in_memory.rs
+++ b/crates/l2/storage/src/store_db/in_memory.rs
@@ -197,10 +197,10 @@ impl StoreEngineRollup for Store {
         privileged_tx_inc: u64,
         messages_inc: u64,
     ) -> Result<(), RollupStoreError> {
-        let mut values = self.inner()?.operations_counts;
-        values[0] += transaction_inc;
-        values[1] += privileged_tx_inc;
-        values[2] += messages_inc;
+        let mut inner = self.inner()?;
+        inner.operations_counts[0] += transaction_inc;
+        inner.operations_counts[1] += privileged_tx_inc;
+        inner.operations_counts[2] += messages_inc;
         Ok(())
     }
 


### PR DESCRIPTION
**Motivation**

The in-memory rollup store did not actually update the operations counters. The `update_operations_count` method modified a local copy of the operations_counts array instead of the field inside StoreInner, so `get_operations_count` always returned [0, 0, 0] regardless of how many operations were processed. This also made the in-memory backend diverge from the SQL implementation, which persists and increments these counters correctly.

**Description**

Fixed `update_operations_count` in the in-memory store to mutate `StoreInner::operations_counts` directly under the mutex guard. As a result, subsequent calls to get_operations_count now return the accumulated numbers of transactions, privileged transactions, and messages, matching the behavior of the SQL backend and making metrics based on these values accurate when using the in-memory engine.

