### PR TITLE
ci(l1): pin Amsterdam EELS branch and make CI job required

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,0 +1,4 @@
+# Amsterdam (BAL) hive test configuration
+# Pinned from ethereum/execution-specs devnets/bal/3 @ 2026-04-14
+fixtures: https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz
+eels_commit: 5c6e20abf3586f52d9e58393203ca07f2d0151fe

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -123,7 +123,7 @@ jobs:
             if [[ "$SIM_LIMIT" == *"fork_Amsterdam"* ]]; then
               # Amsterdam tests use fixtures_bal which includes BAL-specific tests
               FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz"
-              FLAGS+=" --sim.buildarg branch=devnets/bal/3"
+              FLAGS+=" --sim.buildarg branch=5c6e20abf3586f52d9e58393203ca07f2d0151fe"
             else
               # All other forks (Prague, Osaka, Cancun, Shanghai, Paris) use fixtures_develop
               # which includes comprehensive test coverage including static tests

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -123,6 +123,7 @@ jobs:
             if [[ "$SIM_LIMIT" == *"fork_Amsterdam"* ]]; then
               # Amsterdam tests use fixtures_bal which includes BAL-specific tests
               FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz"
+              # Pinned from devnets/bal/3 @ 2026-04-14
               FLAGS+=" --sim.buildarg branch=5c6e20abf3586f52d9e58393203ca07f2d0151fe"
             else
               # All other forks (Prague, Osaka, Cancun, Shanghai, Paris) use fixtures_develop

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -110,21 +110,29 @@ jobs:
 
       # Set custom args defined in Dockerfile to pin execution-spec-tests versions
       # See: https://github.com/ethereum/hive/blob/c2dab60f898b94afe8eeac505f60dcde59205e77/simulators/ethereum/eest/consume-rlp/Dockerfile#L4-L8
+      - name: Load Amsterdam config
+        id: amsterdam-config
+        shell: bash
+        run: |
+          echo "fixtures=$(yq -r '.fixtures' .github/config/hive/amsterdam.yaml)" >> "$GITHUB_OUTPUT"
+          echo "eels_commit=$(yq -r '.eels_commit' .github/config/hive/amsterdam.yaml)" >> "$GITHUB_OUTPUT"
+
       - name: Determine hive flags
         id: hive-flags
         shell: bash
         env:
           SIMULATION: ${{ matrix.test.simulation }}
           SIM_LIMIT: ${{ matrix.test.limit || '' }}
+          AMSTERDAM_FIXTURES: ${{ steps.amsterdam-config.outputs.fixtures }}
+          AMSTERDAM_EELS_COMMIT: ${{ steps.amsterdam-config.outputs.eels_commit }}
         run: |
           FLAGS="--sim.parallelism ${{ matrix.test.parallelism || 4 }} --sim.loglevel 1"
           if [[ "$SIMULATION" == "ethereum/eels/consume-engine" || "$SIMULATION" == "ethereum/eels/consume-rlp" ]]; then
             # Use fork-specific fixtures to ensure comprehensive test coverage
             if [[ "$SIM_LIMIT" == *"fork_Amsterdam"* ]]; then
-              # Amsterdam tests use fixtures_bal which includes BAL-specific tests
-              FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz"
-              # Pinned from devnets/bal/3 @ 2026-04-14
-              FLAGS+=" --sim.buildarg branch=5c6e20abf3586f52d9e58393203ca07f2d0151fe"
+              # Amsterdam config loaded from .github/config/hive/amsterdam.yaml
+              FLAGS+=" --sim.buildarg fixtures=$AMSTERDAM_FIXTURES"
+              FLAGS+=" --sim.buildarg branch=$AMSTERDAM_EELS_COMMIT"
             else
               # All other forks (Prague, Osaka, Cancun, Shanghai, Paris) use fixtures_develop
               # which includes comprehensive test coverage including static tests

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -233,14 +233,14 @@ jobs:
             simulation: ethereum/engine
             limit: "engine-withdrawals"
             artifact_prefix: engine_withdrawals
-          # Not required while Amsterdam fork spec is still evolving.
-          # Remove optional: true once the fork stabilizes.
+          # Pin EELS branch to a known-good commit to avoid CI breakage
+          # from upstream changes. Bump the commit when ready to pick up new tests.
+          # Source: ethereum/execution-specs devnets/bal/3 @ 2026-04-14
           - name: "Consume Engine Amsterdam"
             simulation: ethereum/eels/consume-engine
             limit: ".*(8024|7708|7778|7843|7928|7954|8037).*"
-            buildarg: "fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz branch=devnets/bal/3"
+            buildarg: "fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz branch=5c6e20abf3586f52d9e58393203ca07f2d0151fe"
             artifact_prefix: consume_engine_amsterdam
-            optional: true
           # Investigate this test
           # - name: "Sync"
           #   simulation: ethereum/sync

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -233,13 +233,11 @@ jobs:
             simulation: ethereum/engine
             limit: "engine-withdrawals"
             artifact_prefix: engine_withdrawals
-          # Pin EELS branch to a known-good commit to avoid CI breakage
-          # from upstream changes. Bump the commit when ready to pick up new tests.
-          # Source: ethereum/execution-specs devnets/bal/3 @ 2026-04-14
+          # Amsterdam config is loaded from .github/config/hive/amsterdam.yaml
           - name: "Consume Engine Amsterdam"
             simulation: ethereum/eels/consume-engine
             limit: ".*(8024|7708|7778|7843|7928|7954|8037).*"
-            buildarg: "fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/bal@v5.6.1/fixtures_bal.tar.gz branch=5c6e20abf3586f52d9e58393203ca07f2d0151fe"
+            amsterdam: true
             artifact_prefix: consume_engine_amsterdam
           # Investigate this test
           # - name: "Sync"
@@ -270,21 +268,36 @@ jobs:
             echo "EOF"
           } >>"$GITHUB_OUTPUT"
 
+      - name: Load Amsterdam config
+        id: amsterdam-config
+        shell: bash
+        run: |
+          echo "fixtures=$(yq -r '.fixtures' .github/config/hive/amsterdam.yaml)" >> "$GITHUB_OUTPUT"
+          echo "eels_commit=$(yq -r '.eels_commit' .github/config/hive/amsterdam.yaml)" >> "$GITHUB_OUTPUT"
+
       - name: Determine hive flags
         id: hive-flags
         shell: bash
         env:
           SIM_LIMIT: ${{ matrix.limit }}
           SIM_BUILDARG: ${{ matrix.buildarg }}
+          AMSTERDAM: ${{ matrix.amsterdam || 'false' }}
+          AMSTERDAM_FIXTURES: ${{ steps.amsterdam-config.outputs.fixtures }}
+          AMSTERDAM_EELS_COMMIT: ${{ steps.amsterdam-config.outputs.eels_commit }}
         run: |
           FLAGS='--sim.parallelism 4 --sim.loglevel 3'
           if [[ -n "$SIM_LIMIT" ]]; then
             escaped_limit=${SIM_LIMIT//\'/\'\\\'\'}
             FLAGS+=" --sim.limit '$escaped_limit'"
           fi
-          for arg in $SIM_BUILDARG; do
-            FLAGS+=" --sim.buildarg $arg"
-          done
+          if [[ "$AMSTERDAM" == "true" ]]; then
+            FLAGS+=" --sim.buildarg fixtures=$AMSTERDAM_FIXTURES"
+            FLAGS+=" --sim.buildarg branch=$AMSTERDAM_EELS_COMMIT"
+          else
+            for arg in $SIM_BUILDARG; do
+              FLAGS+=" --sim.buildarg $arg"
+            done
+          fi
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -201,7 +201,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, docker_build]
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
-    continue-on-error: ${{ matrix.optional || false }}
     env:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     strategy:


### PR DESCRIPTION
## Summary
- Pin the EELS reference branch to commit `5c6e20ab` (devnets/bal/3 @ 2026-04-14) instead of tracking the branch directly, which is a moving target that can break CI unexpectedly.
- Remove `optional: true` from the Amsterdam Consume Engine job so it becomes a required check in PR CI.
- Apply the same pin to the daily hive report workflow.

## Test plan
- [ ] Amsterdam Consume Engine hive job passes in CI with the pinned commit