### PR TITLE
docs(l2): fix broken Taiko links in based rollup references

### DIFF
--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --exclude 'localhost' --exclude 'medium.com' docs/
+          args: --no-progress --exclude 'localhost' --exclude 'medium.com' --exclude 'mirror.xyz' docs/
           fail: true
 
   deploy:

--- a/docs/l2/fundamentals/based.md
+++ b/docs/l2/fundamentals/based.md
@@ -417,7 +417,7 @@ The following links, repos, and projects have been important in the development 
 
 - [Based Rollups by Justin Drake (current accepted definition)](https://ethresear.ch/t/based-rollups-superpowers-from-l1-sequencing/15016)
 - [Based Rollups by Spire](https://docs.spire.dev/education-hub/what-is-a-based-rollup)
-- [Based Rollups by Taiko](https://docs.taiko.xyz/taiko-alethia-protocol/protocol-design/based-rollups/)
+- [Based Rollups by Taiko](https://docs.taiko.xyz/protocol/based-rollups)
 - [Based Rollups by Gattaca](https://ethresear.ch/t/becoming-based-a-path-towards-decentralised-sequencing/21733)
   - [Analysis on Gattaca's Based Rollup Approach by Spire](https://docs.spire.dev/education-hub/based-rollups-overview)
 
@@ -429,7 +429,6 @@ The following links, repos, and projects have been important in the development 
 
 - [Based Ticketing Rollup by George Spasov](https://hackmd.io/@Perseverance/Syk2oQU36)
 - [Based Contestable Rollup by Taiko (Taiko Alethia)](https://taiko.mirror.xyz/Z4I5ZhreGkyfdaL5I9P0Rj0DNX4zaWFmcws-0CVMJ2A)
-- [Native Based Rollup by Taiko (Taiko Gwyneth)](https://docs.taiko.xyz/taiko-gwyneth-protocol/what-is-taiko-gwyneth/)
 
 ### Misc
 


### PR DESCRIPTION
## Motivation

The `Link Check` job fails on any PR touching `docs/**` because three Taiko links in `docs/l2/fundamentals/based.md` trip lychee: two `docs.taiko.xyz` URLs return 404, and one `taiko.mirror.xyz` URL is blocked by anti-bot protection (same behavior as `medium.com`, which is already excluded).

## Description

- Update the "Based Rollups by Taiko" link to `https://docs.taiko.xyz/protocol/based-rollups` (current page on the Taiko docs site).
- Remove the "Taiko Gwyneth" entry — returns 404, no successor found in the new docs.
- Keep the `taiko.mirror.xyz` link (content is live, just bot-blocked) and exclude `mirror.xyz` from lychee, same treatment as the existing `medium.com` exclusion.