### PR TITLE
feat(l1): skip receipt validation during full sync batch execution

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1138,13 +1138,16 @@ impl Blockchain {
         block: &Block,
         chain_config: &ChainConfig,
         vm: &mut Evm,
+        skip_receipt_validation: bool,
     ) -> Result<BlockExecutionResult, ChainError> {
         // Validate the block pre-execution
         validate_block_pre_execution(block, parent_header, chain_config, ELASTICITY_MULTIPLIER)?;
         let (execution_result, bal) = vm.execute_block(block)?;
         // Validate execution went alright
         validate_gas_used(execution_result.block_gas_used, &block.header)?;
-        validate_receipts_root(&block.header, &execution_result.receipts, &NativeCrypto)?;
+        if !skip_receipt_validation {
+            validate_receipts_root(&block.header, &execution_result.receipts, &NativeCrypto)?;
+        }
         validate_requests_hash(&block.header, chain_config, &execution_result.requests)?;
         if let Some(bal) = &bal {
             validate_block_access_list_hash(
@@ -2211,7 +2214,7 @@ impl Blockchain {
             };
 
             let BlockExecutionResult { receipts, .. } = self
-                .execute_block_from_state(&parent_header, block, &chain_config, &mut vm)
+                .execute_block_from_state(&parent_header, block, &chain_config, &mut vm, true)
                 .map_err(|err| {
                     (
                         err,

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1308,6 +1308,7 @@ impl Blockchain {
         block: &Block,
         chain_config: &ChainConfig,
         vm: &mut Evm,
+        skip_receipt_validation: bool,
     ) -> Result<BlockExecutionResult, ChainError> {
         // Validate the block pre-execution
         validate_block_pre_execution(block, parent_header, chain_config, ELASTICITY_MULTIPLIER)?;
@@ -1322,7 +1323,9 @@ impl Blockchain {
             );
             return Err(e.into());
         }
-        validate_receipts_root(&block.header, &execution_result.receipts, &NativeCrypto)?;
+        if !skip_receipt_validation {
+            validate_receipts_root(&block.header, &execution_result.receipts, &NativeCrypto)?;
+        }
         validate_requests_hash(&block.header, chain_config, &execution_result.requests)?;
         if let Some(bal) = &bal {
             validate_block_access_list_hash(
@@ -2441,7 +2444,7 @@ impl Blockchain {
             };
 
             let BlockExecutionResult { receipts, .. } = self
-                .execute_block_from_state(&parent_header, block, &chain_config, &mut vm)
+                .execute_block_from_state(&parent_header, block, &chain_config, &mut vm, true)
                 .map_err(|err| {
                     (
                         err,


### PR DESCRIPTION
## Summary
- Adds `skip_receipt_validation` parameter to `execute_block_from_state()`
- Skips `validate_receipts_root()` only in the `add_blocks_in_batch()` path (full sync)
- All other execution paths (CL blocks, pipeline) still validate receipts
- Since we download from trusted peers with a verified header chain, and the state root validation at end of each batch ensures correctness, receipt re-validation is redundant during full sync

Closes #6482

## Test plan
- [ ] Run full sync on hoodi with `FULL_SYNC_BLOCK_LIMIT=50000` and verify it completes without errors
- [ ] Compare sync time with and without this change to measure improvement
- [ ] Verify normal CL block processing still validates receipts