### PR TITLE
feat(l2): add --watcher.start-l1-block to skip old L1 blocks on restart

### DIFF
--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -201,6 +201,7 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
                 check_interval_ms: opts.watcher_opts.watch_interval_ms,
                 max_block_step: opts.watcher_opts.max_block_step.into(),
                 watcher_block_delay: opts.watcher_opts.watcher_block_delay,
+                start_l1_block: opts.watcher_opts.start_l1_block,
                 l1_blob_base_fee_update_interval: opts.watcher_opts.l1_fee_update_interval_ms,
                 l2_rpc_urls: opts.watcher_opts.l2_rpc_urls.unwrap_or_default(),
                 l2_chain_ids: opts.watcher_opts.l2_chain_ids.unwrap_or_default(),
@@ -420,6 +421,15 @@ pub struct WatcherOptions {
     )]
     pub watcher_block_delay: u64,
     #[arg(
+        long = "watcher.start-l1-block",
+        value_name = "UINT64",
+        env = "ETHREX_WATCHER_START_L1_BLOCK",
+        help = "L1 block number to start scanning from, skipping older blocks. \
+                Useful when restarting a node to avoid re-scanning from the contract deployment block.",
+        help_heading = "L1 Watcher options"
+    )]
+    pub start_l1_block: Option<u64>,
+    #[arg(
         long = "watcher.l1-fee-update-interval-ms",
         value_name = "ADDRESS",
         default_value = "60000",
@@ -457,6 +467,7 @@ impl Default for WatcherOptions {
             watch_interval_ms: 1000,
             max_block_step: 5000,
             watcher_block_delay: 0,
+            start_l1_block: None,
             l1_fee_update_interval_ms: 60000,
             router_address: None,
             l2_rpc_urls: None,

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -60,6 +60,10 @@ pub struct L1WatcherConfig {
     pub check_interval_ms: u64,
     pub max_block_step: U256,
     pub watcher_block_delay: u64,
+    /// Starting L1 block number for the watcher.
+    /// When set, the watcher starts scanning from this block instead of
+    /// the contract deployment block, avoiding long catch-up times on restart.
+    pub start_l1_block: Option<u64>,
     pub l1_blob_base_fee_update_interval: u64,
     pub l2_rpc_urls: Vec<Url>,
     pub l2_chain_ids: Vec<u64>,

--- a/crates/l2/sequencer/l1_watcher.rs
+++ b/crates/l2/sequencer/l1_watcher.rs
@@ -110,7 +110,13 @@ impl L1Watcher {
                 chain_id,
             });
         }
-        let last_block_fetched = U256::zero();
+        let last_block_fetched = match watcher_config.start_l1_block {
+            Some(block) => {
+                info!("L1 Watcher starting from configured block {block}");
+                U256::from(block)
+            }
+            None => U256::zero(),
+        };
         let chain_id_topic = {
             let u256 = U256::from(store.get_chain_config().chain_id);
             let bytes = u256.to_big_endian();


### PR DESCRIPTION
**Motivation**

When restarting a node that has been running for several months, the L1 watcher starts scanning from the block where the bridge contract was deployed. This means it re-scans all historical L1 blocks, which can take 3+ hours before the node catches up.

**Description**

Add a `--watcher.start-l1-block` CLI option (also configurable via `ETHREX_WATCHER_START_L1_BLOCK` env var) that lets operators specify an L1 block number to start scanning from, skipping older blocks. When set, the watcher uses this value instead of querying the bridge contract's `lastFetchedL1Block()`.

This is useful for node operators restarting nodes that have already processed all historical deposits — they can set the start block to a recent L1 block and avoid the multi-hour catch-up.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — N/A, no storage changes