### PR TITLE
ci(l1): restore admin namespace for daily snapsync

### DIFF
--- a/.github/actions/snapsync-run/action.yml
+++ b/.github/actions/snapsync-run/action.yml
@@ -72,6 +72,7 @@ runs:
             el_extra_params:
               - "--syncmode=snap"
               - "--log.level=info"
+              - "--http.api=eth,net,web3,debug,admin,txpool"
             cl_type: ${CL_TYPE}
             cl_image: ${CL_IMAGE}
             count: 1
@@ -104,7 +105,7 @@ runs:
       uses: ethpandaops/kurtosis-assertoor-github-action@v1
       with:
         enclave_name: ethrex-assertoor-${{ inputs.network }}-${{ inputs.cl_type }}
-        kurtosis_version: 1.15.2
+        kurtosis_version: 1.18.2
         ethereum_package_url: github.com/ethpandaops/ethereum-package
         ethereum_package_branch: 82e5a7178138d892c0c31c3839c89d53ffd42d9a
         ethereum_package_args: .github/config/assertoor/network_params.generated.yaml


### PR DESCRIPTION
## Summary

- Add `--http.api=eth,net,web3,debug,admin,txpool` to the snapsync action's generated kurtosis config so `admin_*` is reachable again.
- Bump `kurtosis_version` 1.15.2 → 1.18.2.

## Why

#6627 hardened the HTTP JSON-RPC defaults so a fresh ethrex only serves `eth,net,web3`. The other in-tree kurtosis configs (`fixtures/networks/default.yaml`, the assertoor `network_params_*` files) were updated in that PR, but the snapsync action's inline generator in `.github/actions/snapsync-run/action.yml` was missed.

As a result the daily snapsync workflow now fails when ethereum-package probes the node for its enode:

```
Caused by: No field '.result.enode | split("?") | .[0]' was found on input
'{"error":{"code":-32601,"message":"Method not found: admin_nodeInfo"},"id":1,"jsonrpc":"2.0"}'
```
(see https://github.com/lambdaclass/ethrex/actions/runs/25771205079/job/75694542045)

Adding the namespace allowlist back into `el_extra_params` restores the prior behavior. `--http.addr=0.0.0.0` is already set by ethereum-package's ethrex launcher, so no address change is needed.

## Test plan

- [ ] Daily Snapsync Check workflow goes green on hoodi (and sepolia on the next scheduled run).