### PR TITLE
fix(l1): fix lighthouse typo in monitoring docs

### DIFF
--- a/docs/l1/running/monitoring.md
+++ b/docs/l1/running/monitoring.md
@@ -30,7 +30,7 @@ _**Note:** You might want to restart the docker containers in case of an update 
 
 This will launch Prometheus and Grafana, already set up to scrape ethrex metrics.
 
-**Note: We depend on `ethereum-metrics-exporter` for some key metrics to define variables on the Grafana dashboards. For it to work properly we need the consensus client to expose its RPC endpoints. For example if you are running lighthhouse you may need to add `--http` and `--http-address 0.0.0.0` flags to it before the dashboards pick up all metrics. This won't be needed in the near future**
+**Note: We depend on `ethereum-metrics-exporter` for some key metrics to define variables on the Grafana dashboards. For it to work properly we need the consensus client to expose its RPC endpoints. For example if you are running lighthouse you may need to add `--http` and `--http-address 0.0.0.0` flags to it before the dashboards pick up all metrics. This won't be needed in the near future**
 
 ## Logs
 


### PR DESCRIPTION
## Summary
- Fix "lighthhouse" → "lighthouse" typo in `docs/l1/running/monitoring.md`
- Missed by #6139 which fixed ~100 other doc typos

## Test plan
- [x] Verify the correction reads correctly in context