### PR TITLE
fix(l1): don't emit `removed_storage` for accounts created within batch

### DIFF
--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -285,18 +285,18 @@ impl GeneralizedDatabase {
             // Edge cases that can make this true:
             //   1. Account was destroyed and created again afterwards.
             //   2. Account was destroyed but then was sent ETH, so it's not going to be completely removed from the trie.
-            // Only set removed_storage if the initial (pre-batch) account actually had storage
-            // in the trie. If it didn't (e.g. account was created within the batch), there's
-            // nothing to remove, and emitting removed_storage=true would cause a spurious
-            // empty account to be inserted into the state trie.
-            let removed_storage = new_state_account.status == AccountStatus::DestroyedModified
-                && initial_state_account.has_storage;
+            let was_destroyed = new_state_account.status == AccountStatus::DestroyedModified;
+            // Only emit removed_storage if the account actually had storage in the trie.
+            // If it didn't (e.g. account was created within the batch), there's nothing to
+            // remove, and emitting removed_storage=true would cause a spurious empty
+            // account to be inserted into the state trie.
+            let removed_storage = was_destroyed && initial_state_account.has_storage;
 
             // 2. Storage has been updated if the current value is different from the one before execution.
             let mut added_storage: FxHashMap<_, _> = Default::default();
 
             for (key, new_value) in &new_state_account.storage {
-                let old_value = if !removed_storage {
+                let old_value = if !was_destroyed {
                     initial_state_account.storage.get(key).ok_or_else(|| { VMError::Internal(InternalError::Custom(format!("Failed to get old value from account's initial storage for address: {address:?}. For key: {key:?}")))})?
                 } else {
                     // There's not an "old value" if the contract was destroyed and re-created.
@@ -391,18 +391,18 @@ impl GeneralizedDatabase {
             // Edge cases that can make this true:
             //   1. Account was destroyed and created again afterwards.
             //   2. Account was destroyed but then was sent ETH, so it's not going to be completely removed from the trie.
-            // Only set removed_storage if the initial (pre-batch) account actually had storage
-            // in the trie. If it didn't (e.g. account was created within the batch), there's
-            // nothing to remove, and emitting removed_storage=true would cause a spurious
-            // empty account to be inserted into the state trie.
-            let removed_storage = new_state_account.status == AccountStatus::DestroyedModified
-                && initial_state_account.has_storage;
+            let was_destroyed = new_state_account.status == AccountStatus::DestroyedModified;
+            // Only emit removed_storage if the account actually had storage in the trie.
+            // If it didn't (e.g. account was created within the batch), there's nothing to
+            // remove, and emitting removed_storage=true would cause a spurious empty
+            // account to be inserted into the state trie.
+            let removed_storage = was_destroyed && initial_state_account.has_storage;
 
             // 2. Storage has been updated if the current value is different from the one before execution.
             let mut added_storage: FxHashMap<_, _> = Default::default();
 
             for (key, new_value) in &new_state_account.storage {
-                let old_value = if !removed_storage {
+                let old_value = if !was_destroyed {
                     initial_state_account.storage.get(key).ok_or_else(|| { VMError::Internal(InternalError::Custom(format!("Failed to get old value from account's initial storage for address: {address}")))})?
                 } else {
                     // There's not an "old value" if the contract was destroyed and re-created.


### PR DESCRIPTION
get_state_transitions() emitted removed_storage=true for any DestroyedModified account, even if the account was created within the batch and never had storage in the trie. This caused apply_account_updates_from_trie_batch to insert a spurious empty account leaf, corrupting the state root.

Guard removed_storage on initial_state_account.has_storage so it is only set when there is actual storage to clear.

**Motivation**

Batched fullsync was failing when resuming from a partial state due to a state root mismatch, but it worked properly when `batch_size=1`.

**Description**

  - **Root cause:** `get_state_transitions()` emitted `removed_storage=true` for any `DestroyedModified` account, even if the account was created within the batch and never had storage in the trie. When
  `apply_account_updates_from_trie_batch` processed this update, it didn't find the account in the trie, created a default `AccountState`, and unconditionally inserted it — adding a spurious empty account leaf
  to the state trie, corrupting the state root.
  - **Fix:** Guard `removed_storage` on `initial_state_account.has_storage` in both `get_state_transitions()` and `get_state_transitions_tx()`, so it is only set when there is actual pre-existing storage to
  clear.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.