### PR TITLE
feat(l1): add txpool_contentFrom and txpool_inspect to the rpc namespace

### DIFF
--- a/crates/networking/rpc/mempool.rs
+++ b/crates/networking/rpc/mempool.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ethrex_common::{types::TxKind, Address};
+use ethrex_common::{Address, types::TxKind};
 use ethrex_crypto::NativeCrypto;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -120,7 +120,10 @@ pub fn inspect(context: RpcApiContext) -> Result<Value, RpcErr> {
                 gas_price
             ),
         };
-        pending.entry(sender).or_default().insert(tx.nonce(), summary);
+        pending
+            .entry(sender)
+            .or_default()
+            .insert(tx.nonce(), summary);
     }
     let response = MempoolInspect {
         pending,

--- a/crates/networking/rpc/mempool.rs
+++ b/crates/networking/rpc/mempool.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ethrex_common::Address;
+use ethrex_common::{types::TxKind, Address, U256};
 use ethrex_crypto::NativeCrypto;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -22,6 +22,22 @@ pub struct MempoolContent {
 struct MempoolStatus {
     pending: String,
     queued: String,
+}
+
+type MempoolContentByNonce = HashMap<u64, RpcTransaction>;
+
+#[derive(Serialize, Deserialize)]
+pub struct MempoolContentFrom {
+    pub pending: MempoolContentByNonce,
+    pub queued: MempoolContentByNonce,
+}
+
+type MempoolInspectEntry = HashMap<Address, HashMap<u64, String>>;
+
+#[derive(Serialize, Deserialize)]
+pub struct MempoolInspect {
+    pub pending: MempoolInspectEntry,
+    pub queued: MempoolInspectEntry,
 }
 
 /// Handling of rpc endpoint `mempool_content`
@@ -53,5 +69,66 @@ pub fn status(context: RpcApiContext) -> Result<Value, RpcErr> {
         queued: format!("{queued:#x}"),
     };
 
+    Ok(serde_json::to_value(response)?)
+}
+
+/// Handling of rpc endpoint `txpool_contentFrom`
+pub fn content_from(params: &Option<Vec<Value>>, context: RpcApiContext) -> Result<Value, RpcErr> {
+    let params = params
+        .as_ref()
+        .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+    if params.len() != 1 {
+        return Err(RpcErr::BadParams(format!(
+            "Expected one param and {} were provided",
+            params.len()
+        )));
+    }
+    let address: Address = serde_json::from_value(params[0].clone())?;
+    let transactions = context.blockchain.mempool.content()?;
+    let mut by_nonce: MempoolContentByNonce = HashMap::new();
+    for tx in transactions {
+        if tx.sender(&NativeCrypto)? == address {
+            by_nonce.insert(tx.nonce(), RpcTransaction::build(tx, None, None, None)?);
+        }
+    }
+    let response = MempoolContentFrom {
+        pending: by_nonce,
+        // We have no concept of "queued" transactions yet so we will leave this empty
+        queued: HashMap::new(),
+    };
+    Ok(serde_json::to_value(response)?)
+}
+
+/// Handling of rpc endpoint `txpool_inspect`
+pub fn inspect(context: RpcApiContext) -> Result<Value, RpcErr> {
+    let transactions = context.blockchain.mempool.content()?;
+    let mut pending: MempoolInspectEntry = HashMap::new();
+    for tx in transactions {
+        let sender = tx.sender(&NativeCrypto)?;
+        let gas_price = tx
+            .max_fee_per_gas()
+            .map(U256::from)
+            .unwrap_or_else(|| tx.gas_price());
+        let summary = match tx.to() {
+            TxKind::Call(to) => format!(
+                "{to:#x}: {} wei + {} gas × {} wei",
+                tx.value(),
+                tx.gas_limit(),
+                gas_price
+            ),
+            TxKind::Create => format!(
+                "contract creation: {} wei + {} gas × {} wei",
+                tx.value(),
+                tx.gas_limit(),
+                gas_price
+            ),
+        };
+        pending.entry(sender).or_default().insert(tx.nonce(), summary);
+    }
+    let response = MempoolInspect {
+        pending,
+        // We have no concept of "queued" transactions yet so we will leave this empty
+        queued: HashMap::new(),
+    };
     Ok(serde_json::to_value(response)?)
 }

--- a/crates/networking/rpc/mempool.rs
+++ b/crates/networking/rpc/mempool.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ethrex_common::{types::TxKind, Address, U256};
+use ethrex_common::{types::TxKind, Address};
 use ethrex_crypto::NativeCrypto;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -105,10 +105,7 @@ pub fn inspect(context: RpcApiContext) -> Result<Value, RpcErr> {
     let mut pending: MempoolInspectEntry = HashMap::new();
     for tx in transactions {
         let sender = tx.sender(&NativeCrypto)?;
-        let gas_price = tx
-            .max_fee_per_gas()
-            .map(U256::from)
-            .unwrap_or_else(|| tx.gas_price());
+        let gas_price = tx.gas_price();
         let summary = match tx.to() {
             TxKind::Call(to) => format!(
                 "{to:#x}: {} wei + {} gas × {} wei",

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -896,7 +896,9 @@ pub fn map_mempool_requests(req: &RpcRequest, contex: RpcApiContext) -> Result<V
     match req.method.as_str() {
         // TODO: The endpoint name matches geth's endpoint for compatibility, consider changing it in the future
         "txpool_content" => mempool::content(contex),
+        "txpool_contentFrom" => mempool::content_from(&req.params, contex),
         "txpool_status" => mempool::status(contex),
+        "txpool_inspect" => mempool::inspect(contex),
         unknown_mempool_method => Err(RpcErr::MethodNotFound(unknown_mempool_method.to_owned())),
     }
 }


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
This PR implements txpool_contentFrom and txpool_inspect RPC methods in ethrex, the only two txpool namespace methods missing from the client. The goal is to evaluate full compatibility with https://github.com/ethereum/execution-apis/pull/758, which standardizes the txpool namespace across Ethereum execution clients.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

