### PR TITLE
perf(l1): download bytecodes concurrently with storage during snap sync

### DIFF
--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -327,10 +327,13 @@ pub async fn request_account_range(
 pub async fn request_bytecodes(
     peers: &mut PeerHandler,
     all_bytecode_hashes: &[H256],
+    update_metrics: bool,
 ) -> Result<Option<Vec<Bytes>>, SnapError> {
-    METRICS
-        .current_step
-        .set(CurrentStepValue::RequestingBytecodes);
+    if update_metrics {
+        METRICS
+            .current_step
+            .set(CurrentStepValue::RequestingBytecodes);
+    }
     if all_bytecode_hashes.is_empty() {
         return Ok(Some(Vec::new()));
     }


### PR DESCRIPTION
## Summary
- Download bytecodes concurrently with storage ranges/insertion instead of sequentially after healing, eliminating the bytecodes phase from the critical path
- Skip already-stored bytecodes, start download earlier (during account trie building), fix metrics conflict during concurrent run, and add progress logging

## Description

During snap sync, bytecodes are content-addressed (hash = key), so they're safe to download regardless of pivot staleness. Previously, bytecodes were downloaded sequentially after all healing completed (~6 min on mainnet). This PR spawns a background task that starts downloading bytecodes during account insertion and runs concurrently with storage download/insertion.

**Changes:**
- `snap_sync.rs`: Spawn background bytecode download task using `oneshot` channel to receive code hashes from `insert_accounts`. Extract `download_bytecodes()` and `read_code_hashes_from_dir()` helpers. Handle healing-discovered bytecodes separately.
- `code_collector.rs`: Add `flush_all()` (non-consuming flush for mid-insertion use) and `dir()` accessor.
- `client.rs`: Add `update_metrics` parameter to `request_bytecodes()` to prevent overwriting `current_step` during concurrent download.

**Benchmark (Ethereum mainnet, ethrex-mainnet-4):**

| Phase | With PR | Baseline | Delta |
|-------|---------|----------|-------|
| Headers | 15:30 | 15:50 | -0:20 |
| Account Insertion | 13:20 | 13:40 | -0:20 |
| Storage (DL + Insert) | 53:00 | 53:00 | 0:00 |
| Healing | 2:20 | 2:20 | 0:00 |
| Bytecodes (sequential) | **0:00** | **6:23** | **-6:23** |
| **Total** | **1:29:47** | **1:32:48** | **-3:01 (-3.3%)** |

Bytecodes (2.1M hashes, 8 min download) finished 46 minutes before storage insertion ended.

## How to Test
1. Run ethrex with snap sync on mainnet or Hoodi with a consensus client
2. Verify "Background bytecode download starting for N unique code hashes" appears during account insertion
3. Verify "Bytecode progress: X/Y downloaded" messages appear during storage phases
4. Verify "Background bytecode download complete" appears after healing
5. Verify no sequential bytecodes phase at the end