### PR TITLE
feat(l1): punishSpammer — drop highest-nonce half on per-sender cap breach

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -184,7 +184,7 @@ pub struct Options {
     )]
     pub mempool_max_size: usize,
     #[arg(
-        help = "Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap. Matches the 16-slot default of geth, reth, nethermind and erigon.",
+        help = "Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap.",
         long = "mempool.account-slots",
         default_value_t = 16,
         value_name = "MEMPOOL_ACCOUNT_SLOTS",

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -184,6 +184,15 @@ pub struct Options {
     )]
     pub mempool_max_size: usize,
     #[arg(
+        help = "Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap. Matches the 16-slot default of geth, reth, nethermind and erigon.",
+        long = "mempool.account-slots",
+        default_value_t = 16,
+        value_name = "MEMPOOL_ACCOUNT_SLOTS",
+        help_heading = "Node options",
+        env = "ETHREX_MEMPOOL_ACCOUNT_SLOTS"
+    )]
+    pub mempool_account_slots: usize,
+    #[arg(
         long = "http.addr",
         default_value = "0.0.0.0",
         value_name = "ADDRESS",
@@ -450,6 +459,7 @@ impl Default for Options {
             dev: Default::default(),
             force: false,
             mempool_max_size: Default::default(),
+            mempool_account_slots: 16,
             tx_broadcasting_time_interval: Default::default(),
             target_peers: Default::default(),
             lookup_interval: Default::default(),

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -10,7 +10,7 @@ use std::{
 
 use clap::{ArgAction, Parser as ClapParser, Subcommand as ClapSubcommand};
 use ethrex_blockchain::{
-    BlockchainOptions, BlockchainType, L2Config,
+    BlockchainOptions, BlockchainType, DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT, L2Config,
     error::{ChainError, InvalidBlockError},
 };
 use ethrex_common::types::{Block, DEFAULT_BUILDER_GAS_CEIL, Genesis, validate_block_body};
@@ -186,7 +186,7 @@ pub struct Options {
     #[arg(
         help = "Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap.",
         long = "mempool.max-pending-txs-per-account",
-        default_value_t = 16,
+        default_value_t = DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT,
         value_name = "MAX_PENDING_TXS_PER_ACCOUNT",
         help_heading = "Node options",
         env = "ETHREX_MEMPOOL_MAX_PENDING_TXS_PER_ACCOUNT"
@@ -459,7 +459,7 @@ impl Default for Options {
             dev: Default::default(),
             force: false,
             mempool_max_size: Default::default(),
-            mempool_max_pending_txs_per_account: 16,
+            mempool_max_pending_txs_per_account: DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT,
             tx_broadcasting_time_interval: Default::default(),
             target_peers: Default::default(),
             lookup_interval: Default::default(),

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -193,6 +193,16 @@ pub struct Options {
     )]
     pub mempool_max_pending_txs_per_account: usize,
     #[arg(
+        help = "When a sender exceeds the per-account pending-tx cap, also drop the highest-nonce half of their existing pool entries. The breaching tx is still rejected; this only frees pool budget for legitimate senders.",
+        long = "mempool.punish-spammer",
+        default_value_t = true,
+        value_name = "BOOL",
+        help_heading = "Node options",
+        env = "ETHREX_MEMPOOL_PUNISH_SPAMMER",
+        action = clap::ArgAction::Set
+    )]
+    pub mempool_punish_spammer: bool,
+    #[arg(
         long = "http.addr",
         default_value = "0.0.0.0",
         value_name = "ADDRESS",
@@ -460,6 +470,7 @@ impl Default for Options {
             force: false,
             mempool_max_size: Default::default(),
             mempool_max_pending_txs_per_account: DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT,
+            mempool_punish_spammer: true,
             tx_broadcasting_time_interval: Default::default(),
             target_peers: Default::default(),
             lookup_interval: Default::default(),

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -185,13 +185,13 @@ pub struct Options {
     pub mempool_max_size: usize,
     #[arg(
         help = "Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap.",
-        long = "mempool.account-slots",
+        long = "mempool.max-pending-txs-per-account",
         default_value_t = 16,
-        value_name = "MEMPOOL_ACCOUNT_SLOTS",
+        value_name = "MAX_PENDING_TXS_PER_ACCOUNT",
         help_heading = "Node options",
-        env = "ETHREX_MEMPOOL_ACCOUNT_SLOTS"
+        env = "ETHREX_MEMPOOL_MAX_PENDING_TXS_PER_ACCOUNT"
     )]
-    pub mempool_account_slots: usize,
+    pub mempool_max_pending_txs_per_account: usize,
     #[arg(
         long = "http.addr",
         default_value = "0.0.0.0",
@@ -459,7 +459,7 @@ impl Default for Options {
             dev: Default::default(),
             force: false,
             mempool_max_size: Default::default(),
-            mempool_account_slots: 16,
+            mempool_max_pending_txs_per_account: 16,
             tx_broadcasting_time_interval: Default::default(),
             target_peers: Default::default(),
             lookup_interval: Default::default(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -529,6 +529,7 @@ pub async fn init_l1(
             max_blobs_per_block: opts.max_blobs_per_block,
             precompute_witnesses: opts.precompute_witnesses,
             precompile_cache_enabled: !opts.no_precompile_cache,
+            account_slots: opts.mempool_account_slots,
         },
     );
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -530,6 +530,7 @@ pub async fn init_l1(
             precompute_witnesses: opts.precompute_witnesses,
             precompile_cache_enabled: !opts.no_precompile_cache,
             max_pending_txs_per_account: opts.mempool_max_pending_txs_per_account,
+            punish_spammer: opts.mempool_punish_spammer,
         },
     );
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -529,7 +529,7 @@ pub async fn init_l1(
             max_blobs_per_block: opts.max_blobs_per_block,
             precompute_witnesses: opts.precompute_witnesses,
             precompile_cache_enabled: !opts.no_precompile_cache,
-            account_slots: opts.mempool_account_slots,
+            max_pending_txs_per_account: opts.mempool_max_pending_txs_per_account,
         },
     );
 

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -224,6 +224,7 @@ pub async fn init_l2(
         max_blobs_per_block: None, // L2 doesn't support blob transactions
         precompute_witnesses: opts.node_opts.precompute_witnesses,
         precompile_cache_enabled: true,
+        account_slots: opts.node_opts.mempool_account_slots,
     };
 
     let blockchain = init_blockchain(store.clone(), blockchain_opts.clone());

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -225,6 +225,7 @@ pub async fn init_l2(
         precompute_witnesses: opts.node_opts.precompute_witnesses,
         precompile_cache_enabled: true,
         max_pending_txs_per_account: opts.node_opts.mempool_max_pending_txs_per_account,
+        punish_spammer: opts.node_opts.mempool_punish_spammer,
     };
 
     let blockchain = init_blockchain(store.clone(), blockchain_opts.clone());

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -224,7 +224,7 @@ pub async fn init_l2(
         max_blobs_per_block: None, // L2 doesn't support blob transactions
         precompute_witnesses: opts.node_opts.precompute_witnesses,
         precompile_cache_enabled: true,
-        account_slots: opts.node_opts.mempool_account_slots,
+        max_pending_txs_per_account: opts.node_opts.mempool_max_pending_txs_per_account,
     };
 
     let blockchain = init_blockchain(store.clone(), blockchain_opts.clone());

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -235,6 +235,12 @@ pub struct BlockchainOptions {
     /// the mempool. A replacement at an existing `(sender, nonce)` bypasses
     /// this check.
     pub max_pending_txs_per_account: usize,
+    /// Erigon-style punishment policy: when the per-sender cap is breached,
+    /// drop the highest-nonce half of the sender's existing pool entries
+    /// in addition to rejecting the new transaction. The breaching tx is
+    /// still rejected; this only frees pool budget for legitimate senders.
+    /// Defaults to `true`.
+    pub punish_spammer: bool,
 }
 
 impl Default for BlockchainOptions {
@@ -247,6 +253,7 @@ impl Default for BlockchainOptions {
             precompute_witnesses: false,
             precompile_cache_enabled: true,
             max_pending_txs_per_account: DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT,
+            punish_spammer: true,
         }
     }
 }
@@ -2351,6 +2358,7 @@ impl Blockchain {
             sender,
             MempoolTransaction::new(transaction, sender),
             self.options.max_pending_txs_per_account,
+            self.options.punish_spammer,
         )?;
         Ok(hash)
     }
@@ -2380,6 +2388,7 @@ impl Blockchain {
             sender,
             MempoolTransaction::new(transaction, sender),
             self.options.max_pending_txs_per_account,
+            self.options.punish_spammer,
         )?;
 
         Ok(hash)

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2515,9 +2515,18 @@ impl Blockchain {
         // If it exists check if the new tx has higher fees
         let tx_to_replace_hash = self.mempool.find_tx_to_replace(sender, nonce, tx)?;
 
+        if tx
+            .chain_id()
+            .is_some_and(|chain_id| chain_id != config.chain_id)
+        {
+            return Err(MempoolError::InvalidChainId(config.chain_id));
+        }
+
         // Per-account pending-tx cap. Replacement candidates (same
         // `(sender, nonce)`) bypass the cap — they don't grow the
-        // sender's pool footprint.
+        // sender's pool footprint. Placed after the chain-id check so a
+        // wrong-chain submission from a sender at the cap surfaces the
+        // more specific `InvalidChainId` error.
         if tx_to_replace_hash.is_none() {
             let count = self.mempool.count_for_sender(sender)?;
             if count >= self.options.max_pending_txs_per_account {
@@ -2526,13 +2535,6 @@ impl Blockchain {
                     limit: self.options.max_pending_txs_per_account,
                 });
             }
-        }
-
-        if tx
-            .chain_id()
-            .is_some_and(|chain_id| chain_id != config.chain_id)
-        {
-            return Err(MempoolError::InvalidChainId(config.chain_id));
         }
 
         Ok(tx_to_replace_hash)

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2346,8 +2346,12 @@ impl Blockchain {
         // Add blobs bundle before the transaction so that when add_transaction
         // notifies payload builders the blob data is already available.
         self.mempool.add_blobs_bundle(hash, blobs_bundle)?;
-        self.mempool
-            .add_transaction(hash, sender, MempoolTransaction::new(transaction, sender))?;
+        self.mempool.add_transaction(
+            hash,
+            sender,
+            MempoolTransaction::new(transaction, sender),
+            self.options.max_pending_txs_per_account,
+        )?;
         Ok(hash)
     }
 
@@ -2371,8 +2375,12 @@ impl Blockchain {
         }
 
         // Add transaction to storage
-        self.mempool
-            .add_transaction(hash, sender, MempoolTransaction::new(transaction, sender))?;
+        self.mempool.add_transaction(
+            hash,
+            sender,
+            MempoolTransaction::new(transaction, sender),
+            self.options.max_pending_txs_per_account,
+        )?;
 
         Ok(hash)
     }
@@ -2522,20 +2530,13 @@ impl Blockchain {
             return Err(MempoolError::InvalidChainId(config.chain_id));
         }
 
-        // Per-account pending-tx cap. Replacement candidates (same
-        // `(sender, nonce)`) bypass the cap — they don't grow the
-        // sender's pool footprint. Placed after the chain-id check so a
-        // wrong-chain submission from a sender at the cap surfaces the
-        // more specific `InvalidChainId` error.
-        if tx_to_replace_hash.is_none() {
-            let count = self.mempool.count_for_sender(sender)?;
-            if count >= self.options.max_pending_txs_per_account {
-                return Err(MempoolError::MaxPendingTxsPerAccountExceeded {
-                    count,
-                    limit: self.options.max_pending_txs_per_account,
-                });
-            }
-        }
+        // The per-account pending-tx cap is enforced atomically inside
+        // `Mempool::add_transaction` (under the same write lock as the
+        // insertion) so concurrent submissions can't both pass a stale
+        // count check and race past the limit. Replacement candidates
+        // bypass it implicitly: the caller removes the old tx before
+        // `add_transaction` runs, so the post-removal count is one
+        // below the cap and the new insertion stays within it.
 
         Ok(tx_to_replace_hash)
     }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -231,12 +231,10 @@ pub struct BlockchainOptions {
     /// warmer thread and the executor. Set to false (via `--no-precompile-cache`) to
     /// disable the cache for benchmarking purposes.
     pub precompile_cache_enabled: bool,
-    /// Maximum number of pending transactions a single sender may hold in the
-    /// mempool. Matches the 16-slot default of every peer EL client
-    /// (geth `AccountSlots`, reth `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`,
-    /// erigon `AccountSlots`). A replacement at an existing `(sender, nonce)`
-    /// bypasses this check.
-    pub account_slots: usize,
+    /// Maximum number of pending transactions a single sender may hold in
+    /// the mempool. A replacement at an existing `(sender, nonce)` bypasses
+    /// this check.
+    pub max_pending_txs_per_account: usize,
 }
 
 impl Default for BlockchainOptions {
@@ -248,15 +246,13 @@ impl Default for BlockchainOptions {
             max_blobs_per_block: None,
             precompute_witnesses: false,
             precompile_cache_enabled: true,
-            account_slots: DEFAULT_ACCOUNT_SLOTS,
+            max_pending_txs_per_account: DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT,
         }
     }
 }
 
-/// Default per-sender pending-slot cap. Matches geth `AccountSlots = 16`,
-/// reth `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER = 16`, erigon `AccountSlots = 16`,
-/// and nethermind `MaxPendingBlobTxsPerSender = 16`.
-pub const DEFAULT_ACCOUNT_SLOTS: usize = 16;
+/// Default per-account pending-tx cap.
+pub const DEFAULT_MAX_PENDING_TXS_PER_ACCOUNT: usize = 16;
 
 #[derive(Debug, Clone)]
 pub struct BatchBlockProcessingFailure {
@@ -2519,17 +2515,15 @@ impl Blockchain {
         // If it exists check if the new tx has higher fees
         let tx_to_replace_hash = self.mempool.find_tx_to_replace(sender, nonce, tx)?;
 
-        // Per-sender slot cap. Replacement candidates (same (sender, nonce))
-        // bypass the cap — they don't grow the sender's pool footprint.
-        // Peer-policy default of 16, matches geth `AccountSlots`,
-        // reth `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`, erigon `AccountSlots`,
-        // and nethermind `MaxPendingBlobTxsPerSender`.
+        // Per-account pending-tx cap. Replacement candidates (same
+        // `(sender, nonce)`) bypass the cap — they don't grow the
+        // sender's pool footprint.
         if tx_to_replace_hash.is_none() {
             let count = self.mempool.count_for_sender(sender)?;
-            if count >= self.options.account_slots {
-                return Err(MempoolError::SenderSlotsExceeded {
+            if count >= self.options.max_pending_txs_per_account {
+                return Err(MempoolError::MaxPendingTxsPerAccountExceeded {
                     count,
-                    limit: self.options.account_slots,
+                    limit: self.options.max_pending_txs_per_account,
                 });
             }
         }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -231,6 +231,12 @@ pub struct BlockchainOptions {
     /// warmer thread and the executor. Set to false (via `--no-precompile-cache`) to
     /// disable the cache for benchmarking purposes.
     pub precompile_cache_enabled: bool,
+    /// Maximum number of pending transactions a single sender may hold in the
+    /// mempool. Matches the 16-slot default of every peer EL client
+    /// (geth `AccountSlots`, reth `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`,
+    /// erigon `AccountSlots`). A replacement at an existing `(sender, nonce)`
+    /// bypasses this check.
+    pub account_slots: usize,
 }
 
 impl Default for BlockchainOptions {
@@ -242,9 +248,15 @@ impl Default for BlockchainOptions {
             max_blobs_per_block: None,
             precompute_witnesses: false,
             precompile_cache_enabled: true,
+            account_slots: DEFAULT_ACCOUNT_SLOTS,
         }
     }
 }
+
+/// Default per-sender pending-slot cap. Matches geth `AccountSlots = 16`,
+/// reth `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER = 16`, erigon `AccountSlots = 16`,
+/// and nethermind `MaxPendingBlobTxsPerSender = 16`.
+pub const DEFAULT_ACCOUNT_SLOTS: usize = 16;
 
 #[derive(Debug, Clone)]
 pub struct BatchBlockProcessingFailure {
@@ -2506,6 +2518,21 @@ impl Blockchain {
         // Check the nonce of pendings TXs in the mempool from the same sender
         // If it exists check if the new tx has higher fees
         let tx_to_replace_hash = self.mempool.find_tx_to_replace(sender, nonce, tx)?;
+
+        // Per-sender slot cap. Replacement candidates (same (sender, nonce))
+        // bypass the cap — they don't grow the sender's pool footprint.
+        // Peer-policy default of 16, matches geth `AccountSlots`,
+        // reth `TXPOOL_MAX_ACCOUNT_SLOTS_PER_SENDER`, erigon `AccountSlots`,
+        // and nethermind `MaxPendingBlobTxsPerSender`.
+        if tx_to_replace_hash.is_none() {
+            let count = self.mempool.count_for_sender(sender)?;
+            if count >= self.options.account_slots {
+                return Err(MempoolError::SenderSlotsExceeded {
+                    count,
+                    limit: self.options.account_slots,
+                });
+            }
+        }
 
         if tx
             .chain_id()

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -83,8 +83,8 @@ pub enum MempoolError {
     TxMaxInitCodeSizeError,
     #[error("Transaction max data size exceeded")]
     TxMaxDataSizeError,
-    #[error("Sender has {count} pending transactions, exceeds the per-sender cap of {limit}")]
-    SenderSlotsExceeded { count: usize, limit: usize },
+    #[error("Sender has {count} pending transactions, exceeds the per-account cap of {limit}")]
+    MaxPendingTxsPerAccountExceeded { count: usize, limit: usize },
     #[error("Transaction gas limit exceeded")]
     TxGasLimitExceededError,
     #[error(

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -83,6 +83,8 @@ pub enum MempoolError {
     TxMaxInitCodeSizeError,
     #[error("Transaction max data size exceeded")]
     TxMaxDataSizeError,
+    #[error("Sender has {count} pending transactions, exceeds the per-sender cap of {limit}")]
+    SenderSlotsExceeded { count: usize, limit: usize },
     #[error("Transaction gas limit exceeded")]
     TxGasLimitExceededError,
     #[error(

--- a/crates/blockchain/error.rs
+++ b/crates/blockchain/error.rs
@@ -83,7 +83,9 @@ pub enum MempoolError {
     TxMaxInitCodeSizeError,
     #[error("Transaction max data size exceeded")]
     TxMaxDataSizeError,
-    #[error("Sender has {count} pending transactions, exceeds the per-account cap of {limit}")]
+    #[error(
+        "Sender has {count} pending transactions; adding a new one would exceed the per-account cap of {limit}"
+    )]
     MaxPendingTxsPerAccountExceeded { count: usize, limit: usize },
     #[error("Transaction gas limit exceeded")]
     TxGasLimitExceededError,

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -141,14 +141,33 @@ impl Mempool {
             .map_err(|error| StoreError::MempoolReadLock(error.to_string()))
     }
 
-    /// Add transaction to the pool without doing validity checks
+    /// Add transaction to the pool without doing validity checks.
+    ///
+    /// Enforces the per-sender pending-tx cap atomically: the count is
+    /// re-checked under the same write lock that performs the insertion.
+    /// Replacement candidates (same `(sender, nonce)`) must have already
+    /// been removed via `remove_transaction` so this counter reflects the
+    /// post-replacement state. Returns
+    /// [`MempoolError::MaxPendingTxsPerAccountExceeded`] if the cap would
+    /// be exceeded.
     pub fn add_transaction(
         &self,
         hash: H256,
         sender: Address,
         transaction: MempoolTransaction,
-    ) -> Result<(), StoreError> {
+        max_pending_txs_per_account: usize,
+    ) -> Result<(), MempoolError> {
         let mut inner = self.write()?;
+        let count = inner
+            .txs_by_sender_nonce
+            .range((sender, 0)..=(sender, u64::MAX))
+            .count();
+        if count >= max_pending_txs_per_account {
+            return Err(MempoolError::MaxPendingTxsPerAccountExceeded {
+                count,
+                limit: max_pending_txs_per_account,
+            });
+        }
         // Prune the order queue if it has grown too much
         if inner.txs_order.len() > inner.mempool_prune_threshold {
             // NOTE: we do this to avoid borrow checker errors
@@ -602,7 +621,7 @@ mod tests {
         let tx = build_tx(nonce);
         let mtx = MempoolTransaction::new(tx, sender);
         let hash = mtx.hash();
-        pool.add_transaction(hash, sender, mtx).unwrap();
+        pool.add_transaction(hash, sender, mtx, usize::MAX).unwrap();
         hash
     }
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -171,28 +171,26 @@ impl Mempool {
             .range((sender, 0)..=(sender, u64::MAX))
             .count();
         if count >= max_pending_txs_per_account {
-            if punish_spammer {
-                // Drop the upper half of the sender's pool entries,
-                // rounded up so odd counts still lose the median entry
-                // (`ceil(count / 2)`). A single-entry sender therefore
-                // loses its only tx; the policy applies uniformly.
-                let dropped_count = count.div_ceil(2);
-                // Collect victims first so the iterator no longer borrows
-                // `txs_by_sender_nonce` when we mutate it via removal.
-                let victims: Vec<H256> = inner
+            // Drop the upper half of the sender's pool entries, rounded up so
+            // odd counts still lose the median entry (`ceil(count / 2)`).
+            // Skip the prune when `count <= 1`: dropping the only entry adds
+            // no useful punishment (the sender already gets the new tx
+            // rejected) and turns interactions with delegated cap=1 into
+            // "every cap-breach wipes the sender's lone tx".
+            let mut dropped_count = 0usize;
+            if punish_spammer && count > 1 {
+                // Collect the sender's nonce range once, in reverse, so we
+                // can read victims and new_top_nonce in a single pass and
+                // release the immutable borrow before mutating the map.
+                let entries: Vec<(u64, H256)> = inner
                     .txs_by_sender_nonce
                     .range((sender, 0)..=(sender, u64::MAX))
                     .rev()
-                    .take(dropped_count)
-                    .map(|(_, hash)| *hash)
+                    .map(|((_, nonce), hash)| (*nonce, *hash))
                     .collect();
-                let new_top_nonce = inner
-                    .txs_by_sender_nonce
-                    .range((sender, 0)..=(sender, u64::MAX))
-                    .rev()
-                    .nth(dropped_count)
-                    .map(|((_, nonce), _)| *nonce);
-                for victim_hash in &victims {
+                dropped_count = count.div_ceil(2);
+                let new_top_nonce = entries.get(dropped_count).map(|(nonce, _)| *nonce);
+                for (_, victim_hash) in entries.iter().take(dropped_count) {
                     inner.remove_transaction_with_lock(victim_hash)?;
                 }
                 warn!(
@@ -204,7 +202,7 @@ impl Mempool {
                 );
             }
             return Err(MempoolError::MaxPendingTxsPerAccountExceeded {
-                count,
+                count: count.saturating_sub(dropped_count),
                 limit: max_pending_txs_per_account,
             });
         }
@@ -850,6 +848,51 @@ mod tests {
                 pool.get_blobs_bundle(*h).unwrap().is_some(),
                 "blob bundle for surviving tx {h:?} should still be present"
             );
+        }
+    }
+
+    #[test]
+    fn punish_spammer_skips_prune_when_count_is_one() {
+        // With cap = 1 and a single pending tx, the prune-on-breach policy
+        // would wipe the sender's only tx on every cap-breach attempt, which
+        // is especially harmful when combined with delegated cap=1 (every
+        // collision wipes the prior tx). The implementation skips the prune
+        // when `count <= 1`.
+        let pool = Mempool::new(64);
+        let sender = Address::from_low_u64_be(7);
+        add_tx(&pool, sender, 0);
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 1);
+
+        submit_at_cap(&pool, sender, 1, 1, true);
+
+        // The pre-existing single tx must survive.
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 1);
+    }
+
+    #[test]
+    fn punish_spammer_reports_post_prune_count() {
+        // The rejection error must reflect the sender's count AFTER the prune
+        // so RPC clients see the actual post-state, not the pre-prune count.
+        let pool = Mempool::new(64);
+        let sender = Address::from_low_u64_be(8);
+        for nonce in 0..16u64 {
+            add_tx(&pool, sender, nonce);
+        }
+
+        let tx = build_tx(16);
+        let mtx = MempoolTransaction::new(tx, sender);
+        let hash = mtx.hash();
+        let err = pool
+            .add_transaction(hash, sender, mtx, 16, true)
+            .expect_err("expected per-account cap rejection");
+
+        match err {
+            MempoolError::MaxPendingTxsPerAccountExceeded { count, limit } => {
+                // 16 - ceil(16/2) = 16 - 8 = 8 remaining after the prune.
+                assert_eq!(count, 8);
+                assert_eq!(limit, 16);
+            }
+            other => panic!("expected MaxPendingTxsPerAccountExceeded, got {other:?}"),
         }
     }
 }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -150,12 +150,20 @@ impl Mempool {
     /// post-replacement state. Returns
     /// [`MempoolError::MaxPendingTxsPerAccountExceeded`] if the cap would
     /// be exceeded.
+    ///
+    /// When `punish_spammer` is true, breaching the cap additionally
+    /// drops the highest-nonce half of the sender's existing pool entries
+    /// (rounded up for odd counts) before returning the error. Erigon-style
+    /// punishment: a sender hitting the cap is likely spamming future
+    /// nonces, so freeing those slots reclaims pool budget for transactions
+    /// more likely to execute next. The new transaction is still rejected.
     pub fn add_transaction(
         &self,
         hash: H256,
         sender: Address,
         transaction: MempoolTransaction,
         max_pending_txs_per_account: usize,
+        punish_spammer: bool,
     ) -> Result<(), MempoolError> {
         let mut inner = self.write()?;
         let count = inner
@@ -163,6 +171,38 @@ impl Mempool {
             .range((sender, 0)..=(sender, u64::MAX))
             .count();
         if count >= max_pending_txs_per_account {
+            if punish_spammer {
+                // Drop the upper half of the sender's pool entries,
+                // rounded up so odd counts still lose the median entry
+                // (`ceil(count / 2)`). A single-entry sender therefore
+                // loses its only tx; the policy applies uniformly.
+                let dropped_count = count.div_ceil(2);
+                // Collect victims first so the iterator no longer borrows
+                // `txs_by_sender_nonce` when we mutate it via removal.
+                let victims: Vec<H256> = inner
+                    .txs_by_sender_nonce
+                    .range((sender, 0)..=(sender, u64::MAX))
+                    .rev()
+                    .take(dropped_count)
+                    .map(|(_, hash)| *hash)
+                    .collect();
+                let new_top_nonce = inner
+                    .txs_by_sender_nonce
+                    .range((sender, 0)..=(sender, u64::MAX))
+                    .rev()
+                    .nth(dropped_count)
+                    .map(|((_, nonce), _)| *nonce);
+                for victim_hash in &victims {
+                    inner.remove_transaction_with_lock(victim_hash)?;
+                }
+                warn!(
+                    target: "mempool",
+                    sender = ?sender,
+                    dropped_count,
+                    new_top_nonce = ?new_top_nonce,
+                    "punishSpammer: per-sender cap breached; dropped highest-nonce half of sender's pool entries"
+                );
+            }
             return Err(MempoolError::MaxPendingTxsPerAccountExceeded {
                 count,
                 limit: max_pending_txs_per_account,
@@ -621,7 +661,8 @@ mod tests {
         let tx = build_tx(nonce);
         let mtx = MempoolTransaction::new(tx, sender);
         let hash = mtx.hash();
-        pool.add_transaction(hash, sender, mtx, usize::MAX).unwrap();
+        pool.add_transaction(hash, sender, mtx, usize::MAX, true)
+            .unwrap();
         hash
     }
 
@@ -669,5 +710,146 @@ mod tests {
         let b = Address::from_low_u64_be(2);
         add_tx(&pool, a, 0);
         assert_eq!(pool.count_for_sender(b).unwrap(), 0);
+    }
+
+    /// Helper that submits a new tx for `sender` at `nonce` with the given
+    /// cap and punish flag, expecting it to be rejected with
+    /// `MaxPendingTxsPerAccountExceeded`.
+    fn submit_at_cap(
+        pool: &Mempool,
+        sender: Address,
+        nonce: u64,
+        cap: usize,
+        punish_spammer: bool,
+    ) {
+        let tx = build_tx(nonce);
+        let mtx = MempoolTransaction::new(tx, sender);
+        let hash = mtx.hash();
+        let err = pool
+            .add_transaction(hash, sender, mtx, cap, punish_spammer)
+            .expect_err("expected per-account cap rejection");
+        assert!(
+            matches!(err, MempoolError::MaxPendingTxsPerAccountExceeded { .. }),
+            "expected MaxPendingTxsPerAccountExceeded, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn punish_spammer_drops_highest_nonce_half_at_cap() {
+        let pool = Mempool::new(128);
+        let sender = Address::from_low_u64_be(1);
+        // Fill the sender up to a cap of 16.
+        for nonce in 0..16u64 {
+            add_tx(&pool, sender, nonce);
+        }
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 16);
+
+        // 17th tx is rejected and triggers punishment.
+        submit_at_cap(&pool, sender, 16, 16, true);
+
+        // 8 highest-nonce entries (nonces 8..16) should be dropped.
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 8);
+        let inner = pool.read().unwrap();
+        let remaining_nonces: Vec<u64> = inner
+            .txs_by_sender_nonce
+            .range((sender, 0)..=(sender, u64::MAX))
+            .map(|((_, n), _)| *n)
+            .collect();
+        assert_eq!(remaining_nonces, (0..8u64).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn punish_spammer_disabled_leaves_existing_txs() {
+        let pool = Mempool::new(128);
+        let sender = Address::from_low_u64_be(1);
+        for nonce in 0..16u64 {
+            add_tx(&pool, sender, nonce);
+        }
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 16);
+
+        // With punish_spammer = false, the new tx is rejected but the
+        // existing 16 entries are untouched.
+        submit_at_cap(&pool, sender, 16, 16, false);
+
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 16);
+    }
+
+    #[test]
+    fn below_cap_admits_normally_without_punishment() {
+        let pool = Mempool::new(64);
+        let sender = Address::from_low_u64_be(1);
+        // Cap is 2; sender currently has 1 pending.
+        add_tx(&pool, sender, 0);
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 1);
+
+        let tx = build_tx(1);
+        let mtx = MempoolTransaction::new(tx, sender);
+        let hash = mtx.hash();
+        pool.add_transaction(hash, sender, mtx, 2, true)
+            .expect("below-cap submission should be admitted");
+
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 2);
+    }
+
+    #[test]
+    fn punish_spammer_removes_blob_bundles_for_dropped_blob_txs() {
+        use ethrex_common::types::{BlobsBundle, EIP4844Transaction};
+
+        let pool = Mempool::new(128);
+        let sender = Address::from_low_u64_be(1);
+
+        // Build 16 entries alternating blob and non-blob txs. Blob txs sit
+        // at odd nonces so half of them (the highest-nonce ones: 9, 11, 13, 15)
+        // fall into the dropped upper half.
+        let mut blob_hashes_in_upper_half: Vec<H256> = Vec::new();
+        let mut blob_hashes_in_lower_half: Vec<H256> = Vec::new();
+        for nonce in 0..16u64 {
+            let (tx, is_blob) = if nonce % 2 == 1 {
+                (
+                    Transaction::EIP4844Transaction(EIP4844Transaction {
+                        nonce,
+                        ..Default::default()
+                    }),
+                    true,
+                )
+            } else {
+                (build_tx(nonce), false)
+            };
+            let mtx = MempoolTransaction::new(tx, sender);
+            let hash = mtx.hash();
+            if is_blob {
+                pool.add_blobs_bundle(hash, BlobsBundle::default()).unwrap();
+                if nonce >= 8 {
+                    blob_hashes_in_upper_half.push(hash);
+                } else {
+                    blob_hashes_in_lower_half.push(hash);
+                }
+            }
+            pool.add_transaction(hash, sender, mtx, usize::MAX, true)
+                .unwrap();
+        }
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 16);
+        for h in &blob_hashes_in_upper_half {
+            assert!(pool.get_blobs_bundle(*h).unwrap().is_some());
+        }
+
+        // Trigger punishment with cap = 16.
+        submit_at_cap(&pool, sender, 16, 16, true);
+
+        // Upper-half blob bundles must be gone; lower-half blob bundles
+        // must remain.
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 8);
+        for h in &blob_hashes_in_upper_half {
+            assert!(
+                pool.get_blobs_bundle(*h).unwrap().is_none(),
+                "blob bundle for dropped tx {h:?} should have been removed"
+            );
+        }
+        for h in &blob_hashes_in_lower_half {
+            assert!(
+                pool.get_blobs_bundle(*h).unwrap().is_some(),
+                "blob bundle for surviving tx {h:?} should still be present"
+            );
+        }
     }
 }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -193,6 +193,16 @@ impl Mempool {
                 for (_, victim_hash) in entries.iter().take(dropped_count) {
                     inner.remove_transaction_with_lock(victim_hash)?;
                 }
+                // `remove_transaction_with_lock` doesn't touch `txs_order`,
+                // so each victim leaves a tombstone behind. The natural
+                // lazy-sweep eventually cleans them up via the
+                // `mempool_prune_threshold` check below, but a sustained
+                // spam loop can race ahead of the threshold. Sweep
+                // `txs_order` once here, scoped to this punishment fire, so
+                // the queue stays roughly aligned with `transaction_pool`.
+                let txpool = core::mem::take(&mut inner.transaction_pool);
+                inner.txs_order.retain(|h| txpool.contains_key(h));
+                inner.transaction_pool = txpool;
                 warn!(
                     target: "mempool",
                     sender = ?sender,
@@ -754,6 +764,14 @@ mod tests {
             .map(|((_, n), _)| *n)
             .collect();
         assert_eq!(remaining_nonces, (0..8u64).collect::<Vec<_>>());
+        // `txs_order` must NOT carry tombstones for the dropped hashes —
+        // they were cleaned up by the per-punishment sweep so the
+        // `mempool_prune_threshold` check below counts accurately.
+        assert_eq!(
+            inner.txs_order.len(),
+            inner.transaction_pool.len(),
+            "txs_order must align with transaction_pool after punishment",
+        );
     }
 
     #[test]

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -451,6 +451,17 @@ impl Mempool {
         Ok(contains)
     }
 
+    /// Returns the number of pending transactions currently held in the
+    /// mempool for `sender`. Used by the per-sender slot cap at admission.
+    pub fn count_for_sender(&self, sender: Address) -> Result<usize, MempoolError> {
+        let inner = self.read()?;
+        let count = inner
+            .txs_by_sender_nonce
+            .range((sender, 0)..=(sender, u64::MAX))
+            .count();
+        Ok(count)
+    }
+
     pub fn find_tx_to_replace(
         &self,
         sender: Address,
@@ -573,4 +584,71 @@ pub fn transaction_intrinsic_gas(
         .ok_or(MempoolError::TxGasOverflowError)?;
 
     Ok(gas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethrex_common::types::EIP1559Transaction;
+
+    fn build_tx(nonce: u64) -> Transaction {
+        Transaction::EIP1559Transaction(EIP1559Transaction {
+            nonce,
+            ..Default::default()
+        })
+    }
+
+    fn add_tx(pool: &Mempool, sender: Address, nonce: u64) -> H256 {
+        let tx = build_tx(nonce);
+        let mtx = MempoolTransaction::new(tx, sender);
+        let hash = mtx.hash();
+        pool.add_transaction(hash, sender, mtx).unwrap();
+        hash
+    }
+
+    #[test]
+    fn count_for_sender_empty_pool() {
+        let pool = Mempool::new(64);
+        let sender = Address::from_low_u64_be(1);
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 0);
+    }
+
+    #[test]
+    fn count_for_sender_one_tx() {
+        let pool = Mempool::new(64);
+        let sender = Address::from_low_u64_be(1);
+        add_tx(&pool, sender, 0);
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 1);
+    }
+
+    #[test]
+    fn count_for_sender_many_nonces() {
+        let pool = Mempool::new(64);
+        let sender = Address::from_low_u64_be(1);
+        for nonce in 0..5 {
+            add_tx(&pool, sender, nonce);
+        }
+        assert_eq!(pool.count_for_sender(sender).unwrap(), 5);
+    }
+
+    #[test]
+    fn count_for_sender_isolates_senders() {
+        let pool = Mempool::new(64);
+        let a = Address::from_low_u64_be(1);
+        let b = Address::from_low_u64_be(2);
+        add_tx(&pool, a, 0);
+        add_tx(&pool, a, 1);
+        add_tx(&pool, b, 0);
+        assert_eq!(pool.count_for_sender(a).unwrap(), 2);
+        assert_eq!(pool.count_for_sender(b).unwrap(), 1);
+    }
+
+    #[test]
+    fn count_for_sender_unknown_returns_zero() {
+        let pool = Mempool::new(64);
+        let a = Address::from_low_u64_be(1);
+        let b = Address::from_low_u64_be(2);
+        add_tx(&pool, a, 0);
+        assert_eq!(pool.count_for_sender(b).unwrap(), 0);
+    }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,6 +102,7 @@ Node options:
 
           [env: ETHREX_MEMPOOL_PUNISH_SPAMMER=]
           [default: true]
+          [possible values: true, false]
 
       --precompute-witnesses
           Once synced, computes execution witnesses upon receiving newPayload messages and stores them in local storage

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -91,10 +91,10 @@ Node options:
           [env: ETHREX_MEMPOOL_MAX_SIZE=]
           [default: 10000]
 
-      --mempool.account-slots <MEMPOOL_ACCOUNT_SLOTS>
+      --mempool.max-pending-txs-per-account <MAX_PENDING_TXS_PER_ACCOUNT>
           Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap.
 
-          [env: ETHREX_MEMPOOL_ACCOUNT_SLOTS=]
+          [env: ETHREX_MEMPOOL_MAX_PENDING_TXS_PER_ACCOUNT=]
           [default: 16]
 
       --precompute-witnesses

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -91,6 +91,12 @@ Node options:
           [env: ETHREX_MEMPOOL_MAX_SIZE=]
           [default: 10000]
 
+      --mempool.account-slots <MEMPOOL_ACCOUNT_SLOTS>
+          Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap. Matches the 16-slot default of geth, reth, nethermind and erigon.
+
+          [env: ETHREX_MEMPOOL_ACCOUNT_SLOTS=]
+          [default: 16]
+
       --precompute-witnesses
           Once synced, computes execution witnesses upon receiving newPayload messages and stores them in local storage
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -92,7 +92,7 @@ Node options:
           [default: 10000]
 
       --mempool.account-slots <MEMPOOL_ACCOUNT_SLOTS>
-          Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap. Matches the 16-slot default of geth, reth, nethermind and erigon.
+          Maximum number of pending transactions a single sender may hold in the mempool. Replacements at an existing (sender, nonce) bypass this cap.
 
           [env: ETHREX_MEMPOOL_ACCOUNT_SLOTS=]
           [default: 16]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,6 +97,12 @@ Node options:
           [env: ETHREX_MEMPOOL_MAX_PENDING_TXS_PER_ACCOUNT=]
           [default: 16]
 
+      --mempool.punish-spammer <BOOL>
+          When a sender exceeds the per-account pending-tx cap, also drop the highest-nonce half of their existing pool entries. The breaching tx is still rejected; this only frees pool budget for legitimate senders.
+
+          [env: ETHREX_MEMPOOL_PUNISH_SPAMMER=]
+          [default: true]
+
       --precompute-witnesses
           Once synced, computes execution witnesses upon receiving newPayload messages and stores them in local storage
 

--- a/test/tests/blockchain/mempool_tests.rs
+++ b/test/tests/blockchain/mempool_tests.rs
@@ -370,10 +370,10 @@ fn test_filter_mempool_transactions() {
     let mempool = Mempool::new(MEMPOOL_MAX_SIZE_TEST);
     let filter = |tx: &Transaction| -> bool { matches!(tx, Transaction::EIP4844Transaction(_)) };
     mempool
-        .add_transaction(blob_tx_hash, blob_tx_sender, blob_tx.clone())
+        .add_transaction(blob_tx_hash, blob_tx_sender, blob_tx.clone(), usize::MAX, false)
         .unwrap();
     mempool
-        .add_transaction(plain_tx_hash, plain_tx_sender, plain_tx)
+        .add_transaction(plain_tx_hash, plain_tx_sender, plain_tx, usize::MAX, false)
         .unwrap();
     let txs = mempool.filter_transactions_with_filter_fn(&filter).unwrap();
     assert_eq!(
@@ -440,7 +440,13 @@ fn blobs_bundle_insert_and_remove() {
             .unwrap();
 
         mempool
-            .add_transaction(hash, sender, MempoolTransaction::new(tx, sender))
+            .add_transaction(
+                hash,
+                sender,
+                MempoolTransaction::new(tx, sender),
+                usize::MAX,
+                false,
+            )
             .expect("Failed to add blob transaction");
     }
 


### PR DESCRIPTION
## Motivation

When a sender exceeds the per-sender pending-tx cap (#6603), the default behavior is to reject only the *new* transaction. A persistent spammer can keep pinning their existing 16 (or whatever the cap is) pool slots indefinitely, paying nothing while denying other senders the budget. The geth/erigon punishment pattern: on cap breach, ALSO drop the breaching sender's highest-nonce half of pool entries.

## Description

- `Mempool::add_transaction` accepts a `punish_spammer: bool` flag. When set AND the sender's pending count is `>= max_pending_txs_per_account` AND the count is `> 1`, the per-sender entries are sorted by nonce descending and the top `ceil(N/2)` are removed via `remove_transaction_with_lock`. The new incoming tx is still rejected with `MaxPendingTxsPerAccountExceeded { count: post_prune_count, limit }`.
- Skips the prune when count `<= 1` so a tighter cap (e.g. delegated_sender_cap = 1 from #6630) doesn't make every collision wipe the sender's lone tx.
- After punishment, sweeps `txs_order` against the live `transaction_pool` so dropped hashes don't leave tombstones that skew the lazy `mempool_prune_threshold` accounting.
- CLI: `--mempool.punish-spammer` (env `ETHREX_MEMPOOL_PUNISH_SPAMMER`, default `true`). Operators who want pure-reject (no eviction) semantics can disable it.

## Behavioral change

Senders that hit the per-account cap are penalised: they lose their upper-half pool entries on every cap-breach attempt, in addition to having the new tx rejected. Default-on for all networks; operators can opt out via the CLI flag.

## Notes

Stacked on top of `feat/mempool-account-slots-cap` (PR #6603) because the atomic cap check it extends only exists on that branch. The PR diff shows only the punishment-specific delta.
