### PR TITLE
feat(l1): dual-stack IPv6 support and ENR-based outbound connections

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -298,12 +298,18 @@ pub struct Options {
     #[arg(
         long = "p2p.addr",
         value_name = "ADDRESS",
-        help = "Bind address for the TCP RLPx socket. Also used as the default bind address for UDP discovery unless --discovery.addr is set.",
-        long_help = "The address to bind the TCP RLPx socket to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.",
+        value_delimiter = ',',
+        num_args = 0..,
+        help = "Bind address(es) for the TCP RLPx transport. Also used as the default bind address for UDP discovery unless --discovery.addr is set.",
+        long_help = "One or two comma-separated addresses to bind RLPx TCP listeners to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. \
+            Supply a single IPv4 address for IPv4-only, a single IPv6 address for IPv6-only, \
+            or both (e.g. 0.0.0.0,::) for dual-stack. \
+            Defaults to the auto-detected local IP. \
+            See also --nat.extip to announce a different external address.",
         help_heading = "P2P options",
         env = "ETHREX_P2P_ADDR"
     )]
-    pub p2p_addr: Option<String>,
+    pub p2p_addr: Vec<String>,
     #[arg(
         long = "nat.extip",
         value_name = "IP",
@@ -481,7 +487,7 @@ impl Default for Options {
             authrpc_port: Default::default(),
             authrpc_jwtsecret: Default::default(),
             p2p_disabled: Default::default(),
-            p2p_addr: None,
+            p2p_addr: vec![],
             nat_extip: None,
             p2p_port: Default::default(),
             discovery_addr: None,

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -33,7 +33,7 @@ use std::env;
 use std::{
     fs,
     io::IsTerminal,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -446,47 +446,91 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
 
     let local_public_key = public_key_from_signing_key(signer);
 
-    let (rlpx_bind_addr, rlpx_external_addr) = resolve_p2p_endpoints(
-        opts.p2p_addr.as_deref(),
-        opts.nat_extip.as_deref(),
-        local_ip().ok(),
-        local_ipv6().ok(),
-    );
+    // Parse --p2p.addr into bind addresses. Supports one or two comma-separated
+    // entries (e.g. "0.0.0.0,::") for dual-stack operation.
+    let nat_extip: Option<IpAddr> = opts
+        .nat_extip
+        .as_deref()
+        .map(|s| s.parse().expect("Failed to parse --nat.extip address"));
+
+    let rlpx_bind_addrs: Vec<IpAddr> = if opts.p2p_addr.is_empty() {
+        // No explicit bind address — default to one entry.
+        // Match address family to --nat.extip when set.
+        let bind = match nat_extip {
+            Some(ext) if ext.is_ipv6() => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+            Some(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            None => local_ip().unwrap_or_else(|_| {
+                local_ipv6().expect("Neither ipv4 nor ipv6 local address found")
+            }),
+        };
+        vec![bind]
+    } else {
+        opts.p2p_addr
+            .iter()
+            .map(|a| a.parse().expect("Failed to parse --p2p.addr address"))
+            .collect()
+    };
+
+    // For each bind address derive the external (announced) address.
+    let rlpx_external_addrs: Vec<IpAddr> = rlpx_bind_addrs
+        .iter()
+        .map(|bind| {
+            if !bind.is_unspecified() {
+                // Specific bind address — announce as-is, unless --nat.extip matches family.
+                nat_extip
+                    .filter(|e| e.is_ipv4() == bind.is_ipv4())
+                    .unwrap_or(*bind)
+            } else {
+                // Wildcard — auto-detect or use --nat.extip for matching family.
+                nat_extip
+                    .filter(|e| e.is_ipv4() == bind.is_ipv4())
+                    .unwrap_or_else(|| {
+                        if bind.is_ipv4() {
+                            local_ip().unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
+                        } else {
+                            local_ipv6().unwrap_or(IpAddr::V6(Ipv6Addr::UNSPECIFIED))
+                        }
+                    })
+            }
+        })
+        .collect();
 
     // Determine discovery bind address.
     // --discovery.addr sets the UDP bind addr independently of RLPx.
-    // Defaults to rlpx_bind_addr so the two channels co-locate by default.
+    // Defaults to the first RLPx bind addr so the two channels co-locate.
+    let default_discovery_bind = rlpx_bind_addrs
+        .first()
+        .copied()
+        .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
     let discovery_bind_addr: IpAddr = opts
         .discovery_addr
         .as_deref()
-        .map(|a| {
-            let addr: IpAddr = a.parse().expect("Failed to parse --discovery.addr address");
-            assert!(
-                addr.is_ipv4() == rlpx_external_addr.is_ipv4(),
-                "--discovery.addr and external address must use the same address family (both IPv4 or both IPv6)"
-            );
-            addr
-        })
-        .unwrap_or(rlpx_bind_addr);
+        .map(|a| a.parse().expect("Failed to parse --discovery.addr address"))
+        .unwrap_or(default_discovery_bind);
 
-    // Discovery external address: always use rlpx_external_addr (which is
-    // --nat.extip when set) so the announced address reflects what peers see.
-    // Only fall back to the discovery bind addr when no NAT external IP is
-    // configured and the bind addr is a specific (non-wildcard) IP.
-    let discovery_external_addr = if opts.nat_extip.is_some() {
-        rlpx_external_addr
-    } else if !discovery_bind_addr.is_unspecified() {
+    // Discovery external address: use the explicit discovery bind addr when it
+    // is a specific (non-wildcard) IP; otherwise fall back to primary RLPx external addr.
+    let discovery_external_addr = if !discovery_bind_addr.is_unspecified() {
         discovery_bind_addr
     } else {
-        rlpx_external_addr
+        rlpx_external_addrs
+            .first()
+            .copied()
+            .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     };
 
-    let node = Node::new(rlpx_external_addr, udp_port, tcp_port, local_public_key);
+    // Primary external address for the enode URL (first in the list).
+    let primary_external_addr = rlpx_external_addrs
+        .first()
+        .copied()
+        .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
+    let node = Node::new(primary_external_addr, udp_port, tcp_port, local_public_key);
     let network_config = NetworkConfig {
         discovery_bind_addr,
         discovery_external_addr,
-        rlpx_bind_addr,
-        rlpx_external_addr,
+        rlpx_bind_addrs,
+        rlpx_external_addrs,
         tcp_port,
         udp_port,
     };
@@ -501,21 +545,21 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
 
 pub fn get_local_node_record(
     datadir: &Path,
-    local_p2p_node: &Node,
+    network_config: &NetworkConfig,
     signer: &SecretKey,
 ) -> NodeRecord {
     match read_node_config_file(datadir) {
         Ok(Some(ref mut config)) => {
-            NodeRecord::from_node(local_p2p_node, config.node_record.seq + 1, signer)
-                .expect("Node record could not be created from local node")
+            NodeRecord::from_network_config(network_config, config.node_record.seq + 1, signer)
+                .expect("Node record could not be created from network config")
         }
         _ => {
             let timestamp = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            NodeRecord::from_node(local_p2p_node, timestamp, signer)
-                .expect("Node record could not be created from local node")
+            NodeRecord::from_network_config(network_config, timestamp, signer)
+                .expect("Node record could not be created from network config")
         }
     }
 }
@@ -617,7 +661,7 @@ pub async fn init_l1(
 
     let (local_p2p_node, network_config) = get_local_p2p_node(&opts, &signer);
 
-    let local_node_record = get_local_node_record(&datadir, &local_p2p_node, &signer);
+    let local_node_record = get_local_node_record(&datadir, &network_config, &signer);
 
     let peer_table =
         PeerTableServer::spawn(local_p2p_node.node_id(), opts.target_peers, store.clone());

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -241,7 +241,7 @@ pub async fn init_l2(
 
     let (local_p2p_node, network_config) = get_local_p2p_node(&opts.node_opts, &signer);
 
-    let local_node_record = get_local_node_record(&datadir, &local_p2p_node, &signer);
+    let local_node_record = get_local_node_record(&datadir, &network_config, &signer);
 
     // TODO: Check every module starts properly.
     let tracker = TaskTracker::new();

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -148,13 +148,18 @@ pub async fn start_network(
         error!("Failed to start discovery server: {e}");
     })?;
 
-    context.tracker.spawn(serve_p2p_requests(context.clone()));
+    // Spawn one TCP listener per RLPx bind address. A dual-stack node will
+    // have two entries here (e.g. 0.0.0.0:30303 and [::]:30303).
+    for tcp_addr in context.network_config.bind_tcp_addrs() {
+        context
+            .tracker
+            .spawn(serve_p2p_requests(context.clone(), tcp_addr));
+    }
 
     Ok(())
 }
 
-pub(crate) async fn serve_p2p_requests(context: P2PContext) {
-    let tcp_addr = context.network_config.bind_tcp_addr();
+pub(crate) async fn serve_p2p_requests(context: P2PContext, tcp_addr: SocketAddr) {
     let external_tcp_addr = context.local_node.tcp_addr();
     let listener = match listener(tcp_addr) {
         Ok(result) => result,

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -231,13 +231,19 @@ impl Contact {
         self.enr_request_hash = Some(request_hash);
     }
 
-    // If hash does not match, ignore. Otherwise, reset enr_request_hash
+    // If hash does not match, ignore. Otherwise, reset enr_request_hash and
+    // refresh the node's TCP connection address from the ENR so that the
+    // RLPx initiator can reach the peer (including IPv6-only peers).
     pub fn record_enr_response_received(&mut self, request_hash: H256, record: NodeRecord) {
         if self
             .enr_request_hash
             .take_if(|h| *h == request_hash)
             .is_some()
         {
+            if let Some((ip, tcp_port)) = record.decode_pairs().connection_addr() {
+                self.node.ip = ip;
+                self.node.tcp_port = tcp_port;
+            }
             self.record = Some(record);
         }
     }

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -550,27 +550,23 @@ impl NodeRecord {
                     record
                         .pairs
                         .push(("ip".into(), ipv4.encode_to_vec().into()));
-                    record.pairs.push((
-                        "tcp".into(),
-                        network_config.tcp_port.encode_to_vec().into(),
-                    ));
-                    record.pairs.push((
-                        "udp".into(),
-                        network_config.udp_port.encode_to_vec().into(),
-                    ));
+                    record
+                        .pairs
+                        .push(("tcp".into(), network_config.tcp_port.encode_to_vec().into()));
+                    record
+                        .pairs
+                        .push(("udp".into(), network_config.udp_port.encode_to_vec().into()));
                 }
                 IpAddr::V6(ipv6) => {
                     record
                         .pairs
                         .push(("ip6".into(), ipv6.encode_to_vec().into()));
-                    record.pairs.push((
-                        "tcp6".into(),
-                        network_config.tcp_port.encode_to_vec().into(),
-                    ));
-                    record.pairs.push((
-                        "udp6".into(),
-                        network_config.udp_port.encode_to_vec().into(),
-                    ));
+                    record
+                        .pairs
+                        .push(("tcp6".into(), network_config.tcp_port.encode_to_vec().into()));
+                    record
+                        .pairs
+                        .push(("udp6".into(), network_config.udp_port.encode_to_vec().into()));
                 }
             }
         }

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -39,23 +39,38 @@ pub struct NetworkConfig {
     pub discovery_bind_addr: IpAddr,
     /// IP address announced to peers via discv4 Ping/Pong and ENR.
     pub discovery_external_addr: IpAddr,
-    /// Address to bind the TCP RLPx listener to.
-    pub rlpx_bind_addr: IpAddr,
-    /// IP address announced to peers for RLPx connections and ENR.
-    pub rlpx_external_addr: IpAddr,
+    /// Addresses to bind TCP RLPx listeners to. One entry per IP family for
+    /// dual-stack (e.g. `[0.0.0.0, ::]`); single entry for single-stack.
+    pub rlpx_bind_addrs: Vec<IpAddr>,
+    /// IP addresses announced to peers for RLPx connections and ENR.
+    /// Mirrors `rlpx_bind_addrs` but holds the externally-reachable IPs
+    /// (relevant behind NAT or for specific interface binding).
+    pub rlpx_external_addrs: Vec<IpAddr>,
     pub tcp_port: u16,
     pub udp_port: u16,
 }
 
 impl NetworkConfig {
-    /// Returns the socket address to bind the TCP RLPx listener to.
-    pub fn bind_tcp_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.rlpx_bind_addr, self.tcp_port)
+    /// Returns one socket address per RLPx bind address to listen on.
+    pub fn bind_tcp_addrs(&self) -> Vec<SocketAddr> {
+        self.rlpx_bind_addrs
+            .iter()
+            .map(|ip| SocketAddr::new(*ip, self.tcp_port))
+            .collect()
     }
 
     /// Returns the socket address to bind the UDP discovery socket to.
     pub fn bind_udp_addr(&self) -> SocketAddr {
         SocketAddr::new(self.discovery_bind_addr, self.udp_port)
+    }
+
+    /// Returns the primary external RLPx address (first entry). Used for
+    /// single-stack code paths and enode URL construction.
+    pub fn primary_rlpx_external_addr(&self) -> IpAddr {
+        self.rlpx_external_addrs
+            .first()
+            .copied()
+            .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     }
 
     /// Builds a `NetworkConfig` where all addresses are taken from `node`.
@@ -64,8 +79,8 @@ impl NetworkConfig {
         Self {
             discovery_bind_addr: node.ip,
             discovery_external_addr: node.ip,
-            rlpx_bind_addr: node.ip,
-            rlpx_external_addr: node.ip,
+            rlpx_bind_addrs: vec![node.ip],
+            rlpx_external_addrs: vec![node.ip],
             tcp_port: node.tcp_port,
             udp_port: node.udp_port,
         }
@@ -345,6 +360,19 @@ pub struct NodeRecordPairs {
 }
 
 impl NodeRecordPairs {
+    /// Returns the best TCP connection address for this peer, preferring IPv4
+    /// over IPv6. Returns `None` if neither `ip`+`tcp` nor `ip6`+`tcp6` are
+    /// present in the ENR.
+    pub fn connection_addr(&self) -> Option<(IpAddr, u16)> {
+        if let (Some(ip), Some(port)) = (self.ip, self.tcp_port) {
+            return Some((IpAddr::V4(ip), port));
+        }
+        if let (Some(ip6), Some(port)) = (self.ip6, self.tcp6_port) {
+            return Some((IpAddr::V6(ip6), port));
+        }
+        None
+    }
+
     pub fn try_from_raw_pairs(
         pairs: Vec<(Bytes, Bytes)>,
     ) -> Result<NodeRecordPairs, RLPDecodeError> {
@@ -483,6 +511,75 @@ impl NodeRecord {
             pairs,
             ..Default::default()
         };
+        record.signature = record.sign_record(signer)?;
+
+        Ok(record)
+    }
+
+    /// Builds a dual-stack ENR from a [`NetworkConfig`].
+    ///
+    /// For every address in `network_config.rlpx_external_addrs`:
+    /// - An IPv4 address contributes `ip` / `tcp` / `udp` ENR pairs.
+    /// - An IPv6 address contributes `ip6` / `tcp6` / `udp6` ENR pairs.
+    ///
+    /// If both families are present the resulting record advertises both,
+    /// allowing peers to reach the node over whichever family they support.
+    pub fn from_network_config(
+        network_config: &NetworkConfig,
+        seq: u64,
+        signer: &SecretKey,
+    ) -> Result<Self, NodeError> {
+        let mut record = NodeRecord {
+            seq,
+            ..Default::default()
+        };
+        record
+            .pairs
+            .push(("id".into(), "v4".encode_to_vec().into()));
+        record.pairs.push((
+            "secp256k1".into(),
+            PublicKey::from_secret_key(secp256k1::SECP256K1, signer)
+                .serialize()
+                .encode_to_vec()
+                .into(),
+        ));
+
+        for addr in &network_config.rlpx_external_addrs {
+            match addr {
+                IpAddr::V4(ipv4) => {
+                    record
+                        .pairs
+                        .push(("ip".into(), ipv4.encode_to_vec().into()));
+                    record.pairs.push((
+                        "tcp".into(),
+                        network_config.tcp_port.encode_to_vec().into(),
+                    ));
+                    record.pairs.push((
+                        "udp".into(),
+                        network_config.udp_port.encode_to_vec().into(),
+                    ));
+                }
+                IpAddr::V6(ipv6) => {
+                    record
+                        .pairs
+                        .push(("ip6".into(), ipv6.encode_to_vec().into()));
+                    record.pairs.push((
+                        "tcp6".into(),
+                        network_config.tcp_port.encode_to_vec().into(),
+                    ));
+                    record.pairs.push((
+                        "udp6".into(),
+                        network_config.udp_port.encode_to_vec().into(),
+                    ));
+                }
+            }
+        }
+
+        // ENR pairs must be sorted by key and unique; deduplicate in case
+        // both families map to the same family (e.g. two IPv4 addrs).
+        record.pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        record.pairs.dedup_by(|a, b| a.0 == b.0);
+
         record.signature = record.sign_record(signer)?;
 
         Ok(record)

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -561,12 +561,14 @@ impl NodeRecord {
                     record
                         .pairs
                         .push(("ip6".into(), ipv6.encode_to_vec().into()));
-                    record
-                        .pairs
-                        .push(("tcp6".into(), network_config.tcp_port.encode_to_vec().into()));
-                    record
-                        .pairs
-                        .push(("udp6".into(), network_config.udp_port.encode_to_vec().into()));
+                    record.pairs.push((
+                        "tcp6".into(),
+                        network_config.tcp_port.encode_to_vec().into(),
+                    ));
+                    record.pairs.push((
+                        "udp6".into(),
+                        network_config.udp_port.encode_to_vec().into(),
+                    ));
                 }
             }
         }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -126,8 +126,8 @@ P2P options:
       --p2p.disabled
           [env: ETHREX_P2P_DISABLED=]
 
-      --p2p.addr <ADDRESS>
-          The address to bind the TCP RLPx socket to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
+      --p2p.addr [<ADDRESS>...]
+          One or two comma-separated addresses to bind RLPx TCP listeners to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Supply a single IPv4 address for IPv4-only, a single IPv6 address for IPv6-only, or both (e.g. 0.0.0.0,::) for dual-stack. Defaults to the auto-detected local IP. See also --nat.extip to announce a different external address.
 
           [env: ETHREX_P2P_ADDR=]
 
@@ -359,8 +359,8 @@ P2P options:
 
           [env: ETHREX_P2P_DISABLED=]
 
-      --p2p.addr <ADDRESS>
-          The address to bind the TCP RLPx socket to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
+      --p2p.addr [<ADDRESS>...]
+          One or two comma-separated addresses to bind RLPx TCP listeners to. Also used as the default bind address for UDP discovery unless --discovery.addr is set. Supply a single IPv4 address for IPv4-only, a single IPv6 address for IPv6-only, or both (e.g. 0.0.0.0,::) for dual-stack. Defaults to the auto-detected local IP. See also --nat.extip to announce a different external address.
 
           [env: ETHREX_P2P_ADDR=]
 


### PR DESCRIPTION
Closes #5354

## Summary

- **Dual-stack RLPx listeners**: `--p2p.addr` now accepts a comma-separated list (e.g. `--p2p.addr 0.0.0.0,::`) and `start_network()` spawns one TCP listener per entry.
- **Dual-stack ENR advertisement**: `NodeRecord::from_network_config()` emits both `ip`/`tcp`/`udp` (IPv4) and `ip6`/`tcp6`/`udp6` (IPv6) ENR pairs when both families are configured.
- **ENR-based outbound connections**: `Contact::record_enr_response_received()` now updates `node.ip` and `node.tcp_port` from the received ENR, so the RLPx initiator can connect to IPv6-only peers.
- **`NodeRecordPairs::connection_addr()`**: helper that picks the best TCP address from an ENR (IPv4 preferred, IPv6 fallback).
- **`NetworkConfig` refactor**: `rlpx_bind_addr`/`rlpx_external_addr` (scalar) replaced by `rlpx_bind_addrs`/`rlpx_external_addrs` (`Vec<IpAddr>`).

## Depends on

- #5424 (decouples discv4 address from RLPx address)
- #5425 (decouples bind address from external address)

## Test plan

- [ ] `cargo check` passes (verified locally)
- [ ] Single-stack IPv4 default: `--p2p.addr 0.0.0.0` behaves identically to before
- [ ] Dual-stack: `--p2p.addr 0.0.0.0,::` binds two listeners
- [ ] NAT: `--p2p.addr 0.0.0.0 --nat.extip <pub_ip>` still announces correct external address
- [ ] ENR from an IPv6-only peer updates `contact.node.ip` so outbound connection uses IPv6