### PR TITLE
fix(l1): mark unresponsive peers as disposable to prevent snapsync stalls

### DIFF
--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -90,6 +90,8 @@ async fn ask_peer_head_number(
         }
         Ok(_other_msgs) => Err(PeerHandlerError::UnexpectedResponseFromPeer(peer_id)),
         Err(PeerConnectionError::Timeout) => {
+            // Mark this peer as disposable so it gets pruned and replaced
+            let _ = peer_table.set_disposable(peer_id);
             Err(PeerHandlerError::ReceiveMessageFromPeerTimeout(peer_id))
         }
         Err(_other_err) => Err(PeerHandlerError::ReceiveMessageFromPeer(peer_id)),
@@ -448,13 +450,15 @@ impl PeerHandler {
                         warn!(
                             "[SYNCING] Received empty/invalid headers from peer, penalizing peer {peer_id}"
                         );
+                        let _ = self.peer_table.set_disposable(peer_id);
                         return Ok(None);
                     }
                 }
-                // Timeouted
+                // Timeout or invalid response - mark peer as disposable
                 warn!(
                     "[SYNCING] Didn't receive block headers from peer, penalizing peer {peer_id}..."
                 );
+                let _ = self.peer_table.set_disposable(peer_id);
                 Ok(None)
             }
         }
@@ -536,6 +540,7 @@ impl PeerHandler {
                     "[SYNCING] Didn't receive block bodies from peer, penalizing peer {peer_id}..."
                 );
                 self.peer_table.record_failure(peer_id)?;
+                let _ = self.peer_table.set_disposable(peer_id);
                 Ok(None)
             }
         }

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -971,11 +971,15 @@ impl PeerTableServer {
         None
     }
 
-    /// Iterate over all contacts across all buckets.
+    /// Iterate over all contacts across all buckets (main and replacement lists).
     fn iter_contacts(&self) -> impl Iterator<Item = (&H256, &Contact)> {
-        self.buckets
-            .iter()
-            .flat_map(|bucket| bucket.contacts.iter().map(|(id, c)| (id, c)))
+        self.buckets.iter().flat_map(|bucket| {
+            bucket
+                .contacts
+                .iter()
+                .chain(bucket.replacements.iter())
+                .map(|(id, c)| (id, c))
+        })
     }
 
     // --- Peer selection ---
@@ -1048,8 +1052,10 @@ impl PeerTableServer {
     }
 
     fn do_get_contact_to_initiate(&mut self) -> Option<Contact> {
+        // Check both main contacts and replacements in each bucket.
+        // Replacements may contain fresher peers that haven't been tried yet.
         for bucket in &self.buckets {
-            for (node_id, contact) in &bucket.contacts {
+            for (node_id, contact) in bucket.contacts.iter().chain(bucket.replacements.iter()) {
                 if !self.peers.contains_key(node_id)
                     && !self.already_tried_peers.contains(node_id)
                     && contact.knows_us

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -86,9 +86,12 @@ impl KBucket {
         })
     }
 
-    /// Find a mutable reference to a contact by node ID within this bucket.
+    /// Find a mutable reference to a contact by node ID (main or replacement list).
     fn get_mut(&mut self, node_id: &H256) -> Option<&mut Contact> {
-        self.contacts
+        if let Some((_, c)) = self.contacts.iter_mut().find(|(id, _)| id == node_id) {
+            return Some(c);
+        }
+        self.replacements
             .iter_mut()
             .find(|(id, _)| id == node_id)
             .map(|(_, c)| c)
@@ -909,10 +912,10 @@ impl PeerTableServer {
         bucket_index(&self.local_node_id, node_id)
     }
 
-    /// Look up a contact by node ID (O(K) within the bucket).
+    /// Look up a contact by node ID in main or replacement list (O(K) within the bucket).
     fn get_contact(&self, node_id: &H256) -> Option<&Contact> {
         let idx = self.bucket_for(node_id)?;
-        self.buckets[idx].get(node_id)
+        self.buckets[idx].get_any(node_id)
     }
 
     /// Look up a mutable reference to a contact by node ID.

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -1011,15 +1011,37 @@ impl PeerTableServer {
 
     // --- Contact operations ---
 
+    /// Prune disposable contacts from both main and replacement lists.
+    /// When a main contact is removed, a replacement is automatically promoted.
     fn prune(&mut self) {
-        let disposable_contacts: Vec<H256> = self
-            .iter_contacts()
-            .filter_map(|(id, c)| c.disposable.then_some(*id))
-            .collect();
+        for bucket in &mut self.buckets {
+            // Collect disposable contacts from main list
+            let main_disposable: Vec<H256> = bucket
+                .contacts
+                .iter()
+                .filter(|(_, c)| c.disposable)
+                .map(|(id, _)| *id)
+                .collect();
 
-        for node_id in disposable_contacts {
-            if let Some(idx) = self.bucket_for(&node_id) {
-                self.buckets[idx].remove_and_promote(&node_id);
+            // Remove from main list and promote replacements
+            for node_id in main_disposable {
+                bucket.remove_and_promote(&node_id);
+                self.discarded_contacts.insert(node_id);
+            }
+
+            // Remove disposable contacts from replacement list
+            // (these don't get promoted, just removed)
+            let replacement_disposable: Vec<H256> = bucket
+                .replacements
+                .iter()
+                .filter(|(_, c)| c.disposable)
+                .map(|(id, _)| *id)
+                .collect();
+
+            bucket
+                .replacements
+                .retain(|(id, _)| !replacement_disposable.contains(id));
+            for node_id in replacement_disposable {
                 self.discarded_contacts.insert(node_id);
             }
         }

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -130,6 +130,9 @@ pub async fn sync_cycle_snap(
     let mut attempts = 0;
 
     loop {
+        // Prune dead/unresponsive peers periodically to allow replacements to be promoted
+        let _ = peers.peer_table.prune_table();
+
         debug!("Requesting Block Headers from {current_head}");
 
         let Some(mut block_headers) = peers


### PR DESCRIPTION
# fix(p2p): Mark unresponsive peers as disposable to prevent snapsync stalls

## Summary

Fixes snapsync failures caused by the Kademlia k-bucket implementation introduced in PR #6458. The issue manifested as "Node failed to snapsync" errors after 3h35m with "Failed to receive block headers" when the peer count remained stuck at 6 peers throughout the sync.

Closes #XXXX (if issue exists)
Related to #6458

## Problem

After PR #6458 introduced proper Kademlia k-bucket routing tables, long-running snapsync operations would fail because:

1. **Unresponsive peers weren't being pruned**: Contacts that timeout during RLPx operations were never marked as `disposable`, so they remained in the main bucket list indefinitely
2. **Replacement contacts couldn't be promoted**: New discovered peers went into replacement lists (when buckets were full), but since dead peers weren't removed, replacements never got promoted
3. **No periodic pruning during sync**: The `prune()` function was only called manually, not during sync loops
4. **Incomplete prune implementation**: The `prune()` function only checked main contacts, leaving disposable contacts in replacement lists

### Evidence from CI Artifacts

Analysis of failed CI run artifacts (lighthouse-sepolia) showed:
- Peer count stuck at **6 peers** throughout entire 3h35m sync
- Sync rate drops to **0 slots/s** at 09:28:06 and never recovers
- Final error: `"Peer handler error: Failed to receive block headers"`
- Peers exist but become unresponsive, yet no new peers are discovered/connected

## Changes

### 1. Enhanced `prune()` to handle replacement lists (`peer_table.rs`)
```rust
fn prune(&mut self) {
    for bucket in &mut self.buckets {
        // Remove from main list and promote replacements
        for node_id in main_disposable {
            bucket.remove_and_promote(&node_id);
            self.discarded_contacts.insert(node_id);
        }

        // Remove disposable contacts from replacement list
        bucket.replacements.retain(|(id, _)| !replacement_disposable.contains(id));
    }
}
```

### 2. Mark peers as disposable on timeout/error (`peer_handler.rs`)
- Added `peer_table.set_disposable(peer_id)` calls when:
  - `PeerConnectionError::Timeout` occurs in `request_sync_head()`
  - Empty/invalid headers received from peer
  - Block bodies request fails or times out

### 3. Added periodic pruning to sync loop (`snap_sync.rs`)
```rust
loop {
    // Prune dead/unresponsive peers periodically to allow replacements to be promoted
    let _ = peers.peer_table.prune_table();

    // ... sync operations
}
```

## Test Plan

- [x] Code compiles with `cargo check`
- [x] Passes `cargo fmt`
- [ ] Run daily snapsync test on lighthouse-sepolia (should not timeout at 3h35m)
- [ ] Run daily snapsync test on prysm-sepolia
- [ ] Verify peer count increases during long sync operations
- [ ] Verify dead peers are replaced with active peers from replacement lists

## Expected Behavior After Fix

1. When a peer times out during snapsync, it's marked as disposable
2. Next prune cycle removes it from the bucket and promotes a replacement
3. New peers can be discovered and connected throughout the sync
4. Peer count should fluctuate as dead peers are replaced with healthy ones
5. Long-running syncs should not stall due to unresponsive peers

## Metrics to Monitor

- Peer count during sync (should not stay constant for hours)
- Sync rate (should not drop to 0 and stay there)
- Peer churn (disposable peers removed, replacements promoted)
- Time to complete snapsync (should be < 3h35m timeout)

## Breaking Changes

None - this is a bug fix that makes the Kademlia implementation work as intended.

## Additional Context

The root cause was that Kademlia's replacement list feature (designed to hold candidate peers until main contacts fail) wasn't working because peers were never marked as failed during sync operations. This is a critical fix for production deployments running long sync operations.