### PR TITLE
fix(levm): skip nonce validation in eth_call simulations

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -1162,6 +1162,7 @@ impl LEVM {
             is_privileged: matches!(tx, Transaction::PrivilegedL2Transaction(_)),
             fee_token: tx.fee_token(),
             disable_balance_check: false,
+            disable_nonce_check: false,
         };
 
         Ok(env)
@@ -1222,6 +1223,7 @@ impl LEVM {
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
 
         env.block_gas_limit = i64::MAX as u64; // disable block gas limit
+        env.disable_nonce_check = true;
 
         adjust_disabled_base_fee(&mut env);
 
@@ -1688,6 +1690,7 @@ fn env_from_generic(
         is_privileged: false,
         fee_token: tx.fee_token,
         disable_balance_check: false,
+        disable_nonce_check: false,
     })
 }
 

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -44,6 +44,9 @@ pub struct Environment {
     /// When true, skip balance deduction in `deduct_caller`. Used by the prewarmer
     /// to avoid early reverts on insufficient balance so that warming touches more storage.
     pub disable_balance_check: bool,
+    /// When true, skip nonce validation. Used by `eth_call` simulations
+    /// where the caller typically doesn't provide a nonce.
+    pub disable_nonce_check: bool,
 }
 
 /// This struct holds special configuration variables specific to the

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -76,7 +76,7 @@ impl Hook for DefaultHook {
             .map_err(|_| TxValidationError::NonceIsMax)?;
 
         // check for nonce mismatch
-        if sender_info.nonce != vm.env.tx_nonce {
+        if !vm.env.disable_nonce_check && sender_info.nonce != vm.env.tx_nonce {
             return Err(TxValidationError::NonceMismatch {
                 expected: sender_info.nonce,
                 actual: vm.env.tx_nonce,

--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -511,7 +511,7 @@ fn prepare_execution_fee_token(vm: &mut VM<'_>) -> Result<(), crate::errors::VME
         .map_err(|_| TxValidationError::NonceIsMax)?;
 
     // check for nonce mismatch
-    if sender_info.nonce != vm.env.tx_nonce {
+    if !vm.env.disable_nonce_check && sender_info.nonce != vm.env.tx_nonce {
         return Err(TxValidationError::NonceMismatch {
             expected: sender_info.nonce,
             actual: vm.env.tx_nonce,


### PR DESCRIPTION
## Motivation

`eth_call` validates the transaction nonce against the sender account nonce. When the caller does not provide a nonce (the normal case for read-only calls), it defaults to `0`. Any account with nonce > 0 gets a `NonceMismatch` error.

For reference, Geth skips nonce validation entirely for `eth_call` via a `SkipNonceChecks` flag in `core/state_transition.go`.

Closes #6312

## Description

Add a `disable_nonce_check` flag to `Environment` (following the existing `disable_balance_check` pattern) and set it to `true` in `simulate_tx_from_generic`, which is the code path used by `eth_call` and `eth_estimateGas`.

**Changes:**
- `environment.rs`: Added `disable_nonce_check: bool` field
- `backends/levm/mod.rs`: Set flag to `true` in `simulate_tx_from_generic`; set to `false` in explicit `Environment` constructors
- `hooks/default_hook.rs`, `hooks/l2_hook.rs`: Guard nonce mismatch check with `!vm.env.disable_nonce_check`