### PR TITLE
perf(rpc): avoid decode+re-encode in newPayload transactions root

### DIFF
--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -341,6 +341,17 @@ pub fn compute_transactions_root(transactions: &[Transaction]) -> H256 {
     Trie::compute_hash_from_unsorted_iter(iter)
 }
 
+/// Computes the transactions root from raw encoded transaction bytes.
+/// This avoids decoding and re-encoding transactions when the canonical
+/// encoding is already available.
+pub fn compute_transactions_root_from_encoded<T: AsRef<[u8]>>(encoded_transactions: &[T]) -> H256 {
+    let iter = encoded_transactions
+        .iter()
+        .enumerate()
+        .map(|(idx, tx)| (idx.encode_to_vec(), tx.as_ref().to_vec()));
+    Trie::compute_hash_from_unsorted_iter(iter)
+}
+
 pub fn compute_receipts_root(receipts: &[Receipt]) -> H256 {
     let iter = receipts
         .iter()

--- a/crates/networking/rpc/types/payload.rs
+++ b/crates/networking/rpc/types/payload.rs
@@ -8,8 +8,8 @@ use ethrex_common::{
     serde_utils,
     types::{
         BlobsBundle, Block, BlockBody, BlockHash, BlockHeader, Transaction, Withdrawal,
-        block_access_list::BlockAccessList, compute_transactions_root, compute_withdrawals_root,
-        requests::EncodedRequests,
+        block_access_list::BlockAccessList, compute_transactions_root_from_encoded,
+        compute_withdrawals_root, requests::EncodedRequests,
     },
 };
 
@@ -106,6 +106,10 @@ impl ExecutionPayload {
         requests_hash: Option<H256>,
         block_access_list_hash: Option<H256>,
     ) -> Result<Block, RLPDecodeError> {
+        // Compute transactions root from raw encoded bytes to avoid decoding and re-encoding
+        let transactions_root =
+            compute_transactions_root_from_encoded(&self.transactions.iter().map(|tx| &tx.0).collect::<Vec<_>>());
+
         let body = BlockBody {
             transactions: self
                 .transactions
@@ -120,7 +124,7 @@ impl ExecutionPayload {
             ommers_hash: *DEFAULT_OMMERS_HASH,
             coinbase: self.fee_recipient,
             state_root: self.state_root,
-            transactions_root: compute_transactions_root(&body.transactions),
+            transactions_root,
             receipts_root: self.receipts_root,
             logs_bloom: self.logs_bloom,
             difficulty: 0.into(),


### PR DESCRIPTION
## Summary

- Adds `compute_transactions_root_from_encoded()` function that computes the transactions root directly from raw encoded bytes
- Modifies `ExecutionPayload::into_block()` to use this function instead of re-encoding decoded transactions

When converting an `ExecutionPayload` to a `Block` in the `newPayloadV3`/`V4` handlers, we were:
1. Decoding all transactions from raw bytes to `Transaction` structs  
2. Computing the transactions root by re-encoding each transaction back to bytes

Since `EncodedTransaction` already contains the canonical encoding, we now skip the re-encoding step by computing the root directly from the raw bytes.

## Test plan

- [x] `cargo test -p ethrex-common compute_transactions_root` passes
- [x] `cargo test -p ethrex-rpc deserialize_payload_into_block` passes