### PR TITLE
fix(l2): advance L1 watcher cursor only after processing

### DIFF
--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -308,7 +308,11 @@ impl L1Watcher {
                 .await
                 .map_err(|e| {
                     L1WatcherError::Custom(format!(
-                        "Failed to add mint transaction to the mempool: {e:#?}"
+                        "Failed to add mint transaction to the mempool \
+                        (to: {:x}, value: {}, transactionId: {:#}): {e:#?}",
+                        privileged_transaction_data.to_address,
+                        privileged_transaction_data.value,
+                        privileged_transaction_data.transaction_id
                     ))
                 })?;
 


### PR DESCRIPTION
**Motivation**

Currently if there is an error while adding a privileged transaction, we permanently ignore it. This leaves a gap in processed privileged transactions, eventually leading us to exceed the inclusion deadline.

**Description**

We advance the processing cursor only after a success so it can be retried, and actually generate an error instead of silently discarding it.