### PR TITLE
fix(l2): lightweight RocksDB config for checkpoint stores

### DIFF
--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -48,7 +48,6 @@ use ethrex_rpc::{
     clients::eth::{EthClient, Overrides},
     types::block_identifier::{BlockIdentifier, BlockTag},
 };
-use ethrex_storage::EngineType;
 use ethrex_storage::Store;
 use ethrex_storage_rollup::StoreRollup;
 use ethrex_vm::BlockExecutionResult;
@@ -1146,17 +1145,12 @@ impl L1Committer {
         path: &Path,
         rollup_store: &StoreRollup,
     ) -> Result<(Store, Arc<Blockchain>), CommitterError> {
-        #[cfg(feature = "rocksdb")]
-        let engine_type = EngineType::RocksDB;
-        #[cfg(not(feature = "rocksdb"))]
-        let engine_type = EngineType::InMemory;
-
         if !path.exists() {
             info!("Creating genesis checkpoint at path {path:?}");
         }
 
         let checkpoint_store = {
-            let mut checkpoint_store_inner = Store::new(path, engine_type)?;
+            let mut checkpoint_store_inner = Store::new_checkpoint(path)?;
 
             checkpoint_store_inner.add_initial_state(genesis).await?;
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -43,6 +43,10 @@ tokio = { workspace = true, features = ["full"] }
 [lib]
 path = "./lib.rs"
 
+[[example]]
+name = "rocksdb_memory_comparison"
+required-features = ["rocksdb"]
+
 [lints.clippy]
 unwrap_used = "deny"
 redundant_clone = "warn"

--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -201,6 +201,114 @@ impl RocksDBBackend {
         }
         Ok(Self { db: Arc::new(db) })
     }
+
+    /// Opens a RocksDB instance with lightweight settings suitable for checkpoint stores.
+    ///
+    /// Checkpoint stores are short-lived: they re-execute a handful of blocks and are then
+    /// dropped. The aggressive buffer settings of `open()` waste ~1.5-3 GB of memory per
+    /// instance for buffers that are barely used. This method uses much smaller buffers.
+    pub fn open_checkpoint(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        opts.set_max_open_files(256);
+        opts.set_max_file_opening_threads(4);
+
+        opts.set_max_background_jobs(2);
+
+        opts.set_level_zero_file_num_compaction_trigger(4);
+        opts.set_level_zero_slowdown_writes_trigger(20);
+        opts.set_level_zero_stop_writes_trigger(36);
+        opts.set_target_file_size_base(64 * 1024 * 1024); // 64MB
+        opts.set_max_bytes_for_level_base(256 * 1024 * 1024); // 256MB
+        opts.set_max_bytes_for_level_multiplier(10.0);
+        opts.set_level_compaction_dynamic_level_bytes(true);
+
+        opts.set_db_write_buffer_size(64 * 1024 * 1024); // 64MB (was 1GB)
+        opts.set_write_buffer_size(16 * 1024 * 1024); // 16MB (was 128MB)
+        opts.set_max_write_buffer_number(2);
+        opts.set_min_write_buffer_number_to_merge(1);
+
+        opts.set_wal_recovery_mode(rocksdb::DBRecoveryMode::PointInTime);
+        opts.set_max_total_wal_size(128 * 1024 * 1024); // 128MB (was 2GB)
+        opts.set_wal_bytes_per_sync(8 * 1024 * 1024); // 8MB
+        opts.set_bytes_per_sync(8 * 1024 * 1024); // 8MB
+        opts.set_use_fsync(false);
+
+        opts.set_enable_pipelined_write(true);
+        opts.set_allow_concurrent_memtable_write(true);
+        opts.set_enable_write_thread_adaptive_yield(true);
+        opts.set_compaction_readahead_size(2 * 1024 * 1024); // 2MB
+        opts.set_advise_random_on_open(false);
+        opts.set_compression_type(rocksdb::DBCompressionType::None);
+
+        let existing_cfs = DBWithThreadMode::<MultiThreaded>::list_cf(&opts, path.as_ref())
+            .unwrap_or_else(|_| vec!["default".to_string()]);
+
+        let mut all_cfs_to_open = HashSet::new();
+        all_cfs_to_open.extend(existing_cfs.iter().cloned());
+        all_cfs_to_open.extend(TABLES.iter().map(|table| table.to_string()));
+
+        let cf_descriptors: Vec<_> = all_cfs_to_open
+            .iter()
+            .map(|cf_name| {
+                let mut cf_opts = Options::default();
+                cf_opts.set_write_buffer_size(16 * 1024 * 1024); // 16MB uniform
+                cf_opts.set_max_write_buffer_number(2);
+                cf_opts.set_target_file_size_base(64 * 1024 * 1024); // 64MB
+                cf_opts.set_level_zero_file_num_compaction_trigger(4);
+                cf_opts.set_level_zero_slowdown_writes_trigger(20);
+                cf_opts.set_level_zero_stop_writes_trigger(36);
+                cf_opts.set_compression_type(rocksdb::DBCompressionType::None);
+
+                let mut block_opts = BlockBasedOptions::default();
+                block_opts.set_block_size(16 * 1024); // 16KB
+                cf_opts.set_block_based_table_factory(&block_opts);
+
+                ColumnFamilyDescriptor::new(cf_name, cf_opts)
+            })
+            .collect();
+
+        let db = DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+            &opts,
+            path.as_ref(),
+            cf_descriptors,
+        )
+        .map_err(|e| {
+            StoreError::Custom(format!(
+                "Failed to open checkpoint RocksDB with all CFs: {}",
+                e
+            ))
+        })?;
+
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    /// Returns the total size of all memtables across all column families (in bytes).
+    ///
+    /// Queries the `rocksdb.cur-size-all-mem-tables` property for each CF and sums them.
+    /// Useful for measuring and comparing memory usage between store configurations.
+    pub fn mem_table_total_size(&self) -> u64 {
+        let mut total: u64 = 0;
+        for table in TABLES {
+            if let Some(cf) = self.db.cf_handle(table)
+                && let Ok(Some(val)) = self
+                    .db
+                    .property_int_value_cf(&cf, "rocksdb.cur-size-all-mem-tables")
+            {
+                total += val;
+            }
+        }
+        // Also include the "default" CF
+        if let Ok(Some(val)) = self
+            .db
+            .property_int_value("rocksdb.cur-size-all-mem-tables")
+        {
+            total += val;
+        }
+        total
+    }
 }
 
 impl Drop for RocksDBBackend {

--- a/crates/storage/examples/rocksdb_memory_comparison.rs
+++ b/crates/storage/examples/rocksdb_memory_comparison.rs
@@ -1,0 +1,69 @@
+//! Compares memtable memory configuration between the standard and checkpoint RocksDB stores.
+//!
+//! Shows both the configured write buffer limits (maximum potential allocation) and the
+//! actual current memtable sizes. RocksDB allocates memtables in small arena blocks that
+//! grow toward the configured limit, so the real savings appear under production workload.
+//!
+//! Run with:
+//! ```sh
+//! cargo run -p ethrex-storage --example rocksdb_memory_comparison --features rocksdb
+//! ```
+
+#[cfg(feature = "rocksdb")]
+fn main() {
+    use ethrex_storage::backend::rocksdb::RocksDBBackend;
+
+    let tmp_standard = tempfile::tempdir().expect("failed to create temp dir");
+    let tmp_checkpoint = tempfile::tempdir().expect("failed to create temp dir");
+
+    let standard = RocksDBBackend::open(tmp_standard.path()).expect("failed to open standard DB");
+    let checkpoint = RocksDBBackend::open_checkpoint(tmp_checkpoint.path())
+        .expect("failed to open checkpoint DB");
+
+    let standard_bytes = standard.mem_table_total_size();
+    let checkpoint_bytes = checkpoint.mem_table_total_size();
+
+    let num_cfs = ethrex_storage::api::tables::TABLES.len() + 1; // +1 for "default"
+
+    // Standard store configured limits (from open()):
+    // - db_write_buffer_size: 1 GB global
+    // - Per-CF write buffers range from 64 MB to 512 MB
+    // - max_write_buffer_number ranges from 3 to 6
+    // Theoretical max: sum of (write_buffer_size * max_write_buffer_number) per CF
+    // Conservative estimate: ~1 GB global cap limits actual allocation
+    let standard_configured_mb = 1024; // 1 GB db_write_buffer_size
+
+    // Checkpoint store configured limits (from open_checkpoint()):
+    // - db_write_buffer_size: 64 MB global
+    // - Per-CF write buffers: 16 MB uniform
+    // - max_write_buffer_number: 2 for all CFs
+    let checkpoint_configured_mb = 64; // 64 MB db_write_buffer_size
+
+    println!("=== Configured write buffer limits ===");
+    println!("Standard store:   {standard_configured_mb:>6} MB  (db_write_buffer_size)");
+    println!("Checkpoint store: {checkpoint_configured_mb:>6} MB  (db_write_buffer_size)");
+    println!(
+        "Reduction factor: {:.0}x",
+        standard_configured_mb as f64 / checkpoint_configured_mb as f64
+    );
+
+    println!();
+    println!("=== Current memtable allocation ({num_cfs} column families) ===");
+    println!(
+        "Standard store:   {standard_bytes:>12} bytes ({:.1} MB)",
+        standard_bytes as f64 / 1024.0 / 1024.0
+    );
+    println!(
+        "Checkpoint store: {checkpoint_bytes:>12} bytes ({:.1} MB)",
+        checkpoint_bytes as f64 / 1024.0 / 1024.0
+    );
+    println!("(Memtables grow toward the configured limit under write pressure)");
+}
+
+#[cfg(not(feature = "rocksdb"))]
+fn main() {
+    eprintln!("This example requires the `rocksdb` feature. Run with:");
+    eprintln!(
+        "  cargo run -p ethrex-storage --example rocksdb_memory_comparison --features rocksdb"
+    );
+}

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1451,6 +1451,27 @@ impl Store {
         }
     }
 
+    /// Creates a Store backed by a lightweight RocksDB configuration.
+    ///
+    /// Checkpoint stores are short-lived (re-execute a handful of blocks then dropped),
+    /// so they don't need the aggressive buffer settings of the main store. This avoids
+    /// wasting ~1.5-3 GB of memory per checkpoint instance.
+    #[cfg(feature = "rocksdb")]
+    pub fn new_checkpoint(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let db_path = path.as_ref().to_path_buf();
+        validate_store_schema_version(&db_path)?;
+        let backend = Arc::new(RocksDBBackend::open_checkpoint(path)?);
+        Self::from_backend(backend, db_path, DB_COMMIT_THRESHOLD)
+    }
+
+    /// Fallback for non-rocksdb builds: creates a regular in-memory store.
+    #[cfg(not(feature = "rocksdb"))]
+    pub fn new_checkpoint(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let db_path = path.as_ref().to_path_buf();
+        let backend = Arc::new(InMemoryBackend::open()?);
+        Self::from_backend(backend, db_path, IN_MEMORY_COMMIT_THRESHOLD)
+    }
+
     fn from_backend(
         backend: Arc<dyn StorageBackend>,
         db_path: PathBuf,


### PR DESCRIPTION
## Motivation

During L2 batch production, checkpoint RocksDB stores are created via `Store::new()` → `RocksDBBackend::open()`, inheriting the same aggressive buffer settings as the main long-lived store. This wastes ~1.5-3 GB of memory per checkpoint instance for buffers that are barely used, since checkpoints only re-execute a handful of blocks before being dropped.

Closes #6298

## Description

Add a new `RocksDBBackend::open_checkpoint()` method with lightweight settings and a corresponding `Store::new_checkpoint()`. Update the single checkpoint creation callsite in `l1_committer.rs`.

Key setting reductions:

| Setting | Standard | Checkpoint |
|---------|----------|------------|
| `db_write_buffer_size` | 1 GB | 64 MB |
| Per-CF `write_buffer_size` | 128-512 MB | 16 MB |
| `max_write_buffer_number` | 3-6 | 2 |
| `max_open_files` | unlimited | 256 |
| `max_background_jobs` | 8 | 2 |
| `max_total_wal_size` | 2 GB | 128 MB |
| `target_file_size_base` | 512 MB | 64 MB |
| `max_bytes_for_level_base` | 2 GB | 256 MB |

Also includes a measurement example binary (`rocksdb_memory_comparison`) for comparing the two configurations and a `mem_table_total_size()` helper for querying RocksDB memtable usage.

## How to Test

```bash
# 1. Compile check (both crates)
cargo check -p ethrex-storage --features rocksdb
cargo check -p ethrex-l2 --features rocksdb

# 2. Run the measurement example
cargo run -p ethrex-storage --example rocksdb_memory_comparison --features rocksdb
# Expected output: shows 16x reduction in configured write buffer limits (1024 MB → 64 MB)

# 3. Lint and format
cargo clippy -p ethrex-storage --features rocksdb --all-targets -- -D warnings
cargo clippy -p ethrex-l2 --features rocksdb --all-targets -- -D warnings
cargo fmt --all -- --check

# 4. Tests
cargo test -p ethrex-storage --features rocksdb
```

## Checklist

- [x] Lint passes
- [x] Format passes
- [x] Tests pass