### PR TITLE
feat(levm): implement EIP-7981 increase access list cost

### DIFF
--- a/crates/blockchain/constants.rs
+++ b/crates/blockchain/constants.rs
@@ -18,6 +18,16 @@ pub const TX_ACCESS_LIST_ADDRESS_GAS: u64 = 2400;
 // Gas cost for each storage key specified on access lists
 pub const TX_ACCESS_LIST_STORAGE_KEY_GAS: u64 = 1900;
 
+// EIP-7981 (Amsterdam): access list floor token multiplier.
+// Matches TOTAL_COST_FLOOR_PER_TOKEN at Amsterdam (EIP-7976: 16).
+pub const TX_ACCESS_LIST_FLOOR_PER_TOKEN: u64 = 16;
+
+// EIP-7981: byte lengths for access list entries used to compute floor tokens.
+pub const TX_ACCESS_LIST_ADDRESS_BYTES: u64 = 20;
+pub const TX_ACCESS_LIST_STORAGE_KEY_BYTES: u64 = 32;
+// Per EIP-7623: every byte of access list data counts as STANDARD_TOKEN_COST (4) floor tokens.
+pub const TX_ACCESS_LIST_STANDARD_TOKEN_COST: u64 = 4;
+
 // Gas cost for each non zero byte on transaction data
 pub const TX_DATA_NON_ZERO_GAS: u64 = 68;
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -7,8 +7,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     constants::{
-        TX_ACCESS_LIST_ADDRESS_GAS, TX_ACCESS_LIST_STORAGE_KEY_GAS, TX_CREATE_GAS_COST,
-        TX_DATA_NON_ZERO_GAS, TX_DATA_NON_ZERO_GAS_EIP2028, TX_DATA_ZERO_GAS_COST, TX_GAS_COST,
+        TX_ACCESS_LIST_ADDRESS_BYTES, TX_ACCESS_LIST_ADDRESS_GAS, TX_ACCESS_LIST_FLOOR_PER_TOKEN,
+        TX_ACCESS_LIST_STANDARD_TOKEN_COST, TX_ACCESS_LIST_STORAGE_KEY_BYTES,
+        TX_ACCESS_LIST_STORAGE_KEY_GAS, TX_CREATE_GAS_COST, TX_DATA_NON_ZERO_GAS,
+        TX_DATA_NON_ZERO_GAS_EIP2028, TX_DATA_ZERO_GAS_COST, TX_GAS_COST,
         TX_INIT_CODE_WORD_GAS_COST,
     },
     error::MempoolError,
@@ -564,6 +566,34 @@ pub fn transaction_intrinsic_gas(
     gas = gas
         .checked_add(storage_keys_count * TX_ACCESS_LIST_STORAGE_KEY_GAS)
         .ok_or(MempoolError::TxGasOverflowError)?;
+
+    // EIP-7981 (Amsterdam): add TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_access_list,
+    // where floor_tokens_in_access_list = access_list_bytes * 4 (flat, not zero/nonzero weighted).
+    if config.is_amsterdam_activated(header.timestamp) {
+        let mut access_list_bytes: u64 = 0;
+        for (_, keys) in tx.access_list() {
+            access_list_bytes = access_list_bytes
+                .checked_add(TX_ACCESS_LIST_ADDRESS_BYTES)
+                .ok_or(MempoolError::TxGasOverflowError)?;
+            access_list_bytes = access_list_bytes
+                .checked_add(
+                    (keys.len() as u64)
+                        .checked_mul(TX_ACCESS_LIST_STORAGE_KEY_BYTES)
+                        .ok_or(MempoolError::TxGasOverflowError)?,
+                )
+                .ok_or(MempoolError::TxGasOverflowError)?;
+        }
+        let access_list_tokens = access_list_bytes
+            .checked_mul(TX_ACCESS_LIST_STANDARD_TOKEN_COST)
+            .ok_or(MempoolError::TxGasOverflowError)?;
+        gas = gas
+            .checked_add(
+                access_list_tokens
+                    .checked_mul(TX_ACCESS_LIST_FLOOR_PER_TOKEN)
+                    .ok_or(MempoolError::TxGasOverflowError)?,
+            )
+            .ok_or(MempoolError::TxGasOverflowError)?;
+    }
 
     Ok(gas)
 }

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -7,7 +7,7 @@ use crate::{
 use ExceptionalHalt::OutOfGas;
 use bytes::Bytes;
 /// Contains the gas costs of the EVM instructions
-use ethrex_common::{U256, types::Fork};
+use ethrex_common::{Address, H256, U256, types::Fork};
 use malachite::base::num::logic::traits::*;
 use malachite::{Natural, base::num::basic::traits::Zero as _};
 
@@ -184,6 +184,12 @@ pub const BLOB_GAS_PER_BLOB: u64 = 131072;
 // Access lists costs
 pub const ACCESS_LIST_STORAGE_KEY_COST: u64 = 1900;
 pub const ACCESS_LIST_ADDRESS_COST: u64 = 2400;
+// Byte lengths for access list entries, used to compute floor tokens per EIP-7981.
+pub const ACCESS_LIST_ADDRESS_BYTES: u64 = 20;
+pub const ACCESS_LIST_STORAGE_KEY_BYTES: u64 = 32;
+// EIP-7976 (Amsterdam): TOTAL_COST_FLOOR_PER_TOKEN raised to 16.
+// Duplicated here so EIP-7981 can use the Amsterdam multiplier without depending on EIP-7976.
+pub const TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM: u64 = 16;
 
 // Precompile costs
 pub const ECRECOVER_COST: u64 = 3000;
@@ -597,6 +603,19 @@ pub fn selfdestruct(
     SELFDESTRUCT_STATIC
         .checked_add(dynamic_cost)
         .ok_or(OutOfGas.into())
+}
+
+/// EIP-7981: floor_tokens_in_access_list = access_list_bytes * STANDARD_TOKEN_COST,
+/// where access_list_bytes = 20 * addresses + 32 * storage_keys (flat, not zero/nonzero weighted).
+pub fn tokens_in_access_list_data(access_list: &[(Address, Vec<H256>)]) -> u64 {
+    let mut total_bytes: u64 = 0;
+    for (_, storage_keys) in access_list {
+        total_bytes = total_bytes.saturating_add(ACCESS_LIST_ADDRESS_BYTES);
+        total_bytes = total_bytes.saturating_add(
+            (storage_keys.len() as u64).saturating_mul(ACCESS_LIST_STORAGE_KEY_BYTES),
+        );
+    }
+    total_bytes.saturating_mul(STANDARD_TOKEN_COST)
 }
 
 pub fn tx_calldata(calldata: &Bytes) -> Result<u64, VMError> {

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -2,7 +2,9 @@ use crate::{
     account::LevmAccount,
     constants::*,
     errors::{ContextResult, ExceptionalHalt, InternalError, TxValidationError, VMError},
-    gas_cost::{self, STANDARD_TOKEN_COST, TOTAL_COST_FLOOR_PER_TOKEN},
+    gas_cost::{
+        self, STANDARD_TOKEN_COST, TOTAL_COST_FLOOR_PER_TOKEN, TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM,
+    },
     hooks::hook::Hook,
     utils::*,
     vm::VM,
@@ -391,18 +393,33 @@ pub fn validate_min_gas_limit(vm: &mut VM<'_>) -> Result<(), VMError> {
         return Err(TxValidationError::IntrinsicGasTooLow.into());
     }
 
-    // calldata_cost = tokens_in_calldata * 4
+    // EIP-7623: tokens_in_calldata = nonzero_bytes * 4 + zero_bytes
     let calldata_cost: u64 = gas_cost::tx_calldata(&calldata)?;
-
-    // same as calculated in gas_used()
     let tokens_in_calldata: u64 = calldata_cost / STANDARD_TOKEN_COST;
 
-    // floor_cost_by_tokens = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
-    let floor_cost_by_tokens = tokens_in_calldata
-        .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN)
-        .ok_or(InternalError::Overflow)?
-        .checked_add(TX_BASE_COST)
-        .ok_or(InternalError::Overflow)?;
+    // EIP-7981 (Amsterdam): use unweighted calldata length, include access list tokens,
+    // and use the Amsterdam floor multiplier.
+    // floor_tokens_in_calldata = (zero_bytes + nonzero_bytes) * 4 = calldata.len() * 4
+    let floor_cost_by_tokens = if vm.env.config.fork >= Fork::Amsterdam {
+        let floor_tokens_in_calldata = (calldata.len() as u64)
+            .checked_mul(STANDARD_TOKEN_COST)
+            .ok_or(InternalError::Overflow)?;
+        let access_list_tokens = gas_cost::tokens_in_access_list_data(vm.tx.access_list());
+        let total_tokens = floor_tokens_in_calldata
+            .checked_add(access_list_tokens)
+            .ok_or(InternalError::Overflow)?;
+        total_tokens
+            .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM)
+            .ok_or(InternalError::Overflow)?
+            .checked_add(TX_BASE_COST)
+            .ok_or(InternalError::Overflow)?
+    } else {
+        tokens_in_calldata
+            .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN)
+            .ok_or(InternalError::Overflow)?
+            .checked_add(TX_BASE_COST)
+            .ok_or(InternalError::Overflow)?
+    };
 
     // EIP-8037 (Amsterdam+): Regular gas is capped at TX_MAX_GAS_LIMIT — reject if
     // intrinsic regular gas or calldata floor exceeds the cap (no amount of gas_limit

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -9,7 +9,7 @@ use crate::{
         self, ACCESS_LIST_ADDRESS_COST, ACCESS_LIST_STORAGE_KEY_COST, BLOB_GAS_PER_BLOB,
         COLD_ADDRESS_ACCESS_COST, CREATE_BASE_COST, REGULAR_GAS_CREATE, STANDARD_TOKEN_COST,
         STATE_GAS_AUTH_TOTAL, STATE_GAS_NEW_ACCOUNT, TOTAL_COST_FLOOR_PER_TOKEN,
-        WARM_ADDRESS_ACCESS_COST,
+        TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM, WARM_ADDRESS_ACCESS_COST,
     },
     vm::{Substate, VM},
 };
@@ -501,6 +501,16 @@ impl<'a> VM<'a> {
 
         regular_gas = regular_gas.checked_add(access_lists_cost).ok_or(OutOfGas)?;
 
+        // EIP-7981 (Amsterdam): charge TOTAL_COST_FLOOR_PER_TOKEN (16, per EIP-7976)
+        // per access-list floor token as part of the intrinsic cost.
+        if fork >= Fork::Amsterdam {
+            let access_list_tokens = gas_cost::tokens_in_access_list_data(self.tx.access_list());
+            let data_cost = access_list_tokens
+                .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM)
+                .ok_or(InternalError::Overflow)?;
+            regular_gas = regular_gas.checked_add(data_cost).ok_or(OutOfGas)?;
+        }
+
         // Authorization List Cost
         // `unwrap_or_default` will return an empty vec when the `authorization_list` field is None.
         // If the vec is empty, the len will be 0, thus the authorization_list_cost is 0.
@@ -549,9 +559,21 @@ impl<'a> VM<'a> {
         // see it in https://eips.ethereum.org/EIPS/eip-7623
         let tokens_in_calldata: u64 = gas_cost::tx_calldata(calldata)? / STANDARD_TOKEN_COST;
 
-        // min_gas_used = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
-        let mut min_gas_used: u64 = tokens_in_calldata
-            .checked_mul(TOTAL_COST_FLOOR_PER_TOKEN)
+        // EIP-7981 (Amsterdam): Include access list tokens in the floor calculation,
+        // and use the Amsterdam multiplier (EIP-7976).
+        let (total_tokens, floor_per_token) = if self.env.config.fork >= Fork::Amsterdam {
+            let access_list_tokens = gas_cost::tokens_in_access_list_data(self.tx.access_list());
+            let total = tokens_in_calldata
+                .checked_add(access_list_tokens)
+                .ok_or(InternalError::Overflow)?;
+            (total, TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM)
+        } else {
+            (tokens_in_calldata, TOTAL_COST_FLOOR_PER_TOKEN)
+        };
+
+        // min_gas_used = TX_BASE_COST + floor_per_token * total_tokens
+        let mut min_gas_used: u64 = total_tokens
+            .checked_mul(floor_per_token)
             .ok_or(InternalError::Overflow)?;
 
         min_gas_used = min_gas_used

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -553,17 +553,21 @@ impl<'a> VM<'a> {
             &self.current_call_frame.calldata
         };
 
-        // tokens_in_calldata = nonzero_bytes_in_calldata * 4 + zero_bytes_in_calldata
+        // EIP-7623: tokens_in_calldata = nonzero_bytes_in_calldata * 4 + zero_bytes_in_calldata
         // tx_calldata = nonzero_bytes_in_calldata * 16 + zero_bytes_in_calldata * 4
         // this is actually tokens_in_calldata * STANDARD_TOKEN_COST
         // see it in https://eips.ethereum.org/EIPS/eip-7623
         let tokens_in_calldata: u64 = gas_cost::tx_calldata(calldata)? / STANDARD_TOKEN_COST;
 
-        // EIP-7981 (Amsterdam): Include access list tokens in the floor calculation,
-        // and use the Amsterdam multiplier (EIP-7976).
+        // EIP-7981 (Amsterdam): Use unweighted calldata length for the floor calculation,
+        // include access list tokens, and use the Amsterdam multiplier (EIP-7976).
+        // floor_tokens_in_calldata = (zero_bytes + nonzero_bytes) * 4 = calldata.len() * 4
         let (total_tokens, floor_per_token) = if self.env.config.fork >= Fork::Amsterdam {
+            let floor_tokens_in_calldata = (calldata.len() as u64)
+                .checked_mul(STANDARD_TOKEN_COST)
+                .ok_or(InternalError::Overflow)?;
             let access_list_tokens = gas_cost::tokens_in_access_list_data(self.tx.access_list());
-            let total = tokens_in_calldata
+            let total = floor_tokens_in_calldata
                 .checked_add(access_list_tokens)
                 .ok_or(InternalError::Overflow)?;
             (total, TOTAL_COST_FLOOR_PER_TOKEN_AMSTERDAM)


### PR DESCRIPTION
> **Note:** EIP-7981 is not yet CFI'd nor included in any devnet. This is a proactive implementation — spec details may change.

## Summary
- Add access list data token counting to EIP-7623 floor calculation
- Charge ACCESS_LIST_DATA_COST_PER_TOKEN (10) per token in intrinsic gas
- Prevents access lists from bypassing calldata floor pricing

## EIP Reference
https://eips.ethereum.org/EIPS/eip-7981

## Test plan
- [ ] Verify access list tokens contribute to floor for Amsterdam+
- [ ] Verify access list data cost charged in intrinsic gas for Amsterdam+
- [ ] Verify pre-Amsterdam behavior unchanged
- [ ] Run existing EVM tests