### PR TITLE
perf(l1): fill all peer slots per tick in snap sync healing dispatch

### DIFF
--- a/crates/networking/p2p/sync/healing/storage.rs
+++ b/crates/networking/p2p/sync/healing/storage.rs
@@ -331,7 +331,7 @@ async fn ask_peers_for_nodes(
     task_sender: &Sender<Result<TrieNodes, RequestStorageTrieNodesError>>,
     logged_no_free_peers_count: &mut u32,
 ) {
-    if (requests.len() as u32) < MAX_IN_FLIGHT_REQUESTS && !download_queue.is_empty() {
+    while (requests.len() as u32) < MAX_IN_FLIGHT_REQUESTS && !download_queue.is_empty() {
         let Some((peer_id, connection)) = peers
             .peer_table
             .get_best_peer(&SUPPORTED_SNAP_CAPABILITIES)
@@ -347,7 +347,7 @@ async fn ask_peers_for_nodes(
             *logged_no_free_peers_count -= 1;
             // Sleep for a bit to avoid busy polling
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-            return;
+            break;
         };
         let at = download_queue.len().saturating_sub(STORAGE_BATCH_SIZE);
         let download_chunk = download_queue.split_off(at);


### PR DESCRIPTION
## Motivation

The healing dispatch loops in both state and storage healing used an `if` guard to check whether a new request could be sent to a peer. This meant **at most one request was dispatched per tick**, even when multiple peer slots were available. With `MAX_IN_FLIGHT_REQUESTS = 8`, it took 8 ticks to fully saturate all available peers — leaving them idle most of the time.

## Description

Change the `if` guard to a `while` loop so all available peer slots are filled in a single tick:

**`healing/storage.rs`** (`ask_peers_for_nodes`):
- `if` → `while` on the dispatch condition
- `return` → `break` when no peers are available (exit loop, not function)

**`healing/state.rs`** (`heal_state_trie`):
- Restructure the single-dispatch `if` block into a `while` loop with the same fill-all-slots semantics
- When no peers are available, re-add the batch to the queue and `break`

No changes to the healing logic itself — only the dispatch cadence.

## Benchmark results

Measured on Hoodi snap sync (`ethrex-mainnet-test-2`, Ryzen 9 9950X3D):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Storage accounts needing healing | 10,191 | 1,284 | **-87%** |
| Storage healing phase duration | 0:20 | 0:10 | -50% |

Faster dispatch means trie nodes are fetched and inserted before the healing check runs, leaving fewer gaps to repair.

Note: state healing was skipped in both runs (pivot block state root matched), so the `state.rs` change could not be validated in this run. The fix is structurally identical to the `storage.rs` one.

## How to test

- Run a Hoodi snap sync and observe Phase 7 (Storage Healing) item count and duration
- Compare against a baseline run on the same network