### PR TITLE
ci(l2): increase contract_deployer retry count to fix flaky SP1 CI

### DIFF
--- a/crates/l2/docker-compose.yaml
+++ b/crates/l2/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
   contract_deployer:
     container_name: contract_deployer
     image: "ethrex:main-l2"
-    restart: on-failure:10
+    restart: on-failure:20
     build:
       context: ../../
       args:


### PR DESCRIPTION
**Motivation**

The `Integration Test Prover SP1` CI workflow fails intermittently when the `contract_deployer` container can't connect to `ethrex_l1` in time. The error is a gRPC transport EOF during the Docker build step. The workflow itself [suggests increasing the retry count](https://github.com/lambdaclass/ethrex/blob/main/.github/workflows/main_prover.yaml#L92) in `docker-compose.yaml` when this happens.

**Description**

Increase the `contract_deployer` service `restart: on-failure` retry count from 10 to 20, giving `ethrex_l1` more time to become ready before the deployer gives up.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.