### PR TITLE
refactor(levm): unify variable naming

### DIFF
--- a/crates/vm/errors.rs
+++ b/crates/vm/errors.rs
@@ -42,7 +42,7 @@ impl From<InternalError> for EvmError {
     fn from(value: InternalError) -> Self {
         match value {
             InternalError::Database(err) => err.into(),
-            other => EvmError::Custom(other.to_string()),
+            err => EvmError::Custom(err.to_string()),
         }
     }
 }


### PR DESCRIPTION
Use consistent variable naming in match arm for InternalError conversion