### PR TITLE
chore(l1): bump CL clients, Kurtosis, and pin all GH Actions

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -87,25 +87,25 @@ runs:
 
     - name: Login to DockerHub (for rate limiting)
       if: inputs.dockerhub_username != '' && inputs.dockerhub_password != ''
-      uses: docker/login-action@v3
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}
 
     - name: Login to ghcr.io (for cache)
       if: inputs.username != '' && inputs.password != '' && inputs.cache_write == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
         registry: ghcr.io
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - id: build-image
       name: Build Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         context: .
         file: ./Dockerfile

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -18,7 +18,7 @@ runs:
         echo "Rust version: ${rust_version}"
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
       with:
         toolchain: ${{ steps.rustver.outputs.rust_version }}
         components: ${{ inputs.components }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,5 +24,5 @@ runs:
         components: ${{ inputs.components }}
 
     - name: Add Rust Cache
-      uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,5 +24,5 @@ runs:
         components: ${{ inputs.components }}
 
     - name: Add Rust Cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
 

--- a/.github/actions/snapsync-run/action.yml
+++ b/.github/actions/snapsync-run/action.yml
@@ -30,12 +30,12 @@ inputs:
   cl_image:
     description: Consensus layer Docker image and tag.
     required: false
-    default: sigp/lighthouse:v8.0.1
+    default: sigp/lighthouse:v8.1.3
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     # We need to run this step because kurtosis uses cached docker images but we want the latest ethrex image
     - name: Remove cached ethrex image
@@ -101,10 +101,10 @@ runs:
         fi
 
     - name: Run assertoor
-      uses: ethpandaops/kurtosis-assertoor-github-action@v1
+      uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
       with:
         enclave_name: ethrex-assertoor-${{ inputs.network }}-${{ inputs.cl_type }}
-        kurtosis_version: 1.15.2
+        kurtosis_version: 1.17.7
         ethereum_package_url: github.com/ethpandaops/ethereum-package
         ethereum_package_branch: 82e5a7178138d892c0c31c3839c89d53ffd42d9a
         ethereum_package_args: .github/config/assertoor/network_params.generated.yaml

--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -2,13 +2,13 @@ participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.16.1
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
     count: 2
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
 
 additional_services:

--- a/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
+++ b/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
@@ -2,19 +2,19 @@ participants:
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: teku
-    cl_image: consensys/teku:25.6.0
+    cl_image: consensys/teku:26.3.0
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: prysm
-    cl_image: gcr.io/offchainlabs/prysm/beacon-chain:v6.0.4
+    cl_image: gcr.io/offchainlabs/prysm/beacon-chain:v7.1.3
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
 

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -2,12 +2,12 @@ participants:
   - el_type: geth
     el_image: ethereum/client-go:v1.16.1
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
 
 additional_services:

--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -44,11 +44,11 @@ jobs:
           fi
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Collect failed job names
         id: failed_jobs
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -100,13 +100,13 @@ jobs:
 
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Set custom args defined in Dockerfile to pin execution-spec-tests versions
       # See: https://github.com/ethereum/hive/blob/c2dab60f898b94afe8eeac505f60dcde59205e77/simulators/ethereum/eest/consume-rlp/Dockerfile#L4-L8
@@ -143,14 +143,14 @@ jobs:
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run Hive Simulation
         id: run-hive-action
-        uses: ethpandaops/hive-github-action@v0.5.0
+        uses: ethpandaops/hive-github-action@1aa8d73dad34de13afbb3113ab16c1a462d2fbc3 # v0.5.0
         continue-on-error: true
         with:
           simulator: ${{ matrix.test.simulation }}
@@ -168,13 +168,13 @@ jobs:
       artifact_name: results_daily.md
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Download all results
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: hive/workspace/logs
           pattern: "*_daily-results.zip"
@@ -217,7 +217,7 @@ jobs:
         run: cargo run --manifest-path tooling/Cargo.toml -p hive_report > results.md
 
       - name: Upload daily result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: results_daily.md
           path: |
@@ -236,10 +236,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download hive results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.hive-report.outputs.artifact_name }}
 

--- a/.github/workflows/daily_loc_report.yaml
+++ b/.github/workflows/daily_loc_report.yaml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Restore cache
         id: cache-loc-report
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: tooling/loc/loc_report.json
           key: loc-report-${{ github.ref_name }}-${{ github.run_id }}
@@ -52,7 +52,7 @@ jobs:
           cd tooling/loc && make loc
 
       - name: Tailscale
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
         with:
           oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: Save new loc_report.json to cache
         if: success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: tooling/loc/loc_report.json
           key: loc-report-${{ github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -86,7 +86,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set start timestamp
         id: start
@@ -106,7 +106,7 @@ jobs:
           network: ${{ matrix.network }}
           timeout: ${{ matrix.timeout }}
           cl_type: lighthouse
-          cl_image: "sigp/lighthouse:v8.0.1"
+          cl_image: "sigp/lighthouse:v8.1.3"
           build_local: "true"
           build_profile: ${{ needs.prepare.outputs.build_profile }}
 
@@ -133,7 +133,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set start timestamp
         id: start
@@ -153,7 +153,7 @@ jobs:
           network: ${{ matrix.network }}
           timeout: ${{ matrix.timeout }}
           cl_type: prysm
-          cl_image: "gcr.io/offchainlabs/prysm/beacon-chain:v7.1.0"
+          cl_image: "gcr.io/offchainlabs/prysm/beacon-chain:v7.1.3"
           build_local: "true"
           build_profile: ${{ needs.prepare.outputs.build_profile }}
 

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: gpu
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set up Docker Buildx
         # if: ${{ always() && github.event_name == 'merge_group' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       # This step is needed because of an state bug in the GPU runner.
       # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.

--- a/.github/workflows/manual_docker_performance_publish.yaml
+++ b/.github/workflows/manual_docker_performance_publish.yaml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -27,8 +27,8 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -109,7 +109,7 @@ jobs:
         runner: [ubuntu-22.04, ubuntu-22.04-arm, macos-15]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -132,7 +132,7 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -149,7 +149,7 @@ jobs:
           variant: l1
           cache_write: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
@@ -175,10 +175,10 @@ jobs:
           #   ethereum_package_args: "./.github/config/assertoor/network_params_ethrex_multiple_cl.yaml"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download etherex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image
           path: /tmp
@@ -188,10 +188,10 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Run assertoor
-        uses: ethpandaops/kurtosis-assertoor-github-action@v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
         with:
           enclave_name: ${{ matrix.enclave_name }}
-          kurtosis_version: "1.15.2"
+          kurtosis_version: "1.17.7"
           ethereum_package_url: "github.com/ethpandaops/ethereum-package"
           ethereum_package_branch: "82e5a7178138d892c0c31c3839c89d53ffd42d9a"
           ethereum_package_args: ${{ matrix.ethereum_package_args }}
@@ -248,10 +248,10 @@ jobs:
           #   artifact_prefix: sync
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image
           path: /tmp
@@ -289,14 +289,14 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Run Hive Simulation
         id: run-hive-action
-        uses: ethpandaops/hive-github-action@v0.5.0
+        uses: ethpandaops/hive-github-action@1aa8d73dad34de13afbb3113ab16c1a462d2fbc3 # v0.5.0
         with:
           hive_repository: ethereum/hive
           hive_version: 88786d9744dabb08bdaec8d8b53142cde6e6b79a
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload Hive Failure Logs
         if: ${{ failure() && steps.verify-hive-results.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: hive_failed_logs_${{ matrix.artifact_prefix }}
           path: src/results/failed_logs
@@ -342,7 +342,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -380,7 +380,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk

--- a/.github/workflows/pr-main_l1_l2_dev.yaml
+++ b/.github/workflows/pr-main_l1_l2_dev.yaml
@@ -27,8 +27,8 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -28,8 +28,8 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -79,7 +79,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -123,7 +123,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
@@ -140,10 +140,10 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build L1 docker image
         uses: ./.github/actions/build-docker
@@ -158,7 +158,7 @@ jobs:
           cache_write: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
@@ -172,10 +172,10 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build L2 docker image
         uses: ./.github/actions/build-docker
@@ -192,7 +192,7 @@ jobs:
           cache_write: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ethrex_image_l2
           path: /tmp/ethrex_image_l2.tar
@@ -205,7 +205,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -214,7 +214,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
 
@@ -337,7 +337,7 @@ jobs:
             compose_targets: [docker-compose.yaml]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -361,7 +361,7 @@ jobs:
           docker compose -f ${{ join(matrix.compose_targets, ' -f ') }} up --detach web3signer
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image
           path: /tmp
@@ -371,7 +371,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image_l2
           path: /tmp
@@ -497,7 +497,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -509,7 +509,7 @@ jobs:
         uses: ./.github/actions/install-solc
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image
           path: /tmp
@@ -519,7 +519,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image_l2
           path: /tmp
@@ -529,7 +529,7 @@ jobs:
           docker load --input /tmp/ethrex_image_l2.tar
 
       - name: Set up Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
 
       - name: Set up QEMU
         run: |
@@ -632,12 +632,12 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image
           path: /tmp
@@ -647,7 +647,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image_l2
           path: /tmp
@@ -699,7 +699,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -723,7 +723,7 @@ jobs:
           cargo test -p ethrex-test l2:: --no-run --release
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image
           path: /tmp
@@ -733,7 +733,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex_image_l2
           path: /tmp

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -25,8 +25,8 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -49,13 +49,13 @@ jobs:
         backend: ["sp1", "risc0", "zisk"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
 
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
 
       - name: Install RISC0
         if: matrix.backend == 'risc0'
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
 
       - name: Check exec
         run: |
@@ -122,9 +122,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
       - name: Check tdx
         run: |
           cd crates/l2/tee/quote-gen

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/free-disk
 
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install RISC0
         if: matrix.backend == 'risc0'
@@ -106,7 +106,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check exec
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Add Rust Cache
-        uses: Swatinem/rust-cache@98c8021b550208e191a6d4e3c1210774756feab5 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Check tdx
         run: |
           cd crates/l2/tee/quote-gen

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -24,8 +24,8 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@51f3067b56fe8ae331890c77d4e454f6d60615ff # v31
 
       - name: Build image
         run: |

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -60,7 +60,7 @@ jobs:
           cat tooling/ef_tests/state/test_result_pr_short.txt
 
       - name: Upload PR branch EF-test results.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr-ef-test-data
           path: tooling/ef_tests/state/test_result_pr_short.txt
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
 
@@ -108,7 +108,7 @@ jobs:
           cat tooling/ef_tests/state/test_result_main_short.txt
 
       - name: Upload main branch EF-test results.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: main-ef-test-data
           path: tooling/ef_tests/state/test_result_main_short.txt
@@ -120,16 +120,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download main branch ef tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: main-ef-test-data
           path: tooling/ef_tests/state/
 
       - name: Download PR branch ef tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-ef-test-data
           path: tooling/ef_tests/state/
@@ -150,7 +150,7 @@ jobs:
       - name: Find comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -161,7 +161,7 @@ jobs:
       # If the condition is met, create or update the comment with the summary.
       - name: Create comment
         if: ${{ steps.branch_diffs.outcome == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -174,7 +174,7 @@ jobs:
       # If both conditions are met, update the comment saying that all tests pass.
       - name: Update comment
         if: ${{ steps.branch_diffs.outcome != 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && steps.fc.outputs.comment-id != '' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -220,12 +220,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Install hyperfine
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: hyperfine@1.16
 

--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -22,10 +22,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v2
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
         with:
           mdbook-version: "0.4.51"
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload docs artifact
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: docs
           path: book/html
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: --no-progress --exclude 'localhost' --exclude 'medium.com' docs/
           fail: true
@@ -65,13 +65,13 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs
           path: book/html
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: book/html

--- a/.github/workflows/pr_check_l2_genesis.yml
+++ b/.github/workflows/pr_check_l2_genesis.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/pr_github_metadata.yaml
+++ b/.github/workflows/pr_github_metadata.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR author
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             await github.rest.issues.addAssignees({
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Apply labels from PR title
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const run = require('./.github/scripts/set-pr-labels.js');

--- a/.github/workflows/pr_github_status_l1.yaml
+++ b/.github/workflows/pr_github_status_l1.yaml
@@ -32,16 +32,16 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.PROJECT_SYNC_APP_ID }}
           private-key: ${{ secrets.PROJECT_SYNC_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Update PR status
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/pr_lint_gha.yaml
+++ b/.github/workflows/pr_lint_gha.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install actionlint
         run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/pr_lint_gha.yaml
+++ b/.github/workflows/pr_lint_gha.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install actionlint
-        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/v1.7.11/scripts/download-actionlint.bash)
 
       - name: Run actionlint
         run: ./actionlint -ignore SC2086 -ignore SC2006 -ignore SC2046

--- a/.github/workflows/pr_lint_license.yaml
+++ b/.github/workflows/pr_lint_license.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check license files exist
         run: |

--- a/.github/workflows/pr_lint_pr_title.yml
+++ b/.github/workflows/pr_lint_pr_title.yml
@@ -19,7 +19,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr_lint_readme.yaml
+++ b/.github/workflows/pr_lint_readme.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr_loc.yaml
+++ b/.github/workflows/pr_loc.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout PR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -38,7 +38,7 @@ jobs:
           echo "merge_base=$MERGE_BASE" >> $GITHUB_OUTPUT
       
       - name: Checkout merge base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ steps.find_merge_base.outputs.merge_base }}
@@ -56,7 +56,7 @@ jobs:
         run: mv tooling/loc/current_detailed_loc_report.json tooling/loc/previous_detailed_loc_report.json
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           clean: "false" # Don't clean the workspace, so we can keep the previous report
           ref: ${{ github.event.pull_request.head.sha }}
@@ -87,7 +87,7 @@ jobs:
       - name: Find comment
         if: steps.check_report.outputs.report_exists == 'true'
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create Comment
         if: steps.check_report.outputs.report_exists == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_perf_blocks_exec.yaml
+++ b/.github/workflows/pr_perf_blocks_exec.yaml
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Populate cache
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: cache
         with:
           path: bin/ethrex-${{ matrix.branch }}
           key: binary-${{ matrix.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           lfs: true
@@ -64,18 +64,18 @@ jobs:
         run: git lfs checkout
 
       - name: Install Hyperfine
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: hyperfine@1.16
 
       - name: Fetch base binary
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: bin/ethrex-base
           key: binary-base-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Fetch HEAD binary
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: bin/ethrex-head
           key: binary-head-${{ github.run_id }}-${{ github.run_attempt }}
@@ -90,7 +90,7 @@ jobs:
           "./bin/ethrex-{bin} --network fixtures/genesis/perf-ci.json --force import ./fixtures/blockchain/l2-1k-erc20.rlp --removedb"
           echo -e "## Benchmark Block Execution Results Comparison Against Main\n\n$(cat bench_pr_comparison.md)" > bench_pr_comparison.md
       - name: Upload PR results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr-result
           path: bench_pr_comparison.md
@@ -98,7 +98,7 @@ jobs:
       - name: Find comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create or update comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_perf_build_block_bench.yml
+++ b/.github/workflows/pr_perf_build_block_bench.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Benchmarks
-        uses: boa-dev/criterion-compare-action@v3
+        uses: boa-dev/criterion-compare-action@adfd3a94634fe2041ce5613eb7df09d247555b87 # v3
         with:
           cwd: "benches/benches"
           benchName: "build_block_benchmark"

--- a/.github/workflows/pr_perf_changelog.yml
+++ b/.github/workflows/pr_perf_changelog.yml
@@ -15,4 +15,4 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'performance')
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@204e7d3ef26579f4cd0fd759c57032656fdf23c7 # v3

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -36,7 +36,7 @@ jobs:
           cd crates/vm/levm
           make build-revm-comparison
       - name: Upload main benchmark binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pr-binary
           path: crates/vm/levm/target/release/benchmark
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -57,7 +57,7 @@ jobs:
           cd crates/vm/levm
           make build-revm-comparison
       - name: Upload main benchmark binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: main-binary
           path: crates/vm/levm/target/release/benchmark
@@ -68,10 +68,10 @@ jobs:
     needs: [benchmark-pr, benchmark-main]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install hyperfine
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: hyperfine@1.19
 
@@ -79,13 +79,13 @@ jobs:
         uses: ./.github/actions/install-solc
 
       - name: Download PR binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-binary
           path: ./pr
 
       - name: Download main binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: main-binary
           path: ./main
@@ -101,7 +101,7 @@ jobs:
       - name: Find comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Create or update comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_upgradeability.yaml
+++ b/.github/workflows/pr_upgradeability.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
 

--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "NEW_TAG=$(echo ${{ github.event.release.tag_name }} | tr -d v)" >> $GITHUB_ENV
 
       - name: Login to Docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         if: ${{ matrix.os == 'linux' }}
@@ -90,7 +90,7 @@ jobs:
         uses: ./.github/actions/install-sp1
       - name: Set up QEMU (only Linux ARM)
         if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: amd64
 
@@ -101,7 +101,7 @@ jobs:
         uses: ./.github/actions/install-risc0
 
       - name: Install CUDA (only Linux x86 GPU)
-        uses: Jimver/cuda-toolkit@v0.2.24
+        uses: Jimver/cuda-toolkit@c35baa1a18fd1fc9dcf47c5bd839bf30559c0bc3 # v0.2.24
         if: ${{ matrix.platform == 'ubuntu-22.04' && matrix.stack == 'l2_gpu' }}
         id: cuda-toolkit
         with:
@@ -110,7 +110,7 @@ jobs:
           sub-packages: '["nvcc"]'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -132,14 +132,14 @@ jobs:
           mv crates/guest-program/bin/sp1/out/riscv32im-succinct-zkvm-vk-u32 verification_keys/ethrex-riscv32im-succinct-zkvm-vk-u32
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ethrex${{ matrix.l2_suffix }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.gpu_suffix }}
           path: ethrex${{ matrix.l2_suffix }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.gpu_suffix }}
 
       - name: Upload verification keys
         if: ${{ matrix.platform == 'ubuntu-22.04' && matrix.stack == 'l2_gpu' }} # Run only once
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: verification_keys
           path: verification_keys/
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -207,13 +207,13 @@ jobs:
           fi
 
       - name: Upload ethrex guest elf artifact - ${{ matrix.zkvm }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ env.ELF_ARTIFACT }}
           path: ${{ env.ELF_ARTIFACT }}
 
       - name: Upload ethrex guest verification keys - ${{ matrix.zkvm }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.zkvm }}_verification_keys
           path: ${{ matrix.zkvm }}_verification_keys/
@@ -234,31 +234,31 @@ jobs:
           echo "SANITIZED_REF=$SANITIZED" >> $GITHUB_ENV
 
       - name: Download SP1 elf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex-riscv32im-sp1-elf-${{ env.SANITIZED_REF }}
           path: ethrex_guests/sp1/
 
       - name: Download SP1 verification keys artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sp1_verification_keys
           path: ethrex_guests/sp1/
 
       - name: Download RISC0 elf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex-riscv32im-risc0-elf-${{ env.SANITIZED_REF }}
           path: ethrex_guests/risc0/
 
       - name: Download RISC0 verification keys artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: risc0_verification_keys
           path: ethrex_guests/risc0/
 
       - name: Download ZisK elf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ethrex-riscv64ima-zisk-elf-${{ env.SANITIZED_REF }}
           path: ethrex_guests/zisk/
@@ -269,7 +269,7 @@ jobs:
           tar -czvf ../ethrex-guests.tar.gz .
 
       - name: Upload ethrex guests artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ethrex-guests.tar.gz
           path: ethrex-guests.tar.gz
@@ -280,10 +280,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download verification keys artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: verification_keys
           path: crates/l2/contracts/src/
@@ -294,7 +294,7 @@ jobs:
           tar -czvf ../../../../ethrex-contracts.tar.gz .
 
       - name: Upload contracts artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ethrex-contracts.tar.gz
           path: ethrex-contracts.tar.gz
@@ -322,7 +322,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -385,7 +385,7 @@ jobs:
 
     steps:
       - name: Login to Docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -416,12 +416,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ./bin
           pattern: "ethrex*" # This includes the binaries, elf files, ethrex-verification-keys.tar.gz, and ethrex-contracts.tar.gz
@@ -436,7 +436,7 @@ jobs:
 
       - name: Update CHANGELOG
         id: changelog
-        uses: requarks/changelog-action@v1
+        uses: requarks/changelog-action@6d71e098526ee17bae963f058d34cd763378337f # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fromTag: ${{ github.ref_name }}
@@ -444,7 +444,7 @@ jobs:
           writeToFile: false
 
       - name: Finalize Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/fixtures/networks/default.yaml
+++ b/fixtures/networks/default.yaml
@@ -3,28 +3,28 @@ participants:
   # - el_type: erigon
   #   el_image: ethpandaops/erigon:main-764a2c50
   #   cl_type: lighthouse
-  #   cl_image: sigp/lighthouse:v8.0.0-rc.1
+  #   cl_image: sigp/lighthouse:v8.1.3
   #   validator_count: 32
   # - el_type: reth
   #   el_image: ghcr.io/paradigmxyz/reth:v1.2.2
   #   cl_type: lighthouse
-  #   cl_image: sigp/lighthouse:v8.0.0-rc.1
+  #   cl_image: sigp/lighthouse:v8.1.3
   #   validator_count: 32
   - el_type: besu
     el_image: ethpandaops/besu:main-142a5e6
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
   - el_type: geth
     el_image: ethereum/client-go:v1.15.2
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
     count: 1
   - el_type: ethrex
     el_image: ethrex:local
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
     # snooper_enabled: true
 

--- a/fixtures/networks/ethrex_only.yaml
+++ b/fixtures/networks/ethrex_only.yaml
@@ -2,20 +2,20 @@ participants:
   - el_type: ethrex
     el_image: ethrex:local
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   - el_type: ethrex
     el_image: ethrex:local
     cl_type: teku
-    cl_image: consensys/teku:25.6.0
+    cl_image: consensys/teku:26.3.0
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
   # Not working on Mac
   # - el_type: ethrex
   #   el_image: ethrex:local
   #   cl_type: prysm
-  # cl_image: gcr.io/offchainlabs/prysm/beacon-chain:v6.0.4
+  # cl_image: gcr.io/offchainlabs/prysm/beacon-chain:v7.1.3
   # validator_count: 32
   # ethereum_metrics_exporter_enabled: true
 

--- a/fixtures/networks/hoodi.yaml
+++ b/fixtures/networks/hoodi.yaml
@@ -2,7 +2,7 @@ participants:
   - el_type: ethrex
     el_image: ethrex:local
     cl_type: lighthouse
-    cl_image: sigp/lighthouse:v8.0.0-rc.1
+    cl_image: sigp/lighthouse:v8.1.3
     count: 1
 
 ethereum_metrics_exporter_enabled: true

--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -33,7 +33,7 @@ x-ethrex-common: &ethrex-common
   restart: unless-stopped
 
 x-consensus-common: &consensus-common
-  image: sigp/lighthouse:v8.0.1
+  image: sigp/lighthouse:v8.1.3
   restart: unless-stopped
 
 services:


### PR DESCRIPTION
## Summary

- Bump all consensus layer client images to latest stable versions
- Bump Kurtosis engine to latest
- Pin all GitHub Actions to full commit SHAs to mitigate supply chain attacks

## CL Client Bumps

| Client | Old | New | Notes |
|--------|-----|-----|-------|
| Lighthouse | `v8.0.0-rc.1` / `v8.0.1` | `v8.1.3` | **Mandatory security upgrade**, multiple CVEs patched in v8.1.1-v8.1.3 |
| Prysm | `v6.0.4` / `v7.1.0` | `v7.1.3` | Logging revamp, performance optimizations, go-ethereum security update |
| Teku | `25.6.0` | `26.3.0` | Mandatory fix for mainnet beacon state serialization issue |

## Infra Bumps

| Component | Old | New |
|-----------|-----|-----|
| Kurtosis | `1.15.2` | `1.17.7` | 

## GitHub Actions: SHA Pinning

All GitHub Actions are now pinned to full commit SHAs instead of mutable version tags (e.g. `@v4`). This is a security hardening measure against supply chain attacks where a compromised or hijacked action tag could inject malicious code into CI runs. This has happened in the wild (e.g. the [`tj-actions/changed-files` incident in March 2025](https://www.stepsecurity.io/blog/tj-actions-changed-files-supply-chain-attack) which exfiltrated CI secrets from ~23,000 repos).

Each pinned SHA has a version comment for maintainability (e.g. `actions/checkout@de0fac...# v6.0.2`).

16 actions were also bumped to their latest major versions (mostly Node 24 runtime upgrades). No breaking changes affect our workflows.

## Context

The "Sync sepolia - Prysm" daily snapsync job was failing because the Prysm beacon container (`v7.1.0`) wasn't starting at all (zero log output, port timeout). Bumping to `v7.1.3` should help, though the root cause appeared to be transient (other sync jobs with Prysm on hoodi passed fine).

## Test plan

- [ ] Daily snapsync jobs pass with updated CL clients
- [ ] PR CI (assertoor, hive) passes with pinned actions