### PR TITLE
chore(l1,l2): bump version to 10.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-benches"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "criterion 0.5.1",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum 0.8.9",
  "ethrex-common",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-monitor"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4280,7 +4280,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-repl"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "clap",
  "colored 2.2.0",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "criterion 0.7.0",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4356,7 +4356,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-test"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 default-members = ["cmd/ethrex"]
 
 [workspace.package]
-version = "9.0.0"
+version = "10.0.0"
 edition = "2024"
 authors = ["LambdaClass"]
 documentation = "https://docs.ethrex.xyz"

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -641,6 +641,13 @@ pub fn migrate_datadir_if_needed(
 
     // Verify chain IDs match.
     let Some(db_chain_id) = read_chain_id_from_db(base_datadir) else {
+        warn!(
+            "Found a database at {base_datadir:?} with valid store metadata but could not \
+             read its chain ID. Skipping automatic migration to {network_datadir:?}. \
+             If this is a pre-v10 database you intend to reuse, stop ethrex and move its \
+             contents into {network_datadir:?} manually before restarting. See the logs \
+             above for the specific error from the storage layer."
+        );
         return;
     };
     let expected_chain_id = match network.get_genesis() {

--- a/crates/guest-program/bin/openvm/Cargo.lock
+++ b/crates/guest-program/bin/openvm/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-openvm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/openvm/Cargo.toml
+++ b/crates/guest-program/bin/openvm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "9.0.0"
+version = "10.0.0"
 name = "ethrex-guest-openvm"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/guest-program/bin/risc0/Cargo.lock
+++ b/crates/guest-program/bin/risc0/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-risc0"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "c-kzg",
  "ethrex-common",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/crates/guest-program/bin/risc0/Cargo.toml
+++ b/crates/guest-program/bin/risc0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-risc0"
-version = "9.0.0"
+version = "10.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/sp1/Cargo.lock
+++ b/crates/guest-program/bin/sp1/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-sp1"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ethrex-guest-program",
  "ethrex-vm",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/sp1/Cargo.toml
+++ b/crates/guest-program/bin/sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-sp1"
-version = "9.0.0"
+version = "10.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/zisk/Cargo.lock
+++ b/crates/guest-program/bin/zisk/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-zisk"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/zisk/Cargo.toml
+++ b/crates/guest-program/bin/zisk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "9.0.0"
+version = "10.0.0"
 name = "ethrex-guest-zisk"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -47,7 +47,7 @@ const DB_SCHEMA: [&str; 22] = [
     "CREATE TABLE IF NOT EXISTS operation_count (_id INT PRIMARY KEY, transactions INT, privileged_transactions INT, messages INT)",
     "INSERT INTO operation_count VALUES (0, 0, 0, 0) ON CONFLICT(_id) DO NOTHING",
     "CREATE TABLE IF NOT EXISTS latest_sent (_id INT PRIMARY KEY, batch INT, verified_at INT DEFAULT 0)",
-    "INSERT INTO latest_sent VALUES (0, 0, 0) ON CONFLICT(_id) DO NOTHING",
+    "INSERT INTO latest_sent (_id, batch) VALUES (0, 0) ON CONFLICT(_id) DO NOTHING",
     "CREATE TABLE IF NOT EXISTS batch_proofs (batch INT, prover_type INT, proof BLOB, PRIMARY KEY (batch, prover_type))",
     "CREATE TABLE IF NOT EXISTS block_signatures (block_hash BLOB PRIMARY KEY, signature BLOB)",
     "CREATE TABLE IF NOT EXISTS batch_signatures (batch INT PRIMARY KEY, signature BLOB)",

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "quote-gen"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "configfs-tsm",
  "ethrex-blockchain",

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote-gen"
-version = "9.0.0"
+version = "10.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -52,7 +52,9 @@ use std::{
     },
     thread::JoinHandle,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
+#[cfg(feature = "rocksdb")]
+use tracing::warn;
 
 /// Maximum number of execution witnesses to keep in the database
 pub const MAX_WITNESSES: u64 = 128;

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -52,7 +52,7 @@ use std::{
     },
     thread::JoinHandle,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Maximum number of execution witnesses to keep in the database
 pub const MAX_WITNESSES: u64 = 128;
@@ -3264,18 +3264,58 @@ pub fn has_valid_db(path: &Path) -> bool {
 /// store initialization. Returns `None` if the database doesn't exist or
 /// the chain config can't be read. Always returns `None` when compiled
 /// without the `rocksdb` feature.
+///
+/// Each failure mode logs a warning so callers (and operators) can diagnose
+/// why an existing database was not usable — previously every error was
+/// silently swallowed by `.ok()?`.
 pub fn read_chain_id_from_db(path: &Path) -> Option<u64> {
     if !has_valid_db(path) {
         return None;
     }
     #[cfg(feature = "rocksdb")]
     {
-        let backend = RocksDBBackend::open(path).ok()?;
-        let read = backend.begin_read().ok()?;
+        let backend = match RocksDBBackend::open(path) {
+            Ok(backend) => backend,
+            Err(e) => {
+                warn!("Failed to open RocksDB at {path:?} to read chain ID: {e}");
+                return None;
+            }
+        };
+        let read = match backend.begin_read() {
+            Ok(read) => read,
+            Err(e) => {
+                warn!("Failed to begin read transaction at {path:?}: {e}");
+                return None;
+            }
+        };
         let key = chain_data_key(ChainDataIndex::ChainConfig);
-        let bytes = read.get(CHAIN_DATA, &key).ok()??;
-        let config: ethrex_common::types::ChainConfig = serde_json::from_slice(&bytes).ok()?;
-        Some(config.chain_id)
+        let bytes = match read.get(CHAIN_DATA, &key) {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => {
+                warn!("Chain config entry not found in database at {path:?}");
+                return None;
+            }
+            Err(e) => {
+                warn!("Failed to read chain config from database at {path:?}: {e}");
+                return None;
+            }
+        };
+        // Only extract chain_id here: the stored `ChainConfig` JSON may include
+        // fields whose serialization changed across releases (e.g. pre-v10 wrote
+        // `terminal_total_difficulty` as a plain number, v10 expects hex string).
+        // Deserializing the full struct would reject otherwise-migratable v9 data.
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ChainIdOnly {
+            chain_id: u64,
+        }
+        match serde_json::from_slice::<ChainIdOnly>(&bytes) {
+            Ok(partial) => Some(partial.chain_id),
+            Err(e) => {
+                warn!("Failed to deserialize chain ID from database at {path:?}: {e}");
+                None
+            }
+        }
     }
     #[cfg(not(feature = "rocksdb"))]
     {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -52,9 +52,9 @@ use std::{
     },
     thread::JoinHandle,
 };
-use tracing::{debug, error, info};
 #[cfg(feature = "rocksdb")]
 use tracing::warn;
+use tracing::{debug, error, info};
 
 /// Maximum number of execution witnesses to keep in the database
 pub const MAX_WITNESSES: u64 = 128;

--- a/crates/vm/levm/bench/revm_comparison/Cargo.lock
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -211,7 +211,7 @@ Block building options:
           Block extra data message.
 
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 9.0.0"]
+          [default: "ethrex 10.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
@@ -415,7 +415,7 @@ Block building options:
           Block extra data message.
 
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 9.0.0"]
+          [default: "ethrex 10.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -836,11 +836,11 @@ dependencies = [
  "clap 4.6.0",
  "clap_complete",
  "ethrex",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-rpc",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "eyre",
  "hex",
  "lazy_static",
@@ -2903,12 +2903,12 @@ dependencies = [
  "bytes",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-prover",
- "ethrex-rlp 9.0.0",
- "ethrex-storage 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-vm",
  "hex",
  "lazy_static",
@@ -2928,11 +2928,11 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 9.0.0",
- "ethrex-storage 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-vm",
  "hex",
  "itertools 0.13.0",
@@ -2957,12 +2957,12 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-l2-rpc",
  "ethrex-levm",
- "ethrex-rlp 9.0.0",
- "ethrex-storage 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-vm",
  "hex",
  "prettytable-rs",
@@ -3194,14 +3194,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "clap 4.6.0",
  "directories",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-config",
  "ethrex-crypto",
  "ethrex-dev",
@@ -3212,10 +3212,10 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-p2p",
  "ethrex-repl",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-storage-rollup",
  "ethrex-vm",
  "eyre",
@@ -3245,16 +3245,16 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
- "ethrex-rlp 9.0.0",
- "ethrex-storage 9.0.0",
- "ethrex-trie 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-storage 10.0.0",
+ "ethrex-trie 10.0.0",
  "ethrex-vm",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3293,14 +3293,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 9.0.0",
- "ethrex-trie 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-trie 10.0.0",
  "hex",
  "hex-literal",
  "hex-simd",
@@ -3322,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-p2p",
  "hex",
  "serde",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3376,14 +3376,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-vm",
  "hex",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3411,7 +3411,7 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
@@ -3419,12 +3419,12 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-monitor",
  "ethrex-p2p",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 9.0.0",
+ "ethrex-trie 10.0.0",
  "ethrex-vm",
  "futures",
  "hex",
@@ -3449,11 +3449,11 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambdaworks-crypto 0.13.0",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3475,14 +3475,14 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-guest-program",
  "ethrex-l2",
  "ethrex-l2-common",
  "ethrex-prover",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-sdk",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-vm",
  "hex",
  "rkyv",
@@ -3498,19 +3498,19 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum 0.8.8",
  "bytes",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-p2p",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-rpc",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-storage-rollup",
  "hex",
  "reqwest 0.12.28",
@@ -3528,13 +3528,13 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "malachite",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3545,10 +3545,10 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum 0.8.8",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -3565,13 +3565,13 @@ dependencies = [
  "bytes",
  "chrono",
  "crossterm 0.29.0",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-config",
  "ethrex-l2-common",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-storage-rollup",
  "futures",
  "hex",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3599,14 +3599,14 @@ dependencies = [
  "ctr",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-metrics",
- "ethrex-rlp 9.0.0",
- "ethrex-storage 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-storage 10.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 9.0.0",
+ "ethrex-trie 10.0.0",
  "futures",
  "hex",
  "hkdf",
@@ -3634,14 +3634,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bincode",
  "bytes",
  "clap 4.6.0",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-guest-program",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-vm",
  "rkyv",
  "serde",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -3706,13 +3706,13 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
  "ethrex-p2p",
- "ethrex-rlp 9.0.0",
- "ethrex-storage 9.0.0",
- "ethrex-trie 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-storage 10.0.0",
+ "ethrex-trie 10.0.0",
  "ethrex-vm",
  "hex",
  "hex-literal",
@@ -3736,14 +3736,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "ethrex-rpc",
  "ethrex-sdk-contract-utils",
  "hex",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -3791,14 +3791,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
- "ethrex-rlp 9.0.0",
- "ethrex-trie 9.0.0",
+ "ethrex-rlp 10.0.0",
+ "ethrex-trie 10.0.0",
  "fastbloom",
  "lru 0.16.3",
  "rayon",
@@ -3813,12 +3813,12 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "async-trait",
  "bincode",
  "ethereum-types",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-l2-common",
  "futures",
  "rkyv",
@@ -3849,14 +3849,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "lazy_static",
  "rayon",
  "rkyv",
@@ -3867,15 +3867,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "9.0.0"
+version = "10.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "dyn-clone",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 9.0.0",
+ "ethrex-rlp 10.0.0",
  "rayon",
  "rustc-hash 2.1.2",
  "serde",
@@ -5518,7 +5518,7 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
  "ethrex-rpc",
@@ -5722,9 +5722,9 @@ dependencies = [
  "clap 4.6.0",
  "ethrex-blockchain",
  "ethrex-common 1.0.0",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-storage 1.0.0",
- "ethrex-storage 9.0.0",
+ "ethrex-storage 10.0.0",
  "tokio",
 ]
 
@@ -7563,7 +7563,7 @@ version = "4.0.0"
 dependencies = [
  "ethrex",
  "ethrex-blockchain",
- "ethrex-common 9.0.0",
+ "ethrex-common 10.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",


### PR DESCRIPTION
**Motivation**

Prepare the v10.0.0 release by bumping the workspace version and merging the release branch back to main. The branch also carries a hotfix found during pre-release testing on the mainnet snapsync test servers.

**Description**

- Bump workspace version from 9.0.0 to 10.0.0 in the root `Cargo.toml`, the guest-program `Cargo.toml` files (sp1, risc0, openvm, zisk) and `crates/l2/tee/quote-gen/Cargo.toml`; refresh lockfiles.
- Update the `--builder.extra-data` default in `docs/CLI.md` to `ethrex 10.0.0` in both ethrex and ethrex L2 sections.
- Fix silent datadir migration failure when upgrading from pre-v10 databases: `read_chain_id_from_db` now extracts only `chain_id` from the stored `ChainConfig` (unaffected by the new `hex_str_opt` attribute on `terminal_total_difficulty`) and each failure mode logs a `warn` instead of being swallowed by `.ok()?`. Verified on a real v9 mainnet database (449 GB): migrated into the new `~/.local/share/ethrex/mainnet/` layout and resumed at the same block without re-sync.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — N/A, no storage schema change (hotfix only affects the migration read path).