### PR TITLE
docs(l1): bump mdbook version

### DIFF
--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
         with:
-          mdbook-version: "0.4.51"
+          mdbook-version: "0.5.2"
 
       - name: Install mdbook dependencies
         run: make docs-deps

--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,9 @@ mermaid-init.js mermaid.min.js &:
 		&& exit 1)
 
 docs-deps: ## 📦 Install dependencies for generating the documentation
-	cargo install --version 0.9.4 mdbook-katex
-	cargo install --version 0.9.1 mdbook-linkcheck2
-	cargo install --version 0.8.0 mdbook-alerts
-	cargo install --version 0.15.0 mdbook-mermaid
+	cargo install --version 0.10.0-alpha mdbook-katex
+	cargo install --version 0.12.0 mdbook-linkcheck2
+	cargo install --version 0.17.0 mdbook-mermaid
 
 docs: mermaid-init.js mermaid.min.js ## 📚 Generate the documentation
 	mdbook build

--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,9 @@ mermaid-init.js mermaid.min.js &:
 		&& exit 1)
 
 docs-deps: ## 📦 Install dependencies for generating the documentation
-	cargo install --version 0.10.0-alpha mdbook-katex
-	cargo install --version 0.12.0 mdbook-linkcheck2
-	cargo install --version 0.17.0 mdbook-mermaid
+	cargo install --locked --version 0.10.0-alpha mdbook-katex
+	cargo install --locked --version 0.12.0 mdbook-linkcheck2
+	cargo install --locked --version 0.17.0 mdbook-mermaid
 
 docs: mermaid-init.js mermaid.min.js ## 📚 Generate the documentation
 	mdbook build

--- a/book.toml
+++ b/book.toml
@@ -27,6 +27,7 @@ additional-js = ["mermaid.min.js", "mermaid-init.js"]
 
 # keep README links working in mdBook output
 [output.html.redirect]
+"/ROADMAP.html" = "/roadmap.html"
 "/getting-started/README.html" = "/getting-started/index.html"
 "/getting-started/installation/README.html" = "/getting-started/installation/index.html"
 "/l1/running/README.html" = "/l1/running/index.html"

--- a/book.toml
+++ b/book.toml
@@ -7,12 +7,6 @@ title = "Ethrex"
 [rust]
 edition = "2024"
 
-# To render GitHub style alerts
-# https://github.com/lambdalisue/rs-mdbook-alerts
-[preprocessor.alerts]
-# This is to avoid warnings about incomplete links on each alert
-renderers = ["html", "linkcheck2"]
-
 # To render Mermaid diagrams
 # https://github.com/badboy/mdbook-mermaid
 [preprocessor.mermaid]

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -24,8 +24,9 @@ We welcome contributions to the documentation! If you want to help improve or ex
 
 We use some mdBook preprocessors and backends for extra features:
 
-- [`mdbook-alerts`](https://github.com/lambdalisue/rs-mdbook-alerts) for custom markdown syntax.
 - [`mdbook-mermaid`](https://github.com/badboy/mdbook-mermaid) for diagrams.
+- [`mdbook-katex`](https://github.com/lzanini/mdbook-katex) for LaTeX math expressions.
+- [`mdbook-linkcheck2`](https://github.com/marxin/mdbook-linkcheck2) for checking broken links during the build.
 - [`lychee`](https://github.com/lycheeverse/lychee) for checking broken links (optional, runs automatically in CI).
 
 You can install mdBook and all dependencies with:

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -27,7 +27,8 @@ We use some mdBook preprocessors and backends for extra features:
 - [`mdbook-mermaid`](https://github.com/badboy/mdbook-mermaid) for diagrams.
 - [`mdbook-katex`](https://github.com/lzanini/mdbook-katex) for LaTeX math expressions.
 - [`mdbook-linkcheck2`](https://github.com/marxin/mdbook-linkcheck2) for checking broken links during the build.
-- [`lychee`](https://github.com/lycheeverse/lychee) for checking broken links (optional, runs automatically in CI).
+
+We also use [`lychee`](https://github.com/lycheeverse/lychee) to check for broken links in CI.
 
 You can install mdBook and all dependencies with:
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -130,7 +130,7 @@
 
 # Roadmap
 
-- [Roadmap](../ROADMAP.md)
+- [Roadmap](./roadmap.md)
 
 # Why ethrex
 

--- a/docs/developers/l1/dashboards.md
+++ b/docs/developers/l1/dashboards.md
@@ -205,17 +205,17 @@ Row panels showing process-level and host-level metrics to help you monitor reso
 ![Process & Server info row](img/process_and_server_info_row.png)
 
 ### Uptime
-Displays time since the Ethrex process started. _[need proper instance labels]_ 
+Displays time since the Ethrex process started. _\[need proper instance labels\]_ 
 
 ![Uptime](img/uptime.png)
 
 ### Threads
-Shows the number of tokio process threads in use. _[need proper instance labels]_
+Shows the number of tokio process threads in use. _\[need proper instance labels\]_
 
 ![Threads](img/threads.png)
 
 ### Open FDs
-Reports current file descriptor usage so you can compare against limits. _[need proper instance labels]_
+Reports current file descriptor usage so you can compare against limits. _\[need proper instance labels\]_
 
 ![Open FDs](img/open_fds.png)
 

--- a/docs/l2/stages.md
+++ b/docs/l2/stages.md
@@ -207,7 +207,7 @@ Based rollups delegate sequencing to Ethereum L1 validators rather than using a 
 
 **Scroll** became the first ZK rollup to achieve Stage 1 (April 2025) through the Euclid upgrade, which introduced permissionless sequencing fallback and a 12-member Security Council with 75% threshold.
 
-**zkSync Era** is currently experiencing a **proof system pause** due to a vulnerability, causing partial liveness failure. Previously, a critical bug in zk-circuits was discovered that could have led to $1.9B in potential losses if exploited.
+**zkSync Era** is currently experiencing a **proof system pause** due to a vulnerability, causing partial liveness failure. Previously, a critical bug in zk-circuits was discovered that could have led to \$1.9B in potential losses if exploited.
 
 > *L2BEAT states they "haven't finished evaluation" of zkSync Era's Stage 1 elements - not that zkSync fails requirements. The main pending item is a forced inclusion mechanism. With 75% of proving already delegated to external provers and decentralized sequencing (ChonkyBFT) underway, zkSync appears architecturally Stage 1-ready.
 
@@ -230,7 +230,7 @@ Based rollups delegate sequencing to Ethereum L1 validators rather than using a 
 |---------|-------------------|
 | Taiko Alethia | Funds at risk from compromised SGX; ZK optional; unverified contracts |
 | Scroll | No upgrade delay; emergency verifier upgrade occurred Aug 2025 |
-| zkSync Era | Proof system currently paused; prior $1.9B bug discovered |
+| zkSync Era | Proof system currently paused; prior \$1.9B bug discovered |
 | Starknet | Shared SHARP verifier; SC has instant upgrade power |
 | Arbitrum One | Malicious upgrade risk; optimistic delay (~6.4 days) |
 | Optimism | No exit window for SC upgrades; dispute game vulnerabilities |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,1 @@
+ROADMAP.md

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,1 +1,1 @@
-ROADMAP.md
+{{#include ../ROADMAP.md}}


### PR DESCRIPTION
**Motivation**

mdbook recently released a new major version 0.5

**Description**

This PR bumps the mdbook version to the latest (0.5.2), fixes some warnings when running `make docs`, fixes a 404 error when loading the roadmap page, and adds `--locked` to `docs-deps` target commands.

One of the major changes from 0.5 is adding support for admonitions, so the mdbook-alerts plugin is no longer needed and was removed.


