### PR TITLE
ci(l1,l2): bump deprecated GitHub Actions to v6

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -87,25 +87,25 @@ runs:
 
     - name: Login to DockerHub (for rate limiting)
       if: inputs.dockerhub_username != '' && inputs.dockerhub_password != ''
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}
 
     - name: Login to ghcr.io (for cache)
       if: inputs.username != '' && inputs.password != '' && inputs.cache_write == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - id: build-image
       name: Build Docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile

--- a/.github/actions/snapsync-run/action.yml
+++ b/.github/actions/snapsync-run/action.yml
@@ -35,7 +35,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # We need to run this step because kurtosis uses cached docker images but we want the latest ethrex image
     - name: Remove cached ethrex image

--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Collect failed job names
         id: failed_jobs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Collect failed job names
         id: failed_jobs

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -152,7 +152,7 @@ jobs:
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -106,7 +106,7 @@ jobs:
           large-packages: false
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Set custom args defined in Dockerfile to pin execution-spec-tests versions
       # See: https://github.com/ethereum/hive/blob/c2dab60f898b94afe8eeac505f60dcde59205e77/simulators/ethereum/eest/consume-rlp/Dockerfile#L4-L8
@@ -177,13 +177,13 @@ jobs:
       artifact_name: results_daily.md
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Download all results
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: hive/workspace/logs
           pattern: "*_daily-results.zip"
@@ -226,7 +226,7 @@ jobs:
         run: cargo run --manifest-path tooling/Cargo.toml -p hive_report > results.md
 
       - name: Upload daily result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: results_daily.md
           path: |
@@ -245,10 +245,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download hive results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ${{ needs.hive-report.outputs.artifact_name }}
 

--- a/.github/workflows/daily_loc_report.yaml
+++ b/.github/workflows/daily_loc_report.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/daily_loc_report.yaml
+++ b/.github/workflows/daily_loc_report.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Restore cache
         id: cache-loc-report
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: tooling/loc/loc_report.json
           key: loc-report-${{ github.ref_name }}-${{ github.run_id }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: Save new loc_report.json to cache
         if: success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: tooling/loc/loc_report.json
           key: loc-report-${{ github.ref_name }}-${{ github.run_id }}

--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -86,7 +86,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set start timestamp
         id: start
@@ -133,7 +133,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set start timestamp
         id: start

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: gpu
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
       - name: Setup Rust Environment

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set up Docker Buildx
         # if: ${{ always() && github.event_name == 'merge_group' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # This step is needed because of an state bug in the GPU runner.
       # Issue to fix this: https://github.com/lambdaclass/ethrex/pull/2741.

--- a/.github/workflows/manual_docker_performance_publish.yaml
+++ b/.github/workflows/manual_docker_performance_publish.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/manual_docker_performance_publish.yaml
+++ b/.github/workflows/manual_docker_performance_publish.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -28,7 +28,7 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -301,7 +301,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -109,7 +109,7 @@ jobs:
         runner: [ubuntu-22.04, ubuntu-22.04-arm, macos-15]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -132,7 +132,7 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -149,7 +149,7 @@ jobs:
           variant: l1
           cache_write: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
@@ -175,10 +175,10 @@ jobs:
           #   ethereum_package_args: "./.github/config/assertoor/network_params_ethrex_multiple_cl.yaml"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download etherex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image
           path: /tmp
@@ -245,10 +245,10 @@ jobs:
           #   artifact_prefix: sync
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image
           path: /tmp
@@ -325,7 +325,7 @@ jobs:
 
       - name: Upload Hive Failure Logs
         if: ${{ failure() && steps.verify-hive-results.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: hive_failed_logs_${{ matrix.artifact_prefix }}
           path: src/results/failed_logs
@@ -354,7 +354,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -392,7 +392,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk

--- a/.github/workflows/pr-main_l1_l2_dev.yaml
+++ b/.github/workflows/pr-main_l1_l2_dev.yaml
@@ -28,7 +28,7 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/pr-main_l1_l2_dev.yaml
+++ b/.github/workflows/pr-main_l1_l2_dev.yaml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -29,7 +29,7 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build L1 docker image
         uses: ./.github/actions/build-docker
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build L2 docker image
         uses: ./.github/actions/build-docker

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -214,7 +214,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -79,7 +79,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -123,7 +123,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
@@ -140,7 +140,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -158,7 +158,7 @@ jobs:
           cache_write: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ethrex_image
           path: /tmp/ethrex_image.tar
@@ -172,7 +172,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -192,7 +192,7 @@ jobs:
           cache_write: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ethrex_image_l2
           path: /tmp/ethrex_image_l2.tar
@@ -205,7 +205,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -337,7 +337,7 @@ jobs:
             compose_targets: [docker-compose.yaml]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -361,7 +361,7 @@ jobs:
           docker compose -f ${{ join(matrix.compose_targets, ' -f ') }} up --detach web3signer
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image
           path: /tmp
@@ -371,7 +371,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image_l2
           path: /tmp
@@ -497,7 +497,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -509,7 +509,7 @@ jobs:
         uses: ./.github/actions/install-solc
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image
           path: /tmp
@@ -519,7 +519,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image_l2
           path: /tmp
@@ -632,12 +632,12 @@ jobs:
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image
           path: /tmp
@@ -647,7 +647,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image_l2
           path: /tmp
@@ -699,7 +699,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -723,7 +723,7 @@ jobs:
           cargo test -p ethrex-test l2:: --no-run --release
 
       - name: Download ethrex image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image
           path: /tmp
@@ -733,7 +733,7 @@ jobs:
           docker load --input /tmp/ethrex_image.tar
 
       - name: Download ethrex L2 image artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex_image_l2
           path: /tmp

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -49,7 +49,7 @@ jobs:
         backend: ["sp1", "risc0", "zisk"]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2
 
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Add Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Check tdx

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -26,7 +26,7 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -25,7 +25,7 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -61,7 +61,7 @@ jobs:
           cat tooling/ef_tests/state/test_result_pr_short.txt
 
       - name: Upload PR branch EF-test results.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr-ef-test-data
           path: tooling/ef_tests/state/test_result_pr_short.txt
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -122,7 +122,7 @@ jobs:
           cat tooling/ef_tests/state/test_result_main_short.txt
 
       - name: Upload main branch EF-test results.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: main-ef-test-data
           path: tooling/ef_tests/state/test_result_main_short.txt
@@ -134,16 +134,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download main branch ef tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: main-ef-test-data
           path: tooling/ef_tests/state/
 
       - name: Download PR branch ef tests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: pr-ef-test-data
           path: tooling/ef_tests/state/
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr-main_levm.yaml
+++ b/.github/workflows/pr-main_levm.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Find comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -175,7 +175,7 @@ jobs:
       # If the condition is met, create or update the comment with the summary.
       - name: Create comment
         if: ${{ steps.branch_diffs.outcome == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -188,7 +188,7 @@ jobs:
       # If both conditions are met, update the comment saying that all tests pass.
       - name: Update comment
         if: ${{ steps.branch_diffs.outcome != 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true && steps.fc.outputs.comment-id != '' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -22,7 +22,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload docs artifact
         if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docs
           path: book/html
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check links
         uses: lycheeverse/lychee-action@v2
@@ -65,7 +65,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: docs
           path: book/html

--- a/.github/workflows/pr_check_l2_genesis.yml
+++ b/.github/workflows/pr_check_l2_genesis.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/pr_github_metadata.yaml
+++ b/.github/workflows/pr_github_metadata.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Apply labels from PR title
         uses: actions/github-script@v7

--- a/.github/workflows/pr_github_metadata.yaml
+++ b/.github/workflows/pr_github_metadata.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR author
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.addAssignees({
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Apply labels from PR title
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const run = require('./.github/scripts/set-pr-labels.js');

--- a/.github/workflows/pr_github_status_l1.yaml
+++ b/.github/workflows/pr_github_status_l1.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.PROJECT_SYNC_APP_ID }}
           private-key: ${{ secrets.PROJECT_SYNC_PRIVATE_KEY }}
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Update PR status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |

--- a/.github/workflows/pr_github_status_l1.yaml
+++ b/.github/workflows/pr_github_status_l1.yaml
@@ -38,7 +38,7 @@ jobs:
           private-key: ${{ secrets.PROJECT_SYNC_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Update PR status
         uses: actions/github-script@v7

--- a/.github/workflows/pr_lint_gha.yaml
+++ b/.github/workflows/pr_lint_gha.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install actionlint
         run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/pr_lint_license.yaml
+++ b/.github/workflows/pr_lint_license.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check license files exist
         run: |

--- a/.github/workflows/pr_lint_pr_title.yml
+++ b/.github/workflows/pr_lint_pr_title.yml
@@ -19,7 +19,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr_lint_readme.yaml
+++ b/.github/workflows/pr_lint_readme.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr_loc.yaml
+++ b/.github/workflows/pr_loc.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Find comment
         if: steps.check_report.outputs.report_exists == 'true'
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Create Comment
         if: steps.check_report.outputs.report_exists == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_loc.yaml
+++ b/.github/workflows/pr_loc.yaml
@@ -22,7 +22,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout PR Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -38,7 +38,7 @@ jobs:
           echo "merge_base=$MERGE_BASE" >> $GITHUB_OUTPUT
       
       - name: Checkout merge base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.find_merge_base.outputs.merge_base }}
@@ -56,7 +56,7 @@ jobs:
         run: mv tooling/loc/current_detailed_loc_report.json tooling/loc/previous_detailed_loc_report.json
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           clean: "false" # Don't clean the workspace, so we can keep the previous report
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr_nostd.yaml
+++ b/.github/workflows/pr_nostd.yaml
@@ -27,7 +27,7 @@ jobs:
     name: no_std build check (riscv64imac)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.91.0

--- a/.github/workflows/pr_perf_blocks_exec.yaml
+++ b/.github/workflows/pr_perf_blocks_exec.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Find comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create or update comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_perf_blocks_exec.yaml
+++ b/.github/workflows/pr_perf_blocks_exec.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Populate cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: bin/ethrex-${{ matrix.branch }}
@@ -69,13 +69,13 @@ jobs:
           tool: hyperfine@1.16
 
       - name: Fetch base binary
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: bin/ethrex-base
           key: binary-base-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Fetch HEAD binary
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: bin/ethrex-head
           key: binary-head-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/pr_perf_blocks_exec.yaml
+++ b/.github/workflows/pr_perf_blocks_exec.yaml
@@ -32,7 +32,7 @@ jobs:
           key: binary-${{ matrix.branch }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           ref: ${{ github.event.pull_request[matrix.branch].sha }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           lfs: true
@@ -90,7 +90,7 @@ jobs:
           "./bin/ethrex-{bin} --network fixtures/genesis/perf-ci.json --force import ./fixtures/blockchain/l2-1k-erc20.rlp --removedb"
           echo -e "## Benchmark Block Execution Results Comparison Against Main\n\n$(cat bench_pr_comparison.md)" > bench_pr_comparison.md
       - name: Upload PR results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr-result
           path: bench_pr_comparison.md

--- a/.github/workflows/pr_perf_build_block_bench.yml
+++ b/.github/workflows/pr_perf_build_block_bench.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Find comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         continue-on-error: true
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Create or update comment
         if: ${{ github.event.pull_request.head.repo.fork != true }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_perf_levm.yaml
+++ b/.github/workflows/pr_perf_levm.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -36,7 +36,7 @@ jobs:
           cd crates/vm/levm
           make build-revm-comparison
       - name: Upload main benchmark binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr-binary
           path: crates/vm/levm/target/release/benchmark
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
         with:
@@ -57,7 +57,7 @@ jobs:
           cd crates/vm/levm
           make build-revm-comparison
       - name: Upload main benchmark binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: main-binary
           path: crates/vm/levm/target/release/benchmark
@@ -68,7 +68,7 @@ jobs:
     needs: [benchmark-pr, benchmark-main]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install hyperfine
         uses: taiki-e/install-action@v2
@@ -79,13 +79,13 @@ jobs:
         uses: ./.github/actions/install-solc
 
       - name: Download PR binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: pr-binary
           path: ./pr
 
       - name: Download main binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: main-binary
           path: ./main

--- a/.github/workflows/pr_upgradeability.yaml
+++ b/.github/workflows/pr_upgradeability.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/pr_upgradeability.yaml
+++ b/.github/workflows/pr_upgradeability.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "NEW_TAG=$(echo ${{ github.event.release.tag_name }} | tr -d v)" >> $GITHUB_ENV
 
       - name: Login to Docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: ./.github/actions/install-sp1
       - name: Set up QEMU (only Linux ARM)
         if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: amd64
 
@@ -101,7 +101,7 @@ jobs:
         uses: ./.github/actions/install-risc0
 
       - name: Install CUDA (only Linux x86 GPU)
-        uses: Jimver/cuda-toolkit@v0.2.24
+        uses: Jimver/cuda-toolkit@v0.2.35
         if: ${{ matrix.platform == 'ubuntu-22.04' && matrix.stack == 'l2_gpu' }}
         id: cuda-toolkit
         with:
@@ -385,7 +385,7 @@ jobs:
 
     steps:
       - name: Login to Docker registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -444,7 +444,7 @@ jobs:
           writeToFile: false
 
       - name: Finalize Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         if: ${{ matrix.os == 'linux' }}
@@ -132,14 +132,14 @@ jobs:
           mv crates/guest-program/bin/sp1/out/riscv32im-succinct-zkvm-vk-u32 verification_keys/ethrex-riscv32im-succinct-zkvm-vk-u32
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ethrex${{ matrix.l2_suffix }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.gpu_suffix }}
           path: ethrex${{ matrix.l2_suffix }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.gpu_suffix }}
 
       - name: Upload verification keys
         if: ${{ matrix.platform == 'ubuntu-22.04' && matrix.stack == 'l2_gpu' }} # Run only once
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verification_keys
           path: verification_keys/
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -207,13 +207,13 @@ jobs:
           fi
 
       - name: Upload ethrex guest elf artifact - ${{ matrix.zkvm }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.ELF_ARTIFACT }}
           path: ${{ env.ELF_ARTIFACT }}
 
       - name: Upload ethrex guest verification keys - ${{ matrix.zkvm }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.zkvm }}_verification_keys
           path: ${{ matrix.zkvm }}_verification_keys/
@@ -234,31 +234,31 @@ jobs:
           echo "SANITIZED_REF=$SANITIZED" >> $GITHUB_ENV
 
       - name: Download SP1 elf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex-riscv32im-sp1-elf-${{ env.SANITIZED_REF }}
           path: ethrex_guests/sp1/
 
       - name: Download SP1 verification keys artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: sp1_verification_keys
           path: ethrex_guests/sp1/
 
       - name: Download RISC0 elf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex-riscv32im-risc0-elf-${{ env.SANITIZED_REF }}
           path: ethrex_guests/risc0/
 
       - name: Download RISC0 verification keys artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: risc0_verification_keys
           path: ethrex_guests/risc0/
 
       - name: Download ZisK elf artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ethrex-riscv64ima-zisk-elf-${{ env.SANITIZED_REF }}
           path: ethrex_guests/zisk/
@@ -269,7 +269,7 @@ jobs:
           tar -czvf ../ethrex-guests.tar.gz .
 
       - name: Upload ethrex guests artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ethrex-guests.tar.gz
           path: ethrex-guests.tar.gz
@@ -280,10 +280,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download verification keys artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: verification_keys
           path: crates/l2/contracts/src/
@@ -294,7 +294,7 @@ jobs:
           tar -czvf ../../../../ethrex-contracts.tar.gz .
 
       - name: Upload contracts artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ethrex-contracts.tar.gz
           path: ethrex-contracts.tar.gz
@@ -322,7 +322,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk
@@ -416,12 +416,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: ./bin
           pattern: "ethrex*" # This includes the binaries, elf files, ethrex-verification-keys.tar.gz, and ethrex-contracts.tar.gz


### PR DESCRIPTION
**Motivation**

Silence the [Node.js 20 deprecation warnings](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) emitted on every workflow run. GitHub forces Node.js 24 on June 2nd, 2026 and removes the Node.js 20 runner on September 16th, 2026.

**Description**

Bumps every first-party `actions/*` reference still on Node 20 to its latest Node-24 major:

| Action | From | To | Refs |
|---|---|---|---|
| `actions/checkout` | `v4` | `v6` | 66 |
| `actions/download-artifact` | `v4` | `v6` | 24 |
| `actions/upload-artifact` | `v4` | `v6` | 17 |
| `actions/github-script` | `v7` | `v8` | 4 |
| `actions/setup-node` | `v4` | `v6` | 2 |
| `actions/cache/restore` | `v3` | `v5` | 2 |
| `actions/cache` | `v4` | `v5` | 1 |
| `actions/cache/restore` | `v4` | `v5` | 1 |
| `actions/cache/save` | `v4` | `v5` | 1 |
| `actions/create-github-app-token` | `v2` | `v3` | 1 |

**119 references → 0** for first-party actions on Node 20. Third-party actions still on Node 20 (`dorny/paths-filter@v3`, `docker/{build-push,login,setup-buildx,setup-qemu}-action`, `softprops/action-gh-release@v2`, `peter-evans/*`, etc.) are deliberately out of scope — separate upstreams, separate breaking-change review.

**Breaking-change check** (all verified safe for our usage):
- Artifact actions v5+: artifacts are now immutable. Every `upload-artifact` `name:` is unique or matrix-templated.
- `setup-node` v5/v6: auto-cache only triggers when `package.json` has a `packageManager` field. Ours doesn't.
- `github-script` v8: pure runtime bump (v9 changes `getOctokit`/`require('@actions/github')` — held back).
- `create-github-app-token` v3: removes custom proxy handling; we don't set `HTTP_PROXY`.
- `actions/cache` v5: pure runtime bump.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) — N/A
