### PR TITLE
feat(l1,l2): harden HTTP JSON-RPC defaults

### DIFF
--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -12,9 +12,9 @@ participants:
     validator_count: 32
     # ethereum-package's el_admin_node_info.star bootstrap calls admin_nodeInfo
     # to discover the enode; the new ethrex defaults only serve eth/net/web3,
-    # so opt admin/debug/txpool back in for this devnet.
+    # so opt admin/debug/txpool back in for this devnet. --http.addr is
+    # already set by ethereum-package's ethrex launcher.
     el_extra_params:
-      - "--http.addr=0.0.0.0"
       - "--http.api=eth,net,web3,debug,admin,txpool"
 
 additional_services:

--- a/.github/config/assertoor/network_params_blob.yaml
+++ b/.github/config/assertoor/network_params_blob.yaml
@@ -10,6 +10,12 @@ participants:
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v8.0.0-rc.1
     validator_count: 32
+    # ethereum-package's el_admin_node_info.star bootstrap calls admin_nodeInfo
+    # to discover the enode; the new ethrex defaults only serve eth/net/web3,
+    # so opt admin/debug/txpool back in for this devnet.
+    el_extra_params:
+      - "--http.addr=0.0.0.0"
+      - "--http.api=eth,net,web3,debug,admin,txpool"
 
 additional_services:
   - assertoor

--- a/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
+++ b/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
@@ -1,3 +1,6 @@
+# ethereum-package's el_admin_node_info.star bootstrap calls admin_nodeInfo
+# to discover the enode; the new ethrex defaults only serve eth/net/web3, so
+# every ethrex participant opts admin/debug/txpool back in for this devnet.
 participants:
   - el_type: ethrex
     el_image: ethrex:ci
@@ -5,18 +8,27 @@ participants:
     cl_image: sigp/lighthouse:v8.0.0-rc.1
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
+    el_extra_params:
+      - "--http.addr=0.0.0.0"
+      - "--http.api=eth,net,web3,debug,admin,txpool"
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: teku
     cl_image: consensys/teku:25.6.0
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
+    el_extra_params:
+      - "--http.addr=0.0.0.0"
+      - "--http.api=eth,net,web3,debug,admin,txpool"
   - el_type: ethrex
     el_image: ethrex:ci
     cl_type: prysm
     cl_image: gcr.io/offchainlabs/prysm/beacon-chain:v6.0.4
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
+    el_extra_params:
+      - "--http.addr=0.0.0.0"
+      - "--http.api=eth,net,web3,debug,admin,txpool"
 
 network_params:
   # The address of the staking contract address on the Eth1 chain

--- a/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
+++ b/.github/config/assertoor/network_params_ethrex_multiple_cl.yaml
@@ -1,6 +1,7 @@
 # ethereum-package's el_admin_node_info.star bootstrap calls admin_nodeInfo
 # to discover the enode; the new ethrex defaults only serve eth/net/web3, so
 # every ethrex participant opts admin/debug/txpool back in for this devnet.
+# --http.addr is already set by ethereum-package's ethrex launcher.
 participants:
   - el_type: ethrex
     el_image: ethrex:ci
@@ -9,7 +10,6 @@ participants:
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
     el_extra_params:
-      - "--http.addr=0.0.0.0"
       - "--http.api=eth,net,web3,debug,admin,txpool"
   - el_type: ethrex
     el_image: ethrex:ci
@@ -18,7 +18,6 @@ participants:
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
     el_extra_params:
-      - "--http.addr=0.0.0.0"
       - "--http.api=eth,net,web3,debug,admin,txpool"
   - el_type: ethrex
     el_image: ethrex:ci
@@ -27,7 +26,6 @@ participants:
     validator_count: 32
     ethereum_metrics_exporter_enabled: true
     el_extra_params:
-      - "--http.addr=0.0.0.0"
       - "--http.api=eth,net,web3,debug,admin,txpool"
 
 network_params:

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -11,9 +11,9 @@ participants:
     validator_count: 32
     # ethereum-package's el_admin_node_info.star bootstrap calls admin_nodeInfo
     # to discover the enode; the new ethrex defaults only serve eth/net/web3,
-    # so opt admin/debug/txpool back in for this devnet.
+    # so opt admin/debug/txpool back in for this devnet. --http.addr is
+    # already set by ethereum-package's ethrex launcher.
     el_extra_params:
-      - "--http.addr=0.0.0.0"
       - "--http.api=eth,net,web3,debug,admin,txpool"
 
 additional_services:

--- a/.github/config/assertoor/network_params_tx.yaml
+++ b/.github/config/assertoor/network_params_tx.yaml
@@ -9,6 +9,12 @@ participants:
     cl_type: lighthouse
     cl_image: sigp/lighthouse:v8.0.0-rc.1
     validator_count: 32
+    # ethereum-package's el_admin_node_info.star bootstrap calls admin_nodeInfo
+    # to discover the enode; the new ethrex defaults only serve eth/net/web3,
+    # so opt admin/debug/txpool back in for this devnet.
+    el_extra_params:
+      - "--http.addr=0.0.0.0"
+      - "--http.api=eth,net,web3,debug,admin,txpool"
 
 additional_services:
   - assertoor

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -311,7 +311,7 @@ jobs:
         uses: ethpandaops/hive-github-action@v0.5.0
         with:
           hive_repository: ethereum/hive
-          hive_version: fbc845b230c5758382e7eb6b58e277d9afebf3e7
+          hive_version: 1c27560a1f8ac09dda26038d7a1394243e99025d
           simulator: ${{ matrix.simulation }}
           client: ethrex
           client_config: ${{ steps.client-config.outputs.config }}

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -185,9 +185,10 @@ pub struct Options {
     pub mempool_max_size: usize,
     #[arg(
         long = "http.addr",
-        default_value = "0.0.0.0",
+        default_value = "127.0.0.1",
         value_name = "ADDRESS",
         help = "Listening address for the http rpc server.",
+        long_help = "Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).",
         help_heading = "RPC options",
         env = "ETHREX_HTTP_ADDR"
     )]
@@ -201,6 +202,18 @@ pub struct Options {
         env = "ETHREX_HTTP_PORT"
     )]
     pub http_port: String,
+    #[arg(
+        long = "http.api",
+        default_value = "eth,net,web3",
+        value_name = "NAMESPACES",
+        value_delimiter = ',',
+        value_parser = utils::parse_http_namespace,
+        help = "Comma-separated JSON-RPC namespaces enabled over HTTP/WS.",
+        long_help = "Comma-separated list of JSON-RPC namespaces exposed on the public HTTP and WebSocket endpoints. Defaults to `eth,net,web3`. Enable `admin`, `debug` or `txpool` only when needed; the `engine` namespace is served on the authenticated RPC port and cannot be toggled here.",
+        help_heading = "RPC options",
+        env = "ETHREX_HTTP_API"
+    )]
+    pub http_api: Vec<ethrex_rpc::RpcNamespace>,
     #[arg(
         long = "ws.enabled",
         default_value = "false",
@@ -381,7 +394,7 @@ impl Options {
             network: Some(Network::LocalDevnet),
             datadir: DB_ETHREX_DEV_L1.into(),
             dev: true,
-            http_addr: "0.0.0.0".to_string(),
+            http_addr: "127.0.0.1".to_string(),
             http_port: "8545".to_string(),
             authrpc_port: "8551".to_string(),
             metrics_port: "9090".to_string(),
@@ -404,7 +417,7 @@ impl Options {
             metrics_port: "3702".into(),
             metrics_enabled: true,
             dev: true,
-            http_addr: "0.0.0.0".into(),
+            http_addr: "127.0.0.1".into(),
             http_port: "1729".into(),
             authrpc_addr: "localhost".into(),
             authrpc_port: "8551".into(),
@@ -424,6 +437,7 @@ impl Default for Options {
         Self {
             http_addr: Default::default(),
             http_port: Default::default(),
+            http_api: ethrex_rpc::DEFAULT_HTTP_API.to_vec(),
             ws_enabled: false,
             ws_addr: Default::default(),
             ws_port: Default::default(),
@@ -1109,4 +1123,51 @@ pub async fn export_blocks(
         path = %path,
         "Exported blocks to file"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use ethrex_rpc::RpcNamespace;
+
+    /// `--http.addr` must default to `127.0.0.1` so a fresh install on a public
+    /// host is not exposed to the open internet.
+    #[test]
+    fn http_addr_defaults_to_loopback() {
+        let cli = CLI::parse_from(["ethrex"]);
+        assert_eq!(cli.opts.http_addr, "127.0.0.1");
+    }
+
+    /// `--http.api` must default to `eth,net,web3`. Operators have to opt in
+    /// explicitly to expose `admin`, `debug` or `txpool`.
+    #[test]
+    fn http_api_defaults_to_safe_namespaces() {
+        let cli = CLI::parse_from(["ethrex"]);
+        assert_eq!(
+            cli.opts.http_api,
+            vec![RpcNamespace::Eth, RpcNamespace::Net, RpcNamespace::Web3]
+        );
+    }
+
+    #[test]
+    fn http_api_parses_comma_separated_values() {
+        let cli = CLI::parse_from(["ethrex", "--http.api", "eth,debug,admin"]);
+        assert_eq!(
+            cli.opts.http_api,
+            vec![RpcNamespace::Eth, RpcNamespace::Debug, RpcNamespace::Admin]
+        );
+    }
+
+    #[test]
+    fn http_api_rejects_engine_namespace() {
+        let result = CLI::try_parse_from(["ethrex", "--http.api", "eth,engine"]);
+        assert!(result.is_err(), "engine must not be allowed on --http.api");
+    }
+
+    #[test]
+    fn http_api_rejects_unknown_namespace() {
+        let result = CLI::try_parse_from(["ethrex", "--http.api", "eth,bogus"]);
+        assert!(result.is_err());
+    }
 }

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -233,6 +233,7 @@ pub async fn init_rpc_api(
         log_filter_handler,
         opts.gas_limit,
         opts.extra_data.clone(),
+        opts.http_api.iter().copied().collect(),
     );
 
     tracker.spawn(rpc_api);

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -55,6 +55,8 @@ fn init_rpc_api(
 ) {
     init_datadir(&opts.datadir);
 
+    let allowed_namespaces: std::collections::HashSet<_> = opts.http_api.iter().copied().collect();
+    let ethrex_namespace_allowed = l2_opts.http_api_ethrex;
     let rpc_api = ethrex_l2_rpc::start_api(
         get_http_socket_addr(opts),
         ws,
@@ -73,6 +75,8 @@ fn init_rpc_api(
         log_filter_handler,
         l2_gas_limit,
         l2_opts.sponsored_gas_limit,
+        allowed_namespaces,
+        ethrex_namespace_allowed,
     );
 
     tracker.spawn(rpc_api);

--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -53,6 +53,16 @@ pub struct Options {
         help_heading = "L2 options"
     )]
     pub sponsored_gas_limit: u64,
+    #[arg(
+        long = "http.api.ethrex",
+        default_value_t = true,
+        action = clap::ArgAction::Set,
+        value_name = "BOOLEAN",
+        env = "ETHREX_HTTP_API_ETHREX",
+        help = "Expose L2-specific ethrex_* RPC methods over HTTP/WS. Enabled by default for L2 nodes.",
+        help_heading = "L2 options"
+    )]
+    pub http_api_ethrex: bool,
 }
 
 impl Default for Options {
@@ -66,6 +76,7 @@ impl Default for Options {
             )
             .unwrap(),
             sponsored_gas_limit: DEFAULT_SPONSORED_GAS_LIMIT,
+            http_api_ethrex: true,
         }
     }
 }

--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -70,6 +70,23 @@ pub fn read_chain_file(chain_rlp_path: &str) -> Vec<Block> {
     decode::chain_file(chain_file).expect("Failed to decode chain rlp file")
 }
 
+pub fn parse_http_namespace(s: &str) -> eyre::Result<ethrex_rpc::RpcNamespace> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err(eyre::eyre!("empty namespace in --http.api"));
+    }
+    if trimmed.eq_ignore_ascii_case("engine") {
+        return Err(eyre::eyre!(
+            "`engine` cannot be enabled on --http.api; it is served on the authenticated RPC port"
+        ));
+    }
+    ethrex_rpc::RpcNamespace::from_prefix(&trimmed.to_ascii_lowercase()).ok_or_else(|| {
+        eyre::eyre!(
+            "unknown RPC namespace {trimmed:?}; expected one of eth, net, web3, debug, admin, txpool"
+        )
+    })
+}
+
 pub fn parse_sync_mode(s: &str) -> eyre::Result<SyncMode> {
     match s {
         "full" => Ok(SyncMode::Full),

--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -232,6 +232,11 @@ async fn handle_http_request(
 /// Handle requests that can come from either clients or other users
 pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
     match resolve_namespace(&req.method) {
+        // `Eth` is handled here (not delegated to L1) so that L2-specific
+        // overrides in `map_eth_requests` see the full L2 context. Because we
+        // bypass `ethrex_rpc::map_http_requests`, the `--http.api` allowlist
+        // guard must be enforced explicitly here. Any future namespace that
+        // gains a dedicated arm before the `_` fallthrough must do the same.
         Ok(RpcNamespace::L1RpcNamespace(L1RpcNamespace::Eth)) => {
             if !context
                 .l1_ctx

--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -19,6 +19,7 @@ use ethrex_p2p::sync_manager::SyncManager;
 use ethrex_p2p::types::Node;
 use ethrex_p2p::types::NodeRecord;
 use ethrex_rpc::RpcHandler as L1RpcHandler;
+use ethrex_rpc::RpcNamespace as L1RpcNamespace;
 use ethrex_rpc::debug::execution_witness::ExecutionWitnessRequest;
 use ethrex_rpc::{
     ClientVersion, GasTipEstimator, NodeData, RpcRequestWrapper, WebSocketConfig,
@@ -28,7 +29,7 @@ use ethrex_rpc::{
 use ethrex_storage::Store;
 use serde_json::Value;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     future::IntoFuture,
     net::SocketAddr,
     sync::{Arc, Mutex},
@@ -51,6 +52,8 @@ pub struct RpcApiContext {
     pub sponsor_pk: SecretKey,
     pub rollup_store: StoreRollup,
     pub sponsored_gas_limit: u64,
+    /// Whether L2-specific `ethrex_*` methods are reachable over HTTP/WS.
+    pub ethrex_namespace_allowed: bool,
 }
 
 pub trait RpcHandler: Sized {
@@ -91,6 +94,8 @@ pub async fn start_api(
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     l2_gas_limit: u64,
     sponsored_gas_limit: u64,
+    allowed_namespaces: HashSet<L1RpcNamespace>,
+    ethrex_namespace_allowed: bool,
 ) -> Result<(), RpcErr> {
     // TODO: Refactor how filters are handled,
     // filters are used by the filters endpoints (eth_newFilter, eth_getFilterChanges, ...etc)
@@ -121,11 +126,13 @@ pub async fn start_api(
             gas_ceil: l2_gas_limit,
             block_worker_channel,
             ws: ws.clone(),
+            allowed_namespaces: Arc::new(allowed_namespaces),
         },
         valid_delegation_addresses,
         sponsor_pk,
         rollup_store,
         sponsored_gas_limit,
+        ethrex_namespace_allowed,
     };
 
     // Periodically clean up the active filters for the filters endpoints.
@@ -225,10 +232,26 @@ async fn handle_http_request(
 /// Handle requests that can come from either clients or other users
 pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
     match resolve_namespace(&req.method) {
-        Ok(RpcNamespace::L1RpcNamespace(ethrex_rpc::RpcNamespace::Eth)) => {
+        Ok(RpcNamespace::L1RpcNamespace(L1RpcNamespace::Eth)) => {
+            if !context
+                .l1_ctx
+                .allowed_namespaces
+                .contains(&L1RpcNamespace::Eth)
+            {
+                return Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotFound(
+                    req.method.clone(),
+                )));
+            }
             map_eth_requests(req, context).await
         }
-        Ok(RpcNamespace::EthrexL2) => map_l2_requests(req, context).await,
+        Ok(RpcNamespace::EthrexL2) => {
+            if !context.ethrex_namespace_allowed {
+                return Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotFound(
+                    req.method.clone(),
+                )));
+            }
+            map_l2_requests(req, context).await
+        }
         _ => ethrex_rpc::map_http_requests(req, context.l1_ctx)
             .await
             .map_err(RpcErr::L1RpcErr),
@@ -278,6 +301,49 @@ pub async fn map_l2_requests(req: &RpcRequest, context: RpcApiContext) -> Result
         "ethrex_getL1BlobBaseFee" => GetL1BlobBaseFeeRequest::call(req, context).await,
         unknown_ethrex_l2_method => {
             Err(ethrex_rpc::RpcErr::MethodNotFound(unknown_ethrex_l2_method.to_owned()).into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethrex_storage::{EngineType, Store};
+    use ethrex_storage_rollup::EngineTypeRollup;
+
+    async fn test_context(ethrex_namespace_allowed: bool) -> RpcApiContext {
+        let storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        let l1_ctx = ethrex_rpc::test_utils::default_context_with_storage(storage).await;
+        let rollup_store = ethrex_storage_rollup::StoreRollup::new(
+            std::path::Path::new(""),
+            EngineTypeRollup::InMemory,
+        )
+        .expect("Failed to create rollup store");
+        RpcApiContext {
+            l1_ctx,
+            valid_delegation_addresses: vec![],
+            sponsor_pk: SecretKey::from_byte_array(&[0xab; 32]).unwrap(),
+            rollup_store,
+            sponsored_gas_limit: 0,
+            ethrex_namespace_allowed,
+        }
+    }
+
+    /// With `--http.api.ethrex=false`, L2-specific `ethrex_*` methods must be
+    /// rejected at the dispatcher with MethodNotFound and never reach handlers.
+    #[tokio::test]
+    async fn ethrex_namespace_blocked_when_disabled() {
+        let body = r#"{"jsonrpc":"2.0","method":"ethrex_batchNumber","params":[],"id":1}"#;
+        let request: RpcRequest = serde_json::from_str(body).unwrap();
+        let context = test_context(false).await;
+
+        let result = map_http_requests(&request, context).await;
+        match result {
+            Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotFound(method))) => {
+                assert_eq!(method, "ethrex_batchNumber");
+            }
+            other => panic!("expected MethodNotFound, got {other:?}"),
         }
     }
 }

--- a/crates/networking/rpc/lib.rs
+++ b/crates/networking/rpc/lib.rs
@@ -94,3 +94,10 @@ pub use rpc::{
 };
 pub use subscription_manager::{SubscriptionManager, SubscriptionManagerProtocol};
 pub use utils::{RpcErr, RpcErrorMetadata, RpcNamespace};
+
+/// Default namespaces enabled on the public HTTP/WS RPC endpoint.
+///
+/// Operators who need `admin`, `debug` or `txpool` must enable them explicitly
+/// via `--http.api`.
+pub const DEFAULT_HTTP_API: &[RpcNamespace] =
+    &[RpcNamespace::Eth, RpcNamespace::Net, RpcNamespace::Web3];

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -74,7 +74,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use spawned_concurrency::tasks::ActorRef;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     future::IntoFuture,
     net::SocketAddr,
     sync::{Arc, Mutex},
@@ -213,6 +213,12 @@ pub struct RpcApiContext {
     pub block_worker_channel: UnboundedSender<BlockWorkerMessage>,
     /// WebSocket configuration. `None` when the WS server is disabled.
     pub ws: Option<WebSocketConfig>,
+    /// Set of RPC namespaces that are allowed over the public HTTP/WS endpoints.
+    ///
+    /// Methods belonging to namespaces not in this set return `MethodNotFound`.
+    /// The `engine` namespace is always served via the authenticated RPC port
+    /// and is not gated here.
+    pub allowed_namespaces: Arc<HashSet<RpcNamespace>>,
 }
 
 /// Configuration for the WebSocket RPC server.
@@ -504,6 +510,7 @@ pub async fn start_api(
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     gas_ceil: u64,
     extra_data: String,
+    allowed_namespaces: HashSet<RpcNamespace>,
 ) -> Result<(), RpcErr> {
     // TODO: Refactor how filters are handled,
     // filters are used by the filters endpoints (eth_newFilter, eth_getFilterChanges, ...etc)
@@ -527,6 +534,7 @@ pub async fn start_api(
         gas_ceil,
         block_worker_channel,
         ws: ws.clone(),
+        allowed_namespaces: Arc::new(allowed_namespaces),
     };
 
     // Periodically clean up the active filters for the filters endpoints.
@@ -939,17 +947,24 @@ pub async fn handle_eth_unsubscribe(
 
 /// Handle requests that can come from either clients or other users
 pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
-    match req.namespace() {
-        Ok(RpcNamespace::Eth) => map_eth_requests(req, context).await,
-        Ok(RpcNamespace::Admin) => map_admin_requests(req, context).await,
-        Ok(RpcNamespace::Debug) => map_debug_requests(req, context).await,
-        Ok(RpcNamespace::Web3) => map_web3_requests(req, context),
-        Ok(RpcNamespace::Net) => map_net_requests(req, context).await,
-        Ok(RpcNamespace::Mempool) => map_mempool_requests(req, context),
-        Ok(RpcNamespace::Engine) => Err(RpcErr::Internal(
-            "Engine namespace not allowed in map_http_requests".to_owned(),
-        )),
-        Err(rpc_err) => Err(rpc_err),
+    let namespace = match req.namespace() {
+        Ok(ns) => ns,
+        Err(rpc_err) => return Err(rpc_err),
+    };
+    // Engine is served on the authenticated port only; treat as not found here.
+    if matches!(namespace, RpcNamespace::Engine) || !context.allowed_namespaces.contains(&namespace)
+    {
+        return Err(RpcErr::MethodNotFound(req.method.clone()));
+    }
+    match namespace {
+        RpcNamespace::Eth => map_eth_requests(req, context).await,
+        RpcNamespace::Admin => map_admin_requests(req, context).await,
+        RpcNamespace::Debug => map_debug_requests(req, context).await,
+        RpcNamespace::Web3 => map_web3_requests(req, context),
+        RpcNamespace::Net => map_net_requests(req, context).await,
+        RpcNamespace::Mempool => map_mempool_requests(req, context),
+        // Engine is rejected by the guard above.
+        RpcNamespace::Engine => unreachable!(),
     }
 }
 
@@ -1191,6 +1206,77 @@ mod tests {
     use std::io::BufReader;
     use std::str::FromStr;
     use std::{fs::File, path::Path};
+
+    /// With the default `--http.api` allowlist (`eth,net,web3`), requests for
+    /// disabled namespaces like `debug_*` must return MethodNotFound and never
+    /// reach the handler.
+    #[tokio::test]
+    async fn http_api_allowlist_blocks_debug_namespace_by_default() {
+        let body = r#"{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x0"],"id":1}"#;
+        let request: RpcRequest = serde_json::from_str(body).unwrap();
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let mut context = default_context_with_storage(storage).await;
+        context.allowed_namespaces = Arc::new(crate::DEFAULT_HTTP_API.iter().copied().collect());
+
+        let result = map_http_requests(&request, context).await;
+        match result {
+            Err(RpcErr::MethodNotFound(method)) => {
+                assert_eq!(method, "debug_traceTransaction");
+            }
+            other => panic!("expected MethodNotFound, got {other:?}"),
+        }
+    }
+
+    /// The default allowlist must keep `eth_*`, `net_*`, and `web3_*` reachable.
+    #[tokio::test]
+    async fn http_api_allowlist_default_routes_standard_namespaces() {
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let mut context = default_context_with_storage(storage).await;
+        context.allowed_namespaces = Arc::new(crate::DEFAULT_HTTP_API.iter().copied().collect());
+
+        for method in ["eth_chainId", "net_version", "web3_clientVersion"] {
+            let body = format!(r#"{{"jsonrpc":"2.0","method":"{method}","params":[],"id":1}}"#);
+            let request: RpcRequest = serde_json::from_str(&body).unwrap();
+            let result = map_http_requests(&request, context.clone()).await;
+            assert!(
+                !matches!(result, Err(RpcErr::MethodNotFound(_))),
+                "default allowlist should route {method}, got {result:?}"
+            );
+        }
+    }
+
+    /// The Engine namespace must never be served over the public HTTP endpoint,
+    /// even if an operator passes `engine` to `--http.api` (the CLI rejects it,
+    /// but defense-in-depth: the dispatcher still refuses).
+    #[tokio::test]
+    async fn engine_namespace_rejected_on_http() {
+        let body = r#"{"jsonrpc":"2.0","method":"engine_forkchoiceUpdatedV3","params":[],"id":1}"#;
+        let request: RpcRequest = serde_json::from_str(body).unwrap();
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let mut context = default_context_with_storage(storage).await;
+        let mut all_with_engine: HashSet<RpcNamespace> =
+            crate::test_utils::all_namespaces_for_tests();
+        all_with_engine.insert(RpcNamespace::Engine);
+        context.allowed_namespaces = Arc::new(all_with_engine);
+
+        let result = map_http_requests(&request, context).await;
+        assert!(matches!(result, Err(RpcErr::MethodNotFound(_))));
+    }
 
     // Maps string rpc response to RpcSuccessResponse as serde Value
     // This is used to avoid failures due to field order and allow easier string comparisons for responses

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -829,12 +829,20 @@ where
     E: Into<RpcErrorMetadata>,
 {
     match req.method.as_str() {
-        "eth_subscribe" => {
-            let result = handle_eth_subscribe(&req, context, out_tx, subscription_ids).await;
-            rpc_response(req.id, result).ok()
-        }
-        "eth_unsubscribe" => {
-            let result = handle_eth_unsubscribe(&req, context, subscription_ids).await;
+        "eth_subscribe" | "eth_unsubscribe" => {
+            // Subscriptions are part of the `eth` namespace and must obey the
+            // same `--http.api` allowlist as regular `eth_*` requests; otherwise
+            // a node started with e.g. `--http.api web3` would still expose
+            // `eth_subscribe("newHeads")` over WS.
+            if !context.allowed_namespaces.contains(&RpcNamespace::Eth) {
+                let err: Result<Value, RpcErr> = Err(RpcErr::MethodNotFound(req.method.clone()));
+                return rpc_response(req.id, err).ok();
+            }
+            let result = if req.method == "eth_subscribe" {
+                handle_eth_subscribe(&req, context, out_tx, subscription_ids).await
+            } else {
+                handle_eth_unsubscribe(&req, context, subscription_ids).await
+            };
             rpc_response(req.id, result).ok()
         }
         _ => {
@@ -1253,6 +1261,57 @@ mod tests {
                 "default allowlist should route {method}, got {result:?}"
             );
         }
+    }
+
+    /// WebSocket subscriptions live in the `eth` namespace and must obey the
+    /// same `--http.api` allowlist as regular `eth_*` requests. A node started
+    /// without `eth` in the allowlist must not serve `eth_subscribe` over WS.
+    #[tokio::test]
+    async fn ws_subscribe_blocked_when_eth_namespace_disabled() {
+        let body = r#"{"jsonrpc":"2.0","method":"eth_subscribe","params":["newHeads"],"id":1}"#;
+        let request: RpcRequest = serde_json::from_str(body).unwrap();
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let mut context = default_context_with_storage(storage).await;
+        // Allow everything except `eth` so the WS path is the only thing under test.
+        let mut without_eth: HashSet<RpcNamespace> = crate::test_utils::all_namespaces_for_tests();
+        without_eth.remove(&RpcNamespace::Eth);
+        context.allowed_namespaces = Arc::new(without_eth);
+
+        let (out_tx, _out_rx) = tokio::sync::mpsc::channel::<String>(1);
+        let mut subscription_ids: Vec<String> = Vec::new();
+        let route_request = |_req: RpcRequest| async move {
+            panic!(
+                "route_request must not be called for eth_subscribe when the namespace is disabled"
+            );
+            #[allow(unreachable_code)]
+            Ok::<Value, RpcErr>(Value::Null)
+        };
+
+        let response = process_ws_request(
+            request,
+            &context,
+            &out_tx,
+            &mut subscription_ids,
+            &route_request,
+        )
+        .await
+        .expect("process_ws_request should return an error response");
+
+        let err = response.get("error").expect("expected error field");
+        assert_eq!(
+            err.get("code").and_then(|v| v.as_i64()),
+            Some(-32601),
+            "expected MethodNotFound (-32601), got {response}"
+        );
+        assert!(
+            subscription_ids.is_empty(),
+            "no subscription should have been registered"
+        );
     }
 
     /// The Engine namespace must never be served over the public HTTP endpoint,

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -959,13 +959,7 @@ pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Resu
         Ok(ns) => ns,
         Err(rpc_err) => return Err(rpc_err),
     };
-    // Engine is served on the authenticated port only; reject it here regardless
-    // of the allowlist. The CLI parser already rejects `--http.api engine`, but
-    // `allowed_namespaces` can also be built programmatically (e.g. in tests or
-    // future call sites), so this explicit guard is defense-in-depth: even if
-    // Engine ends up in the set, HTTP dispatch must refuse it.
-    if matches!(namespace, RpcNamespace::Engine) || !context.allowed_namespaces.contains(&namespace)
-    {
+    if !context.allowed_namespaces.contains(&namespace) {
         return Err(RpcErr::MethodNotFound(req.method.clone()));
     }
     match namespace {
@@ -975,8 +969,11 @@ pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Resu
         RpcNamespace::Web3 => map_web3_requests(req, context),
         RpcNamespace::Net => map_net_requests(req, context).await,
         RpcNamespace::Mempool => map_mempool_requests(req, context),
-        // Engine is rejected by the guard above.
-        RpcNamespace::Engine => unreachable!(),
+        // Engine is served on the authenticated port only. The CLI parser
+        // already rejects `--http.api engine`, but `allowed_namespaces` can
+        // also be built programmatically (e.g. in tests or future call sites),
+        // so HTTP dispatch must refuse Engine even if it ends up in the set.
+        RpcNamespace::Engine => Err(RpcErr::MethodNotFound(req.method.clone())),
     }
 }
 

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -959,7 +959,11 @@ pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Resu
         Ok(ns) => ns,
         Err(rpc_err) => return Err(rpc_err),
     };
-    // Engine is served on the authenticated port only; treat as not found here.
+    // Engine is served on the authenticated port only; reject it here regardless
+    // of the allowlist. The CLI parser already rejects `--http.api engine`, but
+    // `allowed_namespaces` can also be built programmatically (e.g. in tests or
+    // future call sites), so this explicit guard is defense-in-depth: even if
+    // Engine ends up in the set, HTTP dispatch must refuse it.
     if matches!(namespace, RpcNamespace::Engine) || !context.allowed_namespaces.contains(&namespace)
     {
         return Err(RpcErr::MethodNotFound(req.method.clone()));

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -8,6 +8,7 @@
 use crate::{
     eth::gas_tip_estimator::GasTipEstimator,
     rpc::{ClientVersion, NodeData, RpcApiContext, start_api, start_block_executor},
+    utils::RpcNamespace,
 };
 use bytes::Bytes;
 use ethrex_blockchain::Blockchain;
@@ -32,7 +33,7 @@ use ethrex_storage::{EngineType, Store};
 use hex_literal::hex;
 use secp256k1::SecretKey;
 use spawned_concurrency::tasks::ActorRef;
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{collections::HashSet, net::SocketAddr, str::FromStr, sync::Arc};
 use tokio::sync::Mutex as TokioMutex;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 // Base price for each test transaction.
@@ -258,10 +259,23 @@ pub async fn start_test_api() -> tokio::task::JoinHandle<()> {
             None,
             DEFAULT_BUILDER_GAS_CEIL,
             String::new(),
+            all_namespaces_for_tests(),
         )
         .await
         .unwrap()
     })
+}
+
+/// All known namespaces, used in tests so handlers from any namespace can be exercised.
+pub fn all_namespaces_for_tests() -> HashSet<RpcNamespace> {
+    HashSet::from([
+        RpcNamespace::Eth,
+        RpcNamespace::Net,
+        RpcNamespace::Web3,
+        RpcNamespace::Debug,
+        RpcNamespace::Admin,
+        RpcNamespace::Mempool,
+    ])
 }
 
 pub async fn default_context_with_storage(storage: Store) -> RpcApiContext {
@@ -293,6 +307,7 @@ pub async fn default_context_with_storage(storage: Store) -> RpcApiContext {
         gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
         block_worker_channel,
         ws: None,
+        allowed_namespaces: Arc::new(all_namespaces_for_tests()),
     }
 }
 

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -237,19 +237,6 @@ pub enum RpcNamespace {
 }
 
 impl RpcNamespace {
-    /// Returns the lowercase prefix used in method names (e.g., "eth", "txpool").
-    pub fn as_prefix(&self) -> &'static str {
-        match self {
-            RpcNamespace::Engine => "engine",
-            RpcNamespace::Eth => "eth",
-            RpcNamespace::Admin => "admin",
-            RpcNamespace::Debug => "debug",
-            RpcNamespace::Web3 => "web3",
-            RpcNamespace::Net => "net",
-            RpcNamespace::Mempool => "txpool",
-        }
-    }
-
     /// Parses a namespace name from its CLI/method-prefix form.
     pub fn from_prefix(s: &str) -> Option<Self> {
         match s {
@@ -322,17 +309,7 @@ impl RpcRequest {
 }
 
 pub fn resolve_namespace(maybe_namespace: &str, method: String) -> Result<RpcNamespace, RpcErr> {
-    match maybe_namespace {
-        "engine" => Ok(RpcNamespace::Engine),
-        "eth" => Ok(RpcNamespace::Eth),
-        "admin" => Ok(RpcNamespace::Admin),
-        "debug" => Ok(RpcNamespace::Debug),
-        "web3" => Ok(RpcNamespace::Web3),
-        "net" => Ok(RpcNamespace::Net),
-        // TODO: The namespace is set to match geth's namespace for compatibility, consider changing it in the future
-        "txpool" => Ok(RpcNamespace::Mempool),
-        _ => Err(RpcErr::MethodNotFound(method)),
-    }
+    RpcNamespace::from_prefix(maybe_namespace).ok_or(RpcErr::MethodNotFound(method))
 }
 
 impl Default for RpcRequest {

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -218,6 +218,7 @@ impl From<ethrex_crypto::CryptoError> for RpcErr {
 ///
 /// Methods are namespaced by prefix (e.g., `eth_getBalance` is in the `Eth` namespace).
 /// Different namespaces may have different authentication requirements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RpcNamespace {
     /// Engine API methods for consensus client communication (requires JWT auth).
     Engine,
@@ -233,6 +234,35 @@ pub enum RpcNamespace {
     Net,
     /// Transaction pool inspection methods (exposed as `txpool_*`).
     Mempool,
+}
+
+impl RpcNamespace {
+    /// Returns the lowercase prefix used in method names (e.g., "eth", "txpool").
+    pub fn as_prefix(&self) -> &'static str {
+        match self {
+            RpcNamespace::Engine => "engine",
+            RpcNamespace::Eth => "eth",
+            RpcNamespace::Admin => "admin",
+            RpcNamespace::Debug => "debug",
+            RpcNamespace::Web3 => "web3",
+            RpcNamespace::Net => "net",
+            RpcNamespace::Mempool => "txpool",
+        }
+    }
+
+    /// Parses a namespace name from its CLI/method-prefix form.
+    pub fn from_prefix(s: &str) -> Option<Self> {
+        match s {
+            "engine" => Some(RpcNamespace::Engine),
+            "eth" => Some(RpcNamespace::Eth),
+            "admin" => Some(RpcNamespace::Admin),
+            "debug" => Some(RpcNamespace::Debug),
+            "web3" => Some(RpcNamespace::Web3),
+            "net" => Some(RpcNamespace::Net),
+            "txpool" => Some(RpcNamespace::Mempool),
+            _ => None,
+        }
+    }
 }
 
 /// JSON-RPC request identifier.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -165,16 +165,22 @@ P2P options:
 
 RPC options:
       --http.addr <ADDRESS>
-          Listening address for the http rpc server.
+          Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).
 
           [env: ETHREX_HTTP_ADDR=]
-          [default: 0.0.0.0]
+          [default: 127.0.0.1]
 
       --http.port <PORT>
           Listening port for the http rpc server.
 
           [env: ETHREX_HTTP_PORT=]
           [default: 8545]
+
+      --http.api <NAMESPACES>
+          Comma-separated list of JSON-RPC namespaces exposed on the public HTTP and WebSocket endpoints. Defaults to `eth,net,web3`. Enable `admin`, `debug` or `txpool` only when needed; the `engine` namespace is served on the authenticated RPC port and cannot be toggled here.
+
+          [env: ETHREX_HTTP_API=]
+          [default: eth,net,web3]
 
       --ws.enabled
           Enable websocket rpc server. Disabled by default.
@@ -369,16 +375,22 @@ P2P options:
 
 RPC options:
       --http.addr <ADDRESS>
-          Listening address for the http rpc server.
+          Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).
 
           [env: ETHREX_HTTP_ADDR=]
-          [default: 0.0.0.0]
+          [default: 127.0.0.1]
 
       --http.port <PORT>
           Listening port for the http rpc server.
 
           [env: ETHREX_HTTP_PORT=]
           [default: 8545]
+
+      --http.api <NAMESPACES>
+          Comma-separated list of JSON-RPC namespaces exposed on the public HTTP and WebSocket endpoints. Defaults to `eth,net,web3`. Enable `admin`, `debug` or `txpool` only when needed; the `engine` namespace is served on the authenticated RPC port and cannot be toggled here.
+
+          [env: ETHREX_HTTP_API=]
+          [default: eth,net,web3]
 
       --ws.enabled
           Enable websocket rpc server. Disabled by default.
@@ -672,6 +684,18 @@ L2 options:
 
           [env: SPONSOR_PRIVATE_KEY=]
           [default: 0xffd790338a2798b648806fc8635ac7bf14af15425fed0c8f25bcc5febaa9b192]
+
+      --sponsored-gas-limit <GAS_LIMIT>
+          Maximum gas limit for sponsored transactions. Transactions that estimate more gas than this will be rejected.
+
+          [env: ETHREX_SPONSORED_GAS_LIMIT=]
+          [default: 500000]
+
+      --http.api.ethrex <BOOLEAN>
+          Expose L2-specific ethrex_* RPC methods over HTTP/WS. Enabled by default for L2 nodes.
+
+          [env: ETHREX_HTTP_API_ETHREX=]
+          [default: true]
 
 Monitor options:
       --no-monitor

--- a/docs/eip-8025-zkboost-testnet.md
+++ b/docs/eip-8025-zkboost-testnet.md
@@ -156,7 +156,6 @@ Four components, four terminals (or tmux windows).
 ethrex/target/release/ethrex \
   --network ~/eip8025-testnet/genesis/genesis.json \
   --http.port 8545 \
-  --http.addr 0.0.0.0 \
   --http.api eth,net,web3,debug \
   --authrpc.port 8551 \
   --authrpc.jwtsecret ~/eip8025-testnet/jwtsecret \
@@ -165,7 +164,7 @@ ethrex/target/release/ethrex \
   --datadir /tmp/ethrex-eip8025-data
 ```
 
-`--http.api eth,net,web3,debug` is required so zkboost can call `debug_executionWitnessByBlockHash` and `debug_chainConfig`; the default allowlist (`eth,net,web3`) blocks the `debug_*` namespace.
+`--http.api eth,net,web3,debug` is required so zkboost can call `debug_executionWitnessByBlockHash` and `debug_chainConfig`; the default allowlist (`eth,net,web3`) blocks the `debug_*` namespace. zkboost runs on the same host and talks to `http://localhost:8545`, so the loopback default for `--http.addr` is fine.
 
 ### Terminal 2: zkboost
 

--- a/docs/eip-8025-zkboost-testnet.md
+++ b/docs/eip-8025-zkboost-testnet.md
@@ -157,12 +157,15 @@ ethrex/target/release/ethrex \
   --network ~/eip8025-testnet/genesis/genesis.json \
   --http.port 8545 \
   --http.addr 0.0.0.0 \
+  --http.api eth,net,web3,debug \
   --authrpc.port 8551 \
   --authrpc.jwtsecret ~/eip8025-testnet/jwtsecret \
   --syncmode full \
   --p2p.disabled \
   --datadir /tmp/ethrex-eip8025-data
 ```
+
+`--http.api eth,net,web3,debug` is required so zkboost can call `debug_executionWitnessByBlockHash` and `debug_chainConfig`; the default allowlist (`eth,net,web3`) blocks the `debug_*` namespace.
 
 ### Terminal 2: zkboost
 

--- a/docs/getting-started/installation/docker_images.md
+++ b/docs/getting-started/installation/docker_images.md
@@ -56,6 +56,7 @@ docker run \
     -p 9090:9090 \
     --name ethrex \
     ghcr.io/lambdaclass/ethrex \
+    --http.addr 0.0.0.0 \
     --authrpc.addr 0.0.0.0
 ```
 
@@ -68,6 +69,8 @@ docker run \
   - `30303`: P2P networking (TCP/UDP)
   - `9090`: Metrics (TCP)
 - Mounts the Docker volume `ethrex` to persist blockchain data
+
+`--http.addr 0.0.0.0` is required inside the container so the published port `8545` is reachable from the host. The flag only changes the container-internal bind; whether the RPC port is exposed beyond the host is still controlled by the `-p 8545:8545` mapping (and any firewall in front of the host). Only enable additional JSON-RPC namespaces with `--http.api eth,net,web3,...` when you actually need them; `admin_*`, `debug_*`, and `txpool_*` are unauthenticated.
 
 **Tip:** You can add more Ethrex CLI arguments at the end of the command as needed.
 

--- a/docs/internal/l1/syncing_holesky.md
+++ b/docs/internal/l1/syncing_holesky.md
@@ -17,8 +17,10 @@ Pass holesky as a network and the jwt secret we set in the previous step.
 This will launch the node in full sync mode, in order to test out snap sync you can add the flag `--syncmode snap`.
 
 ```bash
-cargo run --release --bin ethrex -- --http.addr 0.0.0.0 --network holesky --authrpc.jwtsecret ~/secrets/jwt.hex
+cargo run --release --bin ethrex -- --network holesky --authrpc.jwtsecret ~/secrets/jwt.hex
 ```
+
+The HTTP JSON-RPC server binds to `127.0.0.1` by default and only serves the `eth,net,web3` namespaces. If you need to query state from another host or use `debug_*` methods during sync, pass `--http.addr 0.0.0.0 --http.api eth,net,web3,debug`.
 
 ### Step 3: Set up a Consensus Node
 

--- a/docs/internal/l1/syncing_holesky.md
+++ b/docs/internal/l1/syncing_holesky.md
@@ -20,7 +20,7 @@ This will launch the node in full sync mode, in order to test out snap sync you 
 cargo run --release --bin ethrex -- --network holesky --authrpc.jwtsecret ~/secrets/jwt.hex
 ```
 
-The HTTP JSON-RPC server binds to `127.0.0.1` by default and only serves the `eth,net,web3` namespaces. If you need to query state from another host or use `debug_*` methods during sync, pass `--http.addr 0.0.0.0 --http.api eth,net,web3,debug`.
+The HTTP JSON-RPC server binds to `127.0.0.1` by default and only serves the `eth,net,web3` namespaces. To call `debug_*` methods during sync from the same machine, pass `--http.api eth,net,web3,debug`. To reach the RPC port from another host, pass `--http.addr 0.0.0.0`.
 
 ### Step 3: Set up a Consensus Node
 

--- a/docs/l1/architecture/crate_map.md
+++ b/docs/l1/architecture/crate_map.md
@@ -141,12 +141,15 @@ impl VM {
 **Purpose:** JSON-RPC API server.
 
 **Supported Namespaces:**
-- `eth_*` - Standard Ethereum methods
-- `debug_*` - Debugging and tracing
-- `txpool_*` - Mempool inspection
-- `admin_*` - Node administration
-- `engine_*` - Consensus client communication
-- `web3_*` - Web3 utilities
+- `eth_*` - Standard Ethereum methods (HTTP, default-enabled)
+- `net_*` - Network information (HTTP, default-enabled)
+- `web3_*` - Web3 utilities (HTTP, default-enabled)
+- `debug_*` - Debugging and tracing (HTTP, opt-in via `--http.api`)
+- `admin_*` - Node administration (HTTP, opt-in via `--http.api`)
+- `txpool_*` - Mempool inspection (HTTP, opt-in via `--http.api`)
+- `engine_*` - Consensus client communication (auth-rpc port only, JWT-authenticated)
+
+Namespaces not in the `--http.api` allowlist return `MethodNotFound` over HTTP/WS. The `engine` namespace is served exclusively on the authenticated RPC port and cannot be exposed via `--http.api`.
 
 **Architecture:**
 ```rust

--- a/docs/l1/architecture/overview.md
+++ b/docs/l1/architecture/overview.md
@@ -229,7 +229,9 @@ Key configuration options:
 | `--datadir` | Data directory for DB and keys | `~/.ethrex` |
 | `--syncmode` | Sync mode (`full` or `snap`) | `snap` |
 | `--authrpc.port` | Engine API port | `8551` |
+| `--http.addr` | JSON-RPC HTTP bind address | `127.0.0.1` |
 | `--http.port` | JSON-RPC HTTP port | `8545` |
+| `--http.api` | JSON-RPC namespaces enabled over HTTP/WS | `eth,net,web3` |
 | `--discovery.port` | P2P discovery port | `30303` |
 
 See [Configuration](../running/configuration.md) for the complete reference.

--- a/docs/l1/running/configuration.md
+++ b/docs/l1/running/configuration.md
@@ -39,7 +39,15 @@ Default ports used by ethrex:
 
 You can change ports with the corresponding flags: `--http.port`, `--authrpc.port`, `--p2p.port`, `--discovery.port`, `--metrics.port`.
 
-All services listen on `0.0.0.0` by default, except for the auth RPC, which listens on `127.0.0.1`. This can also be changed with flags (e.g., `--http.addr`).
+The HTTP JSON-RPC and Auth RPC servers listen on `127.0.0.1` by default so a fresh install on a public host is not exposed to the open internet. P2P networking and metrics listen on `0.0.0.0`. Use the corresponding `--http.addr`, `--authrpc.addr`, `--metrics.addr` flags to override.
+
+The HTTP RPC also restricts which JSON-RPC namespaces it serves. By default only `eth`, `net`, and `web3` are reachable; enable `admin`, `debug`, or `txpool` explicitly with `--http.api`, for example:
+
+```sh
+ethrex --http.addr 0.0.0.0 --http.api eth,net,web3,debug
+```
+
+Only bind the HTTP RPC on a public interface when the node sits behind a trusted firewall or reverse proxy; the `admin_*`, `debug_*`, and `txpool_*` namespaces are unauthenticated.
 
 ## Log Levels
 

--- a/docs/l1/running/configuration.md
+++ b/docs/l1/running/configuration.md
@@ -44,10 +44,10 @@ The HTTP JSON-RPC and Auth RPC servers listen on `127.0.0.1` by default so a fre
 The HTTP RPC also restricts which JSON-RPC namespaces it serves. By default only `eth`, `net`, and `web3` are reachable; enable `admin`, `debug`, or `txpool` explicitly with `--http.api`, for example:
 
 ```sh
-ethrex --http.addr 0.0.0.0 --http.api eth,net,web3,debug
+ethrex --http.api eth,net,web3,debug
 ```
 
-Only bind the HTTP RPC on a public interface when the node sits behind a trusted firewall or reverse proxy; the `admin_*`, `debug_*`, and `txpool_*` namespaces are unauthenticated.
+`--http.api` is independent of `--http.addr`: it controls which methods are served on the port, not who can reach it. If you also need remote callers to reach the RPC port, pass `--http.addr 0.0.0.0` — only do so when the node sits behind a trusted firewall or reverse proxy, since the `admin_*`, `debug_*`, and `txpool_*` namespaces are unauthenticated.
 
 ## Log Levels
 

--- a/docs/workflows/debug_execution_witness_benchmarking.md
+++ b/docs/workflows/debug_execution_witness_benchmarking.md
@@ -64,6 +64,8 @@ lighthouse bn --network <NETWORK> --execution-endpoint http://localhost:8551 --e
 
 ### Ethrex (Execution Client)
 
+> **Note on RPC defaults:** As of the HTTP JSON-RPC hardening change, ethrex binds the HTTP RPC to `127.0.0.1` and only serves `eth,net,web3` by default. The `debug_*` namespace (which `debug_executionWitness` belongs to) is **not** in the default allowlist, so this benchmark will fail with `MethodNotFound` unless you opt in with `--http.api`. The example below already enables it.
+
 ```bash
 cargo run --release --bin ethrex -- --http.addr 0.0.0.0 --http.api eth,net,web3,debug --network <NETWORK> --authrpc.jwtsecret ~/secrets/jwt.hex --precompute-witnesses
 ```

--- a/docs/workflows/debug_execution_witness_benchmarking.md
+++ b/docs/workflows/debug_execution_witness_benchmarking.md
@@ -65,11 +65,13 @@ lighthouse bn --network <NETWORK> --execution-endpoint http://localhost:8551 --e
 ### Ethrex (Execution Client)
 
 ```bash
-cargo run --release --bin ethrex -- --http.addr 0.0.0.0 --network <NETWORK> --authrpc.jwtsecret ~/secrets/jwt.hex --precompute-witnesses
+cargo run --release --bin ethrex -- --http.addr 0.0.0.0 --http.api eth,net,web3,debug --network <NETWORK> --authrpc.jwtsecret ~/secrets/jwt.hex --precompute-witnesses
 ```
 
 **Critical flags:**
 - `--precompute-witnesses` - **REQUIRED** for this benchmark. Generates and stores execution witnesses during payload execution.
+- `--http.api eth,net,web3,debug` - **REQUIRED** for this benchmark. The default allowlist (`eth,net,web3`) does not expose `debug_executionWitness`; add `debug` so the benchmark can call it.
+- `--http.addr 0.0.0.0` - only needed if the load generator runs on a different host. The default binds on `127.0.0.1`.
 
 **Notes:**
 - Run in release mode for performance

--- a/fixtures/networks/default.yaml
+++ b/fixtures/networks/default.yaml
@@ -28,10 +28,10 @@ participants:
     validator_count: 32
     # snooper_enabled: true
     # Preserve the previous devnet-only RPC behavior after the default RPC
-    # hardening: bind on all interfaces inside the kurtosis network and expose
-    # admin/debug/txpool so test tooling can hit them.
+    # hardening: expose admin/debug/txpool so test tooling can hit them.
+    # --http.addr is already set to 0.0.0.0 by ethereum-package's ethrex
+    # launcher, so we only need to widen the namespace allowlist here.
     el_extra_params:
-      - "--http.addr=0.0.0.0"
       - "--http.api=eth,net,web3,debug,admin,txpool"
 
 ethereum_metrics_exporter_enabled: true

--- a/fixtures/networks/default.yaml
+++ b/fixtures/networks/default.yaml
@@ -27,6 +27,12 @@ participants:
     cl_image: sigp/lighthouse:v8.0.0-rc.1
     validator_count: 32
     # snooper_enabled: true
+    # Preserve the previous devnet-only RPC behavior after the default RPC
+    # hardening: bind on all interfaces inside the kurtosis network and expose
+    # admin/debug/txpool so test tooling can hit them.
+    el_extra_params:
+      - "--http.addr=0.0.0.0"
+      - "--http.api=eth,net,web3,debug,admin,txpool"
 
 ethereum_metrics_exporter_enabled: true
 

--- a/tooling/l2/dev/docker-compose.yaml
+++ b/tooling/l2/dev/docker-compose.yaml
@@ -394,7 +394,7 @@ services:
       - source: ethrex-sponsor-addresses
         target: /usr/local/bin/sponsorable-addresses.txt
     command: >
-      l2 --dev --no-monitor --proof-coordinator.addr 0.0.0.0 --admin-server.addr 0.0.0.0 --block-producer.block-time 1000 --sponsorable-addresses sponsorable-addresses.txt
+      l2 --dev --no-monitor --http.addr 0.0.0.0 --http.api eth,net,web3,debug,txpool --proof-coordinator.addr 0.0.0.0 --admin-server.addr 0.0.0.0 --block-producer.block-time 1000 --sponsorable-addresses sponsorable-addresses.txt
 
   ethrex-prover:
     container_name: ethrex-prover

--- a/tooling/sync/Makefile
+++ b/tooling/sync/Makefile
@@ -185,6 +185,7 @@ start-ethrex: ## Start ethrex for the network given by NETWORK.
 	@echo $(RUSTFLAGS)
 	cd $(ETHREX_DIR) && RUST_LOG=3 cargo run $(PROFILING_CFG) --release --features "rocksdb sync-test metrics" --bin ethrex -- \
     		--http.addr 0.0.0.0 \
+    		--http.api eth,net,web3,admin \
     		--http.port 8545 \
     		--authrpc.port 8551 \
     		--p2p.port 30303\
@@ -232,7 +233,7 @@ server-sync:
 
 	sleep 0.2
 
-	tmux new-window -t sync:2 -n ethrex "cd ../.. && ulimit -n 1000000 && rm -rf ~/.local/share/ethrex && RUST_LOG=info,ethrex_p2p::sync=debug $(if $(DEBUG_ASSERT),RUSTFLAGS='-C debug-assertions=yes') $(if $(HEALING),SKIP_START_SNAP_SYNC=1) cargo run $(PROFILING_CFG) --release --bin ethrex --features rocksdb --  --http.addr 0.0.0.0 --metrics --metrics.port 3701 --network $(SERVER_SYNC_NETWORK) $(if $(MEMORY),--datadir memory) --authrpc.jwtsecret ~/secrets/jwt.hex $(if $(or $(FULL_SYNC),$(HEALING)),--syncmode full)  2>&1 | tee $(LOGS_FILE)"
+	tmux new-window -t sync:2 -n ethrex "cd ../.. && ulimit -n 1000000 && rm -rf ~/.local/share/ethrex && RUST_LOG=info,ethrex_p2p::sync=debug $(if $(DEBUG_ASSERT),RUSTFLAGS='-C debug-assertions=yes') $(if $(HEALING),SKIP_START_SNAP_SYNC=1) cargo run $(PROFILING_CFG) --release --bin ethrex --features rocksdb --  --http.addr 0.0.0.0 --http.api eth,net,web3,admin --metrics --metrics.port 3701 --network $(SERVER_SYNC_NETWORK) $(if $(MEMORY),--datadir memory) --authrpc.jwtsecret ~/secrets/jwt.hex $(if $(or $(FULL_SYNC),$(HEALING)),--syncmode full)  2>&1 | tee $(LOGS_FILE)"
 
 # ==============================================================================
 # Docker Compose Multi-Network Snapsync

--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -80,6 +80,7 @@ services:
       - ethrex-hoodi:/data
     command: >
       --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
       --network hoodi
       --authrpc.addr 0.0.0.0
       --authrpc.jwtsecret /secrets/jwt.hex
@@ -129,6 +130,7 @@ services:
       - ethrex-sepolia:/data
     command: >
       --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
       --network sepolia
       --authrpc.addr 0.0.0.0
       --authrpc.jwtsecret /secrets/jwt.hex
@@ -178,6 +180,7 @@ services:
       - ethrex-mainnet:/data
     command: >
       --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
       --network mainnet
       --authrpc.addr 0.0.0.0
       --authrpc.jwtsecret /secrets/jwt.hex
@@ -226,6 +229,7 @@ services:
       - ethrex-hoodi-2:/data
     command: >
       --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
       --network hoodi
       --authrpc.addr 0.0.0.0
       --authrpc.jwtsecret /secrets/jwt.hex

--- a/tooling/sync/docker-compose.yml
+++ b/tooling/sync/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - RUST_LOG=ethrex_p2p::rlpx::eth::blocks=off,ethrex_p2p::sync=debug,ethrex_p2p::network=info,spawned_concurrency::tasks::gen_server=off
     command: >
       --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
       --authrpc.addr 0.0.0.0
       --network hoodi
       --authrpc.jwtsecret /secrets/jwt.hex


### PR DESCRIPTION
## Summary

- Bind `--http.addr` to `127.0.0.1` by default instead of `0.0.0.0`.
- Add `--http.api` flag (default `eth,net,web3`) that gates HTTP/WS JSON-RPC dispatch on a namespace allowlist. Disabled namespaces return `MethodNotFound`.
- Add `--http.api.ethrex` (L2 only, default `true`) for the L2-specific `ethrex_*` namespace.
- Preserve current devnet behavior by passing `--http.addr=0.0.0.0 --http.api=eth,net,web3,debug,admin,txpool` to the ethrex participant in `fixtures/networks/default.yaml`.
- Update in-tree tooling (sync compose/Makefile, L2 dev compose) to opt into the namespaces they actually use.
- Update in-tree docs and CLI reference to reflect the new defaults.

The two new defaults are independent. `--http.addr` controls who can reach the RPC port (loopback vs. remote). `--http.api` controls which methods are served on the port. To call `debug_*` from the same machine, pass `--http.api ...,debug`; you do not need `--http.addr 0.0.0.0` for that.

> **BREAKING:** the HTTP JSON-RPC now binds to `127.0.0.1` and only serves `eth,net,web3` by default. Operators that want remote callers must pass `--http.addr 0.0.0.0`. Operators that want `admin_*`, `debug_*`, or `txpool_*` (locally or remotely) must pass `--http.api` to enable those namespaces.

## Why

Before this change, a fresh `ethrex` install:

1. Bound the HTTP JSON-RPC to `0.0.0.0`, so any host that could route to the machine could reach port 8545.
2. Served every JSON-RPC namespace on that endpoint, including `admin_*`, `debug_*`, and `txpool_*`, with **no authentication**. `handle_http_request` (`crates/networking/rpc/rpc.rs:647`) takes no auth header and never calls `authenticate()`; only the engine-RPC handler at `:673` does JWT.

So before this PR: anyone who could reach port 8545 could call:

- `admin_addPeer(enode)` — inject a peer of their choice into your peer set.
- `admin_removePeer(enode)` — kick a peer you depend on.
- `admin_setLogLevel("trace")` — flip your node to trace logging, fill the disk, slow it down.
- `admin_nodeInfo` / `admin_peers` / `admin_peerScores` — full enumeration of your topology.
- `debug_traceTransaction` / `debug_traceBlockByNumber` — re-execute arbitrary blocks under tracing; trivial CPU-pinning DoS.
- `txpool_content` / `txpool_inspect` — read every pending tx in your local mempool in real time.

No JWT, no API key, no source check, nothing. Just `POST /` and you're in. And with the old `--http.addr` defaulting to `0.0.0.0`, a fresh install on any cloud VM without a host firewall exposed all of that to the public internet on port 8545.

The other major EL clients (geth, reth, nethermind, besu) all bind the HTTP RPC to `127.0.0.1` by default and only expose `eth,net,web3` (or nothing at all); ethrex was an outlier.

After this change:

- The HTTP RPC is loopback-only out of the box, so a fresh install behind no firewall is not exposed.
- Even when an operator opts in to `--http.addr 0.0.0.0` (reverse proxy, docker, kurtosis), only `eth,net,web3` are reachable unless they also pass `--http.api` to enable additional namespaces. They have to make a deliberate decision to expose `admin`/`debug`/`txpool`.
- The two new defaults close two different doors: loopback prevents remote reach even if the operator enables admin/debug/txpool, and the allowlist prevents unsafe namespaces from being served even if the operator binds `0.0.0.0`.
- The `engine` namespace is doubly protected: the CLI parser rejects `--http.api engine`, and `map_http_requests` rejects it even if the set is constructed in code. It is only served on the authenticated RPC port (which already defaulted to `127.0.0.1`).

Requiring JWT (or some other auth) for `admin_*` even when it's exposed is the proper long-term fix — that's how geth's `--authrpc.api admin,debug` pattern works. Out of scope here; worth a follow-up.

## Implementation notes

- `RpcApiContext` now carries an `Arc<HashSet<RpcNamespace>>` allowlist. `map_http_requests` returns `MethodNotFound` for namespaces not in the set, matching the behavior operators get from other EL clients.
- L2's `RpcApiContext` reuses the L1 allowlist (so `debug`/`admin`/`txpool` gating is shared) and adds a separate `ethrex_namespace_allowed: bool` for L2-specific methods.
- The WebSocket handler routes through the same `map_http_requests`, so WS is gated transparently.

## Tests

- `crates/networking/rpc/rpc.rs::tests::http_api_allowlist_blocks_debug_namespace_by_default` — `debug_traceTransaction` with the default allowlist returns `MethodNotFound` and never reaches the handler.
- `crates/networking/rpc/rpc.rs::tests::http_api_allowlist_default_routes_standard_namespaces` — default allowlist still routes `eth_*`, `net_*`, `web3_*`.
- `crates/networking/rpc/rpc.rs::tests::engine_namespace_rejected_on_http` — even if `Engine` is somehow placed in the set, HTTP dispatch refuses it.
- `crates/l2/networking/rpc/rpc.rs::tests::ethrex_namespace_blocked_when_disabled` — `ethrex_*` returns `MethodNotFound` when `--http.api.ethrex` is false.
- `cmd/ethrex/cli.rs::tests` — 5 tests covering default `http_addr` is `127.0.0.1`, default `http_api` is `[Eth, Net, Web3]`, parsing comma-separated values, and that `engine` and unknown namespaces are rejected at parse time.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `make lint-l1`, `make lint-l2` all clean.

## Hive will break without a paired upstream PR

The hive client launcher (`ethereum/hive` `clients/ethrex/ethrex.sh`) lives in the upstream hive repo, not in this tree. Once this PR merges, the launcher will keep working for the engine/eth namespaces but `rpc-compat` suites that hit `debug_*` / `admin_*` / `txpool_*` will start returning `MethodNotFound`, and the corresponding hive tests will turn red in CI.

Plan: open a PR against `ethereum/hive` that feature-detects the flag so the same launcher works against both old and new ethrex binaries:

```bash
# Configure RPC. Probe the binary for --http.api support so this script
# works against both old (no allowlist) and new (default allowlist of
# eth,net,web3) ethrex builds.
HTTP_API_FLAG=""
if "$ethrex" --help 2>&1 | grep -q -- '--http.api'; then
    HTTP_API_FLAG="--http.api=eth,net,web3,debug,admin,txpool"
fi
FLAGS="$FLAGS --http.addr=0.0.0.0 --authrpc.addr=0.0.0.0 $HTTP_API_FLAG"
```

The grep-on-help approach avoids hard-coding which ethrex versions support the flag and works regardless of build order across the two repos. The upstream PR can ship before, with, or after this one; whichever lands second won't break hive.

## Test plan

- [ ] CI: `cargo test`, `make lint-l1`, `make lint-l2`
- [ ] Devnet smoke: `kurtosis run --enclave ethrex github.com/lambdaclass/ethrex-package --args-file fixtures/networks/default.yaml` and verify ethrex still answers `debug_traceTransaction` from the kurtosis network
- [ ] Sync tooling: bring up `tooling/sync/docker-compose.yml` and run `peer_top.py` to confirm `admin_*` still works after the new `--http.api` flag
- [ ] Hive: once the paired upstream PR lands, rerun the engine/rpc-compat suites
