### PR TITLE
test(l1): add builder/validator parity check to blockchain ef-tests

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -650,61 +650,76 @@ impl Blockchain {
                 continue;
             }
 
-            // Set BAL index for this transaction (1-indexed per EIP-7928)
-            // Index is based on current transaction count + 1
-            // Must happen BEFORE tx_checkpoint: set_bal_index flushes net-zero
-            // filters for the previous (committed) tx, which may insert reads.
-            #[allow(clippy::cast_possible_truncation)]
-            let tx_index = (context.payload.body.transactions.len() + 1) as u16;
-            context.vm.set_bal_index(tx_index);
-
-            // EIP-7928: Lightweight tx-level checkpoint before trying the tx.
-            // If the tx is rejected, restore so only included txs affect the BAL.
-            // Taken after set_bal_index (which flushes previous tx) but before
-            // this tx's touches, so rejected txs leave no trace.
-            let bal_checkpoint = context
-                .vm
-                .db
-                .bal_recorder
-                .as_ref()
-                .map(|r| r.tx_checkpoint());
-
-            // Record tx sender and recipient for BAL
-            if let Some(recorder) = context.vm.db.bal_recorder_mut() {
-                recorder.record_touched_address(head_tx.tx.sender());
-                if let TxKind::Call(to) = head_tx.to() {
-                    recorder.record_touched_address(to);
-                }
+            match self.apply_tx_to_payload(head_tx, context) {
+                Ok(()) => txs.shift()?,
+                Err(_) => txs.pop(),
             }
-
-            // Execute tx
-            let receipt = match self.apply_transaction(&head_tx, context) {
-                Ok(receipt) => {
-                    txs.shift()?;
-                    metrics!(METRICS_TX.inc_tx_with_type(MetricsTxType(head_tx.tx_type())));
-                    receipt
-                }
-                // Ignore following txs from sender
-                Err(e) => {
-                    debug!("Failed to execute transaction: {tx_hash:x}, {e}");
-                    metrics!(METRICS_TX.inc_tx_errors(e.to_metric()));
-                    // Restore BAL recorder to pre-tx state so rejected txs
-                    // don't pollute the block access list.
-                    if let (Some(recorder), Some(checkpoint)) =
-                        (context.vm.db.bal_recorder_mut(), bal_checkpoint)
-                    {
-                        recorder.tx_restore(checkpoint);
-                    }
-                    txs.pop();
-                    continue;
-                }
-            };
-            // Add transaction to block
-            debug!("Adding transaction: {} to payload", tx_hash);
-            context.payload.body.transactions.push(head_tx.into());
-            // Save receipt for hash calculation
-            context.receipts.push(receipt);
         }
+        Ok(())
+    }
+
+    /// Apply a single transaction to the in-progress payload.
+    ///
+    /// Runs the per-tx pipeline: EIP-7928 BAL index/checkpoint setup,
+    /// sender/recipient recording, dispatch to blob/plain execution, and on
+    /// failure rolls the BAL recorder back so rejected txs leave no trace.
+    /// On success the tx is appended to the payload body and the receipt
+    /// to `context.receipts`.
+    ///
+    /// Caller is responsible for mempool bookkeeping (advancing or dropping
+    /// the sender's queue) — this function only mutates the payload context.
+    pub fn apply_tx_to_payload(
+        &self,
+        head: HeadTransaction,
+        context: &mut PayloadBuildContext,
+    ) -> Result<(), ChainError> {
+        let tx_hash = head.tx.hash();
+
+        // Set BAL index for this transaction (1-indexed per EIP-7928).
+        // Must happen BEFORE tx_checkpoint: set_bal_index flushes net-zero
+        // filters for the previous (committed) tx, which may insert reads.
+        #[allow(clippy::cast_possible_truncation)]
+        let tx_index = (context.payload.body.transactions.len() + 1) as u16;
+        context.vm.set_bal_index(tx_index);
+
+        // EIP-7928: lightweight tx-level checkpoint before trying the tx.
+        // If the tx is rejected, restore so only included txs affect the BAL.
+        // Taken after set_bal_index (which flushes previous tx) but before
+        // this tx's touches, so rejected txs leave no trace.
+        let bal_checkpoint = context
+            .vm
+            .db
+            .bal_recorder
+            .as_ref()
+            .map(|r| r.tx_checkpoint());
+
+        if let Some(recorder) = context.vm.db.bal_recorder_mut() {
+            recorder.record_touched_address(head.tx.sender());
+            if let TxKind::Call(to) = head.to() {
+                recorder.record_touched_address(to);
+            }
+        }
+
+        let receipt = match self.apply_transaction(&head, context) {
+            Ok(receipt) => {
+                metrics!(METRICS_TX.inc_tx_with_type(MetricsTxType(head.tx_type())));
+                receipt
+            }
+            Err(e) => {
+                debug!("Failed to execute transaction: {tx_hash:x}, {e}");
+                metrics!(METRICS_TX.inc_tx_errors(e.to_metric()));
+                if let (Some(recorder), Some(checkpoint)) =
+                    (context.vm.db.bal_recorder_mut(), bal_checkpoint)
+                {
+                    recorder.tx_restore(checkpoint);
+                }
+                return Err(e);
+            }
+        };
+
+        debug!("Adding transaction: {} to payload", tx_hash);
+        context.payload.body.transactions.push(head.into());
+        context.receipts.push(receipt);
         Ok(())
     }
 

--- a/tooling/ef_tests/blockchain/Cargo.toml
+++ b/tooling/ef_tests/blockchain/Cargo.toml
@@ -34,6 +34,11 @@ c-kzg = ["ethrex-blockchain/c-kzg"]
 sp1 = ["ethrex-guest-program/sp1-build-elf", "ethrex-prover/sp1"]
 stateless = []
 l2 = ["ethrex-guest-program/l2", "ethrex-prover/l2"]
+# Cross-checks the block builder against ef-test fixtures: for each Amsterdam
+# fixture, runs the builder over the fixture txs and asserts the produced
+# block matches the fixture header. Off by default — keep `make test` runtime
+# intact.
+builder-parity = []
 
 [[test]]
 name = "all"

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -74,6 +74,9 @@ test-stateless: $(VECTORS_TARGETS) amsterdam-vectors zkevm-vectors
 test-stateless-zkevm: $(VECTORS_TARGETS) amsterdam-vectors zkevm-vectors
 	cargo test --profile release-with-debug --features stateless -- eip8025_optional_proofs
 
-test: ## 🧪 Run blockchain tests with LEVM both with state and stateless 
+test-builder-parity: $(VECTORS_TARGETS) amsterdam-vectors ## 🧪 Cross-check builder vs validator on Amsterdam fixtures
+	cargo test --profile release-with-debug --features builder-parity
+
+test: ## 🧪 Run blockchain tests with LEVM both with state and stateless
 	$(MAKE) test-levm
 	$(MAKE) test-stateless

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -9,8 +9,18 @@ use ethrex_blockchain::{
     error::{ChainError, InvalidBlockError},
     fork_choice::apply_fork_choice,
 };
+#[cfg(feature = "builder-parity")]
+use ethrex_blockchain::{
+    BlockchainType,
+    payload::{BuildPayloadArgs, HeadTransaction, PayloadBuildContext, create_payload},
+};
 #[cfg(feature = "stateless")]
 use ethrex_common::types::block_execution_witness::RpcExecutionWitness;
+#[cfg(feature = "builder-parity")]
+use ethrex_common::{
+    U256,
+    types::{ELASTICITY_MULTIPLIER, MempoolTransaction},
+};
 use ethrex_common::{
     constants::EMPTY_KECCACK_HASH,
     types::{
@@ -18,6 +28,8 @@ use ethrex_common::{
         InvalidBlockHeaderError, block_access_list::BlockAccessList,
     },
 };
+#[cfg(feature = "builder-parity")]
+use ethrex_crypto::NativeCrypto;
 use ethrex_guest_program::input::ProgramInput;
 #[cfg(feature = "sp1")]
 use ethrex_prover::Sp1Backend;
@@ -102,6 +114,8 @@ pub async fn run_ef_test(
     // same final state is reached.
     if test.network == Fork::Amsterdam {
         run_two_pass_parallel(test_key, test).await?;
+        #[cfg(feature = "builder-parity")]
+        run_builder_parity(test_key, test).await?;
     }
 
     // Run stateless if backend was specified for this.
@@ -240,6 +254,175 @@ async fn run_two_pass_parallel(test_key: &str, test: &TestUnit) -> Result<(), St
     // Verify post-state matches expected
     check_poststate_against_db(test_key, test, &store2).await;
     Ok(())
+}
+
+/// Drive the block builder over each fixture's transactions and assert it
+/// produces a block matching the fixture header. Catches builder/validator
+/// drift on EIP-7928 BAL construction and on receipts/state/requests roots,
+/// gas accounting, and bloom.
+///
+/// Skips fixtures with `expect_exception` (validator-side checks) and any
+/// fixture containing 4844 blob txs (no blob bundle in the fixture format).
+#[cfg(feature = "builder-parity")]
+async fn run_builder_parity(test_key: &str, test: &TestUnit) -> Result<(), String> {
+    if test.blocks.iter().any(|b| b.expect_exception.is_some()) {
+        return Ok(());
+    }
+
+    let has_blob_tx = test.blocks.iter().any(|bf| {
+        bf.block().is_some_and(|b| {
+            b.transactions
+                .iter()
+                .any(|t| matches!(&t.transaction_type, Some(ty) if ty.low_u64() == 3))
+        })
+    });
+    if has_blob_tx {
+        return Ok(());
+    }
+
+    let store = build_store_for_test(test).await;
+    let blockchain = Blockchain::new(store.clone(), BlockchainOptions::default());
+
+    for block_fixture in test.blocks.iter() {
+        let expected: CoreBlock = block_fixture.block().unwrap().clone().into();
+        let expected_header = expected.header.clone();
+
+        let args = BuildPayloadArgs {
+            parent: expected_header.parent_hash,
+            timestamp: expected_header.timestamp,
+            fee_recipient: expected_header.coinbase,
+            random: expected_header.prev_randao,
+            withdrawals: expected.body.withdrawals.clone(),
+            beacon_root: expected_header.parent_beacon_block_root,
+            slot_number: expected_header.slot_number,
+            version: 0,
+            elasticity_multiplier: ELASTICITY_MULTIPLIER,
+            gas_ceil: expected_header.gas_limit,
+        };
+
+        let payload = create_payload(&args, &store, expected_header.extra_data.clone())
+            .map_err(|e| format!("Builder parity {test_key}: create_payload failed: {e:?}"))?;
+        let mut ctx = PayloadBuildContext::new(payload, &store, &BlockchainType::L1)
+            .map_err(|e| format!("Builder parity {test_key}: ctx failed: {e:?}"))?;
+
+        // calc_gas_limit clamps to parent±delta; force exact match for fixtures
+        // that pin a specific gas_limit not reachable by one step from parent.
+        ctx.payload.header.gas_limit = expected_header.gas_limit;
+        ctx.remaining_gas = expected_header.gas_limit;
+
+        blockchain.apply_system_operations(&mut ctx).map_err(|e| {
+            format!("Builder parity {test_key}: apply_system_operations failed: {e:?}")
+        })?;
+
+        for tx in &expected.body.transactions {
+            let sender = tx
+                .sender(&NativeCrypto)
+                .map_err(|e| format!("Builder parity {test_key}: sender recovery failed: {e:?}"))?;
+            let head = HeadTransaction {
+                tx: MempoolTransaction::new(tx.clone(), sender),
+                tip: U256::zero(),
+            };
+            blockchain
+                .apply_tx_to_payload(head, &mut ctx)
+                .map_err(|e| format!("Builder parity {test_key}: apply_tx failed: {e:?}"))?;
+        }
+
+        if ctx.is_amsterdam {
+            #[allow(clippy::cast_possible_truncation)]
+            let post_tx_index = (ctx.payload.body.transactions.len() + 1) as u16;
+            ctx.vm.set_bal_index(post_tx_index);
+            if let Some(recorder) = ctx.vm.db.bal_recorder_mut()
+                && let Some(withdrawals) = &ctx.payload.body.withdrawals
+            {
+                recorder.extend_touched_addresses(withdrawals.iter().map(|w| w.address));
+            }
+        }
+
+        blockchain
+            .extract_requests(&mut ctx)
+            .map_err(|e| format!("Builder parity {test_key}: extract_requests failed: {e:?}"))?;
+        blockchain
+            .apply_withdrawals(&mut ctx)
+            .map_err(|e| format!("Builder parity {test_key}: apply_withdrawals failed: {e:?}"))?;
+        blockchain
+            .finalize_payload(&mut ctx)
+            .map_err(|e| format!("Builder parity {test_key}: finalize_payload failed: {e:?}"))?;
+
+        let mismatches = collect_header_mismatches(&ctx.payload.header, &expected_header);
+        if !mismatches.is_empty() {
+            return Err(format!(
+                "Builder parity {test_key} block {}: {}",
+                expected_header.number,
+                mismatches.join("; ")
+            ));
+        }
+
+        // Advance the chain with the (parity-verified) expected block so the
+        // next iteration can use it as parent.
+        let hash = expected.hash();
+        blockchain
+            .add_block_pipeline(expected.clone(), None)
+            .map_err(|e| format!("Builder parity {test_key}: add_block failed: {e:?}"))?;
+        apply_fork_choice(&store, hash, hash, hash)
+            .await
+            .map_err(|e| format!("Builder parity {test_key}: fork choice failed: {e:?}"))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "builder-parity")]
+fn collect_header_mismatches(
+    produced: &CoreBlockHeader,
+    expected: &CoreBlockHeader,
+) -> Vec<String> {
+    let mut m = Vec::new();
+    if produced.state_root != expected.state_root {
+        m.push(format!(
+            "state_root: got {} expected {}",
+            produced.state_root, expected.state_root
+        ));
+    }
+    if produced.transactions_root != expected.transactions_root {
+        m.push(format!(
+            "transactions_root: got {} expected {}",
+            produced.transactions_root, expected.transactions_root
+        ));
+    }
+    if produced.receipts_root != expected.receipts_root {
+        m.push(format!(
+            "receipts_root: got {} expected {}",
+            produced.receipts_root, expected.receipts_root
+        ));
+    }
+    if produced.withdrawals_root != expected.withdrawals_root {
+        m.push(format!(
+            "withdrawals_root: got {:?} expected {:?}",
+            produced.withdrawals_root, expected.withdrawals_root
+        ));
+    }
+    if produced.requests_hash != expected.requests_hash {
+        m.push(format!(
+            "requests_hash: got {:?} expected {:?}",
+            produced.requests_hash, expected.requests_hash
+        ));
+    }
+    if produced.block_access_list_hash != expected.block_access_list_hash {
+        m.push(format!(
+            "block_access_list_hash: got {:?} expected {:?}",
+            produced.block_access_list_hash, expected.block_access_list_hash
+        ));
+    }
+    if produced.gas_used != expected.gas_used {
+        m.push(format!(
+            "gas_used: got {} expected {}",
+            produced.gas_used, expected.gas_used
+        ));
+    }
+    if produced.logs_bloom != expected.logs_bloom {
+        m.push("logs_bloom mismatch".to_string());
+    }
+    m
 }
 
 fn exception_is_expected(


### PR DESCRIPTION
## Summary

Cross-checks ethrex's block builder against the same EEST fixtures the validator already runs. For each Amsterdam fixture, the builder constructs a block from the fixture's parent + transactions and the produced header is compared to the expected fixture header.

- New `Blockchain::apply_tx_to_payload` extracts the per-tx pipeline (BAL index/checkpoint, sender/recipient touches, execute, rollback-on-err, push) out of `fill_transactions` so the same code path can be driven by the test runner. Pure code-motion — functionally equivalent to the previous inline body.
- New `run_builder_parity` driver in `tooling/ef_tests/blockchain/test_runner.rs`. For each Amsterdam fixture without `expect_exception` and without 4844 blob txs, builds a block from the fixture parent + txs, runs `apply_system_operations` → `apply_tx_to_payload` over fixture txs in order → post-tx BAL bookkeeping → `extract_requests` → `apply_withdrawals` → `finalize_payload`, then asserts produced `state_root`, `transactions_root`, `receipts_root`, `withdrawals_root`, `requests_hash`, `block_access_list_hash`, `gas_used`, and `logs_bloom` match the fixture header.

Off by default (feature ` + "`builder-parity`" + `). Run with:

` + "```" + `
make -C tooling/ef_tests/blockchain test-builder-parity
` + "```" + `

## Why

The validator never *constructs* a header from scratch — it only validates pre-built ones. That leaves a class of builder-side bugs uncaught:

- Builder-side header construction (the eight fields above)
- System-call drift between builder's `apply_system_operations` and validator's `prepare_block`
- Request-extraction drift between `Blockchain::extract_requests` and `LEVM::extract_all_requests_levm`
- Builder-side gas accumulation in `apply_plain_transaction` vs validator's accumulation in `LEVM::execute_block*`

The two-pass-parallel test only exercises the validator paths. This PR adds the builder-side cross-check.

## Test plan

- [ ] ` + "`make -C tooling/ef_tests/blockchain test`" + ` (default) still passes — no behavioural change to `fill_transactions`
- [ ] ` + "`make -C tooling/ef_tests/blockchain test-builder-parity`" + ` passes on existing Amsterdam fixtures
- [ ] Sabotage smoke check: temporarily zero out `transactions_root` in `finalize_payload` → parity reports the exact mismatch field. Verified on bal-devnet-6 (where this PR's sibling commit landed): produces `transactions_root: got 0x0000…0000 expected 0x4028…f1cc`. Revert before merge.