### PR TITLE
ci(l1): run AI reviews only when PR is marked ready for review

### DIFF
--- a/.github/workflows/pr_ai_review.yaml
+++ b/.github/workflows/pr_ai_review.yaml
@@ -1,7 +1,7 @@
 # AI Code Review using lambdaclass/actions reusable workflows
 #
 # Triggers:
-# - Automatically on PR open/ready_for_review
+# - Automatically when PR is marked as ready for review
 # - On-demand via PR comments: /kimi, /codex, /claude (requires write access)
 #
 # Custom prompt: .github/prompts/ai-review.md
@@ -15,7 +15,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ready_for_review]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/pr_ai_review.yaml
+++ b/.github/workflows/pr_ai_review.yaml
@@ -1,7 +1,7 @@
 # AI Code Review using lambdaclass/actions reusable workflows
 #
 # Triggers:
-# - Automatically when PR is marked as ready for review
+# - Automatically on PR open (non-draft) or when marked as ready for review
 # - On-demand via PR comments: /kimi, /codex, /claude (requires write access)
 #
 # Custom prompt: .github/prompts/ai-review.md
@@ -15,7 +15,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 
@@ -27,16 +27,19 @@ permissions:
 
 jobs:
   kimi-review:
+    if: github.event.pull_request.draft == false
     uses: lambdaclass/actions/.github/workflows/ai-review-kimi.yml@v1
     secrets:
       KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
 
   codex-review:
+    if: github.event.pull_request.draft == false
     uses: lambdaclass/actions/.github/workflows/ai-review-codex.yml@v1
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   claude-review:
+    if: github.event.pull_request.draft == false
     uses: lambdaclass/actions/.github/workflows/ai-review-claude.yml@v1
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
**Motivation**

AI reviews currently run both when a PR is opened (including drafts) and when it's marked as ready for review. This causes duplicate reviews that clutter the PR history with long, spammy comments flagging known in-progress issues, making the actual review harder to follow.

**Description**

Remove the `opened` event type from the `pull_request` trigger in the AI review workflow, keeping only `ready_for_review`. On-demand reviews via PR comments (`/kimi`, `/codex`, `/claude`) still work on drafts if needed.

**Note:** The `claude-review` CI failure on this PR is expected — the workflow on `main` still has the `opened` trigger, so it ran and failed on this draft. This will resolve itself once merged.

**Checklist**

- [x] No code changes — workflow-only