### PR TITLE
fix(levm): restore `exists` flag on transaction revert

### DIFF
--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -82,6 +82,7 @@ pub fn restore_cache_state(
             current_account.info = account.info;
             current_account.status = account.status;
             current_account.has_storage = account.has_storage;
+            current_account.exists = account.exists;
         }
     }
 


### PR DESCRIPTION
## Summary

- Restore the `exists` field in `restore_cache_state` alongside `info`, `status`, and `has_storage`

When a transaction reverts, `restore_cache_state` restores account fields from the backup but omits `exists`. Since `mark_modified()` unconditionally sets `exists = true`, a reverted transaction that touched a non-existent account leaves a stale `exists = true` in the cache.

In batch execution (fullsync `add_blocks_in_batch`), the VM cache persists across all 1024 blocks. A later block's EIP-7702 auth processing reads the stale flag at step 7 (`authority_exists`) and incorrectly applies a 12,500 gas refund (`REFUND_AUTH_PER_EXISTING_ACCOUNT`), causing a gas mismatch at block **25,032,351** on mainnet.

The `exists` field was already stored in the `CallFrameBackup` (added in `call_frame.rs:316`) but never used during restore. This was introduced in #6330 which added `status` and `has_storage` to the restore but missed `exists`.

## Test plan

- [ ] Verify fullsync on mainnet passes block 25,032,351 in batch mode
- [ ] Run EF tests (`make test-blockchain-levm`)
- [ ] Verify the `exists` flag is correctly `false` after reverting a tx that touched a non-existent account