### PR TITLE
fix: correct error message for `MetricsGatherer` spawn failure

### DIFF
--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -168,7 +168,7 @@ pub async fn start_l2(
     let metrics_gatherer = MetricsGatherer::spawn(&cfg, rollup_store.clone(), l2_url)
         .await
         .inspect_err(|err| {
-            error!("Error starting Block Producer: {err}");
+            error!("Error starting Metrics Gatherer: {err}");
         });
     let mut verifier_handle = None;
 


### PR DESCRIPTION
## Why?
The error message when MetricsGatherer fails to spawn incorrectly said "Block Producer" due to a copy-paste mistake.
 
## What changed?
Fixed the error message to correctly identify MetricsGatherer as the failing component.





