### PR TITLE
ci(l1): prevent AI review comments from using `#N` notation that GitHub auto-links as issue references

### DIFF
--- a/.github/prompts/ai-review.md
+++ b/.github/prompts/ai-review.md
@@ -17,3 +17,7 @@ Ethereum-specific considerations:
 
 Be concise and specific. Provide line references when suggesting changes.
 If the code looks good, acknowledge it briefly.
+
+Formatting rules:
+- NEVER use `#N` (e.g. #1, #2) for enumeration — GitHub renders those as issue/PR references. Use `1.`, `2.`, etc. or bullet points instead.
+- When referring back to items, use "Item 1", "Point 2", etc. — never "Issue #1" or "#1".


### PR DESCRIPTION
## Motivation

The Claude AI code reviewer (`.github/workflows/pr_ai_review.yaml`) enumerates findings using `#1`, `#2`, etc., which GitHub auto-links as references to issues/PRs. This clutters PR activity feeds and confuses readers. Example: https://github.com/lambdaclass/ethrex/pull/6186#issuecomment-3887011988

## Description

Add formatting rules to the AI review prompt (`.github/prompts/ai-review.md`) instructing the model to use `1.`, `2.` or bullet points instead of `#N`, and to refer back to items as "Item 1", "Point 2" rather than "Issue #1".

## Checklist

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.