### PR TITLE
fix(l1): persist fullsync header progress across sync cycles

### DIFF
--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -218,7 +218,7 @@ pub async fn sync_cycle_full(
     // Request all block headers between the sync head and our local chain
     // We will begin from the sync head so that we download the latest state first, ensuring we follow the correct chain
     // This step is not parallelized
-    let mut start_block_number;
+    let mut start_block_number = 0;
     let mut end_block_number = 0;
     let mut headers = vec![];
     let mut single_batch = true;
@@ -230,6 +230,14 @@ pub async fn sync_cycle_full(
     // a synced node. Set on the first batch of headers we fetch.
     let mut started_behind = false;
     let mut sync_target_logged = false;
+
+    // Check for progress saved from a previous aborted cycle
+    let mut prior_progress = store.get_fullsync_progress()?;
+    if let Some((prev_lowest, _)) = &prior_progress {
+        info!(
+            "Found prior fullsync progress: headers stored down to block {prev_lowest}, will resume from there"
+        );
+    }
 
     // Request and store all block headers from the advertised sync head
     loop {
@@ -251,6 +259,14 @@ pub async fn sync_cycle_full(
                         ?sync_head,
                         "Sync failed to find target block header after {attempts} attempts, aborting to wait for a newer sync head"
                     );
+                    // Save progress so the next cycle can resume from here instead of
+                    // re-downloading every header from the sync head again.
+                    if end_block_number > 0 {
+                        info!(
+                            "Saving fullsync progress at block {start_block_number} for next cycle"
+                        );
+                        store.set_fullsync_progress(start_block_number, sync_head)?;
+                    }
                     return Ok(());
                 }
                 attempts += 1;
@@ -406,6 +422,60 @@ pub async fn sync_cycle_full(
         }
         store.add_fullsync_batch(block_headers).await?;
         single_batch = false;
+
+        // Check if we've connected to headers stored from a previous cycle.
+        if let Some((prev_lowest, prev_resume_hash)) = prior_progress
+            && start_block_number >= prev_lowest
+        {
+            // Connect only when the hash chain is actually continuous, not merely
+            // when the same block *number* is present. FULLSYNC_HEADERS is keyed by
+            // number, so a stored header from a different fork (a reorg between
+            // cycles, or a long-range attack) could sit at the same number. Jumping
+            // to its `prev_resume_hash` would make us request headers honest peers
+            // can't serve, exhaust the retries, re-persist the same bad anchor, and
+            // wedge sync forever. `sync_head` here is the parent hash our lowest
+            // header points to, so a genuine continuation must hash-match it.
+            let connected = if start_block_number == prev_lowest {
+                // Reached the stored lowest block: the parent we now seek must be
+                // the same parent the previous cycle persisted.
+                sync_head == prev_resume_hash
+            } else {
+                // Above the stored region: the stored header just below our batch
+                // must be the parent our lowest header points to.
+                store
+                    .read_fullsync_batch(start_block_number - 1, 1)
+                    .await?
+                    .first()
+                    .and_then(|o| o.as_ref())
+                    .map(|h| h.hash() == sync_head)
+                    .unwrap_or(false)
+            };
+
+            if connected {
+                info!(
+                    "Connected to previously stored headers at block {start_block_number}, resuming from block {prev_lowest}",
+                );
+                // Jump to where the previous cycle left off
+                sync_head = prev_resume_hash;
+                start_block_number = prev_lowest;
+
+                if store.is_canonical_sync(sync_head)? || sync_head.is_zero() {
+                    break;
+                }
+                // Continue downloading from the previous cycle's resume point
+                continue;
+            } else {
+                // Stored progress belongs to a different chain than the current
+                // consensus-provided sync head. Discard the orphaned headers and
+                // anchor so we keep descending from the honest head instead of
+                // chasing a stale/forged resume point on every cycle.
+                warn!(
+                    "Stored fullsync progress at block {prev_lowest} does not link to the current chain; discarding it and resyncing from the consensus head"
+                );
+                store.clear_fullsync_headers().await?;
+                prior_progress = None;
+            }
+        }
     }
     end_block_number += 1;
     start_block_number = start_block_number.max(1);

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1515,7 +1515,43 @@ impl Store {
     }
 
     pub async fn clear_fullsync_headers(&self) -> Result<(), StoreError> {
+        self.clear_fullsync_progress()?;
         self.backend.clear_table(FULLSYNC_HEADERS)
+    }
+
+    /// Stores the lowest block number reached during header download and the hash
+    /// to resume fetching from, so the next sync cycle can continue where it left off.
+    pub fn set_fullsync_progress(
+        &self,
+        lowest_block: BlockNumber,
+        resume_hash: H256,
+    ) -> Result<(), StoreError> {
+        let mut data = lowest_block.to_le_bytes().to_vec();
+        data.extend_from_slice(resume_hash.as_bytes());
+        self.write(MISC_VALUES, b"fullsync_progress".to_vec(), data)
+    }
+
+    /// Returns the saved fullsync progress: (lowest_block_number, resume_hash).
+    pub fn get_fullsync_progress(&self) -> Result<Option<(BlockNumber, H256)>, StoreError> {
+        let Some(data) = self.read(MISC_VALUES, b"fullsync_progress".to_vec())? else {
+            return Ok(None);
+        };
+        if data.len() != 8 + 32 {
+            return Ok(None);
+        }
+        let lowest_block = u64::from_le_bytes(
+            data[..8]
+                .try_into()
+                .expect("fullsync_progress: lowest_block slice is exactly 8 bytes"),
+        );
+        let resume_hash = H256::from_slice(&data[8..40]);
+        Ok(Some((lowest_block, resume_hash)))
+    }
+
+    pub fn clear_fullsync_progress(&self) -> Result<(), StoreError> {
+        // Ignore error if the key doesn't exist
+        let _ = self.delete(MISC_VALUES, b"fullsync_progress".to_vec());
+        Ok(())
     }
 
     /// Delete a key from a table


### PR DESCRIPTION
## Summary
- Full sync was losing all header download progress when a cycle aborted after peer failures. Each new cycle restarted from the chain head, re-downloading tens of thousands of headers before hitting the same failure point indefinitely.
- Now persists the lowest block reached and resume hash in `MISC_VALUES`, so the next cycle bridges the gap from the new sync head to stored headers and continues from the previous abort point.
- Fixes retry off-by-one (`>` to `>=`) in both full and snap sync so attempt count matches `MAX_HEADER_FETCH_ATTEMPTS`.
- Resets attempt counter after a successful fetch so it tracks consecutive failures, not cumulative.
- Replaces fixed 5s retry delay with gentle backoff (1s, 2s, 3s, 5s, 10s).

## Test plan
- [ ] Run full sync against mainnet/testnet and verify logs show "Connected to previously stored headers" on cycle 2+ after an abort
- [ ] Verify retry logs show correct "attempt N/5" counts and increasing delays
- [ ] Verify successful completion clears progress via `clear_fullsync_headers`