### PR TITLE
ci(l2): pin ZisK installer and toolchain version

### DIFF
--- a/.github/actions/install-zisk/action.yml
+++ b/.github/actions/install-zisk/action.yml
@@ -12,7 +12,8 @@ runs:
 
     - name: Install ZisK
       shell: bash
-      # Must match the `ziskos` tag in crates/guest-program/bin/zisk/Cargo.toml.
+      # Must match the `ziskos` tag in both crates/guest-program/Cargo.toml
+      # and crates/guest-program/bin/zisk/Cargo.toml.
       env:
         ZISK_VERSION: "0.16.1"
       run: |
@@ -21,5 +22,5 @@ runs:
         mkdir -p "$HOME/.zisk/bin"
         retry curl -fsSL "https://raw.githubusercontent.com/0xPolygonHermez/zisk/v${ZISK_VERSION}/ziskup/ziskup" -o "$HOME/.zisk/bin/ziskup"
         chmod +x "$HOME/.zisk/bin/ziskup"
-        "$HOME/.zisk/bin/ziskup" -v "${ZISK_VERSION}"
+        retry "$HOME/.zisk/bin/ziskup" -v "${ZISK_VERSION}"
         echo "$HOME/.zisk/bin" >> $GITHUB_PATH

--- a/.github/actions/install-zisk/action.yml
+++ b/.github/actions/install-zisk/action.yml
@@ -12,9 +12,14 @@ runs:
 
     - name: Install ZisK
       shell: bash
+      # Must match the `ziskos` tag in crates/guest-program/bin/zisk/Cargo.toml.
+      env:
+        ZISK_VERSION: "0.16.1"
       run: |
         source "$GITHUB_WORKSPACE/.github/scripts/retry.sh"
 
-        retry curl https://raw.githubusercontent.com/0xPolygonHermez/zisk/main/ziskup/install.sh -o /tmp/zisk_install.sh
-        bash /tmp/zisk_install.sh
+        mkdir -p "$HOME/.zisk/bin"
+        retry curl -fsSL "https://raw.githubusercontent.com/0xPolygonHermez/zisk/v${ZISK_VERSION}/ziskup/ziskup" -o "$HOME/.zisk/bin/ziskup"
+        chmod +x "$HOME/.zisk/bin/ziskup"
+        "$HOME/.zisk/bin/ziskup" -v "${ZISK_VERSION}"
         echo "$HOME/.zisk/bin" >> $GITHUB_PATH

--- a/crates/guest-program/Cargo.toml
+++ b/crates/guest-program/Cargo.toml
@@ -27,6 +27,7 @@ libssz-merkle = { workspace = true, optional = true }
 # zkVM crypto dependencies (pure Rust, compile for RISC-V targets)
 k256 = { workspace = true, optional = true }
 substrate-bn = { version = "0.6.0", optional = true }
+# Must match ZISK_VERSION in .github/actions/install-zisk/action.yml.
 ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", tag = "v0.16.1", optional = true, default-features = false, features = ["inputcpy"] }
 
 [build-dependencies]

--- a/crates/guest-program/bin/zisk/Cargo.toml
+++ b/crates/guest-program/bin/zisk/Cargo.toml
@@ -13,6 +13,7 @@ codegen-units = 1
 panic = "abort"
 
 [dependencies]
+# Must match ZISK_VERSION in .github/actions/install-zisk/action.yml.
 ziskos = { git = "https://github.com/0xPolygonHermez/zisk.git", tag = "v0.16.1" }
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 


### PR DESCRIPTION
**Motivation**

Every PR build of `lint_zk` has been failing since 2026-04-30 because `Install ZisK` aborts:

```
ziskup: line 151: /dev/tty: No such device or address
##[error]Process completed with exit code 1.
```

The action curls `install.sh` from upstream `main`, which fetches `ziskup` from `main`. Upstream commit [`391ec97514`](https://github.com/0xPolygonHermez/zisk/commit/391ec97514) (2026-04-15) added an interactive `read < /dev/tty` CPU/GPU prompt that fails under non-tty CI once the runner image stopped detecting CUDA.

Skipping just the prompt would only paper over this instance; the underlying issue is that the action tracks two moving targets on upstream `main` (`install.sh` and the `ziskup` it pulls).

**Description**

Bypass `install.sh` and curl `ziskup` directly at the `v${ZISK_VERSION}` release tag, then invoke it with `-v ${ZISK_VERSION}`. A single `ZISK_VERSION` env var drives both the script source and the binary download — guaranteed consistent because they ship together at each tag.

`ZISK_VERSION` = `0.16.1`, matching the `ziskos` tag in [`crates/guest-program/bin/zisk/Cargo.toml:16`](https://github.com/lambdaclass/ethrex/blob/main/crates/guest-program/bin/zisk/Cargo.toml#L16). Reciprocal comments on both sides flag that they bump together.

Did not use ziskup's `GH_RUNNER` env path because it forces `SETUP_KEY=proving` and downloads the heavy proving key.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — N/A