### PR TITLE
feat(l1): bound memory usage of healing

### DIFF
--- a/crates/networking/p2p/snap/constants.rs
+++ b/crates/networking/p2p/snap/constants.rs
@@ -74,6 +74,20 @@ pub const REQUEST_RETRY_ATTEMPTS: u32 = 5;
 /// Maximum number of concurrent in-flight requests during storage healing.
 pub const MAX_IN_FLIGHT_REQUESTS: u32 = 77;
 
+/// Soft limit on the number of entries in the storage healing queue.
+///
+/// Each `StorageHealingQueueEntry` holds a cloned trie `Node` (branch nodes are
+/// ~1 KB on the heap via `Box<BranchNode>`), three `Nibbles` paths (~200 B), and
+/// `HashMap` bucket overhead — on the order of 1 KB per entry. At 1_000_000
+/// entries that's ~1 GB of resident memory for the pending-parents map alone.
+///
+/// When this threshold is exceeded, the dispatcher stops issuing new download
+/// requests and waits for in-flight responses to drain the queue via
+/// `commit_node` cascades. Because the download queue is a max-heap by depth,
+/// in-flight work is the deepest available — which is what frees pending
+/// parents fastest.
+pub const HEALING_QUEUE_SOFT_LIMIT: usize = 1_000_000;
+
 // =============================================================================
 // BLOCK SYNC CONFIGURATION
 // =============================================================================

--- a/crates/networking/p2p/snap/constants.rs
+++ b/crates/networking/p2p/snap/constants.rs
@@ -74,19 +74,28 @@ pub const REQUEST_RETRY_ATTEMPTS: u32 = 5;
 /// Maximum number of concurrent in-flight requests during storage healing.
 pub const MAX_IN_FLIGHT_REQUESTS: u32 = 77;
 
-/// Soft limit on the number of entries in the storage healing queue.
+/// Soft limit on the number of entries in the storage healing queue
+/// (`StorageHealingQueue` — the pending-parents `HashMap` drained by
+/// `commit_node` cascades). Sized to bound resident memory of that map near
+/// ~1 GB.
 ///
-/// Each `StorageHealingQueueEntry` holds a cloned trie `Node` (branch nodes are
-/// ~1 KB on the heap via `Box<BranchNode>`), three `Nibbles` paths (~200 B), and
-/// `HashMap` bucket overhead — on the order of 1 KB per entry. At 1_000_000
-/// entries that's ~1 GB of resident memory for the pending-parents map alone.
+/// Per-entry cost, branch-dominated worst case:
+/// - `NodeResponse.node`: a branch `Node` is a `Box<BranchNode>` with 16
+///   `NodeRef` choices (~56 B each in the `Hash` variant) plus `ValueRLP`
+///   header, ≈ 950 B on the heap.
+/// - `NodeResponse.node_request`: three `Nibbles` (each a `Vec<u8>`, ~24 B
+///   header + up to 64 B data) + one `H256`, ≈ 250 B inline+heap.
+/// - `HashMap<(Nibbles, Nibbles), _>` key and bucket overhead, ≈ 100 B.
 ///
-/// When this threshold is exceeded, the dispatcher stops issuing new download
-/// requests and waits for in-flight responses to drain the queue via
-/// `commit_node` cascades. Because the download queue is a max-heap by depth,
-/// in-flight work is the deepest available — which is what frees pending
-/// parents fastest.
-pub const HEALING_QUEUE_SOFT_LIMIT: usize = 1_000_000;
+/// Total ≈ 1.3 KB per entry → 800_000 entries ≈ 1.0 GB. Leaf-dominated
+/// entries are smaller, so this is an upper-bound estimate. The limit gates
+/// `healing_queue` only; `download_queue` is a separate (smaller) allocation.
+///
+/// When exceeded, the dispatcher stops issuing new download requests and
+/// waits for in-flight responses to drain the queue. The download queue is a
+/// max-heap by depth, so in-flight work is the deepest available — which
+/// frees pending parents fastest via `commit_node` cascades.
+pub const HEALING_QUEUE_SOFT_LIMIT: usize = 800_000;
 
 // =============================================================================
 // BLOCK SYNC CONFIGURATION

--- a/crates/networking/p2p/snap/constants.rs
+++ b/crates/networking/p2p/snap/constants.rs
@@ -74,12 +74,15 @@ pub const REQUEST_RETRY_ATTEMPTS: u32 = 5;
 /// Maximum number of concurrent in-flight requests during storage healing.
 pub const MAX_IN_FLIGHT_REQUESTS: u32 = 77;
 
-/// Soft limit on the number of entries in the storage healing queue
-/// (`StorageHealingQueue` — the pending-parents `HashMap` drained by
-/// `commit_node` cascades). Sized to bound resident memory of that map near
-/// ~1 GB.
+/// Soft limit on the number of entries in a healing pending-parents queue.
 ///
-/// Per-entry cost, branch-dominated worst case:
+/// Shared by storage healing (`StorageHealingQueue`) and state healing
+/// (`StateHealingQueue`). Both are `HashMap`s of nodes awaiting their missing
+/// children; both are drained via `commit_node` cascades. The limit is sized
+/// for the larger of the two (storage) and is therefore conservative for
+/// state.
+///
+/// Storage per-entry cost, branch-dominated worst case:
 /// - `NodeResponse.node`: a branch `Node` is a `Box<BranchNode>` with 16
 ///   `NodeRef` choices (~56 B each in the `Hash` variant) plus `ValueRLP`
 ///   header, ≈ 950 B on the heap.
@@ -87,9 +90,12 @@ pub const MAX_IN_FLIGHT_REQUESTS: u32 = 77;
 ///   header + up to 64 B data) + one `H256`, ≈ 250 B inline+heap.
 /// - `HashMap<(Nibbles, Nibbles), _>` key and bucket overhead, ≈ 100 B.
 ///
-/// Total ≈ 1.3 KB per entry → 800_000 entries ≈ 1.0 GB. Leaf-dominated
-/// entries are smaller, so this is an upper-bound estimate. The limit gates
-/// `healing_queue` only; `download_queue` is a separate (smaller) allocation.
+/// Total ≈ 1.3 KB per entry → 800_000 entries ≈ 1.0 GB. State entries omit
+/// the extra `acc_path` `Nibbles` and use a single-`Nibbles` key, so they're
+/// smaller — the same count uses less memory on that side. Leaf-dominated
+/// entries are smaller still, so this is an upper-bound estimate. The limit
+/// gates the pending-parents map only; the download queue is a separate
+/// (smaller) allocation.
 ///
 /// When exceeded, the dispatcher stops issuing new download requests and
 /// waits for in-flight responses to drain the queue. The download queue is a

--- a/crates/networking/p2p/sync/healing/state.rs
+++ b/crates/networking/p2p/sync/healing/state.rs
@@ -75,6 +75,13 @@ pub async fn heal_state_trie_wrap(
 /// Returns true if healing was fully completed or false if we need to resume healing on the next sync cycle
 /// This method also stores modified storage roots in the db for heal_storage_trie
 /// Note: downloaders only gets updated when heal_state_trie, once per snap cycle
+// TODO: `paths` and `healing_queue` are both unbounded here. Storage healing
+// caps its pending-parents map via `HEALING_QUEUE_SOFT_LIMIT` and uses a
+// depth-ordered download queue to keep memory in check; state healing has
+// no equivalent guard. The state trie is much smaller than aggregate storage
+// so this has not been a problem in practice, but if state-healing OOMs ever
+// appear the same pattern (depth-priority heap + soft-limit backpressure)
+// applies.
 #[allow(clippy::too_many_arguments)]
 async fn heal_state_trie(
     state_root: H256,

--- a/crates/networking/p2p/sync/healing/state.rs
+++ b/crates/networking/p2p/sync/healing/state.rs
@@ -9,8 +9,8 @@
 //! All healed accounts will also have their bytecodes and storages healed by the corresponding processes
 
 use std::{
-    cmp::min,
-    collections::{BTreeMap, HashMap},
+    cmp::Ordering as CmpOrdering,
+    collections::{BTreeMap, BinaryHeap, HashMap},
     sync::atomic::Ordering,
     time::{Duration, Instant},
 };
@@ -29,7 +29,7 @@ use crate::{
     rlpx::p2p::SUPPORTED_SNAP_CAPABILITIES,
     snap::{
         SnapError,
-        constants::{NODE_BATCH_SIZE, SHOW_PROGRESS_INTERVAL_DURATION},
+        constants::{HEALING_QUEUE_SOFT_LIMIT, NODE_BATCH_SIZE, SHOW_PROGRESS_INTERVAL_DURATION},
         request_state_trienodes,
     },
     sync::{AccountStorageRoots, SyncError, code_collector::CodeHashCollector},
@@ -37,6 +37,36 @@ use crate::{
 };
 
 use super::types::{HealingQueueEntry, StateHealingQueue};
+
+/// `RequestMetadata` ordered by `path` depth, deepest first.
+///
+/// Used inside a `BinaryHeap` (max-heap) so the dispatcher pops the deepest
+/// pending node available. Same rationale as storage healing: depth-first
+/// draining is what shrinks `healing_queue` fastest — committing a leaf
+/// cascades up through its ancestors via `commit_node`, freeing pending
+/// parents.
+#[derive(Debug, Clone)]
+struct DepthOrderedMetadata(RequestMetadata);
+
+impl PartialEq for DepthOrderedMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.path.len() == other.0.path.len()
+    }
+}
+
+impl Eq for DepthOrderedMetadata {}
+
+impl PartialOrd for DepthOrderedMetadata {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DepthOrderedMetadata {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
+        self.0.path.len().cmp(&other.0.path.len())
+    }
+}
 
 pub async fn heal_state_trie_wrap(
     state_root: H256,
@@ -75,13 +105,6 @@ pub async fn heal_state_trie_wrap(
 /// Returns true if healing was fully completed or false if we need to resume healing on the next sync cycle
 /// This method also stores modified storage roots in the db for heal_storage_trie
 /// Note: downloaders only gets updated when heal_state_trie, once per snap cycle
-// TODO: `paths` and `healing_queue` are both unbounded here. Storage healing
-// caps its pending-parents map via `HEALING_QUEUE_SOFT_LIMIT` and uses a
-// depth-ordered download queue to keep memory in check; state healing has
-// no equivalent guard. The state trie is much smaller than aggregate storage
-// so this has not been a problem in practice, but if state-healing OOMs ever
-// appear the same pattern (depth-priority heap + soft-limit backpressure)
-// applies.
 #[allow(clippy::too_many_arguments)]
 async fn heal_state_trie(
     state_root: H256,
@@ -93,12 +116,16 @@ async fn heal_state_trie(
     storage_accounts: &mut AccountStorageRoots,
     code_hash_collector: &mut CodeHashCollector,
 ) -> Result<bool, SyncError> {
-    // Add the current state trie root to the pending paths
-    let mut paths: Vec<RequestMetadata> = vec![RequestMetadata {
-        hash: state_root,
-        path: Nibbles::default(), // We need to be careful, the root parent is a special case
-        parent_path: Nibbles::default(),
-    }];
+    // Add the current state trie root to the pending paths. `paths` is a
+    // max-heap by depth so the dispatcher always pops the deepest pending
+    // node — this bounds both `paths` and `healing_queue` by resolving deep
+    // subtrees first instead of expanding the BFS frontier.
+    let mut paths: BinaryHeap<DepthOrderedMetadata> =
+        BinaryHeap::from([DepthOrderedMetadata(RequestMetadata {
+            hash: state_root,
+            path: Nibbles::default(), // We need to be careful, the root parent is a special case
+            parent_path: Nibbles::default(),
+        })]);
     let mut last_update = Instant::now();
     let mut inflight_tasks: u64 = 0;
     let mut is_stale = false;
@@ -108,6 +135,10 @@ async fn heal_state_trie(
     let mut leafs_healed = 0;
     let mut empty_try_recv: u64 = 0;
     let mut heals_per_cycle: u64 = 0;
+    // Count of loop iterations where dispatch was skipped because
+    // `healing_queue.len() >= HEALING_QUEUE_SOFT_LIMIT`. Reset every progress
+    // interval — logged value is a per-interval rate, not a cumulative total.
+    let mut backpressure_stalls: u64 = 0;
     let mut nodes_to_write: Vec<(Nibbles, Node)> = Vec::new();
     let mut db_joinset = tokio::task::JoinSet::new();
 
@@ -148,11 +179,13 @@ async fn heal_state_trie(
                 downloads_rate,
                 paths_to_go = paths.len(),
                 pending_nodes = healing_queue.len(),
+                backpressure_stalls,
                 heals_per_cycle,
                 "State Healing",
             );
             downloads_success = 0;
             downloads_fail = 0;
+            backpressure_stalls = 0;
         }
 
         // Attempt to receive a response from one of the peers
@@ -201,19 +234,33 @@ async fn heal_state_trie(
                 }
                 // If the peers failed to respond, reschedule the task by adding the batch to the paths vector
                 Err(_) => {
-                    // TODO: Check if it's faster to reach the leafs of the trie
-                    // by doing batch.extend(paths);paths = batch
-                    // Or with a VecDequeue
-                    paths.extend(batch);
+                    paths.extend(batch.into_iter().map(DepthOrderedMetadata));
                     downloads_fail += 1;
                     peers.peer_table.record_failure(peer_id)?;
                 }
             }
         }
 
-        if !is_stale {
-            let batch: Vec<RequestMetadata> =
-                paths.drain(0..min(paths.len(), NODE_BATCH_SIZE)).collect();
+        // Backpressure: while the pending-parents map is at its soft limit,
+        // stop dispatching new downloads and let in-flight requests drain it.
+        // Because `paths` is a max-heap by depth, in-flight work is the
+        // deepest available — exactly what cascades commits up through
+        // `healing_queue` and frees entries fastest.
+        //
+        // The `inflight_tasks == 0` escape hatch is required: only in-flight
+        // responses drain `healing_queue` via `commit_node` cascades. Without
+        // it, reaching `inflight_tasks == 0 && healing_queue >= SOFT_LIMIT`
+        // would spin with nothing in-flight to refill the channel.
+        let gate_open = healing_queue.len() < HEALING_QUEUE_SOFT_LIMIT || inflight_tasks == 0;
+        if !is_stale && gate_open {
+            let batch_size = paths.len().min(NODE_BATCH_SIZE);
+            let mut batch: Vec<RequestMetadata> = Vec::with_capacity(batch_size);
+            for _ in 0..batch_size {
+                match paths.pop() {
+                    Some(DepthOrderedMetadata(req)) => batch.push(req),
+                    None => break,
+                }
+            }
             if !batch.is_empty() {
                 longest_path_seen = usize::max(
                     batch
@@ -233,7 +280,7 @@ async fn heal_state_trie(
                     .unwrap_or(None)
                 else {
                     // If there are no peers available, re-add the batch to the paths vector, and continue
-                    paths.extend(batch);
+                    paths.extend(batch.into_iter().map(DepthOrderedMetadata));
 
                     // Log ~ once every 10 seconds
                     if logged_no_free_peers_count == 0 {
@@ -268,6 +315,8 @@ async fn heal_state_trie(
                 });
                 tokio::task::yield_now().await;
             }
+        } else if !is_stale {
+            backpressure_stalls += 1;
         }
 
         // If there is at least one "batch" of nodes to heal, heal it
@@ -283,7 +332,7 @@ async fn heal_state_trie(
             .inspect_err(|err| {
                 debug!(error=?err, "We have found a sync error while trying to write to DB a batch")
             })?;
-            paths.extend(return_paths);
+            paths.extend(return_paths.into_iter().map(DepthOrderedMetadata));
         }
 
         let is_done = paths.is_empty() && nodes_to_heal.is_empty() && inflight_tasks == 0;
@@ -472,4 +521,47 @@ pub fn node_pending_children(
         _ => {}
     }
     Ok((pending_children_count, paths))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata_at_depth(depth: usize) -> RequestMetadata {
+        RequestMetadata {
+            hash: H256::zero(),
+            path: Nibbles::from_bytes(&vec![0u8; depth.div_ceil(2)]).slice(0, depth),
+            parent_path: Nibbles::default(),
+        }
+    }
+
+    #[test]
+    fn binary_heap_pops_deepest_first() {
+        let depths = [1usize, 5, 3, 2, 4, 0, 7, 6];
+        let mut heap: BinaryHeap<DepthOrderedMetadata> = depths
+            .iter()
+            .map(|&d| DepthOrderedMetadata(metadata_at_depth(d)))
+            .collect();
+
+        let mut popped = Vec::new();
+        while let Some(DepthOrderedMetadata(req)) = heap.pop() {
+            popped.push(req.path.len());
+        }
+
+        let mut expected: Vec<usize> = depths.to_vec();
+        expected.sort_by(|a, b| b.cmp(a));
+        assert_eq!(popped, expected);
+    }
+
+    #[test]
+    fn equal_depth_pops_without_panic() {
+        let mut heap: BinaryHeap<DepthOrderedMetadata> = (0..10)
+            .map(|_| DepthOrderedMetadata(metadata_at_depth(4)))
+            .collect();
+        let mut count = 0;
+        while heap.pop().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, 10);
+    }
 }

--- a/crates/networking/p2p/sync/healing/state.rs
+++ b/crates/networking/p2p/sync/healing/state.rs
@@ -41,10 +41,10 @@ use super::types::{HealingQueueEntry, StateHealingQueue};
 /// `RequestMetadata` ordered by `path` depth, deepest first.
 ///
 /// Used inside a `BinaryHeap` (max-heap) so the dispatcher pops the deepest
-/// pending node available. Same rationale as storage healing: depth-first
-/// draining is what shrinks `healing_queue` fastest — committing a leaf
-/// cascades up through its ancestors via `commit_node`, freeing pending
-/// parents.
+/// pending node available. Depth-first draining is what shrinks `healing_queue`
+/// fastest: committing a leaf cascades up through its ancestors via
+/// `commit_node`, freeing pending parents. Shallow-first would instead keep
+/// expanding the frontier and grow the queue without bound.
 #[derive(Debug, Clone)]
 struct DepthOrderedMetadata(RequestMetadata);
 
@@ -138,7 +138,7 @@ async fn heal_state_trie(
     // Count of loop iterations where dispatch was skipped because
     // `healing_queue.len() >= HEALING_QUEUE_SOFT_LIMIT`. Reset every progress
     // interval — logged value is a per-interval rate, not a cumulative total.
-    let mut backpressure_stalls: u64 = 0;
+    let mut backpressure_stalls: usize = 0;
     let mut nodes_to_write: Vec<(Nibbles, Node)> = Vec::new();
     let mut db_joinset = tokio::task::JoinSet::new();
 
@@ -153,6 +153,11 @@ async fn heal_state_trie(
     let mut logged_no_free_peers_count = 0;
 
     loop {
+        // Unconditional yield: ensures we cooperate with the tokio runtime even
+        // when backpressure skips the dispatch branch (which holds the only
+        // other yield point) and the response channel is empty.
+        tokio::task::yield_now().await;
+
         if last_update.elapsed() >= SHOW_PROGRESS_INTERVAL_DURATION {
             let num_peers = peers
                 .peer_table
@@ -251,72 +256,73 @@ async fn heal_state_trie(
         // responses drain `healing_queue` via `commit_node` cascades. Without
         // it, reaching `inflight_tasks == 0 && healing_queue >= SOFT_LIMIT`
         // would spin with nothing in-flight to refill the channel.
-        let gate_open = healing_queue.len() < HEALING_QUEUE_SOFT_LIMIT || inflight_tasks == 0;
-        if !is_stale && gate_open {
-            let batch_size = paths.len().min(NODE_BATCH_SIZE);
-            let mut batch: Vec<RequestMetadata> = Vec::with_capacity(batch_size);
-            for _ in 0..batch_size {
-                match paths.pop() {
-                    Some(DepthOrderedMetadata(req)) => batch.push(req),
-                    None => break,
-                }
-            }
-            if !batch.is_empty() {
-                longest_path_seen = usize::max(
-                    batch
-                        .iter()
-                        .map(|request_metadata| request_metadata.path.len())
-                        .max()
-                        .unwrap_or_default(),
-                    longest_path_seen,
-                );
-                let Some((peer_id, connection)) = peers
-                    .peer_table
-                    .get_best_peer(SUPPORTED_SNAP_CAPABILITIES.to_vec())
-                    .await
-                    .inspect_err(
-                        |err| debug!(err=?err, "Error requesting a peer to perform state healing"),
-                    )
-                    .unwrap_or(None)
-                else {
-                    // If there are no peers available, re-add the batch to the paths vector, and continue
-                    paths.extend(batch.into_iter().map(DepthOrderedMetadata));
-
-                    // Log ~ once every 10 seconds
-                    if logged_no_free_peers_count == 0 {
-                        trace!("We are missing peers in heal_state_trie");
-                        logged_no_free_peers_count = 1000;
+        if !is_stale {
+            let gate_open = healing_queue.len() < HEALING_QUEUE_SOFT_LIMIT || inflight_tasks == 0;
+            if gate_open {
+                let batch_size = paths.len().min(NODE_BATCH_SIZE);
+                let mut batch: Vec<RequestMetadata> = Vec::with_capacity(batch_size);
+                for _ in 0..batch_size {
+                    match paths.pop() {
+                        Some(DepthOrderedMetadata(req)) => batch.push(req),
+                        None => break,
                     }
-                    logged_no_free_peers_count -= 1;
+                }
+                if !batch.is_empty() {
+                    longest_path_seen = usize::max(
+                        batch
+                            .iter()
+                            .map(|request_metadata| request_metadata.path.len())
+                            .max()
+                            .unwrap_or_default(),
+                        longest_path_seen,
+                    );
+                    let Some((peer_id, connection)) = peers
+                        .peer_table
+                        .get_best_peer(SUPPORTED_SNAP_CAPABILITIES.to_vec())
+                        .await
+                        .inspect_err(|err| {
+                            debug!(err=?err, "Error requesting a peer to perform state healing")
+                        })
+                        .unwrap_or(None)
+                    else {
+                        // If there are no peers available, re-add the batch to the paths vector, and continue
+                        paths.extend(batch.into_iter().map(DepthOrderedMetadata));
 
-                    // Sleep a bit to avoid busy polling
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                    continue;
-                };
+                        // Log ~ once every 10 seconds
+                        if logged_no_free_peers_count == 0 {
+                            trace!("We are missing peers in heal_state_trie");
+                            logged_no_free_peers_count = 1000;
+                        }
+                        logged_no_free_peers_count -= 1;
 
-                let tx = task_sender.clone();
-                inflight_tasks += 1;
+                        // Sleep a bit to avoid busy polling
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        continue;
+                    };
 
-                let peer_table = peers.peer_table.clone();
-                tokio::spawn(async move {
-                    // TODO: check errors to determine whether the current block is stale
-                    let response = request_state_trienodes(
-                        peer_id,
-                        connection,
-                        peer_table,
-                        state_root,
-                        batch.clone(),
-                    )
-                    .await;
-                    // TODO: add error handling
-                    tx.send((peer_id, response, batch)).await.inspect_err(
-                        |err| debug!(error=?err, "Failed to send state trie nodes response"),
-                    )
-                });
-                tokio::task::yield_now().await;
+                    let tx = task_sender.clone();
+                    inflight_tasks += 1;
+
+                    let peer_table = peers.peer_table.clone();
+                    tokio::spawn(async move {
+                        // TODO: check errors to determine whether the current block is stale
+                        let response = request_state_trienodes(
+                            peer_id,
+                            connection,
+                            peer_table,
+                            state_root,
+                            batch.clone(),
+                        )
+                        .await;
+                        // TODO: add error handling
+                        tx.send((peer_id, response, batch)).await.inspect_err(
+                            |err| debug!(error=?err, "Failed to send state trie nodes response"),
+                        )
+                    });
+                }
+            } else {
+                backpressure_stalls += 1;
             }
-        } else if !is_stale {
-            backpressure_stalls += 1;
         }
 
         // If there is at least one "batch" of nodes to heal, heal it

--- a/crates/networking/p2p/sync/healing/storage.rs
+++ b/crates/networking/p2p/sync/healing/storage.rs
@@ -102,7 +102,9 @@ pub struct StorageHealer {
     empty_count: usize,
     disconnected_count: usize,
     /// Count of loop iterations where dispatch was skipped because
-    /// `healing_queue.len() >= HEALING_QUEUE_SOFT_LIMIT`.
+    /// `healing_queue.len() >= HEALING_QUEUE_SOFT_LIMIT`. Reset every
+    /// progress interval — the logged value is a per-interval rate, not a
+    /// cumulative total.
     backpressure_stalls: usize,
 }
 
@@ -293,7 +295,13 @@ pub async fn heal_storage_trie(
         // the download queue is a max-heap by depth, the in-flight work is the
         // deepest available — exactly what cascades commits up through
         // `healing_queue` and frees entries fastest.
-        if state.healing_queue.len() < HEALING_QUEUE_SOFT_LIMIT {
+        //
+        // The `requests.is_empty()` escape hatch is required: only in-flight
+        // responses drain `healing_queue` via `commit_node` cascades. If we
+        // ever reach `requests.is_empty() && healing_queue >= SOFT_LIMIT`
+        // without this override, the loop spins with nothing in-flight to
+        // refill the channel, and healing stalls until staleness fires.
+        if state.healing_queue.len() < HEALING_QUEUE_SOFT_LIMIT || state.requests.is_empty() {
             ask_peers_for_nodes(
                 &mut state.download_queue,
                 &mut state.requests,
@@ -359,14 +367,14 @@ pub async fn heal_storage_trie(
                     .remove(&request_id)
                     .expect("request disappeared");
                 state.failed_downloads += 1;
+                let peer_id = inflight_request.peer_id;
                 state.download_queue.extend(
                     inflight_request
                         .requests
-                        .iter()
-                        .cloned()
+                        .into_iter()
                         .map(DepthOrderedRequest),
                 );
-                peers.peer_table.record_failure(inflight_request.peer_id)?;
+                peers.peer_table.record_failure(peer_id)?;
             }
         }
     }
@@ -643,7 +651,7 @@ fn get_initial_downloads(
     let trie = store
         .open_locked_state_trie(state_root)
         .expect("We should be able to open the store");
-    let initial: Vec<NodeRequest> = account_paths
+    account_paths
         .healed_accounts
         .par_iter()
         .filter_map(|acc_path| {
@@ -658,15 +666,14 @@ fn get_initial_downloads(
                 return None;
             }
 
-            Some(NodeRequest {
+            Some(DepthOrderedRequest(NodeRequest {
                 acc_path: Nibbles::from_bytes(&acc_path.0),
                 storage_path: Nibbles::default(), // We need to be careful, the root parent is a special case
                 parent: Nibbles::default(),
                 hash: account.storage_root,
-            })
+            }))
         })
-        .collect();
-    initial.into_iter().map(DepthOrderedRequest).collect()
+        .collect()
 }
 
 /// Returns the full paths to the node's missing children and grandchildren

--- a/crates/networking/p2p/sync/healing/storage.rs
+++ b/crates/networking/p2p/sync/healing/storage.rs
@@ -9,8 +9,8 @@ use crate::{
     snap::{
         RequestStorageTrieNodesError,
         constants::{
-            MAX_IN_FLIGHT_REQUESTS, MAX_RESPONSE_BYTES, SHOW_PROGRESS_INTERVAL_DURATION,
-            STORAGE_BATCH_SIZE,
+            HEALING_QUEUE_SOFT_LIMIT, MAX_IN_FLIGHT_REQUESTS, MAX_RESPONSE_BYTES,
+            SHOW_PROGRESS_INTERVAL_DURATION, STORAGE_BATCH_SIZE,
         },
         request_storage_trienodes,
     },
@@ -27,7 +27,8 @@ use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, Node};
 use rand::random;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
-    collections::{HashMap, VecDeque},
+    cmp::Ordering as CmpOrdering,
+    collections::{BinaryHeap, HashMap},
     sync::atomic::Ordering,
     time::Instant,
 };
@@ -74,8 +75,11 @@ pub struct StorageHealer {
     /// We use this to track what is still to be downloaded
     /// After processing the nodes it may be left empty,
     /// but if we have too many requests in flight
-    /// we may want to throttle the new requests
-    download_queue: VecDeque<NodeRequest>,
+    /// we may want to throttle the new requests.
+    ///
+    /// Ordered by depth (deepest first) to bound memory: deep nodes resolve
+    /// leaves that cascade up through `healing_queue` and free pending parents.
+    download_queue: BinaryHeap<DepthOrderedRequest>,
     /// Arc<dyn> to the db, clone freely
     store: Store,
     /// Memory of everything stored
@@ -97,6 +101,9 @@ pub struct StorageHealer {
     failed_downloads: usize,
     empty_count: usize,
     disconnected_count: usize,
+    /// Count of loop iterations where dispatch was skipped because
+    /// `healing_queue.len() >= HEALING_QUEUE_SOFT_LIMIT`.
+    backpressure_stalls: usize,
 }
 
 /// This struct stores the metadata we need when we request a node
@@ -110,6 +117,36 @@ pub struct NodeRequest {
     parent: Nibbles,
     /// What hash was requested. We use this for validation
     hash: H256,
+}
+
+/// `NodeRequest` ordered by `storage_path` depth, deepest first.
+///
+/// Used inside a `BinaryHeap` (max-heap) so the dispatcher pops the deepest
+/// pending node available. Depth-first draining is what shrinks `healing_queue`
+/// fastest: committing a leaf cascades up through its ancestors via
+/// `commit_node`, freeing pending parents. Shallow-first would instead keep
+/// expanding the frontier and grow the queue without bound.
+#[derive(Debug, Clone)]
+struct DepthOrderedRequest(NodeRequest);
+
+impl PartialEq for DepthOrderedRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.storage_path.len() == other.0.storage_path.len()
+    }
+}
+
+impl Eq for DepthOrderedRequest {}
+
+impl PartialOrd for DepthOrderedRequest {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DepthOrderedRequest {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
+        self.0.storage_path.len().cmp(&other.0.storage_path.len())
+    }
 }
 
 /// This algorithm 'heals' the storage trie. That is to say, it downloads data until all accounts have the storage indicated
@@ -152,6 +189,7 @@ pub async fn heal_storage_trie(
         failed_downloads: Default::default(),
         empty_count: Default::default(),
         disconnected_count: Default::default(),
+        backpressure_stalls: Default::default(),
     };
 
     // With this we track what's going on with the tasks in flight
@@ -190,6 +228,8 @@ pub async fn heal_storage_trie(
                 snap_peer_count,
                 inflight_requests = state.requests.len(),
                 download_queue_len = state.download_queue.len(),
+                healing_queue_len = state.healing_queue.len(),
+                backpressure_stalls = state.backpressure_stalls,
                 maximum_depth = state.maximum_length_seen,
                 leaves_healed = state.leafs_healed,
                 global_leaves_healed = global_leafs_healed,
@@ -206,6 +246,7 @@ pub async fn heal_storage_trie(
             state.failed_downloads = 0;
             state.empty_count = 0;
             state.disconnected_count = 0;
+            state.backpressure_stalls = 0;
         }
 
         let is_done = state.requests.is_empty() && state.download_queue.is_empty();
@@ -247,16 +288,25 @@ pub async fn heal_storage_trie(
             return Ok(false);
         }
 
-        ask_peers_for_nodes(
-            &mut state.download_queue,
-            &mut state.requests,
-            &mut requests_task_joinset,
-            peers,
-            state.state_root,
-            &task_sender,
-            &mut logged_no_free_peers_count,
-        )
-        .await;
+        // Backpressure: while the pending-parents map is at its soft limit, stop
+        // dispatching new downloads and let in-flight requests drain it. Because
+        // the download queue is a max-heap by depth, the in-flight work is the
+        // deepest available — exactly what cascades commits up through
+        // `healing_queue` and frees entries fastest.
+        if state.healing_queue.len() < HEALING_QUEUE_SOFT_LIMIT {
+            ask_peers_for_nodes(
+                &mut state.download_queue,
+                &mut state.requests,
+                &mut requests_task_joinset,
+                peers,
+                state.state_root,
+                &task_sender,
+                &mut logged_no_free_peers_count,
+            )
+            .await;
+        } else {
+            state.backpressure_stalls += 1;
+        }
 
         let _ = requests_task_joinset.try_join_next();
 
@@ -309,9 +359,13 @@ pub async fn heal_storage_trie(
                     .remove(&request_id)
                     .expect("request disappeared");
                 state.failed_downloads += 1;
-                state
-                    .download_queue
-                    .extend(inflight_request.requests.clone());
+                state.download_queue.extend(
+                    inflight_request
+                        .requests
+                        .iter()
+                        .cloned()
+                        .map(DepthOrderedRequest),
+                );
                 peers.peer_table.record_failure(inflight_request.peer_id)?;
             }
         }
@@ -320,7 +374,7 @@ pub async fn heal_storage_trie(
 
 /// it grabs N peers to ask for data
 async fn ask_peers_for_nodes(
-    download_queue: &mut VecDeque<NodeRequest>,
+    download_queue: &mut BinaryHeap<DepthOrderedRequest>,
     requests: &mut HashMap<u64, InflightRequest>,
     requests_task_joinset: &mut JoinSet<
         Result<u64, TrySendError<Result<TrieNodes, RequestStorageTrieNodesError>>>,
@@ -348,8 +402,15 @@ async fn ask_peers_for_nodes(
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
             return;
         };
-        let at = download_queue.len().saturating_sub(STORAGE_BATCH_SIZE);
-        let download_chunk = download_queue.split_off(at);
+        // Pop the deepest STORAGE_BATCH_SIZE items from the heap.
+        let mut download_chunk: Vec<NodeRequest> =
+            Vec::with_capacity(STORAGE_BATCH_SIZE.min(download_queue.len()));
+        for _ in 0..STORAGE_BATCH_SIZE {
+            match download_queue.pop() {
+                Some(DepthOrderedRequest(req)) => download_chunk.push(req),
+                None => break,
+            }
+        }
         let req_id: u64 = random();
         let (paths, inflight_requests_data) = create_node_requests(download_chunk);
         requests.insert(
@@ -382,9 +443,7 @@ async fn ask_peers_for_nodes(
     }
 }
 
-fn create_node_requests(
-    node_requests: VecDeque<NodeRequest>,
-) -> (Vec<Vec<Bytes>>, Vec<NodeRequest>) {
+fn create_node_requests(node_requests: Vec<NodeRequest>) -> (Vec<Vec<Bytes>>, Vec<NodeRequest>) {
     let mut mapped_requests: HashMap<Nibbles, Vec<NodeRequest>> = HashMap::new();
 
     for request in node_requests {
@@ -418,7 +477,7 @@ fn create_node_requests(
 async fn zip_requeue_node_responses_score_peer(
     requests: &mut HashMap<u64, InflightRequest>,
     peer_handler: &mut PeerHandler,
-    download_queue: &mut VecDeque<NodeRequest>,
+    download_queue: &mut BinaryHeap<DepthOrderedRequest>,
     trie_nodes: &TrieNodes,
     succesful_downloads: &mut usize,
     failed_downloads: &mut usize,
@@ -440,7 +499,7 @@ async fn zip_requeue_node_responses_score_peer(
         *failed_downloads += 1;
         peer_handler.peer_table.record_failure(request.peer_id)?;
 
-        download_queue.extend(request.requests);
+        download_queue.extend(request.requests.into_iter().map(DepthOrderedRequest));
         return Ok(None);
     }
 
@@ -453,7 +512,7 @@ async fn zip_requeue_node_responses_score_peer(
         );
         *failed_downloads += 1;
         peer_handler.peer_table.record_failure(request.peer_id)?;
-        download_queue.extend(request.requests);
+        download_queue.extend(request.requests.into_iter().map(DepthOrderedRequest));
         return Ok(None);
     }
 
@@ -490,7 +549,13 @@ async fn zip_requeue_node_responses_score_peer(
         .collect::<Result<Vec<NodeResponse>, RLPDecodeError>>()
     {
         if request.requests.len() > nodes_size {
-            download_queue.extend(request.requests.into_iter().skip(nodes_size));
+            download_queue.extend(
+                request
+                    .requests
+                    .into_iter()
+                    .skip(nodes_size)
+                    .map(DepthOrderedRequest),
+            );
         }
         *succesful_downloads += 1;
         peer_handler.peer_table.record_success(request.peer_id)?;
@@ -498,7 +563,7 @@ async fn zip_requeue_node_responses_score_peer(
     } else {
         *failed_downloads += 1;
         peer_handler.peer_table.record_failure(request.peer_id)?;
-        download_queue.extend(request.requests);
+        download_queue.extend(request.requests.into_iter().map(DepthOrderedRequest));
         Ok(None)
     }
 }
@@ -506,7 +571,7 @@ async fn zip_requeue_node_responses_score_peer(
 #[allow(clippy::too_many_arguments)]
 fn process_node_responses(
     node_processing_queue: &mut Vec<NodeResponse>,
-    download_queue: &mut VecDeque<NodeRequest>,
+    download_queue: &mut BinaryHeap<DepthOrderedRequest>,
     store: &Store,
     healing_queue: &mut StorageHealingQueue,
     leafs_healed: &mut usize,
@@ -559,7 +624,11 @@ fn process_node_responses(
                     pending_children_count,
                 },
             );
-            download_queue.extend(pending_children_nibbles);
+            download_queue.extend(
+                pending_children_nibbles
+                    .into_iter()
+                    .map(DepthOrderedRequest),
+            );
         }
     }
 
@@ -570,37 +639,34 @@ fn get_initial_downloads(
     store: &Store,
     state_root: H256,
     account_paths: &AccountStorageRoots,
-) -> VecDeque<NodeRequest> {
+) -> BinaryHeap<DepthOrderedRequest> {
     let trie = store
         .open_locked_state_trie(state_root)
         .expect("We should be able to open the store");
-    let mut initial_requests: VecDeque<NodeRequest> = VecDeque::new();
-    initial_requests.extend(
-        account_paths
-            .healed_accounts
-            .par_iter()
-            .filter_map(|acc_path| {
-                // Accounts can be deleted from the trie after the healing process happens
-                // This is an edge case where an account with value got deleted by
-                // a self destruct contract creation step
-                let rlp = trie
-                    .get(acc_path.as_bytes())
-                    .expect("We should be able to open the store")?;
-                let account = AccountState::decode(&rlp).expect("We should have a valid account");
-                if account.storage_root == *EMPTY_TRIE_HASH {
-                    return None;
-                }
+    let initial: Vec<NodeRequest> = account_paths
+        .healed_accounts
+        .par_iter()
+        .filter_map(|acc_path| {
+            // Accounts can be deleted from the trie after the healing process happens
+            // This is an edge case where an account with value got deleted by
+            // a self destruct contract creation step
+            let rlp = trie
+                .get(acc_path.as_bytes())
+                .expect("We should be able to open the store")?;
+            let account = AccountState::decode(&rlp).expect("We should have a valid account");
+            if account.storage_root == *EMPTY_TRIE_HASH {
+                return None;
+            }
 
-                Some(NodeRequest {
-                    acc_path: Nibbles::from_bytes(&acc_path.0),
-                    storage_path: Nibbles::default(), // We need to be careful, the root parent is a special case
-                    parent: Nibbles::default(),
-                    hash: account.storage_root,
-                })
+            Some(NodeRequest {
+                acc_path: Nibbles::from_bytes(&acc_path.0),
+                storage_path: Nibbles::default(), // We need to be careful, the root parent is a special case
+                parent: Nibbles::default(),
+                hash: account.storage_root,
             })
-            .collect::<VecDeque<_>>(),
-    );
-    initial_requests
+        })
+        .collect();
+    initial.into_iter().map(DepthOrderedRequest).collect()
 }
 
 /// Returns the full paths to the node's missing children and grandchildren
@@ -726,5 +792,49 @@ fn commit_node(
     } else {
         healing_queue.insert(parent_key, parent_entry);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_at_depth(depth: usize) -> NodeRequest {
+        NodeRequest {
+            acc_path: Nibbles::default(),
+            storage_path: Nibbles::from_bytes(&vec![0u8; depth.div_ceil(2)]).slice(0, depth),
+            parent: Nibbles::default(),
+            hash: H256::zero(),
+        }
+    }
+
+    #[test]
+    fn binary_heap_pops_deepest_first() {
+        let depths = [1usize, 5, 3, 2, 4, 0, 7, 6];
+        let mut heap: BinaryHeap<DepthOrderedRequest> = depths
+            .iter()
+            .map(|&d| DepthOrderedRequest(request_at_depth(d)))
+            .collect();
+
+        let mut popped = Vec::new();
+        while let Some(DepthOrderedRequest(req)) = heap.pop() {
+            popped.push(req.storage_path.len());
+        }
+
+        let mut expected: Vec<usize> = depths.to_vec();
+        expected.sort_by(|a, b| b.cmp(a));
+        assert_eq!(popped, expected);
+    }
+
+    #[test]
+    fn equal_depth_pops_without_panic() {
+        let mut heap: BinaryHeap<DepthOrderedRequest> = (0..10)
+            .map(|_| DepthOrderedRequest(request_at_depth(4)))
+            .collect();
+        let mut count = 0;
+        while heap.pop().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, 10);
     }
 }


### PR DESCRIPTION
**Motivation**

For large networks storage healing might end up loading hundreds of millions of nodes into the pending queue.

**Description**

We use a priority queue to ensure deep nodes are resolved first instead of opening new tries. We also set a soft cap after which download goes slower to ensure parallelism doesn't cause the limit to be substantially exceeded. The limit is not hard as we prefer a risk of OOM rather than a stall.