### PR TITLE
ci(l1): always run Test wrapper so matrix failures actually block PRs

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -338,7 +338,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, test]
     # Make sure this job runs even if the previous jobs failed or were skipped
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() }}
     steps:
       - name: Check if any job failed
         run: |

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -396,4 +396,11 @@ mod test {
                 .unwrap()
         )
     }
+
+    // TEMP: intentional failure to verify the always() change makes the L1 Test
+    // wrapper actually fail. Revert this commit before merging.
+    #[test]
+    fn always_blocks_demo_intentional_failure() {
+        panic!("intentional CI failure for PR #6582 verification — revert before merge");
+    }
 }

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -396,11 +396,4 @@ mod test {
                 .unwrap()
         )
     }
-
-    // TEMP: intentional failure to verify the always() change makes the L1 Test
-    // wrapper actually fail. Revert this commit before merging.
-    #[test]
-    fn always_blocks_demo_intentional_failure() {
-        panic!("intentional CI failure for PR #6582 verification — revert before merge");
-    }
 }


### PR DESCRIPTION
**Motivation**

The `Test` required check in `pr-main_l1.yaml` is a wrapper that aggregates the matrix `Test - {ubuntu-22.04, ubuntu-22.04-arm, macos-15}` jobs so each runner doesn't have to be required individually. Its `if:` was missing `always()`, so when a matrix job failed or was cancelled, GitHub's implicit "all needs must succeed" gate skipped the wrapper. The required check resolved to `SKIPPED`, which counts as passing — so real test failures didn't block PRs.

Observed on PR #6527: `Test - ubuntu-22.04-arm` failed, the other two were cancelled by fail-fast, `Test` resolved to "green".

The `Integration Test`, `Integration Test L2`, and LEVM `Integration Test` wrappers in the repo all already include `always()`.

**Description**

Adds `always()` to the wrapper's `if:`. Mentioning `always()` disables the implicit needs-success gate; the existing `run_tests == 'true'` short-circuit still skips the wrapper on docs-only / L2-only PRs, so trigger and path-filter scoping is unchanged.

**Verified**

A temporary commit added an intentionally-failing unit test (since reverted in `ebad1123f`). On the resulting CI run with the `always()` change applied: `Test - ubuntu-22.04-arm` failed (intentional), the other two runners were cancelled by fail-fast, and the `Test` wrapper job correctly reported `FAILURE` instead of `SKIPPED`, blocking the PR (`mergeStateStatus: BLOCKED`). Wrapper job: https://github.com/lambdaclass/ethrex/actions/runs/25457738098/job/74693835932

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) — N/A