### PR TITLE
ci(l1,l2): add fork-author guard on PR-triggered self-hosted runner jobs

### DIFF
--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -71,6 +71,11 @@ jobs:
 
   engine-restart:
     name: Restart Kurtosis Engine
+    # Self-hosted runner: only fire for non-PR events or in-org PRs.
+    # Fork PRs would otherwise execute attacker-controlled code on ethrex-sync.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ethrex-sync
     steps:
       - name: Restart engine to match CLI version
@@ -79,6 +84,9 @@ jobs:
   sync-lighthouse:
     needs: [prepare, engine-restart]
     name: Sync ${{ matrix.network }} - Lighthouse
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ethrex-sync
     strategy:
       fail-fast: false
@@ -126,6 +134,9 @@ jobs:
   sync-prysm:
     needs: [prepare, engine-restart]
     name: Sync ${{ matrix.network }} - Prysm
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ethrex-sync
     strategy:
       fail-fast: false

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -32,6 +32,11 @@ env:
 jobs:
   test:
     name: Integration Test Prover SP1
+    # Self-hosted GPU runner: only fire for non-PR events or in-org PRs.
+    # Fork PRs would otherwise execute attacker-controlled code on the GPU CI machine.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: gpu
     steps:
       - name: Checkout sources


### PR DESCRIPTION
**Motivation**

Both `daily_snapsync.yaml` and `main_prover.yaml` dispatch code to non-ephemeral self-hosted runners (`ethrex-sync` and `gpu`) without a fork-author guard.

**Description**

Adds the canonical fork-author guard to every job that targets a self-hosted runner:

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

The condition permits scheduled runs, `workflow_dispatch`, and in-org PRs unchanged; fork PRs (`head.repo != github.repository`) silently skip the self-hosted job.

Per-file changes:

- `daily_snapsync.yaml` — guards added to `engine-restart`, `sync-lighthouse`, `sync-prysm` (all three target `ethrex-sync`). The `prepare` job is left untouched because it runs on `ubuntu-latest` and is safe for fork PR code.
- `main_prover.yaml` — guard added to the single `test` job (targets `gpu`).

Guards are placed on every self-hosted job individually rather than only the gate jobs, so the protection survives future refactors that might remove a `needs:` dependency.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
