### PR TITLE
ci(l2): run pre-built binary directly in SP1 prover integration test

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -145,7 +145,7 @@ jobs:
         # if: ${{ always() && github.event_name == 'merge_group' }}
         run: |
           cd crates/l2
-          ../../target/release/ethrex l2 prover --proof-coordinators tcp://127.0.0.1:3900 --backend sp1 &
+          RUST_LOG=info,ethrex_prover_lib=debug ../../target/release/ethrex l2 prover --proof-coordinators tcp://127.0.0.1:3900 --backend sp1 &
           docker logs --follow ethrex_l2 | grep -E "INFO|WARN|ERROR" & DOCKER_LOGS_L2_PID=$!
           docker logs --follow ethrex_l1 & DOCKER_LOGS_L1_PID=$!
           PROPOSER_COINBASE_ADDRESS=0x0007a881CD95B1484fca47615B64803dad620C8d cargo test -p ethrex-test l2_integration_test --release --features l2 -- --nocapture --test-threads=1


### PR DESCRIPTION
**Motivation**

The "Run test" step in the SP1 prover CI uses `make init-prover-sp1` which runs `cargo run --features sp1`. This re-enters cargo's build system even though the binary was already compiled in the earlier "Build prover" step. The `sp1-build` build script can re-trigger and fail if the `succinct` rustup toolchain is transiently unavailable (observed in run [56446381529](https://github.com/lambdaclass/ethrex/actions/runs/21693281695/job/62557818922)).

**Description**

Replace `make init-prover-sp1 GPU=true` with a direct invocation of the pre-built binary (`../../target/release/ethrex l2 prover ...`). Since `build-prover-sp1` already compiled the binary with the correct features (`l2,l2-sql,gpu,sp1`), there's no need to go through cargo again. This avoids the `sp1-build` build script, toolchain resolution, and potential race conditions with the concurrent `cargo test` process.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.