### PR TITLE
fix(l1): remove value from branch node to enforce empty invariant (#5772)

### DIFF
--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use ethrex_rlp::encode::RLPEncode;
 
 use crate::{
@@ -10,7 +8,7 @@ use crate::{
 use super::{ExtensionNode, LeafNode, Node, NodeRef, ValueOrHash};
 
 /// Branch Node of an an Ethereum Compatible Patricia Merkle Trie
-/// Contains the node's value and the hash of its children nodes
+/// Contains the hash of its children nodes
 #[derive(
     Debug,
     Clone,
@@ -24,7 +22,6 @@ use super::{ExtensionNode, LeafNode, Node, NodeRef, ValueOrHash};
 )]
 pub struct BranchNode {
     pub choices: [NodeRef; 16],
-    pub value: ValueRLP,
 }
 
 impl BranchNode {
@@ -33,28 +30,14 @@ impl BranchNode {
     /// Empty choice array for more convenient node-building
     pub const EMPTY_CHOICES: [NodeRef; 16] = [Self::EMPTY_REF; 16];
 
-    /// Creates a new branch node given its children, without any stored value
+    /// Creates a new branch node given its children
     pub fn new(choices: [NodeRef; 16]) -> Self {
-        Self {
-            choices,
-            value: Default::default(),
-        }
-    }
-
-    /// Creates a new branch node given its children and value
-    pub const fn new_with_value(choices: [NodeRef; 16], value: ValueRLP) -> Self {
-        Self { choices, value }
-    }
-
-    /// Updates the node's path and value
-    pub fn update(&mut self, new_value: ValueRLP) {
-        self.value = new_value;
+        Self { choices }
     }
 
     /// Retrieves a value from the subtrie originating from this node given its path
     pub fn get(&self, db: &dyn TrieDB, mut path: Nibbles) -> Result<Option<ValueRLP>, TrieError> {
-        // If path is at the end, return to its own value if present.
-        // Otherwise, check the corresponding choice and delegate accordingly if present.
+        // Check the corresponding choice and delegate accordingly if present.
         if let Some(choice) = path.next_choice() {
             // Delegate to children if present
             let child_ref = &self.choices[choice];
@@ -73,8 +56,8 @@ impl BranchNode {
                 Ok(None)
             }
         } else {
-            // Return internal value if present.
-            Ok((!self.value.is_empty()).then_some(self.value.clone()))
+            // Branch nodes don't hold values
+            Ok(None)
         }
     }
 
@@ -132,12 +115,9 @@ impl BranchNode {
                     }
                 }
             }
-        } else if let ValueOrHash::Value(value) = value {
-            // Insert into self
-            self.update(value);
         } else {
-            // Value in branches don't happen in our use-case.
-            todo!("handle override case (error?)")
+            // Branch nodes don't hold values
+            unreachable!("branch nodes should never receive a value directly")
         }
 
         Ok(())
@@ -198,12 +178,8 @@ impl BranchNode {
                 None
             }
         } else {
-            // Remove own value (if it has one) and return it
-            if !self.value.is_empty() {
-                Some(mem::take(&mut self.value))
-            } else {
-                None
-            }
+            // Branch nodes don't hold values, nothing to remove
+            None
         };
 
         // Step 2: Restructure self
@@ -213,13 +189,11 @@ impl BranchNode {
             .enumerate()
             .filter(|(_, child)| child.is_valid())
             .collect::<Vec<_>>();
-        let new_node = match (children.len(), !self.value.is_empty()) {
-            // If this node still has a value but no longer has children, convert it into a leaf node
-            (0, true) => NodeRemoveResult::New(
-                LeafNode::new(Nibbles::from_hex(vec![16]), mem::take(&mut self.value)).into(),
-            ),
-            // If this node doesn't have a value and has only one child, replace it with its child node
-            (1, false) => {
+        let new_node = match children.len() {
+            // If this node doesn't have children, the trie is empty
+            0 => NodeRemoveResult::Mutated,
+            // If this node has only one child, replace it with its child node
+            1 => {
                 let (choice_index, child_ref) = children.get_mut(0).unwrap();
                 let Some(child) = child_ref
                     .get_node_mut(db, base_path.current().append_new(*choice_index as u8))?
@@ -428,28 +402,7 @@ mod test {
         assert_eq!(node.get(trie.db.as_ref(), path).unwrap(), Some(value));
     }
 
-    #[test]
-    fn insert_passthrough() {
-        let trie = Trie::new_temp();
-        let node = pmt_node! { @(trie)
-            branch {
-                0 => leaf { vec![0, 16] => vec![0x12, 0x34, 0x56, 0x78] },
-                1 => leaf { vec![0, 16] => vec![0x34, 0x56, 0x78, 0x9A] },
-            }
-        };
 
-        // The extension node is ignored since it's irrelevant in this test.
-        let path = Nibbles::from_bytes(&[0x00]).offset(2);
-        let value = vec![0x1];
-
-        let mut new_node = node.clone();
-        new_node
-            .insert(trie.db.as_ref(), path, value.clone().into())
-            .unwrap();
-
-        assert_eq!(new_node.choices, node.choices);
-        assert_eq!(new_node.value, value);
-    }
 
     #[test]
     fn remove_choice_into_inner() {
@@ -488,57 +441,7 @@ mod test {
         assert_eq!(value, Some(vec![0x00]));
     }
 
-    #[test]
-    fn remove_choice_into_value() {
-        let trie = Trie::new_temp();
-        let mut node = pmt_node! { @(trie)
-            branch {
-                0 => leaf { vec![0, 16] => vec![0x00] },
-            } with_leaf { &[0x01] => vec![0xFF] }
-        };
 
-        let (node, value) = node
-            .remove(trie.db.as_ref(), Nibbles::from_bytes(&[0x00]))
-            .unwrap();
-
-        assert!(matches!(node, Some(NodeRemoveResult::New(Node::Leaf(_)))));
-        assert_eq!(value, Some(vec![0x00]));
-    }
-
-    #[test]
-    fn remove_value_into_inner() {
-        let trie = Trie::new_temp();
-        let mut node = pmt_node! { @(trie)
-            branch {
-                0 => leaf { vec![0, 16] => vec![0x00] },
-            } with_leaf { &[0x1] => vec![0xFF] }
-        };
-
-        let (node, value) = node
-            .remove(trie.db.as_ref(), Nibbles::from_bytes(&[]))
-            .unwrap();
-
-        assert!(matches!(node, Some(NodeRemoveResult::New(Node::Leaf(_)))));
-        assert_eq!(value, Some(vec![0xFF]));
-    }
-
-    #[test]
-    fn remove_value() {
-        let trie = Trie::new_temp();
-        let mut node = pmt_node! { @(trie)
-            branch {
-                0 => leaf { vec![0, 16] => vec![0x00] },
-                1 => leaf { vec![0, 16] => vec![0x10] },
-            } with_leaf { &[0x1] => vec![0xFF] }
-        };
-
-        let (node, value) = node
-            .remove(trie.db.as_ref(), Nibbles::from_bytes(&[]))
-            .unwrap();
-
-        assert!(matches!(node, Some(NodeRemoveResult::Mutated)));
-        assert_eq!(value, Some(vec![0xFF]));
-    }
 
     #[test]
     fn compute_hash_two_choices() {
@@ -591,56 +494,7 @@ mod test {
         );
     }
 
-    #[test]
-    fn compute_hash_one_choice_with_value() {
-        let node = pmt_node! { @(trie)
-            branch {
-                2 => leaf { vec![0, 16] => vec![0x20] },
-                4 => leaf { vec![0, 16] => vec![0x40] },
-            } with_leaf { &[0x1] => vec![0x1] }
-        };
 
-        assert_eq!(
-            node.compute_hash().as_ref(),
-            &[
-                0xD5, 0x80, 0x80, 0xC2, 0x30, 0x20, 0x80, 0xC2, 0x30, 0x40, 0x80, 0x80, 0x80, 0x80,
-                0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01,
-            ],
-        );
-    }
-
-    #[test]
-    fn compute_hash_all_choices_with_value() {
-        let node = pmt_node! { @(trie)
-            branch {
-                0x0 => leaf { vec![0, 16] => vec![0x00] },
-                0x1 => leaf { vec![0, 16] => vec![0x10] },
-                0x2 => leaf { vec![0, 16] => vec![0x20] },
-                0x3 => leaf { vec![0, 16] => vec![0x30] },
-                0x4 => leaf { vec![0, 16] => vec![0x40] },
-                0x5 => leaf { vec![0, 16] => vec![0x50] },
-                0x6 => leaf { vec![0, 16] => vec![0x60] },
-                0x7 => leaf { vec![0, 16] => vec![0x70] },
-                0x8 => leaf { vec![0, 16] => vec![0x80] },
-                0x9 => leaf { vec![0, 16] => vec![0x90] },
-                0xA => leaf { vec![0, 16] => vec![0xA0] },
-                0xB => leaf { vec![0, 16] => vec![0xB0] },
-                0xC => leaf { vec![0, 16] => vec![0xC0] },
-                0xD => leaf { vec![0, 16] => vec![0xD0] },
-                0xE => leaf { vec![0, 16] => vec![0xE0] },
-                0xF => leaf { vec![0, 16] => vec![0xF0] },
-            } with_leaf { &[0x1] => vec![0x1] }
-        };
-
-        assert_eq!(
-            node.compute_hash().as_ref(),
-            &[
-                0x2A, 0x85, 0x67, 0xC5, 0x63, 0x4A, 0x87, 0xBA, 0x19, 0x6F, 0x2C, 0x65, 0x15, 0x16,
-                0x66, 0x37, 0xE0, 0x9A, 0x34, 0xE6, 0xC9, 0xB0, 0x4D, 0xA5, 0x6F, 0xC4, 0x70, 0x4E,
-                0x38, 0x61, 0x7D, 0x8E
-            ],
-        );
-    }
 
     #[test]
     fn symmetric_encoding_a() {
@@ -690,7 +544,7 @@ mod test {
                 0xD => leaf { vec![0, 16] => vec![0xD0] },
                 0xE => leaf { vec![0, 16] => vec![0xE0] },
                 0xF => leaf { vec![0, 16] => vec![0xF0] },
-            } with_leaf { &[0x1] => vec![0x1] }
+            }
         }
         .into();
         assert_eq!(Node::decode(&node.encode_to_vec()).unwrap(), node)

--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -68,8 +68,8 @@ impl BranchNode {
         mut path: Nibbles,
         value: ValueOrHash,
     ) -> Result<(), TrieError> {
-        // If path is at the end, insert or replace its own value.
-        // Otherwise, check the corresponding choice and insert or delegate accordingly.
+        // Check the corresponding choice in the path and insert or delegate accordingly.
+        // Branch nodes don't hold values, so paths cannot end here securely.
         if let Some(choice) = path.next_choice() {
             match (&mut self.choices[choice], value) {
                 // Create new child (leaf node)
@@ -116,8 +116,9 @@ impl BranchNode {
                 }
             }
         } else {
-            // Branch nodes don't hold values
-            unreachable!("branch nodes should never receive a value directly")
+            return Err(TrieError::Verify(
+                "Key paths may not be prefixes of each other since branch values are not supported".to_string(),
+            ));
         }
 
         Ok(())
@@ -131,22 +132,19 @@ impl BranchNode {
         db: &dyn TrieDB,
         mut path: Nibbles,
     ) -> Result<(Option<NodeRemoveResult>, Option<ValueRLP>), TrieError> {
-        /* Possible flow paths:
+        /* Possible flow paths for remaining children:
             Step 1: Removal
-                Branch { [ ... ] Value } -> Branch { [...], None, None } (remove from self)
-                Branch { [ childA, ... ], Value } -> Branch { [childA', ... ], Value } (remove from child)
+                Branch { [ childA, ... ] } -> Branch { [childA', ... ] } (remove from child)
 
             Step 2: Restructure
-                [0 children]
-                Branch { [], Value } -> Leaf { Value } (no children, with value)
-                Branch { [], None } -> Branch { [], None } (no children, no value)
-                [1 child]
+                [0 children remaining]
+                (Impossible as branches securely hold 2+ choices, shrinking below 1 is handled inside 1 child case)
+                [1 child remaining]
                 Branch { [ ExtensionChild], _ , _ } -> Extension { ChoiceIndex+ExtensionChildPrefx, ExtensionChildChild }
                 Branch { [ BranchChild ], None } -> Extension { ChoiceIndex, BranchChild }
                 Branch { [ LeafChild], None } -> LeafChild
-                Branch { [LeafChild], Value } -> Branch { [ LeafChild ], Value }
-                [+1 children]
-                Branch { [childA, childB, ... ], None } ->   Branch { [childA, childB, ... ], None }
+                [+1 children remaining]
+                Branch { [childA, childB, ... ], None } ->   Branch { [childA, childB, ... ] }
         */
         let base_path = path.clone();
 

--- a/crates/common/trie/node/extension.rs
+++ b/crates/common/trie/node/extension.rs
@@ -104,8 +104,8 @@ impl ExtensionNode {
             let mut choices = BranchNode::EMPTY_CHOICES;
             let mut branch_node = if self.prefix.at(0) == 16 {
                 match new_node.get_node_mut(db, path.current())? {
-                    Some(Node::Leaf(leaf)) => {
-                        BranchNode::new_with_value(choices, leaf.value.clone())
+                    Some(Node::Leaf(_)) => {
+                        return Err(TrieError::Verify("Key paths may not be prefixes of each other since branch values are not supported".to_string()));
                     }
                     Some(_) => {
                         return Err(TrieError::InconsistentTree(Box::new(

--- a/crates/common/trie/node/leaf.rs
+++ b/crates/common/trie/node/leaf.rs
@@ -70,32 +70,9 @@ impl LeafNode {
             let new_leaf_choice_idx = path.at(match_index);
             self.partial = self.partial.offset(match_index + 1);
 
-            let branch_node = if self_choice_idx == 16 {
-                // Create a new leaf node and store the value in it
-                // Create a new branch node with the leaf as a child and store self's value
-                // Branch { [ Leaf { Value } , ... ], SelfValue}
-                let mut choices = BranchNode::EMPTY_CHOICES;
-                choices[new_leaf_choice_idx] = match value {
-                    ValueOrHash::Value(value) => {
-                        Node::from(LeafNode::new(path.offset(match_index + 1), value)).into()
-                    }
-                    ValueOrHash::Hash(hash) => hash.into(),
-                };
-                BranchNode::new_with_value(choices, mem::take(&mut self.value))
-            } else if new_leaf_choice_idx == 16 {
-                // Create a branch node with self as a child and store the value in the branch node
-                // Branch { [Self,...], Value }
-                let mut choices = BranchNode::EMPTY_CHOICES;
-                let child: Node = self.take().into();
-                choices[self_choice_idx] = child.into();
-                BranchNode::new_with_value(
-                    choices,
-                    match value {
-                        ValueOrHash::Value(value) => value,
-                        // Value in branches don't happen in our use-case.
-                        ValueOrHash::Hash(_) => todo!("handle override case (error?)"),
-                    },
-                )
+            let branch_node = if self_choice_idx == 16 || new_leaf_choice_idx == 16 {
+                return Err(TrieError::Verify("Key paths may not be prefixes of each other since branch values are not supported".to_string()));
+
             } else {
                 // Create a new leaf node and store the path and value in it
                 // Create a new branch node with the leaf and self as children

--- a/crates/common/trie/rlp.rs
+++ b/crates/common/trie/rlp.rs
@@ -15,7 +15,7 @@ use crate::{Nibbles, NodeHash};
 
 impl RLPEncode for BranchNode {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
-        let value_len = <[u8] as RLPEncode>::length(&self.value);
+        let value_len = <[u8] as RLPEncode>::length(&[] as &[u8]);
         let payload_len = self.choices.iter().fold(value_len, |acc, child| {
             acc + RLPEncode::length(child.compute_hash_ref())
         });
@@ -28,12 +28,12 @@ impl RLPEncode for BranchNode {
                 NodeHash::Inline((encoded, len)) => buf.put_slice(&encoded[..*len as usize]),
             }
         }
-        <[u8] as RLPEncode>::encode(&self.value, buf);
+        <[u8] as RLPEncode>::encode(&[] as &[u8], buf);
     }
 
     // Duplicated to prealloc the buffer and avoid calculating the payload length twice
     fn encode_to_vec(&self) -> Vec<u8> {
-        let value_len = <[u8] as RLPEncode>::length(&self.value);
+        let value_len = <[u8] as RLPEncode>::length(&[] as &[u8]);
         let choices_len = self.choices.iter().fold(0, |acc, child| {
             acc + RLPEncode::length(child.compute_hash_ref())
         });
@@ -51,7 +51,7 @@ impl RLPEncode for BranchNode {
                 }
             }
         }
-        <[u8] as RLPEncode>::encode(&self.value, &mut buf);
+        <[u8] as RLPEncode>::encode(&[] as &[u8], &mut buf);
 
         buf
     }
@@ -135,9 +135,13 @@ impl RLPDecode for Node {
                 });
                 let (value, _) =
                     decode_bytes(rlp_items[16].expect("we already checked the length"))?;
+                if !value.is_empty() {
+                    return Err(RLPDecodeError::Custom(
+                        "Branch node has a value".to_string(),
+                    ));
+                }
                 BranchNode {
                     choices,
-                    value: value.to_vec(),
                 }
                 .into()
             }

--- a/crates/common/trie/test_utils.rs
+++ b/crates/common/trie/test_utils.rs
@@ -21,26 +21,7 @@ macro_rules! pmt_node {
             choices
         })
     };
-    (
-        @( $trie:expr )
-        branch { $( $choice:expr => $child_type:ident { $( $child_tokens:tt )* } ),+ $(,)? }
-        with_leaf { $path:expr => $value:expr }
-        $( offset $offset:expr )?
-    ) => {{
-        $crate::node::BranchNode::new_with_value({
-            #[allow(unused_variables)]
-            let offset = true $( ^ $offset )?;
-            let mut choices = $crate::node::BranchNode::EMPTY_CHOICES;
-            $(
-                choices[$choice as usize] = $crate::node::Node::from(
-                    pmt_node! { @($trie)
-                        $child_type { $( $child_tokens )* }
-                        offset offset
-                    }).into();
-            )*
-            choices
-        }, $value)
-    }};
+
 
     (
         @( $trie:expr )

--- a/crates/common/trie/trie_iter.rs
+++ b/crates/common/trie/trie_iter.rs
@@ -177,9 +177,7 @@ impl TrieIterator {
     // TODO: construct path from nibbles
     pub fn content(self) -> impl Iterator<Item = (PathRLP, ValueRLP)> {
         self.filter_map(|(p, n)| match n {
-            Node::Branch(branch_node) => {
-                (!branch_node.value.is_empty()).then_some((p.to_bytes(), branch_node.value))
-            }
+            Node::Branch(_) => None,
             Node::Extension(_) => None,
             Node::Leaf(leaf_node) => Some((p.to_bytes(), leaf_node.value)),
         })

--- a/crates/common/trie/verify_range.rs
+++ b/crates/common/trie/verify_range.rs
@@ -231,7 +231,7 @@ fn process_proof_nodes(
                         choice,
                     )?;
                 }
-                node.value
+                Vec::new()
             }
             Node::Extension(node) => {
                 current_path.extend(&node.prefix);


### PR DESCRIPTION
Fixes #5772

## Motivation
Previously, our API assumed that [BranchNode](cci:2://file:///crates/common/trie/node/branch.rs:22:0-24:1)s don't hold values, but the struct still contained a [value](cci:1://file:///zkp%20projects/ethrex/crates/storage/store.rs:2659:4-2663:5) field. We want to strictly enforce this invariant at the compiler level.

Also, regarding the concern about [withdrawals_root](cci:1://file:///crates/common/types/block.rs:351:0-358:1) computation: I verified that the root computations use sequential `idx.encode_to_vec()` RLP keys.

 These indices never produce prefix collisions that land exactly on a 16th terminator nibble, so they always securely terminate in [LeafNode](cci:2://file:///crates/common/trie/node/leaf.rs:27:0-30:1)s. The branch [value](cci:1://file:////crates/storage/store.rs:2659:4-2663:5) field is safely unused everywhere.

## Description
This PR makes [BranchNode](cci:2:///crates/common/trie/node/branch.rs:22:0-24:1) structural by completely removing its [value](cci:1://file:///zkp%20projects/ethrex/crates/storage/store.rs:2659:4-2663:5) field.

* **[branch.rs](cci:7://file:///crates/common/trie/node/branch.rs:0:0-0:0)**: Removed `value: ValueRLP`, `new_with_value()`, and [update()](cci:1://file:///crates/storage/store.rs:3104:4-3107:5).
* **[leaf.rs](cci:7://file:///crates/common/trie/node/leaf.rs:0:0-0:0) & [extension.rs](cci:7://file:///crates/common/trie/node/extension.rs:0:0-0:0)**: In the impossible edge-case where a key insertion tries to terminate exactly *on* an existing branch, it now explicitly returns `TrieError::Verify` instead of silently allocating a branch value.
* **[rlp.rs](cci:7://file:///crates/common/trie/rlp.rs:0:0-0:0)**: Branch payload serialization now hardcodes the 17th item as an empty byte slice (`&[]`) to maintain network encoding compatibility.
* **Tests**: Cleaned up [verify_range.rs](cci:7://file:///crates/common/trie/verify_range.rs:0:0-0:0), [trie_iter.rs](cci:7://file:///crates/common/trie/trie_iter.rs:0:0-0:0), and removed the `with_leaf` test macro since branch values can no longer be artificially constructed.
