### PR TITLE
fix(l1): re-enable rayon feature on blockchain crate

### DIFF
--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -42,7 +42,7 @@ path = "./blockchain.rs"
 [features]
 default = ["secp256k1"]
 rayon = ["ethrex-vm/rayon"]
-secp256k1 = ["ethrex-common/secp256k1", "ethrex-vm/secp256k1"]
+secp256k1 = ["ethrex-common/secp256k1", "ethrex-vm/secp256k1", "rayon"]
 c-kzg = ["ethrex-common/c-kzg", "ethrex-vm/c-kzg"]
 metrics = ["ethrex-metrics/transactions"]
 eip-8025 = ["ethrex-common/eip-8025"]


### PR DESCRIPTION
**Motivation**

On #6560 we disabled rayon for zkVMs by gating it's usage, but we forgot to enable it on the blockchain crate outside zkVMs. This causes a big performance regression.

**Description**

We enable it when secp256k1 is enabled, mirroring what ethrex-vm does.