### PR TITLE
fix(l1): update existing contact ENR on NODES response

### DIFF
--- a/crates/networking/p2p/discv5/peer_table.rs
+++ b/crates/networking/p2p/discv5/peer_table.rs
@@ -870,8 +870,7 @@ impl PeerTableServer {
                             let is_fork_id_valid =
                                 Self::evaluate_fork_id(&node_record, &self.store).await;
                             let contact = occupied_entry.get_mut();
-                            if contact.node.ip != node.ip
-                                || contact.node.udp_port != node.udp_port
+                            if contact.node.ip != node.ip || contact.node.udp_port != node.udp_port
                             {
                                 contact.validation_timestamp = None;
                                 contact.ping_req_id = None;


### PR DESCRIPTION
**Motivation**

`new_contact_records()` only inserted new contacts (`Entry::Vacant`), silently discarding updated ENRs for already-known peers. This made the FINDNODE(distance=0) request from #5910 ineffective — the request was sent but the response couldn't update the existing record.

**Description**

- Handle `Entry::Occupied` in `new_contact_records()`: when the incoming record has a higher `seq` than the existing one, update the contact's `node`, `record`, and `is_fork_id_valid`.
- Add ENR signature validation (`verify_signature()`) upfront for all records, which was previously missing even for new contacts.
- Hoist shared logic (discarded contacts check, fork ID validation) before the `match` to avoid duplication.

Closes #6166