### PR TITLE
perf(l1): split account range downloads into concurrent partitions

### DIFF
--- a/crates/networking/p2p/snap/constants.rs
+++ b/crates/networking/p2p/snap/constants.rs
@@ -43,8 +43,12 @@ pub const HASH_MAX: H256 = H256([0xFF; 32]);
 /// during the initial snap sync phases.
 pub const RANGE_FILE_CHUNK_SIZE: usize = 1024 * 1024 * 64;
 
-/// Number of chunks to split the account range into for parallel downloading.
+/// Number of chunks to split each account range partition into for parallel downloading.
 pub const ACCOUNT_RANGE_CHUNK_COUNT: usize = 800;
+
+/// Maximum number of concurrent partitions for account range downloads.
+/// Each partition covers a disjoint slice of the address space and downloads independently.
+pub const MAX_ACCOUNT_PARTITIONS: usize = 8;
 
 /// Number of storage accounts to process per batch during state healing.
 pub const STORAGE_BATCH_SIZE: usize = 300;

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -249,6 +249,11 @@ pub async fn snap_sync(
     block_sync_state: &mut SnapBlockSyncState,
     datadir: &Path,
 ) -> Result<(), SyncError> {
+    // Enable sync mode: relax compaction triggers for higher write throughput
+    if let Err(e) = store.set_sync_mode() {
+        warn!("Failed to enable RocksDB sync mode: {e}");
+    }
+
     // snap-sync: launch tasks to fetch blocks and state in parallel
     // - Fetch each block's body and its receipt via eth p2p requests
     // - Fetch the pivot block's state via snap p2p requests
@@ -295,8 +300,6 @@ pub async fn snap_sync(
         info!("Starting to download account ranges from peers");
         request_account_range(
             peers,
-            H256::zero(),
-            H256::repeat_byte(0xff),
             account_state_snapshots_dir.as_ref(),
             &mut pivot_header,
             block_sync_state,
@@ -559,6 +562,11 @@ pub async fn snap_sync(
     *METRICS.bytecode_download_end_time.lock().await = Some(SystemTime::now());
 
     debug_assert!(validate_bytecodes(store.clone(), pivot_header.state_root));
+
+    // Restore normal mode: reset compaction triggers and compact trie CFs
+    if let Err(e) = store.set_normal_mode() {
+        warn!("Failed to restore RocksDB normal mode: {e}");
+    }
 
     store_block_bodies(vec![pivot_header.clone()], peers.clone(), store.clone()).await?;
 


### PR DESCRIPTION
## Motivation

Currently `request_account_range()` downloads accounts sequentially — one chunk at a time, one peer at a time. Nethermind splits the account address space into N partitions for concurrent download from different peers.

## Description

Split `[0, 2^256)` into 8 concurrent partitions, each downloading independently:

- `compute_partitions()` splits the address space into 8 non-overlapping ranges
- Each partition runs as a separate tokio task with its own peer via `JoinSet`
- Shared state (`pivot_header`, `block_sync_state`) wrapped in `Arc<RwLock/Mutex>` with double-checked locking for pivot updates
- Snapshot file naming uses `Arc<AtomicU64>` counter to avoid filename collisions between partitions
- Download count metrics use `fetch_add` with delta tracking so partitions don't clobber each other

SST files from different partitions have non-overlapping key ranges, so `ingest_external_file` handles them correctly without additional merge logic.

## How to Test

- Run snap sync on hoodi and verify account download uses multiple peers concurrently
- Check that all partitions complete and account trie is correctly built
- Compare total account download time vs single-stream baseline