### PR TITLE
feat(l1): add ssz encoding for witness in eip-8025

### DIFF
--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -62,7 +62,7 @@ pub struct GuestProgramState {
 /// It is essentially an `RpcExecutionWitness` but it also contains `ChainConfig`,
 /// and `first_block_number`.
 #[derive(
-    Default, Serialize, Deserialize, rkyv::Serialize, rkyv::Deserialize, rkyv::Archive, Clone,
+    Default, Serialize, Deserialize, rkyv::Serialize, rkyv::Deserialize, rkyv::Archive, Clone, Debug,
 )]
 pub struct ExecutionWitness {
     // Contract bytecodes needed for stateless execution.
@@ -82,6 +82,329 @@ pub struct ExecutionWitness {
     #[rkyv(with = MapKV<H256Wrapper, Identity>)]
     pub storage_trie_roots: BTreeMap<H256, Node>,
 }
+
+#[cfg(feature = "eip-8025")]
+mod ssz_witness {
+    use super::*;
+    use libssz::{SszDecode, SszEncode};
+    use libssz_derive::{SszDecode as DeriveSszDecode, SszEncode as DeriveSszEncode};
+    use libssz_types::SszList;
+    use std::sync::Arc;
+
+    // Constants set based on the Ethereum spec
+    const MAX_WITNESS_NODES: usize = 1 << 20;
+    const MAX_WITNESS_CODES: usize = 1 << 16;
+    const MAX_WITNESS_HEADERS: usize = 256;
+    const MAX_BYTES_PER_WITNESS_NODE: usize = 1 << 20;
+    const MAX_BYTES_PER_CODE: usize = 1 << 24;
+    const MAX_BYTES_PER_HEADER: usize = 1 << 10;
+
+    // TODO: think about these constants
+    const MAX_CHAIN_CONFIG_BYTES: usize = 1 << 10;
+    const MAX_STORAGE_TRIE_ROOTS: usize = 1 << 20;
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum ExecutionWitnessSszError {
+        #[error("invalid SSZ list bounds: {0}")]
+        InvalidSszType(String),
+        #[error("SSZ decode error: {0}")]
+        SszDecode(#[from] libssz::DecodeError),
+        #[error("RLP decode error: {0}")]
+        RlpDecode(#[from] RLPDecodeError),
+        #[error("chain config error: {0}")]
+        ChainConfig(String),
+        #[error("trie error: {0}")]
+        Trie(#[from] TrieError),
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    #[ssz(enum_behaviour = "union")]
+    enum SszNodeRef {
+        Index(u32),
+        Hash(SszList<u8, 32>),
+        None,
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    struct SszBranchNode {
+        choices: SszList<SszNodeRef, 16>,
+        value: SszList<u8, 128>,
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    struct SszExtensionNode {
+        prefix: SszList<u8, 64>,
+        child: SszNodeRef,
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    struct SszLeafNode {
+        partial: SszList<u8, 64>,
+        value: SszList<u8, 128>,
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    #[ssz(enum_behaviour = "union")]
+    enum SszNode {
+        Branch(SszBranchNode),
+        Extension(SszExtensionNode),
+        Leaf(SszLeafNode),
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    struct SszStorageTrieRoot {
+        address: SszList<u8, 32>,
+        root_index: SszNodeRef,
+    }
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    struct SszExecutionWitness {
+        codes: SszList<SszList<u8, MAX_BYTES_PER_CODE>, MAX_WITNESS_CODES>,
+        block_headers_bytes: SszList<SszList<u8, MAX_BYTES_PER_HEADER>, MAX_WITNESS_HEADERS>,
+        first_block_number: u64,
+        chain_config_bytes: SszList<u8, MAX_CHAIN_CONFIG_BYTES>,
+        initial_state_root_index: SszNodeRef,
+        storage_trie_root_indices: SszList<SszStorageTrieRoot, MAX_STORAGE_TRIE_ROOTS>,
+        state_nodes: SszList<SszNode, MAX_WITNESS_NODES>,
+    }
+
+    fn to_ssz_bytes<const MAX: usize>(
+        bytes: Vec<u8>,
+    ) -> Result<SszList<u8, MAX>, ExecutionWitnessSszError> {
+        SszList::try_from(bytes)
+            .map_err(|e| ExecutionWitnessSszError::InvalidSszType(e.to_string()))
+    }
+
+    fn to_ssz_vec_vec<const MAX_ITEMS: usize, const MAX_ITEM_BYTES: usize>(
+        items: Vec<Vec<u8>>,
+    ) -> Result<SszList<SszList<u8, MAX_ITEM_BYTES>, MAX_ITEMS>, ExecutionWitnessSszError> {
+        let mut out = Vec::with_capacity(items.len());
+        for item in items {
+            out.push(
+                SszList::try_from(item)
+                    .map_err(|e| ExecutionWitnessSszError::InvalidSszType(e.to_string()))?,
+            );
+        }
+        SszList::try_from(out).map_err(|e| ExecutionWitnessSszError::InvalidSszType(e.to_string()))
+    }
+
+    impl ExecutionWitness {
+        pub fn to_ssz_bytes(&self) -> Result<Vec<u8>, ExecutionWitnessSszError> {
+            let mut state_nodes = Vec::new();
+            fn add_node(
+                node: &Node,
+                state_nodes: &mut Vec<SszNode>,
+            ) -> Result<SszNodeRef, ExecutionWitnessSszError> {
+                let ssz_node = match node {
+                    Node::Branch(branch) => {
+                        let mut choices = Vec::with_capacity(16);
+                        for child in &branch.choices {
+                            let ssz_child = match child {
+                                NodeRef::Node(n, _) => add_node(n, state_nodes)?,
+                                NodeRef::Hash(hash) => SszNodeRef::Hash(
+                                    SszList::try_from(hash.as_ref().to_vec()).map_err(|e| {
+                                        ExecutionWitnessSszError::InvalidSszType(e.to_string())
+                                    })?,
+                                ),
+                            };
+                            choices.push(ssz_child);
+                        }
+                        SszNode::Branch(SszBranchNode {
+                            choices: SszList::try_from(choices).unwrap(),
+                            value: SszList::try_from(branch.value.clone()).unwrap(),
+                        })
+                    }
+                    Node::Extension(ext) => {
+                        let ssz_child = match &ext.child {
+                            NodeRef::Node(n, _) => add_node(n, state_nodes)?,
+                            NodeRef::Hash(hash) => SszNodeRef::Hash(
+                                SszList::try_from(hash.as_ref().to_vec()).map_err(|e| {
+                                    ExecutionWitnessSszError::InvalidSszType(e.to_string())
+                                })?,
+                            ),
+                        };
+                        SszNode::Extension(SszExtensionNode {
+                            prefix: SszList::try_from(ext.prefix.encode_compact()).unwrap(),
+                            child: ssz_child,
+                        })
+                    }
+                    Node::Leaf(leaf) => SszNode::Leaf(SszLeafNode {
+                        partial: SszList::try_from(leaf.partial.encode_compact()).unwrap(),
+                        value: SszList::try_from(leaf.value.clone()).unwrap(),
+                    }),
+                };
+                let index = state_nodes.len() as u32;
+                state_nodes.push(ssz_node);
+                Ok(SszNodeRef::Index(index))
+            }
+
+            let initial_state_root_index = if let Some(root) = &self.state_trie_root {
+                add_node(root, &mut state_nodes)?
+            } else {
+                SszNodeRef::None
+            };
+
+            let mut storage_root_indices = Vec::new();
+            for (address, root) in &self.storage_trie_roots {
+                let index = add_node(root, &mut state_nodes)?;
+                storage_root_indices.push(SszStorageTrieRoot {
+                    address: SszList::try_from(address.0.to_vec()).unwrap(),
+                    root_index: index,
+                });
+            }
+
+            let ssz = SszExecutionWitness {
+                codes: to_ssz_vec_vec::<MAX_WITNESS_CODES, MAX_BYTES_PER_CODE>(self.codes.clone())?,
+                block_headers_bytes: to_ssz_vec_vec::<MAX_WITNESS_HEADERS, MAX_BYTES_PER_HEADER>(
+                    self.block_headers_bytes.clone(),
+                )?,
+                first_block_number: self.first_block_number,
+                chain_config_bytes: to_ssz_bytes::<MAX_CHAIN_CONFIG_BYTES>(
+                    self.chain_config.encode_bytes(),
+                )?,
+                initial_state_root_index,
+                storage_trie_root_indices: SszList::try_from(storage_root_indices).unwrap(),
+                state_nodes: SszList::try_from(state_nodes).unwrap(),
+            };
+            Ok(ssz.to_ssz())
+        }
+
+        pub fn from_ssz_bytes(
+            bytes: &[u8],
+            _crypto: &dyn Crypto,
+        ) -> Result<Self, ExecutionWitnessSszError> {
+            let ssz_witness = SszExecutionWitness::from_ssz_bytes(bytes)?;
+            let chain_config = ChainConfig::decode_bytes(&ssz_witness.chain_config_bytes)
+                .map_err(ExecutionWitnessSszError::ChainConfig)?;
+
+            fn decode_node_hash(
+                hash_bytes: &[u8],
+            ) -> Result<ethrex_trie::NodeHash, ExecutionWitnessSszError> {
+                match hash_bytes.len() {
+                    0..32 => {
+                        let mut inline = [0_u8; 31];
+                        inline[..hash_bytes.len()].copy_from_slice(hash_bytes);
+                        Ok(ethrex_trie::NodeHash::Inline((
+                            inline,
+                            hash_bytes.len() as u8,
+                        )))
+                    }
+                    32 => Ok(ethrex_trie::NodeHash::Hashed(H256::from_slice(hash_bytes))),
+                    _ => Err(ExecutionWitnessSszError::InvalidSszType(
+                        "invalid hash length in node reference".to_string(),
+                    )),
+                }
+            }
+
+            fn rebuild_node_ref(
+                ssz_ref: &SszNodeRef,
+                nodes: &[SszNode],
+            ) -> Result<NodeRef, ExecutionWitnessSszError> {
+                match ssz_ref {
+                    SszNodeRef::Index(i) => {
+                        let node = rebuild_node_by_index(*i as usize, nodes)?;
+                        Ok(NodeRef::Node(Arc::new(node), std::sync::OnceLock::new()))
+                    }
+                    SszNodeRef::Hash(hash_bytes) => {
+                        let node_hash = decode_node_hash(hash_bytes.as_ref())?;
+                        Ok(NodeRef::Hash(node_hash))
+                    }
+                    SszNodeRef::None => Ok(NodeRef::Hash(ethrex_trie::NodeHash::default())),
+                }
+            }
+
+            fn rebuild_node_by_index(
+                index: usize,
+                nodes: &[SszNode],
+            ) -> Result<Node, ExecutionWitnessSszError> {
+                let ssz_node = nodes.get(index).ok_or_else(|| {
+                    ExecutionWitnessSszError::InvalidSszType("Node index out of bounds".to_string())
+                })?;
+                let node = match ssz_node {
+                    SszNode::Branch(b) => {
+                        let mut choices =
+                            [(); 16].map(|_| NodeRef::Hash(ethrex_trie::NodeHash::default()));
+                        for (i, choice_ref) in b.choices.iter().enumerate() {
+                            let child_ref = rebuild_node_ref(choice_ref, nodes)?;
+                            if child_ref.is_valid() {
+                                choices[i] = child_ref;
+                            }
+                        }
+                        let value = if b.value.is_empty() {
+                            None
+                        } else {
+                            Some(b.value.to_vec())
+                        };
+                        Node::Branch(Box::new(ethrex_trie::node::BranchNode {
+                            choices,
+                            value: value.unwrap_or_default(),
+                        }))
+                    }
+                    SszNode::Extension(e) => {
+                        let child = rebuild_node_ref(&e.child, nodes)?;
+                        if !child.is_valid() {
+                            return Err(ExecutionWitnessSszError::InvalidSszType(
+                                "Extension must have a child".to_string(),
+                            ));
+                        }
+                        Node::Extension(ethrex_trie::node::ExtensionNode {
+                            prefix: Nibbles::decode_compact(&e.prefix),
+                            child,
+                        })
+                    }
+                    SszNode::Leaf(l) => Node::Leaf(ethrex_trie::node::LeafNode {
+                        partial: Nibbles::decode_compact(&l.partial),
+                        value: l.value.to_vec(),
+                    }),
+                };
+                Ok(node)
+            }
+
+            fn rebuild_node(
+                ssz_ref: &SszNodeRef,
+                nodes: &[SszNode],
+            ) -> Result<Option<Node>, ExecutionWitnessSszError> {
+                match ssz_ref {
+                    SszNodeRef::None => Ok(None),
+                    SszNodeRef::Index(i) => rebuild_node_by_index(*i as usize, nodes).map(Some),
+                    SszNodeRef::Hash(_) => Err(ExecutionWitnessSszError::InvalidSszType(
+                        "root node cannot be a hash reference".to_string(),
+                    )),
+                }
+            }
+
+            let state_nodes = ssz_witness.state_nodes.into_inner();
+            let state_trie_root =
+                rebuild_node(&ssz_witness.initial_state_root_index, &state_nodes)?;
+            let mut storage_trie_roots = BTreeMap::new();
+            for item in ssz_witness.storage_trie_root_indices {
+                if let Some(root) = rebuild_node(&item.root_index, &state_nodes)? {
+                    storage_trie_roots.insert(H256::from_slice(&item.address), root);
+                }
+            }
+
+            Ok(Self {
+                codes: ssz_witness
+                    .codes
+                    .into_iter()
+                    .map(|l| l.into_inner())
+                    .collect(),
+                block_headers_bytes: ssz_witness
+                    .block_headers_bytes
+                    .into_iter()
+                    .map(|l| l.into_inner())
+                    .collect(),
+                first_block_number: ssz_witness.first_block_number,
+                chain_config,
+                state_trie_root,
+                storage_trie_roots,
+            })
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+pub use ssz_witness::ExecutionWitnessSszError;
 
 /// RPC-friendly representation of an execution witness.
 ///

--- a/crates/common/types/eip8025_ssz.rs
+++ b/crates/common/types/eip8025_ssz.rs
@@ -4,33 +4,38 @@
 //! `NewPayloadRequest` and producing the `PublicInput` committed to by
 //! execution proofs.
 
+use bytes::Bytes;
 use libssz::{SszDecode, SszEncode};
 use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
 use libssz_merkle::{HashTreeRoot, Sha256Hasher};
 use libssz_types::{SszList, SszVector};
 
+use super::requests::EncodedRequests;
+
 // ── Spec limits (Electra) ──────────────────────────────────────────
 
-/// MAX_TRANSACTIONS_PER_PAYLOAD (Electra).
-const MAX_TRANSACTIONS: usize = 1_048_576;
-/// MAX_WITHDRAWALS_PER_PAYLOAD (Electra).
-const MAX_WITHDRAWALS: usize = 16;
-/// MAX_BYTES_PER_TRANSACTION.
+/// `MAX_TRANSACTIONS_PER_PAYLOAD` (Electra).
+const MAX_TRANSACTIONS_PER_PAYLOAD: usize = 1_048_576;
+/// `MAX_WITHDRAWALS_PER_PAYLOAD` (Electra).
+const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 16;
+/// `MAX_BYTES_PER_TRANSACTION`.
 const MAX_BYTES_PER_TRANSACTION: usize = 1_073_741_824;
-/// MAX_EXTRA_DATA_BYTES.
+/// `MAX_EXTRA_DATA_BYTES`.
 const MAX_EXTRA_DATA_BYTES: usize = 32;
-/// MAX_DEPOSIT_REQUESTS_PER_PAYLOAD (Electra).
-const MAX_DEPOSIT_REQUESTS: usize = 8192;
-/// MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD (Electra).
-const MAX_WITHDRAWAL_REQUESTS: usize = 16;
-/// MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD (Electra).
-const MAX_CONSOLIDATION_REQUESTS: usize = 1;
-/// MAX_BLOB_COMMITMENTS_PER_BLOCK (Electra).
-const MAX_BLOB_COMMITMENTS: usize = 4096;
-/// MAX_EXECUTION_REQUESTS (EIP-7685).
-const MAX_EXECUTION_REQUESTS: usize = 16;
-/// MAX_EXECUTION_REQUEST_BYTES.
-const MAX_EXECUTION_REQUEST_BYTES: usize = 1_073_741_824;
+/// `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` (Electra).
+const MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: usize = 8192;
+/// `MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD` (Electra).
+const MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: usize = 16;
+/// `MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD` (Electra).
+const MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: usize = 2;
+/// `MAX_BLOB_COMMITMENTS_PER_BLOCK` (Electra).
+const MAX_BLOB_COMMITMENTS_PER_BLOCK: usize = 4096;
+
+// ── EIP-7685 request type prefixes ─────────────────────────────────
+
+const DEPOSIT_REQUEST_TYPE: u8 = 0x00;
+const WITHDRAWAL_REQUEST_TYPE: u8 = 0x01;
+const CONSOLIDATION_REQUEST_TYPE: u8 = 0x02;
 
 // ── Bytes20 wrapper (address) ──────────────────────────────────────
 //
@@ -95,7 +100,7 @@ impl From<Bytes20> for [u8; 20] {
 // `logs_bloom` is `ByteVector[BYTES_PER_LOGS_BLOOM]` in the CL spec —
 // a fixed-length SSZ vector of 256 bytes.
 
-/// BYTES_PER_LOGS_BLOOM from the CL spec.
+/// `BYTES_PER_LOGS_BLOOM` from the CL spec.
 pub const BYTES_PER_LOGS_BLOOM: usize = 256;
 
 /// `ByteVector[256]` — the logs bloom as a fixed-size SSZ vector.
@@ -158,41 +163,52 @@ pub struct ExecutionPayload {
     /// `base_fee_per_gas` encoded as a 256-bit unsigned integer (little-endian).
     pub base_fee_per_gas: [u8; 32],
     pub block_hash: [u8; 32],
-    pub transactions: SszList<SszList<u8, MAX_BYTES_PER_TRANSACTION>, MAX_TRANSACTIONS>,
-    pub withdrawals: SszList<Withdrawal, MAX_WITHDRAWALS>,
+    pub transactions: SszList<SszList<u8, MAX_BYTES_PER_TRANSACTION>, MAX_TRANSACTIONS_PER_PAYLOAD>,
+    pub withdrawals: SszList<Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD>,
     pub blob_gas_used: u64,
     pub excess_blob_gas: u64,
-    pub deposit_requests: SszList<DepositRequest, MAX_DEPOSIT_REQUESTS>,
-    pub withdrawal_requests: SszList<WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS>,
-    pub consolidation_requests: SszList<ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS>,
 }
 
-// ── ExecutionPayloadHeader ─────────────────────────────────────────
+// ── ExecutionRequests ──────────────────────────────────────────────
 
-/// Headerized version of `ExecutionPayload`: variable-length lists are
-/// replaced by their `hash_tree_root`.
+/// SSZ `ExecutionRequests` container (Electra) — the typed EIP-7685 bundle
+/// that the CL commits to alongside `ExecutionPayload`.
 #[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode, HashTreeRoot)]
-pub struct ExecutionPayloadHeader {
-    pub parent_hash: [u8; 32],
-    pub fee_recipient: Bytes20,
-    pub state_root: [u8; 32],
-    pub receipts_root: [u8; 32],
-    pub logs_bloom: LogsBloom,
-    pub prev_randao: [u8; 32],
-    pub block_number: u64,
-    pub gas_limit: u64,
-    pub gas_used: u64,
-    pub timestamp: u64,
-    pub extra_data: SszList<u8, MAX_EXTRA_DATA_BYTES>,
-    pub base_fee_per_gas: [u8; 32],
-    pub block_hash: [u8; 32],
-    pub transactions_root: [u8; 32],
-    pub withdrawals_root: [u8; 32],
-    pub blob_gas_used: u64,
-    pub excess_blob_gas: u64,
-    pub deposit_requests_root: [u8; 32],
-    pub withdrawal_requests_root: [u8; 32],
-    pub consolidation_requests_root: [u8; 32],
+pub struct ExecutionRequests {
+    pub deposits: SszList<DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD>,
+    pub withdrawals: SszList<WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD>,
+    pub consolidations: SszList<ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD>,
+}
+
+impl ExecutionRequests {
+    /// Produce the EIP-7685 encoded form: three `EncodedRequests` entries,
+    /// one per request type, each `[type_byte] ++ concat(ssz_encode(item))`.
+    ///
+    /// The three request types are all fixed-size SSZ containers, so their
+    /// SSZ encoding is byte-for-byte the EL wire concatenation that
+    /// `compute_requests_hash` expects.
+    pub fn to_encoded_requests(&self) -> Vec<EncodedRequests> {
+        fn encode<T: SszEncode>(
+            type_byte: u8,
+            items: impl IntoIterator<Item = T>,
+        ) -> EncodedRequests {
+            let mut buf = Vec::new();
+            buf.push(type_byte);
+            for item in items {
+                item.ssz_append(&mut buf);
+            }
+            EncodedRequests(Bytes::from(buf))
+        }
+
+        vec![
+            encode(DEPOSIT_REQUEST_TYPE, self.deposits.iter().cloned()),
+            encode(WITHDRAWAL_REQUEST_TYPE, self.withdrawals.iter().cloned()),
+            encode(
+                CONSOLIDATION_REQUEST_TYPE,
+                self.consolidations.iter().cloned(),
+            ),
+        ]
+    }
 }
 
 // ── NewPayloadRequest ──────────────────────────────────────────────
@@ -202,20 +218,9 @@ pub struct ExecutionPayloadHeader {
 #[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode, HashTreeRoot)]
 pub struct NewPayloadRequest {
     pub execution_payload: ExecutionPayload,
-    pub versioned_hashes: SszList<[u8; 32], MAX_BLOB_COMMITMENTS>,
+    pub versioned_hashes: SszList<[u8; 32], MAX_BLOB_COMMITMENTS_PER_BLOCK>,
     pub parent_beacon_block_root: [u8; 32],
-    pub execution_requests:
-        SszList<SszList<u8, MAX_EXECUTION_REQUEST_BYTES>, MAX_EXECUTION_REQUESTS>,
-}
-
-/// Headerized version of `NewPayloadRequest`.
-#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode, HashTreeRoot)]
-pub struct NewPayloadRequestHeader {
-    pub execution_payload_header: ExecutionPayloadHeader,
-    pub versioned_hashes: SszList<[u8; 32], MAX_BLOB_COMMITMENTS>,
-    pub parent_beacon_block_root: [u8; 32],
-    pub execution_requests:
-        SszList<SszList<u8, MAX_EXECUTION_REQUEST_BYTES>, MAX_EXECUTION_REQUESTS>,
+    pub execution_requests: ExecutionRequests,
 }
 
 // ── PublicInput ────────────────────────────────────────────────────
@@ -227,53 +232,12 @@ pub struct PublicInput {
     pub new_payload_request_root: [u8; 32],
 }
 
-// ── Conversion helpers ─────────────────────────────────────────────
-
-impl ExecutionPayload {
-    /// Produce the headerized version by computing `hash_tree_root` of
-    /// each variable-length list field.
-    pub fn to_header(&self, hasher: &impl Sha256Hasher) -> ExecutionPayloadHeader {
-        ExecutionPayloadHeader {
-            parent_hash: self.parent_hash,
-            fee_recipient: self.fee_recipient,
-            state_root: self.state_root,
-            receipts_root: self.receipts_root,
-            logs_bloom: self.logs_bloom.clone(),
-            prev_randao: self.prev_randao,
-            block_number: self.block_number,
-            gas_limit: self.gas_limit,
-            gas_used: self.gas_used,
-            timestamp: self.timestamp,
-            extra_data: self.extra_data.clone(),
-            base_fee_per_gas: self.base_fee_per_gas,
-            block_hash: self.block_hash,
-            transactions_root: self.transactions.hash_tree_root(hasher),
-            withdrawals_root: self.withdrawals.hash_tree_root(hasher),
-            blob_gas_used: self.blob_gas_used,
-            excess_blob_gas: self.excess_blob_gas,
-            deposit_requests_root: self.deposit_requests.hash_tree_root(hasher),
-            withdrawal_requests_root: self.withdrawal_requests.hash_tree_root(hasher),
-            consolidation_requests_root: self.consolidation_requests.hash_tree_root(hasher),
-        }
-    }
-}
-
 impl NewPayloadRequest {
     /// Compute the `hash_tree_root` of this request — the value that
     /// becomes the execution proof's public input.
     pub fn public_input(&self, hasher: &impl Sha256Hasher) -> PublicInput {
         PublicInput {
             new_payload_request_root: self.hash_tree_root(hasher),
-        }
-    }
-
-    /// Produce the headerized version.
-    pub fn to_header(&self, hasher: &impl Sha256Hasher) -> NewPayloadRequestHeader {
-        NewPayloadRequestHeader {
-            execution_payload_header: self.execution_payload.to_header(hasher),
-            versioned_hashes: self.versioned_hashes.clone(),
-            parent_beacon_block_root: self.parent_beacon_block_root,
-            execution_requests: self.execution_requests.clone(),
         }
     }
 }
@@ -291,22 +255,26 @@ mod tests {
             fee_recipient: Bytes20([2u8; 20]),
             state_root: [3u8; 32],
             receipts_root: [4u8; 32],
-            logs_bloom: vec![0u8; 256].try_into().unwrap(),
+            logs_bloom: vec![0u8; 256].try_into().expect("logs_bloom length"),
             prev_randao: [5u8; 32],
             block_number: 42,
             gas_limit: 30_000_000,
             gas_used: 21_000,
             timestamp: 1_700_000_000,
-            extra_data: vec![0xAB, 0xCD].try_into().unwrap(),
+            extra_data: vec![0xAB, 0xCD].try_into().expect("extra_data fits"),
             base_fee_per_gas: {
                 let mut b = [0u8; 32];
                 b[0] = 7; // 7 in LE
                 b
             },
             block_hash: [6u8; 32],
-            transactions: vec![vec![0xDE, 0xAD, 0xBE, 0xEF].try_into().unwrap()]
-                .try_into()
-                .unwrap(),
+            transactions: vec![
+                vec![0xDE, 0xAD, 0xBE, 0xEF]
+                    .try_into()
+                    .expect("tx bytes fit"),
+            ]
+            .try_into()
+            .expect("txs fit"),
             withdrawals: vec![Withdrawal {
                 index: 0,
                 validator_index: 1,
@@ -314,36 +282,27 @@ mod tests {
                 amount: 1_000_000,
             }]
             .try_into()
-            .unwrap(),
+            .expect("withdrawals fit"),
             blob_gas_used: 0,
             excess_blob_gas: 0,
-            deposit_requests: vec![].try_into().unwrap(),
-            withdrawal_requests: vec![].try_into().unwrap(),
-            consolidation_requests: vec![].try_into().unwrap(),
+        }
+    }
+
+    fn empty_requests() -> ExecutionRequests {
+        ExecutionRequests {
+            deposits: vec![].try_into().expect("empty deposits"),
+            withdrawals: vec![].try_into().expect("empty withdrawals"),
+            consolidations: vec![].try_into().expect("empty consolidations"),
         }
     }
 
     fn sample_request() -> NewPayloadRequest {
         NewPayloadRequest {
             execution_payload: sample_payload(),
-            versioned_hashes: vec![].try_into().unwrap(),
+            versioned_hashes: vec![].try_into().expect("empty versioned_hashes"),
             parent_beacon_block_root: [8u8; 32],
-            execution_requests: vec![].try_into().unwrap(),
+            execution_requests: empty_requests(),
         }
-    }
-
-    #[test]
-    fn test_ssz_root_roundtrip_payload_vs_header() {
-        let request = sample_request();
-        let header = request.to_header(&HASHER);
-
-        let request_root = request.hash_tree_root(&HASHER);
-        let header_root = header.hash_tree_root(&HASHER);
-
-        assert_eq!(
-            request_root, header_root,
-            "NewPayloadRequest root must equal NewPayloadRequestHeader root"
-        );
     }
 
     #[test]
@@ -360,43 +319,54 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_vs_nonempty_list_roots_differ() {
-        let payload = sample_payload();
-        let header = payload.to_header(&HASHER);
-
-        let empty_payload = ExecutionPayload {
-            transactions: vec![].try_into().unwrap(),
-            withdrawals: vec![].try_into().unwrap(),
-            deposit_requests: vec![].try_into().unwrap(),
-            withdrawal_requests: vec![].try_into().unwrap(),
-            consolidation_requests: vec![].try_into().unwrap(),
-            ..sample_payload()
-        };
-        let empty_header = empty_payload.to_header(&HASHER);
-
-        // Non-empty lists (sample has 1 tx + 1 withdrawal) produce different roots
-        // than empty lists.
-        assert_ne!(
-            header.transactions_root, empty_header.transactions_root,
-            "Non-empty transactions root must differ from empty"
-        );
-        assert_ne!(
-            header.withdrawals_root, empty_header.withdrawals_root,
-            "Non-empty withdrawals root must differ from empty"
-        );
-
-        // deposit/withdrawal/consolidation requests are empty in both, so roots match.
-        assert_eq!(
-            header.deposit_requests_root, empty_header.deposit_requests_root,
-            "Both-empty deposit_requests roots must match"
-        );
-    }
-
-    #[test]
     fn test_ssz_root_is_deterministic() {
         let request = sample_request();
         let root1 = request.hash_tree_root(&HASHER);
         let root2 = request.hash_tree_root(&HASHER);
         assert_eq!(root1, root2, "Same request must produce same root");
+    }
+
+    #[test]
+    fn test_execution_requests_to_encoded_bytes() {
+        let requests = ExecutionRequests {
+            deposits: vec![DepositRequest {
+                pubkey: [0x11; 48],
+                withdrawal_credentials: [0x22; 32],
+                amount: 32_000_000_000,
+                signature: [0x33; 96],
+                index: 7,
+            }]
+            .try_into()
+            .expect("one deposit fits"),
+            withdrawals: vec![WithdrawalRequest {
+                source_address: Bytes20([0x44; 20]),
+                validator_pubkey: [0x55; 48],
+                amount: 1_000_000,
+            }]
+            .try_into()
+            .expect("one withdrawal fits"),
+            consolidations: vec![ConsolidationRequest {
+                source_address: Bytes20([0x66; 20]),
+                source_pubkey: [0x77; 48],
+                target_pubkey: [0x88; 48],
+            }]
+            .try_into()
+            .expect("one consolidation fits"),
+        };
+
+        let encoded = requests.to_encoded_requests();
+        assert_eq!(encoded.len(), 3, "must emit 3 EIP-7685 entries");
+
+        // Deposit: [0x00] ++ 192 bytes
+        assert_eq!(encoded[0].0[0], DEPOSIT_REQUEST_TYPE);
+        assert_eq!(encoded[0].0.len(), 1 + 192);
+
+        // Withdrawal: [0x01] ++ 76 bytes
+        assert_eq!(encoded[1].0[0], WITHDRAWAL_REQUEST_TYPE);
+        assert_eq!(encoded[1].0.len(), 1 + 76);
+
+        // Consolidation: [0x02] ++ 116 bytes
+        assert_eq!(encoded[2].0[0], CONSOLIDATION_REQUEST_TYPE);
+        assert_eq!(encoded[2].0.len(), 1 + 116);
     }
 }

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -12,6 +12,11 @@ use std::{
 };
 use tracing::warn;
 
+#[cfg(feature = "eip-8025")]
+use libssz::{SszDecode, SszEncode};
+#[cfg(feature = "eip-8025")]
+use libssz_derive::{SszDecode as DeriveSszDecode, SszEncode as DeriveSszEncode};
+
 use super::{
     AccountState, Block, BlockBody, BlockHeader, BlockNumber, INITIAL_BASE_FEE,
     compute_receipts_root, compute_transactions_root, compute_withdrawals_root,
@@ -273,6 +278,288 @@ pub struct ChainConfig {
 
     #[serde(default)]
     pub enable_verkle_at_genesis: bool,
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeriveSszEncode, DeriveSszDecode)]
+#[ssz(enum_behaviour = "union")]
+enum OptionalU64 {
+    None,
+    Some(u64),
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<Option<u64>> for OptionalU64 {
+    fn from(value: Option<u64>) -> Self {
+        match value {
+            Some(v) => Self::Some(v),
+            None => Self::None,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<OptionalU64> for Option<u64> {
+    fn from(value: OptionalU64) -> Self {
+        match value {
+            OptionalU64::None => None,
+            OptionalU64::Some(v) => Some(v),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeriveSszEncode, DeriveSszDecode)]
+#[ssz(enum_behaviour = "union")]
+enum OptionalU128 {
+    None,
+    Some(u128),
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<Option<u128>> for OptionalU128 {
+    fn from(value: Option<u128>) -> Self {
+        match value {
+            Some(v) => Self::Some(v),
+            None => Self::None,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<OptionalU128> for Option<u128> {
+    fn from(value: OptionalU128) -> Self {
+        match value {
+            OptionalU128::None => None,
+            OptionalU128::Some(v) => Some(v),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeriveSszEncode, DeriveSszDecode)]
+#[ssz(enum_behaviour = "union")]
+enum OptionalForkBlobSchedule {
+    None,
+    Some(SszForkBlobSchedule),
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<Option<ForkBlobSchedule>> for OptionalForkBlobSchedule {
+    fn from(value: Option<ForkBlobSchedule>) -> Self {
+        match value {
+            Some(v) => Self::Some(v.into()),
+            None => Self::None,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<OptionalForkBlobSchedule> for Option<ForkBlobSchedule> {
+    fn from(value: OptionalForkBlobSchedule) -> Self {
+        match value {
+            OptionalForkBlobSchedule::None => None,
+            OptionalForkBlobSchedule::Some(v) => Some(v.into()),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeriveSszEncode, DeriveSszDecode)]
+struct SszForkBlobSchedule {
+    base_fee_update_fraction: u64,
+    max: u32,
+    target: u32,
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<ForkBlobSchedule> for SszForkBlobSchedule {
+    fn from(value: ForkBlobSchedule) -> Self {
+        Self {
+            base_fee_update_fraction: value.base_fee_update_fraction,
+            max: value.max,
+            target: value.target,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<SszForkBlobSchedule> for ForkBlobSchedule {
+    fn from(value: SszForkBlobSchedule) -> Self {
+        Self {
+            base_fee_update_fraction: value.base_fee_update_fraction,
+            max: value.max,
+            target: value.target,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeriveSszEncode, DeriveSszDecode)]
+struct SszBlobSchedule {
+    cancun: SszForkBlobSchedule,
+    prague: SszForkBlobSchedule,
+    osaka: SszForkBlobSchedule,
+    bpo1: SszForkBlobSchedule,
+    bpo2: SszForkBlobSchedule,
+    bpo3: OptionalForkBlobSchedule,
+    bpo4: OptionalForkBlobSchedule,
+    bpo5: OptionalForkBlobSchedule,
+    amsterdam: OptionalForkBlobSchedule,
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<BlobSchedule> for SszBlobSchedule {
+    fn from(value: BlobSchedule) -> Self {
+        Self {
+            cancun: value.cancun.into(),
+            prague: value.prague.into(),
+            osaka: value.osaka.into(),
+            bpo1: value.bpo1.into(),
+            bpo2: value.bpo2.into(),
+            bpo3: value.bpo3.into(),
+            bpo4: value.bpo4.into(),
+            bpo5: value.bpo5.into(),
+            amsterdam: value.amsterdam.into(),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<SszBlobSchedule> for BlobSchedule {
+    fn from(value: SszBlobSchedule) -> Self {
+        Self {
+            cancun: value.cancun.into(),
+            prague: value.prague.into(),
+            osaka: value.osaka.into(),
+            bpo1: value.bpo1.into(),
+            bpo2: value.bpo2.into(),
+            bpo3: value.bpo3.into(),
+            bpo4: value.bpo4.into(),
+            bpo5: value.bpo5.into(),
+            amsterdam: value.amsterdam.into(),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, DeriveSszEncode, DeriveSszDecode)]
+struct SszChainConfig {
+    chain_id: u64,
+    homestead_block: OptionalU64,
+    dao_fork_block: OptionalU64,
+    dao_fork_support: bool,
+    eip150_block: OptionalU64,
+    eip155_block: OptionalU64,
+    eip158_block: OptionalU64,
+    byzantium_block: OptionalU64,
+    constantinople_block: OptionalU64,
+    petersburg_block: OptionalU64,
+    istanbul_block: OptionalU64,
+    muir_glacier_block: OptionalU64,
+    berlin_block: OptionalU64,
+    london_block: OptionalU64,
+    arrow_glacier_block: OptionalU64,
+    gray_glacier_block: OptionalU64,
+    merge_netsplit_block: OptionalU64,
+    shanghai_time: OptionalU64,
+    cancun_time: OptionalU64,
+    prague_time: OptionalU64,
+    verkle_time: OptionalU64,
+    osaka_time: OptionalU64,
+    bpo1_time: OptionalU64,
+    bpo2_time: OptionalU64,
+    bpo3_time: OptionalU64,
+    bpo4_time: OptionalU64,
+    bpo5_time: OptionalU64,
+    amsterdam_time: OptionalU64,
+    terminal_total_difficulty: OptionalU128,
+    terminal_total_difficulty_passed: bool,
+    blob_schedule: SszBlobSchedule,
+    deposit_contract_address: [u8; 20],
+    enable_verkle_at_genesis: bool,
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<ChainConfig> for SszChainConfig {
+    fn from(value: ChainConfig) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            homestead_block: value.homestead_block.into(),
+            dao_fork_block: value.dao_fork_block.into(),
+            dao_fork_support: value.dao_fork_support,
+            eip150_block: value.eip150_block.into(),
+            eip155_block: value.eip155_block.into(),
+            eip158_block: value.eip158_block.into(),
+            byzantium_block: value.byzantium_block.into(),
+            constantinople_block: value.constantinople_block.into(),
+            petersburg_block: value.petersburg_block.into(),
+            istanbul_block: value.istanbul_block.into(),
+            muir_glacier_block: value.muir_glacier_block.into(),
+            berlin_block: value.berlin_block.into(),
+            london_block: value.london_block.into(),
+            arrow_glacier_block: value.arrow_glacier_block.into(),
+            gray_glacier_block: value.gray_glacier_block.into(),
+            merge_netsplit_block: value.merge_netsplit_block.into(),
+            shanghai_time: value.shanghai_time.into(),
+            cancun_time: value.cancun_time.into(),
+            prague_time: value.prague_time.into(),
+            verkle_time: value.verkle_time.into(),
+            osaka_time: value.osaka_time.into(),
+            bpo1_time: value.bpo1_time.into(),
+            bpo2_time: value.bpo2_time.into(),
+            bpo3_time: value.bpo3_time.into(),
+            bpo4_time: value.bpo4_time.into(),
+            bpo5_time: value.bpo5_time.into(),
+            amsterdam_time: value.amsterdam_time.into(),
+            terminal_total_difficulty: value.terminal_total_difficulty.into(),
+            terminal_total_difficulty_passed: value.terminal_total_difficulty_passed,
+            blob_schedule: value.blob_schedule.into(),
+            deposit_contract_address: *value.deposit_contract_address.as_fixed_bytes(),
+            enable_verkle_at_genesis: value.enable_verkle_at_genesis,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<SszChainConfig> for ChainConfig {
+    fn from(value: SszChainConfig) -> Self {
+        Self {
+            chain_id: value.chain_id,
+            homestead_block: value.homestead_block.into(),
+            dao_fork_block: value.dao_fork_block.into(),
+            dao_fork_support: value.dao_fork_support,
+            eip150_block: value.eip150_block.into(),
+            eip155_block: value.eip155_block.into(),
+            eip158_block: value.eip158_block.into(),
+            byzantium_block: value.byzantium_block.into(),
+            constantinople_block: value.constantinople_block.into(),
+            petersburg_block: value.petersburg_block.into(),
+            istanbul_block: value.istanbul_block.into(),
+            muir_glacier_block: value.muir_glacier_block.into(),
+            berlin_block: value.berlin_block.into(),
+            london_block: value.london_block.into(),
+            arrow_glacier_block: value.arrow_glacier_block.into(),
+            gray_glacier_block: value.gray_glacier_block.into(),
+            merge_netsplit_block: value.merge_netsplit_block.into(),
+            shanghai_time: value.shanghai_time.into(),
+            cancun_time: value.cancun_time.into(),
+            prague_time: value.prague_time.into(),
+            verkle_time: value.verkle_time.into(),
+            osaka_time: value.osaka_time.into(),
+            bpo1_time: value.bpo1_time.into(),
+            bpo2_time: value.bpo2_time.into(),
+            bpo3_time: value.bpo3_time.into(),
+            bpo4_time: value.bpo4_time.into(),
+            bpo5_time: value.bpo5_time.into(),
+            amsterdam_time: value.amsterdam_time.into(),
+            terminal_total_difficulty: value.terminal_total_difficulty.into(),
+            terminal_total_difficulty_passed: value.terminal_total_difficulty_passed,
+            blob_schedule: value.blob_schedule.into(),
+            deposit_contract_address: Address::from(value.deposit_contract_address),
+            enable_verkle_at_genesis: value.enable_verkle_at_genesis,
+        }
+    }
 }
 
 lazy_static::lazy_static! {
@@ -660,6 +947,23 @@ impl ChainConfig {
         timestamp_based_forks.retain(|block_timestamp| *block_timestamp > genesis_header.timestamp);
 
         (block_number_based_forks, timestamp_based_forks)
+    }
+
+    /// Encode ChainConfig as SSZ bytes through an SSZ-only wrapper.
+    /// Optional values are represented as SSZ unions:
+    /// - selector 0 => None
+    /// - selector 1 + payload bytes => Some(value)
+    #[cfg(feature = "eip-8025")]
+    pub fn encode_bytes(&self) -> Vec<u8> {
+        SszChainConfig::from(*self).to_ssz()
+    }
+
+    /// Decode ChainConfig from SSZ bytes produced by `encode_bytes`.
+    #[cfg(feature = "eip-8025")]
+    pub fn decode_bytes(data: &[u8]) -> Result<Self, String> {
+        SszChainConfig::from_ssz_bytes(data)
+            .map(ChainConfig::from)
+            .map_err(|e| format!("failed to decode chain config bytes: {e}"))
     }
 }
 

--- a/crates/guest-program/src/l1/input.rs
+++ b/crates/guest-program/src/l1/input.rs
@@ -2,15 +2,7 @@ use ethrex_common::types::Block;
 use ethrex_common::types::block_execution_witness::ExecutionWitness;
 
 /// Input for the L1 stateless validation program.
-#[derive(
-    Clone,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Deserialize,
-    rkyv::Serialize,
-    rkyv::Archive,
-)]
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ProgramInput {
     /// Blocks to execute.
     pub blocks: Vec<Block>,
@@ -28,12 +20,12 @@ impl ProgramInput {
     }
 }
 
-/// Encode a `NewPayloadRequest` (SSZ) and `ExecutionWitness` (rkyv) into the
+/// Encode a `NewPayloadRequest` (SSZ) and `ExecutionWitness` (SSZ) into the
 /// EIP-8025 length-prefixed wire format:
 ///
-///   `[ssz_len: u32 LE] [ssz_bytes] [rkyv_bytes]`
+///   `[ssz_len: u32 LE] [ssz_bytes] [witness_ssz_bytes]`
 ///
-/// Returns an error if rkyv serialization of the execution witness fails.
+/// Returns an error if SSZ serialization of the execution witness fails.
 #[cfg(feature = "eip-8025")]
 pub fn encode_eip8025(
     new_payload_request: &ethrex_common::types::eip8025_ssz::NewPayloadRequest,
@@ -43,13 +35,14 @@ pub fn encode_eip8025(
 
     let ssz_bytes = new_payload_request.to_ssz();
     let ssz_len = ssz_bytes.len() as u32;
-    let rkyv_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(execution_witness)
-        .map_err(|e| ProgramInputEncodeError::Rkyv(e.to_string()))?;
+    let witness_ssz_bytes = execution_witness
+        .to_ssz_bytes()
+        .map_err(ProgramInputEncodeError::WitnessSsz)?;
 
-    let mut out = Vec::with_capacity(4 + ssz_bytes.len() + rkyv_bytes.len());
+    let mut out = Vec::with_capacity(4 + ssz_bytes.len() + witness_ssz_bytes.len());
     out.extend_from_slice(&ssz_len.to_le_bytes());
     out.extend_from_slice(&ssz_bytes);
-    out.extend_from_slice(&rkyv_bytes);
+    out.extend_from_slice(&witness_ssz_bytes);
     Ok(out)
 }
 
@@ -61,6 +54,7 @@ pub fn encode_eip8025(
 #[cfg(feature = "eip-8025")]
 pub fn decode_eip8025(
     bytes: &[u8],
+    crypto: &dyn ethrex_crypto::Crypto,
 ) -> Result<
     (
         ethrex_common::types::eip8025_ssz::NewPayloadRequest,
@@ -79,13 +73,13 @@ pub fn decode_eip8025(
         return Err(ProgramInputDecodeError::TooShort);
     }
     let ssz_bytes = &bytes[4..4 + ssz_len];
-    let rkyv_bytes = &bytes[4 + ssz_len..];
+    let witness_ssz_bytes = &bytes[4 + ssz_len..];
 
     let new_payload_request =
         ethrex_common::types::eip8025_ssz::NewPayloadRequest::from_ssz_bytes(ssz_bytes)
             .map_err(ProgramInputDecodeError::Ssz)?;
-    let execution_witness = rkyv::from_bytes::<ExecutionWitness, rkyv::rancor::Error>(rkyv_bytes)
-        .map_err(|e| ProgramInputDecodeError::Rkyv(e.to_string()))?;
+    let execution_witness = ExecutionWitness::from_ssz_bytes(witness_ssz_bytes, crypto)
+        .map_err(ProgramInputDecodeError::WitnessSsz)?;
 
     Ok((new_payload_request, execution_witness))
 }
@@ -93,14 +87,14 @@ pub fn decode_eip8025(
 #[cfg(feature = "eip-8025")]
 #[derive(Debug)]
 pub enum ProgramInputEncodeError {
-    Rkyv(String),
+    WitnessSsz(ethrex_common::types::block_execution_witness::ExecutionWitnessSszError),
 }
 
 #[cfg(feature = "eip-8025")]
 impl core::fmt::Display for ProgramInputEncodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Rkyv(e) => write!(f, "rkyv encode error: {e}"),
+            Self::WitnessSsz(e) => write!(f, "execution witness SSZ encode error: {e}"),
         }
     }
 }
@@ -110,7 +104,7 @@ impl core::fmt::Display for ProgramInputEncodeError {
 pub enum ProgramInputDecodeError {
     TooShort,
     Ssz(libssz::DecodeError),
-    Rkyv(String),
+    WitnessSsz(ethrex_common::types::block_execution_witness::ExecutionWitnessSszError),
 }
 
 #[cfg(feature = "eip-8025")]
@@ -119,7 +113,7 @@ impl core::fmt::Display for ProgramInputDecodeError {
         match self {
             Self::TooShort => write!(f, "input too short"),
             Self::Ssz(e) => write!(f, "SSZ decode error: {e}"),
-            Self::Rkyv(e) => write!(f, "rkyv decode error: {e}"),
+            Self::WitnessSsz(e) => write!(f, "execution witness SSZ decode error: {e}"),
         }
     }
 }

--- a/crates/guest-program/src/l1/mod.rs
+++ b/crates/guest-program/src/l1/mod.rs
@@ -9,3 +9,5 @@ pub use input::{ProgramInputDecodeError, ProgramInputEncodeError};
 pub use input::{decode_eip8025, encode_eip8025};
 pub use output::ProgramOutput;
 pub use program::execution_program;
+#[cfg(feature = "eip-8025")]
+pub use program::execution_program_eip8025_bytes;

--- a/crates/guest-program/src/l1/program.rs
+++ b/crates/guest-program/src/l1/program.rs
@@ -72,36 +72,37 @@ pub fn execution_program(
     // Compute the hash_tree_root before consuming the payload.
     let request_root = new_payload_request.hash_tree_root(&Sha2Hasher);
 
-    // Transform SSZ NewPayloadRequest → Block
-    let block = new_payload_request_to_block(&new_payload_request, crypto.as_ref())
-        .map_err(|e| ExecutionError::Internal(format!("payload conversion: {e}")))?;
-
-    // Validate block_hash: the SSZ payload carries block_hash which must match
-    // the hash of the reconstructed block header.
-    let computed_hash = block.hash();
-    let expected_hash =
-        ethrex_common::H256::from_slice(&new_payload_request.execution_payload.block_hash);
-    if computed_hash != expected_hash {
-        return Err(ExecutionError::Internal(format!(
-            "block_hash mismatch: expected {expected_hash:?}, got {computed_hash:?}"
-        )));
-    }
-
-    // Validate blob versioned hashes
-    validate_versioned_hashes(&block, &new_payload_request)?;
-
-    // Execute statelessly — reuse the common `execute_blocks` infrastructure
-    let _result = execute_blocks(
-        &[block],
-        execution_witness,
-        ELASTICITY_MULTIPLIER,
-        |db, _| Ok(Evm::new_for_l1(db.clone(), crypto.clone())),
-        crypto.clone(),
-    )?;
+    validate_eip8025_execution(&new_payload_request, execution_witness, crypto)?;
 
     Ok(ProgramOutput {
         new_payload_request_root: request_root,
         valid: true,
+    })
+}
+
+/// Decode and execute the L1 stateless validation program from EIP-8025 wire
+/// bytes.
+///
+/// The wire format is `[ssz_len: u32 LE][ssz_bytes][rkyv_bytes]`, matching
+/// [`decode_eip8025`](super::decode_eip8025).
+#[cfg(feature = "eip-8025")]
+pub fn execution_program_eip8025_bytes(
+    bytes: &[u8],
+    crypto: Arc<dyn Crypto>,
+) -> Result<ProgramOutput, ExecutionError> {
+    use libssz_merkle::{HashTreeRoot, Sha2Hasher};
+
+    let (new_payload_request, execution_witness) = super::decode_eip8025(bytes, crypto.as_ref())
+        .map_err(|err| {
+            ExecutionError::Internal(format!("failed to decode EIP-8025 input: {err}"))
+        })?;
+
+    let request_root = new_payload_request.hash_tree_root(&Sha2Hasher);
+    let valid = validate_eip8025_execution(&new_payload_request, execution_witness, crypto).is_ok();
+
+    Ok(ProgramOutput {
+        new_payload_request_root: request_root,
+        valid,
     })
 }
 
@@ -113,7 +114,7 @@ fn new_payload_request_to_block(
 ) -> Result<ethrex_common::types::Block, String> {
     use bytes::Bytes;
     use ethrex_common::constants::DEFAULT_OMMERS_HASH;
-    use ethrex_common::types::requests::{EncodedRequests, compute_requests_hash};
+    use ethrex_common::types::requests::compute_requests_hash;
     use ethrex_common::types::{
         Block, BlockBody, BlockHeader, Transaction, Withdrawal, compute_transactions_root,
         compute_withdrawals_root,
@@ -144,15 +145,8 @@ fn new_payload_request_to_block(
         })
         .collect();
 
-    // Build execution_requests from the SSZ field for requests_hash
-    let execution_requests: Vec<EncodedRequests> = req
-        .execution_requests
-        .iter()
-        .map(|r| {
-            let raw: Vec<u8> = r.iter().copied().collect();
-            EncodedRequests(Bytes::from(raw))
-        })
-        .collect();
+    // Build execution_requests from the SSZ typed ExecutionRequests field
+    let execution_requests = req.execution_requests.to_encoded_requests();
     let requests_hash = compute_requests_hash(&execution_requests);
 
     // Convert base_fee_per_gas from [u8; 32] LE uint256 to u64
@@ -231,4 +225,64 @@ fn validate_versioned_hashes(
     }
 
     Ok(())
+}
+
+#[cfg(feature = "eip-8025")]
+fn validate_eip8025_execution(
+    new_payload_request: &ethrex_common::types::eip8025_ssz::NewPayloadRequest,
+    execution_witness: ethrex_common::types::block_execution_witness::ExecutionWitness,
+    crypto: Arc<dyn Crypto>,
+) -> Result<(), ExecutionError> {
+    // Transform SSZ NewPayloadRequest → Block
+    let block = new_payload_request_to_block(new_payload_request, crypto.as_ref())
+        .map_err(|e| ExecutionError::Internal(format!("payload conversion: {e}")))?;
+
+    // Validate block_hash: the SSZ payload carries block_hash which must match
+    // the hash of the reconstructed block header.
+    let computed_hash = block.hash();
+    let expected_hash =
+        ethrex_common::H256::from_slice(&new_payload_request.execution_payload.block_hash);
+    if computed_hash != expected_hash {
+        return Err(ExecutionError::Internal(format!(
+            "block_hash mismatch: expected {expected_hash:?}, got {computed_hash:?}"
+        )));
+    }
+
+    // Validate blob versioned hashes
+    validate_versioned_hashes(&block, new_payload_request)?;
+
+    // Execute statelessly — reuse the common `execute_blocks` infrastructure
+    let _result = execute_blocks(
+        &[block],
+        execution_witness,
+        ELASTICITY_MULTIPLIER,
+        |db, _| Ok(Evm::new_for_l1(db.clone(), crypto.clone())),
+        crypto.clone(),
+    )?;
+
+    Ok(())
+}
+
+#[cfg(all(test, feature = "eip-8025"))]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        common::ExecutionError, crypto::NativeCrypto, l1::execution_program_eip8025_bytes,
+    };
+
+    #[test]
+    fn execution_program_eip8025_bytes_rejects_invalid_wire_bytes() {
+        let err = match execution_program_eip8025_bytes(&[], Arc::new(NativeCrypto)) {
+            Ok(_) => panic!("expected invalid EIP-8025 input to fail decoding"),
+            Err(err) => err,
+        };
+
+        match err {
+            ExecutionError::Internal(msg) => {
+                assert_eq!(msg, "failed to decode EIP-8025 input: input too short");
+            }
+            other => panic!("expected internal decode error, got {other:?}"),
+        }
+    }
 }

--- a/crates/guest-program/src/lib.rs
+++ b/crates/guest-program/src/lib.rs
@@ -33,6 +33,8 @@ pub mod execution {
 #[cfg(not(feature = "l2"))]
 pub mod execution {
     pub use crate::l1::execution_program;
+    #[cfg(feature = "eip-8025")]
+    pub use crate::l1::execution_program_eip8025_bytes;
 }
 
 // When running clippy, the ELFs are not built, so we define them empty.


### PR DESCRIPTION
**Update:** Let's wait until the changes are finalized in #6550 

**Motivation**

Replace `rkyv` encoding of `ExecutionWitness` with SSZ. The structure of `ExecutionWitness` might change further, so this PR is a good middle step towards making EIP-8025 more [spec-compliant](https://github.com/ethereum/execution-specs/blob/projects/zkevm/src/ethereum/forks/amsterdam/stateless.py).

Related to issue https://github.com/lambdaclass/ethrex/issues/6502, but this PR does not yet make decoding faster.

**Description**

Changes add SSZ encoding by using `libssz`

- Added `SszExecutionWitness` as the SSZ representation for `ExecutionWitness`.
- Implemented conversion between SSZ bytes and `ExecutionWitness`.
- Integrated related changes from PR6516 https://github.com/lambdaclass/ethrex/pull/6516
- Added byte encoding for `ChainConfig`

Can be (almost) directly plugged into [ere-guests PR39](https://github.com/eth-act/ere-guests/pull/39)

