### PR TITLE
ci(l1): loop HTML comment removal to prevent incomplete sanitization

### DIFF
--- a/.github/scripts/set-pr-status.js
+++ b/.github/scripts/set-pr-status.js
@@ -151,7 +151,12 @@ module.exports = async ({ github, context }) => {
     // Gets all issue numbers that would be closed if the PR is merged.
     function extractLinkedIssueNumbers(prBody) {
         const body = prBody || "";
-        const withoutComments = body.replace(/<!--[\s\S]*?-->/g, "");
+        let withoutComments = body;
+        let previous;
+        do {
+            previous = withoutComments;
+            withoutComments = withoutComments.replace(/<!--[\s\S]*?-->/g, "");
+        } while (withoutComments !== previous);
         const matches = [...withoutComments.matchAll(/(?:close[sd]?|fixe[sd]?|resolve[sd]?)\s+#(\d+)/gi)];
         return matches.map(match => parseInt(match[1], 10));
     }


### PR DESCRIPTION
## Summary

Fixes [CodeQL alert #119](https://github.com/lambdaclass/ethrex/security/code-scanning/119) (`js/incomplete-multi-character-sanitization`).

### Problem

In `.github/scripts/set-pr-status.js`, `extractLinkedIssueNumbers` strips HTML comments from PR bodies before extracting "closes #N" keywords. The regex used a single-pass replacement:

```js
const withoutComments = body.replace(/<!--[\s\S]*?-->/g, "");
```

A single-pass replacement of `<!--...-->` can leave behind a valid HTML comment if the input is crafted so that removing one match creates a new one. For example, input `<!-<!-- foo -->->` would produce `<!-- foo -->` after one pass.

This means a malicious PR author could hide closing keywords inside crafted comment nesting to manipulate project board status. The practical risk is low (CI context, trusted-ish input), but the fix is trivial.

### Fix

Replace the single-pass `.replace()` with a loop that repeats until stable:

```js
let withoutComments = body;
let previous;
do {
    previous = withoutComments;
    withoutComments = withoutComments.replace(/<!--[\s\S]*?-->/g, "");
} while (withoutComments !== previous);
```

This is the approach recommended by [CodeQL's own documentation](https://codeql.github.com/codeql-query-help/javascript/js-incomplete-multi-character-sanitization/) for this exact alert type.

## Test plan

- No behavioral change for normal PR bodies — the single pass already removes all comments; the loop just adds a no-op second iteration confirming stability
- Edge case: nested/overlapping comment markers like `<!-<!-- foo -->->` are now fully stripped across multiple iterations
- Resolves CodeQL alert `js/incomplete-multi-character-sanitization`