### PR TITLE
style(l1): fix Receipts69 code

### DIFF
--- a/crates/networking/p2p/rlpx/message.rs
+++ b/crates/networking/p2p/rlpx/message.rs
@@ -130,7 +130,7 @@ impl Message {
             }
             Message::GetReceipts(_) => eth_version.eth_capability_offset() + GetReceipts::CODE,
             Message::Receipts68(_) => eth_version.eth_capability_offset() + Receipts68::CODE,
-            Message::Receipts69(_) => eth_version.eth_capability_offset() + Receipts68::CODE,
+            Message::Receipts69(_) => eth_version.eth_capability_offset() + Receipts69::CODE,
             Message::BlockRangeUpdate(_) => {
                 eth_version.eth_capability_offset() + BlockRangeUpdate::CODE
             }


### PR DESCRIPTION
**Motivation**

We used `Receipts68::CODE` for Receipts69, which generated noise during reviews of adjacent code.

**Description**

This PR has no functional changes as the code for [Receipts68](https://github.com/lambdaclass/ethrex/blob/main/crates/networking/p2p/rlpx/eth/eth68/receipts.rs#L54) and [Receipts69](https://github.com/lambdaclass/ethrex/blob/main/crates/networking/p2p/rlpx/eth/eth69/receipts.rs#L31) are identical.
