### PR TITLE
perf(l1): move SST files into temp DB during snap sync ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2026-04-27
+
+- Reduce peak disk usage during snap sync by moving SST files into the temp DB instead of copying [#6532](https://github.com/lambdaclass/ethrex/pull/6532)
+
 ### 2026-03-30
 
 - Replace per-block thread spawning with persistent thread pool for merkleization [#6344](https://github.com/lambdaclass/ethrex/pull/6344)

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -1196,7 +1196,12 @@ async fn insert_accounts(
         .into_iter()
         .map(|res| res.path())
         .collect();
-    db.ingest_external_file(file_paths)
+    // Move SST files into the temp DB instead of copying them. The snapshot dir
+    // and the temp DB live under the same datadir, so rename succeeds and we
+    // avoid keeping two on-disk copies of the leaf data during ingest.
+    let mut ingest_opts = rocksdb::IngestExternalFileOptions::default();
+    ingest_opts.set_move_files(true);
+    db.ingest_external_file_opts(&ingest_opts, file_paths)
         .map_err(|err| SyncError::RocksDBError(err.into_string()))?;
     let iter = db.full_iterator(rocksdb::IteratorMode::Start);
     for account in iter {
@@ -1301,7 +1306,12 @@ async fn insert_storages(
         .into_iter()
         .map(|res| res.path())
         .collect();
-    db.ingest_external_file(file_paths)
+    // Move SST files into the temp DB instead of copying them. The snapshot dir
+    // and the temp DB live under the same datadir, so rename succeeds and we
+    // avoid keeping two on-disk copies of the leaf data during ingest.
+    let mut ingest_opts = rocksdb::IngestExternalFileOptions::default();
+    ingest_opts.set_move_files(true);
+    db.ingest_external_file_opts(&ingest_opts, file_paths)
         .map_err(|err| SyncError::RocksDBError(err.into_string()))?;
     let snapshot = db.snapshot();
 


### PR DESCRIPTION
**Motivation**

During storage insertion in snapsync, we use substantially more disk.

**Description**

Uses RocksDB move-based ingestion to reduce peak usage.
