### PR TITLE
fix(l1): handle skipped intermediate forks in next_fork

### DIFF
--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -508,33 +508,29 @@ impl ChainConfig {
     }
 
     pub fn next_fork(&self, block_timestamp: u64) -> Option<Fork> {
-        let next = if self.is_amsterdam_activated(block_timestamp) {
-            None
-        } else if self.is_bpo5_activated(block_timestamp) && self.amsterdam_time.is_some() {
-            Some(Fork::Amsterdam)
-        } else if self.is_bpo4_activated(block_timestamp) && self.bpo5_time.is_some() {
-            Some(Fork::BPO5)
-        } else if self.is_bpo3_activated(block_timestamp) && self.bpo4_time.is_some() {
-            Some(Fork::BPO4)
-        } else if self.is_bpo2_activated(block_timestamp) && self.bpo3_time.is_some() {
-            Some(Fork::BPO3)
-        } else if self.is_bpo1_activated(block_timestamp) && self.bpo2_time.is_some() {
-            Some(Fork::BPO2)
-        } else if self.is_osaka_activated(block_timestamp) && self.bpo1_time.is_some() {
-            Some(Fork::BPO1)
-        } else if self.is_prague_activated(block_timestamp) && self.osaka_time.is_some() {
-            Some(Fork::Osaka)
-        } else if self.is_cancun_activated(block_timestamp) && self.prague_time.is_some() {
-            Some(Fork::Prague)
-        } else if self.is_shanghai_activated(block_timestamp) && self.cancun_time.is_some() {
-            Some(Fork::Cancun)
-        } else {
-            None
-        };
-        match next {
-            Some(fork) if fork > self.fork(block_timestamp) => next,
-            _ => None,
-        }
+        // Pick the scheduled fork with the smallest activation timestamp strictly
+        // greater than `block_timestamp`. Iterating all timestamp-based forks avoids
+        // bugs when intermediate forks (e.g. BPOs) are skipped in a network's schedule.
+        [
+            Fork::Shanghai,
+            Fork::Cancun,
+            Fork::Prague,
+            Fork::Osaka,
+            Fork::BPO1,
+            Fork::BPO2,
+            Fork::BPO3,
+            Fork::BPO4,
+            Fork::BPO5,
+            Fork::Amsterdam,
+        ]
+        .into_iter()
+        .filter_map(|fork| {
+            self.get_activation_timestamp_for_fork(fork)
+                .filter(|&t| t > block_timestamp)
+                .map(|t| (fork, t))
+        })
+        .min_by(|a, b| a.1.cmp(&b.1).then_with(|| (a.0 as u8).cmp(&(b.0 as u8))))
+        .map(|(fork, _)| fork)
     }
 
     pub fn get_last_scheduled_fork(&self) -> Fork {
@@ -1145,5 +1141,48 @@ mod tests {
 
         let error_message = result.unwrap_err().to_string();
         assert!(error_message.contains("missing field `depositContractAddress`"),);
+    }
+
+    #[test]
+    fn next_fork_skips_unscheduled_intermediate_forks() {
+        // bal-devnet-7 layout: every post-merge fork up to Osaka at t=0, Amsterdam
+        // scheduled later, no BPOs scheduled. `next_fork` must return Amsterdam
+        // even though the BPO chain between Osaka and Amsterdam is empty.
+        let config = ChainConfig {
+            shanghai_time: Some(0),
+            cancun_time: Some(0),
+            prague_time: Some(0),
+            osaka_time: Some(0),
+            amsterdam_time: Some(1_779_098_127),
+            ..Default::default()
+        };
+        assert_eq!(config.next_fork(0), Some(Fork::Amsterdam));
+        assert_eq!(config.next_fork(1_779_098_126), Some(Fork::Amsterdam));
+        assert_eq!(config.next_fork(1_779_098_127), None);
+    }
+
+    #[test]
+    fn next_fork_picks_earliest_scheduled() {
+        // Contiguous schedule: at Cancun, next should be Prague (not Osaka).
+        let config = ChainConfig {
+            shanghai_time: Some(0),
+            cancun_time: Some(100),
+            prague_time: Some(200),
+            osaka_time: Some(300),
+            ..Default::default()
+        };
+        assert_eq!(config.next_fork(150), Some(Fork::Prague));
+        assert_eq!(config.next_fork(250), Some(Fork::Osaka));
+        assert_eq!(config.next_fork(300), None);
+    }
+
+    #[test]
+    fn next_fork_returns_none_when_at_last_scheduled() {
+        let config = ChainConfig {
+            shanghai_time: Some(0),
+            cancun_time: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(config.next_fork(0), None);
     }
 }

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -511,6 +511,11 @@ impl ChainConfig {
         // Pick the scheduled fork with the smallest activation timestamp strictly
         // greater than `block_timestamp`. Iterating all timestamp-based forks avoids
         // bugs when intermediate forks (e.g. BPOs) are skipped in a network's schedule.
+        //
+        // NOTE: every timestamp-based fork MUST appear here in chronological order.
+        // Omitting a fork will silently cause `next_fork` to skip it; ties are
+        // broken by array position, so the order also encodes the canonical
+        // schedule independent of the `Fork` enum's discriminants.
         [
             Fork::Shanghai,
             Fork::Cancun,
@@ -524,13 +529,14 @@ impl ChainConfig {
             Fork::Amsterdam,
         ]
         .into_iter()
-        .filter_map(|fork| {
+        .enumerate()
+        .filter_map(|(pos, fork)| {
             self.get_activation_timestamp_for_fork(fork)
                 .filter(|&t| t > block_timestamp)
-                .map(|t| (fork, t))
+                .map(|t| (fork, t, pos))
         })
-        .min_by(|a, b| a.1.cmp(&b.1).then_with(|| (a.0 as u8).cmp(&(b.0 as u8))))
-        .map(|(fork, _)| fork)
+        .min_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)))
+        .map(|(fork, _, _)| fork)
     }
 
     pub fn get_last_scheduled_fork(&self) -> Fork {


### PR DESCRIPTION
## Summary
- `ChainConfig::next_fork` returned `None` on networks that skip intermediate forks (e.g. Osaka @0, no BPOs scheduled, Amsterdam later) because the old if-chain required every fork's immediate successor to be scheduled to advance.
- That made `eth_config` (EIP-7910) report `next: null` on bal-devnet-7, which dora flags as 6 missing fields when comparing client vs expected network config.
- Replaced the if-chain with a scan over timestamp-based forks, picking the one with the smallest activation strictly greater than `block_timestamp`.

## Repro (before fix)
Run any client against bal-devnet-7 (Shanghai/Cancun/Prague/Osaka @0, Amsterdam @1779098127, no BPOs) and call `eth_config` at the genesis block. Old code falls through to the `prague_activated && osaka_time.is_some()` branch returning `Some(Osaka)`, then the final guard `fork > self.fork(ts) == Osaka > Osaka` rejects it.

## Test plan
- [x] `cargo test -p ethrex-common --lib next_fork` (3 new unit tests cover bal-devnet-7, contiguous schedules, and end-of-schedule)
- [x] `cargo test -p ethrex-rpc --lib eth_config` (existing Hoodi-based integration test still passes)
- [ ] Run against bal-devnet-7 kurtosis enclave and confirm dora shows 0 missing fields for the ethrex client