### PR TITLE
levm: stop refunding state-gas spill on top-level halt (EIP-8037)

### DIFF
--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -188,29 +188,28 @@ impl Hook for DefaultHook {
 
         // EIP-8037 (Amsterdam+): unused reservoir is always returned to sender.
         // Per EELS, state_gas_left is preserved even on exceptional halt — only
-        // regular gas_left is burned.  The user does NOT pay for unspent reservoir.
+        // regular gas_left is burned. The user does NOT pay for unspent reservoir.
         // On top-level failure (revert/halt/oog), execution-time state-gas draws
-        // (both from reservoir and spilled to gas_remaining) are refunded too,
-        // since the corresponding state operations were rolled back. The
-        // post-setup snapshot captures the reservoir balance after intrinsic +
-        // auth processing; the spill counter tracks gas_remaining bytes that
-        // would otherwise be charged to the user for now-rolled-back state ops.
+        // FROM THE RESERVOIR are refunded (the state ops were rolled back). Spill
+        // draws — gas_remaining bytes consumed because the reservoir was empty —
+        // are *regular gas* consumed and stay burned per EIP-8037 §"Block-level
+        // gas accounting": on exceptional halt remaining `gas_left` is attributed
+        // to `execution_regular_gas_used` and any prior charges to gas_remaining
+        // (whether from opcode execution or state-gas spill) stay counted.
+        // Refunding the spill here under-charges block_regular_gas_used and lets
+        // the miner over-fill the block past gas_limit, producing blocks that
+        // peer validators (geth, erigon) reject with "gas limit reached".
         if vm.env.config.fork >= Fork::Amsterdam {
             let to_subtract = if ctx_result.is_success() {
                 vm.state_gas_reservoir
             } else {
-                // On top-level failure, refund only the execution-time draws (delta
-                // between post-setup snapshot and current). Intrinsic-time draws
-                // (auth tuples, CREATE-tx target charge) stay charged to the user.
+                // On top-level failure, refund unused reservoir + reservoir-time
+                // execution draws. NOT spill: that was regular gas paid up-front.
                 let reservoir_drawn = vm
                     .state_gas_reservoir_post_setup
                     .saturating_sub(vm.state_gas_reservoir);
-                let spill_drawn = vm
-                    .state_gas_spill
-                    .saturating_sub(vm.state_gas_spill_post_setup);
                 vm.state_gas_reservoir
                     .saturating_add(reservoir_drawn)
-                    .saturating_add(spill_drawn)
             };
             ctx_result.gas_used = ctx_result.gas_used.saturating_sub(to_subtract);
         }


### PR DESCRIPTION
## Summary

When a state op (SSTORE, code deposit, account creation) finds the
`state_gas_reservoir` empty, EIP-8037 lets the cost spill into the regular
gas budget — `state_gas_spill` tracks the cumulative bytes thus charged.
`DefaultHook::finalize_execution` previously refunded this spill on
top-level revert/halt/oog along with the unused reservoir and reservoir-time
draws. That is wrong for the regular-gas dimension.

EIP-8037 §"Block-level gas accounting" states that on exceptional halt the
remaining `gas_left` is attributed to `execution_regular_gas_used` and any
prior charges to `gas_remaining` (whether from opcode execution or
state-gas spill into regular) stay counted. The reservoir is preserved
and refunded; spilled regular gas is not.

The bug under-charged `block_regular_gas_used` for failed state-heavy txs
(e.g. storagerefundtx with `slots_per_call=500` going OOG mid-execution):
instead of the spec-mandated full gas_limit, ethrex charged ~5.25M of a
13.95M tx — the gap = the spill that should not have been refunded. The
miner consequently packed more such failed txs into the block than fit,
producing a block whose header gasUsed was under the limit but whose
true `block_regular_gas_used` exceeded 100M when re-validated by peer
clients (geth, erigon), yielding cross-client "gas limit reached"
rejections and forking the chain.

## Reproduction

Reproduced on `bal-devnet-5` in a heterogeneous Kurtosis enclave (2× geth
+ 2× erigon + 2× ethrex on lighthouse, spamoor 5-scenario load).
ethrex's per-tx miner trace showed:

```
EIP8037 miner-tx: status=Revert(ExceptionalHalt(OutOfGas))
                  tx_limit=13950000 regular=5246211 state=0 gas_used=5246211
```

Geth correctly recorded `txRegular=13,950,000` for the same tx. After this
fix ethrex stops producing over-filled blocks; ethrex-attributable
cross-client rejections drop to zero (verified on `devnet5-het-ethrex-fix`).

## Test plan

- [x] Builds clean against `bal-devnet-5`.
- [x] Reproduces the bug pre-fix in a 6-node Kurtosis het.
- [x] After fix: ethrex no longer produces blocks rejected by geth/erigon.
- [ ] CI / spec tests pass (delegating to maintainers).