### PR TITLE
fix(l2): enforce privileged tx inclusion in aligned mode

### DIFF
--- a/crates/l2/contracts/src/l1/OnChainProposer.sol
+++ b/crates/l2/contracts/src/l1/OnChainProposer.sol
@@ -489,6 +489,13 @@ contract OnChainProposer is
                 );
             }
 
+            if (
+                ICommonBridge(BRIDGE).hasExpiredPrivilegedTransactions() &&
+                batchCommitments[batchNumber].nonPrivilegedTransactions != 0
+            ) {
+                revert ExpiredPrivilegedTransactionDeadline();
+            }
+
             // Reconstruct public inputs from commitments
             bytes memory publicInputs = _getPublicInputsFromCommitment(
                 batchNumber


### PR DESCRIPTION
**Motivation**

Unlike `verifyBatches`, `verifyBatchesAligned` doesn't check that privileged transactions are being included.

**Description**

Adds the check.

