### PR TITLE
fix(l1): force final progress print on snap sync phase completion

### DIFF
--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -318,10 +318,22 @@ pub async fn periodically_show_peer_stats_during_syncing(
         if current_step != previous_step && current_step != CurrentStepValue::None {
             // Log completion of previous phase (if any)
             if previous_step != CurrentStepValue::None {
-                let phase_elapsed = format_duration(phase_start_time.elapsed());
-                log_phase_completion(
+                // Force a final progress print so the bar doesn't look incomplete
+                let phase_elapsed = phase_start_time.elapsed();
+                let total_elapsed = format_duration(start.elapsed());
+                log_phase_progress(
                     previous_step,
                     phase_elapsed,
+                    &total_elapsed,
+                    peer_number,
+                    &prev_interval,
+                )
+                .await;
+
+                let phase_elapsed_str = format_duration(phase_start_time.elapsed());
+                log_phase_completion(
+                    previous_step,
+                    phase_elapsed_str,
                     &phase_metrics(previous_step, &phase_start).await,
                 );
             }


### PR DESCRIPTION
## Motivation

The snap sync progress logs are printed every 10s. When a phase finishes between prints, its progress bar is never shown at its final state — the next print detects the transition and jumps straight to the completion message, leaving the bar looking incomplete (e.g. stuck at 75%).

## Description

Force a final `log_phase_progress()` call for the finishing phase right before `log_phase_completion()`, so the bar always reaches its end state before the completion line is printed.

**Before:**
```
  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░  75.0%   ← stale, from 10s ago
✓ BLOCK HEADERS complete: 1,234 headers in 15s 200ms
── PHASE 2/8: ACCOUNT RANGES ──────────────
```

**After:**
```
  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ 100.0%   ← forced final print
✓ BLOCK HEADERS complete: 1,234 headers in 15s 200ms
── PHASE 2/8: ACCOUNT RANGES ──────────────
```

## How to test

Run a snap sync and observe that each phase's progress bar is printed at its final state before the completion message appears.