### PR TITLE
fix(l1): reject blob versioned hash with non-0x01 prefix in LEVM tx validation

### DIFF
--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -66,7 +66,7 @@ pub const MAX_BLOB_COUNT_ELECTRA: u32 = 9;
 // Max blob count per tx (introduced by Osaka fork)
 pub const MAX_BLOB_COUNT_TX: usize = 6;
 
-pub const VALID_BLOB_PREFIXES: [u8; 2] = [0x01, 0x02];
+pub const VALID_BLOB_PREFIXES: [u8; 1] = [VERSIONED_HASH_VERSION_KZG];
 
 // Block constants
 pub const LAST_AVAILABLE_BLOCK_LIMIT: u64 = 256;


### PR DESCRIPTION
**Motivation**

LEVM's tx-validation hook accepts type-3 transactions with `blob_versioned_hashes[i][0] == 0x02` in addition to the spec-mandated `0x01`. Per [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction), `VERSIONED_HASH_VERSION_KZG = 0x01` is the only valid prefix. Every other client (geth, erigon, besu, nethermind, reth) rejects `0x02`, so an ethrex validator that proposes a block containing such a tx splits consensus.

Reachable via `engine_newPayloadV4`. Not reachable via `eth_sendRawTransaction` — the mempool path's `BlobsBundle.validate_blob_commitment_hashes` already rejects mismatches. EIP-7594 doesn't change the on-chain format, so no fork-gate is needed.

**Description**

In `crates/vm/levm/src/constants.rs:69`, restrict `VALID_BLOB_PREFIXES` to `[VERSIONED_HASH_VERSION_KZG]` (the canonical constant declared on line 48).

**Reproduction**

besu + ethrex kurtosis devnet, malformed `engine_newPayloadV4`:
- besu: `INVALID — Invalid versionedHash`
- ethrex before: `INVALID — Receipts Root does not match …` (LEVM waved the prefix through; execution ran, failed downstream)
- ethrex after: `INVALID — Invalid blob versioned hash` (matches besu)

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — N/A