### PR TITLE
fix(l2): add documentation about invalid proof deletion

### DIFF
--- a/crates/l2/sequencer/l1_proof_sender.rs
+++ b/crates/l2/sequencer/l1_proof_sender.rs
@@ -490,6 +490,12 @@ impl L1ProofSender {
 
     /// Returns the prover type whose proof is invalid based on the RPC error data
     /// (custom error selector), or `None` if the data doesn't indicate an invalid proof.
+    ///
+    /// These three selectors cover all proof-related errors:
+    /// `_verifyBatchInternal` wraps each verifier call in try/catch, so any
+    /// verifier failure becomes one of these. Other reverts (BatchNotSequential,
+    /// etc.) are ordering issues where deleting proofs would be wrong.
+    /// Aligned mode uses `AlignedProofVerificationFailed` instead (see l1_proof_verifier).
     fn invalid_proof_type_from_data(data: &str) -> Option<ProverType> {
         if data.starts_with(INVALID_TDX_PROOF_SELECTOR) {
             Some(ProverType::TDX)
@@ -503,7 +509,8 @@ impl L1ProofSender {
     }
 
     /// If the error data contains an invalid proof custom error selector,
-    /// deletes the offending proof from the store.
+    /// deletes the offending proof from the store. Unrecognized errors are
+    /// left alone — see `invalid_proof_type_from_data`.
     async fn try_delete_invalid_proof(
         &self,
         data: &str,

--- a/docs/l2/fundamentals/distributed_proving.md
+++ b/docs/l2/fundamentals/distributed_proving.md
@@ -67,7 +67,7 @@ For example, if batches 5, 6, 7 are fully proven but batch 8 is missing a proof,
 
 On **any** multi-batch error (gas limit exceeded, calldata too large, invalid proof, etc.), the proof sender falls back to sending each batch individually. Since on-chain verification is sequential (`batchNumber == lastVerifiedBatch + 1`), the fallback stops at the first failing batch — remaining batches are retried on the next tick.
 
-During single-batch fallback, if the error indicates an invalid proof (e.g. "Invalid SP1 proof"), that proof is deleted from the store so a prover can re-prove it.
+During single-batch fallback, if the revert indicates an invalid proof, that proof is deleted from the store so a prover can re-prove it.
 
 ## Configuration reference
 


### PR DESCRIPTION
**Motivation**

If we somehow generate an invalid proof or some attacker manages to connect to the proof collector, we want to delete the broken proof and generate a real one.

On aligned mode we don't know which proof caused the issue, so we remove all of them.

This behavior was implemented in #3866, but the assumptions weren't well-documented.

**Description**

Explains the assumption that the only errors a invalid proof could cause look like InvalidXYZProof.