### PR TITLE
feat(l1): track unrecognized discovery packets

### DIFF
--- a/crates/blockchain/metrics/p2p.rs
+++ b/crates/blockchain/metrics/p2p.rs
@@ -1,4 +1,6 @@
-use prometheus::{Encoder, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder};
+use prometheus::{
+    Encoder, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder,
+};
 use std::sync::LazyLock;
 
 use crate::MetricsError;
@@ -10,6 +12,7 @@ pub struct MetricsP2P {
     peer_count: IntGauge,
     peer_clients: IntGaugeVec,
     disconnections: IntCounterVec,
+    unrecognized_discovery_packets: IntCounter,
 }
 
 impl Default for MetricsP2P {
@@ -36,6 +39,11 @@ impl MetricsP2P {
                 &["reason", "client_name"],
             )
             .expect("Failed to create disconnections metric"),
+            unrecognized_discovery_packets: IntCounter::new(
+                "ethrex_p2p_unrecognized_discovery_packets",
+                "Total number of discovery packets not matching discv4 or discv5",
+            )
+            .expect("Failed to create unrecognized_discovery_packets metric"),
         }
     }
 
@@ -67,6 +75,10 @@ impl MetricsP2P {
             .inc_by(0);
     }
 
+    pub fn inc_unrecognized_discovery_packets(&self) {
+        self.unrecognized_discovery_packets.inc();
+    }
+
     pub fn gather_metrics(&self) -> Result<String, MetricsError> {
         let r = Registry::new();
 
@@ -75,6 +87,8 @@ impl MetricsP2P {
         r.register(Box::new(self.peer_clients.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
         r.register(Box::new(self.disconnections.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.unrecognized_discovery_packets.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
 
         let encoder = TextEncoder::new();

--- a/crates/networking/p2p/discovery/multiplexer.rs
+++ b/crates/networking/p2p/discovery/multiplexer.rs
@@ -22,11 +22,11 @@ use crate::discv4::{
     messages::Packet as Discv4Packet,
     server::{DiscoveryServer as Discv4Server, Discv4Message, InMessage as Discv4InMessage},
 };
-
 use crate::discv5::{
     messages::Packet as Discv5Packet,
     server::{DiscoveryServer as Discv5Server, Discv5Message, InMessage as Discv5InMessage},
 };
+use crate::metrics::METRICS;
 
 /// Minimum packet size for a valid discv4 packet.
 /// hash (32) + signature (65) + type (1) = 98 bytes
@@ -170,8 +170,10 @@ impl DiscoveryMultiplexer {
     async fn route_packet(&mut self, data: &[u8], from: SocketAddr) {
         if is_discv4_packet(data) {
             self.route_to_discv4(data, from).await;
-        } else {
-            self.route_to_discv5(data, from).await;
+        } else if self.route_to_discv5(data, from).await == Some(false) {
+            // Packet failed both discv4 hash check and discv5 decode
+            debug!(from=?from, len=data.len(), "Received unrecognized discovery packet");
+            METRICS.record_unrecognized_discovery_packet();
         }
     }
 
@@ -200,13 +202,15 @@ impl DiscoveryMultiplexer {
     }
 
     /// Route a packet to the discv5 handler.
-    async fn route_to_discv5(&mut self, data: &[u8], from: SocketAddr) {
+    /// Returns `Some(true)` if decoded as discv5, `Some(false)` if decode failed,
+    /// `None` if discv5 is disabled or handle is unavailable.
+    async fn route_to_discv5(&mut self, data: &[u8], from: SocketAddr) -> Option<bool> {
         if !self.config.discv5_enabled {
-            return;
+            return None;
         }
 
         let Some(handle) = &mut self.discv5_handle else {
-            return;
+            return None;
         };
 
         // Decode the discv5 packet
@@ -216,9 +220,11 @@ impl DiscoveryMultiplexer {
                 if let Err(e) = handle.cast(Discv5InMessage::Message(Box::new(msg))).await {
                     debug!(error=?e, "Failed to send discv5 message to handler");
                 }
+                Some(true)
             }
             Err(e) => {
                 debug!(error=?e, "Failed to decode discv5 packet");
+                Some(false)
             }
         }
     }

--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -54,6 +54,9 @@ pub struct Metrics {
     /// RLPx connection attempt failures grouped and counted by reason
     pub connection_attempt_failures: Arc<Mutex<BTreeMap<String, u64>>>,
 
+    /// Discovery packets that don't match discv4 or discv5
+    pub unrecognized_discovery_packets: IntCounter,
+
     /* Snap Sync */
     // Common
     pub sync_head_block: AtomicU64,
@@ -268,6 +271,16 @@ impl Metrics {
         self.pings_sent.inc();
 
         self.update_rate(&mut events, &self.pings_sent_rate);
+    }
+
+    pub fn record_unrecognized_discovery_packet(&self) {
+        self.unrecognized_discovery_packets.inc();
+
+        #[cfg(feature = "metrics")]
+        {
+            use ethrex_metrics::p2p::METRICS_P2P;
+            METRICS_P2P.inc_unrecognized_discovery_packets();
+        }
     }
 
     pub async fn record_new_rlpx_conn_disconnection(
@@ -675,6 +688,16 @@ impl Default for Metrics {
             .register(Box::new(storage_leaves_downloaded.clone()))
             .expect("Failed to register storage_leaves_downloaded counter");
 
+        let unrecognized_discovery_packets = IntCounter::new(
+            "unrecognized_discovery_packets",
+            "Total number of discovery packets not matching discv4 or discv5",
+        )
+        .expect("Failed to create unrecognized_discovery_packets counter");
+
+        registry
+            .register(Box::new(unrecognized_discovery_packets.clone()))
+            .expect("Failed to register unrecognized_discovery_packets counter");
+
         Metrics {
             _registry: registry,
             enabled: Arc::new(Mutex::new(false)),
@@ -704,6 +727,8 @@ impl Default for Metrics {
             disconnections_by_client_type: Arc::new(Mutex::new(BTreeMap::new())),
 
             connection_attempt_failures: Arc::new(Mutex::new(BTreeMap::new())),
+
+            unrecognized_discovery_packets,
 
             /* Snap Sync */
             // Common


### PR DESCRIPTION
Closes #6400

Adds a metric counter for discovery packets that don't match discv4 or discv5. The multiplexer’s route_to_discv5 now returns whether decoding succeeded. When a packet fails both the discv4 hash check and discv5 decode, it gets counted via a new `unrecognized_discovery_packets` counter in both the internal Metrics struct and the Prometheus-exported MetricsP2P (exposed as `ethrex_p2p_unrecognized_discovery_packets`).

Note: this will likely need a rebase after #6398 merges, since both touch `route_packet`. The changes are complementary — #6398 adds positive filtering logic, this PR adds the tracking.

**Changes:**
- crates/networking/p2p/discovery/multiplexer.rs: `route_to_discv5` returns `bool`, `route_packet` detects and counts unrecognized packets
- crates/networking/p2p/metrics.rs: new `unrecognized_discovery_packets` IntCounter + `record_unrecognized_discovery_packet()` method
- crates/blockchain/metrics/p2p.rs: new `unrecognized_discovery_packets` IntCounter in MetricsP2P + Prometheus registration