### PR TITLE
perf(l1): reduce BAL parallel-path overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 2026-05-14
 
 - Skip `vm.run_execution()` for transfers to codeless EOAs [#6570](https://github.com/lambdaclass/ethrex/pull/6570)
+- Reduce BAL parallel-path overhead: overlap merkleization with execution, memoize per-BAL code derivation, and move per-tx BAL validation inside the exec closure [#6639](https://github.com/lambdaclass/ethrex/pull/6639)
 
 ### 2026-04-27
 

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -865,36 +865,40 @@ impl Blockchain {
         const NUM_WORKERS: usize = 16;
         let parent_state_root = parent_header.state_root;
 
-        // === Stage A: Drain + accumulate all AccountUpdates ===
-        // BAL guarantees completeness, so we block until execution finishes.
-        let mut all_updates: FxHashMap<Address, AccountUpdate> = FxHashMap::default();
-        for updates in rx {
-            let current_length = queue_length.fetch_sub(1, Ordering::Acquire);
-            *max_queue_length = current_length.max(*max_queue_length);
-            for update in updates {
-                match all_updates.entry(update.address) {
-                    Entry::Vacant(e) => {
-                        e.insert(update);
-                    }
-                    Entry::Occupied(mut e) => {
-                        e.get_mut().merge(update);
-                    }
-                }
+        // === Stage A: receive the single BAL-derived batch ===
+        // execute_block_parallel calls bal_to_account_updates BEFORE the rayon tx
+        // loop and sends exactly one Vec<AccountUpdate>. Receiving once (instead of
+        // draining until channel close = exec end) lets Stage B's parallel storage
+        // roots overlap with parallel exec instead of serializing after it.
+        //
+        // BAL accounts are unique by address (one entry per touched address), so
+        // no merge step is needed — skip the FxHashMap detour entirely.
+        let updates: Vec<AccountUpdate> = match rx.recv() {
+            Ok(updates) => {
+                let current_length = queue_length.fetch_sub(1, Ordering::Acquire);
+                *max_queue_length = current_length.max(*max_queue_length);
+                updates
             }
-        }
+            Err(_) => {
+                // Channel closed without a message — execution failed before
+                // bal_to_account_updates ran. Return empty work so the exec
+                // error surfaces in execution_result rather than being masked.
+                Vec::new()
+            }
+        };
 
-        // Extract witness accumulator before consuming updates
+        // Witness accumulator (clone since we move `updates` into Stage B below).
         let accumulated_updates = if self.options.precompute_witnesses {
-            Some(all_updates.values().cloned().collect::<Vec<_>>())
+            Some(updates.clone())
         } else {
             None
         };
 
-        // Extract code updates and build work items with pre-hashed addresses
+        // Build work items with pre-hashed addresses + extract code updates.
         let mut code_updates: Vec<(H256, Code)> = Vec::new();
-        let mut accounts: Vec<(H256, AccountUpdate)> = Vec::with_capacity(all_updates.len());
-        for (addr, update) in all_updates {
-            let hashed = keccak(addr);
+        let mut accounts: Vec<(H256, AccountUpdate)> = Vec::with_capacity(updates.len());
+        for update in updates {
+            let hashed = keccak(update.address);
             if let Some(info) = &update.info
                 && let Some(code) = &update.code
             {

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -163,6 +163,11 @@ enum BalValidationError {
     Database(String),
 }
 
+/// Pre-computed `(code_hash, Code)` pairs for a single BAL account's
+/// `code_changes`, indexed by change position. `None` represents the empty
+/// code (cleared / EOA). See `seed_db_from_bal` for the cache contract.
+type BalAccountCodeCache = Vec<(H256, Option<Code>)>;
+
 impl LEVM {
     /// Execute a block and return the execution result.
     ///
@@ -438,6 +443,7 @@ impl LEVM {
                         bal,
                         last_tx_idx,
                         &validation_index.accounts_by_min_index,
+                        None,
                     )
                     .is_ok()
                         && let VMType::L1 = vm_type
@@ -460,6 +466,7 @@ impl LEVM {
                 bal,
                 last_tx_idx,
                 &validation_index.accounts_by_min_index,
+                None,
             )?;
 
             // Order must match geth: requests (system calls) BEFORE withdrawals.
@@ -791,31 +798,9 @@ impl LEVM {
                 continue;
             }
 
-            // Load pre-state for unchanged fields (cache hit after prefetch)
-            let prestate = store
-                .get_account_state(addr)
-                .map_err(|e| EvmError::Custom(format!("bal_to_account_updates: {e}")))?;
-
-            // Final balance: last entry (highest index) or prestate
-            let balance = acct_changes
-                .balance_changes
-                .last()
-                .map(|c| c.post_balance)
-                .unwrap_or(prestate.balance);
-
-            // Final nonce: last entry or prestate
-            let nonce = acct_changes
-                .nonce_changes
-                .last()
-                .map(|c| c.post_nonce)
-                .unwrap_or(prestate.nonce);
-
-            // Final code: last entry or prestate
-            let (code_hash, code) = if let Some(c) = acct_changes.code_changes.last() {
-                Self::code_from_bal(&c.new_code)
-            } else {
-                (prestate.code_hash, None)
-            };
+            let last_balance = acct_changes.balance_changes.last().map(|c| c.post_balance);
+            let last_nonce = acct_changes.nonce_changes.last().map(|c| c.post_nonce);
+            let last_code_change = acct_changes.code_changes.last();
 
             // Storage: per slot, last entry (highest index)
             let mut added_storage = FxHashMap::with_capacity_and_hasher(
@@ -829,6 +814,72 @@ impl LEVM {
                 }
             }
 
+            let has_info_changes =
+                last_balance.is_some() || last_nonce.is_some() || last_code_change.is_some();
+
+            // Fast path 1: storage-only update. No info changes, can't be a removal
+            // (BAL only records actual modifications, so prestate fields are unchanged →
+            // post non-empty unless prestate was already empty, in which case removed=false
+            // by definition). Skip prestate fetch entirely.
+            if !has_info_changes {
+                updates.push(AccountUpdate {
+                    address: addr,
+                    removed: false,
+                    info: None,
+                    code: None,
+                    added_storage,
+                    removed_storage: false,
+                });
+                continue;
+            }
+
+            // Compute would-be post-state info for the fast-path test.
+            let post_balance_zero = last_balance.is_some_and(|b| b.is_zero());
+            let post_nonce_zero = last_nonce.is_some_and(|n| n == 0);
+            let post_code_empty = last_code_change.is_some_and(|c| c.new_code.is_empty());
+            let post_could_be_empty = post_balance_zero && post_nonce_zero && post_code_empty;
+            let has_full_info_coverage =
+                last_balance.is_some() && last_nonce.is_some() && last_code_change.is_some();
+
+            // Fast path 2: BAL fully specifies post-state info AND post is non-empty.
+            // No prestate needed: removal is impossible (post non-empty), and post-state
+            // info comes entirely from BAL.
+            if has_full_info_coverage && !post_could_be_empty {
+                let (code_hash, code) = Self::code_from_bal(
+                    &last_code_change
+                        .expect("checked by has_full_info_coverage")
+                        .new_code,
+                );
+                let info = AccountInfo {
+                    code_hash,
+                    balance: last_balance.expect("checked by has_full_info_coverage"),
+                    nonce: last_nonce.expect("checked by has_full_info_coverage"),
+                };
+                updates.push(AccountUpdate {
+                    address: addr,
+                    removed: false,
+                    info: Some(info),
+                    code,
+                    added_storage,
+                    removed_storage: false,
+                });
+                continue;
+            }
+
+            // Slow path: partial info coverage OR post-state may be empty (removal check).
+            // Load pre-state for unchanged fields / removal detection (cache hit after prefetch).
+            let prestate = store
+                .get_account_state(addr)
+                .map_err(|e| EvmError::Custom(format!("bal_to_account_updates: {e}")))?;
+
+            let balance = last_balance.unwrap_or(prestate.balance);
+            let nonce = last_nonce.unwrap_or(prestate.nonce);
+            let (code_hash, code) = if let Some(c) = last_code_change {
+                Self::code_from_bal(&c.new_code)
+            } else {
+                (prestate.code_hash, None)
+            };
+
             // Detect account removal (EIP-161): post-state empty but pre-state existed
             let post_empty = balance.is_zero() && nonce == 0 && code_hash == *EMPTY_KECCACK_HASH;
             let pre_empty = prestate.balance.is_zero()
@@ -836,15 +887,9 @@ impl LEVM {
                 && prestate.code_hash == *EMPTY_KECCACK_HASH;
             let removed = post_empty && !pre_empty;
 
-            let balance_changed = acct_changes
-                .balance_changes
-                .last()
-                .is_some_and(|c| c.post_balance != prestate.balance);
-            let nonce_changed = acct_changes
-                .nonce_changes
-                .last()
-                .is_some_and(|c| c.post_nonce != prestate.nonce);
-            let code_changed = acct_changes.code_changes.last().is_some();
+            let balance_changed = last_balance.is_some_and(|b| b != prestate.balance);
+            let nonce_changed = last_nonce.is_some_and(|n| n != prestate.nonce);
+            let code_changed = last_code_change.is_some();
             let acc_info_updated = balance_changed || nonce_changed || code_changed;
 
             if !removed && !acc_info_updated && added_storage.is_empty() {
@@ -861,7 +906,7 @@ impl LEVM {
                 None
             };
 
-            let update = AccountUpdate {
+            updates.push(AccountUpdate {
                 address: addr,
                 removed,
                 info,
@@ -874,8 +919,7 @@ impl LEVM {
                 // so `added_storage` already contains those zeroed entries and
                 // the trie update is correct without setting removed_storage.
                 removed_storage: false,
-            };
-            updates.push(update);
+            });
         }
 
         Ok(updates)
@@ -897,6 +941,7 @@ impl LEVM {
         bal: &BlockAccessList,
         max_idx: u32,
         accounts_by_min_index: &[(u32, usize)],
+        code_cache: Option<&[BalAccountCodeCache]>,
     ) -> Result<(), EvmError> {
         // Only visit accounts whose minimum change index <= max_idx.
         let end = accounts_by_min_index.partition_point(|(min_idx, _)| *min_idx <= max_idx);
@@ -929,11 +974,18 @@ impl LEVM {
             }
 
             // Compute code update before borrowing acc (borrow checker: can't access
-            // db.codes while acc holds a mutable borrow of db)
+            // db.codes while acc holds a mutable borrow of db).
+            // Cache hit avoids redundant keccak + jump-target scan when the same code
+            // change is replayed across multiple txs in the parallel loop.
             let code_update = if code_pos > 0 {
-                Some(Self::code_from_bal(
-                    &acct_changes.code_changes[code_pos - 1].new_code,
-                ))
+                let code_idx = code_pos - 1;
+                if let Some(cache) = code_cache {
+                    Some(cache[acct_idx][code_idx].clone())
+                } else {
+                    Some(Self::code_from_bal(
+                        &acct_changes.code_changes[code_idx].new_code,
+                    ))
+                }
             } else {
                 None
             };
@@ -1105,31 +1157,57 @@ impl LEVM {
                 .is_some_and(|a| a.storage.contains_key(key))
         });
 
-        // Pre-compute capacity hint for per-tx DBs from BAL account count.
-        let bal_account_count = bal.accounts().len();
+        // Pre-compute Code objects (hash + jump_targets) once per BAL code change.
+        // Without this, every tx that re-applies the same code change in seed_db_from_bal
+        // re-keccaks and re-scans the same bytecode. Stress blocks have 10-30 code changes
+        // and 200-500 txs, so the savings compound. Outer Vec indexed by BAL account index;
+        // inner indexed by code_change position. `Code` clone is cheap relative to recompute
+        // (Bytes is refcounted; only jump_targets Vec<u32> heap-clones).
+        let code_cache: Vec<BalAccountCodeCache> = bal
+            .accounts()
+            .iter()
+            .map(|ac| {
+                ac.code_changes
+                    .iter()
+                    .map(|c| Self::code_from_bal(&c.new_code))
+                    .collect()
+            })
+            .collect();
 
         // 2. Execute all txs in parallel (embarrassingly parallel, BAL-seeded).
-        //    BAL validation is deferred to after the gas limit check (step 3) so that
-        //    blocks exceeding gas limit produce GAS_USED_OVERFLOW before BAL mismatch.
+        //    Per-tx BAL validation runs INSIDE the closure (alongside exec) so the
+        //    serial post-loop only handles gas accounting and shared-set bookkeeping.
+        //    The `validation_error` field carries any per-tx BAL validation failure;
+        //    it is surfaced AFTER the gas-limit check so that GAS_USED_OVERFLOW takes
+        //    priority over BAL mismatch errors (the BAL is built assuming rejected
+        //    txs; the miner balance in the BAL won't match execution that ran all txs).
+        //
+        //    `current_state` and `codes` are dropped inside the closure after
+        //    validation runs, so they don't need to traverse the rayon boundary.
+        //    Per-tx reduction summaries (`destroyed_addresses`, `read_keys`) are
+        //    pre-computed for the post-loop's `unread_storage_reads` cleanup.
         type TxExecResult = (
             usize,
             TxType,
             ExecutionReport,
-            FxHashMap<Address, LevmAccount>,
-            FxHashMap<H256, ethrex_common::types::Code>,
             FxHashSet<Address>,   // accessed_accounts tracker (coarse)
-            Vec<Address>,         // shadow recorder touched_addresses (EIP-7928 exact)
-            Vec<(Address, U256)>, // shadow recorder storage_reads (EIP-7928 exact)
+            Vec<Address>,         // destroyed addresses (clear all reads for these)
+            Vec<(Address, H256)>, // read keys (specific entries to clear)
+            Option<EvmError>,     // deferred BAL validation error (gas check first)
         );
 
         let exec_results: Result<Vec<TxExecResult>, EvmError> = (0..n_txs)
             .into_par_iter()
             .map(|tx_idx| -> Result<_, EvmError> {
                 let (tx, sender) = &txs_with_sender[tx_idx];
+                // Per-tx capacity hint: most txs touch <10 accounts. Sizing to the full
+                // BAL account count (often 100s on stress blocks) inflates per-task allocator
+                // pressure × n_rayon_workers. Use a small constant; HashMap grows on demand.
+                const PER_TX_DB_CAPACITY: usize = 32;
                 let mut tx_db = GeneralizedDatabase::new_with_shared_base_and_capacity(
                     store.clone(),
                     system_seed.clone(),
-                    bal_account_count,
+                    PER_TX_DB_CAPACITY,
                 );
                 // Small capacity: parallel txs rarely nest >8 call frames, and
                 // over-allocating per-tx wastes memory across many rayon tasks.
@@ -1144,6 +1222,7 @@ impl LEVM {
                     bal,
                     u32::try_from(tx_idx).unwrap_or(u32::MAX),
                     &validation_index.accounts_by_min_index,
+                    Some(&code_cache),
                 )?;
 
                 // Enable accessed_accounts tracker (coarse) for `unaccessed_pure_accounts`
@@ -1185,28 +1264,103 @@ impl LEVM {
                     .take()
                     .map(|mut r| (r.take_touched_addresses(), r.take_storage_reads()))
                     .unwrap_or_default();
+
+                // Pre-compute per-tx summaries for the post-loop's unread_storage_reads
+                // cleanup, then drop current_state/codes (they don't cross the rayon
+                // boundary). Destroyed accounts clear ALL their reads; non-destroyed
+                // accounts clear only the slots they actually loaded.
+                let mut destroyed_addresses: Vec<Address> = Vec::new();
+                let mut read_keys: Vec<(Address, H256)> = Vec::new();
+                for (addr, acct) in &current_state {
+                    if matches!(
+                        acct.status,
+                        AccountStatus::Destroyed | AccountStatus::DestroyedModified
+                    ) {
+                        destroyed_addresses.push(*addr);
+                    } else {
+                        for key in acct.storage.keys() {
+                            read_keys.push((*addr, *key));
+                        }
+                    }
+                }
+
+                // Run BAL validation inside the closure. Errors are deferred to the
+                // serial post-loop so the gas-limit check can take priority.
+                let bal_idx = u32::try_from(tx_idx + 1).unwrap_or(u32::MAX);
+                let seed_idx = u32::try_from(tx_idx).unwrap_or(u32::MAX);
+                let validation_error: Option<EvmError> = (|| {
+                    Self::validate_tx_execution(
+                        bal_idx,
+                        seed_idx,
+                        &current_state,
+                        &codes,
+                        bal,
+                        validation_index,
+                        &system_seed,
+                        &store,
+                    )
+                    .map_err(|e| {
+                        EvmError::Custom(format!("BAL validation failed for tx {tx_idx}: {e}"))
+                    })?;
+
+                    // EIP-7928 (Group B): missing-account check.
+                    for addr in &shadow_touched {
+                        if !validation_index.addr_to_idx.contains_key(addr) {
+                            return Err(EvmError::Custom(format!(
+                                "BAL validation failed for tx {tx_idx}: account {addr:?} was \
+                                 accessed during execution but is missing from BAL"
+                            )));
+                        }
+                    }
+                    // EIP-7928 (Group B): missing storage_read check.
+                    for (addr, slot) in &shadow_reads {
+                        let Some(&bal_acct_idx) = validation_index.addr_to_idx.get(addr) else {
+                            // Already caught by the touched-address check above.
+                            continue;
+                        };
+                        let acct = &bal.accounts()[bal_acct_idx];
+                        let in_changes = acct
+                            .storage_changes
+                            .binary_search_by(|sc| sc.slot.cmp(slot))
+                            .is_ok();
+                        let in_reads = acct.storage_reads.contains(slot);
+                        if !in_changes && !in_reads {
+                            return Err(EvmError::Custom(format!(
+                                "BAL validation failed for tx {tx_idx}: storage slot {slot} of \
+                                 account {addr:?} was read during execution but is missing from \
+                                 BAL (no storage_changes or storage_reads entry)"
+                            )));
+                        }
+                    }
+                    Ok(())
+                })()
+                .err();
+
+                drop(current_state);
+                drop(codes);
+
                 Ok((
                     tx_idx,
                     tx.tx_type(),
                     report,
-                    current_state,
-                    codes,
                     tracked,
-                    shadow_touched,
-                    shadow_reads,
+                    destroyed_addresses,
+                    read_keys,
+                    validation_error,
                 ))
             })
             .collect();
 
         let mut exec_results = exec_results?;
 
-        // Sort so gas accounting and validation happen in tx order.
-        exec_results.sort_unstable_by_key(|(idx, _, _, _, _, _, _, _)| *idx);
+        // Sort so gas accounting and validation surfacing happen in tx order.
+        exec_results.sort_unstable_by_key(|(idx, _, _, _, _, _, _)| *idx);
 
-        // 3. Gas limit check — must happen BEFORE BAL validation so that blocks
-        //    exceeding the gas limit produce GAS_USED_OVERFLOW instead of a BAL
-        //    mismatch error (the BAL is built assuming rejected txs, so the miner
-        //    balance in the BAL won't match execution that ran all txs).
+        // 3. Gas limit check — must happen BEFORE surfacing any BAL validation
+        //    error so that blocks exceeding the gas limit produce
+        //    GAS_USED_OVERFLOW instead of a BAL mismatch error (the BAL is
+        //    built assuming rejected txs, so the miner balance in the BAL won't
+        //    match execution that ran all txs).
         //
         //    EIP-8037 PR #2703: also enforce the per-tx 2D inclusion check
         //    against running block totals. A tx whose worst-case regular or
@@ -1215,7 +1369,7 @@ impl LEVM {
         let mut block_regular_gas_used = 0_u64;
         let mut block_state_gas_used = 0_u64;
         let mut tx_gas_breakdowns: Vec<TxGasBreakdown> = Vec::with_capacity(exec_results.len());
-        for (tx_idx, _, report, _, _, _, _, _) in &exec_results {
+        for (tx_idx, _, report, _, _, _, _) in &exec_results {
             let (tx, _) = txs_with_sender
                 .get(*tx_idx)
                 .ok_or_else(|| EvmError::Custom(format!("tx index {tx_idx} out of bounds")))?;
@@ -1246,95 +1400,42 @@ impl LEVM {
             )));
         }
 
-        // 4. Per-tx BAL validation — now safe to run after gas limit is confirmed OK.
-        //    Also mark off storage_reads that appear in per-tx execution state.
-        for (tx_idx, _, _, current_state, codes, tracked_accounts, shadow_touched, shadow_reads) in
-            &exec_results
-        {
-            let bal_idx = u32::try_from(*tx_idx + 1).unwrap_or(u32::MAX);
-            let seed_idx = u32::try_from(*tx_idx).unwrap_or(u32::MAX);
-            Self::validate_tx_execution(
-                bal_idx,
-                seed_idx,
-                current_state,
-                codes,
-                bal,
-                validation_index,
-                &system_seed,
-                &store,
-            )
-            .map_err(|e| EvmError::Custom(format!("BAL validation failed for tx {tx_idx}: {e}")))?;
+        // 4. Surface earliest deferred BAL validation error (post gas check).
+        for (_, _, _, _, _, _, val_err) in &mut exec_results {
+            if let Some(err) = val_err.take() {
+                return Err(err);
+            }
+        }
 
-            // Mark storage_reads that were actually loaded during this tx.
-            // storage_reads slots are NOT in storage_changes (conflict check ensures this),
-            // so they're not seeded. If a slot appears in the per-tx state's storage,
-            // the tx genuinely read it via SLOAD.
-            // Special case: selfdestruct clears storage from the final state, so reads
-            // that happened before destruction are no longer visible. For destroyed
-            // accounts, mark ALL their BAL storage_reads as satisfied.
-            if !unread_storage_reads.is_empty() {
-                for (addr, acct) in current_state {
-                    if matches!(
-                        acct.status,
-                        AccountStatus::Destroyed | AccountStatus::DestroyedModified
-                    ) {
-                        unread_storage_reads.retain(|&(a, _)| a != *addr);
-                    } else {
-                        for key in acct.storage.keys() {
-                            unread_storage_reads.remove(&(*addr, *key));
-                        }
-                    }
+        // 5. Apply per-tx summaries to the shared `unread_storage_reads` and
+        //    `unaccessed_pure_accounts` checklists. The per-tx closures
+        //    pre-computed these from `current_state` before dropping it.
+        if !unread_storage_reads.is_empty() {
+            for (_, _, _, _, destroyed, read_keys, _) in &exec_results {
+                for addr in destroyed {
+                    unread_storage_reads.retain(|&(a, _)| a != *addr);
+                }
+                for entry in read_keys {
+                    unread_storage_reads.remove(entry);
                 }
             }
-
-            // Mark pure-access accounts that were accessed during this tx.
+        }
+        if !unaccessed_pure_accounts.is_empty() {
             // The coinbase is always accessed during fee finalization (geth's
             // readerTracker records it), even when the miner fee is zero and
             // ethrex skips the load_account call.
-            if !unaccessed_pure_accounts.is_empty() {
-                unaccessed_pure_accounts.remove(&header.coinbase);
+            unaccessed_pure_accounts.remove(&header.coinbase);
+            for (_, _, _, tracked_accounts, _, _, _) in &exec_results {
                 for addr in tracked_accounts {
                     unaccessed_pure_accounts.remove(addr);
                 }
             }
-
-            // EIP-7928 (Group B): missing-access detection using the shadow recorder.
-            // For each address the per-tx shadow recorder marked as touched, the header
-            // BAL must contain an entry for it. For each storage read, the header BAL
-            // must carry the slot either in storage_changes or storage_reads.
-            for addr in shadow_touched {
-                if !validation_index.addr_to_idx.contains_key(addr) {
-                    return Err(EvmError::Custom(format!(
-                        "BAL validation failed for tx {tx_idx}: account {addr:?} was \
-                         accessed during execution but is missing from BAL"
-                    )));
-                }
-            }
-            for (addr, slot) in shadow_reads {
-                let Some(&bal_acct_idx) = validation_index.addr_to_idx.get(addr) else {
-                    // Already caught by the touched-address check above.
-                    continue;
-                };
-                let acct = &bal.accounts()[bal_acct_idx];
-                let in_changes = acct
-                    .storage_changes
-                    .binary_search_by(|sc| sc.slot.cmp(slot))
-                    .is_ok();
-                let in_reads = acct.storage_reads.contains(slot);
-                if !in_changes && !in_reads {
-                    return Err(EvmError::Custom(format!(
-                        "BAL validation failed for tx {tx_idx}: storage slot {slot} of \
-                         account {addr:?} was read during execution but is missing from \
-                         BAL (no storage_changes or storage_reads entry)"
-                    )));
-                }
-            }
         }
 
-        // 5. Build receipts in tx order.
+        // 6. Build receipts in tx order.
         let mut receipts = Vec::with_capacity(n_txs);
         let mut cumulative_gas_used = 0_u64;
-        for (_, tx_type, report, _, _, _, _, _) in exec_results {
+        for (_, tx_type, report, _, _, _, _) in exec_results {
             cumulative_gas_used += report.gas_spent;
             let receipt = Receipt::new(
                 tx_type,

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -1420,10 +1420,14 @@ impl LEVM {
                 }
             }
         }
-        if !unaccessed_pure_accounts.is_empty() {
+        if !unaccessed_pure_accounts.is_empty() && !exec_results.is_empty() {
             // The coinbase is always accessed during fee finalization (geth's
             // readerTracker records it), even when the miner fee is zero and
-            // ethrex skips the load_account call.
+            // ethrex skips the load_account call. Only exempt the coinbase
+            // when at least one tx ran — fee finalization never happens for
+            // 0-tx blocks (empty / withdrawal-only), so a BAL entry for the
+            // coinbase there IS extraneous and must surface as a validation
+            // error (covers EELS `test_bal_invalid_extraneous_coinbase`).
             unaccessed_pure_accounts.remove(&header.coinbase);
             for (_, _, _, tracked_accounts, _, _, _) in &exec_results {
                 for addr in tracked_accounts {

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -777,11 +777,16 @@ impl<'a> VM<'a> {
         key: H256,
         current_value: U256,
     ) -> Result<(), InternalError> {
+        // Pre-size the inner map to 8 to avoid the rehash chain on the first
+        // few SSTOREs of every fresh account in a tx. Default `or_default()`
+        // starts at capacity 0 → 4 → 8 → ... triggering multiple
+        // `hashbrown::reserve_rehash` allocations per account (~3% of total
+        // CPU on the BAL parallel path, per flamegraph).
         self.current_call_frame
             .call_frame_backup
             .original_account_storage_slots
             .entry(address)
-            .or_default()
+            .or_insert_with(|| FxHashMap::with_capacity_and_hasher(8, Default::default()))
             .entry(key)
             .or_insert(current_value);
 


### PR DESCRIPTION
## Summary

Rebased onto current `main` (post bal-devnet-7-pr squash merge). **Scope reduced** from the original bundle: dropped the `CachingDatabase` `RwLock<HashMap>` → `DashMap` swap and the 500ms → 100ms `import-bench` sleep tweak. Both require coordinated zkVM-feature-gating work that isn't done here.

Remaining changes target the BAL parallel-execution path (`execute_block_parallel` + `handle_merkleization_bal` + `seed_db_from_bal`). All changes are within already rayon-gated code paths -- zkVM builds (sp1/risc0/zisk/eip-8025) are unaffected.

### What is in this PR

- **A. `handle_merkleization_bal` overlap fix** (`crates/blockchain/blockchain.rs`): `for updates in rx { ... }` blocked until channel close (= exec end). `execute_block_parallel` sends exactly one batch up front from `bal_to_account_updates`, so draining nothing useful serialized Stage B (parallel storage roots) after exec instead of overlapping with it. Replaced with a single `rx.recv()` and dropped the `FxHashMap` merge step (BAL guarantees one entry per address).
- **Q1. Skip prestate read in `bal_to_account_updates` when BAL covers all info fields** (`crates/vm/backends/levm/mod.rs`): two fast paths added -- storage-only updates (info: None, removed: false by construction); full info coverage with non-empty post (removal impossible, info from BAL alone). Slow path keeps existing behavior for partial coverage.
- **Q2. Per-tx `GeneralizedDatabase` capacity cap at 32** (`execute_block_parallel`): previously sized to `bal.accounts().len()` (often 100s on stress blocks); p50 tx touches <10 accounts. Reduced allocator pressure across rayon workers.
- **Q3. Memoize `code_from_bal` results across `seed_db_from_bal` calls**: pre-compute `Code` objects (hash + jump_targets) once per BAL code change before the par_iter; pass cache via optional param to `seed_db_from_bal`. Saves N-1 keccak+jump-target scans per code change per block (N = tx count).
- **Q8. Move per-tx BAL validation into the rayon par_iter closure** (`execute_block_parallel`): eliminates a serial post-exec validation pass (~3 ms median across 200 txs). Drops `current_state` and `codes` inside the closure after validation runs -- they no longer cross the rayon boundary, reducing per-tx allocator pressure. Closure returns deferred `Option<EvmError>` so gas-limit check still takes priority over BAL mismatch errors.
- **Coinbase exemption fix**: gated the post-exec `unaccessed_pure_accounts` coinbase removal on `!exec_results.is_empty()` to fix 0-tx-block regression (Q8 had hoisted the removal outside the per-tx loop, silently exempting coinbase on empty/withdrawal-only blocks). Found via EELS `test_bal_invalid_extraneous_coinbase[empty_block|withdrawal_only]`.
- **Pre-size `backup_storage_slot` inner map** (separate commit): avoids rehash chain growth in the slot backup tracker.

### What was dropped from the original bundle (deferred to follow-ups)

- **DashMap. `CachingDatabase` RwLock<HashMap> → DashMap**: the `Cargo.toml` rayon gating from #6662 makes the levm crate's rayon dep optional (zkVM builds skip rayon entirely). The DashMap swap rewrites struct fields and methods unconditionally; to land cleanly it needs paired zkVM-fallback variants matching the existing `#[cfg(all(feature = "rayon", not(feature = "eip-8025")))]` pattern. Split out to its own PR.
- **C. `import-bench` 500ms → 100ms sleep**: superseded by #6666 which replaces the sleep with `Store::wait_for_persistence_idle()` entirely.

### Headline numbers (from the original bundle, before reduced scope)

460-block mainnet-mix fixture from bal-devnet-7 kurtosis localnet (~670 tx/s spamoor mix, 65 Mgas median, ~200 tx/block, 452/460 blocks carry BAL):

| Metric                  | Value          |
|-------------------------|----------------|
| Wall time               | 5.06 s         |
| Per-block median        | ~8 ms          |
| Per-block Ggas/s median | 7.67           |
| Per-block Ggas/s p90    | 8.32           |
| Per-block Ggas/s max    | 13.49          |
| Warmer/exec overlap     | 99 %           |

Numbers above include the DashMap change; expect a regression of a few % once that's removed (perf record showed 11% CPU on the RwLock contention -- DashMap removed that; without it some of that comes back, exact figure pending re-bench).

## Test plan

- [x] `cargo check -p ethrex` (default features) -- clean
- [x] `cargo check -p ethrex-levm --no-default-features --features sp1` (zkVM mode, no rayon) -- clean
- [x] `cargo fmt --check` -- clean
- [ ] CI: `make test`, EF tests, Hive Amsterdam
- [ ] Re-bench on 460-block fixture without DashMap to quantify regression