### PR TITLE
feat(l1): reject contract senders at mempool admission (EIP-3607)

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -54,7 +54,7 @@ use ::tracing::{debug, error, info, instrument, warn};
 use constants::{AMSTERDAM_MAX_INITCODE_SIZE, MAX_INITCODE_SIZE, POST_OSAKA_GAS_LIMIT_CAP};
 use error::MempoolError;
 use error::{ChainError, InvalidBlockError};
-use ethrex_common::constants::{EMPTY_TRIE_HASH, MIN_BASE_FEE_PER_BLOB_GAS};
+use ethrex_common::constants::{EMPTY_KECCACK_HASH, EMPTY_TRIE_HASH, MIN_BASE_FEE_PER_BLOB_GAS};
 
 use crossbeam::channel::{self as cb, TryRecvError, select};
 // Re-export stateless validation functions for backwards compatibility
@@ -66,6 +66,7 @@ use ethrex_common::types::MAX_TX_SIZE;
 use ethrex_common::types::block_access_list::BlockAccessList;
 use ethrex_common::types::block_execution_witness::ExecutionWitness;
 use ethrex_common::types::fee_config::FeeConfig;
+use ethrex_common::types::is_eip7702_delegation;
 use ethrex_common::types::{
     AccountInfo, AccountState, AccountUpdate, BalSynthesisItem, Block, BlockHash, BlockHeader,
     BlockNumber, ChainConfig, Code, Receipt, Transaction, WrappedEIP4844Transaction,
@@ -2955,6 +2956,20 @@ impl Blockchain {
         if let Some(sender_acc_info) = maybe_sender_acc_info {
             if nonce < sender_acc_info.nonce || nonce == u64::MAX {
                 return Err(MempoolError::NonceTooLow);
+            }
+
+            // EIP-3607: reject txs from senders with deployed code, unless the
+            // code is an EIP-7702 delegation designation (the account is still
+            // an EOA in spirit, just pointing at delegate code).
+            if sender_acc_info.code_hash != *EMPTY_KECCACK_HASH {
+                let is_delegation = match self.storage.get_account_code(sender_acc_info.code_hash) {
+                    Ok(Some(code)) => is_eip7702_delegation(code.bytecode.as_ref()),
+                    Ok(None) => false,
+                    Err(e) => return Err(e.into()),
+                };
+                if !is_delegation {
+                    return Err(MempoolError::SenderIsContract);
+                }
             }
 
             let tx_cost = tx

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -54,7 +54,7 @@ use ::tracing::{debug, error, info, instrument, warn};
 use constants::{AMSTERDAM_MAX_INITCODE_SIZE, MAX_INITCODE_SIZE, POST_OSAKA_GAS_LIMIT_CAP};
 use error::MempoolError;
 use error::{ChainError, InvalidBlockError};
-use ethrex_common::constants::{EMPTY_KECCACK_HASH, EMPTY_TRIE_HASH, MIN_BASE_FEE_PER_BLOB_GAS};
+use ethrex_common::constants::{EMPTY_KECCAK_HASH, EMPTY_TRIE_HASH, MIN_BASE_FEE_PER_BLOB_GAS};
 
 use crossbeam::channel::{self as cb, TryRecvError, select};
 // Re-export stateless validation functions for backwards compatibility
@@ -2968,7 +2968,7 @@ impl Blockchain {
             // length matches do we fetch + verify the prefix. This avoids
             // pulling potentially large contract bytecode on every contract
             // sender that hits admission.
-            if sender_acc_info.code_hash != *EMPTY_KECCACK_HASH {
+            if sender_acc_info.code_hash != *EMPTY_KECCAK_HASH {
                 let metadata_len = self
                     .storage
                     .get_code_metadata(sender_acc_info.code_hash)?
@@ -2988,7 +2988,7 @@ impl Blockchain {
                                 sender_acc_info.code_hash
                             ))
                         })?;
-                    is_eip7702_delegation(code.bytecode.as_ref())
+                    is_eip7702_delegation(code.code())
                 } else {
                     false
                 };

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2958,15 +2958,17 @@ impl Blockchain {
                 return Err(MempoolError::NonceTooLow);
             }
 
-            // EIP-3607: reject txs from senders with deployed code, unless the
-            // code is an EIP-7702 delegation designation (the account is still
-            // an EOA in spirit, just pointing at delegate code).
+            // EIP-3607: reject txs from senders with deployed code, unless
+            // the code is an EIP-7702 delegation designation (the account is
+            // still an EOA in spirit, just pointing at delegate code). When
+            // the code hash is set but `get_account_code` returns `None`,
+            // the store is inconsistent or pruned; we conservatively treat
+            // that as non-delegation and reject the tx.
             if sender_acc_info.code_hash != *EMPTY_KECCACK_HASH {
-                let is_delegation = match self.storage.get_account_code(sender_acc_info.code_hash) {
-                    Ok(Some(code)) => is_eip7702_delegation(code.bytecode.as_ref()),
-                    Ok(None) => false,
-                    Err(e) => return Err(e.into()),
-                };
+                let is_delegation = self
+                    .storage
+                    .get_account_code(sender_acc_info.code_hash)?
+                    .is_some_and(|code| is_eip7702_delegation(code.bytecode.as_ref()));
                 if !is_delegation {
                     return Err(MempoolError::SenderIsContract);
                 }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2967,7 +2967,7 @@ impl Blockchain {
             // we reject without loading the bytecode. Only when the metadata
             // length matches do we fetch + verify the prefix. This avoids
             // pulling potentially large contract bytecode on every contract
-            // sender that hits admission (Copilot / @MegaRedHand review).
+            // sender that hits admission.
             if sender_acc_info.code_hash != *EMPTY_KECCACK_HASH {
                 let metadata_len = self
                     .storage
@@ -2978,8 +2978,7 @@ impl Blockchain {
                     // bytecode is then missing from the store, the DB is
                     // inconsistent — surface that as `StoreError` instead of
                     // silently treating the sender as a contract (which would
-                    // wrongly reject a valid 7702-delegated EOA per
-                    // Copilot/@codex review).
+                    // wrongly reject a valid 7702-delegated EOA).
                     let code = self
                         .storage
                         .get_account_code(sender_acc_info.code_hash)?

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2974,9 +2974,22 @@ impl Blockchain {
                     .get_code_metadata(sender_acc_info.code_hash)?
                     .map(|m| m.length);
                 let is_delegation = if metadata_len == Some(EIP7702_DELEGATED_CODE_LEN as u64) {
-                    self.storage
+                    // Metadata says the code is delegation-shaped; if the
+                    // bytecode is then missing from the store, the DB is
+                    // inconsistent — surface that as `StoreError` instead of
+                    // silently treating the sender as a contract (which would
+                    // wrongly reject a valid 7702-delegated EOA per
+                    // Copilot/@codex review).
+                    let code = self
+                        .storage
                         .get_account_code(sender_acc_info.code_hash)?
-                        .is_some_and(|code| is_eip7702_delegation(code.bytecode.as_ref()))
+                        .ok_or_else(|| {
+                            StoreError::Custom(format!(
+                                "code missing for hash {:?} despite present metadata",
+                                sender_acc_info.code_hash
+                            ))
+                        })?;
+                    is_eip7702_delegation(code.bytecode.as_ref())
                 } else {
                     false
                 };

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -66,12 +66,12 @@ use ethrex_common::types::MAX_TX_SIZE;
 use ethrex_common::types::block_access_list::BlockAccessList;
 use ethrex_common::types::block_execution_witness::ExecutionWitness;
 use ethrex_common::types::fee_config::FeeConfig;
-use ethrex_common::types::is_eip7702_delegation;
 use ethrex_common::types::{
     AccountInfo, AccountState, AccountUpdate, BalSynthesisItem, Block, BlockHash, BlockHeader,
     BlockNumber, ChainConfig, Code, Receipt, Transaction, WrappedEIP4844Transaction,
     synthesize_bal_updates, validate_block_body,
 };
+use ethrex_common::types::{EIP7702_DELEGATED_CODE_LEN, is_eip7702_delegation};
 use ethrex_common::types::{ELASTICITY_MULTIPLIER, P2PTransaction};
 use ethrex_common::types::{Fork, MempoolTransaction};
 use ethrex_common::utils::keccak;
@@ -2960,15 +2960,26 @@ impl Blockchain {
 
             // EIP-3607: reject txs from senders with deployed code, unless
             // the code is an EIP-7702 delegation designation (the account is
-            // still an EOA in spirit, just pointing at delegate code). When
-            // the code hash is set but `get_account_code` returns `None`,
-            // the store is inconsistent or pruned; we conservatively treat
-            // that as non-delegation and reject the tx.
+            // still an EOA in spirit, just pointing at delegate code).
+            //
+            // Length-based fast path: any code whose length isn't exactly
+            // `EIP7702_DELEGATED_CODE_LEN` (23) cannot be a delegation, so
+            // we reject without loading the bytecode. Only when the metadata
+            // length matches do we fetch + verify the prefix. This avoids
+            // pulling potentially large contract bytecode on every contract
+            // sender that hits admission (Copilot / @MegaRedHand review).
             if sender_acc_info.code_hash != *EMPTY_KECCACK_HASH {
-                let is_delegation = self
+                let metadata_len = self
                     .storage
-                    .get_account_code(sender_acc_info.code_hash)?
-                    .is_some_and(|code| is_eip7702_delegation(code.bytecode.as_ref()));
+                    .get_code_metadata(sender_acc_info.code_hash)?
+                    .map(|m| m.length);
+                let is_delegation = if metadata_len == Some(EIP7702_DELEGATED_CODE_LEN as u64) {
+                    self.storage
+                        .get_account_code(sender_acc_info.code_hash)?
+                        .is_some_and(|code| is_eip7702_delegation(code.bytecode.as_ref()))
+                } else {
+                    false
+                };
                 if !is_delegation {
                     return Err(MempoolError::SenderIsContract);
                 }

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -83,6 +83,8 @@ pub enum MempoolError {
     TxMaxInitCodeSizeError,
     #[error("Transaction encoded size ({actual} bytes) exceeds the {limit}-byte limit")]
     TxSizeExceeded { actual: usize, limit: usize },
+    #[error("Transaction sender is a contract account (EIP-3607)")]
+    SenderIsContract,
     #[error("Transaction gas limit exceeded")]
     TxGasLimitExceededError,
     #[error(

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -291,6 +291,19 @@ pub fn code_hash(code: &Bytes, crypto: &dyn Crypto) -> H256 {
     H256(crypto.keccak256(code.as_ref()))
 }
 
+/// EIP-7702 delegation designation: an EOA whose code is `0xef0100 || address`.
+/// See <https://eips.ethereum.org/EIPS/eip-7702>.
+pub const EIP7702_DELEGATION_PREFIX: [u8; 3] = [0xef, 0x01, 0x00];
+/// Total byte length of an EIP-7702 delegation designation: 3-byte prefix
+/// plus the 20-byte target address.
+pub const EIP7702_DELEGATED_CODE_LEN: usize = 23;
+
+/// Returns true iff `code` is a valid EIP-7702 delegation designation
+/// (exactly 23 bytes, prefixed with `0xef0100`).
+pub fn is_eip7702_delegation(code: &[u8]) -> bool {
+    code.len() == EIP7702_DELEGATED_CODE_LEN && code.starts_with(&EIP7702_DELEGATION_PREFIX)
+}
+
 impl RLPEncode for AccountInfo {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
         Encoder::new(buf)
@@ -495,5 +508,50 @@ mod test {
             H256::from_str("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
                 .unwrap()
         )
+    }
+
+    #[test]
+    fn test_is_eip7702_delegation_valid() {
+        // 0xef0100 || 20-byte address
+        let mut code = Vec::with_capacity(23);
+        code.extend_from_slice(&EIP7702_DELEGATION_PREFIX);
+        code.extend_from_slice(&[0x42; 20]);
+        assert!(is_eip7702_delegation(&code));
+    }
+
+    #[test]
+    fn test_is_eip7702_delegation_rejects_empty() {
+        assert!(!is_eip7702_delegation(&[]));
+    }
+
+    #[test]
+    fn test_is_eip7702_delegation_rejects_short() {
+        // Prefix only, no address.
+        assert!(!is_eip7702_delegation(&EIP7702_DELEGATION_PREFIX));
+    }
+
+    #[test]
+    fn test_is_eip7702_delegation_rejects_long() {
+        // Correct prefix but 24 bytes total.
+        let mut code = Vec::with_capacity(24);
+        code.extend_from_slice(&EIP7702_DELEGATION_PREFIX);
+        code.extend_from_slice(&[0x42; 21]);
+        assert!(!is_eip7702_delegation(&code));
+    }
+
+    #[test]
+    fn test_is_eip7702_delegation_rejects_wrong_prefix() {
+        // Right length, wrong magic.
+        let mut code = Vec::with_capacity(23);
+        code.extend_from_slice(&[0xef, 0x01, 0x01]); // off by one in the last prefix byte
+        code.extend_from_slice(&[0x42; 20]);
+        assert!(!is_eip7702_delegation(&code));
+    }
+
+    #[test]
+    fn test_is_eip7702_delegation_rejects_arbitrary_contract_code() {
+        // Real contract code starting with anything else.
+        let code = vec![0x60, 0x60, 0x60, 0x40, 0x52 /* ... */];
+        assert!(!is_eip7702_delegation(&code));
     }
 }

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -187,11 +187,10 @@ pub fn word_to_address(word: U256) -> Address {
 // ================== EIP-7702 related functions =====================
 
 pub fn code_has_delegation(code: &[u8]) -> Result<bool, VMError> {
-    if code.len() == EIP7702_DELEGATED_CODE_LEN {
-        let first_3_bytes = &code.get(..3).ok_or(InternalError::Slicing)?;
-        return Ok(*first_3_bytes == SET_CODE_DELEGATION_BYTES);
-    }
-    Ok(false)
+    // Delegate to the canonical predicate in `ethrex-common` so the
+    // EIP-7702 designation check (`0xef0100 || address`, exactly 23 bytes)
+    // has a single source of truth. Signature kept as `&[u8]` for callers.
+    Ok(ethrex_common::types::is_eip7702_delegation(code))
 }
 
 /// Gets the address inside the bytecode if it has been


### PR DESCRIPTION
**Motivation**

Every major Ethereum execution client enforces EIP-3607: transactions whose recovered sender has deployed code are rejected, except where the code is an EIP-7702 delegation designation (the account is still an EOA in spirit, just pointing at delegate code). Without this check, contract accounts can submit invalid transactions that waste pool space and gossip bandwidth.

**Description**

- New helper `is_eip7702_delegation(code: &[u8]) -> bool` plus `EIP7702_DELEGATION_PREFIX = 0xef0100` and `EIP7702_DELEGATED_CODE_LEN = 23` constants in `crates/common/types/account.rs`.
- `Blockchain::validate_transaction` now inspects the sender's `code_hash`; if non-empty, it fetches the code (a single extra store hit only when the sender actually has code) and routes through `is_eip7702_delegation`. Non-delegation contract senders are rejected with the new `MempoolError::SenderIsContract`.
- Six unit tests for the delegation predicate covering: empty, valid 23-byte designation, too-short, too-long, wrong-prefix, and arbitrary contract code.