### PR TITLE
feat(levm): implement EIP-7904 compute gas cost increase

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -41,6 +41,14 @@ pub const SHR: u64 = 3;
 pub const SAR: u64 = 3;
 pub const KECCAK25_STATIC: u64 = 30;
 pub const KECCAK25_DYNAMIC_BASE: u64 = 6;
+
+// EIP-7904 (Amsterdam): Compute gas cost increase
+pub const DIV_AMSTERDAM: u64 = 15;
+pub const SDIV_AMSTERDAM: u64 = 20;
+pub const MOD_AMSTERDAM: u64 = 12;
+pub const MULMOD_AMSTERDAM: u64 = 11;
+pub const KECCAK25_STATIC_AMSTERDAM: u64 = 45;
+
 pub const CALLDATALOAD: u64 = 3;
 pub const CALLDATASIZE: u64 = 2;
 pub const CALLDATACOPY_STATIC: u64 = 3;
@@ -225,6 +233,14 @@ pub const POINT_EVALUATION_COST: u64 = 50000;
 
 pub const BLAKE2F_ROUND_COST: u64 = 1;
 
+// EIP-7904 (Amsterdam): Precompile gas cost increases
+pub const ECADD_COST_AMSTERDAM: u64 = 314;
+pub const POINT_EVALUATION_COST_AMSTERDAM: u64 = 89363;
+pub const BLS12_381_G1ADD_COST_AMSTERDAM: u64 = 643;
+pub const BLS12_381_G2ADD_COST_AMSTERDAM: u64 = 765;
+pub const BLAKE2F_CONSTANT_COST_AMSTERDAM: u64 = 170;
+pub const BLAKE2F_ROUND_COST_AMSTERDAM: u64 = 2;
+
 pub const BLS12_381_MSM_MULTIPLIER: u64 = 1000;
 pub const BLS12_381_G1_K_DISCOUNT: [u64; 128] = [
     1000, 949, 848, 797, 764, 750, 738, 728, 719, 712, 705, 698, 692, 687, 682, 677, 673, 669, 665,
@@ -343,13 +359,19 @@ pub fn keccak256(
     new_memory_size: usize,
     current_memory_size: usize,
     size: usize,
+    fork: Fork,
 ) -> Result<u64, VMError> {
+    let static_cost = if fork >= Fork::Amsterdam {
+        KECCAK25_STATIC_AMSTERDAM
+    } else {
+        KECCAK25_STATIC
+    };
     copy_behavior(
         new_memory_size,
         current_memory_size,
         size,
         KECCAK25_DYNAMIC_BASE,
-        KECCAK25_STATIC,
+        static_cost,
     )
 }
 

--- a/crates/vm/levm/src/opcode_handlers/arithmetic.rs
+++ b/crates/vm/levm/src/opcode_handlers/arithmetic.rs
@@ -20,7 +20,7 @@ use crate::{
     opcode_handlers::OpcodeHandler,
     vm::VM,
 };
-use ethrex_common::{U256, U512};
+use ethrex_common::{U256, U512, types::Fork};
 
 /// Implementation for the `ADD` opcode.
 pub struct OpAddHandler;
@@ -72,7 +72,8 @@ pub struct OpDivHandler;
 impl OpcodeHandler for OpDivHandler {
     #[inline(always)]
     fn eval(vm: &mut VM<'_>) -> Result<OpcodeResult, VMError> {
-        vm.current_call_frame.increase_consumed_gas(gas_cost::DIV)?;
+        let gas = if vm.env.config.fork >= Fork::Amsterdam { gas_cost::DIV_AMSTERDAM } else { gas_cost::DIV };
+        vm.current_call_frame.increase_consumed_gas(gas)?;
 
         let [lhs, rhs] = *vm.current_call_frame.stack.pop()?;
         match lhs.checked_div(rhs) {
@@ -89,8 +90,9 @@ pub struct OpSDivHandler;
 impl OpcodeHandler for OpSDivHandler {
     #[inline(always)]
     fn eval(vm: &mut VM<'_>) -> Result<OpcodeResult, VMError> {
+        let gas = if vm.env.config.fork >= Fork::Amsterdam { gas_cost::SDIV_AMSTERDAM } else { gas_cost::SDIV };
         vm.current_call_frame
-            .increase_consumed_gas(gas_cost::SDIV)?;
+            .increase_consumed_gas(gas)?;
 
         let [mut lhs, mut rhs] = *vm.current_call_frame.stack.pop()?;
 
@@ -124,7 +126,8 @@ pub struct OpModHandler;
 impl OpcodeHandler for OpModHandler {
     #[inline(always)]
     fn eval(vm: &mut VM<'_>) -> Result<OpcodeResult, VMError> {
-        vm.current_call_frame.increase_consumed_gas(gas_cost::MOD)?;
+        let gas = if vm.env.config.fork >= Fork::Amsterdam { gas_cost::MOD_AMSTERDAM } else { gas_cost::MOD };
+        vm.current_call_frame.increase_consumed_gas(gas)?;
 
         let [lhs, rhs] = *vm.current_call_frame.stack.pop()?;
         match lhs.checked_rem(rhs) {
@@ -200,8 +203,9 @@ pub struct OpMulModHandler;
 impl OpcodeHandler for OpMulModHandler {
     #[inline(always)]
     fn eval(vm: &mut VM<'_>) -> Result<OpcodeResult, VMError> {
+        let gas = if vm.env.config.fork >= Fork::Amsterdam { gas_cost::MULMOD_AMSTERDAM } else { gas_cost::MULMOD };
         vm.current_call_frame
-            .increase_consumed_gas(gas_cost::MULMOD)?;
+            .increase_consumed_gas(gas)?;
 
         let [multiplicand, multiplier, modulus] = *vm.current_call_frame.stack.pop()?;
         if modulus.is_zero() || multiplicand.is_zero() || multiplier.is_zero() {

--- a/crates/vm/levm/src/opcode_handlers/keccak.rs
+++ b/crates/vm/levm/src/opcode_handlers/keccak.rs
@@ -25,6 +25,7 @@ impl OpcodeHandler for OpKeccak256Handler {
                 calculate_memory_size(offset, len)?,
                 vm.current_call_frame.memory.len(),
                 len,
+                vm.env.config.fork,
             )?)?;
 
         vm.current_call_frame

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -15,10 +15,12 @@ use crate::{
     constants::VERSIONED_HASH_VERSION_KZG,
     errors::{InternalError, PrecompileError, VMError},
     gas_cost::{
-        self, BLAKE2F_ROUND_COST, BLS12_381_G1_K_DISCOUNT, BLS12_381_G1ADD_COST,
-        BLS12_381_G2_K_DISCOUNT, BLS12_381_G2ADD_COST, BLS12_381_MAP_FP_TO_G1_COST,
-        BLS12_381_MAP_FP2_TO_G2_COST, ECADD_COST, ECMUL_COST, G1_MUL_COST, G2_MUL_COST,
-        POINT_EVALUATION_COST,
+        self, BLAKE2F_CONSTANT_COST_AMSTERDAM, BLAKE2F_ROUND_COST, BLAKE2F_ROUND_COST_AMSTERDAM,
+        BLS12_381_G1ADD_COST_AMSTERDAM, BLS12_381_G1_K_DISCOUNT, BLS12_381_G1ADD_COST,
+        BLS12_381_G2ADD_COST_AMSTERDAM, BLS12_381_G2_K_DISCOUNT, BLS12_381_G2ADD_COST,
+        BLS12_381_MAP_FP_TO_G1_COST, BLS12_381_MAP_FP2_TO_G2_COST, ECADD_COST,
+        ECADD_COST_AMSTERDAM, ECMUL_COST, G1_MUL_COST, G2_MUL_COST, POINT_EVALUATION_COST,
+        POINT_EVALUATION_COST_AMSTERDAM,
     },
 };
 
@@ -692,13 +694,14 @@ pub fn increase_left_pad(result: &Bytes, m_size: usize) -> Bytes {
 pub fn ecadd(
     calldata: &Bytes,
     gas_remaining: &mut u64,
-    _fork: Fork,
+    fork: Fork,
     crypto: &dyn Crypto,
 ) -> Result<Bytes, VMError> {
     // If calldata does not reach the required length, we should fill the rest with zeros
     let calldata = fill_with_zeros(calldata, 128);
 
-    increase_precompile_consumed_gas(ECADD_COST, gas_remaining)?;
+    let cost = if fork >= Fork::Amsterdam { ECADD_COST_AMSTERDAM } else { ECADD_COST };
+    increase_precompile_consumed_gas(cost, gas_remaining)?;
 
     let (Some(first_point), Some(second_point)) =
         (parse_bn254_g1(&calldata, 0), parse_bn254_g1(&calldata, 64))
@@ -863,7 +866,7 @@ pub fn ecpairing(
 pub fn blake2f(
     calldata: &Bytes,
     gas_remaining: &mut u64,
-    _fork: Fork,
+    fork: Fork,
     crypto: &dyn Crypto,
 ) -> Result<Bytes, VMError> {
     if calldata.len() != 213 {
@@ -874,7 +877,9 @@ pub fn blake2f(
 
     let rounds = calldata.get_u32();
 
-    let gas_cost = u64::from(rounds) * BLAKE2F_ROUND_COST;
+    let constant_cost = if fork >= Fork::Amsterdam { BLAKE2F_CONSTANT_COST_AMSTERDAM } else { 0 };
+    let round_cost = if fork >= Fork::Amsterdam { BLAKE2F_ROUND_COST_AMSTERDAM } else { BLAKE2F_ROUND_COST };
+    let gas_cost = constant_cost + u64::from(rounds) * round_cost;
     increase_precompile_consumed_gas(gas_cost, gas_remaining)?;
 
     let mut h = [0; 8];
@@ -923,7 +928,7 @@ const POINT_EVALUATION_OUTPUT_BYTES: [u8; 64] = [
 fn point_evaluation(
     calldata: &Bytes,
     gas_remaining: &mut u64,
-    _fork: Fork,
+    fork: Fork,
     crypto: &dyn Crypto,
 ) -> Result<Bytes, VMError> {
     if calldata.len() != 192 {
@@ -931,7 +936,7 @@ fn point_evaluation(
     }
 
     // Consume gas
-    let gas_cost = POINT_EVALUATION_COST;
+    let gas_cost = if fork >= Fork::Amsterdam { POINT_EVALUATION_COST_AMSTERDAM } else { POINT_EVALUATION_COST };
     increase_precompile_consumed_gas(gas_cost, gas_remaining)?;
 
     // Parse inputs
@@ -1056,7 +1061,7 @@ fn parse_bls12_padded_fp(padded: &[u8; 64]) -> Result<[u8; 48], VMError> {
 pub fn bls12_g1add(
     calldata: &Bytes,
     gas_remaining: &mut u64,
-    _fork: Fork,
+    fork: Fork,
     crypto: &dyn Crypto,
 ) -> Result<Bytes, VMError> {
     let (x_data, calldata) = calldata
@@ -1070,7 +1075,8 @@ pub fn bls12_g1add(
     }
 
     // Apply precompile gas cost.
-    increase_precompile_consumed_gas(BLS12_381_G1ADD_COST, gas_remaining)
+    let cost = if fork >= Fork::Amsterdam { BLS12_381_G1ADD_COST_AMSTERDAM } else { BLS12_381_G1ADD_COST };
+    increase_precompile_consumed_gas(cost, gas_remaining)
         .map_err(|_| PrecompileError::NotEnoughGas)?;
 
     // Parse two 128-byte padded G1 points into 48-byte unpadded coordinates.
@@ -1167,7 +1173,7 @@ pub fn bls12_g1msm(
 pub fn bls12_g2add(
     calldata: &Bytes,
     gas_remaining: &mut u64,
-    _fork: Fork,
+    fork: Fork,
     crypto: &dyn Crypto,
 ) -> Result<Bytes, VMError> {
     let (x_data, calldata) = calldata
@@ -1181,7 +1187,8 @@ pub fn bls12_g2add(
     }
 
     // Apply precompile gas cost.
-    increase_precompile_consumed_gas(BLS12_381_G2ADD_COST, gas_remaining)
+    let cost = if fork >= Fork::Amsterdam { BLS12_381_G2ADD_COST_AMSTERDAM } else { BLS12_381_G2ADD_COST };
+    increase_precompile_consumed_gas(cost, gas_remaining)
         .map_err(|_| PrecompileError::NotEnoughGas)?;
 
     // Parse two 256-byte padded G2 points into four 48-byte unpadded coordinates each.

--- a/fixtures/networks/bal-devnet-3.yaml
+++ b/fixtures/networks/bal-devnet-3.yaml
@@ -21,6 +21,8 @@ participants:
   cl_image: ethpandaops/lodestar:bal-devnet-3
   el_type: ethrex
   el_image: ethrex:local
+  el_extra_params:
+  - --syncmode=full
   count: 1
 ethereum_genesis_generator_params:
   image: ethpandaops/ethereum-genesis-generator:5.3.1


### PR DESCRIPTION
> **Note:** EIP-7904 is not yet CFI'd nor included in any devnet. This is a proactive implementation — spec details may change.

## Summary
- Fork-gate increased gas costs for underpriced opcodes (DIV, SDIV, MOD, MULMOD, KECCAK256) and precompiles (ECADD, BLAKE2F, POINT_EVALUATION, BLS12_G1ADD, BLS12_G2ADD) behind Amsterdam
- Enables safe gas limit increase from 20→60 Mgas/s by removing compute bottlenecks

## EIP Reference
https://eips.ethereum.org/EIPS/eip-7904

## Test plan
- [ ] Verify gas costs match EIP spec values for Amsterdam fork
- [ ] Verify pre-Amsterdam gas costs unchanged
- [ ] Run existing EVM tests