### PR TITLE
test(l1): add restart stall reproduction test using eth-docker

### DIFF
--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -354,7 +354,7 @@ multisync-loop-auto: ## Continuous loop with auto-update: pull latest, build, an
 # ==============================================================================
 
 RESTART_TEST_NETWORK ?= hoodi
-RESTART_TEST_COUNT ?= 3
+RESTART_TEST_COUNT ?= 0
 RESTART_TEST_FEE_RECIPIENT ?=
 ETH_DOCKER_DIR ?= $(HOME)/eth-docker
 


### PR DESCRIPTION
## Motivation

A Discord user reported that ethrex sometimes stalls while downloading headers after a restart when running inside [eth-docker](https://github.com/ethstaker/eth-docker). This is intermittent and hard to catch manually, so we need an automated reproduction test.

## Description

Adds `tooling/sync/restart_stall_test.py` — a Python script that automates the full reproduction cycle using eth-docker with ethrex (execution) + Prysm (consensus).

### How it works

**Phase 1 — Fresh snap sync:**
1. Stops any existing eth-docker containers and removes volumes (`docker compose down -v`)
2. Starts eth-docker (`docker compose up -d`)
3. Polls `eth_syncing` RPC until sync completes (8h timeout)
4. Verifies block progress post-sync (22m of new blocks)
5. Sends Slack notification on completion

**Phase 2 — Continuous restart cycles (runs forever, Ctrl+C to stop):**

Each cycle:
1. Removes execution and consensus containers (`docker compose rm -f -s`)
2. Removes all data volumes: `ethrex-el-data`, `prysmconsensus-data`, `prysmvalidator-data` (preserves JWT)
3. Recreates containers with fresh volumes (`docker compose up -d execution consensus`)
4. Waits for node RPC to come up
5. Waits for full snap sync completion (8h timeout)
6. Verifies block progress post-sync (22m)
7. Reports PASS/FAIL with sync time
8. Sends Slack notification on failure
9. Saves execution + consensus logs
10. Repeats from step 1

On Ctrl+C, prints a summary of all completed cycles and saves it to `summary.txt`.

Use `--restart-count N` to limit to N cycles instead of running forever.

**Phase 2 with `--keep-data` — Quick restart (no wipe):**
1. Stops only the execution client (`docker compose stop execution`), keeping consensus running and volumes intact
2. Restarts the execution client (`docker compose start execution`)
3. Monitors for stall: watches `eth_blockNumber` progress, detects if the node stops advancing
4. Reports result: `ok` (caught up), `stall` (no progress), `timeout` (still progressing but didn't catch up in time), or `unresponsive` (node never came back)

This mode is useful for testing restart recovery without re-syncing.

### Configuration

The `--configure` flag auto-writes eth-docker's `.env` from `default.env` with:
- `COMPOSE_FILE=prysm.yml:ethrex.yml:el-shared.yml` (el-shared.yml publishes the RPC port to the host for monitoring)
- `NETWORK` (default: hoodi)
- `CHECKPOINT_SYNC_URL` (auto-set based on network: mainnet, hoodi, holesky, sepolia)
- `FEE_RECIPIENT` (optional, via `--fee-recipient`)
- `ETHREX_DOCKER_REPO=ghcr.io/lambdaclass/ethrex`
- Slack webhook URLs from the local `.env`

Uses `docker compose` directly instead of `./ethd` commands to avoid interactive confirmation prompts when running non-interactively (e.g. in tmux).

### Timeouts (all configurable via env vars, all in seconds)

| Variable | Default | Description |
|----------|---------|-------------|
| `SYNC_TIMEOUT` | 8 hours | Max time for initial sync |
| `BLOCK_PROCESSING_DURATION` | 22 min | Post-sync block progress verification |
| `BLOCK_STALL_TIMEOUT` | 10 min | Time without progress during initial sync to declare stall |
| `RESTART_STALL_TIMEOUT` | 15 min | Time without progress after restart to declare stall |
| `NODE_STARTUP_TIMEOUT` | 5 min | Time for node to respond after restart |
| `CHECK_INTERVAL` | 10 sec | RPC polling interval |

### Makefile targets

| Target | Description |
|--------|-------------|
| `make restart-stall-test` | Full test: configure, sync, then continuous restart cycles (Ctrl+C to stop) |
| `make restart-stall-test-skip-sync` | Skip phase 1 (node must already be synced) |
| `make restart-stall-test-keep-data` | Restart without wiping data (stop/start only) |

Variables: `ETH_DOCKER_DIR` (default: `~/eth-docker`), `RESTART_TEST_NETWORK` (default: `hoodi`), `RESTART_TEST_COUNT` (default: `0` = infinite), `RESTART_TEST_FEE_RECIPIENT` (optional).

### Files changed

| File | Change |
|------|--------|
| `tooling/sync/restart_stall_test.py` | Main script with Phase 1/2 logic, continuous cycling, data wipe, Slack notifications |
| `tooling/sync/Makefile` | Add `restart-stall-test`, `restart-stall-test-skip-sync`, and `restart-stall-test-keep-data` targets |

## How to Test

**Prerequisites:** eth-docker cloned at `~/eth-docker`, Docker installed.

```bash
cd tooling/sync

# Full test: configure, sync, then loop forever (Ctrl+C to stop)
make restart-stall-test \
  RESTART_TEST_NETWORK=mainnet \
  RESTART_TEST_FEE_RECIPIENT=0xYourAddress

# Limit to 5 cycles
make restart-stall-test \
  RESTART_TEST_NETWORK=mainnet \
  RESTART_TEST_COUNT=5

# Skip initial sync (node already synced)
make restart-stall-test-skip-sync \
  RESTART_TEST_NETWORK=mainnet

# Quick restart without wipe (stop/start only)
make restart-stall-test-keep-data \
  RESTART_TEST_NETWORK=mainnet

# Or directly with Python
PYTHONUNBUFFERED=1 python3 restart_stall_test.py \
  --eth-docker-dir ~/eth-docker \
  --configure \
  --network mainnet \
  --fee-recipient 0xYourAddress \
  --ethrex-dir ~/ethrex
```

Logs are saved to `tooling/sync/restart_stall_logs/run_YYYYMMDD_HHMMSS/`.