### PR TITLE
perf(l1): unify DB_COMMIT_THRESHOLD and bump 128 to 256

### DIFF
--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -3,6 +3,7 @@ use fastbloom::AtomicBloomFilter;
 use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::{fmt, sync::Arc};
+use crate::store::DB_COMMIT_THRESHOLD;
 
 use ethrex_trie::{Nibbles, TrieDB, TrieError};
 
@@ -69,8 +70,7 @@ impl Default for TrieLayerCache {
             bloom: Self::create_filter(BLOOM_SIZE),
             last_id: 0,
             layers: Default::default(),
-            // TODO (issue #6345): this is coupled with DB_COMMIT_THRESHOLD in store.rs — unify them.
-            commit_threshold: 128,
+            commit_threshold: DB_COMMIT_THRESHOLD,
         }
     }
 }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -60,7 +60,6 @@ pub const MAX_WITNESSES: u64 = 128;
 // We use one constant for in-memory and another for on-disk backends.
 // This is due to tests requiring state older than 128 blocks.
 
-#[allow(unused)]
 pub const DB_COMMIT_THRESHOLD: usize = 256;
 const IN_MEMORY_COMMIT_THRESHOLD: usize = 10000;
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -59,9 +59,9 @@ pub const MAX_WITNESSES: u64 = 128;
 
 // We use one constant for in-memory and another for on-disk backends.
 // This is due to tests requiring state older than 128 blocks.
-// TODO: unify these
+
 #[allow(unused)]
-const DB_COMMIT_THRESHOLD: usize = 128;
+pub const DB_COMMIT_THRESHOLD: usize = 256;
 const IN_MEMORY_COMMIT_THRESHOLD: usize = 10000;
 
 /// Commit threshold for batch (full sync) mode. Each batch layer holds ~1024


### PR DESCRIPTION
**Motivation**
Two sources of truth existed for the same commit threshold value: a hardcoded `128` in `layering.rs` and `DB_COMMIT_THRESHOLD = 128` in `store.rs`. They were coupled but not connected, a maintenance hazard flagged in #6345. This PR consolidates them and folds in the threshold bump from #5944.

**Description**
- Makes `DB_COMMIT_THRESHOLD` `pub` in `store.rs` and increases it from `128` to `256`
- Replaces the hardcoded `commit_threshold: 128` in `layering.rs` with `DB_COMMIT_THRESHOLD`
- Removes the TODO comment referencing #6345
- `IN_MEMORY_COMMIT_THRESHOLD` is unchanged, it serves a separate purpose for test state retention

Closes #5944
Closes #6345


**Checklist**
- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.