### PR TITLE
ci(l1,l2): add issues: write permission to AI review caller workflow

### DIFF
--- a/.github/workflows/pr_ai_review.yaml
+++ b/.github/workflows/pr_ai_review.yaml
@@ -15,7 +15,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
**Motivation**

The AI review workflow (#6106) fails with `startup_failure` on every run. The caller workflow specified explicit permissions (`contents: read`, `pull-requests: write`), which restricts the maximum permissions available to nested reusable workflow jobs. The reusable workflows in `lambdaclass/actions` require additional permissions:

- Kimi: `pull-requests: write` (already granted)
- Codex `post_feedback` job: `issues: write`
- Claude `claude-review` job: `id-token: write`

Missing any of these causes the entire workflow to fail at startup with no logs.

**Description**

Add the missing `issues: write` and `id-token: write` permissions to the caller workflow's permissions block.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.