### PR TITLE
feat(l1,l2): allow CLI flags to be overridden by later occurrences

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -57,7 +57,7 @@ pub fn compute_effective_datadir(base: &Path, network: &Network, dev: bool) -> P
 
 #[allow(clippy::upper_case_acronyms)]
 #[derive(ClapParser)]
-#[command(name="ethrex", author = "Lambdaclass", version=get_client_version_string(), about = "ethrex Execution client")]
+#[command(name="ethrex", author = "Lambdaclass", version=get_client_version_string(), about = "ethrex Execution client", args_override_self = true)]
 pub struct CLI {
     #[command(flatten)]
     pub opts: Options,
@@ -1169,5 +1169,73 @@ mod tests {
     fn http_api_rejects_unknown_namespace() {
         let result = CLI::try_parse_from(["ethrex", "--http.api", "eth,bogus"]);
         assert!(result.is_err());
+    }
+
+    /// Flags hardcoded by external launchers (kurtosis ethereum-package, docker
+    /// compose, etc.) must be overridable from `el_extra_params`. Without
+    /// `overrides_with`, clap errors on a duplicate scalar flag and the node
+    /// fails to start.
+    #[test]
+    fn scalar_launch_flags_allow_last_wins_override() {
+        let cli = CLI::parse_from([
+            "ethrex",
+            "--syncmode=full",
+            "--syncmode=snap",
+            "--log.level=debug",
+            "--log.level=trace",
+            "--http.addr=0.0.0.0",
+            "--http.addr=127.0.0.2",
+            "--http.port=8545",
+            "--http.port=9000",
+            "--authrpc.addr=0.0.0.0",
+            "--authrpc.addr=127.0.0.3",
+            "--authrpc.port=8551",
+            "--authrpc.port=9551",
+            "--authrpc.jwtsecret=a.hex",
+            "--authrpc.jwtsecret=b.hex",
+            "--p2p.port=30303",
+            "--p2p.port=30304",
+            "--discovery.port=30303",
+            "--discovery.port=30305",
+            "--metrics.addr=0.0.0.0",
+            "--metrics.addr=127.0.0.4",
+            "--metrics.port=9090",
+            "--metrics.port=9091",
+            "--builder.gas-limit=30000000",
+            "--builder.gas-limit=45000000",
+        ]);
+        assert!(matches!(cli.opts.syncmode, SyncMode::Snap));
+        assert_eq!(cli.opts.log_level, Level::TRACE);
+        assert_eq!(cli.opts.http_addr, "127.0.0.2");
+        assert_eq!(cli.opts.http_port, "9000");
+        assert_eq!(cli.opts.authrpc_addr, "127.0.0.3");
+        assert_eq!(cli.opts.authrpc_port, "9551");
+        assert_eq!(cli.opts.authrpc_jwtsecret, "b.hex");
+        assert_eq!(cli.opts.p2p_port, "30304");
+        assert_eq!(cli.opts.discovery_port, "30305");
+        assert_eq!(cli.opts.metrics_addr, "127.0.0.4");
+        assert_eq!(cli.opts.metrics_port, "9091");
+        assert_eq!(cli.opts.gas_limit, 45000000);
+    }
+
+    /// `--http.api` should accumulate across repeated invocations (union) so
+    /// operators can extend whatever a launcher passed without restating it.
+    #[test]
+    fn http_api_repeated_flags_accumulate() {
+        let cli = CLI::parse_from([
+            "ethrex",
+            "--http.api=eth,net,web3",
+            "--http.api=debug,admin",
+        ]);
+        assert_eq!(
+            cli.opts.http_api,
+            vec![
+                RpcNamespace::Eth,
+                RpcNamespace::Net,
+                RpcNamespace::Web3,
+                RpcNamespace::Debug,
+                RpcNamespace::Admin,
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Set `args_override_self = true` on the root `Parser` so any scalar CLI flag specified more than once on the command line resolves to the last value instead of erroring out.

`Vec<T>` flags such as `--http.api` keep their `ArgAction::Append` semantics and continue to accumulate across invocations (operator-supplied namespaces are added to whatever the launcher passes, not replaced).

## Why

ethereum-package's ethrex launcher (`src/el/ethrex/ethrex_launcher.star`) and other launch wrappers (docker-compose, kurtosis modules, hive scripts) hardcode a long list of flags before appending `el_extra_params`:

```
--syncmode=full
--log.level=<global>
--http.addr=0.0.0.0
--http.port=8545
--authrpc.addr / --authrpc.port / --authrpc.jwtsecret
--p2p.port / --discovery.port
--metrics.addr / --metrics.port
--builder.gas-limit (when set)
```

Before this change, an operator who needed `--syncmode=snap` (or any other override) had no way to express that through `el_extra_params` — clap rejected the duplicate with:

```
error: the argument '--syncmode <SYNC_MODE>' cannot be used multiple times
```

The recent ethereum-package change that started passing `--syncmode=full` unconditionally turned this into a hard incompatibility: anyone wanting snap sync had to either patch the launcher or pin an old ethereum-package commit. The same problem applies to every other flag the launcher hardcodes.

This is exactly the POSIX last-wins behavior clap's `args_override_self` is designed for, and it's the same model `geth`, `reth`, etc. use for their CLI flags.

## Implementation

One line on the `CLI` struct's `#[command(...)]`:

```rust
#[command(name="ethrex", ..., args_override_self = true)]
```

clap applies `overrides_with("self")` to every `ArgAction::Set` arg automatically. `ArgAction::Append` args (the `Vec<T>` fields) are unaffected.

## Tests

- `scalar_launch_flags_allow_last_wins_override` — 11 scalar flags (`--syncmode`, `--log.level`, `--http.{addr,port}`, `--authrpc.{addr,port,jwtsecret}`, `--p2p.port`, `--discovery.port`, `--metrics.{addr,port}`, `--builder.gas-limit`) verified to honor the last occurrence.
- `http_api_repeated_flags_accumulate` — verifies `--http.api=a,b --http.api=c,d` still accumulates to `[a, b, c, d]` so operators can extend launcher-supplied namespaces.

## Test plan

- [ ] CI: `cargo test`, `cargo clippy --workspace --all-targets`
- [ ] Manual: bump ethereum-package to a commit that hardcodes `--syncmode=full` and confirm `el_extra_params: ["--syncmode=snap"]` no longer aborts ethrex startup.