### PR TITLE
fix(levm): correct stack offset calculations for DUPN and SWAPN (EIP-8024)

### DIFF
--- a/crates/vm/levm/src/opcode_handlers/dup.rs
+++ b/crates/vm/levm/src/opcode_handlers/dup.rs
@@ -47,11 +47,13 @@ impl<'a> VM<'a> {
         };
 
         // Stack grows downwards, so we add the offset to get deeper elements
+        // relative_offset is 1-indexed stack depth (17-235), convert to 0-indexed for array access
+        // The n-th element (1-indexed) is at array index offset + (n-1)
         let absolute_offset = self
             .current_call_frame
             .stack
             .offset
-            .checked_add(usize::from(relative_offset))
+            .checked_add(usize::from(relative_offset).wrapping_sub(1))
             .ok_or(ExceptionalHalt::StackUnderflow)?;
 
         // Verify the offset is within stack bounds

--- a/crates/vm/levm/src/opcode_handlers/exchange.rs
+++ b/crates/vm/levm/src/opcode_handlers/exchange.rs
@@ -47,12 +47,13 @@ impl<'a> VM<'a> {
         };
 
         // Stack grows downwards, so we add the offset to get deeper elements
-        // SWAPN swaps the top element with the element at depth (relative_offset + 1)
+        // SWAPN swaps top with the (n+1)th element where n = decoded relative_offset
+        // The (n+1)th element (1-indexed) is at array index offset + n
         let absolute_offset = self
             .current_call_frame
             .stack
             .offset
-            .checked_add(usize::from(relative_offset).wrapping_add(1))
+            .checked_add(usize::from(relative_offset))
             .ok_or(ExceptionalHalt::StackUnderflow)?;
 
         // Verify the offset is within stack bounds


### PR DESCRIPTION
 - Fix off-by-one error in DUPN: relative_offset is 1-indexed but array access needs 0-indexed
 - Fix incorrect offset in SWAPN: was adding an extra +1 to the stack index

Not enabled yet in this branch because they would fail due to BAL, but this fix fixes 41 ef-tests

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.



