### PR TITLE
feat(l1): pipeline body download with execution

### DIFF
--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -214,9 +214,7 @@ pub async fn sync_cycle_full(
                     }
                 }
             }
-            if !blocks.is_empty()
-                && body_tx.send(Ok((blocks, final_batch))).await.is_err()
-            {
+            if !blocks.is_empty() && body_tx.send(Ok((blocks, final_batch))).await.is_err() {
                 // Receiver dropped (execution loop stopped), stop downloading
                 return;
             }

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -116,53 +116,129 @@ pub async fn sync_cycle_full(
     end_block_number += 1;
     start_block_number = start_block_number.max(1);
 
-    // Download block bodies and execute full blocks in batches
-    for start in (start_block_number..end_block_number).step_by(*EXECUTE_BATCH_SIZE) {
-        let batch_size = EXECUTE_BATCH_SIZE.min((end_block_number - start) as usize);
-        let final_batch = end_block_number == start + batch_size as u64;
-        // Retrieve batch from DB
-        if !single_batch {
-            headers = store
+    // Pipeline: download block bodies in a background task while the main loop executes.
+    // This overlaps network I/O with block execution for better throughput.
+    let (body_tx, mut body_rx) =
+        tokio::sync::mpsc::channel::<Result<(Vec<Block>, bool), SyncError>>(2);
+
+    // Clone resources for the background download task
+    let mut download_peers = peers.clone();
+    let download_store = store.clone();
+
+    let download_task = tokio::spawn(async move {
+        // If single_batch, we already have headers in memory — send them as the one and only batch.
+        if single_batch {
+            let final_batch = true;
+            let mut batch_headers = headers;
+            let mut blocks = Vec::new();
+            while !batch_headers.is_empty() {
+                let end = min(MAX_BLOCK_BODIES_TO_REQUEST, batch_headers.len());
+                let header_batch = &batch_headers[..end];
+                match download_peers.request_block_bodies(header_batch).await {
+                    Ok(Some(bodies)) => {
+                        debug!("Obtained: {} block bodies", bodies.len());
+                        let block_batch = batch_headers
+                            .drain(..bodies.len())
+                            .zip(bodies)
+                            .map(|(header, body)| Block { header, body });
+                        blocks.extend(block_batch);
+                    }
+                    Ok(None) => {
+                        let _ = body_tx.send(Err(SyncError::BodiesNotFound)).await;
+                        return;
+                    }
+                    Err(e) => {
+                        let _ = body_tx.send(Err(e.into())).await;
+                        return;
+                    }
+                }
+            }
+            if !blocks.is_empty() {
+                let _ = body_tx.send(Ok((blocks, final_batch))).await;
+            }
+            return;
+        }
+
+        // Multi-batch path: iterate through all batches, download bodies, and send them.
+        for start in (start_block_number..end_block_number).step_by(*EXECUTE_BATCH_SIZE) {
+            let batch_size = EXECUTE_BATCH_SIZE.min((end_block_number - start) as usize);
+            let final_batch = end_block_number == start + batch_size as u64;
+
+            let batch_headers = match download_store
                 .read_fullsync_batch(start, batch_size as u64)
-                .await?
+                .await
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    let _ = body_tx.send(Err(e.into())).await;
+                    return;
+                }
+            };
+            let mut batch_headers: Vec<_> = match batch_headers
                 .into_iter()
                 .map(|opt| opt.ok_or(SyncError::MissingFullsyncBatch))
-                .collect::<Result<Vec<_>, SyncError>>()?;
+                .collect()
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    let _ = body_tx.send(Err(e)).await;
+                    return;
+                }
+            };
+
+            let mut blocks = Vec::new();
+            while !batch_headers.is_empty() {
+                let end = min(MAX_BLOCK_BODIES_TO_REQUEST, batch_headers.len());
+                let header_batch = &batch_headers[..end];
+                match download_peers.request_block_bodies(header_batch).await {
+                    Ok(Some(bodies)) => {
+                        debug!("Obtained: {} block bodies", bodies.len());
+                        let block_batch = batch_headers
+                            .drain(..bodies.len())
+                            .zip(bodies)
+                            .map(|(header, body)| Block { header, body });
+                        blocks.extend(block_batch);
+                    }
+                    Ok(None) => {
+                        let _ = body_tx.send(Err(SyncError::BodiesNotFound)).await;
+                        return;
+                    }
+                    Err(e) => {
+                        let _ = body_tx.send(Err(e.into())).await;
+                        return;
+                    }
+                }
+            }
+            if !blocks.is_empty() {
+                if body_tx.send(Ok((blocks, final_batch))).await.is_err() {
+                    // Receiver dropped (execution loop stopped), stop downloading
+                    return;
+                }
+            }
         }
-        let mut blocks = Vec::new();
-        // Request block bodies
-        // Download block bodies
-        while !headers.is_empty() {
-            let header_batch = &headers[..min(MAX_BLOCK_BODIES_TO_REQUEST, headers.len())];
-            let bodies = peers
-                .request_block_bodies(header_batch)
-                .await?
-                .ok_or(SyncError::BodiesNotFound)?;
-            debug!("Obtained: {} block bodies", bodies.len());
-            let block_batch = headers
-                .drain(..bodies.len())
-                .zip(bodies)
-                .map(|(header, body)| Block { header, body });
-            blocks.extend(block_batch);
-        }
-        if !blocks.is_empty() {
-            // Execute blocks
-            info!(
-                "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
-                blocks.len(),
-                blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
-                blocks.last().ok_or(SyncError::NoBlocks)?.hash()
-            );
-            add_blocks_in_batch(
-                blockchain.clone(),
-                cancel_token.clone(),
-                blocks,
-                final_batch,
-                store.clone(),
-            )
-            .await?;
-        }
+    });
+
+    // Main loop: receive downloaded batches and execute them
+    while let Some(result) = body_rx.recv().await {
+        let (blocks, final_batch) = result?;
+        info!(
+            "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
+            blocks.len(),
+            blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
+            blocks.last().ok_or(SyncError::NoBlocks)?.hash()
+        );
+        add_blocks_in_batch(
+            blockchain.clone(),
+            cancel_token.clone(),
+            blocks,
+            final_batch,
+            store.clone(),
+        )
+        .await?;
     }
+
+    // Ensure the download task completes and propagate any panics
+    download_task.await?;
 
     // Execute pending blocks
     if !pending_blocks.is_empty() {

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -209,11 +209,11 @@ pub async fn sync_cycle_full(
                     }
                 }
             }
-            if !blocks.is_empty() {
-                if body_tx.send(Ok((blocks, final_batch))).await.is_err() {
-                    // Receiver dropped (execution loop stopped), stop downloading
-                    return;
-                }
+            if !blocks.is_empty()
+                && body_tx.send(Ok((blocks, final_batch))).await.is_err()
+            {
+                // Receiver dropped (execution loop stopped), stop downloading
+                return;
             }
         }
     });

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -214,11 +214,11 @@ pub async fn sync_cycle_full(
                     }
                 }
             }
-            if !blocks.is_empty() {
-                if body_tx.send(Ok((blocks, final_batch))).await.is_err() {
-                    // Receiver dropped (execution loop stopped), stop downloading
-                    return;
-                }
+            if !blocks.is_empty()
+                && body_tx.send(Ok((blocks, final_batch))).await.is_err()
+            {
+                // Receiver dropped (execution loop stopped), stop downloading
+                return;
             }
         }
     });

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -121,53 +121,129 @@ pub async fn sync_cycle_full(
     end_block_number += 1;
     start_block_number = start_block_number.max(1);
 
-    // Download block bodies and execute full blocks in batches
-    for start in (start_block_number..end_block_number).step_by(*EXECUTE_BATCH_SIZE) {
-        let batch_size = EXECUTE_BATCH_SIZE.min((end_block_number - start) as usize);
-        let final_batch = end_block_number == start + batch_size as u64;
-        // Retrieve batch from DB
-        if !single_batch {
-            headers = store
+    // Pipeline: download block bodies in a background task while the main loop executes.
+    // This overlaps network I/O with block execution for better throughput.
+    let (body_tx, mut body_rx) =
+        tokio::sync::mpsc::channel::<Result<(Vec<Block>, bool), SyncError>>(2);
+
+    // Clone resources for the background download task
+    let mut download_peers = peers.clone();
+    let download_store = store.clone();
+
+    let download_task = tokio::spawn(async move {
+        // If single_batch, we already have headers in memory — send them as the one and only batch.
+        if single_batch {
+            let final_batch = true;
+            let mut batch_headers = headers;
+            let mut blocks = Vec::new();
+            while !batch_headers.is_empty() {
+                let end = min(MAX_BLOCK_BODIES_TO_REQUEST, batch_headers.len());
+                let header_batch = &batch_headers[..end];
+                match download_peers.request_block_bodies(header_batch).await {
+                    Ok(Some(bodies)) => {
+                        debug!("Obtained: {} block bodies", bodies.len());
+                        let block_batch = batch_headers
+                            .drain(..bodies.len())
+                            .zip(bodies)
+                            .map(|(header, body)| Block { header, body });
+                        blocks.extend(block_batch);
+                    }
+                    Ok(None) => {
+                        let _ = body_tx.send(Err(SyncError::BodiesNotFound)).await;
+                        return;
+                    }
+                    Err(e) => {
+                        let _ = body_tx.send(Err(e.into())).await;
+                        return;
+                    }
+                }
+            }
+            if !blocks.is_empty() {
+                let _ = body_tx.send(Ok((blocks, final_batch))).await;
+            }
+            return;
+        }
+
+        // Multi-batch path: iterate through all batches, download bodies, and send them.
+        for start in (start_block_number..end_block_number).step_by(*EXECUTE_BATCH_SIZE) {
+            let batch_size = EXECUTE_BATCH_SIZE.min((end_block_number - start) as usize);
+            let final_batch = end_block_number == start + batch_size as u64;
+
+            let batch_headers = match download_store
                 .read_fullsync_batch(start, batch_size as u64)
-                .await?
+                .await
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    let _ = body_tx.send(Err(e.into())).await;
+                    return;
+                }
+            };
+            let mut batch_headers: Vec<_> = match batch_headers
                 .into_iter()
                 .map(|opt| opt.ok_or(SyncError::MissingFullsyncBatch))
-                .collect::<Result<Vec<_>, SyncError>>()?;
+                .collect()
+            {
+                Ok(h) => h,
+                Err(e) => {
+                    let _ = body_tx.send(Err(e)).await;
+                    return;
+                }
+            };
+
+            let mut blocks = Vec::new();
+            while !batch_headers.is_empty() {
+                let end = min(MAX_BLOCK_BODIES_TO_REQUEST, batch_headers.len());
+                let header_batch = &batch_headers[..end];
+                match download_peers.request_block_bodies(header_batch).await {
+                    Ok(Some(bodies)) => {
+                        debug!("Obtained: {} block bodies", bodies.len());
+                        let block_batch = batch_headers
+                            .drain(..bodies.len())
+                            .zip(bodies)
+                            .map(|(header, body)| Block { header, body });
+                        blocks.extend(block_batch);
+                    }
+                    Ok(None) => {
+                        let _ = body_tx.send(Err(SyncError::BodiesNotFound)).await;
+                        return;
+                    }
+                    Err(e) => {
+                        let _ = body_tx.send(Err(e.into())).await;
+                        return;
+                    }
+                }
+            }
+            if !blocks.is_empty() {
+                if body_tx.send(Ok((blocks, final_batch))).await.is_err() {
+                    // Receiver dropped (execution loop stopped), stop downloading
+                    return;
+                }
+            }
         }
-        let mut blocks = Vec::new();
-        // Request block bodies
-        // Download block bodies
-        while !headers.is_empty() {
-            let header_batch = &headers[..min(MAX_BLOCK_BODIES_TO_REQUEST, headers.len())];
-            let bodies = peers
-                .request_block_bodies(header_batch)
-                .await?
-                .ok_or(SyncError::BodiesNotFound)?;
-            debug!("Obtained: {} block bodies", bodies.len());
-            let block_batch = headers
-                .drain(..bodies.len())
-                .zip(bodies)
-                .map(|(header, body)| Block { header, body });
-            blocks.extend(block_batch);
-        }
-        if !blocks.is_empty() {
-            // Execute blocks
-            info!(
-                "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
-                blocks.len(),
-                blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
-                blocks.last().ok_or(SyncError::NoBlocks)?.hash()
-            );
-            add_blocks_in_batch(
-                blockchain.clone(),
-                cancel_token.clone(),
-                blocks,
-                final_batch,
-                store.clone(),
-            )
-            .await?;
-        }
+    });
+
+    // Main loop: receive downloaded batches and execute them
+    while let Some(result) = body_rx.recv().await {
+        let (blocks, final_batch) = result?;
+        info!(
+            "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
+            blocks.len(),
+            blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
+            blocks.last().ok_or(SyncError::NoBlocks)?.hash()
+        );
+        add_blocks_in_batch(
+            blockchain.clone(),
+            cancel_token.clone(),
+            blocks,
+            final_batch,
+            store.clone(),
+        )
+        .await?;
     }
+
+    // Ensure the download task completes and propagate any panics
+    download_task.await?;
 
     // Execute pending blocks
     if !pending_blocks.is_empty() {


### PR DESCRIPTION
## Summary
- Restructures `sync_cycle_full` to overlap body downloads with block execution
- Spawns a background task that downloads bodies and sends batches through `mpsc::channel(2)` (2-batch buffer)
- Main loop receives pre-fetched batches and executes them — next batch downloads while current batch executes
- Handles both single-batch (headers in memory) and multi-batch (headers from store) paths
- Errors from the download task propagate cleanly to the execution loop
- Est. +12-15% throughput by hiding body download latency behind execution

Closes #6479

## Test plan
- [ ] Run full sync on hoodi with `FULL_SYNC_BLOCK_LIMIT=50000` and verify completion
- [ ] Compare total sync time with and without pipelining
- [ ] Verify error handling: download task stops when execution errors