### PR TITLE
ci(l1): revert snapsync kurtosis_version to 1.15.2

### DIFF
--- a/.github/actions/snapsync-run/action.yml
+++ b/.github/actions/snapsync-run/action.yml
@@ -105,7 +105,7 @@ runs:
       uses: ethpandaops/kurtosis-assertoor-github-action@v1
       with:
         enclave_name: ethrex-assertoor-${{ inputs.network }}-${{ inputs.cl_type }}
-        kurtosis_version: 1.18.2
+        kurtosis_version: 1.15.2
         ethereum_package_url: github.com/ethpandaops/ethereum-package
         ethereum_package_branch: 82e5a7178138d892c0c31c3839c89d53ffd42d9a
         ethereum_package_args: .github/config/assertoor/network_params.generated.yaml


### PR DESCRIPTION
**Motivation**

The Daily Snapsync Check workflow has been failing on every run since #6635 merged. The kurtosis-assertoor action installs the CLI via `apt install kurtosis-cli=${kurtosis_version}` against `apt.fury.io/kurtosis-tech`, and that apt repo only publishes up to `1.15.2`. Installing `1.18.2` aborts with:

```
E: Version '1.18.2' for 'kurtosis-cli' was not found
##[error]Process completed with exit code 100.
```

See run https://github.com/lambdaclass/ethrex/actions/runs/25819231059.

The `1.18.2` value came from kurtosis's own "please upgrade" warning, which advertises the latest binary release — that channel is separate from the apt repo CI installs from.

**Description**

Revert `kurtosis_version` in `.github/actions/snapsync-run/action.yml` from `1.18.2` back to `1.15.2`, which matches the latest version actually published in the kurtosis-tech apt repo and is what every other workflow (`pr-main_l1.yaml`) already uses. The admin-namespace fix from #6635 is untouched.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A, CI-only change.