### PR TITLE
feat(l1): add peer scoring by latency and bandwidth

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -15,8 +15,11 @@ use ethrex_blockchain::{
 };
 use ethrex_common::types::{Block, DEFAULT_BUILDER_GAS_CEIL, Genesis, validate_block_body};
 use ethrex_p2p::{
-    discovery::INITIAL_LOOKUP_INTERVAL_MS, peer_table::TARGET_PEERS, sync::SyncMode,
-    tx_broadcaster::BROADCAST_INTERVAL_MS, types::Node,
+    discovery::INITIAL_LOOKUP_INTERVAL_MS,
+    peer_table::{ScoringStrategy, TARGET_PEERS},
+    sync::SyncMode,
+    tx_broadcaster::BROADCAST_INTERVAL_MS,
+    types::Node,
 };
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::{error::StoreError, has_valid_db};
@@ -375,6 +378,28 @@ pub struct Options {
     )]
     pub lookup_interval: f64,
     #[arg(
+        long = "p2p.snap-scoring",
+        default_value = "bandwidth",
+        value_name = "STRATEGY",
+        value_parser = utils::parse_scoring_strategy,
+        help = "Peer scoring strategy during snap sync.",
+        long_help = "Peer scoring strategy during snap sync. One of: success, latency, bandwidth.",
+        help_heading = "P2P options",
+        env = "ETHREX_P2P_SNAP_SCORING"
+    )]
+    pub snap_scoring: ScoringStrategy,
+    #[arg(
+        long = "p2p.live-scoring",
+        default_value = "latency",
+        value_name = "STRATEGY",
+        value_parser = utils::parse_scoring_strategy,
+        help = "Peer scoring strategy during live/full sync.",
+        long_help = "Peer scoring strategy during live/full sync. One of: success, latency, bandwidth.",
+        help_heading = "P2P options",
+        env = "ETHREX_P2P_LIVE_SCORING"
+    )]
+    pub live_scoring: ScoringStrategy,
+    #[arg(
         long = "builder.extra-data",
         default_value = get_minimal_client_version(),
         value_name = "EXTRA_DATA",
@@ -491,6 +516,8 @@ impl Default for Options {
             tx_broadcasting_time_interval: Default::default(),
             target_peers: Default::default(),
             lookup_interval: Default::default(),
+            snap_scoring: Default::default(),
+            live_scoring: Default::default(),
             extra_data: get_minimal_client_version(),
             gas_limit: DEFAULT_BUILDER_GAS_CEIL,
             max_blobs_per_block: None,

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -18,7 +18,7 @@ use ethrex_p2p::{
     DiscoveryConfig,
     network::P2PContext,
     peer_handler::PeerHandler,
-    peer_table::{PeerTable, PeerTableServer},
+    peer_table::{PeerTable, PeerTableServer, ScoringConfig},
     sync::SyncMode,
     sync_manager::SyncManager,
     types::{NetworkConfig, Node, NodeRecord},
@@ -199,6 +199,10 @@ pub async fn init_rpc_api(
     };
 
     // Create SyncManager
+    let scoring_config = ScoringConfig {
+        snap: opts.snap_scoring,
+        live: opts.live_scoring,
+    };
     let syncer = SyncManager::new(
         peer_handler.clone(),
         syncmode,
@@ -206,6 +210,7 @@ pub async fn init_rpc_api(
         blockchain.clone(),
         store.clone(),
         datadir.to_path_buf(),
+        scoring_config,
     )
     .await;
 

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -292,6 +292,10 @@ pub async fn init_l2(
         let peer_handler = PeerHandler::new(peer_table, initiator);
 
         // Create SyncManager
+        let scoring_config = ethrex_p2p::peer_table::ScoringConfig {
+            snap: opts.node_opts.snap_scoring,
+            live: opts.node_opts.live_scoring,
+        };
         let syncer = SyncManager::new(
             peer_handler.clone(),
             &opts.node_opts.syncmode,
@@ -299,6 +303,7 @@ pub async fn init_l2(
             blockchain.clone(),
             store.clone(),
             opts.node_opts.datadir.clone(),
+            scoring_config,
         )
         .await;
 

--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use directories::ProjectDirs;
 use ethrex_common::types::{Block, Genesis};
 use ethrex_p2p::{
-    peer_table::{PeerTable, PeerTableServerProtocol as _},
+    peer_table::{PeerTable, PeerTableServerProtocol as _, ScoringStrategy},
     sync::SyncMode,
     types::{Node, NodeRecord},
 };
@@ -93,6 +93,17 @@ pub fn parse_sync_mode(s: &str) -> eyre::Result<SyncMode> {
         "snap" => Ok(SyncMode::Snap),
         other => Err(eyre::eyre!(
             "Invalid syncmode {other:?} expected either snap or full",
+        )),
+    }
+}
+
+pub fn parse_scoring_strategy(s: &str) -> eyre::Result<ScoringStrategy> {
+    match s {
+        "success" => Ok(ScoringStrategy::Success),
+        "latency" => Ok(ScoringStrategy::Latency),
+        "bandwidth" => Ok(ScoringStrategy::Bandwidth),
+        other => Err(eyre::eyre!(
+            "Invalid scoring strategy {other:?}, expected one of: success, latency, bandwidth",
         )),
     }
 }

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -76,18 +76,15 @@ async fn ask_peer_head_number(
 
     debug!("(Retry {retries}) Requesting sync head {sync_head:?} to peer {peer_id}");
 
-    let req_start = Instant::now();
-    let result = connection
+    match connection
         .outgoing_request(request, PEER_REPLY_TIMEOUT)
-        .await;
-    let elapsed = req_start.elapsed();
-    match result {
+        .await
+    {
         Ok(RLPxMessage::BlockHeaders(BlockHeaders {
             id: _,
             block_headers,
         })) => {
             if !block_headers.is_empty() {
-                let _ = peer_table.record_response_latency(peer_id, elapsed);
                 let sync_head_number = block_headers
                     .last()
                     .ok_or(PeerHandlerError::BlockHeaders)?
@@ -684,18 +681,15 @@ impl PeerHandler {
             reverse: false,
         });
         debug!("get_block_header: requesting header with number {block_number}");
-        let req_start = Instant::now();
-        let result = connection
+        match connection
             .outgoing_request(request, PEER_REPLY_TIMEOUT)
-            .await;
-        let elapsed = req_start.elapsed();
-        match result {
+            .await
+        {
             Ok(RLPxMessage::BlockHeaders(BlockHeaders {
                 id: _,
                 block_headers,
             })) => {
                 if !block_headers.is_empty() {
-                    let _ = self.peer_table.record_response_latency(peer_id, elapsed);
                     return Ok(Some(
                         block_headers
                             .last()

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -22,6 +22,7 @@ use ethrex_common::{
     H256,
     types::{BlockBody, BlockHeader, block_access_list::BlockAccessList, validate_block_body},
 };
+use ethrex_rlp::encode::RLPEncode;
 use ethrex_crypto::NativeCrypto;
 use spawned_concurrency::{error::ActorError, tasks::ActorRef};
 use std::{
@@ -259,10 +260,13 @@ impl PeerHandler {
                 if !elapsed.is_zero() {
                     let _ = self.peer_table.record_response_latency(peer_id, elapsed);
                     if !headers.is_empty() {
-                        let approx_bytes = headers.len() as u64 * 500;
+                        let response_bytes: u64 = headers
+                            .iter()
+                            .map(|h| h.encode_to_vec().len() as u64)
+                            .sum();
                         let _ = self
                             .peer_table
-                            .record_bandwidth(peer_id, approx_bytes, elapsed);
+                            .record_bandwidth(peer_id, response_bytes, elapsed);
                     }
                 }
 

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -464,9 +464,7 @@ impl PeerHandler {
                         return Ok(None);
                     }
                     if are_block_headers_chained(&block_headers, &order) {
-                        let _ = self
-                            .peer_table
-                            .record_response_latency(peer_id, elapsed);
+                        let _ = self.peer_table.record_response_latency(peer_id, elapsed);
                         self.peer_table.record_success(peer_id)?;
                         return Ok(Some(block_headers));
                     }
@@ -556,9 +554,7 @@ impl PeerHandler {
                 {
                     // Check that the response is not empty and does not contain more bodies than the ones requested
                     if !block_bodies.is_empty() && block_bodies.len() <= block_hashes_len {
-                        let _ = self
-                            .peer_table
-                            .record_response_latency(peer_id, elapsed);
+                        let _ = self.peer_table.record_response_latency(peer_id, elapsed);
                         self.peer_table.record_success(peer_id)?;
                         return Ok(Some((block_bodies, peer_id)));
                     }
@@ -699,9 +695,7 @@ impl PeerHandler {
                 block_headers,
             })) => {
                 if !block_headers.is_empty() {
-                    let _ = self
-                        .peer_table
-                        .record_response_latency(peer_id, elapsed);
+                    let _ = self.peer_table.record_response_latency(peer_id, elapsed);
                     return Ok(Some(
                         block_headers
                             .last()

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -27,7 +27,7 @@ use spawned_concurrency::{error::ActorError, tasks::ActorRef};
 use std::{
     collections::{HashSet, VecDeque},
     sync::atomic::Ordering,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use tracing::{debug, error, trace, warn};
 
@@ -233,7 +233,7 @@ impl PeerHandler {
 
         // channel to send the tasks to the peers
         let (task_sender, mut task_receiver) =
-            tokio::sync::mpsc::channel::<(Vec<BlockHeader>, H256, PeerConnection, u64, u64)>(1000);
+            tokio::sync::mpsc::channel::<(Vec<BlockHeader>, H256, PeerConnection, u64, u64, Duration)>(1000);
 
         let mut current_show = 0;
 
@@ -246,9 +246,20 @@ impl PeerHandler {
         let mut logged_no_free_peers_count = 0;
 
         loop {
-            if let Ok((headers, peer_id, _connection, startblock, previous_chunk_limit)) =
+            if let Ok((headers, peer_id, _connection, startblock, previous_chunk_limit, elapsed)) =
                 task_receiver.try_recv()
             {
+                // Feed transfer stats for latency/bandwidth scoring.
+                if !elapsed.is_zero() {
+                    let _ = self.peer_table.record_response_latency(peer_id, elapsed);
+                    if !headers.is_empty() {
+                        let approx_bytes = headers.len() as u64 * 500;
+                        let _ = self
+                            .peer_table
+                            .record_bandwidth(peer_id, approx_bytes, elapsed);
+                    }
+                }
+
                 trace!("We received a download chunk from peer");
                 if headers.is_empty() {
                     self.peer_table.record_failure(peer_id)?;
@@ -337,6 +348,7 @@ impl PeerHandler {
                 trace!(
                     "Sync Log 5: Requesting block headers from peer {peer_id}, chunk_limit: {chunk_limit}"
                 );
+                let req_start = Instant::now();
                 let headers = Self::download_chunk_from_peer(
                     peer_id,
                     &mut connection,
@@ -347,8 +359,9 @@ impl PeerHandler {
                 .await
                 .inspect_err(|err| trace!("Sync Log 6: {peer_id} failed to download chunk: {err}"))
                 .unwrap_or_default();
+                let req_elapsed = req_start.elapsed();
 
-                tx.send((headers, peer_id, connection, startblock, chunk_limit))
+                tx.send((headers, peer_id, connection, startblock, chunk_limit, req_elapsed))
                     .await
                     .inspect_err(|err| {
                         error!("Failed to send headers result through channel. Error: {err}")

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -256,7 +256,6 @@ impl PeerHandler {
             if let Ok((headers, peer_id, _connection, startblock, previous_chunk_limit, elapsed)) =
                 task_receiver.try_recv()
             {
-
                 trace!("We received a download chunk from peer");
                 if headers.is_empty() {
                     self.peer_table.record_failure(peer_id)?;

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -76,15 +76,18 @@ async fn ask_peer_head_number(
 
     debug!("(Retry {retries}) Requesting sync head {sync_head:?} to peer {peer_id}");
 
-    match connection
+    let req_start = Instant::now();
+    let result = connection
         .outgoing_request(request, PEER_REPLY_TIMEOUT)
-        .await
-    {
+        .await;
+    let elapsed = req_start.elapsed();
+    match result {
         Ok(RLPxMessage::BlockHeaders(BlockHeaders {
             id: _,
             block_headers,
         })) => {
             if !block_headers.is_empty() {
+                let _ = peer_table.record_response_latency(peer_id, elapsed);
                 let sync_head_number = block_headers
                     .last()
                     .ok_or(PeerHandlerError::BlockHeaders)?
@@ -256,17 +259,6 @@ impl PeerHandler {
             if let Ok((headers, peer_id, _connection, startblock, previous_chunk_limit, elapsed)) =
                 task_receiver.try_recv()
             {
-                // Feed transfer stats for latency/bandwidth scoring.
-                if !elapsed.is_zero() {
-                    let _ = self.peer_table.record_response_latency(peer_id, elapsed);
-                    if !headers.is_empty() {
-                        let response_bytes: u64 =
-                            headers.iter().map(|h| h.encode_to_vec().len() as u64).sum();
-                        let _ = self
-                            .peer_table
-                            .record_bandwidth(peer_id, response_bytes, elapsed);
-                    }
-                }
 
                 trace!("We received a download chunk from peer");
                 if headers.is_empty() {
@@ -278,6 +270,16 @@ impl PeerHandler {
                     tasks_queue_not_started.push_back((startblock, previous_chunk_limit));
 
                     continue; // Retry with the next peer
+                }
+
+                // Record latency/bandwidth only after validation (non-empty response).
+                if !elapsed.is_zero() {
+                    let _ = self.peer_table.record_response_latency(peer_id, elapsed);
+                    let response_bytes: u64 =
+                        headers.iter().map(|h| h.encode_to_vec().len() as u64).sum();
+                    let _ = self
+                        .peer_table
+                        .record_bandwidth(peer_id, response_bytes, elapsed);
                 }
 
                 downloaded_count += headers.len() as u64;
@@ -442,9 +444,11 @@ impl PeerHandler {
         match self.get_random_peer(&SUPPORTED_ETH_CAPABILITIES).await? {
             None => Ok(None),
             Some((peer_id, mut connection, permit)) => {
+                let req_start = Instant::now();
                 let response = connection
                     .outgoing_request(request, PEER_REPLY_TIMEOUT)
                     .await;
+                let elapsed = req_start.elapsed();
                 drop(permit);
                 if let Ok(RLPxMessage::BlockHeaders(BlockHeaders {
                     id: _,
@@ -460,6 +464,9 @@ impl PeerHandler {
                         return Ok(None);
                     }
                     if are_block_headers_chained(&block_headers, &order) {
+                        let _ = self
+                            .peer_table
+                            .record_response_latency(peer_id, elapsed);
                         self.peer_table.record_success(peer_id)?;
                         return Ok(Some(block_headers));
                     }
@@ -536,9 +543,11 @@ impl PeerHandler {
         match self.get_random_peer(&SUPPORTED_ETH_CAPABILITIES).await? {
             None => Ok(None),
             Some((peer_id, mut connection, permit)) => {
+                let req_start = Instant::now();
                 let response = connection
                     .outgoing_request(request, PEER_REPLY_TIMEOUT)
                     .await;
+                let elapsed = req_start.elapsed();
                 drop(permit);
                 if let Ok(RLPxMessage::BlockBodies(BlockBodies {
                     id: _,
@@ -547,6 +556,9 @@ impl PeerHandler {
                 {
                     // Check that the response is not empty and does not contain more bodies than the ones requested
                     if !block_bodies.is_empty() && block_bodies.len() <= block_hashes_len {
+                        let _ = self
+                            .peer_table
+                            .record_response_latency(peer_id, elapsed);
                         self.peer_table.record_success(peer_id)?;
                         return Ok(Some((block_bodies, peer_id)));
                     }
@@ -676,15 +688,20 @@ impl PeerHandler {
             reverse: false,
         });
         debug!("get_block_header: requesting header with number {block_number}");
-        match connection
+        let req_start = Instant::now();
+        let result = connection
             .outgoing_request(request, PEER_REPLY_TIMEOUT)
-            .await
-        {
+            .await;
+        let elapsed = req_start.elapsed();
+        match result {
             Ok(RLPxMessage::BlockHeaders(BlockHeaders {
                 id: _,
                 block_headers,
             })) => {
                 if !block_headers.is_empty() {
+                    let _ = self
+                        .peer_table
+                        .record_response_latency(peer_id, elapsed);
                     return Ok(Some(
                         block_headers
                             .last()

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -22,8 +22,8 @@ use ethrex_common::{
     H256,
     types::{BlockBody, BlockHeader, block_access_list::BlockAccessList, validate_block_body},
 };
-use ethrex_rlp::encode::RLPEncode;
 use ethrex_crypto::NativeCrypto;
+use ethrex_rlp::encode::RLPEncode;
 use spawned_concurrency::{error::ActorError, tasks::ActorRef};
 use std::{
     collections::{HashSet, VecDeque},
@@ -260,10 +260,8 @@ impl PeerHandler {
                 if !elapsed.is_zero() {
                     let _ = self.peer_table.record_response_latency(peer_id, elapsed);
                     if !headers.is_empty() {
-                        let response_bytes: u64 = headers
-                            .iter()
-                            .map(|h| h.encode_to_vec().len() as u64)
-                            .sum();
+                        let response_bytes: u64 =
+                            headers.iter().map(|h| h.encode_to_vec().len() as u64).sum();
                         let _ = self
                             .peer_table
                             .record_bandwidth(peer_id, response_bytes, elapsed);

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -232,8 +232,14 @@ impl PeerHandler {
         let mut downloaded_count = 0_u64;
 
         // channel to send the tasks to the peers
-        let (task_sender, mut task_receiver) =
-            tokio::sync::mpsc::channel::<(Vec<BlockHeader>, H256, PeerConnection, u64, u64, Duration)>(1000);
+        let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<(
+            Vec<BlockHeader>,
+            H256,
+            PeerConnection,
+            u64,
+            u64,
+            Duration,
+        )>(1000);
 
         let mut current_show = 0;
 
@@ -361,11 +367,18 @@ impl PeerHandler {
                 .unwrap_or_default();
                 let req_elapsed = req_start.elapsed();
 
-                tx.send((headers, peer_id, connection, startblock, chunk_limit, req_elapsed))
-                    .await
-                    .inspect_err(|err| {
-                        error!("Failed to send headers result through channel. Error: {err}")
-                    })
+                tx.send((
+                    headers,
+                    peer_id,
+                    connection,
+                    startblock,
+                    chunk_limit,
+                    req_elapsed,
+                ))
+                .await
+                .inspect_err(|err| {
+                    error!("Failed to send headers result through channel. Error: {err}")
+                })
             });
         }
 

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -133,9 +133,11 @@ impl PeerMetrics {
     }
 
     /// Peers with ≤50ms get MAX_SCORE, ≥5000ms get MIN_SCORE, linear interpolation.
+    /// Returns a neutral midpoint score for peers with no samples yet, so that
+    /// "unknown" is distinguishable from "measured-and-at-boundary".
     pub fn latency_score(&self) -> i64 {
         let Some(ema) = self.latency_ema_ms else {
-            return 0;
+            return (MAX_SCORE + MIN_SCORE) / 2;
         };
         let clamped = ema.clamp(50.0, 5000.0);
         let ratio = (clamped - 50.0) / (5000.0 - 50.0);
@@ -144,9 +146,11 @@ impl PeerMetrics {
     }
 
     /// Peers with ≥2MB/s get MAX_SCORE, ≤10KB/s get MIN_SCORE, log interpolation.
+    /// Returns a neutral midpoint score for peers with no samples yet, so that
+    /// "unknown" is distinguishable from "measured-and-at-boundary".
     pub fn bandwidth_score(&self) -> i64 {
         let Some(ema) = self.bandwidth_ema else {
-            return 0;
+            return (MAX_SCORE + MIN_SCORE) / 2;
         };
         let low = 10_000_f64;
         let high = 2_000_000_f64;

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -528,8 +528,7 @@ pub trait PeerTableServerProtocol: Send + Sync {
     fn record_success(&self, node_id: H256) -> Result<(), ActorError>;
     fn record_failure(&self, node_id: H256) -> Result<(), ActorError>;
     fn record_critical_failure(&self, node_id: H256) -> Result<(), ActorError>;
-    fn record_response_latency(&self, node_id: H256, latency: Duration)
-    -> Result<(), ActorError>;
+    fn record_response_latency(&self, node_id: H256, latency: Duration) -> Result<(), ActorError>;
     fn record_bandwidth(
         &self,
         node_id: H256,

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -1076,7 +1076,7 @@ impl PeerTableServer {
     ) -> bool {
         self.peers.values().any(|peer_data| {
             peer_data.connection.is_some()
-                && self.can_try_more_requests(&peer_data.score, &peer_data.requests)
+                && self.can_try_more_requests(peer_data)
                 && msg
                     .capabilities
                     .iter()
@@ -1235,7 +1235,7 @@ impl PeerTableServer {
                 peer_id: *id,
                 score: peer_data.score,
                 inflight_requests: peer_data.requests,
-                eligible: self.can_try_more_requests(&peer_data.score, &peer_data.requests),
+                eligible: self.can_try_more_requests(peer_data),
                 capabilities: peer_data
                     .supported_capabilities
                     .iter()
@@ -1405,11 +1405,11 @@ impl PeerTableServer {
         capabilities: &[Capability],
         n: usize,
     ) -> Vec<(H256, PeerConnection)> {
-        let mut candidates: Vec<(H256, i64, i64, PeerConnection)> = self
+        let mut candidates: Vec<(H256, &PeerData, PeerConnection)> = self
             .peers
             .iter()
             .filter_map(|(id, peer_data)| {
-                if !self.can_try_more_requests(&peer_data.score, &peer_data.requests)
+                if !self.can_try_more_requests(peer_data)
                     || !capabilities
                         .iter()
                         .any(|cap| peer_data.supported_capabilities.contains(cap))
@@ -1417,16 +1417,16 @@ impl PeerTableServer {
                     None
                 } else {
                     let connection = peer_data.connection.clone()?;
-                    Some((*id, peer_data.score, peer_data.requests, connection))
+                    Some((*id, peer_data, connection))
                 }
             })
             .collect();
 
-        candidates.sort_by_key(|(_, score, reqs, _)| -self.weight_peer(score, reqs));
+        candidates.sort_by_key(|(_, peer_data, _)| -self.weight_peer(peer_data));
         candidates
             .into_iter()
             .take(n)
-            .map(|(id, _, _, conn)| (id, conn))
+            .map(|(id, _, conn)| (id, conn))
             .collect()
     }
 

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -31,6 +31,7 @@ use spawned_concurrency::{
     tasks::{Actor, ActorRef, ActorStart as _, Context, Handler, Response, send_message_on},
 };
 use std::{
+    collections::VecDeque,
     net::IpAddr,
     time::{Duration, Instant},
 };
@@ -45,6 +46,116 @@ const SCORE_WEIGHT: i64 = 1;
 const REQUESTS_WEIGHT: i64 = 1;
 /// Max amount of ongoing requests per peer.
 const MAX_CONCURRENT_REQUESTS_PER_PEER: i64 = 100;
+/// Number of latency/bandwidth samples to keep per peer for scoring.
+const METRICS_WINDOW_SIZE: usize = 20;
+/// Smoothing factor for exponential moving average (0..1, higher = more weight on recent).
+const EMA_ALPHA: f64 = 0.3;
+
+/// Determines which scoring dimension is used for peer selection.
+///
+/// All three dimensions are always collected; the strategy only controls which
+/// one feeds into `weight_peer` / `can_try_more_requests`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ScoringStrategy {
+    /// Score peers by successful/failed request count (the original behaviour).
+    #[default]
+    Success,
+    /// Score peers by response latency (lower is better).
+    Latency,
+    /// Score peers by throughput in bytes/second (higher is better).
+    Bandwidth,
+}
+
+/// Per-phase scoring configuration.
+///
+/// During snap sync, bandwidth matters most (bulk data transfer).
+/// During live/full sync, latency matters most (block-by-block propagation).
+#[derive(Debug, Clone, Copy)]
+pub struct ScoringConfig {
+    /// Strategy used during snap sync.
+    pub snap: ScoringStrategy,
+    /// Strategy used during live/full sync.
+    pub live: ScoringStrategy,
+}
+
+impl Default for ScoringConfig {
+    fn default() -> Self {
+        Self {
+            snap: ScoringStrategy::Bandwidth,
+            live: ScoringStrategy::Latency,
+        }
+    }
+}
+
+/// Rolling performance metrics collected per peer.
+#[derive(Debug, Clone, Default)]
+pub struct PeerMetrics {
+    latency_samples: VecDeque<Duration>,
+    latency_ema_ms: Option<f64>,
+    bandwidth_samples: VecDeque<f64>,
+    bandwidth_ema: Option<f64>,
+}
+
+impl PeerMetrics {
+    pub fn record_latency(&mut self, latency: Duration) {
+        if self.latency_samples.len() >= METRICS_WINDOW_SIZE {
+            self.latency_samples.pop_front();
+        }
+        self.latency_samples.push_back(latency);
+        let ms = latency.as_secs_f64() * 1000.0;
+        self.latency_ema_ms = Some(match self.latency_ema_ms {
+            Some(prev) => prev * (1.0 - EMA_ALPHA) + ms * EMA_ALPHA,
+            None => ms,
+        });
+    }
+
+    pub fn record_bandwidth(&mut self, bytes: u64, elapsed: Duration) {
+        if elapsed.is_zero() || bytes == 0 {
+            return;
+        }
+        let bps = bytes as f64 / elapsed.as_secs_f64();
+        if self.bandwidth_samples.len() >= METRICS_WINDOW_SIZE {
+            self.bandwidth_samples.pop_front();
+        }
+        self.bandwidth_samples.push_back(bps);
+        self.bandwidth_ema = Some(match self.bandwidth_ema {
+            Some(prev) => prev * (1.0 - EMA_ALPHA) + bps * EMA_ALPHA,
+            None => bps,
+        });
+    }
+
+    pub fn latency_ema_ms(&self) -> Option<f64> {
+        self.latency_ema_ms
+    }
+
+    pub fn bandwidth_ema_bps(&self) -> Option<f64> {
+        self.bandwidth_ema
+    }
+
+    /// Peers with ≤50ms get MAX_SCORE, ≥5000ms get MIN_SCORE, linear interpolation.
+    pub fn latency_score(&self) -> i64 {
+        let Some(ema) = self.latency_ema_ms else {
+            return 0;
+        };
+        let clamped = ema.clamp(50.0, 5000.0);
+        let ratio = (clamped - 50.0) / (5000.0 - 50.0);
+        let score_f = MAX_SCORE as f64 - ratio * (MAX_SCORE - MIN_SCORE) as f64;
+        score_f.round() as i64
+    }
+
+    /// Peers with ≥2MB/s get MAX_SCORE, ≤10KB/s get MIN_SCORE, log interpolation.
+    pub fn bandwidth_score(&self) -> i64 {
+        let Some(ema) = self.bandwidth_ema else {
+            return 0;
+        };
+        let low = 10_000_f64;
+        let high = 2_000_000_f64;
+        let clamped = ema.clamp(low, high);
+        let ratio = (clamped.ln() - low.ln()) / (high.ln() - low.ln());
+        let score_f = MIN_SCORE as f64 + ratio * (MAX_SCORE - MIN_SCORE) as f64;
+        score_f.round() as i64
+    }
+}
 /// The target number of RLPx connections to reach.
 pub const TARGET_PEERS: usize = 100;
 /// Maximum number of ENRs to return in a FindNode response (discv4 compatible).
@@ -292,12 +403,14 @@ pub struct PeerData {
     pub is_connection_inbound: bool,
     /// communication channels between the peer data and its active connection
     pub connection: Option<PeerConnection>,
-    /// This tracks the score of a peer
+    /// Success-based score (the original +1/-1 mechanism).
     score: i64,
     /// Track the amount of concurrent requests this peer is handling
     requests: i64,
     /// Timestamp (seconds since UNIX epoch) of the last successful response from this peer
     pub last_response_time: Option<u64>,
+    /// Rolling latency and bandwidth metrics for this peer.
+    pub metrics: PeerMetrics,
 }
 
 impl PeerData {
@@ -316,6 +429,16 @@ impl PeerData {
             score: Default::default(),
             requests: Default::default(),
             last_response_time: None,
+            metrics: Default::default(),
+        }
+    }
+
+    /// Return the effective score for this peer under the given strategy.
+    pub fn effective_score(&self, strategy: ScoringStrategy) -> i64 {
+        match strategy {
+            ScoringStrategy::Success => self.score,
+            ScoringStrategy::Latency => self.metrics.latency_score(),
+            ScoringStrategy::Bandwidth => self.metrics.bandwidth_score(),
         }
     }
 }
@@ -405,6 +528,15 @@ pub trait PeerTableServerProtocol: Send + Sync {
     fn record_success(&self, node_id: H256) -> Result<(), ActorError>;
     fn record_failure(&self, node_id: H256) -> Result<(), ActorError>;
     fn record_critical_failure(&self, node_id: H256) -> Result<(), ActorError>;
+    fn record_response_latency(&self, node_id: H256, latency: Duration)
+    -> Result<(), ActorError>;
+    fn record_bandwidth(
+        &self,
+        node_id: H256,
+        bytes: u64,
+        elapsed: Duration,
+    ) -> Result<(), ActorError>;
+    fn set_scoring_strategy(&self, strategy: ScoringStrategy) -> Result<(), ActorError>;
     fn record_ping_sent(&self, node_id: H256, ping_id: Bytes) -> Result<(), ActorError>;
     fn record_pong_received(&self, node_id: H256, ping_id: Bytes) -> Result<(), ActorError>;
     fn record_enr_request_sent(&self, node_id: H256, request_hash: H256) -> Result<(), ActorError>;
@@ -486,6 +618,8 @@ pub struct PeerTableServer {
     /// allows (k-buckets: 256 × 16 = 4,096 max; this pool: up to 50,000).
     /// K-buckets are still used for all Kademlia protocol operations.
     connection_pool: IndexMap<H256, Node>,
+    /// The active scoring strategy used for peer selection.
+    scoring_strategy: ScoringStrategy,
 }
 
 #[actor(protocol = PeerTableServerProtocol)]
@@ -504,6 +638,7 @@ impl PeerTableServer {
             store,
             sessions: Default::default(),
             connection_pool: IndexMap::with_capacity(MAX_CONNECTION_POOL_SIZE),
+            scoring_strategy: ScoringStrategy::default(),
         }
     }
 
@@ -649,6 +784,37 @@ impl PeerTableServer {
         self.peers
             .entry(msg.node_id)
             .and_modify(|peer_data| peer_data.score = MIN_SCORE_CRITICAL);
+    }
+
+    #[send_handler]
+    async fn handle_record_response_latency(
+        &mut self,
+        msg: peer_table_server_protocol::RecordResponseLatency,
+        _ctx: &Context<Self>,
+    ) {
+        self.peers
+            .entry(msg.node_id)
+            .and_modify(|peer_data| peer_data.metrics.record_latency(msg.latency));
+    }
+
+    #[send_handler]
+    async fn handle_record_bandwidth(
+        &mut self,
+        msg: peer_table_server_protocol::RecordBandwidth,
+        _ctx: &Context<Self>,
+    ) {
+        self.peers
+            .entry(msg.node_id)
+            .and_modify(|peer_data| peer_data.metrics.record_bandwidth(msg.bytes, msg.elapsed));
+    }
+
+    #[send_handler]
+    async fn handle_set_scoring_strategy(
+        &mut self,
+        msg: peer_table_server_protocol::SetScoringStrategy,
+        _ctx: &Context<Self>,
+    ) {
+        self.scoring_strategy = msg.strategy;
     }
 
     #[send_handler]
@@ -1160,14 +1326,20 @@ impl PeerTableServer {
 
     // --- Peer selection ---
 
-    fn weight_peer(&self, score: &i64, requests: &i64) -> i64 {
-        score * SCORE_WEIGHT - requests * REQUESTS_WEIGHT
+    // Weighting function used to select best peer.
+    // Uses the effective score from the active scoring strategy.
+    fn weight_peer(&self, peer_data: &PeerData) -> i64 {
+        let score = peer_data.effective_score(self.scoring_strategy);
+        score * SCORE_WEIGHT - peer_data.requests * REQUESTS_WEIGHT
     }
 
-    fn can_try_more_requests(&self, score: &i64, requests: &i64) -> bool {
+    // Returns if the peer has room for more connections given the current score
+    // and amount of inflight requests.
+    fn can_try_more_requests(&self, peer_data: &PeerData) -> bool {
+        let score = peer_data.effective_score(self.scoring_strategy);
         let score_ratio = (score - MIN_SCORE) as f64 / (MAX_SCORE - MIN_SCORE) as f64;
         let max_requests = (MAX_CONCURRENT_REQUESTS_PER_PEER as f64 * score_ratio).max(1.0);
-        (*requests as f64) < max_requests
+        (peer_data.requests as f64) < max_requests
     }
 
     fn do_get_best_peer(&self, capabilities: &[Capability]) -> Option<(H256, PeerConnection)> {
@@ -1185,7 +1357,7 @@ impl PeerTableServer {
             .iter()
             .filter_map(|(id, peer_data)| {
                 if excluded.contains(id)
-                    || !self.can_try_more_requests(&peer_data.score, &peer_data.requests)
+                    || !self.can_try_more_requests(peer_data)
                     || !capabilities
                         .iter()
                         .any(|cap| peer_data.supported_capabilities.contains(cap))
@@ -1193,11 +1365,11 @@ impl PeerTableServer {
                     None
                 } else {
                     let connection = peer_data.connection.clone()?;
-                    Some((*id, peer_data.score, peer_data.requests, connection))
+                    Some((*id, peer_data, connection))
                 }
             })
-            .max_by_key(|(_, score, reqs, _)| self.weight_peer(score, reqs))
-            .map(|(k, _, _, v)| (k, v))
+            .max_by_key(|(_, peer_data, _)| self.weight_peer(peer_data))
+            .map(|(k, _, v)| (k, v))
     }
 
     /// Returns up to `n` best peers with capability overlap, sorted by weight

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -31,7 +31,6 @@ use spawned_concurrency::{
     tasks::{Actor, ActorRef, ActorStart as _, Context, Handler, Response, send_message_on},
 };
 use std::{
-    collections::VecDeque,
     net::IpAddr,
     time::{Duration, Instant},
 };
@@ -46,8 +45,6 @@ const SCORE_WEIGHT: i64 = 1;
 const REQUESTS_WEIGHT: i64 = 1;
 /// Max amount of ongoing requests per peer.
 const MAX_CONCURRENT_REQUESTS_PER_PEER: i64 = 100;
-/// Number of latency/bandwidth samples to keep per peer for scoring.
-const METRICS_WINDOW_SIZE: usize = 20;
 /// Smoothing factor for exponential moving average (0..1, higher = more weight on recent).
 const EMA_ALPHA: f64 = 0.3;
 
@@ -88,20 +85,21 @@ impl Default for ScoringConfig {
 }
 
 /// Rolling performance metrics collected per peer.
+///
+/// Bandwidth is measured via cumulative bytes and time with exponential
+/// decay, so it reflects actual throughput across many requests rather
+/// than being dominated by per-request latency.
 #[derive(Debug, Clone, Default)]
 pub struct PeerMetrics {
-    latency_samples: VecDeque<Duration>,
     latency_ema_ms: Option<f64>,
-    bandwidth_samples: VecDeque<f64>,
-    bandwidth_ema: Option<f64>,
+    /// Exponentially-decayed cumulative bytes transferred.
+    bandwidth_bytes_acc: f64,
+    /// Exponentially-decayed cumulative transfer time (seconds).
+    bandwidth_time_acc: f64,
 }
 
 impl PeerMetrics {
     pub fn record_latency(&mut self, latency: Duration) {
-        if self.latency_samples.len() >= METRICS_WINDOW_SIZE {
-            self.latency_samples.pop_front();
-        }
-        self.latency_samples.push_back(latency);
         let ms = latency.as_secs_f64() * 1000.0;
         self.latency_ema_ms = Some(match self.latency_ema_ms {
             Some(prev) => prev * (1.0 - EMA_ALPHA) + ms * EMA_ALPHA,
@@ -113,15 +111,13 @@ impl PeerMetrics {
         if elapsed.is_zero() || bytes == 0 {
             return;
         }
-        let bps = bytes as f64 / elapsed.as_secs_f64();
-        if self.bandwidth_samples.len() >= METRICS_WINDOW_SIZE {
-            self.bandwidth_samples.pop_front();
-        }
-        self.bandwidth_samples.push_back(bps);
-        self.bandwidth_ema = Some(match self.bandwidth_ema {
-            Some(prev) => prev * (1.0 - EMA_ALPHA) + bps * EMA_ALPHA,
-            None => bps,
-        });
+        // Decay previous accumulators so recent transfers weigh more,
+        // then add the new sample.  bandwidth = total_bytes / total_time
+        // across the decayed window, which correctly separates throughput
+        // from latency.
+        self.bandwidth_bytes_acc = self.bandwidth_bytes_acc * (1.0 - EMA_ALPHA) + bytes as f64;
+        self.bandwidth_time_acc =
+            self.bandwidth_time_acc * (1.0 - EMA_ALPHA) + elapsed.as_secs_f64();
     }
 
     pub fn latency_ema_ms(&self) -> Option<f64> {
@@ -129,7 +125,11 @@ impl PeerMetrics {
     }
 
     pub fn bandwidth_ema_bps(&self) -> Option<f64> {
-        self.bandwidth_ema
+        if self.bandwidth_time_acc == 0.0 {
+            None
+        } else {
+            Some(self.bandwidth_bytes_acc / self.bandwidth_time_acc)
+        }
     }
 
     /// Peers with ≤50ms get MAX_SCORE, ≥5000ms get MIN_SCORE, linear interpolation.
@@ -149,7 +149,7 @@ impl PeerMetrics {
     /// Returns a neutral midpoint score for peers with no samples yet, so that
     /// "unknown" is distinguishable from "measured-and-at-boundary".
     pub fn bandwidth_score(&self) -> i64 {
-        let Some(ema) = self.bandwidth_ema else {
+        let Some(ema) = self.bandwidth_ema_bps() else {
             return (MAX_SCORE + MIN_SCORE) / 2;
         };
         let low = 10_000_f64;
@@ -438,11 +438,31 @@ impl PeerData {
     }
 
     /// Return the effective score for this peer under the given strategy.
+    ///
+    /// For Latency/Bandwidth strategies, the metric-derived score is combined
+    /// with the success-based `score` so that failure penalties (from
+    /// `record_failure` / `record_critical_failure`) are never silently ignored.
+    /// When `score` is negative (the peer has been penalized), we take the
+    /// minimum of the two so the penalty always takes effect.
     pub fn effective_score(&self, strategy: ScoringStrategy) -> i64 {
         match strategy {
             ScoringStrategy::Success => self.score,
-            ScoringStrategy::Latency => self.metrics.latency_score(),
-            ScoringStrategy::Bandwidth => self.metrics.bandwidth_score(),
+            ScoringStrategy::Latency => {
+                let metric = self.metrics.latency_score();
+                if self.score < 0 {
+                    metric.min(self.score)
+                } else {
+                    metric
+                }
+            }
+            ScoringStrategy::Bandwidth => {
+                let metric = self.metrics.bandwidth_score();
+                if self.score < 0 {
+                    metric.min(self.score)
+                } else {
+                    metric
+                }
+            }
         }
     }
 }

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -144,8 +144,12 @@ pub async fn request_account_range(
     let mut all_accounts_state = Vec::new();
 
     // channel to send the tasks to the peers
-    let (task_sender, mut task_receiver) =
-        tokio::sync::mpsc::channel::<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>, TransferStats)>(1000);
+    let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<(
+        Vec<AccountRangeUnit>,
+        H256,
+        Option<(H256, H256)>,
+        TransferStats,
+    )>(1000);
 
     info!("Starting to download account ranges from peers");
 
@@ -197,9 +201,15 @@ pub async fn request_account_range(
         if let Ok((accounts, peer_id, chunk_start_end, stats)) = task_receiver.try_recv() {
             // Feed transfer stats for bandwidth/latency scoring.
             if !stats.elapsed.is_zero() {
-                let _ = peers.peer_table.record_response_latency(peer_id, stats.elapsed);
+                let _ = peers
+                    .peer_table
+                    .record_response_latency(peer_id, stats.elapsed);
                 if stats.response_bytes > 0 {
-                    let _ = peers.peer_table.record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
+                    let _ = peers.peer_table.record_bandwidth(
+                        peer_id,
+                        stats.response_bytes,
+                        stats.elapsed,
+                    );
                 }
             }
             if let Some((chunk_start, chunk_end)) = chunk_start_end {
@@ -396,9 +406,15 @@ pub async fn request_bytecodes(
             } = result;
             // Feed transfer stats for bandwidth/latency scoring.
             if !stats.elapsed.is_zero() {
-                let _ = peers.peer_table.record_response_latency(peer_id, stats.elapsed);
+                let _ = peers
+                    .peer_table
+                    .record_response_latency(peer_id, stats.elapsed);
                 if stats.response_bytes > 0 {
-                    let _ = peers.peer_table.record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
+                    let _ = peers.peer_table.record_bandwidth(
+                        peer_id,
+                        stats.response_bytes,
+                        stats.elapsed,
+                    );
                 }
             }
 
@@ -481,7 +497,10 @@ pub async fn request_bytecodes(
             let (bytecodes, remaining_start, transfer_stats) = match response {
                 Ok(RLPxMessage::ByteCodes(ByteCodes { id: _, codes })) if !codes.is_empty() => {
                     let response_bytes: u64 = codes.iter().map(|c| c.len() as u64).sum();
-                    let stats = TransferStats { elapsed: req_elapsed, response_bytes };
+                    let stats = TransferStats {
+                        elapsed: req_elapsed,
+                        response_bytes,
+                    };
                     let validated_codes: Vec<Bytes> = codes
                         .into_iter()
                         .zip(hashes_to_request)
@@ -659,9 +678,15 @@ pub async fn request_storage_ranges(
             } = result;
             // Feed transfer stats for bandwidth/latency scoring.
             if !stats.elapsed.is_zero() {
-                let _ = peers.peer_table.record_response_latency(peer_id, stats.elapsed);
+                let _ = peers
+                    .peer_table
+                    .record_response_latency(peer_id, stats.elapsed);
                 if stats.response_bytes > 0 {
-                    let _ = peers.peer_table.record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
+                    let _ = peers.peer_table.record_bandwidth(
+                        peer_id,
+                        stats.response_bytes,
+                        stats.elapsed,
+                    );
                 }
             }
             completed_tasks += 1;
@@ -1149,7 +1174,12 @@ async fn request_account_range_worker(
     chunk_start: H256,
     chunk_end: H256,
     state_root: H256,
-    tx: tokio::sync::mpsc::Sender<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>, TransferStats)>,
+    tx: tokio::sync::mpsc::Sender<(
+        Vec<AccountRangeUnit>,
+        H256,
+        Option<(H256, H256)>,
+        TransferStats,
+    )>,
     permit: RequestPermit,
 ) -> Result<(), SnapError> {
     debug!("Requesting account range from peer {peer_id}, chunk: {chunk_start:?} - {chunk_end:?}");
@@ -1189,7 +1219,10 @@ async fn request_account_range_worker(
             .map(|u| u.account.encode_to_vec().len() + 32)
             .sum::<usize>()
             + proof.iter().map(|p| p.len()).sum::<usize>();
-        let stats = TransferStats { elapsed, response_bytes: response_bytes as u64 };
+        let stats = TransferStats {
+            elapsed,
+            response_bytes: response_bytes as u64,
+        };
 
         if accounts.is_empty() {
             retry(stats)
@@ -1238,7 +1271,10 @@ async fn request_account_range_worker(
             }
         }
     } else {
-        let stats = TransferStats { elapsed, response_bytes: 0 };
+        let stats = TransferStats {
+            elapsed,
+            response_bytes: 0,
+        };
         tracing::debug!("Failed to get account range");
         retry(stats)
     };

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -199,19 +199,6 @@ pub async fn request_account_range(
         }
 
         if let Ok((accounts, peer_id, chunk_start_end, stats)) = task_receiver.try_recv() {
-            // Feed transfer stats for bandwidth/latency scoring.
-            if !stats.elapsed.is_zero() {
-                let _ = peers
-                    .peer_table
-                    .record_response_latency(peer_id, stats.elapsed);
-                if stats.response_bytes > 0 {
-                    let _ = peers.peer_table.record_bandwidth(
-                        peer_id,
-                        stats.response_bytes,
-                        stats.elapsed,
-                    );
-                }
-            }
             if let Some((chunk_start, chunk_end)) = chunk_start_end {
                 if chunk_start <= chunk_end {
                     tasks_queue_not_started.push_back((chunk_start, chunk_end));
@@ -225,6 +212,19 @@ pub async fn request_account_range(
             if accounts.is_empty() {
                 peers.peer_table.record_failure(peer_id)?;
                 continue;
+            }
+            // Record latency/bandwidth only after validation (non-empty response).
+            if !stats.elapsed.is_zero() {
+                let _ = peers
+                    .peer_table
+                    .record_response_latency(peer_id, stats.elapsed);
+                if stats.response_bytes > 0 {
+                    let _ = peers.peer_table.record_bandwidth(
+                        peer_id,
+                        stats.response_bytes,
+                        stats.elapsed,
+                    );
+                }
             }
             peers.peer_table.record_success(peer_id)?;
 
@@ -404,19 +404,6 @@ pub async fn request_bytecodes(
                 remaining_end,
                 transfer_stats: stats,
             } = result;
-            // Feed transfer stats for bandwidth/latency scoring.
-            if !stats.elapsed.is_zero() {
-                let _ = peers
-                    .peer_table
-                    .record_response_latency(peer_id, stats.elapsed);
-                if stats.response_bytes > 0 {
-                    let _ = peers.peer_table.record_bandwidth(
-                        peer_id,
-                        stats.response_bytes,
-                        stats.elapsed,
-                    );
-                }
-            }
 
             debug!(
                 "Downloaded {} bytecodes from peer {peer_id} (current count: {downloaded_count})",
@@ -431,6 +418,19 @@ pub async fn request_bytecodes(
             if bytecodes.is_empty() {
                 peers.peer_table.record_failure(peer_id)?;
                 continue;
+            }
+            // Record latency/bandwidth only after validation (non-empty response).
+            if !stats.elapsed.is_zero() {
+                let _ = peers
+                    .peer_table
+                    .record_response_latency(peer_id, stats.elapsed);
+                if stats.response_bytes > 0 {
+                    let _ = peers.peer_table.record_bandwidth(
+                        peer_id,
+                        stats.response_bytes,
+                        stats.elapsed,
+                    );
+                }
             }
 
             downloaded_count += bytecodes.len() as u64;
@@ -676,18 +676,16 @@ pub async fn request_storage_ranges(
                 remaining_hash_range: (hash_start, hash_end),
                 transfer_stats: stats,
             } = result;
-            // Feed transfer stats for bandwidth/latency scoring.
-            if !stats.elapsed.is_zero() {
+            // Record latency/bandwidth only for responses with actual data.
+            if !stats.elapsed.is_zero() && stats.response_bytes > 0 {
                 let _ = peers
                     .peer_table
                     .record_response_latency(peer_id, stats.elapsed);
-                if stats.response_bytes > 0 {
-                    let _ = peers.peer_table.record_bandwidth(
-                        peer_id,
-                        stats.response_bytes,
-                        stats.elapsed,
-                    );
-                }
+                let _ = peers.peer_table.record_bandwidth(
+                    peer_id,
+                    stats.response_bytes,
+                    stats.elapsed,
+                );
             }
             completed_tasks += 1;
 
@@ -1100,9 +1098,11 @@ pub async fn request_state_trienodes(
             .collect(),
         bytes: MAX_RESPONSE_BYTES,
     });
+    let req_start = Instant::now();
     let response = connection
         .outgoing_request(request, PEER_REPLY_TIMEOUT)
         .await;
+    let elapsed = req_start.elapsed();
     drop(permit);
     let nodes = match response {
         Ok(RLPxMessage::TrieNodes(trie_nodes)) => trie_nodes
@@ -1130,6 +1130,9 @@ pub async fn request_state_trienodes(
             return Err(SnapError::InvalidHash);
         }
     }
+
+    // Record latency only after full validation (decode + hash check).
+    let _ = peer_table.record_response_latency(peer_id, elapsed);
 
     Ok(nodes)
 }

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -1097,11 +1097,9 @@ pub async fn request_state_trienodes(
             .collect(),
         bytes: MAX_RESPONSE_BYTES,
     });
-    let req_start = Instant::now();
     let response = connection
         .outgoing_request(request, PEER_REPLY_TIMEOUT)
         .await;
-    let elapsed = req_start.elapsed();
     drop(permit);
     let nodes = match response {
         Ok(RLPxMessage::TrieNodes(trie_nodes)) => trie_nodes
@@ -1129,9 +1127,6 @@ pub async fn request_state_trienodes(
             return Err(SnapError::InvalidHash);
         }
     }
-
-    // Record latency only after full validation (decode + hash check).
-    let _ = peer_table.record_response_latency(peer_id, elapsed);
 
     Ok(nodes)
 }

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -681,11 +681,10 @@ pub async fn request_storage_ranges(
                 let _ = peers
                     .peer_table
                     .record_response_latency(peer_id, stats.elapsed);
-                let _ = peers.peer_table.record_bandwidth(
-                    peer_id,
-                    stats.response_bytes,
-                    stats.elapsed,
-                );
+                let _ =
+                    peers
+                        .peer_table
+                        .record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
             }
             completed_tasks += 1;
 

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -37,12 +37,19 @@ use std::{
     collections::{BTreeMap, HashMap, VecDeque},
     path::Path,
     sync::atomic::Ordering,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use tracing::{debug, error, info, trace, warn};
 
 // Re-export DumpError from error module
 pub use super::error::DumpError;
+
+/// Lightweight transfer statistics returned by snap workers for bandwidth/latency scoring.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TransferStats {
+    pub elapsed: Duration,
+    pub response_bytes: u64,
+}
 
 /// Metadata for requesting trie nodes
 #[derive(Debug, Clone)]
@@ -69,6 +76,7 @@ struct StorageTaskResult {
     remaining_start: usize,
     remaining_end: usize,
     remaining_hash_range: (H256, Option<H256>),
+    transfer_stats: TransferStats,
 }
 
 #[derive(Debug)]
@@ -137,7 +145,7 @@ pub async fn request_account_range(
 
     // channel to send the tasks to the peers
     let (task_sender, mut task_receiver) =
-        tokio::sync::mpsc::channel::<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>)>(1000);
+        tokio::sync::mpsc::channel::<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>, TransferStats)>(1000);
 
     info!("Starting to download account ranges from peers");
 
@@ -186,7 +194,14 @@ pub async fn request_account_range(
             last_update = SystemTime::now();
         }
 
-        if let Ok((accounts, peer_id, chunk_start_end)) = task_receiver.try_recv() {
+        if let Ok((accounts, peer_id, chunk_start_end, stats)) = task_receiver.try_recv() {
+            // Feed transfer stats for bandwidth/latency scoring.
+            if !stats.elapsed.is_zero() {
+                let _ = peers.peer_table.record_response_latency(peer_id, stats.elapsed);
+                if stats.response_bytes > 0 {
+                    let _ = peers.peer_table.record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
+                }
+            }
             if let Some((chunk_start, chunk_end)) = chunk_start_end {
                 if chunk_start <= chunk_end {
                     tasks_queue_not_started.push_back((chunk_start, chunk_end));
@@ -355,6 +370,7 @@ pub async fn request_bytecodes(
         peer_id: H256,
         remaining_start: usize,
         remaining_end: usize,
+        transfer_stats: TransferStats,
     }
     let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<TaskResult>(1000);
 
@@ -376,7 +392,15 @@ pub async fn request_bytecodes(
                 peer_id,
                 remaining_start,
                 remaining_end,
+                transfer_stats: stats,
             } = result;
+            // Feed transfer stats for bandwidth/latency scoring.
+            if !stats.elapsed.is_zero() {
+                let _ = peers.peer_table.record_response_latency(peer_id, stats.elapsed);
+                if stats.response_bytes > 0 {
+                    let _ = peers.peer_table.record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
+                }
+            }
 
             debug!(
                 "Downloaded {} bytecodes from peer {peer_id} (current count: {downloaded_count})",
@@ -447,13 +471,17 @@ pub async fn request_bytecodes(
                 bytes: MAX_RESPONSE_BYTES,
             });
 
+            let req_start = Instant::now();
             let response = connection
                 .outgoing_request(request, PEER_REPLY_TIMEOUT)
                 .await;
+            let req_elapsed = req_start.elapsed();
             drop(permit);
 
-            let (bytecodes, remaining_start) = match response {
+            let (bytecodes, remaining_start, transfer_stats) = match response {
                 Ok(RLPxMessage::ByteCodes(ByteCodes { id: _, codes })) if !codes.is_empty() => {
+                    let response_bytes: u64 = codes.iter().map(|c| c.len() as u64).sum();
+                    let stats = TransferStats { elapsed: req_elapsed, response_bytes };
                     let validated_codes: Vec<Bytes> = codes
                         .into_iter()
                         .zip(hashes_to_request)
@@ -461,15 +489,17 @@ pub async fn request_bytecodes(
                         .map(|(b, _hash)| b)
                         .collect();
                     let new_remaining_start = chunk_start + validated_codes.len();
-                    (validated_codes, new_remaining_start)
+                    (validated_codes, new_remaining_start, stats)
                 }
                 Ok(RLPxMessage::ByteCodes(_)) => {
                     // Empty response; retry the full chunk.
-                    (Vec::new(), chunk_start)
+                    let stats = TransferStats { elapsed: req_elapsed, response_bytes: 0 };
+                    (Vec::new(), chunk_start, stats)
                 }
                 _ => {
                     tracing::debug!("Failed to get bytecode");
-                    (Vec::new(), chunk_start)
+                    let stats = TransferStats { elapsed: req_elapsed, response_bytes: 0 };
+                    (Vec::new(), chunk_start, stats)
                 }
             };
 
@@ -479,6 +509,7 @@ pub async fn request_bytecodes(
                 peer_id,
                 remaining_start,
                 remaining_end: chunk_end,
+                transfer_stats,
             };
             tx.send(result).await.ok();
         });
@@ -624,7 +655,15 @@ pub async fn request_storage_ranges(
                 remaining_start,
                 remaining_end,
                 remaining_hash_range: (hash_start, hash_end),
+                transfer_stats: stats,
             } = result;
+            // Feed transfer stats for bandwidth/latency scoring.
+            if !stats.elapsed.is_zero() {
+                let _ = peers.peer_table.record_response_latency(peer_id, stats.elapsed);
+                if stats.response_bytes > 0 {
+                    let _ = peers.peer_table.record_bandwidth(peer_id, stats.response_bytes, stats.elapsed);
+                }
+            }
             completed_tasks += 1;
 
             for (_, accounts) in accounts_by_root_hash[start_index..remaining_start].iter() {
@@ -1110,7 +1149,7 @@ async fn request_account_range_worker(
     chunk_start: H256,
     chunk_end: H256,
     state_root: H256,
-    tx: tokio::sync::mpsc::Sender<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>)>,
+    tx: tokio::sync::mpsc::Sender<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>, TransferStats)>,
     permit: RequestPermit,
 ) -> Result<(), SnapError> {
     debug!("Requesting account range from peer {peer_id}, chunk: {chunk_start:?} - {chunk_end:?}");
@@ -1125,25 +1164,35 @@ async fn request_account_range_worker(
 
     // Perform the wire request and release the peer slot as soon as the
     // response (or error) is in — processing below is pure computation.
+    let start = Instant::now();
     let response = connection
         .outgoing_request(request, PEER_REPLY_TIMEOUT)
         .await;
+    let elapsed = start.elapsed();
     drop(permit);
 
-    let retry = || {
+    let retry = |stats: TransferStats| {
         (
             Vec::<AccountRangeUnit>::new(),
             Some((chunk_start, chunk_end)),
+            stats,
         )
     };
-    let (accounts_out, chunk_left) = if let Ok(RLPxMessage::AccountRange(AccountRange {
+    let (accounts_out, chunk_left, stats) = if let Ok(RLPxMessage::AccountRange(AccountRange {
         id: _,
         accounts,
         proof,
     })) = response
     {
+        let response_bytes = accounts
+            .iter()
+            .map(|u| u.account.encode_to_vec().len() + 32)
+            .sum::<usize>()
+            + proof.iter().map(|p| p.len()).sum::<usize>();
+        let stats = TransferStats { elapsed, response_bytes: response_bytes as u64 };
+
         if accounts.is_empty() {
-            retry()
+            retry(stats)
         } else {
             // Validate response — build the verification inputs by borrowing
             // `accounts` so we can still consume it for the filtered output.
@@ -1180,20 +1229,21 @@ async fn request_account_range_worker(
                         .into_iter()
                         .filter(|unit| unit.hash <= chunk_end)
                         .collect::<Vec<_>>();
-                    (filtered, chunk_left)
+                    (filtered, chunk_left, stats)
                 }
                 Err(_) => {
                     tracing::error!("Received invalid account range");
-                    retry()
+                    retry(stats)
                 }
             }
         }
     } else {
+        let stats = TransferStats { elapsed, response_bytes: 0 };
         tracing::debug!("Failed to get account range");
-        retry()
+        retry(stats)
     };
 
-    tx.send((accounts_out, peer_id, chunk_left)).await.ok();
+    tx.send((accounts_out, peer_id, chunk_left, stats)).await.ok();
     Ok::<(), SnapError>(())
 }
 
@@ -1214,12 +1264,13 @@ async fn request_storage_ranges_worker(
 
     // Defaults for the "retry this same range" outcome used by every failure
     // branch below.
-    let retry_outcome = || {
+    let retry_outcome = |stats: TransferStats| {
         (
             Vec::<Vec<(H256, U256)>>::new(),
             task.start_index,
             task.end_index,
             (start_hash, task.end_hash),
+            stats,
         )
     };
 
@@ -1236,12 +1287,14 @@ async fn request_storage_ranges_worker(
 
     // Perform the wire request and release the peer slot as soon as the
     // response (or error) is in — validation below is pure computation.
+    let req_start = Instant::now();
     let response = connection
         .outgoing_request(request, PEER_REPLY_TIMEOUT)
         .await;
+    let req_elapsed = req_start.elapsed();
     drop(permit);
 
-    let (account_storages, remaining_start, remaining_end, remaining_hash_range) = 'outcome: {
+    let (account_storages, remaining_start, remaining_end, remaining_hash_range, transfer_stats) = 'outcome: {
         let Ok(RLPxMessage::StorageRanges(StorageRanges {
             id: _,
             slots,
@@ -1252,17 +1305,27 @@ async fn request_storage_ranges_worker(
             ethrex_metrics::sync::METRICS_SYNC.inc_storage_request("timeout");
             tracing::trace!(peer_id = %peer_id, msg_type = "GetStorageRanges", outcome = "timeout", "Storage range request failed");
             tracing::debug!("Failed to get storage range");
-            break 'outcome retry_outcome();
+            break 'outcome retry_outcome(TransferStats { elapsed: req_elapsed, response_bytes: 0 });
+        };
+        let response_bytes = slots
+            .iter()
+            .flat_map(|acct_slots| acct_slots.iter())
+            .map(|_slot| 32 + 32) // hash + U256 value
+            .sum::<usize>()
+            + proof.iter().map(|p| p.len()).sum::<usize>();
+        let transfer_stats = TransferStats {
+            elapsed: req_elapsed,
+            response_bytes: response_bytes as u64,
         };
         if slots.is_empty() && proof.is_empty() {
             #[cfg(feature = "metrics")]
             ethrex_metrics::sync::METRICS_SYNC.inc_storage_request("empty");
             tracing::trace!(peer_id = %peer_id, msg_type = "StorageRanges", outcome = "empty", "Storage range response empty");
             tracing::debug!("Received empty storage range");
-            break 'outcome retry_outcome();
+            break 'outcome retry_outcome(transfer_stats);
         }
         if slots.len() > chunk_storage_roots.len() || slots.is_empty() {
-            break 'outcome retry_outcome();
+            break 'outcome retry_outcome(transfer_stats);
         }
         let proof = encodable_to_proof(&proof);
         let mut account_storages: Vec<Vec<(H256, U256)>> = vec![];
@@ -1286,7 +1349,7 @@ async fn request_storage_ranges_worker(
                 Some(root) => root,
                 None => {
                     error!("No storage root for account {i}");
-                    break 'outcome retry_outcome();
+                    break 'outcome retry_outcome(transfer_stats);
                 }
             };
 
@@ -1325,7 +1388,7 @@ async fn request_storage_ranges_worker(
         }
 
         if validation_failed {
-            break 'outcome retry_outcome();
+            break 'outcome retry_outcome(transfer_stats);
         }
 
         let (remaining_start, remaining_end, remaining_start_hash) = if should_continue {
@@ -1333,14 +1396,14 @@ async fn request_storage_ranges_worker(
                 Some(storage) => storage,
                 None => {
                     error!("No account storage found, this shouldn't happen");
-                    break 'outcome retry_outcome();
+                    break 'outcome retry_outcome(transfer_stats);
                 }
             };
             let (last_hash, _) = match last_account_storage.last() {
                 Some(last_hash) => last_hash,
                 None => {
                     error!("No last hash found, this shouldn't happen");
-                    break 'outcome retry_outcome();
+                    break 'outcome retry_outcome(transfer_stats);
                 }
             };
             let next_hash_u256 = U256::from_big_endian(&last_hash.0).saturating_add(1.into());
@@ -1358,6 +1421,7 @@ async fn request_storage_ranges_worker(
             remaining_start,
             remaining_end,
             (remaining_start_hash, task.end_hash),
+            transfer_stats,
         )
     };
 
@@ -1368,6 +1432,7 @@ async fn request_storage_ranges_worker(
         remaining_start,
         remaining_end,
         remaining_hash_range,
+        transfer_stats,
     };
     tx.send(task_result).await.ok();
     Ok::<(), SnapError>(())

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -512,12 +512,18 @@ pub async fn request_bytecodes(
                 }
                 Ok(RLPxMessage::ByteCodes(_)) => {
                     // Empty response; retry the full chunk.
-                    let stats = TransferStats { elapsed: req_elapsed, response_bytes: 0 };
+                    let stats = TransferStats {
+                        elapsed: req_elapsed,
+                        response_bytes: 0,
+                    };
                     (Vec::new(), chunk_start, stats)
                 }
                 _ => {
                     tracing::debug!("Failed to get bytecode");
-                    let stats = TransferStats { elapsed: req_elapsed, response_bytes: 0 };
+                    let stats = TransferStats {
+                        elapsed: req_elapsed,
+                        response_bytes: 0,
+                    };
                     (Vec::new(), chunk_start, stats)
                 }
             };
@@ -1276,7 +1282,9 @@ async fn request_account_range_worker(
         retry(stats)
     };
 
-    tx.send((accounts_out, peer_id, chunk_left, stats)).await.ok();
+    tx.send((accounts_out, peer_id, chunk_left, stats))
+        .await
+        .ok();
     Ok::<(), SnapError>(())
 }
 
@@ -1338,7 +1346,10 @@ async fn request_storage_ranges_worker(
             ethrex_metrics::sync::METRICS_SYNC.inc_storage_request("timeout");
             tracing::trace!(peer_id = %peer_id, msg_type = "GetStorageRanges", outcome = "timeout", "Storage range request failed");
             tracing::debug!("Failed to get storage range");
-            break 'outcome retry_outcome(TransferStats { elapsed: req_elapsed, response_bytes: 0 });
+            break 'outcome retry_outcome(TransferStats {
+                elapsed: req_elapsed,
+                response_bytes: 0,
+            });
         };
         let response_bytes = slots
             .iter()

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -11,6 +11,7 @@ mod snap_sync;
 
 use crate::metrics::METRICS;
 use crate::peer_handler::{BlockRequestOrder, PeerHandler, PeerHandlerError};
+use crate::peer_table::{PeerTableServerProtocol as _, ScoringConfig};
 use crate::snap::constants::{EXECUTE_BATCH_SIZE_DEFAULT, MIN_FULL_BLOCKS};
 use crate::utils::delete_leaves_folder;
 use ethrex_blockchain::{Blockchain, error::ChainError};
@@ -112,6 +113,8 @@ pub struct Syncer {
     peers: PeerHandler,
     // Used for cancelling long-living tasks upon shutdown
     cancel_token: CancellationToken,
+    /// Per-phase peer scoring configuration.
+    scoring_config: ScoringConfig,
     blockchain: Arc<Blockchain>,
     /// This string indicates a folder where the snap algorithm will store temporary files that are
     /// used during the syncing process
@@ -127,6 +130,7 @@ impl Syncer {
         blockchain: Arc<Blockchain>,
         datadir: PathBuf,
         diagnostics: Arc<tokio::sync::RwLock<SyncDiagnostics>>,
+        scoring_config: ScoringConfig,
     ) -> Self {
         Self {
             snap_enabled,
@@ -135,6 +139,7 @@ impl Syncer {
             blockchain,
             datadir,
             diagnostics,
+            scoring_config,
         }
     }
 
@@ -204,6 +209,11 @@ impl Syncer {
     async fn sync_cycle(&mut self, sync_head: H256, store: Store) -> Result<(), SyncError> {
         // Take picture of the current sync mode, we will update the original value when we need to
         if self.snap_enabled.load(Ordering::Relaxed) {
+            // Switch to snap-phase scoring strategy.
+            let _ = self
+                .peers
+                .peer_table
+                .set_scoring_strategy(self.scoring_config.snap);
             // Probe the sync head's block number before committing to snap sync.
             // On a fresh devnet the chain head may be only a few blocks deep; the
             // existing in-loop `head_close_to_0` guard in `sync_cycle_snap`
@@ -253,6 +263,11 @@ impl Syncer {
             METRICS.disable().await;
             sync_cycle_result
         } else {
+            // Switch to live-phase scoring strategy.
+            let _ = self
+                .peers
+                .peer_table
+                .set_scoring_strategy(self.scoring_config.live);
             full::sync_cycle_full(
                 &mut self.peers,
                 self.blockchain.clone(),

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -18,6 +18,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     peer_handler::PeerHandler,
+    peer_table::ScoringConfig,
     sync::{SyncDiagnostics, SyncMode, Syncer},
 };
 
@@ -41,6 +42,7 @@ impl SyncManager {
         blockchain: Arc<Blockchain>,
         store: Store,
         datadir: PathBuf,
+        scoring_config: ScoringConfig,
     ) -> Self {
         let snap_enabled = Arc::new(AtomicBool::new(matches!(sync_mode, SyncMode::Snap)));
 
@@ -85,6 +87,7 @@ impl SyncManager {
             blockchain,
             datadir,
             diagnostics.clone(),
+            scoring_config,
         )));
         let sync_manager = Self {
             snap_enabled,

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -333,6 +333,7 @@ pub async fn dummy_sync_manager() -> SyncManager {
         Store::new("temp.db", ethrex_storage::EngineType::InMemory)
             .expect("Failed to start Storage Engine"),
         ".".into(),
+        Default::default(),
     )
     .await
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -178,6 +178,18 @@ P2P options:
           [env: ETHREX_P2P_LOOKUP_INTERVAL=]
           [default: 100]
 
+      --p2p.snap-scoring <STRATEGY>
+          Peer scoring strategy during snap sync. One of: success, latency, bandwidth.
+
+          [env: ETHREX_P2P_SNAP_SCORING=]
+          [default: bandwidth]
+
+      --p2p.live-scoring <STRATEGY>
+          Peer scoring strategy during live/full sync. One of: success, latency, bandwidth.
+
+          [env: ETHREX_P2P_LIVE_SCORING=]
+          [default: latency]
+
 RPC options:
       --http.addr <ADDRESS>
           Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).


### PR DESCRIPTION
## Summary

- Introduces a pluggable `ScoringStrategy` enum (`Success`, `Latency`, `Bandwidth`) for P2P peer selection, with per-phase configuration
- Adds `PeerMetrics` struct on each `PeerData` tracking latency EMA (ms) and bandwidth EMA (bytes/s) using a rolling 20-sample window with exponential moving average (α=0.3)
- Instruments `make_request`, snap sync workers (account range, storage ranges, bytecodes), and header download workers to report `TransferStats` (elapsed time + response bytes)
- All three scoring dimensions are always collected regardless of active strategy

### Per-phase CLI configuration

During snap sync, bandwidth matters most (bulk data transfer). During live/full sync, latency matters most (block-by-block propagation). Two new CLI flags control this:

```
--p2p.snap-scoring <strategy>   # default: bandwidth
--p2p.live-scoring <strategy>   # default: latency
```

Where `<strategy>` is one of: `success`, `latency`, `bandwidth`.

The `Syncer` automatically switches strategy when entering snap vs full/live sync cycles.

## Test plan

- [x] `cargo check --workspace` passes with zero warnings
- [x] `cargo clippy -p ethrex-p2p -p ethrex` passes with zero warnings
- [ ] Verify peer selection behavior under each strategy with live peers
- [ ] Validate that latency/bandwidth EMA converges to expected values under controlled conditions