### PR TITLE
chore(l2): replace hardcoded L2 reviewers with @lambdaclass/ethrex-l2-reviewers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,19 +2,18 @@
 * @lambdaclass/lambda-execution-reviewers
 
 ## ethrex L2 code owners
-crates/l2 @ilitteri @manuelbilbao @avilagaston9
+crates/l2 @lambdaclass/ethrex-l2-reviewers
 crates/l2/contracts/src @jrchatruc @manuelbilbao
-cmd/ethrex/l2 @ilitteri @manuelbilbao @avilagaston9
-cmd/ethrex/build* @ilitteri @manuelbilbao @avilagaston9
-crates/blockchain/dev @ilitteri @manuelbilbao @avilagaston9
-crates/common/crypto @ilitteri @manuelbilbao @avilagaston9
-crates/common/types/blobs_bundle.rs @ilitteri @manuelbilbao @avilagaston9
-crates/common/types/l2 @ilitteri @manuelbilbao @avilagaston9
-crates/common/types/l2.rs @ilitteri @manuelbilbao @avilagaston9
-crates/common/types/transaction.rs @ilitteri @manuelbilbao @avilagaston9
-crates/common/rkyv_utils.rs @ilitteri @manuelbilbao @avilagaston9
-crates/networking/p2p/rlpx/l2 @ilitteri @manuelbilbao @avilagaston9
-crates/networking/rpc/types/transaction.rs @ilitteri @manuelbilbao @avilagaston9
-crates/networking/rpc/clients @ilitteri @manuelbilbao @avilagaston9
-crates/vm/levm/src/hooks/l2_hook.rs @ilitteri @manuelbilbao @avilagaston9
-crates/blockchain/dev @ilitteri @manuelbilbao @avilagaston9
+cmd/ethrex/l2 @lambdaclass/ethrex-l2-reviewers
+cmd/ethrex/build* @lambdaclass/ethrex-l2-reviewers
+crates/blockchain/dev @lambdaclass/ethrex-l2-reviewers
+crates/common/crypto @lambdaclass/ethrex-l2-reviewers
+crates/common/types/blobs_bundle.rs @lambdaclass/ethrex-l2-reviewers
+crates/common/types/l2 @lambdaclass/ethrex-l2-reviewers
+crates/common/types/l2.rs @lambdaclass/ethrex-l2-reviewers
+crates/common/types/transaction.rs @lambdaclass/ethrex-l2-reviewers
+crates/common/rkyv_utils.rs @lambdaclass/ethrex-l2-reviewers
+crates/networking/p2p/rlpx/l2 @lambdaclass/ethrex-l2-reviewers
+crates/networking/rpc/types/transaction.rs @lambdaclass/ethrex-l2-reviewers
+crates/networking/rpc/clients @lambdaclass/ethrex-l2-reviewers
+crates/vm/levm/src/hooks/l2_hook.rs @lambdaclass/ethrex-l2-reviewers


### PR DESCRIPTION
**Motivation**

The L2 code owners were hardcoded as a per-user reviewer list, which forces a CODEOWNERS edit every time L2 reviewer membership changes. Moving to a GitHub team (`@lambdaclass/ethrex-l2-reviewers`) keeps this file stable as membership shifts — additions/removals are handled through GitHub team settings instead of code edits. This matches the convention already used for `@lambdaclass/lambda-execution-reviewers` on the top-level `*` entry.

**Description**

- Replace the hardcoded per-user reviewer list with `@lambdaclass/ethrex-l2-reviewers` on every L2-scoped path.
- Drop the duplicate `crates/blockchain/dev` entry (it was listed twice).
- `crates/l2/contracts/src` is intentionally left untouched — it has a different reviewer set that is not the subject of this change.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.