### PR TITLE
chore(l1): add phase completion markers for snap sync validation

### DIFF
--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -689,6 +689,7 @@ pub fn calculate_staleness_timestamp(timestamp: u64) -> u64 {
 
 pub async fn validate_state_root(store: Store, state_root: H256) -> bool {
     info!("Starting validate_state_root");
+    let start = std::time::Instant::now();
     let validated = tokio::task::spawn_blocking(move || {
         store
             .open_locked_state_trie(state_root)
@@ -698,8 +699,12 @@ pub async fn validate_state_root(store: Store, state_root: H256) -> bool {
     .await
     .expect("We should be able to create threads");
 
+    let elapsed = start.elapsed();
+    let secs = elapsed.as_secs();
+    let elapsed_str = format!("{:02}:{:02}:{:02}", secs / 3600, (secs % 3600) / 60, secs % 60);
     if validated.is_ok() {
         info!("Succesfully validated tree, {state_root} found");
+        info!("✓ STATE ROOT VALIDATION complete: state root verified in {elapsed_str}");
     } else {
         error!("We have failed the validation of the state tree");
         std::process::exit(1);
@@ -709,6 +714,7 @@ pub async fn validate_state_root(store: Store, state_root: H256) -> bool {
 
 pub async fn validate_storage_root(store: Store, state_root: H256) -> bool {
     info!("Starting validate_storage_root");
+    let start = std::time::Instant::now();
     let is_valid = tokio::task::spawn_blocking(move || {
         store
             .iter_accounts(state_root)
@@ -728,15 +734,20 @@ pub async fn validate_storage_root(store: Store, state_root: H256) -> bool {
     })
     .await
     .expect("We should be able to create threads");
+    let elapsed = start.elapsed();
+    let secs = elapsed.as_secs();
+    let elapsed_str = format!("{:02}:{:02}:{:02}", secs / 3600, (secs % 3600) / 60, secs % 60);
     info!("Finished validate_storage_root");
     if is_valid.is_err() {
         std::process::exit(1);
     }
+    info!("✓ STORAGE ROOT VALIDATION complete: all storage roots verified in {elapsed_str}");
     is_valid.is_ok()
 }
 
 pub fn validate_bytecodes(store: Store, state_root: H256) -> bool {
     info!("Starting validate_bytecodes");
+    let start = std::time::Instant::now();
     let mut is_valid = true;
     for (account_hash, account_state) in store
         .iter_accounts(state_root)
@@ -757,6 +768,10 @@ pub fn validate_bytecodes(store: Store, state_root: H256) -> bool {
     if !is_valid {
         std::process::exit(1);
     }
+    let elapsed = start.elapsed();
+    let secs = elapsed.as_secs();
+    let elapsed_str = format!("{:02}:{:02}:{:02}", secs / 3600, (secs % 3600) / 60, secs % 60);
+    info!("✓ BYTECODE VALIDATION complete: all bytecodes verified in {elapsed_str}");
     is_valid
 }
 

--- a/tooling/sync/docker_monitor.py
+++ b/tooling/sync/docker_monitor.py
@@ -58,6 +58,9 @@ PHASE_COMPLETION_PATTERNS = {
     "State Healing": r"✓ STATE HEALING complete: ([\d,]+) state paths healed in (\d+:\d{2}:\d{2})",
     "Storage Healing": r"✓ STORAGE HEALING complete: ([\d,]+) storage accounts healed in (\d+:\d{2}:\d{2})",
     "Bytecodes": r"✓ BYTECODES complete: ([\d,]+) bytecodes in (\d+:\d{2}:\d{2})",
+    "State Root Validation": r"✓ STATE ROOT VALIDATION complete: ([\w ]+) in (\d+:\d{2}:\d{2})",
+    "Storage Root Validation": r"✓ STORAGE ROOT VALIDATION complete: ([\w ]+) in (\d+:\d{2}:\d{2})",
+    "Bytecode Validation": r"✓ BYTECODE VALIDATION complete: ([\w ]+) in (\d+:\d{2}:\d{2})",
 }
 
 


### PR DESCRIPTION
## Motivation

The three post-sync validation steps (`validate_state_root`, `validate_storage_root`, `validate_bytecodes`) run after snap sync healing but don't emit `✓` phase completion markers. This makes them invisible in the docker monitor's Slack notification phase breakdown — validation time is unaccounted for in the per-phase timing report.

## Description

- Add `std::time::Instant` timing to all three validation functions in `snap_sync.rs`
- Emit `✓` markers matching the format used by other phases (e.g. `✓ STATE ROOT VALIDATION complete: state root verified in HH:MM:SS`)
- Register corresponding regex patterns in `docker_monitor.py`'s `PHASE_COMPLETION_PATTERNS` so they appear in the Slack phase breakdown

## How to Test

1. Run a snap sync with `release-with-debug-assertions` profile (validation only runs inside `debug_assert!`)
2. After sync completes, check logs for `✓ STATE ROOT VALIDATION complete:`, `✓ STORAGE ROOT VALIDATION complete:`, `✓ BYTECODE VALIDATION complete:` markers with timing
3. Verify the docker monitor Slack notification includes the validation phases in its breakdown