### PR TITLE
chore(l1): remove reliance on `key` field in `ExecutionWitness`

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1539,15 +1539,6 @@ impl Blockchain {
             block_headers_bytes.push(current_header.encode_to_vec());
         }
 
-        // Create a list of all read/write addresses and storage slots
-        let mut keys = Vec::new();
-        for (address, touched_storage_slots) in touched_account_storage_slots {
-            keys.push(address.as_bytes().to_vec());
-            for slot in touched_storage_slots.iter() {
-                keys.push(slot.as_bytes().to_vec());
-            }
-        }
-
         // Get initial state trie root and embed the rest of the trie into it
         let nodes: BTreeMap<H256, Node> = used_trie_nodes
             .into_iter()
@@ -1568,12 +1559,8 @@ impl Blockchain {
             Trie::new_temp()
         };
         let mut storage_trie_roots = BTreeMap::new();
-        for key in &keys {
-            if key.len() != 20 {
-                continue; // not an address
-            }
-            let address = Address::from_slice(key);
-            let hashed_address = hash_address(&address);
+        for address in touched_account_storage_slots.keys() {
+            let hashed_address = hash_address(address);
             let Some(encoded_account) = state_trie.get(&hashed_address)? else {
                 continue; // empty account, doesn't have a storage trie
             };
@@ -1590,7 +1577,7 @@ impl Blockchain {
                     "execution witness does not contain non-empty storage trie".to_string(),
                 ));
             };
-            storage_trie_roots.insert(address, (*node).clone());
+            storage_trie_roots.insert(*address, (*node).clone());
         }
 
         Ok(ExecutionWitness {
@@ -1600,7 +1587,6 @@ impl Blockchain {
             chain_config: self.storage.get_chain_config(),
             state_trie_root,
             storage_trie_roots,
-            keys,
         })
     }
 
@@ -1781,15 +1767,6 @@ impl Blockchain {
             block_headers_bytes.push(current_header.encode_to_vec());
         }
 
-        // Create a list of all read/write addresses and storage slots
-        let mut keys = Vec::new();
-        for (address, touched_storage_slots) in touched_account_storage_slots {
-            keys.push(address.as_bytes().to_vec());
-            for slot in touched_storage_slots.iter() {
-                keys.push(slot.as_bytes().to_vec());
-            }
-        }
-
         // Get initial state trie root and embed the rest of the trie into it
         let nodes: BTreeMap<H256, Node> = used_trie_nodes
             .into_iter()
@@ -1810,12 +1787,8 @@ impl Blockchain {
             Trie::new_temp()
         };
         let mut storage_trie_roots = BTreeMap::new();
-        for key in &keys {
-            if key.len() != 20 {
-                continue; // not an address
-            }
-            let address = Address::from_slice(key);
-            let hashed_address = hash_address(&address);
+        for address in touched_account_storage_slots.keys() {
+            let hashed_address = hash_address(address);
             let Some(encoded_account) = state_trie.get(&hashed_address)? else {
                 continue; // empty account, doesn't have a storage trie
             };
@@ -1832,7 +1805,7 @@ impl Blockchain {
                     "execution witness does not contain non-empty storage trie".to_string(),
                 ));
             };
-            storage_trie_roots.insert(address, (*node).clone());
+            storage_trie_roots.insert(*address, (*node).clone());
         }
 
         Ok(ExecutionWitness {
@@ -1842,7 +1815,6 @@ impl Blockchain {
             chain_config: self.storage.get_chain_config(),
             state_trie_root,
             storage_trie_roots,
-            keys,
         })
     }
 

--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -79,10 +79,6 @@ pub struct ExecutionWitness {
     /// Root nodes per account storage embedded with the rest of the trie's nodes
     #[rkyv(with = MapKV<H160Wrapper, Identity>)]
     pub storage_trie_roots: BTreeMap<Address, Node>,
-    /// Flattened map of account addresses and storage keys whose values
-    /// are needed for stateless execution.
-    #[rkyv(with = crate::rkyv_utils::VecVecWrapper)]
-    pub keys: Vec<Vec<u8>>,
 }
 
 /// RPC-friendly representation of an execution witness.
@@ -98,6 +94,7 @@ pub struct RpcExecutionWitness {
     )]
     pub state: Vec<Bytes>,
     #[serde(
+        default,
         serialize_with = "serde_utils::bytes::vec::serialize",
         deserialize_with = "serde_utils::bytes::vec::deserialize"
     )]
@@ -127,7 +124,7 @@ impl TryFrom<ExecutionWitness> for RpcExecutionWitness {
         }
         Ok(Self {
             state: nodes.into_iter().map(Bytes::from).collect(),
-            keys: value.keys.into_iter().map(Bytes::from).collect(),
+            keys: Vec::new(),
             codes: value.codes.into_iter().map(Bytes::from).collect(),
             headers: value
                 .block_headers_bytes

--- a/crates/networking/rpc/debug/execution_witness.rs
+++ b/crates/networking/rpc/debug/execution_witness.rs
@@ -107,7 +107,6 @@ pub fn execution_witness_from_rpc_chain_config(
             .collect(),
         state_trie_root,
         storage_trie_roots,
-        keys: rpc_witness.keys.into_iter().map(|b| b.to_vec()).collect(),
     };
 
     Ok(witness)


### PR DESCRIPTION
**Motivation**

The ExecutionWitness test fixtures that are being generated via [execution specs](https://github.com/ethereum/execution-spec-tests/releases/tag/zkevm%40v0.2.0) do not have a `keys` field.

<!-- Why does this pull request exist? What are its goals? -->

**Description**

It seems that the keys `keys` field was being used to get the addresses of the touched accounts, so I replaced it with `touched_account_storage_slots`.

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

