### PR TITLE
fix(l1): truncate hive test slug to avoid filename-too-long error

### DIFF
--- a/.github/scripts/check-hive-results.sh
+++ b/.github/scripts/check-hive-results.sh
@@ -249,10 +249,17 @@ for json_file in "${json_files[@]}"; do
         fi
 
         case_slug="$(slugify "${raw_case_name}")"
+        case_suffix="case-${case_id}"
         if [ -n "${case_slug}" ]; then
-          case_slug="${case_slug}-case-${case_id}"
+          # Truncate the name part so the full component stays under the
+          # 255-char filesystem limit (leave room for suffix + separator).
+          max_name_len=$(( 250 - ${#case_suffix} - 1 ))
+          if [ "${#case_slug}" -gt "${max_name_len}" ]; then
+            case_slug="${case_slug:0:${max_name_len}}"
+          fi
+          case_slug="${case_slug}-${case_suffix}"
         else
-          case_slug="case-${case_id}"
+          case_slug="${case_suffix}"
         fi
 
         client_slug="$(slugify "${client_id}")"


### PR DESCRIPTION
## Summary
- The Amsterdam EIP-7778 Hive tests have names that, once slugified, exceed the Linux 255-character filesystem limit for a single path component.
- `check-hive-results.sh` now truncates the name part of the slug before appending the `-case-{id}` suffix, keeping the total under 250 characters.
- Fixes the `mkdir: File name too long` error currently breaking the **Hive - Consume Engine Amsterdam** job on main.

## Test plan
- [ ] Verify the Hive CI jobs pass on this branch without the "file name too long" error.