### PR TITLE
perf(l1): dynamic RocksDB tuning during snap sync (TuneDbMode)

### DIFF
--- a/crates/storage/api/mod.rs
+++ b/crates/storage/api/mod.rs
@@ -51,6 +51,18 @@ pub trait StorageBackend: Debug + Send + Sync {
     // TODO: remove this and provide historic data via diff-layers
     /// Creates a checkpoint of the current database state at the specified path.
     fn create_checkpoint(&self, path: &Path) -> Result<(), StoreError>;
+
+    /// Switches the backend to sync mode for higher write throughput during
+    /// bulk ingestion (e.g. snap sync). No-op for non-RocksDB backends.
+    fn set_sync_mode(&self) -> Result<(), StoreError> {
+        Ok(())
+    }
+
+    /// Restores normal backend settings after sync and triggers compaction.
+    /// No-op for non-RocksDB backends.
+    fn set_normal_mode(&self) -> Result<(), StoreError> {
+        Ok(())
+    }
 }
 
 /// Read-only transaction interface.

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2581,6 +2581,16 @@ impl Store {
         Ok(())
     }
 
+    /// Switches the storage backend to sync mode for higher write throughput.
+    pub fn set_sync_mode(&self) -> Result<(), StoreError> {
+        self.backend.set_sync_mode()
+    }
+
+    /// Restores normal storage backend settings and triggers compaction.
+    pub fn set_normal_mode(&self) -> Result<(), StoreError> {
+        self.backend.set_normal_mode()
+    }
+
     pub fn get_store_directory(&self) -> Result<PathBuf, StoreError> {
         Ok(self.db_path.clone())
     }


### PR DESCRIPTION
## Motivation

During snap sync, RocksDB write throughput is the bottleneck for state ingestion. Nethermind dynamically adjusts RocksDB LSM parameters during sync (`TuneDbMode`) to maximize write throughput, then restores normal settings and triggers compaction after sync completes.

## Description

Add `set_sync_mode()` and `set_normal_mode()` methods to the RocksDB backend:

- **Sync mode**: Relaxes L0 compaction triggers (64/128/256 vs normal 4/20/36) on all CFs. Increases `max_write_buffer_number` to core_count for trie CFs (ACCOUNT_TRIE_NODES, STORAGE_TRIE_NODES, ACCOUNT_FLATKEYVALUE, STORAGE_FLATKEYVALUE). This prevents write stalls during bulk state ingestion.

- **Normal mode**: Restores standard compaction triggers. Triggers `compact_range_cf()` on all 4 trie CFs to consolidate accumulated L0 files.

Both methods are added to the `StorageBackend` trait with default no-op implementations (non-RocksDB backends unaffected). Called at start/end of `snap_sync()`.

## How to Test

- Run snap sync on hoodi testnet and verify RocksDB write stalls are reduced
- Check logs for "RocksDB sync mode enabled" and "RocksDB normal mode restored"
- Post-sync compaction should be visible in logs