### PR TITLE
perf(l1): lock-free ArcSwap for trie cache + O(1) canonical TX index

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["rt"] }
 fastbloom = "0.14"
 rayon.workspace = true
 lru = "0.16.2"
+arc-swap = "1.7"
 
 [features]
 default = []

--- a/crates/storage/api/tables.rs
+++ b/crates/storage/api/tables.rs
@@ -45,6 +45,15 @@ pub const RECEIPTS: &str = "receipts";
 /// - [`Vec<u8>`] = `(block_number, block_hash, index).encode_to_vec()`
 pub const TRANSACTION_LOCATIONS: &str = "transaction_locations";
 
+/// Canonical transaction index: [`[u8; 32]`] => [`Vec<u8>`]
+/// - [`[u8; 32]`] = `tx_hash.as_bytes()` (32 bytes)
+/// - [`Vec<u8>`] = `(block_number, block_hash, tx_index).encode_to_vec()`
+///
+/// Provides O(1) transaction lookup by hash, pointing only to the canonical chain.
+/// Updated during `forkchoice_update` and falls back to `TRANSACTION_LOCATIONS`
+/// prefix scan for non-indexed transactions (migration period).
+pub const CANONICAL_TX_INDEX: &str = "canonical_tx_index";
+
 /// Chain data column family: [`Vec<u8>`] => [`Vec<u8>`]
 /// - [`Vec<u8>`] = `chain_data_key(ChainDataIndex::ChainConfig)`
 /// - [`Vec<u8>`] = `serde_json::to_string(chain_config)`
@@ -102,7 +111,7 @@ pub const MISC_VALUES: &str = "misc_values";
 /// - [`Vec<u8>`] = `serde_json::to_vec(&witness)`
 pub const EXECUTION_WITNESSES: &str = "execution_witnesses";
 
-pub const TABLES: [&str; 19] = [
+pub const TABLES: [&str; 20] = [
     CHAIN_DATA,
     ACCOUNT_CODES,
     ACCOUNT_CODE_METADATA,
@@ -112,6 +121,7 @@ pub const TABLES: [&str; 19] = [
     HEADERS,
     PENDING_BLOCKS,
     TRANSACTION_LOCATIONS,
+    CANONICAL_TX_INDEX,
     RECEIPTS,
     SNAP_STATE,
     INVALID_CHAINS,

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -6,9 +6,10 @@ use crate::{
         StorageBackend, StorageReadView,
         tables::{
             ACCOUNT_CODE_METADATA, ACCOUNT_CODES, ACCOUNT_FLATKEYVALUE, ACCOUNT_TRIE_NODES,
-            BLOCK_NUMBERS, BODIES, CANONICAL_BLOCK_HASHES, CHAIN_DATA, EXECUTION_WITNESSES,
-            FULLSYNC_HEADERS, HEADERS, INVALID_CHAINS, MISC_VALUES, PENDING_BLOCKS, RECEIPTS,
-            SNAP_STATE, STORAGE_FLATKEYVALUE, STORAGE_TRIE_NODES, TRANSACTION_LOCATIONS,
+            BLOCK_NUMBERS, BODIES, CANONICAL_BLOCK_HASHES, CANONICAL_TX_INDEX, CHAIN_DATA,
+            EXECUTION_WITNESSES, FULLSYNC_HEADERS, HEADERS, INVALID_CHAINS, MISC_VALUES,
+            PENDING_BLOCKS, RECEIPTS, SNAP_STATE, STORAGE_FLATKEYVALUE, STORAGE_TRIE_NODES,
+            TRANSACTION_LOCATIONS,
         },
     },
     apply_prefix,
@@ -41,6 +42,7 @@ use ethrex_trie::{Node, NodeRLP};
 use lru::LruCache;
 use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Serialize};
+use arc_swap::ArcSwap;
 use std::{
     collections::{BTreeMap, HashMap, hash_map::Entry},
     fmt::Debug,
@@ -157,7 +159,8 @@ pub struct Store {
     /// Chain configuration (fork schedule, chain ID, etc.).
     chain_config: ChainConfig,
     /// Cache for trie nodes from recent blocks.
-    trie_cache: Arc<RwLock<Arc<TrieLayerCache>>>,
+    /// Uses `ArcSwap` for lock-free reads (RCU pattern).
+    trie_cache: Arc<ArcSwap<TrieLayerCache>>,
     /// Channel for controlling the FlatKeyValue generator background task.
     flatkeyvalue_control_tx: std::sync::mpsc::SyncSender<FKVGeneratorControlMessage>,
     /// Channel for sending trie updates to the background worker.
@@ -573,7 +576,12 @@ impl Store {
             let tx_hash_bytes = transaction_hash.as_bytes();
             let tx = db.begin_read()?;
 
-            // Use prefix iterator to find all entries with this transaction hash
+            // Fast path: check canonical index first (O(1) lookup)
+            if let Some(value) = tx.get(CANONICAL_TX_INDEX, tx_hash_bytes)? {
+                return Ok(Some(<(BlockNumber, BlockHash, Index)>::decode(&value)?));
+            }
+
+            // Fallback: Use prefix iterator to find all entries with this transaction hash
             let mut iter = tx.prefix_iterator(TRANSACTION_LOCATIONS, tx_hash_bytes)?;
             let mut transaction_locations = Vec::new();
 
@@ -1014,6 +1022,24 @@ impl Store {
                 let head_key = block_number.to_le_bytes();
                 let head_value = block_hash.encode_to_vec();
                 txn.put(CANONICAL_BLOCK_HASHES, &head_key, &head_value)?;
+
+                // Populate canonical transaction index for O(1) lookups.
+                // Read the block body to get transaction hashes.
+                let hash_key = block_hash.encode_to_vec();
+                if let Some(body_bytes) = {
+                    let read_txn = db.begin_read()?;
+                    read_txn.get(BODIES, &hash_key)?
+                } {
+                    let body: BlockBody = BlockBodyRLP::from_bytes(body_bytes)
+                        .to()
+                        .map_err(StoreError::from)?;
+                    for (index, transaction) in body.transactions.iter().enumerate() {
+                        let tx_hash = transaction.hash();
+                        let location_value =
+                            (block_number, block_hash, index as u64).encode_to_vec();
+                        txn.put(CANONICAL_TX_INDEX, tx_hash.as_bytes(), &location_value)?;
+                    }
+                }
             }
 
             for number in (head_number + 1)..=(latest) {
@@ -1477,7 +1503,7 @@ impl Store {
             backend,
             chain_config: Default::default(),
             latest_block_header: Default::default(),
-            trie_cache: Arc::new(RwLock::new(Arc::new(TrieLayerCache::new(commit_threshold)))),
+            trie_cache: Arc::new(ArcSwap::from_pointee(TrieLayerCache::new(commit_threshold))),
             flatkeyvalue_control_tx: fkv_tx,
             trie_update_worker_tx: trie_upd_tx,
             last_computed_flatkeyvalue: Arc::new(RwLock::new(last_written)),
@@ -2470,10 +2496,7 @@ impl Store {
     pub fn open_state_trie(&self, state_root: H256) -> Result<Trie, StoreError> {
         let trie_db = TrieWrapper::new(
             state_root,
-            self.trie_cache
-                .read()
-                .map_err(|_| StoreError::LockError)?
-                .clone(),
+            self.trie_cache.load_full(),
             Box::new(BackendTrieDB::new_for_accounts(
                 self.backend.clone(),
                 self.last_written()?,
@@ -2502,10 +2525,7 @@ impl Store {
     pub fn open_locked_state_trie(&self, state_root: H256) -> Result<Trie, StoreError> {
         let trie_db = TrieWrapper::new(
             state_root,
-            self.trie_cache
-                .read()
-                .map_err(|_| StoreError::LockError)?
-                .clone(),
+            self.trie_cache.load_full(),
             Box::new(state_trie_locked_backend(
                 self.backend.as_ref(),
                 self.last_written()?,
@@ -2525,10 +2545,7 @@ impl Store {
     ) -> Result<Trie, StoreError> {
         let trie_db = TrieWrapper::new(
             state_root,
-            self.trie_cache
-                .read()
-                .map_err(|_| StoreError::LockError)?
-                .clone(),
+            self.trie_cache.load_full(),
             Box::new(BackendTrieDB::new_for_storages(
                 self.backend.clone(),
                 self.last_written()?,
@@ -2759,7 +2776,7 @@ struct TrieUpdate {
 fn apply_trie_updates(
     backend: &dyn StorageBackend,
     fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
-    trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
+    trie_cache: &Arc<ArcSwap<TrieLayerCache>>,
     trie_update: TrieUpdate,
 ) -> Result<(), StoreError> {
     let TrieUpdate {
@@ -2780,15 +2797,12 @@ fn apply_trie_updates(
         })
         .chain(account_updates)
         .collect();
-    // Read-Copy-Update the trie cache with a new layer.
-    let trie = trie_cache
-        .read()
-        .map_err(|_| StoreError::LockError)?
-        .clone();
+    // Read-Copy-Update the trie cache with a new layer (lock-free via ArcSwap).
+    let trie = trie_cache.load_full();
     let mut trie_mut = (*trie).clone();
     trie_mut.put_batch(parent_state_root, child_state_root, new_layer);
     let trie = Arc::new(trie_mut);
-    *trie_cache.write().map_err(|_| StoreError::LockError)? = trie.clone();
+    trie_cache.store(trie.clone());
     // Update finished, signal block processing.
     result_sender
         .send(Ok(()))
@@ -2853,7 +2867,7 @@ fn apply_trie_updates(
     let _ = fkv_ctl.send(FKVGeneratorControlMessage::Continue);
     result?;
     // Phase 3: update diff layers with the removal of bottom layer.
-    *trie_cache.write().map_err(|_| StoreError::LockError)? = Arc::new(trie_mut);
+    trie_cache.store(Arc::new(trie_mut));
     Ok(())
 }
 
@@ -3092,19 +3106,26 @@ fn encode_code(code: &Code) -> Vec<u8> {
     buf
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 struct LatestBlockHeaderCache {
-    current: Arc<Mutex<Arc<BlockHeader>>>,
+    current: Arc<ArcSwap<BlockHeader>>,
+}
+
+impl Default for LatestBlockHeaderCache {
+    fn default() -> Self {
+        Self {
+            current: Arc::new(ArcSwap::from_pointee(BlockHeader::default())),
+        }
+    }
 }
 
 impl LatestBlockHeaderCache {
     pub fn get(&self) -> Arc<BlockHeader> {
-        self.current.lock().expect("poisoned mutex").clone()
+        self.current.load_full()
     }
 
     pub fn update(&self, header: BlockHeader) {
-        let new = Arc::new(header);
-        *self.current.lock().expect("poisoned mutex") = new;
+        self.current.store(Arc::new(header));
     }
 }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1043,13 +1043,51 @@ impl Store {
             }
 
             for number in (head_number + 1)..=(latest) {
-                txn.delete(CANONICAL_BLOCK_HASHES, number.to_le_bytes().as_slice())?;
+                // Purge canonical TX index entries for de-canonicalized blocks (reorg cleanup).
+                let old_hash_key = number.to_le_bytes();
+                if let Some(old_block_hash_bytes) = {
+                    let read_txn = db.begin_read()?;
+                    read_txn.get(CANONICAL_BLOCK_HASHES, &old_hash_key)?
+                } {
+                    let old_block_hash = BlockHash::decode(&old_block_hash_bytes)?;
+                    let body_key = old_block_hash.encode_to_vec();
+                    if let Some(body_bytes) = {
+                        let read_txn = db.begin_read()?;
+                        read_txn.get(BODIES, &body_key)?
+                    } {
+                        let body: BlockBody = BlockBodyRLP::from_bytes(body_bytes)
+                            .to()
+                            .map_err(StoreError::from)?;
+                        for transaction in body.transactions.iter() {
+                            let tx_hash = transaction.hash();
+                            txn.delete(CANONICAL_TX_INDEX, tx_hash.as_bytes())?;
+                        }
+                    }
+                }
+                txn.delete(CANONICAL_BLOCK_HASHES, old_hash_key.as_slice())?;
             }
 
             // Make head canonical
             let head_key = head_number.to_le_bytes();
             let head_value = head_hash.encode_to_vec();
             txn.put(CANONICAL_BLOCK_HASHES, &head_key, &head_value)?;
+
+            // Index head block transactions (head may not be in new_canonical_blocks)
+            let head_hash_key = head_hash.encode_to_vec();
+            if let Some(body_bytes) = {
+                let read_txn = db.begin_read()?;
+                read_txn.get(BODIES, &head_hash_key)?
+            } {
+                let body: BlockBody = BlockBodyRLP::from_bytes(body_bytes)
+                    .to()
+                    .map_err(StoreError::from)?;
+                for (index, transaction) in body.transactions.iter().enumerate() {
+                    let tx_hash = transaction.hash();
+                    let location_value =
+                        (head_number, head_hash, index as u64).encode_to_vec();
+                    txn.put(CANONICAL_TX_INDEX, tx_hash.as_bytes(), &location_value)?;
+                }
+            }
 
             // Update chain data
             let latest_key = chain_data_key(ChainDataIndex::LatestBlockNumber);

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -21,6 +21,7 @@ use crate::{
     utils::{ChainDataIndex, SnapStateIndex},
 };
 
+use arc_swap::ArcSwap;
 use bytes::Bytes;
 use ethrex_common::{
     Address, H256, U256,
@@ -42,7 +43,6 @@ use ethrex_trie::{Node, NodeRLP};
 use lru::LruCache;
 use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Serialize};
-use arc_swap::ArcSwap;
 use std::{
     collections::{BTreeMap, HashMap, hash_map::Entry},
     fmt::Debug,
@@ -1017,19 +1017,37 @@ impl Store {
         let db = self.backend.clone();
         tokio::task::spawn_blocking(move || {
             let mut txn = db.begin_write()?;
+            let read_txn = db.begin_read()?;
 
             for (block_number, block_hash) in new_canonical_blocks {
                 let head_key = block_number.to_le_bytes();
+
+                // Purge old entries from canonical TX index if this block height was already canonical.
+                if let Some(old_block_hash_bytes) =
+                    read_txn.get(CANONICAL_BLOCK_HASHES, &head_key)?
+                {
+                    let old_block_hash = BlockHash::decode(&old_block_hash_bytes)?;
+                    // Only purge if the hash actually changed (reorg at this height).
+                    if old_block_hash != block_hash {
+                        let old_body_key = old_block_hash.encode_to_vec();
+                        if let Some(old_body_bytes) = read_txn.get(BODIES, &old_body_key)? {
+                            let old_body: BlockBody = BlockBodyRLP::from_bytes(old_body_bytes)
+                                .to()
+                                .map_err(StoreError::from)?;
+                            for transaction in old_body.transactions.iter() {
+                                txn.delete(CANONICAL_TX_INDEX, transaction.hash().as_bytes())?;
+                            }
+                        }
+                    }
+                }
+
                 let head_value = block_hash.encode_to_vec();
                 txn.put(CANONICAL_BLOCK_HASHES, &head_key, &head_value)?;
 
                 // Populate canonical transaction index for O(1) lookups.
                 // Read the block body to get transaction hashes.
                 let hash_key = block_hash.encode_to_vec();
-                if let Some(body_bytes) = {
-                    let read_txn = db.begin_read()?;
-                    read_txn.get(BODIES, &hash_key)?
-                } {
+                if let Some(body_bytes) = read_txn.get(BODIES, &hash_key)? {
                     let body: BlockBody = BlockBodyRLP::from_bytes(body_bytes)
                         .to()
                         .map_err(StoreError::from)?;
@@ -1045,16 +1063,12 @@ impl Store {
             for number in (head_number + 1)..=(latest) {
                 // Purge canonical TX index entries for de-canonicalized blocks (reorg cleanup).
                 let old_hash_key = number.to_le_bytes();
-                if let Some(old_block_hash_bytes) = {
-                    let read_txn = db.begin_read()?;
+                if let Some(old_block_hash_bytes) =
                     read_txn.get(CANONICAL_BLOCK_HASHES, &old_hash_key)?
-                } {
+                {
                     let old_block_hash = BlockHash::decode(&old_block_hash_bytes)?;
                     let body_key = old_block_hash.encode_to_vec();
-                    if let Some(body_bytes) = {
-                        let read_txn = db.begin_read()?;
-                        read_txn.get(BODIES, &body_key)?
-                    } {
+                    if let Some(body_bytes) = read_txn.get(BODIES, &body_key)? {
                         let body: BlockBody = BlockBodyRLP::from_bytes(body_bytes)
                             .to()
                             .map_err(StoreError::from)?;
@@ -1069,22 +1083,36 @@ impl Store {
 
             // Make head canonical
             let head_key = head_number.to_le_bytes();
+
+            // Purge old entries from canonical TX index if head block height was already canonical.
+            if let Some(old_block_hash_bytes) = read_txn.get(CANONICAL_BLOCK_HASHES, &head_key)? {
+                let old_block_hash = BlockHash::decode(&old_block_hash_bytes)?;
+                // Only purge if the hash actually changed (reorg at this height).
+                if old_block_hash != head_hash {
+                    let old_body_key = old_block_hash.encode_to_vec();
+                    if let Some(old_body_bytes) = read_txn.get(BODIES, &old_body_key)? {
+                        let old_body: BlockBody = BlockBodyRLP::from_bytes(old_body_bytes)
+                            .to()
+                            .map_err(StoreError::from)?;
+                        for transaction in old_body.transactions.iter() {
+                            txn.delete(CANONICAL_TX_INDEX, transaction.hash().as_bytes())?;
+                        }
+                    }
+                }
+            }
+
             let head_value = head_hash.encode_to_vec();
             txn.put(CANONICAL_BLOCK_HASHES, &head_key, &head_value)?;
 
             // Index head block transactions (head may not be in new_canonical_blocks)
             let head_hash_key = head_hash.encode_to_vec();
-            if let Some(body_bytes) = {
-                let read_txn = db.begin_read()?;
-                read_txn.get(BODIES, &head_hash_key)?
-            } {
+            if let Some(body_bytes) = read_txn.get(BODIES, &head_hash_key)? {
                 let body: BlockBody = BlockBodyRLP::from_bytes(body_bytes)
                     .to()
                     .map_err(StoreError::from)?;
                 for (index, transaction) in body.transactions.iter().enumerate() {
                     let tx_hash = transaction.hash();
-                    let location_value =
-                        (head_number, head_hash, index as u64).encode_to_vec();
+                    let location_value = (head_number, head_hash, index as u64).encode_to_vec();
                     txn.put(CANONICAL_TX_INDEX, tx_hash.as_bytes(), &location_value)?;
                 }
             }


### PR DESCRIPTION
**Motivation**

The storage layer has two performance bottlenecks on hot paths:

1. **Lock contention on reads**: `trie_cache` uses `Arc<RwLock<Arc<TrieLayerCache>>>` and [LatestBlockHeaderCache](cci:2://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:3109:0-3111:1) uses `Arc<Mutex<Arc<BlockHeader>>>`. Every trie lookup and RPC header request acquires a lock, even though reads vastly outnumber writes (RCU pattern).

2. **O(k) transaction lookups**: [get_transaction_location](cci:1://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:568:4-619:5) uses a `prefix_iterator` scan across all block hashes containing a transaction, then filters for canonical blocks — expensive for frequently-queried transactions.

**Description**

### ArcSwap Migration (Lock-Free Reads)
- `trie_cache`: `Arc<RwLock<Arc<TrieLayerCache>>>` → `Arc<ArcSwap<TrieLayerCache>>`
- [LatestBlockHeaderCache](cci:2://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:3109:0-3111:1): `Arc<Mutex<Arc<BlockHeader>>>` → `ArcSwap<BlockHeader>`
- All read sites use `.load_full()` (lock-free), writes use `.store()` (atomic swap)
- Eliminates `.expect("poisoned mutex")` panics in LatestBlockHeaderCache
- [apply_trie_updates()](cci:1://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:2773:0-2871:1) RCU pattern preserved, now fully lock-free

### Canonical TX Index (O(1) Lookups)
- New `CANONICAL_TX_INDEX` table: `tx_hash → (block_number, block_hash, tx_index)`
- Fast-path added in [get_transaction_location()](cci:1://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:568:4-619:5) with graceful fallback to existing prefix scan
- Index populated during [forkchoice_update_inner()](cci:1://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:1007:4-1071:5) for zero-downtime migration

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the [Store](cci:2://file:///c:/Users/Hi/Documents/zkp%20projects/ethrex/crates/storage/store.rs:153:0-189:1) requiring a re-sync.

> Note: The new `CANONICAL_TX_INDEX` table is auto-created from the `TABLES` array on DB initialization. Existing nodes will have an empty index and fall back to the prefix scan until new blocks populate it. A schema version bump may not be required — happy to add one if maintainers prefer.
