### PR TITLE
feat(l1): make amsterdam header default to slot = 0 if no data in genesis

### DIFF
--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -719,7 +719,11 @@ impl Genesis {
                 self.block_access_list_hash
                     .unwrap_or(*EMPTY_BLOCK_ACCESS_LIST_HASH),
             );
-        let slot_number = self.slot_number;
+
+        let slot_number = self
+            .config
+            .is_amsterdam_activated(self.timestamp)
+            .then_some(self.slot_number.unwrap_or(0));
 
         BlockHeader {
             parent_hash: H256::zero(),


### PR DESCRIPTION
Not having this was making our genesis management different from clients like nethermind.