### PR TITLE
ci(l1,l2): filter changelog to feat/fix/perf/refactor/revert and exclude chore

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -442,6 +442,8 @@ jobs:
           fromTag: ${{ github.ref_name }}
           toTag: ${{ env.PREVIOUS_TAG }}
           writeToFile: false
+          restrictToTypes: feat,fix,perf,refactor,revert
+          excludeTypes: build,docs,other,style,chore
 
       - name: Finalize Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
**Motivation**

Release notes generated for tag pushes currently include `chore(...): bump version to X.Y.Z` entries from the prior release cycle (v11.0.0 listed "bump version to 10.0.0"; v12.0.0-rc.2 lists "bump version to 11.0.0"). These bumps are internal release bookkeeping and add noise to user-facing changelogs.

**Description**

Configure `requarks/changelog-action@v1` in `tag_release.yaml` with both a whitelist and a blacklist:

- `restrictToTypes: feat,fix,perf,refactor,revert` keeps the changelog scoped to the conventional-commit types that are meaningful to users.
- `excludeTypes: build,docs,other,style,chore` explicitly drops noise types, including the `chore` bump commits, even if a future change reintroduces them via `restrictToTypes` expansion.

The change is forward-looking: it affects pre-release tag builds (the workflow runs on `v*.*.*-*` only), not retroactive promotions of an existing pre-release to a final version.

**Checklist**

- [ ] Updated \`STORE_SCHEMA_VERSION\` (crates/storage/lib.rs) if the PR includes breaking changes to the \`Store\` requiring a re-sync. — N/A, workflow-only change.