### PR TITLE
fix(l1): exclude multisync_logs from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,5 +21,6 @@ hive/
 ethereum-package/
 tooling/ef_tests/blockchain/vectors
 tooling/ef_tests/state/vectors
+tooling/sync/multisync_logs/
 dev_ethrex_l1/
 dev_ethrex_l2/


### PR DESCRIPTION
**Motivation**

Each `make multisync-loop-auto` cycle invokes `docker compose build` for the multisync image, which copies the entire repo into the BuildKit context. `tooling/sync/multisync_logs/` accumulates ~5 GB per run (`ethrex-mainnet.log` alone is ~3 GB) and is never pruned by the loop. After enough cycles the build context grows to hundreds of GB and eventually fails with `no space left on device`, silently killing the multisync tmux session with no Slack notification.

This was just observed on `ethrex-mainnet-3` running multisync on `test/v12.0.0-rc.2`: 142 run directories totalling **215 GB** caused BuildKit to abort while copying `multisync_logs/run_20260509_195659/ethrex-mainnet.log`, leaving cycle #128 stuck and the loop dead.

**Description**

Add `tooling/sync/multisync_logs/` to `.dockerignore` so the loop's own log output is not bundled into the build context. Build context size stays bounded regardless of how many cycles the loop has run.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.