### PR TITLE
chore(l2): add selector hash comments to custom error declarations

### DIFF
--- a/crates/l2/contracts/src/l1/based/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/based/interfaces/IOnChainProposer.sol
@@ -7,52 +7,52 @@ pragma solidity =0.8.31;
 /// by the proposer to commit batches of l2 blocks and verify proofs.
 interface IOnChainProposer {
     // Initialization errors
-    error MissingRisc0Verifier();
-    error MissingSp1Verifier();
-    error MissingTdxVerifier();
-    error AlignedModeRequiresSp1();
-    error AlignedModeDoesNotSupportRisc0();
-    error CommitHashIsZero();
-    error MissingSp1VerificationKey();
-    error MissingRisc0VerificationKey();
-    error BridgeIsZeroAddress();
-    error BridgeIsContractAddress();
-    error AlreadyInitialized();
-    error SequencerRegistryIsZeroAddress();
-    error SequencerRegistryIsContractAddress();
+    error MissingRisc0Verifier(); // 0x1871c084
+    error MissingSp1Verifier(); // 0xc0b62621
+    error MissingTdxVerifier(); // 0xee7f6b60
+    error AlignedModeRequiresSp1(); // 0xb41e395e
+    error AlignedModeDoesNotSupportRisc0(); // 0xadae5cff
+    error CommitHashIsZero(); // 0x1f14b5aa
+    error MissingSp1VerificationKey(); // 0x544c07b4
+    error MissingRisc0VerificationKey(); // 0x60c177e0
+    error BridgeIsZeroAddress(); // 0x850138f2
+    error BridgeIsContractAddress(); // 0xdf655de9
+    error AlreadyInitialized(); // 0x0dc149f0
+    error SequencerRegistryIsZeroAddress(); // 0xd385dd80
+    error SequencerRegistryIsContractAddress(); // 0x7064abcc
 
     // Commit errors
-    error BatchNumberNotSuccessor();
-    error BatchAlreadyCommitted();
-    error LastBlockHashIsZero();
-    error InvalidPrivilegedTransactionLogs();
-    error InvalidL2MessageRollingHash();
-    error ValidiumBlobPublished();
-    error RollupBlobNotPublished();
-    error MissingVerificationKeyForCommit();
+    error BatchNumberNotSuccessor(); // 0xcd1793fe
+    error BatchAlreadyCommitted(); // 0x884923cf
+    error LastBlockHashIsZero(); // 0xf1cbbe55
+    error InvalidPrivilegedTransactionLogs(); // 0x9e6e5638
+    error InvalidL2MessageRollingHash(); // 0x52ba57cb
+    error ValidiumBlobPublished(); // 0x0c9c8061
+    error RollupBlobNotPublished(); // 0xe1aa9667
+    error MissingVerificationKeyForCommit(); // 0xf6b9798e
 
     // Verify errors
-    error UseAlignedVerification();
-    error UseSmartContractVerification();
-    error BatchNotSequential();
-    error BatchNotCommitted();
-    error EmptyBatchArray();
-    error BatchArrayLengthMismatch();
-    error ExpiredPrivilegedTransactionDeadline();
-    error InvalidRisc0Proof();
-    error InvalidSp1Proof();
-    error InvalidTdxProof();
+    error UseAlignedVerification(); // 0x2da8b4d4
+    error UseSmartContractVerification(); // 0xc8d8ecb9
+    error BatchNotSequential(); // 0xceb05a46
+    error BatchNotCommitted(); // 0xc26a3294
+    error EmptyBatchArray(); // 0x7dc57e7b
+    error BatchArrayLengthMismatch(); // 0xfc5221bd
+    error ExpiredPrivilegedTransactionDeadline(); // 0x1420ad0b
+    error InvalidRisc0Proof(); // 0x14add973
+    error InvalidSp1Proof(); // 0x7ff849b5
+    error InvalidTdxProof(); // 0x62013a95
 
     // Aligned verify errors
-    error IncorrectFirstBatchNumber();
-    error LastBatchExceedsCommitted();
-    error Sp1ProofArrayLengthMismatch();
-    error Risc0ProofArrayLengthMismatch();
-    error AlignedAggregatorCallFailed();
-    error AlignedProofVerificationFailed();
+    error IncorrectFirstBatchNumber(); // 0x5f83abb8
+    error LastBatchExceedsCommitted(); // 0xfbd95da9
+    error Sp1ProofArrayLengthMismatch(); // 0xc1af923d
+    error Risc0ProofArrayLengthMismatch(); // 0x60fecd3e
+    error AlignedAggregatorCallFailed(); // 0x63934992
+    error AlignedProofVerificationFailed(); // 0x44602025
 
     // Access control errors
-    error CallerHasNoSequencingRights();
+    error CallerHasNoSequencingRights(); // 0xac0192af
 
     /// @notice The latest committed batch number.
     /// @return The latest committed batch number as a uint256.

--- a/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IOnChainProposer.sol
@@ -9,50 +9,50 @@ import {ICommonBridge} from "./ICommonBridge.sol";
 /// by the proposer to commit batches of l2 blocks and verify proofs.
 interface IOnChainProposer {
     // Initialization errors
-    error MissingRisc0Verifier();
-    error MissingSp1Verifier();
-    error MissingTdxVerifier();
-    error AlignedModeRequiresSp1();
-    error AlignedModeDoesNotSupportRisc0();
-    error CommitHashIsZero();
-    error MissingSp1VerificationKey();
-    error MissingRisc0VerificationKey();
-    error BridgeIsZeroAddress();
-    error BridgeIsContractAddress();
+    error MissingRisc0Verifier(); // 0x1871c084
+    error MissingSp1Verifier(); // 0xc0b62621
+    error MissingTdxVerifier(); // 0xee7f6b60
+    error AlignedModeRequiresSp1(); // 0xb41e395e
+    error AlignedModeDoesNotSupportRisc0(); // 0xadae5cff
+    error CommitHashIsZero(); // 0x1f14b5aa
+    error MissingSp1VerificationKey(); // 0x544c07b4
+    error MissingRisc0VerificationKey(); // 0x60c177e0
+    error BridgeIsZeroAddress(); // 0x850138f2
+    error BridgeIsContractAddress(); // 0xdf655de9
 
     // Commit errors
-    error BatchNumberNotSuccessor();
-    error BatchAlreadyCommitted();
-    error LastBlockHashIsZero();
-    error InvalidPrivilegedTransactionLogs();
-    error InvalidL2MessageRollingHash();
-    error ValidiumBlobPublished();
-    error RollupBlobNotPublished();
-    error MissingVerificationKeyForCommit();
+    error BatchNumberNotSuccessor(); // 0xcd1793fe
+    error BatchAlreadyCommitted(); // 0x884923cf
+    error LastBlockHashIsZero(); // 0xf1cbbe55
+    error InvalidPrivilegedTransactionLogs(); // 0x9e6e5638
+    error InvalidL2MessageRollingHash(); // 0x52ba57cb
+    error ValidiumBlobPublished(); // 0x0c9c8061
+    error RollupBlobNotPublished(); // 0xe1aa9667
+    error MissingVerificationKeyForCommit(); // 0xf6b9798e
 
     // Verify errors
-    error UseAlignedVerification();
-    error UseSmartContractVerification();
-    error BatchNotSequential();
-    error BatchNotCommitted();
-    error EmptyBatchArray();
-    error BatchArrayLengthMismatch();
-    error ExpiredPrivilegedTransactionDeadline();
-    error InvalidRisc0Proof();
-    error InvalidSp1Proof();
-    error InvalidTdxProof();
+    error UseAlignedVerification(); // 0x2da8b4d4
+    error UseSmartContractVerification(); // 0xc8d8ecb9
+    error BatchNotSequential(); // 0xceb05a46
+    error BatchNotCommitted(); // 0xc26a3294
+    error EmptyBatchArray(); // 0x7dc57e7b
+    error BatchArrayLengthMismatch(); // 0xfc5221bd
+    error ExpiredPrivilegedTransactionDeadline(); // 0x1420ad0b
+    error InvalidRisc0Proof(); // 0x14add973
+    error InvalidSp1Proof(); // 0x7ff849b5
+    error InvalidTdxProof(); // 0x62013a95
 
     // Aligned verify errors
-    error IncorrectFirstBatchNumber();
-    error LastBatchExceedsCommitted();
-    error Sp1ProofArrayLengthMismatch();
-    error Risc0ProofArrayLengthMismatch();
-    error AlignedAggregatorCallFailed();
-    error AlignedProofVerificationFailed();
+    error IncorrectFirstBatchNumber(); // 0x5f83abb8
+    error LastBatchExceedsCommitted(); // 0xfbd95da9
+    error Sp1ProofArrayLengthMismatch(); // 0xc1af923d
+    error Risc0ProofArrayLengthMismatch(); // 0x60fecd3e
+    error AlignedAggregatorCallFailed(); // 0x63934992
+    error AlignedProofVerificationFailed(); // 0x44602025
 
     // Revert errors
-    error CannotRevertVerifiedBatch();
-    error NoBatchesToRevert();
+    error CannotRevertVerifiedBatch(); // 0xdb2665e8
+    error NoBatchesToRevert(); // 0xcd988645
 
     /// @notice The latest committed batch number.
     /// @return The latest committed batch number as a uint256.

--- a/crates/l2/contracts/src/l1/interfaces/IRiscZeroVerifier.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IRiscZeroVerifier.sol
@@ -33,7 +33,7 @@ struct Receipt {
 }
 
 /// @notice Error raised when cryptographic verification of the zero-knowledge proof fails.
-error VerificationFailed();
+error VerificationFailed(); // 0x439cc0cd
 
 /// @notice Verifier interface for RISC Zero receipts of execution.
 interface IRiscZeroVerifier {

--- a/crates/l2/contracts/src/l1/interfaces/IRouter.sol
+++ b/crates/l2/contracts/src/l1/interfaces/IRouter.sol
@@ -54,26 +54,26 @@ interface IRouter {
 
     /// @notice Emitted when a message is sent to a chain that is not registered.
     /// @param chainId The ID of the chain that is not registered.
-    error TransferToChainNotRegistered(uint256 chainId);
+    error TransferToChainNotRegistered(uint256 chainId); // 0x6eadd702
 
     /// @notice Error indicating an invalid address was provided.
     /// @param addr The invalid address.
-    error InvalidAddress(address addr);
+    error InvalidAddress(address addr); // 0x8e4c8aa6
 
     /// @notice Error indicating a chain is already registered.
     /// @param chainId The ID of the already registered chain.
-    error ChainAlreadyRegistered(uint256 chainId);
+    error ChainAlreadyRegistered(uint256 chainId); // 0xfcd46323
 
     /// @notice Error indicating the caller is not a registered bridge.
     /// @param caller The address of the caller.
-    error CallerNotBridge(address caller);
+    error CallerNotBridge(address caller); // 0xa052cf8a
 
     /// @notice Error indicating the caller is not the authorized bridge for `senderChainId`.
     /// @param senderChainId The claimed source chain ID.
     /// @param caller The address of the caller.
-    error InvalidSender(uint256 senderChainId, address caller);
+    error InvalidSender(uint256 senderChainId, address caller); // 0x5bce1a02
 
     /// @notice Error indicating a chain is not registered.
     /// @param chainId The ID of the chain that is not registered.
-    error ChainNotRegistered(uint256 chainId);
+    error ChainNotRegistered(uint256 chainId); // 0xf25ca59c
 }

--- a/crates/l2/contracts/src/l1/interfaces/ITimelock.sol
+++ b/crates/l2/contracts/src/l1/interfaces/ITimelock.sol
@@ -15,10 +15,10 @@ interface ITimelock {
     event EmergencyExecution(address indexed target, uint256 value, bytes data);
 
     // @notice Used for functions that can only be called by the Timelock itself.
-    error TimelockCallerNotSelf();
+    error TimelockCallerNotSelf(); // 0xc8fe83ea
 
     // @notice Used for other initialize() from contracts that the Timelock inherits from
-    error TimelockUseCustomInitialize();
+    error TimelockUseCustomInitialize(); // 0x3f348ad0
 
     /// @notice The OnChainProposer contract controlled by this timelock.
     function onChainProposer() external view returns (IOnChainProposer);


### PR DESCRIPTION
**Motivation**

When debugging on-chain transactions, raw revert data only shows 4-byte selectors. Without a quick reference, identifying which custom error was triggered requires manually computing `keccak256` of each error signature. This slows down debugging, especially when triaging CI failures or investigating reverts from block explorers.

**Description**

Add inline comments with the 4-byte selector hash next to every custom error declaration across all L1 interface contracts:

- `IOnChainProposer.sol` (non-based) — 30 errors
- `IOnChainProposer.sol` (based) — 33 errors
- `IRiscZeroVerifier.sol` — 1 error
- `ITimelock.sol` — 2 errors
- `IRouter.sol` — 6 errors

Format: `error ErrorName(); // 0xabcd1234`

**Note on test coverage**

The existing `error_selectors.rs` test validates selector constants that are actually used in Rust code — that's its purpose. The inline comments added here are developer convenience for reading raw revert data, not constants consumed by the codebase, so extending the test to cover them is unnecessary.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.