### PR TITLE
feat(l1): add BAL parallel execution benchmark infrastructure

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -492,6 +492,19 @@ pub enum Subcommand {
         removedb: bool,
         #[arg(long, action = ArgAction::SetTrue)]
         l2: bool,
+        #[arg(
+            long = "export-bal",
+            value_name = "FILE",
+            help = "Export BALs produced during sequential execution to a single RLP file (concatenated, one per block)"
+        )]
+        export_bal: Option<String>,
+        #[arg(
+            long = "with-bal",
+            value_name = "FILE",
+            help = "Load BALs from a single RLP file and use the parallel execution path",
+            conflicts_with = "export_bal"
+        )]
+        with_bal: Option<String>,
     },
     #[command(
         name = "export",
@@ -622,7 +635,13 @@ impl Subcommand {
                 )
                 .await?;
             }
-            Subcommand::ImportBench { path, removedb, l2 } => {
+            Subcommand::ImportBench {
+                path,
+                removedb,
+                l2,
+                export_bal,
+                with_bal,
+            } => {
                 if removedb {
                     remove_db(&effective_datadir, opts.force);
                 }
@@ -643,6 +662,8 @@ impl Subcommand {
                         perf_logs_enabled: true,
                         ..Default::default()
                     },
+                    export_bal.as_deref(),
+                    with_bal.as_deref(),
                 )
                 .await?;
             }
@@ -865,6 +886,8 @@ pub async fn import_blocks_bench(
     datadir: &Path,
     genesis: Genesis,
     blockchain_opts: BlockchainOptions,
+    export_bal_path: Option<&str>,
+    with_bal_path: Option<&str>,
 ) -> Result<(), ChainError> {
     let start_time = Instant::now();
     init_datadir(datadir);
@@ -872,6 +895,30 @@ pub async fn import_blocks_bench(
     let blockchain = init_blockchain(store.clone(), blockchain_opts);
     regenerate_head_state(&store, &blockchain).await.unwrap();
     let path_metadata = metadata(path).expect("Failed to read path");
+
+    if let Some(bal_path) = export_bal_path {
+        info!(path = %bal_path, "Will export BALs to file");
+    }
+
+    // Pre-load all BALs into memory upfront to avoid per-block I/O during benchmark
+    let preloaded_bals = if let Some(bal_path) = with_bal_path {
+        info!(path = %bal_path, "Loading BALs from file (parallel path)");
+        use ethrex_common::types::block_access_list::BlockAccessList;
+        use ethrex_rlp::decode::RLPDecode as _;
+        let data = std::fs::read(bal_path).expect("Failed to read BAL file");
+        let mut remaining = data.as_slice();
+        let mut bals = Vec::new();
+        while !remaining.is_empty() {
+            let (bal, rest) =
+                BlockAccessList::decode_unfinished(remaining).expect("Failed to decode BAL");
+            bals.push(bal);
+            remaining = rest;
+        }
+        info!(count = bals.len(), "Loaded BALs into memory");
+        Some(bals)
+    } else {
+        None
+    };
 
     // If it's an .rlp file it will be just one chain, but if it's a directory there can be multiple chains.
     let chains: Vec<Vec<Block>> = if path_metadata.is_dir() {
@@ -897,6 +944,7 @@ pub async fn import_blocks_bench(
         vec![utils::read_chain_file(path)]
     };
 
+    let mut exported_bals = Vec::new();
     let mut total_blocks_imported = 0;
     for blocks in chains {
         let size = blocks.len();
@@ -906,6 +954,7 @@ pub async fn import_blocks_bench(
             .collect::<Vec<_>>();
         // Execute block by block
         let mut last_progress_log = Instant::now();
+        let mut bal_index = 0usize;
         for (index, block) in blocks.into_iter().enumerate() {
             let hash = block.hash();
             let number = block.header.number;
@@ -933,13 +982,38 @@ pub async fn import_blocks_bench(
             validate_block_body(&block.header, &block.body, &ethrex_crypto::NativeCrypto)
                 .map_err(InvalidBlockError::InvalidBody)?;
 
-            blockchain
-                .add_block_pipeline(block, None)
-                .inspect_err(|err| match err {
-                    // Block number 1's parent not found, the chain must not belong to the same network as the genesis file
-                    ChainError::ParentNotFound if number == 1 => warn!("The chain file is not compatible with the genesis file. Are you sure you selected the correct network?"),
-                    _ => warn!("Failed to add block {number} with hash {hash:#x}"),
-                })?;
+            // Look up preloaded BAL for this block (if --with-bal was provided).
+            // BALs are only produced for Amsterdam+ blocks, so use a separate counter
+            // that only advances for blocks that have a BAL hash in the header.
+            let bal = if block.header.block_access_list_hash.is_some() {
+                let b = preloaded_bals.as_ref().and_then(|bals| bals.get(bal_index));
+                bal_index += 1;
+                b
+            } else {
+                None
+            };
+
+            if export_bal_path.is_some() {
+                // Sequential path: execute and capture the produced BAL
+                let produced_bal = blockchain
+                    .add_block_pipeline_bal(block, None)
+                    .inspect_err(|err| match err {
+                        ChainError::ParentNotFound if number == 1 => warn!("The chain file is not compatible with the genesis file. Are you sure you selected the correct network?"),
+                        _ => warn!("Failed to add block {number} with hash {hash:#x}"),
+                    })?;
+
+                if let Some(bal) = produced_bal {
+                    exported_bals.push(bal);
+                }
+            } else {
+                // Normal path (or parallel if BAL was loaded)
+                blockchain
+                    .add_block_pipeline(block, bal)
+                    .inspect_err(|err| match err {
+                        ChainError::ParentNotFound if number == 1 => warn!("The chain file is not compatible with the genesis file. Are you sure you selected the correct network?"),
+                        _ => warn!("Failed to add block {number} with hash {hash:#x}"),
+                    })?;
+            }
 
             // TODO: replace this
             // This sleep is because we have a background process writing to disk the last layer
@@ -964,6 +1038,16 @@ pub async fn import_blocks_bench(
         }
 
         total_blocks_imported += size;
+    }
+
+    // Write all exported BALs to a single file
+    if let Some(bal_path) = export_bal_path {
+        let mut buf = Vec::new();
+        for bal in &exported_bals {
+            bal.encode(&mut buf);
+        }
+        std::fs::write(bal_path, &buf).expect("Failed to write BAL file");
+        info!(count = exported_bals.len(), "Exported BALs to file");
     }
 
     let total_duration = start_time.elapsed();

--- a/fixtures/networks/bal-bench-stress.yaml
+++ b/fixtures/networks/bal-bench-stress.yaml
@@ -1,0 +1,65 @@
+participants:
+- cl_type: lodestar
+  cl_image: ethpandaops/lodestar:bal-devnet-3
+  el_type: ethrex
+  el_image: ethrex:local
+  el_extra_params:
+  - --mempool.maxsize=50000
+  - --syncmode=full
+  count: 1
+  supernode: true
+ethereum_genesis_generator_params:
+  image: ethpandaops/ethereum-genesis-generator:5.3.1
+global_log_level: debug
+network_params:
+  preset: minimal
+  seconds_per_slot: 6
+  genesis_delay: 30
+  fulu_fork_epoch: 0
+  gloas_fork_epoch: 2
+  # Elevated gas limit to stress-fill blocks
+  gas_limit: 100000000
+snooper_enabled: false
+additional_services: [dora, spamoor]
+dora_params:
+  image: ethpandaops/dora:eip7928-support
+spamoor_params:
+  image: ethpandaops/spamoor:latest
+  spammers:
+  # --- Balance-only workload (small BAL, easy to parallelize) ---
+  - scenario: eoatx
+    config:
+      throughput: 20
+      max_pending: 500
+      max_wallets: 200
+  # --- Heavy compute (large gas per tx) ---
+  - scenario: gasburnertx
+    config:
+      throughput: 5
+      max_pending: 200
+      gas_units: 500000
+  # --- Storage spam (many SSTORE/SLOAD per tx, wide BAL) ---
+  - scenario: storagespam
+    config:
+      throughput: 5
+      max_pending: 200
+  # --- ERC20 token transfers (shared contract = contention between txs) ---
+  - scenario: erc20tx
+    config:
+      throughput: 10
+      max_pending: 300
+      max_wallets: 100
+  # --- Contract creation (code changes in BAL) ---
+  - scenario: deploytx
+    config:
+      throughput: 2
+      max_pending: 100
+  # --- Uniswap swaps (realistic DeFi, heavy storage + contention) ---
+  - scenario: uniswap-swaps
+    config:
+      throughput: 3
+      max_pending: 100
+port_publisher:
+  additional_services:
+    enabled: true
+    public_port_start: 64400

--- a/fixtures/networks/bal-bench.yaml
+++ b/fixtures/networks/bal-bench.yaml
@@ -1,0 +1,54 @@
+participants:
+- cl_type: lodestar
+  cl_image: ethpandaops/lodestar:bal-devnet-3
+  el_type: ethrex
+  el_image: ethrex:local
+  el_extra_params:
+  - --mempool.maxsize=50000
+  - --syncmode=full
+  count: 1
+  supernode: true
+ethereum_genesis_generator_params:
+  image: ethpandaops/ethereum-genesis-generator:5.3.1
+global_log_level: debug
+network_params:
+  preset: minimal
+  seconds_per_slot: 6
+  genesis_delay: 30
+  fulu_fork_epoch: 0
+  gloas_fork_epoch: 2
+  # Mainnet gas limit as of March 2026
+  gas_limit: 60000000
+snooper_enabled: false
+additional_services: [dora, spamoor]
+dora_params:
+  image: ethpandaops/dora:eip7928-support
+spamoor_params:
+  image: ethpandaops/spamoor:latest
+  spammers:
+  # ~70% simple transfers (dominant on mainnet)
+  - scenario: eoatx
+    config:
+      throughput: 30
+      max_pending: 500
+      max_wallets: 200
+  # ~15% ERC20 token transfers
+  - scenario: erc20tx
+    config:
+      throughput: 6
+      max_pending: 200
+      max_wallets: 100
+  # ~10% DEX swaps
+  - scenario: uniswap-swaps
+    config:
+      throughput: 4
+      max_pending: 150
+  # ~5% contract deploys
+  - scenario: deploytx
+    config:
+      throughput: 2
+      max_pending: 100
+port_publisher:
+  additional_services:
+    enabled: true
+    public_port_start: 64400

--- a/tooling/import_benchmark/BAL_BENCHMARK.md
+++ b/tooling/import_benchmark/BAL_BENCHMARK.md
@@ -1,0 +1,325 @@
+# BAL Parallel Execution Benchmark
+
+## Overview
+
+Benchmark the BAL (Block Access List, EIP-7928) parallel execution validation path
+and, secondarily, BAL construction performance.
+
+The approach:
+1. Run a kurtosis devnet with spamoor to produce blocks with diverse transaction patterns
+2. Export the chain as RLP
+3. Run a sequential bootstrap pass to generate BALs for each block
+4. Benchmark the parallel validation path by replaying blocks with their BALs
+
+```
+┌─ ONE TIME ────────────────────────────────────────────────┐
+│  Kurtosis devnet + spamoor → diverse blocks               │
+│  ethrex export → chain.rlp                                │
+├─ BOOTSTRAP (once per chain.rlp) ─────────────────────────┤
+│  import-bench chain.rlp --export-bal bals.rlp             │
+│    sequential execution, records BALs to single file      │
+├─ BENCHMARK (repeatable, deterministic) ──────────────────┤
+│  import-bench chain.rlp --with-bal bals.rlp  (parallel)   │
+│  import-bench chain.rlp                      (sequential) │
+│  Compare Ggas/s and phase breakdown between both runs     │
+└───────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+- [Kurtosis](https://docs.kurtosis.com/install/#ii-install-the-cli)
+- [Docker](https://docs.docker.com/engine/install/)
+- ethrex built with Amsterdam support
+- spamoor (bundled in the kurtosis ethereum-package)
+
+## Phase 1: Generate the chain fixture
+
+### 1.1 Start the devnet
+
+Two benchmark configs are available, both run a single ethrex supernode with
+no cross-client noise:
+
+**Mainnet-like** (`bal-bench.yaml`) — reportable numbers:
+
+```bash
+make localnet KURTOSIS_CONFIG_FILE=./fixtures/networks/bal-bench.yaml
+```
+
+- 60M gas limit (current mainnet)
+- Mainnet-like tx mix: ~70% transfers, ~15% ERC20, ~10% DEX swaps, ~5% deploys
+
+**Stress test** (`bal-bench-stress.yaml`) — find bottlenecks:
+
+```bash
+make localnet KURTOSIS_CONFIG_FILE=./fixtures/networks/bal-bench-stress.yaml
+```
+
+- 100M gas limit (push blocks to the limit)
+- Storage spam, gas burners, high contention scenarios
+
+Both configs set `--mempool.maxsize=50000` to avoid tx drops under load.
+
+### 1.2 Let it run
+
+Let the devnet run until you have enough blocks. For a meaningful benchmark:
+- **Minimum**: ~100 blocks (quick smoke test)
+- **Recommended**: ~1000 blocks (stable averages)
+- **Ideal**: ~5000+ blocks (captures variance, cache effects, state growth)
+
+At 6s slots, 1000 blocks ≈ 100 minutes.
+
+Monitor progress via dora (the block explorer included in the devnet config)
+or ethrex logs.
+
+### 1.3 Export the chain
+
+Find the ethrex container and current head block:
+
+```bash
+# Get the ethrex container ID
+CID=$(docker ps -q --filter ancestor=ethrex:local | head -n1)
+
+# Check current head via RPC
+curl -s http://$(kurtosis port print lambdanet el-1-ethrex-lighthouse rpc) \
+  -X POST -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq -r '.result'
+```
+
+Export blocks from inside the container:
+
+```bash
+docker exec $CID ethrex export --first 1 --last <HEAD> /tmp/chain.rlp
+docker cp $CID:/tmp/chain.rlp ~/.local/share/ethrex_bal_bench/chain.rlp
+```
+
+### 1.4 Stop the devnet
+
+```bash
+make stop-localnet
+```
+
+### 1.5 Copy the genesis file
+
+You'll need the devnet's genesis file for the import-bench passes. Extract it
+from the kurtosis enclave **before stopping**:
+
+```bash
+kurtosis files download lambdanet genesis_file ~/bal-bench-genesis.json
+```
+
+## Phase 2: Bootstrap — generate BALs
+
+This pass executes the chain sequentially and writes all BALs to a single file.
+
+### 2.1 Prepare the state database
+
+The import-bench needs a store with the genesis state:
+
+```bash
+mkdir -p ~/.local/share/ethrex_bal_bench
+```
+
+### 2.2 Run the bootstrap pass
+
+```bash
+cargo run --release -- \
+  --network ~/bal-bench-genesis.json \
+  --datadir ~/.local/share/ethrex_bal_bench \
+  import-bench chain.rlp --export-bal bals.rlp
+```
+
+This will:
+1. Execute each block sequentially (the normal `add_block_pipeline(block, None)` path)
+2. Record the BAL produced during execution
+3. Write all BALs as concatenated RLP to `bals.rlp` (same format as chain.rlp)
+
+The BALs file is now your fixture for the parallel path.
+
+### 2.3 Verify BAL integrity
+
+Quick sanity check — the BAL hash should match what's in each block header:
+
+```bash
+# The import-bench should log any hash mismatches.
+# If a BAL hash doesn't match the block header's block_access_list_hash,
+# something is wrong with execution or recording.
+```
+
+## Phase 3: Benchmark
+
+### 3.1 Parallel path (primary objective)
+
+```bash
+# Copy the base state (from after genesis init, before block 1)
+cp -r ~/.local/share/ethrex_bal_bench/ethrex ~/.local/share/temp
+
+cargo run --release -- \
+  --network ~/bal-bench-genesis.json \
+  --datadir ~/.local/share/temp \
+  import-bench chain.rlp --with-bal bals.rlp
+```
+
+This loads all BALs into memory upfront (no per-block I/O overhead), then calls
+`add_block_pipeline(block, Some(&bal))` which activates:
+- `validate_header_bal_indices()`
+- `build_validation_index()`
+- `warm_block_from_bal()` (prefetch accounts, storage, codes)
+- `execute_block_parallel()` (rayon-parallelized tx execution)
+- BAL validation (reads, accounts, withdrawals)
+
+The existing perf logs (`perf_logs_enabled: true`) will output per-block:
+- Ggas/s throughput
+- Phase breakdown: validate, exec, merkle (concurrent + drain), store, warmer
+- Merkle overlap percentage
+- Bottleneck identification
+
+### 3.2 Sequential baseline (for comparison)
+
+```bash
+cp -r ~/.local/share/ethrex_bal_bench/ethrex ~/.local/share/temp
+
+cargo run --release -- \
+  --network ~/bal-bench-genesis.json \
+  --datadir ~/.local/share/temp \
+  import-bench chain.rlp
+```
+
+Same blocks, no BAL → sequential `execute_block()` path.
+
+### 3.3 Multiple runs
+
+Use the existing benchmark.sh pattern for multiple repetitions:
+
+```bash
+# Parallel (3 runs)
+for i in 1 2 3; do
+  cp -r ~/.local/share/ethrex_bal_bench/ethrex ~/.local/share/temp
+  cargo run --release -- \
+    --network ~/bal-bench-genesis.json \
+    --datadir ~/.local/share/temp \
+    import-bench chain.rlp --with-bal bals.rlp \
+    2>&1 | tee bench_results/parallel-${i}.log
+done
+
+# Sequential (3 runs)
+for i in 1 2 3; do
+  cp -r ~/.local/share/ethrex_bal_bench/ethrex ~/.local/share/temp
+  cargo run --release -- \
+    --network ~/bal-bench-genesis.json \
+    --datadir ~/.local/share/temp \
+    import-bench chain.rlp \
+    2>&1 | tee bench_results/sequential-${i}.log
+done
+```
+
+### 3.4 Compare results
+
+```bash
+python3 tooling/import_benchmark/parse_bench.py \
+  bench_results/parallel-*.log bench_results/sequential-*.log
+```
+
+> **NOTE**: `parse_bench.py` may need updates to parse the pipeline log format
+> (7 instants) vs the old sequential format (3 instants). Consider extending it
+> to report parallel-specific metrics like warmer time and merkle overlap.
+
+## Metrics to Track
+
+| Metric | Source | What it tells you |
+|--------|--------|-------------------|
+| Ggas/s | `[METRIC] BLOCK EXECUTION THROUGHPUT` | Overall throughput |
+| Exec time (ms) | Pipeline phase breakdown | Raw execution time |
+| Warmer time (ms) | `warmer_duration` | BAL prefetch cost |
+| Merkle overlap % | Pipeline log | How well merkle overlaps with exec |
+| Merkle drain (ms) | Pipeline log | Residual merkle after exec finishes |
+| Parallel speedup | Ggas/s(parallel) / Ggas/s(sequential) | The headline number |
+| Store time (ms) | Pipeline phase | DB write overhead |
+
+## CLI Flags
+
+### `--export-bal <FILE>`
+
+During sequential execution, save all BALs to a single concatenated RLP file:
+
+```
+import-bench chain.rlp --export-bal bals.rlp
+```
+
+BALs are collected in memory during execution and written in one shot at the end.
+
+### `--with-bal <FILE>`
+
+Load pre-computed BALs and use the parallel execution path:
+
+```
+import-bench chain.rlp --with-bal bals.rlp
+```
+
+All BALs are loaded into memory upfront before block execution begins,
+avoiding per-block I/O overhead during the benchmark.
+
+### Both flags are mutually exclusive
+
+`--export-bal` = sequential bootstrap pass.
+`--with-bal` = parallel benchmark pass.
+
+## Spamoor Scenario Tuning
+
+## Spamoor Scenario Reference
+
+| Scenario | BAL Impact | Parallel Impact |
+|----------|-----------|-----------------|
+| `eoatx` | Small BAL (balance-only) | Minimal contention, easy to parallelize |
+| `gasburnertx` | Compute-heavy, moderate BAL | Stresses execution, good parallelism |
+| `storagespam` | Large BAL (many storage slots) | Stresses prefetch, validation |
+| `erc20tx` | Shared contract storage | Contention test — txs touch same contract |
+| `deploytx` | Code change entries | Tests code change recording/validation |
+| `uniswap-swaps` | DEX swaps (heavy storage) | Realistic DeFi, high contention |
+
+Key config parameters per scenario:
+- `throughput` — txs per slot (6s). Higher = more txs in mempool per block
+- `max_pending` — cap on unconfirmed txs. Prevents mempool overflow
+- `max_wallets` — child wallets. More wallets = more unique senders = better parallelism
+- `gas_units` — (gasburnertx) gas burned per tx
+
+To avoid empty blocks, ensure total throughput doesn't overwhelm the mempool.
+Both configs set `--mempool.maxsize=50000` and keep `max_pending` bounded per scenario.
+
+## Fixture Management
+
+Once generated, the fixtures are self-contained:
+
+```
+~/.local/share/ethrex_bal_bench/
+├── chain.rlp              # RLP-encoded blocks (concatenated)
+├── bals.rlp               # RLP-encoded BALs (concatenated, 1:1 with blocks)
+├── ethrex/                # RocksDB state at genesis (base for each run)
+└── genesis.json           # Network genesis
+```
+
+These can be:
+- Shared across team members (deterministic results on same hardware)
+- Versioned (generate new fixtures when BAL format or spamoor config changes)
+- Stored in CI for regression testing
+
+## Troubleshooting
+
+### Blocks are empty / low gas usage
+Spamoor may need time to ramp up. Skip the first ~20 blocks or increase
+`genesis_delay` in the devnet config.
+
+### BAL hash mismatch during parallel benchmark
+The BAL was generated with a different execution than what the block expects.
+Regenerate BALs from the same chain.rlp.
+
+### RocksDB lock errors
+Make sure you're copying the base state to a temp dir before each run,
+not reusing the same datadir.
+
+### 500ms sleep in import-bench
+The current code has a `tokio::time::sleep(Duration::from_millis(500))` between
+blocks to wait for background DB writes. For benchmarking, this adds ~500ms
+overhead per block. Consider:
+- Reducing it for faster iteration
+- Excluding it from timing measurements
+- Or removing it and handling the DB flush synchronously


### PR DESCRIPTION
Add tooling to benchmark the BAL parallel execution path (`execute_block_pipeline`) against sequential execution in a reproducible way.

`fixtures/networks/bal-bench.yaml` — single ethrex supernode + lighthouse kurtosis config with spamoor running `eoatx`, `evm-fuzz`, and `deploytx` scenarios to generate diverse block traffic.

`tooling/import_benchmark/BAL_BENCHMARK.md` — step-by-step workflow: spin up devnet, export chain.rlp, bootstrap pass, benchmark pass.

`cmd/ethrex/cli.rs` — two new flags on `import-bench`:
- `--export-bal <DIR>`: sequential pass via `add_block_pipeline_bal`, writes one RLP file per block
- `--with-bal <DIR>`: loads BALs from disk and routes each block through `add_block_pipeline` with the pre-loaded BAL, activating the parallel path

The two flags conflict, making the intent explicit. The bootstrap/benchmark split means the parallel path runs against deterministic, pre-recorded BALs rather than re-deriving them, so timings are comparable.