### PR TITLE
perf(l1): pipeline bytecode downloads and background storage healing in snap sync

### DIFF
--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -233,6 +233,8 @@ pub enum SyncError {
     RocksDBError(String),
     #[error("Bytecode file error")]
     BytecodeFileError,
+    #[error("Concurrent bytecode download task panicked: {0}")]
+    BytecodeTaskPanicked(String),
     #[error("Error in Peer Table: {0}")]
     PeerTableError(#[from] PeerTableError),
     #[error("Missing fullsync batch")]
@@ -261,6 +263,7 @@ impl SyncError {
             | SyncError::StorageTempDBDirNotFound(_)
             | SyncError::RocksDBError(_)
             | SyncError::BytecodeFileError
+            | SyncError::BytecodeTaskPanicked(_)
             | SyncError::NoLatestCanonical
             | SyncError::PeerTableError(_)
             | SyncError::MissingFullsyncBatch

--- a/crates/networking/p2p/sync/code_collector.rs
+++ b/crates/networking/p2p/sync/code_collector.rs
@@ -6,6 +6,7 @@ use ethrex_common::H256;
 use ethrex_rlp::encode::RLPEncode;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tracing::error;
 
@@ -19,6 +20,8 @@ pub struct CodeHashCollector {
     file_index: u64,
     // JoinSet to manage async disk writes
     disk_tasks: JoinSet<Result<(), DumpError>>,
+    // Optional channel to stream code hashes for concurrent bytecode downloading
+    code_hash_sender: Option<mpsc::UnboundedSender<Vec<H256>>>,
 }
 
 impl CodeHashCollector {
@@ -29,19 +32,38 @@ impl CodeHashCollector {
             snapshots_dir,
             file_index: 0,
             disk_tasks: JoinSet::new(),
+            code_hash_sender: None,
         }
     }
 
-    /// Adds a code hash to the buffer
+    /// Creates the channel and returns the receiver for concurrent bytecode downloading.
+    /// Must be called before any code hashes are added.
+    pub fn take_receiver(&mut self) -> mpsc::UnboundedReceiver<Vec<H256>> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.code_hash_sender = Some(tx);
+        rx
+    }
+
+    /// Adds a code hash to the buffer and sends it through the channel if present
     pub fn add(&mut self, hash: H256) {
-        self.buffer.insert(hash);
+        if self.buffer.insert(hash) && let Some(sender) = &self.code_hash_sender {
+            // Ignore send errors — the receiver may have been dropped if
+            // the bytecode task finished early or errored out
+            let _ = sender.send(vec![hash]);
+        }
     }
 
     // The optimization for rocksdb database doesn't use this method
     #[cfg(not(feature = "rocksdb"))]
     /// Extends the buffer with a list of code hashes
     pub fn extend(&mut self, hashes: impl IntoIterator<Item = H256>) {
-        self.buffer.extend(hashes);
+        let new_hashes: Vec<H256> = hashes
+            .into_iter()
+            .filter(|h| self.buffer.insert(*h))
+            .collect();
+        if !new_hashes.is_empty() && let Some(sender) = &self.code_hash_sender {
+            let _ = sender.send(new_hashes);
+        }
     }
 
     /// Flushes the buffer to a file if the buffer is larger than [`CODE_HASH_WRITE_BUFFER_SIZE`]
@@ -55,13 +77,16 @@ impl CodeHashCollector {
         Ok(())
     }
 
-    /// Finishes the code collector and returns the final index of file
+    /// Finishes the code collector: flushes remaining hashes and closes the channel
     pub async fn finish(mut self) -> Result<(), SyncError> {
         // Final flush if needed
         if !self.buffer.is_empty() {
             let buffer = std::mem::take(&mut self.buffer);
             self.flush_buffer(buffer);
         }
+
+        // Drop the sender to close the channel, signaling the bytecode task to drain
+        self.code_hash_sender.take();
 
         // Wait for all pending writes
         self.disk_tasks


### PR DESCRIPTION
## Motivation

Snap sync phases are strictly sequential: bytecode downloads wait until all healing completes, and storage healing must reach 100% before finalization. This leaves significant time on the table where network I/O and CPU could overlap.

## Description

Two optimizations to the snap sync pipeline:

### 1. Concurrent bytecode downloads
Instead of downloading bytecodes sequentially after all healing completes (Phase 8), stream code hashes via an `mpsc` channel to a concurrent download task that runs alongside phases 3-7 (healing and storage). Bytecodes are content-addressed (hash = key), so this is safe regardless of pivot changes.

- `CodeHashCollector` gains an optional channel sender (`take_receiver()`)
- `download_bytecodes_concurrent()` task spawned before `insert_accounts`, consumes hashes as they arrive
- Channel closes when `code_hash_collector.finish()` drops the sender, signaling the task to drain and complete

### 2. Background storage healing with 99% threshold
Split healing into state (must complete fully) and storage (can proceed at 99% threshold):

- State healing runs first and must complete 100%
- Initial storage healing pass runs with a 5-minute time limit
- Continues without time limit until 99% of account roots are healed
- After finalization (FKV + block store + forkchoice_update), remaining <1% heals in a background task

`heal_storage_trie()` gains a `time_limit: Option<Duration>` parameter and `global_roots_healed` counter for progress tracking.

## Benchmark (Hoodi, ethrex-mainnet-4: 12 cores, 62 GB RAM)

| Run | Time | vs Baseline |
|-----|------|-------------|
| Baseline (Tier 2) | 564s | — |
| **Optimized (Tier 3)** | **489s** | **-13%** |

Bytecodes started downloading at ~6:49 (concurrent with healing) vs ~9:00+ in baseline (after healing).

### Cumulative improvement across tiers

| Tier | Baseline | Optimized | Improvement |
|------|----------|-----------|-------------|
| Tier 1 (PR #6178) | 837s | 664s | -21% |
| Tier 2 (PR #6181) | 791s | 691s | -13% |
| **Tier 3 (this PR)** | 564s | 489s | **-13%** |

## How to Test

1. Run snap sync on Hoodi: `cargo run --release --bin ethrex -- --network hoodi --authrpc.jwtsecret <jwt>`
2. Observe "Concurrent bytecode download complete" log appearing before "Finished healing"
3. Observe "Storage healing target: N/M accounts (99% threshold)" in logs
4. If <1% remains, observe "Spawning background storage healing" after finalization