### PR TITLE
ci(l1): consolidate Slack failure webhooks into a single secret

### DIFF
--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -36,12 +36,7 @@ jobs:
       - name: Select Slack webhook
         id: select_webhook
         run: |
-          WF_NAME="${{ github.event.workflow_run.name }}"
-          if echo "$WF_NAME" | grep -Eiq 'L2'; then
-            echo "webhook=${{ secrets.ETHREX_L2_SLACK_WEBHOOK }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "webhook=${{ secrets.ETHREX_L1_SLACK_WEBHOOK }}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "webhook=${{ secrets.ETHREX_INTERNO_SLACK_WEBHOOK }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -256,11 +256,7 @@ jobs:
         env:
           SLACK_WEBHOOKS: >
             ${{ github.event_name == 'schedule'
-              && format(
-                  '{0} {1}',
-                  secrets.ETHREX_L1_SLACK_WEBHOOK,
-                  secrets.ETHREX_L2_SLACK_WEBHOOK
-                )
+              && secrets.ETHREX_INTERNO_SLACK_WEBHOOK
               || secrets.TEST_CHANNEL_SLACK
             }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -114,7 +114,7 @@ jobs:
         if: always()
         env:
           SLACK_WEBHOOK_URL_SUCCESS: ${{ secrets.ETHREX_NOTIFICATIONS_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_URL_FAILURE: ${{ secrets.ETHREX_L1_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL_FAILURE: ${{ secrets.ETHREX_INTERNO_SLACK_WEBHOOK }}
           REPO: ${{ github.repository }}
           NAME: "lighthouse-${{ matrix.network }}"
           OUTCOME: ${{ steps.snapsync.outcome }}
@@ -161,7 +161,7 @@ jobs:
         if: always()
         env:
           SLACK_WEBHOOK_URL_SUCCESS: ${{ secrets.ETHREX_NOTIFICATIONS_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_URL_FAILURE: ${{ secrets.ETHREX_L1_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL_FAILURE: ${{ secrets.ETHREX_INTERNO_SLACK_WEBHOOK }}
           REPO: ${{ github.repository }}
           NAME: "prysm-${{ matrix.network }}"
           OUTCOME: ${{ steps.snapsync.outcome }}


### PR DESCRIPTION
**Motivation**

Consolidate CI failure notifications onto a single Slack webhook.

**Description**

Replace `ETHREX_L1_SLACK_WEBHOOK` and `ETHREX_L2_SLACK_WEBHOOK` with `ETHREX_INTERNO_SLACK_WEBHOOK` in:

- `.github/workflows/common_failure_alerts.yaml` — collapse the L1/L2 branching into a single webhook.
- `.github/workflows/daily_snapsync.yaml` — update both jobs.
- `.github/workflows/daily_hive_report.yaml` — collapse the two-webhook `format()` call into a single webhook.

The `ETHREX_INTERNO_SLACK_WEBHOOK` repo secret has been created.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A