### PR TITLE
fix(payload): correct execution order and BAL indices in block production

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -434,8 +434,19 @@ impl Blockchain {
         if let BlockchainType::L1 = self.options.r#type {
             self.apply_system_operations(&mut context)?;
         }
-        self.apply_withdrawals(&mut context)?;
         self.fill_transactions(&mut context)?;
+
+        // Per EIP-7928: withdrawals use block_access_index = n_txs + 1
+        #[allow(clippy::cast_possible_truncation)]
+        let withdrawal_index = (context.payload.body.transactions.len() + 1) as u16;
+        context.vm.set_bal_index(withdrawal_index);
+        if let Some(recorder) = context.vm.db.bal_recorder_mut() {
+            if let Some(withdrawals) = &context.payload.body.withdrawals {
+                recorder.extend_touched_addresses(withdrawals.iter().map(|w| w.address));
+            }
+        }
+        self.apply_withdrawals(&mut context)?;
+
         self.extract_requests(&mut context)?;
         self.finalize_payload(&mut context)?;
 


### PR DESCRIPTION
## Summary

- `build_payload()` executed withdrawals **before** transactions, while the Ethereum spec and the validation path (`execute_block_pipeline`) execute them **after**
- This caused every ethrex-produced block to be rejected by all other clients (reth, nimbus-el, geth, besu, nethermind) with BAL hash mismatch
- Reorders to: system calls → transactions → withdrawals → request extraction, and sets BAL `block_access_index` to `n_txs + 1` for the post-tx phase

### Root cause

The wrong order caused:
1. Withdrawal balance changes recorded at BAL index 0 instead of `n+1`
2. Request extraction system calls at wrong BAL index
3. Different intermediate states when withdrawal recipients overlap with tx participants

### Evidence

Slot 193426 / block 167576 on bal-devnet-2: proposed by `hc-lodestar-ethrex-super-1`, rejected by 12 nodes (tracoor). Reth error: `block access list hash mismatch: got 0xa7c74a05..., expected 0xd9ebaecf...`

## Test plan

- [x] Docker image builds successfully
- [x] Node syncs bal-devnet-2 from genesis past Amsterdam fork with zero errors
- [ ] Kurtosis local network: ethrex produces blocks accepted by geth/lighthouse