### PR TITLE
feat(l1): decouple discv4 address from RLPx address

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -323,6 +323,15 @@ pub struct Options {
     )]
     pub p2p_port: String,
     #[arg(
+        long = "discovery.addr",
+        value_name = "ADDRESS",
+        help = "Bind address for the UDP discovery socket.",
+        long_help = "The address to bind the discv4/discv5 UDP socket to. Defaults to --p2p.addr (or 0.0.0.0 if unset). Allows running discovery on a different interface than RLPx.",
+        help_heading = "P2P options",
+        env = "ETHREX_P2P_DISCOVERY_ADDR"
+    )]
+    pub discovery_addr: Option<String>,
+    #[arg(
         long = "discovery.port",
         default_value = "30303",
         value_name = "PORT",
@@ -475,6 +484,7 @@ impl Default for Options {
             p2p_addr: None,
             nat_extip: None,
             p2p_port: Default::default(),
+            discovery_addr: None,
             discovery_port: Default::default(),
             discv4_enabled: true,
             discv5_enabled: true,

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -298,8 +298,8 @@ pub struct Options {
     #[arg(
         long = "p2p.addr",
         value_name = "ADDRESS",
-        help = "Bind address for the P2P protocol (UDP discovery and TCP RLPx).",
-        long_help = "The address to bind P2P sockets to. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.",
+        help = "Bind address for the TCP RLPx socket. Also used as the default bind address for UDP discovery unless --discovery.addr is set.",
+        long_help = "The address to bind the TCP RLPx socket to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.",
         help_heading = "P2P options",
         env = "ETHREX_P2P_ADDR"
     )]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -456,6 +456,10 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
     // Determine discovery bind address.
     // --discovery.addr sets the UDP bind addr independently of RLPx.
     // Defaults to rlpx_bind_addr so the two channels co-locate by default.
+    // NOTE: we currently enforce that discovery and RLPx use the same address
+    // family. Mixed-family (e.g. IPv4 discv4 + IPv6 RLPx) is structurally
+    // supported by NetworkConfig but not yet tested end-to-end. A future
+    // dual-stack PR (feat/p2p-dual-stack-ipv6) will relax this constraint.
     let discovery_bind_addr: IpAddr = opts
         .discovery_addr
         .as_deref()

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -446,16 +446,36 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
 
     let local_public_key = public_key_from_signing_key(signer);
 
-    let (bind_addr, external_addr) = resolve_p2p_endpoints(
+    let (rlpx_bind_addr, rlpx_external_addr) = resolve_p2p_endpoints(
         opts.p2p_addr.as_deref(),
         opts.nat_extip.as_deref(),
         local_ip().ok(),
         local_ipv6().ok(),
     );
 
-    let node = Node::new(external_addr, udp_port, tcp_port, local_public_key);
+    // Determine discovery bind address.
+    // --discovery.addr sets the UDP bind addr independently of RLPx.
+    // Defaults to rlpx_bind_addr so the two channels co-locate by default.
+    let discovery_bind_addr: IpAddr = opts
+        .discovery_addr
+        .as_deref()
+        .map(|a| a.parse().expect("Failed to parse --discovery.addr address"))
+        .unwrap_or(rlpx_bind_addr);
+
+    // Discovery external address: use the explicit discovery bind addr when it
+    // is a specific (non-wildcard) IP; otherwise fall back to rlpx_external_addr.
+    let discovery_external_addr = if !discovery_bind_addr.is_unspecified() {
+        discovery_bind_addr
+    } else {
+        rlpx_external_addr
+    };
+
+    let node = Node::new(rlpx_external_addr, udp_port, tcp_port, local_public_key);
     let network_config = NetworkConfig {
-        bind_addr,
+        discovery_bind_addr,
+        discovery_external_addr,
+        rlpx_bind_addr,
+        rlpx_external_addr,
         tcp_port,
         udp_port,
     };

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -459,7 +459,17 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
     let discovery_bind_addr: IpAddr = opts
         .discovery_addr
         .as_deref()
-        .map(|a| a.parse().expect("Failed to parse --discovery.addr address"))
+        .map(|a| {
+            let addr: IpAddr = a.parse().expect("Failed to parse --discovery.addr address");
+            if let Some(extip) = &opts.nat_extip {
+                let external: IpAddr = extip.parse().expect("Failed to parse --nat.extip address");
+                assert!(
+                    addr.is_ipv4() == external.is_ipv4(),
+                    "--discovery.addr and --nat.extip must use the same address family (both IPv4 or both IPv6)"
+                );
+            }
+            addr
+        })
         .unwrap_or(rlpx_bind_addr);
 
     // Discovery external address: use the explicit discovery bind addr when it

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -461,20 +461,21 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
         .as_deref()
         .map(|a| {
             let addr: IpAddr = a.parse().expect("Failed to parse --discovery.addr address");
-            if let Some(extip) = &opts.nat_extip {
-                let external: IpAddr = extip.parse().expect("Failed to parse --nat.extip address");
-                assert!(
-                    addr.is_ipv4() == external.is_ipv4(),
-                    "--discovery.addr and --nat.extip must use the same address family (both IPv4 or both IPv6)"
-                );
-            }
+            assert!(
+                addr.is_ipv4() == rlpx_external_addr.is_ipv4(),
+                "--discovery.addr and external address must use the same address family (both IPv4 or both IPv6)"
+            );
             addr
         })
         .unwrap_or(rlpx_bind_addr);
 
-    // Discovery external address: use the explicit discovery bind addr when it
-    // is a specific (non-wildcard) IP; otherwise fall back to rlpx_external_addr.
-    let discovery_external_addr = if !discovery_bind_addr.is_unspecified() {
+    // Discovery external address: always use rlpx_external_addr (which is
+    // --nat.extip when set) so the announced address reflects what peers see.
+    // Only fall back to the discovery bind addr when no NAT external IP is
+    // configured and the bind addr is a specific (non-wildcard) IP.
+    let discovery_external_addr = if opts.nat_extip.is_some() {
+        rlpx_external_addr
+    } else if !discovery_bind_addr.is_unspecified() {
         discovery_bind_addr
     } else {
         rlpx_external_addr

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -121,9 +121,19 @@ pub async fn start_network(
             .map_err(NetworkError::UdpSocketError)?,
     );
 
+    // Build a discovery-specific local node using the discovery external address.
+    // This ensures discv4/discv5 Ping `from` endpoints advertise the correct
+    // address when discovery runs on a different interface than RLPx.
+    let discovery_local_node = Node::new(
+        context.network_config.discovery_external_addr,
+        context.network_config.udp_port,
+        context.network_config.tcp_port,
+        context.local_node.public_key,
+    );
+
     DiscoveryServer::spawn(
         context.storage.clone(),
-        context.local_node.clone(),
+        discovery_local_node,
         context.signer,
         udp_socket,
         context.table.clone(),

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -27,8 +27,12 @@ use crate::utils::node_id;
 ///
 /// This supports two independent axes of configuration:
 /// - NAT traversal: bind to `0.0.0.0` but announce a public IP (`--nat.extip`).
-/// - Split transports: run UDP discovery on a different address than TCP RLPx
-///   (`--discovery.addr`), enabling e.g. IPv4 discv4 with IPv6 RLPx.
+/// - Split transports: run UDP discovery on a different interface/address than
+///   TCP RLPx (`--discovery.addr`).
+///
+/// NOTE: all addresses must currently share the same IP family (all IPv4 or
+/// all IPv6). Mixed-family (e.g. IPv4 discovery + IPv6 RLPx) is not yet
+/// supported and will be enabled in a follow-up PR.
 #[derive(Debug, Clone)]
 pub struct NetworkConfig {
     /// Address to bind the UDP discovery socket to.
@@ -256,15 +260,21 @@ impl Node {
             (Some(ipv4), Some(_ipv6)) => IpAddr::from(ipv4),
         };
 
-        // both udp and tcp can be defined in the pairs or only one
-        // in the latter case, we have to default both ports to the one provided
+        // Both udp and tcp can be defined in the pairs or only one;
+        // in the latter case, we default both ports to the one provided.
+        // For IPv6 nodes, ports may be stored under the `udp6`/`tcp6` keys
+        // instead of the IPv4 `udp`/`tcp` keys, so we fall back accordingly.
         let udp_port = pairs
             .udp_port
+            .or(pairs.udp6_port)
             .or(pairs.tcp_port)
+            .or(pairs.tcp6_port)
             .ok_or(NodeError::MissingField("No port found in record".into()))?;
         let tcp_port = pairs
             .tcp_port
+            .or(pairs.tcp6_port)
             .or(pairs.udp_port)
+            .or(pairs.udp6_port)
             .ok_or(NodeError::MissingField("No port found in record".into()))?;
 
         Ok(Self::new(ip, udp_port, tcp_port, public_key))

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -22,34 +22,46 @@ use thiserror::Error;
 use crate::utils::node_id;
 
 /// Holds the local node's network addressing configuration, separating the
-/// socket bind address from the externally-announced address.
+/// socket bind addresses from the externally-announced addresses, and
+/// separating the UDP discovery channel from the TCP RLPx channel.
 ///
-/// This is relevant for nodes running behind NAT: they bind to a private
-/// address (e.g. `0.0.0.0`) but must announce their public IP to peers.
+/// This supports two independent axes of configuration:
+/// - NAT traversal: bind to `0.0.0.0` but announce a public IP (`--nat.extip`).
+/// - Split transports: run UDP discovery on a different address than TCP RLPx
+///   (`--discovery.addr`), enabling e.g. IPv4 discv4 with IPv6 RLPx.
 #[derive(Debug, Clone)]
 pub struct NetworkConfig {
-    /// Address to bind UDP/TCP sockets to (e.g. `0.0.0.0` or `::`)
-    pub bind_addr: IpAddr,
+    /// Address to bind the UDP discovery socket to.
+    pub discovery_bind_addr: IpAddr,
+    /// IP address announced to peers via discv4 Ping/Pong and ENR.
+    pub discovery_external_addr: IpAddr,
+    /// Address to bind the TCP RLPx listener to.
+    pub rlpx_bind_addr: IpAddr,
+    /// IP address announced to peers for RLPx connections and ENR.
+    pub rlpx_external_addr: IpAddr,
     pub tcp_port: u16,
     pub udp_port: u16,
 }
 
 impl NetworkConfig {
-    /// Returns the socket address to bind the TCP listener to.
+    /// Returns the socket address to bind the TCP RLPx listener to.
     pub fn bind_tcp_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.bind_addr, self.tcp_port)
+        SocketAddr::new(self.rlpx_bind_addr, self.tcp_port)
     }
 
-    /// Returns the socket address to bind the UDP socket to.
+    /// Returns the socket address to bind the UDP discovery socket to.
     pub fn bind_udp_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.bind_addr, self.udp_port)
+        SocketAddr::new(self.discovery_bind_addr, self.udp_port)
     }
 
-    /// Builds a `NetworkConfig` where bind and external addresses are both
-    /// taken from `node`. Useful when no NAT mapping is needed.
+    /// Builds a `NetworkConfig` where all addresses are taken from `node`.
+    /// Useful for tests or when no NAT/split-transport mapping is needed.
     pub fn from_node(node: &Node) -> Self {
         Self {
-            bind_addr: node.ip,
+            discovery_bind_addr: node.ip,
+            discovery_external_addr: node.ip,
+            rlpx_bind_addr: node.ip,
+            rlpx_external_addr: node.ip,
             tcp_port: node.tcp_port,
             udp_port: node.udp_port,
         }
@@ -310,13 +322,16 @@ pub struct NodeRecordPairs {
     // I think the confusion comes from the fact that geth decodes the bytes and then builds an IPV4/6 big-integer structure.
     pub tcp_port: Option<u16>,
     pub udp_port: Option<u16>,
+    /// TCP port for IPv6 RLPx connections (ENR key `tcp6`).
+    pub tcp6_port: Option<u16>,
+    /// UDP port for IPv6 discovery (ENR key `udp6`).
+    pub udp6_port: Option<u16>,
     pub secp256k1: Option<H264>,
     // https://github.com/ethereum/devp2p/blob/master/enr-entries/eth.md
     pub eth: Option<ForkId>,
     // Snap entry is being used by some tests such as `test_encode_enr_response`.
     pub snap: Option<Vec<u32>>,
     pub other: Vec<(Bytes, Bytes)>,
-    // TODO implement ipv6 specific ports
 }
 
 impl NodeRecordPairs {
@@ -330,7 +345,9 @@ impl NodeRecordPairs {
                 b"ip" => decoded_pairs.ip = Some(Ipv4Addr::decode(&value)?),
                 b"ip6" => decoded_pairs.ip6 = Some(Ipv6Addr::decode(&value)?),
                 b"tcp" => decoded_pairs.tcp_port = Some(u16::decode(&value)?),
+                b"tcp6" => decoded_pairs.tcp6_port = Some(u16::decode(&value)?),
                 b"udp" => decoded_pairs.udp_port = Some(u16::decode(&value)?),
+                b"udp6" => decoded_pairs.udp6_port = Some(u16::decode(&value)?),
                 b"secp256k1" => decoded_pairs.secp256k1 = Some(H264(<[u8; 33]>::decode(&value)?)),
                 b"snap" => decoded_pairs.snap = Some(Vec::<u32>::decode(&value)?),
                 b"eth" => {
@@ -385,8 +402,14 @@ impl NodeRecordPairs {
         if let Some(tcp) = self.tcp_port {
             pairs.push(("tcp".into(), tcp.encode_to_vec().into()));
         }
+        if let Some(tcp6) = self.tcp6_port {
+            pairs.push(("tcp6".into(), tcp6.encode_to_vec().into()));
+        }
         if let Some(udp) = self.udp_port {
             pairs.push(("udp".into(), udp.encode_to_vec().into()));
+        }
+        if let Some(udp6) = self.udp6_port {
+            pairs.push(("udp6".into(), udp6.encode_to_vec().into()));
         }
         pairs.extend(self.other.clone());
         pairs.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -453,13 +453,19 @@ impl NodeRecord {
             secp256k1: Some(H264::from_slice(
                 &PublicKey::from_secret_key(secp256k1::SECP256K1, signer).serialize(),
             )),
-            tcp_port: Some(node.tcp_port),
-            udp_port: Some(node.udp_port),
             ..Default::default()
         };
         match node.ip.to_canonical() {
-            IpAddr::V4(ip) => pairs.ip = Some(ip),
-            IpAddr::V6(ip) => pairs.ip6 = Some(ip),
+            IpAddr::V4(ip) => {
+                pairs.ip = Some(ip);
+                pairs.tcp_port = Some(node.tcp_port);
+                pairs.udp_port = Some(node.udp_port);
+            }
+            IpAddr::V6(ip) => {
+                pairs.ip6 = Some(ip);
+                pairs.tcp6_port = Some(node.tcp_port);
+                pairs.udp6_port = Some(node.udp_port);
+            }
         }
 
         let mut record = NodeRecord {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -127,7 +127,7 @@ P2P options:
           [env: ETHREX_P2P_DISABLED=]
 
       --p2p.addr <ADDRESS>
-          The address to bind P2P sockets to. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
+          The address to bind the TCP RLPx socket to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
 
           [env: ETHREX_P2P_ADDR=]
 
@@ -360,7 +360,7 @@ P2P options:
           [env: ETHREX_P2P_DISABLED=]
 
       --p2p.addr <ADDRESS>
-          The address to bind P2P sockets to. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
+          The address to bind the TCP RLPx socket to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
 
           [env: ETHREX_P2P_ADDR=]
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -142,6 +142,11 @@ P2P options:
           [env: ETHREX_P2P_PORT=]
           [default: 30303]
 
+      --discovery.addr <ADDRESS>
+          The address to bind the discv4/discv5 UDP socket to. Defaults to --p2p.addr (or 0.0.0.0 if unset). Allows running discovery on a different interface than RLPx.
+
+          [env: ETHREX_P2P_DISCOVERY_ADDR=]
+
       --discovery.port <PORT>
           UDP port for P2P discovery.
 
@@ -369,6 +374,11 @@ P2P options:
 
           [env: ETHREX_P2P_PORT=]
           [default: 30303]
+
+      --discovery.addr <ADDRESS>
+          The address to bind the discv4/discv5 UDP socket to. Defaults to --p2p.addr (or 0.0.0.0 if unset). Allows running discovery on a different interface than RLPx.
+
+          [env: ETHREX_P2P_DISCOVERY_ADDR=]
 
       --discovery.port <PORT>
           UDP port for P2P discovery.

--- a/test/tests/p2p/discovery/discv5_messages_tests.rs
+++ b/test/tests/p2p/discovery/discv5_messages_tests.rs
@@ -9,13 +9,13 @@ use ethrex_p2p::discv5::{
     session::{build_challenge_data, create_id_signature, derive_session_keys},
 };
 use ethrex_p2p::rlpx::utils::compress_pubkey;
-use ethrex_p2p::types::{NodeRecord, NodeRecordPairs};
+use ethrex_p2p::types::{Node, NodeRecord, NodeRecordPairs};
 use ethrex_p2p::utils::{node_id, public_key_from_signing_key};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use hex_literal::hex;
 use secp256k1::SecretKey;
 use std::{
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
 };
 
@@ -657,4 +657,43 @@ fn ticket_packet_codec_roundtrip() {
 
     let buf = pkt.encode_to_vec();
     assert_eq!(TicketMessage::decode(&buf).unwrap(), pkt);
+}
+
+/// Verifies that an IPv6 node can round-trip through ENR encoding:
+/// Node → NodeRecord::from_node → pairs → Node::from_enr
+/// This locks in the `ip6`/`tcp6`/`udp6` ENR key handling.
+#[test]
+fn ipv6_enr_roundtrip() {
+    let signer = SecretKey::from_byte_array(&hex!(
+        "eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f"
+    ))
+    .unwrap();
+    let public_key = public_key_from_signing_key(&signer);
+
+    let ipv6_addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+    let node = Node::new(IpAddr::V6(ipv6_addr), 30303, 30303, public_key);
+
+    // Encode to ENR
+    let record = NodeRecord::from_node(&node, 1, &signer).unwrap();
+    let pairs = record.pairs();
+
+    // Verify IPv6-specific ENR keys are set, IPv4 keys are not
+    assert!(pairs.ip.is_none(), "IPv6 node should not set `ip` field");
+    assert_eq!(pairs.ip6, Some(ipv6_addr));
+    assert!(
+        pairs.tcp_port.is_none(),
+        "IPv6 node should not set `tcp` field"
+    );
+    assert!(
+        pairs.udp_port.is_none(),
+        "IPv6 node should not set `udp` field"
+    );
+    assert_eq!(pairs.tcp6_port, Some(30303));
+    assert_eq!(pairs.udp6_port, Some(30303));
+
+    // Decode back to Node
+    let decoded = Node::from_enr(&record).unwrap();
+    assert_eq!(decoded.ip, IpAddr::V6(ipv6_addr));
+    assert_eq!(decoded.tcp_port, 30303);
+    assert_eq!(decoded.udp_port, 30303);
 }

--- a/test/tests/p2p/discovery/discv5_messages_tests.rs
+++ b/test/tests/p2p/discovery/discv5_messages_tests.rs
@@ -357,6 +357,8 @@ fn encode_ping_handshake_packet_with_enr() {
             ip6: None,
             tcp_port: None,
             udp_port: None,
+            tcp6_port: None,
+            udp6_port: None,
             secp256k1: Some(H264::from_str(key).unwrap()),
             eth: None,
             snap: None,

--- a/test/tests/p2p/types_tests.rs
+++ b/test/tests/p2p/types_tests.rs
@@ -6,6 +6,7 @@ use ethrex_rlp::decode::RLPDecode;
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
+use std::net::IpAddr;
 use std::{net::SocketAddr, str::FromStr};
 
 const TEST_GENESIS: &str = include_str!("../../../fixtures/genesis/l1.json");
@@ -181,5 +182,45 @@ fn verify_enr_signature_fails_when_decode_drops_unknown_pairs() {
     );
     assert_eq!(decoded.pairs().tcp_port, Some(13000));
     assert_eq!(decoded.encode_to_vec(), raw_record);
+    assert!(decoded.verify_signature());
+}
+
+#[test]
+fn node_record_from_ipv6_node_uses_ip6_and_tcp6_udp6() {
+    let signer = SecretKey::from_slice(&[
+        16, 125, 177, 238, 167, 212, 168, 215, 239, 165, 77, 224, 199, 143, 55, 205, 9, 194, 87,
+        139, 92, 46, 30, 191, 74, 37, 68, 242, 38, 225, 104, 246,
+    ])
+    .unwrap();
+
+    let ipv6_addr: IpAddr = "2001:db8::1".parse().unwrap();
+    let node = Node::new(ipv6_addr, 30303, 30303, public_key_from_signing_key(&signer));
+    let record = NodeRecord::from_node(&node, 1, &signer).unwrap();
+    let pairs = record.pairs();
+
+    // IPv6 node must use ip6/tcp6/udp6 ENR keys, not ip/tcp/udp.
+    assert!(pairs.ip.is_none(), "IPv6 node should not set ip (v4) field");
+    assert!(
+        pairs.tcp_port.is_none(),
+        "IPv6 node should not set tcp (v4) field"
+    );
+    assert!(
+        pairs.udp_port.is_none(),
+        "IPv6 node should not set udp (v4) field"
+    );
+    assert!(pairs.ip6.is_some(), "IPv6 node must set ip6 field");
+    assert_eq!(pairs.tcp6_port, Some(30303));
+    assert_eq!(pairs.udp6_port, Some(30303));
+
+    // Round-trip: encode → decode → verify the same fields survive.
+    let encoded = record.encode_to_vec();
+    let decoded = NodeRecord::decode(&encoded).unwrap();
+    let decoded_pairs = decoded.pairs();
+    assert_eq!(decoded_pairs.ip6, pairs.ip6);
+    assert_eq!(decoded_pairs.tcp6_port, Some(30303));
+    assert_eq!(decoded_pairs.udp6_port, Some(30303));
+    assert!(decoded_pairs.ip.is_none());
+    assert!(decoded_pairs.tcp_port.is_none());
+    assert!(decoded_pairs.udp_port.is_none());
     assert!(decoded.verify_signature());
 }


### PR DESCRIPTION
Closes #5424

## Summary

- Extends `NetworkConfig` with four address fields instead of two: `discovery_bind_addr`, `discovery_external_addr`, `rlpx_bind_addr`, `rlpx_external_addr`
- Adds `--discovery.addr` CLI flag (env: `ETHREX_P2P_DISCOVERY_ADDR`) to bind the UDP discovery socket independently of the RLPx TCP socket
- `discv4` and `discv5` servers now receive a `discovery_local_node` built from `discovery_external_addr`, so their Ping `from` endpoints advertise the correct address
- Implements `tcp6`/`udp6` ENR field parsing in `NodeRecordPairs` (removes the TODO)
- `NodeRecord::from_node()` now emits `ip6`/`tcp6`/`udp6` for IPv6 node addresses instead of incorrectly encoding them under the IPv4 `ip`/`tcp`/`udp` keys

## Address resolution logic

| `--discovery.addr` set? | Result |
|---|---|
| No | `discovery_bind_addr` = `rlpx_bind_addr`; `discovery_external_addr` = `rlpx_external_addr` |
| Yes, specific IP | `discovery_bind_addr` = given IP; `discovery_external_addr` = given IP |
| Yes, `0.0.0.0`/`::` | `discovery_bind_addr` = given wildcard; `discovery_external_addr` = `rlpx_external_addr` |

## Part of

This is PR 2 of 3 for IPv6 support (#5354):
- PR 1: decouple bind vs. external address (#5425) ← base branch
- **PR 2 (this):** decouple discv4 address from RLPx address (#5424)
- PR 3: ENR-based outbound connections + dual-stack listeners (#5354)