### PR TITLE
feat(l1): add LRU read cache for trie nodes (#6285)

### DIFF
--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -1,13 +1,38 @@
 use ethrex_common::H256;
 use fastbloom::AtomicBloomFilter;
+use lru::LruCache;
 use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    num::NonZeroUsize,
+    sync::{Arc, RwLock},
+};
 
 use ethrex_trie::{Nibbles, TrieDB, TrieError};
 
 const BLOOM_SIZE: usize = 1_000_000;
 const FALSE_POSITIVE_RATE: f64 = 0.02;
+
+/// Maximum number of entries in the trie read cache.
+/// Caches trie nodes read from disk to avoid repeated RocksDB lookups
+/// for frequently-accessed but unmodified nodes.
+const READ_CACHE_CAPACITY: usize = 200_000;
+
+/// LRU cache for trie nodes read from disk.
+///
+/// Sits between the [`TrieLayerCache`] (which only stores diffs) and the on-disk
+/// backend, caching nodes that were read during execution regardless of whether
+/// they were modified. This avoids repeated disk I/O for hot, unmodified data.
+pub type TrieReadCache = Arc<RwLock<LruCache<Vec<u8>, Vec<u8>, FxBuildHasher>>>;
+
+/// Creates a new [`TrieReadCache`] with the default capacity.
+pub fn new_trie_read_cache() -> TrieReadCache {
+    Arc::new(RwLock::new(LruCache::with_hasher(
+        NonZeroUsize::new(READ_CACHE_CAPACITY).unwrap(),
+        FxBuildHasher,
+    )))
+}
 
 #[derive(Debug, Clone)]
 struct TrieLayer {
@@ -275,6 +300,8 @@ pub struct TrieWrapper {
     /// For state tries this is None; for storage tries this is
     /// `Nibbles::from_bytes(address.as_bytes()).append_new(17)`.
     prefix_nibbles: Option<Nibbles>,
+    /// LRU cache for trie nodes read from disk, shared across all trie accesses.
+    read_cache: TrieReadCache,
 }
 
 impl TrieWrapper {
@@ -283,6 +310,7 @@ impl TrieWrapper {
         inner: Arc<TrieLayerCache>,
         db: Box<dyn TrieDB>,
         prefix: Option<H256>,
+        read_cache: TrieReadCache,
     ) -> Self {
         let prefix_nibbles = prefix.map(|p| Nibbles::from_bytes(p.as_bytes()).append_new(17));
         Self {
@@ -290,6 +318,7 @@ impl TrieWrapper {
             inner,
             db,
             prefix_nibbles,
+            read_cache,
         }
     }
 }
@@ -322,10 +351,30 @@ impl TrieDB for TrieWrapper {
             Some(prefix) => prefix.concat(&key),
             None => key,
         };
+
+        // Level 1: Check in-memory diff layers (bloom filter + layer chain walk)
         if let Some(value) = self.inner.get(self.state_root, key.as_ref()) {
             return Ok(Some(value));
         }
-        self.db.get(key)
+
+        // Level 2: Check the LRU read cache for recently-read disk nodes
+        if let Ok(mut cache) = self.read_cache.write() {
+            if let Some(value) = cache.get(key.as_ref()) {
+                return Ok(Some(value.clone()));
+            }
+        }
+
+        // Level 3: Read from disk (RocksDB)
+        let result = self.db.get(key.clone())?;
+
+        // Populate the read cache on a disk hit
+        if let Some(ref value) = result {
+            if let Ok(mut cache) = self.read_cache.write() {
+                cache.put(key.into_vec(), value.clone());
+            }
+        }
+
+        Ok(result)
     }
 
     fn put_batch(&self, _key_values: Vec<(Nibbles, Vec<u8>)>) -> Result<(), TrieError> {

--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -17,7 +17,10 @@ const FALSE_POSITIVE_RATE: f64 = 0.02;
 /// Maximum number of entries in the trie read cache.
 /// Caches trie nodes read from disk to avoid repeated RocksDB lookups
 /// for frequently-accessed but unmodified nodes.
-const READ_CACHE_CAPACITY: usize = 200_000;
+const READ_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(200_000) {
+    Some(v) => v,
+    None => panic!("READ_CACHE_CAPACITY must be non-zero"),
+};
 
 /// LRU cache for trie nodes read from disk.
 ///
@@ -29,7 +32,7 @@ pub type TrieReadCache = Arc<RwLock<LruCache<Vec<u8>, Vec<u8>, FxBuildHasher>>>;
 /// Creates a new [`TrieReadCache`] with the default capacity.
 pub fn new_trie_read_cache() -> TrieReadCache {
     Arc::new(RwLock::new(LruCache::with_hasher(
-        NonZeroUsize::new(READ_CACHE_CAPACITY).unwrap(),
+        READ_CACHE_CAPACITY,
         FxBuildHasher,
     )))
 }
@@ -358,20 +361,20 @@ impl TrieDB for TrieWrapper {
         }
 
         // Level 2: Check the LRU read cache for recently-read disk nodes
-        if let Ok(mut cache) = self.read_cache.write() {
-            if let Some(value) = cache.get(key.as_ref()) {
-                return Ok(Some(value.clone()));
-            }
+        if let Ok(mut cache) = self.read_cache.write()
+            && let Some(value) = cache.get(key.as_ref())
+        {
+            return Ok(Some(value.clone()));
         }
 
         // Level 3: Read from disk (RocksDB)
         let result = self.db.get(key.clone())?;
 
         // Populate the read cache on a disk hit
-        if let Some(ref value) = result {
-            if let Ok(mut cache) = self.read_cache.write() {
-                cache.put(key.into_vec(), value.clone());
-            }
+        if let Some(ref value) = result
+            && let Ok(mut cache) = self.read_cache.write()
+        {
+            cache.put(key.into_vec(), value.clone());
         }
 
         Ok(result)

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -14,7 +14,7 @@ use crate::{
     apply_prefix,
     backend::in_memory::InMemoryBackend,
     error::StoreError,
-    layering::{TrieLayerCache, TrieWrapper},
+    layering::{TrieLayerCache, TrieReadCache, TrieWrapper, new_trie_read_cache},
     rlp::{BlockBodyRLP, BlockHeaderRLP, BlockRLP},
     trie::{BackendTrieDB, BackendTrieDBLocked},
     utils::{ChainDataIndex, SnapStateIndex},
@@ -162,6 +162,9 @@ pub struct Store {
     chain_config: ChainConfig,
     /// Cache for trie nodes from recent blocks.
     trie_cache: Arc<RwLock<Arc<TrieLayerCache>>>,
+    /// LRU cache for trie nodes read from disk, avoiding repeated RocksDB lookups
+    /// for frequently-accessed but unmodified nodes.
+    trie_read_cache: TrieReadCache,
     /// Channel for controlling the FlatKeyValue generator background task.
     flatkeyvalue_control_tx: std::sync::mpsc::SyncSender<FKVGeneratorControlMessage>,
     /// Channel for sending trie updates to the background worker.
@@ -1489,6 +1492,7 @@ impl Store {
             chain_config: Default::default(),
             latest_block_header: Default::default(),
             trie_cache: Arc::new(RwLock::new(Arc::new(TrieLayerCache::new(commit_threshold)))),
+            trie_read_cache: new_trie_read_cache(),
             flatkeyvalue_control_tx: fkv_tx,
             trie_update_worker_tx: trie_upd_tx,
             last_computed_flatkeyvalue: Arc::new(RwLock::new(last_written)),
@@ -1518,6 +1522,7 @@ impl Store {
         let backend = store.backend.clone();
         let flatkeyvalue_control_tx = store.flatkeyvalue_control_tx.clone();
         let trie_cache = store.trie_cache.clone();
+        let trie_read_cache = store.trie_read_cache.clone();
         /*
             When a block is executed, the write of the bottom-most diff layer to disk is done in the background through this thread.
             This is to improve block execution times, since it's not necessary when executing the next block to have this layer flushed to disk.
@@ -1548,6 +1553,7 @@ impl Store {
                             backend.as_ref(),
                             &flatkeyvalue_control_tx,
                             &trie_cache,
+                            &trie_read_cache,
                             trie_update,
                         )
                         .inspect_err(|err| error!("apply_trie_updates failed: {err}"));
@@ -2490,6 +2496,7 @@ impl Store {
                 self.last_written()?,
             )?),
             None,
+            self.trie_read_cache.clone(),
         );
         Ok(Trie::open(Box::new(trie_db), state_root))
     }
@@ -2522,6 +2529,7 @@ impl Store {
                 self.last_written()?,
             )?),
             None,
+            self.trie_read_cache.clone(),
         );
         Ok(Trie::open(Box::new(trie_db), state_root))
     }
@@ -2545,6 +2553,7 @@ impl Store {
                 self.last_written()?,
             )?),
             Some(account_hash),
+            self.trie_read_cache.clone(),
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
     }
@@ -2568,6 +2577,7 @@ impl Store {
                 last_written,
             )?),
             None,
+            self.trie_read_cache.clone(),
         );
         Ok(Trie::open(Box::new(trie_db), state_root))
     }
@@ -2591,6 +2601,7 @@ impl Store {
                 last_written,
             )?),
             Some(account_hash),
+            self.trie_read_cache.clone(),
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
     }
@@ -2631,6 +2642,7 @@ impl Store {
                 self.last_written()?,
             )?),
             Some(account_hash),
+            self.trie_read_cache.clone(),
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
     }
@@ -2772,6 +2784,7 @@ fn apply_trie_updates(
     backend: &dyn StorageBackend,
     fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
     trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
+    trie_read_cache: &TrieReadCache,
     trie_update: TrieUpdate,
 ) -> Result<(), StoreError> {
     let TrieUpdate {
@@ -2784,7 +2797,7 @@ fn apply_trie_updates(
     } = trie_update;
 
     // Phase 1: update the in-memory diff-layers only, then notify block production.
-    let new_layer = storage_updates
+    let new_layer: Vec<(Nibbles, Vec<u8>)> = storage_updates
         .into_iter()
         .flat_map(|(account_hash, nodes)| {
             nodes
@@ -2793,6 +2806,15 @@ fn apply_trie_updates(
         })
         .chain(account_updates)
         .collect();
+    // Invalidate read cache entries for keys that are now in the diff layers,
+    // preventing stale reads after layers are committed and pruned.
+    if let Ok(mut read_cache) = trie_read_cache.write() {
+        for (path, _value) in new_layer.iter() {
+            let key = AsRef::<[u8]>::as_ref(path).to_vec();
+            read_cache.pop(&key);
+        }
+    }
+
     // Read-Copy-Update the trie cache with a new layer.
     let trie = trie_cache
         .read()


### PR DESCRIPTION
## Summary

- Adds a shared LRU read cache (200K entries) for trie nodes between the `TrieLayerCache` diff layers and RocksDB disk
- Caches nodes read from disk regardless of modification status, avoiding repeated I/O for hot, unmodified data
- Invalidates cache entries in `apply_trie_updates` when keys enter diff layers, preventing stale reads after commit

Closes #6285 (partial — addresses the read cache part; flat cache separation is a future follow-up)

## Design

Lookup order in `TrieWrapper::get()`:
1. **Diff layers** (bloom filter + layer chain walk) — existing, unchanged
2. **LRU read cache** (new) — returns recently-read disk nodes
3. **RocksDB disk** — populates read cache on hit

The read cache is a `Arc<RwLock<LruCache<Vec<u8>, Vec<u8>, FxBuildHasher>>>` shared across all trie accesses via the `Store`. No new dependencies — `lru` was already used for `CodeCache`.

## Test plan

- [x] `cargo build` — full workspace builds cleanly
- [x] `cargo test -p ethrex-storage` — all tests pass
- [x] `cargo test -p ethrex-blockchain` — all tests pass
- [ ] Benchmark with hive/mainnet sync to measure disk I/O reduction
- [ ] Profile `RwLock` contention under parallel block execution