### PR TITLE
docs(l2): fix version number in upgrade docs

### DIFF
--- a/docs/l2/deployment/upgrades.md
+++ b/docs/l2/deployment/upgrades.md
@@ -83,11 +83,11 @@ ALTER TABLE balance_diffs
 ADD COLUMN value_per_token BLOB;
 ```
 
-## From v10 to v11
+## From v9 to v10
 
 ### CommonBridge: L2 gas limit stored on-chain
 
-From v11 onwards, the L2 block gas limit is stored in the `CommonBridge` contract as `l2GasLimit`. The sequencer fetches this value on startup instead of using a CLI flag.
+From v10 onwards, the L2 block gas limit is stored in the `CommonBridge` contract as `l2GasLimit`. The sequencer fetches this value on startup instead of using a CLI flag.
 
 #### Upgrade requirement
 

--- a/docs/l2/deployment/vanilla.md
+++ b/docs/l2/deployment/vanilla.md
@@ -90,7 +90,7 @@ ethrex l2 \
 > - Replace `L1_PROOF_SENDER_PRIVATE_KEY` and `L1_COMMITTER_PRIVATE_KEY` with the private keys for the `L1_PROOF_SENDER_ADDRESS` and `L1_COMMITTER_ADDRESS` from the deployment step.
 > - Replace `L1_RPC_URL` and `PATH_TO_L2_GENESIS_FILE` with the same values used in the deployment step.
 > - Tune throughput with the gas caps:
->   - The L2 block gas limit is stored on-chain in the `CommonBridge` contract (set during deployment via `--l2-gas-limit`, defaults to 30000000). The sequencer fetches this value on startup. See [Upgrades](./upgrades.md#from-v10-to-v11) for how to view and update it.
+>   - The L2 block gas limit is stored on-chain in the `CommonBridge` contract (set during deployment via `--l2-gas-limit`, defaults to 30000000). The sequencer fetches this value on startup. See [Upgrades](./upgrades.md#from-v9-to-v10) for how to view and update it.
 >   - `--committer.batch-gas-limit` (env: `ETHREX_COMMITTER_BATCH_GAS_LIMIT`): Sets the gas limit per batch sent to L1—should be at or above the block gas limit.
 >
 >   You can use either the environment variables or the flags to configure these values.

--- a/docs/l2/fundamentals/contracts.md
+++ b/docs/l2/fundamentals/contracts.md
@@ -129,10 +129,14 @@ Once you have the new contract, you need to do the following three steps:
     rex send <PROXY_ADDRESS> 'upgradeToAndCall(address,bytes)' <NEW_IMPLEMENTATION_ADDRESS> <INITIALIZATION_CALLDATA> --private-key <PRIVATE_KEY>
     ```
 
+    > **Note:** The `OnChainProposer` is owned by the Timelock contract. You cannot call `upgradeToAndCall` on the OCP directly — it will revert with `onlyOwner`. The call must be routed through the Timelock. See [Timelock](./timelock.md) for the available paths (schedule + execute with delay, or `emergencyExecute` for immediate execution by the Security Council).
+    >
+    > The same applies to any operation restricted by `onlyOwner` on the OCP (e.g., `pause`, `unpause`).
+
 3. Check the proxy updated the pointed address to the new implementation. It should return the address of the new implementation:
 
     ```sh
-    curl http://localhost:8545 -d '{"jsonrpc": "2.0", "id": "1", "method": "eth_getStorageAt", "params": [<PROXY_ADDRESS>, "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc", "latest"]}'
+    curl <L1_RPC_URL> -d '{"jsonrpc": "2.0", "id": "1", "method": "eth_getStorageAt", "params": ["<PROXY_ADDRESS>", "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc", "latest"]}'
     ```
 
 ## Transfer ownership


### PR DESCRIPTION
## Motivation

Two issues discovered while writing up a v9 → v10 upgrade runbook:

1. The upgrade section for the CommonBridge `l2GasLimit` migration was labeled "From v10 to v11" but was actually introduced in v10 (i.e., the migration is from v9 to v10).
2. `docs/l2/fundamentals/contracts.md` shows `upgradeToAndCall` being called directly on a contract proxy, but the `OnChainProposer` is owned by the Timelock — so any operator following those steps on the OCP hits an `onlyOwner` revert with no hint as to why.

## Description

**`docs/l2/deployment/upgrades.md`**
- Rename section from "From v10 to v11" to "From v9 to v10"
- Update "From v11 onwards" to "From v10 onwards"

**`docs/l2/deployment/vanilla.md`**
- Fix cross-reference anchor (`#from-v10-to-v11` → `#from-v9-to-v10`)

**`docs/l2/fundamentals/contracts.md`**
- Add a note that the OCP is owned by the Timelock, so `upgradeToAndCall` (and other `onlyOwner` operations like `pause`/`unpause`) cannot be called directly — the call must be routed through the Timelock. Points to the Timelock doc for the available execution paths (scheduled with delay vs. `emergencyExecute`), without prescribing one.