### PR TITLE
feat(l1, l2): add EIP-1898 blockHash support to eth_call

### DIFF
--- a/crates/networking/rpc/types/block_identifier.rs
+++ b/crates/networking/rpc/types/block_identifier.rs
@@ -90,7 +90,16 @@ impl BlockIdentifier {
 }
 
 impl BlockIdentifierOrHash {
-    #[allow(unused)]
+    pub async fn resolve_block_header(
+        &self,
+        storage: &Store,
+    ) -> Result<Option<BlockHeader>, StoreError> {
+        match self.resolve_block_number(storage).await? {
+            Some(block_number) => storage.get_block_header(block_number),
+            _ => Ok(None),
+        }
+    }
+
     pub async fn resolve_block_number(
         &self,
         storage: &Store,


### PR DESCRIPTION
## Summary
- Add support for the `blockHash` parameter to `eth_call` as specified in [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898)
- Previously, 5 of 6 EIP-1898 methods supported block hashes; only `eth_call` used `BlockIdentifier` instead of `BlockIdentifierOrHash`
- Now all 6 methods are consistent: `eth_getBalance`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_getCode`, `eth_call`, and `eth_getProof`

## Changes
- Add `resolve_block_header()` method to `BlockIdentifierOrHash` in `block_identifier.rs`
- Update `CallRequest` struct to use `BlockIdentifierOrHash` instead of `BlockIdentifier` in `transaction.rs`

## Test plan
- [x] `cargo build -p ethrex-rpc` passes
- [x] `cargo test -p ethrex-rpc` passes (46 tests)