### PR TITLE
fix(l1): fix incorrect rpc error message

### DIFF
--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -150,7 +150,7 @@ impl From<RpcErr> for RpcErrorMetadata {
             RpcErr::InvalidPayloadAttributes(data) => RpcErrorMetadata {
                 code: -38003,
                 data: Some(data),
-                message: "Invalid forkchoice state".to_string(),
+                message: "Invalid payload attributes".to_string(),
             },
             RpcErr::UnknownPayload(context) => RpcErrorMetadata {
                 code: -38001,


### PR DESCRIPTION
**Motivation**

The InvalidPayloadAttributes error was shown to the user as "Invalid forkchoice state", possibly due to a copy-paste mistake.

**Description**

This shows a better error.

Fixes item 1.5 in the UX/DevEx roadmap.