### PR TITLE
fix(l2): rollup store SQLite migration for v9 to v10 upgrade

### DIFF
--- a/crates/l2/storage/src/store_db/sql.rs
+++ b/crates/l2/storage/src/store_db/sql.rs
@@ -47,7 +47,7 @@ const DB_SCHEMA: [&str; 22] = [
     "CREATE TABLE IF NOT EXISTS operation_count (_id INT PRIMARY KEY, transactions INT, privileged_transactions INT, messages INT)",
     "INSERT INTO operation_count VALUES (0, 0, 0, 0) ON CONFLICT(_id) DO NOTHING",
     "CREATE TABLE IF NOT EXISTS latest_sent (_id INT PRIMARY KEY, batch INT, verified_at INT DEFAULT 0)",
-    "INSERT INTO latest_sent VALUES (0, 0, 0) ON CONFLICT(_id) DO NOTHING",
+    "INSERT INTO latest_sent (_id, batch) VALUES (0, 0) ON CONFLICT(_id) DO NOTHING",
     "CREATE TABLE IF NOT EXISTS batch_proofs (batch INT, prover_type INT, proof BLOB, PRIMARY KEY (batch, prover_type))",
     "CREATE TABLE IF NOT EXISTS block_signatures (block_hash BLOB PRIMARY KEY, signature BLOB)",
     "CREATE TABLE IF NOT EXISTS batch_signatures (batch INT PRIMARY KEY, signature BLOB)",


### PR DESCRIPTION
## Motivation

When upgrading an ethrex L2 from v9 to v10, the v10 binary panics on startup with:

```
Failed to create StoreRollup: SQLQueryError(SqliteFailure(1, "table latest_sent has 2 columns but 3 values were supplied"))
```

## Description

v10 added a `verified_at` column to the `latest_sent` table. The `DB_SCHEMA` array runs as a single transaction during `init_db()`. On an existing v9 database, `CREATE TABLE IF NOT EXISTS` is a no-op (table already exists with 2 columns), but `INSERT INTO latest_sent VALUES (0, 0, 0)` fails because it supplies 3 values for a 2-column table. This rolls back the entire schema transaction, so the `ALTER TABLE` migration that adds the column never executes.

The fix uses explicit column names in the INSERT: `INSERT INTO latest_sent (_id, batch) VALUES (0, 0)`. This works on both the old 2-column table and the new 3-column table (`verified_at` gets its `DEFAULT 0`).

## How to Test

1. Start an L2 with v9, let it commit a few batches
2. Stop the L2, upgrade to v10
3. Start v10 — should no longer panic on `latest_sent`