### PR TITLE
ci(l1): pin assertoor playbook URLs to pre-refactoring commit

### DIFF
--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -24,10 +24,11 @@ network_params:
   deposit_contract_address: "0x4242424242424242424242424242424242424242"
 
 assertoor_params:
+  image: ethpandaops/assertoor:v0.0.17
   run_stability_check: false
   run_block_proposal_check: false
   tests:
-    - https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/blob-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor/c35b5c3a5fd543bcc843ee0e0af1e6255ca48dbd/playbooks/stable/blob-transactions-test.yaml
     - https://raw.githubusercontent.com/lambdaclass/ethrex/refs/heads/main/.github/config/assertoor/el-stability-check.yaml
 
 tx_fuzz_params:

--- a/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
+++ b/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
@@ -28,7 +28,8 @@ additional_services:
   - dora
 
 assertoor_params:
+  image: ethpandaops/assertoor:v0.0.17
   tests:
     - https://raw.githubusercontent.com/lambdaclass/ethrex/refs/heads/main/.github/config/assertoor/el-stability-check.yaml # Check that all el clients are synced with the corresponding cl
-    - https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/blob-transactions-test.yaml
-    - https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/eoa-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor/c35b5c3a5fd543bcc843ee0e0af1e6255ca48dbd/playbooks/stable/blob-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor/c35b5c3a5fd543bcc843ee0e0af1e6255ca48dbd/playbooks/stable/eoa-transactions-test.yaml

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -30,7 +30,8 @@ network_params:
   deposit_contract_address: "0x4242424242424242424242424242424242424242"
 
 assertoor_params:
+  image: ethpandaops/assertoor:v0.0.17
   run_stability_check: false
   run_block_proposal_check: false
   tests:
-    - https://raw.githubusercontent.com/ethpandaops/assertoor/refs/heads/master/playbooks/stable/eoa-transactions-test.yaml
+    - https://raw.githubusercontent.com/ethpandaops/assertoor/c35b5c3a5fd543bcc843ee0e0af1e6255ca48dbd/playbooks/stable/eoa-transactions-test.yaml


### PR DESCRIPTION
## Summary

Pin all assertoor playbook URL references from `refs/heads/master` to a specific commit (`c35b5c3a5f`) — the last `master` commit before ethpandaops/assertoor PR #137 (major refactoring) was merged.

## Motivation

Since Feb 19 ~17:26 UTC, the assertoor upstream merged a [major refactoring](https://github.com/ethpandaops/assertoor/pull/137) that introduced breaking changes:
- `stopChildOnResult` removed (tasks now self-complete)
- `failTaskCount` / `succeedTaskCount` replaced with `failureThreshold` / `successThreshold`  
- Transaction submission engine replaced with spamoor

Since our configs fetched playbooks from `refs/heads/master`, every CI run after the merge fails the **Blob & Stability Check** — including runs with zero code changes.

## Changes

Pinned 4 playbook URLs across 3 files:
- `network_params_blob.yaml` — `blob-transactions-test.yaml`
- `network_params_tx.yaml` — `eoa-transactions-test.yaml`
- `network_params_ethrex_multiple_cl.yaml` — `blob-transactions-test.yaml` + `eoa-transactions-test.yaml`

## Note

Pinning the playbook URLs may not be sufficient on its own — if Kurtosis is also pulling the latest assertoor Docker image (with the new runtime), the old playbooks may still be interpreted differently. We may also need to pin the assertoor image version in the network params configs.