### PR TITLE
fix(l1): include blob gas in mempool balance check for EIP-4844 transactions

### DIFF
--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -498,8 +498,15 @@ impl Mempool {
     }
 }
 
+/// Filter applied by the payload builder when querying pending transactions
+/// from the pool. NOT a mempool admission gate — all fields here are
+/// query-time filters used to pick block-includable transactions. Admission
+/// rules are enforced in `Blockchain::validate_transaction`.
 #[derive(Debug, Default)]
 pub struct PendingTxFilter {
+    /// Minimum effective priority fee for a transaction to be surfaced to
+    /// the payload builder. This is a block-building filter, not an
+    /// admission check — see `crates/common/types/constants.rs::MIN_GAS_TIP`.
     pub min_tip: Option<u64>,
     pub base_fee: Option<u64>,
     pub blob_fee: Option<u64>,

--- a/crates/common/types/constants.rs
+++ b/crates/common/types/constants.rs
@@ -12,10 +12,8 @@ pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01; // Defined in [EIP-4844](https:
 /// Minimum tip, obtained from geth's default miner config (https://github.com/ethereum/go-ethereum/blob/f750117ad19d623622cc4a46ea361a716ba7407e/miner/miner.go#L56)
 ///
 /// Scope: this constant is consumed only by the RPC gas-price estimators
-/// (`eth_gasPrice`, `eth_maxPriorityFeePerGas`). It is NOT an admission
-/// gate in the mempool — zero-tip transactions are currently admitted.
-/// A dedicated admission-time min-tip floor is tracked in the umbrella
-/// `mempool-hardening-roadmap` change (Tier 1, PR T1b).
+/// (`eth_gasPrice`, `eth_maxPriorityFeePerGas`). It is NOT a mempool
+/// admission gate — zero-tip transactions are currently admitted.
 ///
 /// TODO: This should be configurable along with the tip filter on https://github.com/lambdaclass/ethrex/issues/680
 pub const MIN_GAS_TIP: u64 = 1000000;

--- a/crates/common/types/constants.rs
+++ b/crates/common/types/constants.rs
@@ -10,6 +10,13 @@ pub const MIN_BASE_FEE_PER_BLOB_GAS: u64 = 1; // Defined in [EIP-4844](https://e
 pub const BLOB_BASE_FEE_UPDATE_FRACTION: u64 = 3338477; // Defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01; // Defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
 /// Minimum tip, obtained from geth's default miner config (https://github.com/ethereum/go-ethereum/blob/f750117ad19d623622cc4a46ea361a716ba7407e/miner/miner.go#L56)
+///
+/// Scope: this constant is consumed only by the RPC gas-price estimators
+/// (`eth_gasPrice`, `eth_maxPriorityFeePerGas`). It is NOT an admission
+/// gate in the mempool — zero-tip transactions are currently admitted.
+/// A dedicated admission-time min-tip floor is tracked in the umbrella
+/// `mempool-hardening-roadmap` change (Tier 1, PR T1b).
+///
 /// TODO: This should be configurable along with the tip filter on https://github.com/lambdaclass/ethrex/issues/680
 pub const MIN_GAS_TIP: u64 = 1000000;
 

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -452,10 +452,22 @@ impl Transaction {
             TxType::Privileged => self.gas_price(),
         };
 
-        Some(U256::saturating_add(
+        let base = U256::saturating_add(
             U256::saturating_mul(price, self.gas_limit().into()),
             self.value(),
-        ))
+        );
+
+        // EIP-4844 blob txs pay an additional `blob_gas * max_fee_per_blob_gas`
+        // upfront. Every peer client (geth, reth, nethermind, erigon, besu)
+        // includes this in the balance-sufficiency check.
+        if let Transaction::EIP4844Transaction(tx) = self {
+            let blob_gas = U256::from(crate::constants::GAS_PER_BLOB)
+                .saturating_mul(U256::from(tx.blob_versioned_hashes.len() as u64));
+            let blob_cost = blob_gas.saturating_mul(tx.max_fee_per_blob_gas);
+            return Some(base.saturating_add(blob_cost));
+        }
+
+        Some(base)
     }
 
     pub fn fee_token(&self) -> Option<Address> {
@@ -3716,5 +3728,40 @@ mod tests {
     fn test_eip1559_simple_transfer_size() {
         let tx = Transaction::EIP1559Transaction(EIP1559Transaction::default());
         assert_eq!(tx.encode_to_vec().len(), EIP1559_DEFAULT_SERIALIZED_LENGTH);
+    }
+
+    #[test]
+    fn test_cost_without_base_fee_eip4844_includes_blob_gas() {
+        // Regression test for mempool balance check: for EIP-4844 txs,
+        // cost_without_base_fee() MUST include blob_gas_used * max_fee_per_blob_gas.
+        // Every peer client (geth, reth, nethermind, erigon, besu) does this.
+        use crate::constants::GAS_PER_BLOB;
+
+        let max_fee_per_gas: u64 = 100;
+        let gas: u64 = 21_000;
+        let value = U256::from(7u64);
+        let max_fee_per_blob_gas = U256::from(50u64);
+        let blob_count: usize = 1;
+
+        let tx = Transaction::EIP4844Transaction(EIP4844Transaction {
+            max_fee_per_gas,
+            gas,
+            value,
+            max_fee_per_blob_gas,
+            blob_versioned_hashes: vec![H256::zero(); blob_count],
+            ..Default::default()
+        });
+
+        let got = tx.cost_without_base_fee().expect("cost is computable");
+
+        let gas_cost = U256::from(max_fee_per_gas) * U256::from(gas);
+        let blob_gas = U256::from(GAS_PER_BLOB) * U256::from(blob_count as u64);
+        let blob_cost = blob_gas * max_fee_per_blob_gas;
+        let expected = gas_cost + blob_cost + value;
+
+        assert_eq!(
+            got, expected,
+            "blob-gas term missing from cost_without_base_fee() for EIP-4844"
+        );
     }
 }


### PR DESCRIPTION
**Motivation**

`Transaction::cost_without_base_fee()` at `crates/common/types/transaction.rs:444` is consumed by the mempool balance check in `crates/blockchain/blockchain.rs:2488-2493`. For EIP-4844 transactions it was returning `max_fee_per_gas * gas_limit + value` and omitting the blob-gas component `blob_gas_used * max_fee_per_blob_gas`. This let the mempool admit blob transactions whose sender could not actually afford them; they propagated over the network and failed at block inclusion, wasting pool capacity and peer bandwidth.

Every peer Ethereum execution client (geth `tx.Cost()`, reth `EthPooledTransaction::cost`, nethermind `BalanceTooLowFilter`, erigon `requiredBalance`, besu `upfrontCost`) includes the blob-gas term in this check. ethrex did not.

**Description**

- Extend `Transaction::cost_without_base_fee()` so the EIP-4844 branch adds `blob_versioned_hashes.len() * GAS_PER_BLOB * max_fee_per_blob_gas` using saturating arithmetic, matching the function's existing style.
- Add regression test `test_cost_without_base_fee_eip4844_includes_blob_gas` in `crates/common/types/transaction.rs`. The test fails against the pre-fix code with a delta of exactly `GAS_PER_BLOB * max_fee_per_blob_gas`.
- Document `MIN_GAS_TIP` in `crates/common/types/constants.rs` as an RPC gas-price estimator floor only, not a mempool admission gate (it is consumed exclusively by `eth_gasPrice` / `eth_maxPriorityFeePerGas`).
- Document `PendingTxFilter.min_tip` in `crates/blockchain/mempool.rs` as a payload-builder query filter, not an admission gate.

Previously-admitted EIP-4844 transactions with insufficient balance for blob gas will now be rejected at ingress. This is a correctness fix, not a policy change. A dedicated admission-time minimum-tip floor is tracked separately and is out of scope here.