### PR TITLE
perf(l1): batch receipt retrieval in single read txn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Perf
 
+### 2026-04-29
+
+- Use fixed-width RECEIPTS keys and cursor iteration with early stop for eth_getTransactionReceipt; fix prefix iterator scan in get_transaction_location [#6548](https://github.com/lambdaclass/ethrex/pull/6548)
+
 ### 2026-03-30
 
 - Replace per-block thread spawning with persistent thread pool for merkleization [#6344](https://github.com/lambdaclass/ethrex/pull/6344)

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -1242,7 +1242,7 @@ async fn handle_incoming_message(
                 let start_index = if i == 0 { first_block_receipt_index } else { 0 };
                 let block_receipts = state
                     .storage
-                    .get_receipts_for_block_from_index(hash, start_index)
+                    .get_receipts_for_block_from_index(hash, start_index, None)
                     .await?;
 
                 let mut block_receipt_list = Vec::new();

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::RpcErr,
 };
 use ethrex_common::types::{
-    Block, BlockBody, BlockHash, BlockHeader, BlockNumber, Receipt, calculate_base_fee_per_blob_gas,
+    Block, BlockBody, BlockHash, BlockHeader, Receipt, calculate_base_fee_per_blob_gas,
 };
 use ethrex_storage::Store;
 
@@ -177,7 +177,7 @@ impl RpcHandler for GetBlockReceiptsRequest {
             // Block not found
             _ => return Ok(Value::Null),
         };
-        let receipts = get_all_block_rpc_receipts(block_number, header, body, storage).await?;
+        let receipts = get_all_block_rpc_receipts(header, body, storage, None).await?;
 
         serde_json::to_value(&receipts).map_err(|error| RpcErr::Internal(error.to_string()))
     }
@@ -270,11 +270,11 @@ impl RpcHandler for GetRawReceipts {
         };
         let header = storage.get_block_header(block_number)?;
         let body = storage.get_block_body(block_number).await?;
-        let (header, body) = match (header, body) {
+        let (header, _body) = match (header, body) {
             (Some(header), Some(body)) => (header, body),
             _ => return Ok(Value::Null),
         };
-        let receipts: Vec<String> = get_all_block_receipts(block_number, header, body, storage)
+        let receipts: Vec<String> = get_all_block_receipts(header, storage)
             .await?
             .iter()
             .map(|receipt| {
@@ -329,11 +329,18 @@ impl RpcHandler for GetBlobBaseFee {
     }
 }
 
+/// Fetches RPC receipts for a block, optionally stopping after `target_index`.
+///
+/// When `target_index` is `Some(n)`, only receipts 0..=n are fetched using a
+/// cursor pass — this is the fast path for `eth_getTransactionReceipt` which
+/// only needs one receipt but requires preceding cumulative gas values.
+///
+/// When `target_index` is `None`, all receipts are fetched (for `eth_getBlockReceipts`).
 pub async fn get_all_block_rpc_receipts(
-    block_number: BlockNumber,
     header: BlockHeader,
     body: BlockBody,
     storage: &Store,
+    target_index: Option<u64>,
 ) -> Result<Vec<RpcReceipt>, RpcErr> {
     let mut receipts = Vec::new();
     // Check if this is the genesis block
@@ -353,16 +360,25 @@ pub async fn get_all_block_rpc_receipts(
         .try_into()
         .map_err(|_| RpcErr::Internal("blob_base_fee does not fit in u64".to_owned()))?;
     // Fetch receipt info from block
+    let block_hash = header.hash();
     let block_info = RpcReceiptBlockInfo::from_block_header(header);
-    // Fetch receipt for each tx in the block and add block and tx info
+    // Fetch receipts: only up to target_index+1 when set, otherwise all
+    let fetch_count = target_index
+        .map(|ti| (ti + 1) as usize)
+        .unwrap_or(body.transactions.len());
+    let all_receipts = storage
+        .get_receipts_for_block_from_index(&block_hash, 0, Some(fetch_count))
+        .await?;
     let mut last_cumulative_gas_used = 0;
     let mut current_log_index = 0;
-    for (index, tx) in body.transactions.iter().enumerate() {
+    for (index, (tx, receipt)) in body
+        .transactions
+        .iter()
+        .zip(all_receipts.iter())
+        .enumerate()
+        .take(fetch_count)
+    {
         let index = index as u64;
-        let receipt = match storage.get_receipt(block_number, index).await? {
-            Some(receipt) => receipt,
-            _ => return Err(RpcErr::Internal("Could not get receipt".to_owned())),
-        };
         let gas_used = receipt.cumulative_gas_used - last_cumulative_gas_used;
         let tx_info = RpcReceiptTxInfo::from_transaction(
             tx.clone(),
@@ -385,23 +401,13 @@ pub async fn get_all_block_rpc_receipts(
 }
 
 pub async fn get_all_block_receipts(
-    block_number: BlockNumber,
     header: BlockHeader,
-    body: BlockBody,
     storage: &Store,
 ) -> Result<Vec<Receipt>, RpcErr> {
-    let mut receipts = Vec::new();
     // Check if this is the genesis block
     if header.parent_hash.is_zero() {
-        return Ok(receipts);
+        return Ok(Vec::new());
     }
-    for (index, _) in body.transactions.iter().enumerate() {
-        let index = index as u64;
-        let receipt = match storage.get_receipt(block_number, index).await? {
-            Some(receipt) => receipt,
-            _ => return Err(RpcErr::Internal("Could not get receipt".to_owned())),
-        };
-        receipts.push(receipt);
-    }
-    Ok(receipts)
+    let block_hash = header.hash();
+    Ok(storage.get_receipts_for_block(&block_hash).await?)
 }

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -330,7 +330,7 @@ impl RpcHandler for GetBlobBaseFee {
 }
 
 pub async fn get_all_block_rpc_receipts(
-    _block_number: BlockNumber,
+    block_number: BlockNumber,
     header: BlockHeader,
     body: BlockBody,
     storage: &Store,
@@ -353,14 +353,16 @@ pub async fn get_all_block_rpc_receipts(
         .try_into()
         .map_err(|_| RpcErr::Internal("blob_base_fee does not fit in u64".to_owned()))?;
     // Fetch receipt info from block
-    let block_hash = header.hash();
     let block_info = RpcReceiptBlockInfo::from_block_header(header);
-    // Fetch all receipts in a single cursor pass
-    let all_receipts = storage.get_receipts_for_block(&block_hash).await?;
+    // Fetch receipt for each tx in the block and add block and tx info
     let mut last_cumulative_gas_used = 0;
     let mut current_log_index = 0;
-    for (index, (tx, receipt)) in body.transactions.iter().zip(all_receipts.iter()).enumerate() {
+    for (index, tx) in body.transactions.iter().enumerate() {
         let index = index as u64;
+        let receipt = match storage.get_receipt(block_number, index).await? {
+            Some(receipt) => receipt,
+            _ => return Err(RpcErr::Internal("Could not get receipt".to_owned())),
+        };
         let gas_used = receipt.cumulative_gas_used - last_cumulative_gas_used;
         let tx_info = RpcReceiptTxInfo::from_transaction(
             tx.clone(),
@@ -383,15 +385,23 @@ pub async fn get_all_block_rpc_receipts(
 }
 
 pub async fn get_all_block_receipts(
-    _block_number: BlockNumber,
+    block_number: BlockNumber,
     header: BlockHeader,
-    _body: BlockBody,
+    body: BlockBody,
     storage: &Store,
 ) -> Result<Vec<Receipt>, RpcErr> {
+    let mut receipts = Vec::new();
     // Check if this is the genesis block
     if header.parent_hash.is_zero() {
-        return Ok(Vec::new());
+        return Ok(receipts);
     }
-    let block_hash = header.hash();
-    Ok(storage.get_receipts_for_block(&block_hash).await?)
+    for (index, _) in body.transactions.iter().enumerate() {
+        let index = index as u64;
+        let receipt = match storage.get_receipt(block_number, index).await? {
+            Some(receipt) => receipt,
+            _ => return Err(RpcErr::Internal("Could not get receipt".to_owned())),
+        };
+        receipts.push(receipt);
+    }
+    Ok(receipts)
 }

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -369,6 +369,13 @@ pub async fn get_all_block_rpc_receipts(
     let all_receipts = storage
         .get_receipts_for_block_from_index(&block_hash, 0, Some(fetch_count))
         .await?;
+    if all_receipts.len() != fetch_count {
+        return Err(RpcErr::Internal(format!(
+            "Expected {} receipts, got {}",
+            fetch_count,
+            all_receipts.len()
+        )));
+    }
     let mut last_cumulative_gas_used = 0;
     let mut current_log_index = 0;
     for (index, (tx, receipt)) in body

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -330,7 +330,7 @@ impl RpcHandler for GetBlobBaseFee {
 }
 
 pub async fn get_all_block_rpc_receipts(
-    block_number: BlockNumber,
+    _block_number: BlockNumber,
     header: BlockHeader,
     body: BlockBody,
     storage: &Store,
@@ -353,16 +353,14 @@ pub async fn get_all_block_rpc_receipts(
         .try_into()
         .map_err(|_| RpcErr::Internal("blob_base_fee does not fit in u64".to_owned()))?;
     // Fetch receipt info from block
+    let block_hash = header.hash();
     let block_info = RpcReceiptBlockInfo::from_block_header(header);
-    // Fetch receipt for each tx in the block and add block and tx info
+    // Fetch all receipts in a single cursor pass
+    let all_receipts = storage.get_receipts_for_block(&block_hash).await?;
     let mut last_cumulative_gas_used = 0;
     let mut current_log_index = 0;
-    for (index, tx) in body.transactions.iter().enumerate() {
+    for (index, (tx, receipt)) in body.transactions.iter().zip(all_receipts.iter()).enumerate() {
         let index = index as u64;
-        let receipt = match storage.get_receipt(block_number, index).await? {
-            Some(receipt) => receipt,
-            _ => return Err(RpcErr::Internal("Could not get receipt".to_owned())),
-        };
         let gas_used = receipt.cumulative_gas_used - last_cumulative_gas_used;
         let tx_info = RpcReceiptTxInfo::from_transaction(
             tx.clone(),
@@ -385,23 +383,15 @@ pub async fn get_all_block_rpc_receipts(
 }
 
 pub async fn get_all_block_receipts(
-    block_number: BlockNumber,
+    _block_number: BlockNumber,
     header: BlockHeader,
-    body: BlockBody,
+    _body: BlockBody,
     storage: &Store,
 ) -> Result<Vec<Receipt>, RpcErr> {
-    let mut receipts = Vec::new();
     // Check if this is the genesis block
     if header.parent_hash.is_zero() {
-        return Ok(receipts);
+        return Ok(Vec::new());
     }
-    for (index, _) in body.transactions.iter().enumerate() {
-        let index = index as u64;
-        let receipt = match storage.get_receipt(block_number, index).await? {
-            Some(receipt) => receipt,
-            _ => return Err(RpcErr::Internal("Could not get receipt".to_owned())),
-        };
-        receipts.push(receipt);
-    }
-    Ok(receipts)
+    let block_hash = header.hash();
+    Ok(storage.get_receipts_for_block(&block_hash).await?)
 }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -307,9 +307,6 @@ impl RpcHandler for GetTransactionReceiptRequest {
             block::get_all_block_rpc_receipts(block.header, block.body, storage, Some(index))
                 .await?;
 
-        if receipts.len() != (index as usize + 1) {
-            return Err(RpcErr::Internal("Could not get receipt".to_owned()));
-        }
         serde_json::to_value(receipts.last())
             .map_err(|error| RpcErr::Internal(error.to_string()))
     }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -307,7 +307,9 @@ impl RpcHandler for GetTransactionReceiptRequest {
             block::get_all_block_rpc_receipts(block.header, block.body, storage, Some(index))
                 .await?;
 
-        // The last receipt in the list is the one at `index` (we fetched 0..=index)
+        if receipts.len() != (index as usize + 1) {
+            return Err(RpcErr::Internal("Could not get receipt".to_owned()));
+        }
         serde_json::to_value(receipts.last())
             .map_err(|error| RpcErr::Internal(error.to_string()))
     }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -307,8 +307,7 @@ impl RpcHandler for GetTransactionReceiptRequest {
             block::get_all_block_rpc_receipts(block.header, block.body, storage, Some(index))
                 .await?;
 
-        serde_json::to_value(receipts.last())
-            .map_err(|error| RpcErr::Internal(error.to_string()))
+        serde_json::to_value(receipts.last()).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -292,7 +292,7 @@ impl RpcHandler for GetTransactionReceiptRequest {
             "Requested receipt for transaction {:#x}",
             self.transaction_hash,
         );
-        let (block_number, block_hash, index) = match storage
+        let (_block_number, block_hash, index) = match storage
             .get_transaction_location(self.transaction_hash)
             .await?
         {
@@ -304,10 +304,11 @@ impl RpcHandler for GetTransactionReceiptRequest {
             None => return Ok(Value::Null),
         };
         let receipts =
-            block::get_all_block_rpc_receipts(block_number, block.header, block.body, storage)
+            block::get_all_block_rpc_receipts(block.header, block.body, storage, Some(index))
                 .await?;
 
-        serde_json::to_value(receipts.get(index as usize))
+        // The last receipt in the list is the one at `index` (we fetched 0..=index)
+        serde_json::to_value(receipts.last())
             .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/storage/api/tables.rs
+++ b/crates/storage/api/tables.rs
@@ -31,8 +31,9 @@ pub const ACCOUNT_CODES: &str = "account_codes";
 pub const ACCOUNT_CODE_METADATA: &str = "account_code_metadata";
 
 /// Receipts column family: [`Vec<u8>`] => [`Vec<u8>`]
-/// - [`Vec<u8>`] = `(block_hash, index).encode_to_vec()`
-/// - [`Vec<u8>`] = `receipt.encode_to_vec()`
+/// - Key: `block_hash (32B) || index (8B big-endian u64)` — fixed-width raw key
+///   enabling cursor-based prefix iteration by block hash.
+/// - Value: `receipt.encode_to_vec()`
 pub const RECEIPTS: &str = "receipts";
 
 /// Transaction locations column family: [`Vec<u8>`] => [`Vec<u8>`]

--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -85,7 +85,7 @@ pub use store::{
 /// When bumping this version, add a corresponding migration function to
 /// `migrations::MIGRATIONS`. The migration framework will automatically
 /// upgrade existing databases instead of requiring a full resync.
-pub const STORE_SCHEMA_VERSION: u64 = 1;
+pub const STORE_SCHEMA_VERSION: u64 = 2;
 
 /// Name of the file storing the metadata about the database.
 ///

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -2,8 +2,13 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::api::StorageBackend;
+use crate::api::tables::RECEIPTS;
 use crate::error::StoreError;
+use crate::store::receipt_key;
 use crate::{STORE_METADATA_FILENAME, STORE_SCHEMA_VERSION};
+
+use ethrex_common::H256;
+use ethrex_rlp::decode::RLPDecode;
 
 use super::store::StoreMetadata;
 
@@ -22,10 +27,7 @@ pub type MigrationFn = fn(backend: &dyn StorageBackend) -> Result<(), StoreError
 ///
 /// **Invariant**: `MIGRATIONS.len() == (STORE_SCHEMA_VERSION - 1) as usize`
 /// (empty when `STORE_SCHEMA_VERSION == 1`, one entry when it's 2, etc.)
-pub const MIGRATIONS: &[MigrationFn] = &[
-    // Currently empty — no migrations exist yet.
-    // When STORE_SCHEMA_VERSION is bumped to 2, add migrate_1_to_2 here.
-];
+pub const MIGRATIONS: &[MigrationFn] = &[migrate_1_to_2];
 
 // Compile-time check: the number of migration functions must match the number
 // of version gaps (i.e. STORE_SCHEMA_VERSION - 1).
@@ -90,6 +92,79 @@ fn write_metadata_version(db_path: &Path, version: u64) -> Result<(), StoreError
     file.sync_all()?;
     std::fs::rename(&tmp_path, &metadata_path)?;
 
+    Ok(())
+}
+
+/// Migrates the RECEIPTS table key format from RLP-encoded `(BlockHash, u64)`
+/// to raw `block_hash (32B) || index (8B big-endian u64)`.
+///
+/// This enables efficient cursor-based prefix iteration by block hash.
+///
+/// Crash safety: if interrupted mid-migration, metadata still says v1,
+/// so the migration restarts from scratch on next boot. Keys that fail
+/// RLP decode are assumed to be already migrated and are skipped.
+fn migrate_1_to_2(backend: &dyn StorageBackend) -> Result<(), StoreError> {
+    const BATCH_SIZE: usize = 10_000;
+
+    let txn = backend.begin_read()?;
+    let iter = txn.prefix_iterator(RECEIPTS, &[])?;
+
+    let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
+    let mut delete_keys: Vec<Vec<u8>> = Vec::with_capacity(BATCH_SIZE);
+    let mut migrated: u64 = 0;
+
+    for result in iter {
+        let (old_key, value) = result?;
+
+        // If this key is already 40 bytes (32B hash + 8B index), it's already
+        // in the new format — skip it. This handles crash-restart scenarios.
+        if old_key.len() == 40 {
+            continue;
+        }
+
+        // Try to decode the old RLP key as (H256, u64)
+        let (block_hash, index) = match <(H256, u64)>::decode(old_key.as_ref()) {
+            Ok(decoded) => decoded,
+            Err(_) => {
+                // If RLP decode fails, skip — could be corrupted or already migrated
+                tracing::warn!(
+                    "Skipping RECEIPTS key that failed RLP decode (len={})",
+                    old_key.len()
+                );
+                continue;
+            }
+        };
+
+        let new_key = receipt_key(&block_hash, index);
+        batch.push((new_key, value.to_vec()));
+        delete_keys.push(old_key.to_vec());
+
+        if batch.len() >= BATCH_SIZE {
+            let mut tx = backend.begin_write()?;
+            tx.put_batch(RECEIPTS, batch.clone())?;
+            for dk in &delete_keys {
+                tx.delete(RECEIPTS, dk)?;
+            }
+            tx.commit()?;
+            migrated += batch.len() as u64;
+            tracing::info!("Migration v1→v2: migrated {migrated} RECEIPTS entries so far");
+            batch.clear();
+            delete_keys.clear();
+        }
+    }
+
+    // Flush remaining entries
+    if !batch.is_empty() {
+        let mut tx = backend.begin_write()?;
+        tx.put_batch(RECEIPTS, batch.clone())?;
+        for dk in &delete_keys {
+            tx.delete(RECEIPTS, dk)?;
+        }
+        tx.commit()?;
+        migrated += batch.len() as u64;
+    }
+
+    tracing::info!("Migration v1→v2 complete: migrated {migrated} RECEIPTS entries total");
     Ok(())
 }
 

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -106,27 +106,36 @@ fn write_metadata_version(db_path: &Path, version: u64) -> Result<(), StoreError
 fn migrate_1_to_2(backend: &dyn StorageBackend) -> Result<(), StoreError> {
     const BATCH_SIZE: usize = 10_000;
 
-    let txn = backend.begin_read()?;
-    let iter = txn.prefix_iterator(RECEIPTS, &[])?;
+    // Phase 1: Materialize all old-format keys into memory so we don't hold
+    // a read iterator open while writing to the same column family.
+    // This avoids depending on snapshot semantics that aren't guaranteed
+    // by the StorageBackend trait.
+    let old_entries: Vec<(Vec<u8>, Vec<u8>)> = {
+        let txn = backend.begin_read()?;
+        let iter = txn.prefix_iterator(RECEIPTS, &[])?;
+        let mut entries = Vec::new();
+        for result in iter {
+            let (old_key, value) = result?;
+            // If this key is already 40 bytes (32B hash + 8B index), it's already
+            // in the new format — skip it. This handles crash-restart scenarios.
+            if old_key.len() == 40 {
+                continue;
+            }
+            entries.push((old_key.to_vec(), value.to_vec()));
+        }
+        entries
+    };
 
+    // Phase 2: Re-key entries in batches.
     let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
     let mut delete_keys: Vec<Vec<u8>> = Vec::with_capacity(BATCH_SIZE);
     let mut migrated: u64 = 0;
 
-    for result in iter {
-        let (old_key, value) = result?;
-
-        // If this key is already 40 bytes (32B hash + 8B index), it's already
-        // in the new format — skip it. This handles crash-restart scenarios.
-        if old_key.len() == 40 {
-            continue;
-        }
-
+    for (old_key, value) in &old_entries {
         // Try to decode the old RLP key as (H256, u64)
         let (block_hash, index) = match <(H256, u64)>::decode(old_key.as_ref()) {
             Ok(decoded) => decoded,
             Err(_) => {
-                // If RLP decode fails, skip — could be corrupted or already migrated
                 tracing::warn!(
                     "Skipping RECEIPTS key that failed RLP decode (len={})",
                     old_key.len()
@@ -136,8 +145,8 @@ fn migrate_1_to_2(backend: &dyn StorageBackend) -> Result<(), StoreError> {
         };
 
         let new_key = receipt_key(&block_hash, index);
-        batch.push((new_key, value.to_vec()));
-        delete_keys.push(old_key.to_vec());
+        batch.push((new_key, value.clone()));
+        delete_keys.push(old_key.clone());
 
         if batch.len() >= BATCH_SIZE {
             let mut tx = backend.begin_write()?;
@@ -205,5 +214,63 @@ mod tests {
         let contents = std::fs::read_to_string(&metadata_path).unwrap();
         let metadata: StoreMetadata = serde_json::from_str(&contents).unwrap();
         assert_eq!(metadata.schema_version, STORE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn migrate_1_to_2_converts_rlp_keys_to_fixed_width() {
+        use crate::api::{StorageBackend, StorageReadView};
+        use ethrex_common::types::{Receipt, TxType};
+        use ethrex_rlp::encode::RLPEncode;
+
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+
+        let block_hash = H256::random();
+        let receipts: Vec<Receipt> = (0..5)
+            .map(|i| Receipt::new(TxType::Legacy, true, (i + 1) * 21000, vec![]))
+            .collect();
+
+        // Seed old-format RLP keys: (BlockHash, u64).encode_to_vec()
+        {
+            let mut tx = backend.begin_write().unwrap();
+            let batch: Vec<(Vec<u8>, Vec<u8>)> = receipts
+                .iter()
+                .enumerate()
+                .map(|(i, r)| {
+                    let old_key = (block_hash, i as u64).encode_to_vec();
+                    let value = r.encode_to_vec();
+                    (old_key, value)
+                })
+                .collect();
+            tx.put_batch(RECEIPTS, batch).unwrap();
+            tx.commit().unwrap();
+        }
+
+        // Verify old keys exist
+        {
+            let txn = backend.begin_read().unwrap();
+            let old_key = (block_hash, 0u64).encode_to_vec();
+            assert!(txn.get(RECEIPTS, &old_key).unwrap().is_some());
+        }
+
+        // Run migration
+        migrate_1_to_2(&backend).unwrap();
+
+        // Verify new fixed-width keys exist and old keys are gone
+        let txn = backend.begin_read().unwrap();
+        for i in 0..5u64 {
+            let new_key = receipt_key(&block_hash, i);
+            let value = txn
+                .get(RECEIPTS, &new_key)
+                .unwrap()
+                .expect("new key should exist after migration");
+            let decoded = Receipt::decode(value.as_ref()).unwrap();
+            assert_eq!(decoded, receipts[i as usize]);
+
+            let old_key = (block_hash, i).encode_to_vec();
+            assert!(
+                txn.get(RECEIPTS, &old_key).unwrap().is_none(),
+                "old key should be deleted after migration"
+            );
+        }
     }
 }

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -57,10 +57,12 @@ pub fn run_pending_migrations(
 
         tracing::info!("Running migration v{version} → v{target}");
 
-        migration_for_version(version)(backend, db_path).map_err(|e| StoreError::MigrationFailed {
-            from: version,
-            to: target,
-            reason: e.to_string(),
+        migration_for_version(version)(backend, db_path).map_err(|e| {
+            StoreError::MigrationFailed {
+                from: version,
+                to: target,
+                reason: e.to_string(),
+            }
         })?;
 
         // Persist the new version to metadata.json after each migration step
@@ -164,11 +166,7 @@ fn migrate_1_to_2(backend: &dyn StorageBackend, db_path: &Path) -> Result<(), St
             match file.read_exact(&mut len_buf) {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(e) => {
-                    return Err(StoreError::Custom(format!(
-                        "Failed to read temp file: {e}"
-                    )))
-                }
+                Err(e) => return Err(StoreError::Custom(format!("Failed to read temp file: {e}"))),
             }
             let key_len = u32::from_le_bytes(len_buf) as usize;
             let mut key = vec![0u8; key_len];

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -14,9 +14,9 @@ use super::store::StoreMetadata;
 
 /// A migration function that upgrades the database schema by one version.
 ///
-/// Receives a reference to the storage backend so it can read/write data
-/// as needed for the migration.
-pub type MigrationFn = fn(backend: &dyn StorageBackend) -> Result<(), StoreError>;
+/// Receives a reference to the storage backend and the database directory
+/// path (for temporary files, etc.).
+pub type MigrationFn = fn(backend: &dyn StorageBackend, db_path: &Path) -> Result<(), StoreError>;
 
 /// Migration functions indexed by source version.
 ///
@@ -57,7 +57,7 @@ pub fn run_pending_migrations(
 
         tracing::info!("Running migration v{version} → v{target}");
 
-        migration_for_version(version)(backend).map_err(|e| StoreError::MigrationFailed {
+        migration_for_version(version)(backend, db_path).map_err(|e| StoreError::MigrationFailed {
             from: version,
             to: target,
             reason: e.to_string(),
@@ -100,77 +100,131 @@ fn write_metadata_version(db_path: &Path, version: u64) -> Result<(), StoreError
 ///
 /// This enables efficient cursor-based prefix iteration by block hash.
 ///
-/// Crash safety: if interrupted mid-migration, metadata still says v1,
-/// so the migration restarts from scratch on next boot. Keys that fail
-/// RLP decode are assumed to be already migrated and are skipped.
-fn migrate_1_to_2(backend: &dyn StorageBackend) -> Result<(), StoreError> {
-    const BATCH_SIZE: usize = 10_000;
+/// The migration works in two phases to avoid both holding a read iterator
+/// open during writes (snapshot semantics concern) and materializing all
+/// entries in memory (153M+ entries ≈ 13 GB):
+///
+/// 1. Cursor scan dumps old-format keys to a temporary file, then closes
+///    the iterator immediately.
+/// 2. Keys are read back from the file in batches; each batch does point
+///    lookups for values, writes new keys, and deletes old keys.
+///
+/// Crash safety: if interrupted, metadata still says v1, so the migration
+/// restarts from scratch on next boot. The temp file is overwritten on
+/// restart. Point lookups for already-deleted old keys return `None` and
+/// are skipped.
+fn migrate_1_to_2(backend: &dyn StorageBackend, db_path: &Path) -> Result<(), StoreError> {
+    use std::io::Read;
 
-    // Phase 1: Materialize all old-format keys into memory so we don't hold
-    // a read iterator open while writing to the same column family.
-    // This avoids depending on snapshot semantics that aren't guaranteed
-    // by the StorageBackend trait.
-    let old_entries: Vec<(Vec<u8>, Vec<u8>)> = {
+    const BATCH_SIZE: usize = 10_000;
+    let tmp_path = db_path.join("migration_v1_v2_keys.tmp");
+
+    // Phase 1: Scan all old-format keys with a cursor, dump to temp file.
+    // Only keys are written (length-prefixed), not values — keeps the file
+    // small (~7 GB for 153M keys vs ~50+ GB with values).
+    let key_count = {
         let txn = backend.begin_read()?;
         let iter = txn.prefix_iterator(RECEIPTS, &[])?;
-        let mut entries = Vec::new();
+        let mut file = std::io::BufWriter::new(std::fs::File::create(&tmp_path)?);
+        let mut count: u64 = 0;
         for result in iter {
-            let (old_key, value) = result?;
-            // If this key is already 40 bytes (32B hash + 8B index), it's already
-            // in the new format — skip it. This handles crash-restart scenarios.
-            if old_key.len() == 40 {
+            let (key, _value) = result?;
+            if key.len() == 40 {
                 continue;
             }
-            entries.push((old_key.to_vec(), value.to_vec()));
+            let len = key.len() as u32;
+            file.write_all(&len.to_le_bytes())?;
+            file.write_all(&key)?;
+            count += 1;
         }
-        entries
+        file.into_inner()
+            .map_err(|e| StoreError::Custom(format!("Failed to flush temp file: {e}")))?
+            .sync_all()?;
+        tracing::info!("Migration v1→v2: dumped {count} old-format keys to temp file");
+        count
     };
+    // Iterator and read transaction are dropped here.
 
-    // Phase 2: Re-key entries in batches.
-    let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
-    let mut delete_keys: Vec<Vec<u8>> = Vec::with_capacity(BATCH_SIZE);
+    if key_count == 0 {
+        let _ = std::fs::remove_file(&tmp_path);
+        tracing::info!("Migration v1→v2 complete: nothing to migrate");
+        return Ok(());
+    }
+
+    // Phase 2: Read keys back from temp file in batches, point-lookup
+    // values, and re-key.
+    let mut file = std::io::BufReader::new(std::fs::File::open(&tmp_path)?);
     let mut migrated: u64 = 0;
+    let mut len_buf = [0u8; 4];
 
-    for (old_key, value) in &old_entries {
-        // Try to decode the old RLP key as (H256, u64)
-        let (block_hash, index) = match <(H256, u64)>::decode(old_key.as_ref()) {
-            Ok(decoded) => decoded,
-            Err(_) => {
-                tracing::warn!(
-                    "Skipping RECEIPTS key that failed RLP decode (len={})",
-                    old_key.len()
-                );
-                continue;
+    loop {
+        // Read a batch of keys from the temp file.
+        let mut old_keys: Vec<Vec<u8>> = Vec::with_capacity(BATCH_SIZE);
+        for _ in 0..BATCH_SIZE {
+            match file.read_exact(&mut len_buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => {
+                    return Err(StoreError::Custom(format!(
+                        "Failed to read temp file: {e}"
+                    )))
+                }
             }
-        };
+            let key_len = u32::from_le_bytes(len_buf) as usize;
+            let mut key = vec![0u8; key_len];
+            file.read_exact(&mut key).map_err(|e| {
+                StoreError::Custom(format!("Failed to read key from temp file: {e}"))
+            })?;
+            old_keys.push(key);
+        }
 
-        let new_key = receipt_key(&block_hash, index);
-        batch.push((new_key, value.clone()));
-        delete_keys.push(old_key.clone());
+        if old_keys.is_empty() {
+            break;
+        }
 
-        if batch.len() >= BATCH_SIZE {
+        // Point-lookup values and build the write batch.
+        let txn = backend.begin_read()?;
+        let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(old_keys.len());
+        let mut delete_keys: Vec<Vec<u8>> = Vec::with_capacity(old_keys.len());
+
+        for old_key in old_keys {
+            let (block_hash, index) = match <(H256, u64)>::decode(&old_key) {
+                Ok(decoded) => decoded,
+                Err(_) => {
+                    tracing::warn!(
+                        "Skipping RECEIPTS key that failed RLP decode (len={})",
+                        old_key.len()
+                    );
+                    continue;
+                }
+            };
+            let value = match txn.get(RECEIPTS, &old_key)? {
+                Some(v) => v.to_vec(),
+                None => continue, // already deleted (crash-restart)
+            };
+            let new_key = receipt_key(&block_hash, index);
+            batch.push((new_key, value));
+            delete_keys.push(old_key);
+        }
+        drop(txn);
+
+        // Write batch.
+        if !batch.is_empty() {
+            let count = batch.len() as u64;
             let mut tx = backend.begin_write()?;
-            tx.put_batch(RECEIPTS, batch.clone())?;
+            tx.put_batch(RECEIPTS, batch)?;
             for dk in &delete_keys {
                 tx.delete(RECEIPTS, dk)?;
             }
             tx.commit()?;
-            migrated += batch.len() as u64;
+            migrated += count;
             tracing::info!("Migration v1→v2: migrated {migrated} RECEIPTS entries so far");
-            batch.clear();
-            delete_keys.clear();
         }
     }
 
-    // Flush remaining entries
-    if !batch.is_empty() {
-        let mut tx = backend.begin_write()?;
-        tx.put_batch(RECEIPTS, batch.clone())?;
-        for dk in &delete_keys {
-            tx.delete(RECEIPTS, dk)?;
-        }
-        tx.commit()?;
-        migrated += batch.len() as u64;
+    // Cleanup temp file.
+    if let Err(e) = std::fs::remove_file(&tmp_path) {
+        tracing::warn!("Failed to remove migration temp file: {e}");
     }
 
     tracing::info!("Migration v1→v2 complete: migrated {migrated} RECEIPTS entries total");
@@ -253,7 +307,8 @@ mod tests {
         }
 
         // Run migration
-        migrate_1_to_2(&backend).unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        migrate_1_to_2(&backend, temp_dir.path()).unwrap();
 
         // Verify new fixed-width keys exist and old keys are gone
         let txn = backend.begin_read().unwrap();

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -14,9 +14,9 @@ use super::store::StoreMetadata;
 
 /// A migration function that upgrades the database schema by one version.
 ///
-/// Receives a reference to the storage backend and the database directory
-/// path (for temporary files, etc.).
-pub type MigrationFn = fn(backend: &dyn StorageBackend, db_path: &Path) -> Result<(), StoreError>;
+/// Receives a reference to the storage backend so it can read/write data
+/// as needed for the migration.
+pub type MigrationFn = fn(backend: &dyn StorageBackend) -> Result<(), StoreError>;
 
 /// Migration functions indexed by source version.
 ///
@@ -57,12 +57,10 @@ pub fn run_pending_migrations(
 
         tracing::info!("Running migration v{version} → v{target}");
 
-        migration_for_version(version)(backend, db_path).map_err(|e| {
-            StoreError::MigrationFailed {
-                from: version,
-                to: target,
-                reason: e.to_string(),
-            }
+        migration_for_version(version)(backend).map_err(|e| StoreError::MigrationFailed {
+            from: version,
+            to: target,
+            reason: e.to_string(),
         })?;
 
         // Persist the new version to metadata.json after each migration step
@@ -102,117 +100,54 @@ fn write_metadata_version(db_path: &Path, version: u64) -> Result<(), StoreError
 ///
 /// This enables efficient cursor-based prefix iteration by block hash.
 ///
-/// The migration works in two phases to avoid both holding a read iterator
-/// open during writes (snapshot semantics concern) and materializing all
-/// entries in memory (153M+ entries ≈ 13 GB):
-///
-/// 1. Cursor scan dumps old-format keys to a temporary file, then closes
-///    the iterator immediately.
-/// 2. Keys are read back from the file in batches; each batch does point
-///    lookups for values, writes new keys, and deletes old keys.
+/// The migration opens a single read cursor over the RECEIPTS table and
+/// accumulates writes in a WriteBatch, flushing every `BATCH_SIZE` entries.
+/// The iterator holds a RocksDB snapshot, so it sees a consistent view of
+/// the table regardless of concurrent flushes — new keys written by the
+/// migration are invisible to it.
 ///
 /// Crash safety: if interrupted, metadata still says v1, so the migration
-/// restarts from scratch on next boot. The temp file is overwritten on
-/// restart. Point lookups for already-deleted old keys return `None` and
-/// are skipped.
-fn migrate_1_to_2(backend: &dyn StorageBackend, db_path: &Path) -> Result<(), StoreError> {
-    use std::io::Read;
-
+/// restarts from scratch on next boot. New-format keys (exactly 40 bytes)
+/// are skipped by the iterator, so a partial previous run is harmless.
+fn migrate_1_to_2(backend: &dyn StorageBackend) -> Result<(), StoreError> {
     const BATCH_SIZE: usize = 10_000;
-    let tmp_path = db_path.join("migration_v1_v2_keys.tmp");
 
-    // Phase 1: Scan all old-format keys with a cursor, dump to temp file.
-    // Only keys are written (length-prefixed), not values — keeps the file
-    // small (~7 GB for 153M keys vs ~50+ GB with values).
-    let key_count = {
-        let txn = backend.begin_read()?;
-        let iter = txn.prefix_iterator(RECEIPTS, &[])?;
-        let mut file = std::io::BufWriter::new(std::fs::File::create(&tmp_path)?);
-        let mut count: u64 = 0;
-        for result in iter {
-            let (key, _value) = result?;
-            if key.len() == 40 {
+    let txn = backend.begin_read()?;
+    let iter = txn.prefix_iterator(RECEIPTS, &[])?;
+
+    let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
+    let mut delete_keys: Vec<Vec<u8>> = Vec::with_capacity(BATCH_SIZE);
+    let mut migrated: u64 = 0;
+
+    for result in iter {
+        let (key, value) = result?;
+
+        // Skip new-format keys (already migrated in a previous partial run).
+        if key.len() == 40 {
+            continue;
+        }
+
+        let (block_hash, index) = match <(H256, u64)>::decode(&key) {
+            Ok(decoded) => decoded,
+            Err(_) => {
+                tracing::warn!(
+                    "Skipping RECEIPTS key that failed RLP decode (len={})",
+                    key.len()
+                );
                 continue;
             }
-            let len = key.len() as u32;
-            file.write_all(&len.to_le_bytes())?;
-            file.write_all(&key)?;
-            count += 1;
-        }
-        file.into_inner()
-            .map_err(|e| StoreError::Custom(format!("Failed to flush temp file: {e}")))?
-            .sync_all()?;
-        tracing::info!("Migration v1→v2: dumped {count} old-format keys to temp file");
-        count
-    };
-    // Iterator and read transaction are dropped here.
+        };
 
-    if key_count == 0 {
-        let _ = std::fs::remove_file(&tmp_path);
-        tracing::info!("Migration v1→v2 complete: nothing to migrate");
-        return Ok(());
-    }
+        let new_key = receipt_key(&block_hash, index);
+        batch.push((new_key, value.to_vec()));
+        delete_keys.push(key.to_vec());
 
-    // Phase 2: Read keys back from temp file in batches, point-lookup
-    // values, and re-key.
-    let mut file = std::io::BufReader::new(std::fs::File::open(&tmp_path)?);
-    let mut migrated: u64 = 0;
-    let mut len_buf = [0u8; 4];
-
-    loop {
-        // Read a batch of keys from the temp file.
-        let mut old_keys: Vec<Vec<u8>> = Vec::with_capacity(BATCH_SIZE);
-        for _ in 0..BATCH_SIZE {
-            match file.read_exact(&mut len_buf) {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                Err(e) => return Err(StoreError::Custom(format!("Failed to read temp file: {e}"))),
-            }
-            let key_len = u32::from_le_bytes(len_buf) as usize;
-            let mut key = vec![0u8; key_len];
-            file.read_exact(&mut key).map_err(|e| {
-                StoreError::Custom(format!("Failed to read key from temp file: {e}"))
-            })?;
-            old_keys.push(key);
-        }
-
-        if old_keys.is_empty() {
-            break;
-        }
-
-        // Point-lookup values and build the write batch.
-        let txn = backend.begin_read()?;
-        let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(old_keys.len());
-        let mut delete_keys: Vec<Vec<u8>> = Vec::with_capacity(old_keys.len());
-
-        for old_key in old_keys {
-            let (block_hash, index) = match <(H256, u64)>::decode(&old_key) {
-                Ok(decoded) => decoded,
-                Err(_) => {
-                    tracing::warn!(
-                        "Skipping RECEIPTS key that failed RLP decode (len={})",
-                        old_key.len()
-                    );
-                    continue;
-                }
-            };
-            let value = match txn.get(RECEIPTS, &old_key)? {
-                Some(v) => v.to_vec(),
-                None => continue, // already deleted (crash-restart)
-            };
-            let new_key = receipt_key(&block_hash, index);
-            batch.push((new_key, value));
-            delete_keys.push(old_key);
-        }
-        drop(txn);
-
-        // Write batch.
-        if !batch.is_empty() {
+        if batch.len() >= BATCH_SIZE {
             let count = batch.len() as u64;
             let mut tx = backend.begin_write()?;
-            tx.put_batch(RECEIPTS, batch)?;
-            for dk in &delete_keys {
-                tx.delete(RECEIPTS, dk)?;
+            tx.put_batch(RECEIPTS, std::mem::take(&mut batch))?;
+            for dk in std::mem::take(&mut delete_keys) {
+                tx.delete(RECEIPTS, &dk)?;
             }
             tx.commit()?;
             migrated += count;
@@ -220,9 +155,17 @@ fn migrate_1_to_2(backend: &dyn StorageBackend, db_path: &Path) -> Result<(), St
         }
     }
 
-    // Cleanup temp file.
-    if let Err(e) = std::fs::remove_file(&tmp_path) {
-        tracing::warn!("Failed to remove migration temp file: {e}");
+    // Flush remaining entries.
+    if !batch.is_empty() {
+        let count = batch.len() as u64;
+        let mut tx = backend.begin_write()?;
+        tx.put_batch(RECEIPTS, batch)?;
+        for dk in &delete_keys {
+            tx.delete(RECEIPTS, dk)?;
+        }
+        tx.commit()?;
+        migrated += count;
+        tracing::info!("Migration v1→v2: migrated {migrated} RECEIPTS entries so far");
     }
 
     tracing::info!("Migration v1→v2 complete: migrated {migrated} RECEIPTS entries total");
@@ -305,8 +248,7 @@ mod tests {
         }
 
         // Run migration
-        let temp_dir = tempfile::tempdir().unwrap();
-        migrate_1_to_2(&backend, temp_dir.path()).unwrap();
+        migrate_1_to_2(&backend).unwrap();
 
         // Verify new fixed-width keys exist and old keys are gone
         let txn = backend.begin_read().unwrap();

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1058,18 +1058,23 @@ impl Store {
         &self,
         block_hash: &BlockHash,
     ) -> Result<Vec<Receipt>, StoreError> {
-        self.get_receipts_for_block_from_index(block_hash, 0).await
+        self.get_receipts_for_block_from_index(block_hash, 0, None)
+            .await
     }
 
-    /// Retrieves receipts for a block starting from the given index.
-    /// Used by eth/70 partial receipt requests (EIP-7975).
+    /// Retrieves receipts for a block starting from the given index,
+    /// optionally limited to `max_count` receipts.
     ///
     /// Uses cursor-based prefix iteration over the 32-byte block hash prefix
-    /// for efficient batch retrieval.
+    /// for efficient batch retrieval. Used by:
+    /// - eth/70 partial receipt requests (EIP-7975) via p2p
+    /// - `eth_getTransactionReceipt` RPC with a count limit to avoid
+    ///   fetching the entire block's receipts
     pub async fn get_receipts_for_block_from_index(
         &self,
         block_hash: &BlockHash,
         start_index: u64,
+        max_count: Option<usize>,
     ) -> Result<Vec<Receipt>, StoreError> {
         let backend = self.backend.clone();
         let block_hash = *block_hash;
@@ -1095,6 +1100,11 @@ impl Store {
                     }
                 }
                 receipts.push(Receipt::decode(v.as_ref())?);
+                if let Some(max) = max_count
+                    && receipts.len() >= max
+                {
+                    break;
+                }
             }
             Ok(receipts)
         })

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1092,8 +1092,11 @@ impl Store {
                 if !k.starts_with(&prefix) {
                     break;
                 }
+                if k.len() != 40 {
+                    continue;
+                }
                 // Skip entries before start_index (for eth/70 partial requests)
-                if k.len() == 40 && start_index > 0 {
+                if start_index > 0 {
                     let idx_bytes: [u8; 8] = k[32..40]
                         .try_into()
                         .expect("slice is exactly 8 bytes (checked k.len() == 40)");

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -628,8 +628,7 @@ impl Store {
         index: Index,
         receipt: Receipt,
     ) -> Result<(), StoreError> {
-        // FIXME: Use dupsort table
-        let key = (block_hash, index).encode_to_vec();
+        let key = receipt_key(&block_hash, index);
         let value = receipt.encode_to_vec();
         self.write_async(RECEIPTS, key, value).await
     }
@@ -644,7 +643,7 @@ impl Store {
             .into_iter()
             .enumerate()
             .map(|(index, receipt)| {
-                let key = (block_hash, index as u64).encode_to_vec();
+                let key = receipt_key(&block_hash, index as u64);
                 let value = receipt.encode_to_vec();
                 (key, value)
             })
@@ -671,7 +670,7 @@ impl Store {
         block_hash: BlockHash,
         index: Index,
     ) -> Result<Option<Receipt>, StoreError> {
-        let key = (block_hash, index).encode_to_vec();
+        let key = receipt_key(&block_hash, index);
         self.read_async(RECEIPTS, key)
             .await?
             .map(|bytes| Receipt::decode(bytes.as_slice()))
@@ -1064,28 +1063,43 @@ impl Store {
 
     /// Retrieves receipts for a block starting from the given index.
     /// Used by eth/70 partial receipt requests (EIP-7975).
+    ///
+    /// Uses cursor-based prefix iteration over the 32-byte block hash prefix
+    /// for efficient batch retrieval.
     pub async fn get_receipts_for_block_from_index(
         &self,
         block_hash: &BlockHash,
         start_index: u64,
     ) -> Result<Vec<Receipt>, StoreError> {
-        let mut receipts = Vec::new();
-        let mut index = start_index;
+        let backend = self.backend.clone();
+        let block_hash = *block_hash;
 
-        let txn = self.backend.begin_read()?;
-        loop {
-            let key = (*block_hash, index).encode_to_vec();
-            match txn.get(RECEIPTS, key.as_slice())? {
-                Some(receipt_bytes) => {
-                    let receipt = Receipt::decode(receipt_bytes.as_slice())?;
-                    receipts.push(receipt);
-                    index += 1;
+        tokio::task::spawn_blocking(move || {
+            let txn = backend.begin_read()?;
+            let prefix = block_hash.as_bytes().to_vec();
+            let iter = txn.prefix_iterator(RECEIPTS, &prefix)?;
+            let mut receipts = Vec::new();
+            for result in iter {
+                let (k, v) = result?;
+                if !k.starts_with(&prefix) {
+                    break;
                 }
-                None => break,
+                // Skip entries before start_index (for eth/70 partial requests)
+                if k.len() == 40 && start_index > 0 {
+                    let idx_bytes: [u8; 8] = k[32..40]
+                        .try_into()
+                        .expect("slice is exactly 8 bytes (checked k.len() == 40)");
+                    let idx = u64::from_be_bytes(idx_bytes);
+                    if idx < start_index {
+                        continue;
+                    }
+                }
+                receipts.push(Receipt::decode(v.as_ref())?);
             }
-        }
-
-        Ok(receipts)
+            Ok(receipts)
+        })
+        .await
+        .map_err(|e| StoreError::Custom(format!("Task panicked: {e}")))?
     }
 
     // Snap State methods
@@ -1428,7 +1442,7 @@ impl Store {
 
         for (block_hash, receipts) in update_batch.receipts {
             for (index, receipt) in receipts.into_iter().enumerate() {
-                let key = (block_hash, index as u64).encode_to_vec();
+                let key = receipt_key(&block_hash, index as u64);
                 let value = receipt.encode_to_vec();
                 tx.put(RECEIPTS, &key, &value)?;
             }
@@ -3199,6 +3213,14 @@ fn chain_data_key(index: ChainDataIndex) -> Vec<u8> {
 
 fn snap_state_key(index: SnapStateIndex) -> Vec<u8> {
     (index as u8).encode_to_vec()
+}
+
+/// Builds a fixed-width RECEIPTS key: block_hash (32B) || index (8B BE).
+pub fn receipt_key(block_hash: &BlockHash, index: u64) -> Vec<u8> {
+    let mut key = Vec::with_capacity(40);
+    key.extend_from_slice(block_hash.as_bytes());
+    key.extend_from_slice(&index.to_be_bytes());
+    key
 }
 
 fn encode_code(code: &Code) -> Vec<u8> {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -588,9 +588,12 @@ impl Store {
             let mut transaction_locations = Vec::new();
 
             while let Some(Ok((key, value))) = iter.next() {
-                // Ensure key is exactly tx_hash + block_hash (32 + 32 = 64 bytes)
-                // and starts with our exact tx_hash
-                if key.len() == 64 && &key[0..32] == tx_hash_bytes {
+                // Without a RocksDB prefix extractor, the iterator continues past
+                // the prefix boundary — break as soon as we leave our tx hash range.
+                if !key.starts_with(tx_hash_bytes) {
+                    break;
+                }
+                if key.len() == 64 {
                     transaction_locations.push(<(BlockNumber, BlockHash, Index)>::decode(&value)?);
                 }
             }


### PR DESCRIPTION
## Summary
- Batch all receipt point lookups into a single `spawn_blocking` task with one shared read transaction, eliminating per-receipt `spawn_blocking` + transaction setup overhead
- Refactor `get_all_block_rpc_receipts` and `get_all_block_receipts` to fetch all receipts in one pass instead of one-by-one
- Add cursor-based benchmark alongside point lookups to compare retrieval strategies

## Context
Targets `feat/automatic-db-migrations` (#6519) so we can add a DB migration if the final approach requires schema changes (e.g. new meta entries or prefix-based storage layout).

## Test plan
- [ ] Verify RPC receipt endpoints return correct results (`eth_getTransactionReceipt`, `eth_getBlockReceipts`, `eth_getRawReceipts`)
- [ ] Check benchmark logs on a synced node to compare point lookup vs cursor performance
- [ ] Verify eth/70 partial receipt fetching still works