### PR TITLE
perf(l1): add binaryandhash data block index to all rocksdb CFs for faster point lookups

### DIFF
--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -110,8 +110,6 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(32 * 1024); // 32KB blocks
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -123,8 +121,8 @@ impl RocksDBBackend {
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024); // 16KB
                     block_opts.set_bloom_filter(10.0, false);
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); //  Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); 
+                    block_opts.set_data_block_hash_ratio(0.75); 
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -138,8 +136,8 @@ impl RocksDBBackend {
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024); // 16KB
                     block_opts.set_bloom_filter(10.0, false); // 10 bits per key
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); 
+                    block_opts.set_data_block_hash_ratio(0.75); 
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -153,8 +151,8 @@ impl RocksDBBackend {
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024); // 16KB
                     block_opts.set_bloom_filter(10.0, false); // 10 bits per key
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); 
+                    block_opts.set_data_block_hash_ratio(0.75); 
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -170,8 +168,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(32 * 1024); // 32KB
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); 
+                    block_opts.set_data_block_hash_ratio(0.75);
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -182,8 +180,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(32 * 1024); // 32KB
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); 
+                    block_opts.set_data_block_hash_ratio(0.75); 
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -195,8 +193,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024);
-                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
-                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash);
+                    block_opts.set_data_block_hash_ratio(0.75); 
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }

--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -110,6 +110,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(32 * 1024); // 32KB blocks
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -121,6 +123,8 @@ impl RocksDBBackend {
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024); // 16KB
                     block_opts.set_bloom_filter(10.0, false);
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); //  Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -134,6 +138,8 @@ impl RocksDBBackend {
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024); // 16KB
                     block_opts.set_bloom_filter(10.0, false); // 10 bits per key
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -147,6 +153,8 @@ impl RocksDBBackend {
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024); // 16KB
                     block_opts.set_bloom_filter(10.0, false); // 10 bits per key
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -162,6 +170,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(32 * 1024); // 32KB
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -172,6 +182,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(32 * 1024); // 32KB
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
@@ -183,6 +195,8 @@ impl RocksDBBackend {
 
                     let mut block_opts = BlockBasedOptions::default();
                     block_opts.set_block_size(16 * 1024);
+                    block_opts.set_data_block_index_type(rocksdb::DataBlockIndexType::BinaryAndHash); // Hash index for faster lookups
+                    block_opts.set_data_block_hash_ratio(0.75); // Hash index covers 75% of entries for good performance
                     block_opts.set_block_cache(&block_cache);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }


### PR DESCRIPTION
**Motivation**
Point lookups into RocksDB data blocks currently use binary search. For trie nodes and flat key-value stores, which are heavily read during block execution, this adds unnecessary CPU overhead on each block scan.

**Description**
Enables `DataBlockIndexType::BinaryAndHash` with a hash ratio of `0.75` on all column families. This adds a hash index inside each SST data block so point lookups hit O(1) hash probe instead of O(log n) binary
search, at the cost of ~25% extra space within each data block.

Applied to all CFs: `HEADERS`, `BODIES`, `CANONICAL_BLOCK_HASHES`, `BLOCK_NUMBERS`, `ACCOUNT_TRIE_NODES`, `STORAGE_TRIE_NODES`,  `ACCOUNT_FLATKEYVALUE`, `STORAGE_FLATKEYVALUE`, `ACCOUNT_CODES`, `RECEIPTS`, and the default arm.

**Checklist**
- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR
  includes breaking changes to the `Store` requiring a re-sync.
  
 Closes #5941