### PR TITLE
feat(levm): implement EIP-7976 increase calldata floor cost

### DIFF
--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -197,6 +197,8 @@ pub const P256_VERIFY_COST: u64 = 6900;
 
 // Floor cost per token, specified in https://eips.ethereum.org/EIPS/eip-7623
 pub const TOTAL_COST_FLOOR_PER_TOKEN: u64 = 10;
+// EIP-7976 (Amsterdam): Increase calldata floor cost
+pub const TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM: u64 = 16;
 
 pub const SHA2_256_STATIC_COST: u64 = 60;
 pub const SHA2_256_DYNAMIC_BASE: u64 = 12;

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -2,7 +2,9 @@ use crate::{
     account::LevmAccount,
     constants::*,
     errors::{ContextResult, ExceptionalHalt, InternalError, TxValidationError, VMError},
-    gas_cost::{self, STANDARD_TOKEN_COST, TOTAL_COST_FLOOR_PER_TOKEN},
+    gas_cost::{
+        self, STANDARD_TOKEN_COST, TOTAL_COST_FLOOR_PER_TOKEN, TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM,
+    },
     hooks::hook::Hook,
     utils::*,
     vm::VM,
@@ -391,15 +393,19 @@ pub fn validate_min_gas_limit(vm: &mut VM<'_>) -> Result<(), VMError> {
         return Err(TxValidationError::IntrinsicGasTooLow.into());
     }
 
-    // calldata_cost = tokens_in_calldata * 4
-    let calldata_cost: u64 = gas_cost::tx_calldata(&calldata)?;
-
-    // same as calculated in gas_used()
-    let tokens_in_calldata: u64 = calldata_cost / STANDARD_TOKEN_COST;
-
-    // floor_cost_by_tokens = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
-    let floor_cost_by_tokens = tokens_in_calldata
-        .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN)
+    // Pre-Amsterdam (EIP-7623): tokens_in_calldata = zero_bytes + nonzero_bytes * 4
+    // Amsterdam (EIP-7976): floor_tokens_in_calldata = (zero_bytes + nonzero_bytes) * 4
+    let (floor_tokens, floor_per_token) = if vm.env.config.fork >= Fork::Amsterdam {
+        let tokens = (calldata.len() as u64)
+            .checked_mul(STANDARD_TOKEN_COST)
+            .ok_or(InternalError::Overflow)?;
+        (tokens, TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM)
+    } else {
+        let tokens = gas_cost::tx_calldata(&calldata)? / STANDARD_TOKEN_COST;
+        (tokens, TOTAL_COST_FLOOR_PER_TOKEN)
+    };
+    let floor_cost_by_tokens = floor_tokens
+        .checked_mul(floor_per_token)
         .ok_or(InternalError::Overflow)?
         .checked_add(TX_BASE_COST)
         .ok_or(InternalError::Overflow)?;

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -9,7 +9,7 @@ use crate::{
         self, ACCESS_LIST_ADDRESS_COST, ACCESS_LIST_STORAGE_KEY_COST, BLOB_GAS_PER_BLOB,
         COLD_ADDRESS_ACCESS_COST, CREATE_BASE_COST, REGULAR_GAS_CREATE, STANDARD_TOKEN_COST,
         STATE_GAS_AUTH_TOTAL, STATE_GAS_NEW_ACCOUNT, TOTAL_COST_FLOOR_PER_TOKEN,
-        WARM_ADDRESS_ACCESS_COST,
+        TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM, WARM_ADDRESS_ACCESS_COST,
     },
     vm::{Substate, VM},
 };
@@ -543,15 +543,20 @@ impl<'a> VM<'a> {
             &self.current_call_frame.calldata
         };
 
-        // tokens_in_calldata = nonzero_bytes_in_calldata * 4 + zero_bytes_in_calldata
-        // tx_calldata = nonzero_bytes_in_calldata * 16 + zero_bytes_in_calldata * 4
-        // this is actually tokens_in_calldata * STANDARD_TOKEN_COST
-        // see it in https://eips.ethereum.org/EIPS/eip-7623
-        let tokens_in_calldata: u64 = gas_cost::tx_calldata(calldata)? / STANDARD_TOKEN_COST;
+        // Pre-Amsterdam (EIP-7623): tokens_in_calldata = zero_bytes + nonzero_bytes * 4
+        // Amsterdam (EIP-7976): floor_tokens_in_calldata = (zero_bytes + nonzero_bytes) * 4
+        let (floor_tokens, floor_per_token) = if self.env.config.fork >= Fork::Amsterdam {
+            let tokens = (calldata.len() as u64)
+                .checked_mul(STANDARD_TOKEN_COST)
+                .ok_or(InternalError::Overflow)?;
+            (tokens, TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM)
+        } else {
+            let tokens = gas_cost::tx_calldata(calldata)? / STANDARD_TOKEN_COST;
+            (tokens, TOTAL_COST_FLOOR_PER_TOKEN)
+        };
 
-        // min_gas_used = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
-        let mut min_gas_used: u64 = tokens_in_calldata
-            .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN)
+        let mut min_gas_used: u64 = floor_tokens
+            .checked_mul(floor_per_token)
             .ok_or(InternalError::Overflow)?;
 
         min_gas_used = min_gas_used


### PR DESCRIPTION
> **Note:** EIP-7976 is not yet CFI'd nor included in any devnet. This is a proactive implementation — spec details may change.

## Summary
- Raise TOTAL_COST_FLOOR_PER_TOKEN from 10 to 16 for Amsterdam
- Reduces worst-case block payload size by ~37% (1.07MB → 0.67MB)
- Only ~1.5% of historical transactions would be affected

## EIP Reference
https://eips.ethereum.org/EIPS/eip-7976

## Test plan
- [ ] Verify floor calculation uses 16 for Amsterdam+
- [ ] Verify pre-Amsterdam floor uses 10
- [ ] Run existing EVM tests