### PR TITLE
feat(l1): bal-devnet-7 v7.2.0

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,4 +1,4 @@
 # Amsterdam (BAL) hive test configuration
-# Pinned to tests-bal@v7.1.1 (execution-specs `devnets/bal/7`)
-fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.1.1/fixtures_bal.tar.gz
-eels_commit: bcb8dc5f8934f6d03e09413309a63740fff22e71
+# Pinned to tests-bal@v7.2.0 (execution-specs `devnets/bal/7`)
+fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.2.0/fixtures_bal.tar.gz
+eels_commit: a3e5201a53d8c94e2283ae170a2c71bbc233f7e7

--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -636,6 +636,10 @@ pub enum InvalidBlockHeaderError {
     ParentBeaconBlockRootPresent,
     #[error("Requests hash is present")]
     RequestsHashPresent,
+    #[error("Block access list hash is not present")]
+    BlockAccessListHashNotPresent,
+    #[error("Block access list hash is present")]
+    BlockAccessListHashPresent,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -764,6 +768,13 @@ pub fn validate_prague_header_fields(
     if header.requests_hash.is_none() {
         return Err(InvalidBlockHeaderError::RequestsHashNotPresent);
     }
+    if chain_config.is_amsterdam_activated(header.timestamp) {
+        if header.block_access_list_hash.is_none() {
+            return Err(InvalidBlockHeaderError::BlockAccessListHashNotPresent);
+        }
+    } else if header.block_access_list_hash.is_some() {
+        return Err(InvalidBlockHeaderError::BlockAccessListHashPresent);
+    }
     Ok(())
 }
 
@@ -787,6 +798,9 @@ pub fn validate_cancun_header_fields(
     if header.requests_hash.is_some() {
         return Err(InvalidBlockHeaderError::RequestsHashPresent);
     }
+    if header.block_access_list_hash.is_some() {
+        return Err(InvalidBlockHeaderError::BlockAccessListHashPresent);
+    }
     Ok(())
 }
 
@@ -806,6 +820,9 @@ pub fn validate_pre_cancun_header_fields(
     }
     if header.requests_hash.is_some() {
         return Err(InvalidBlockHeaderError::RequestsHashPresent);
+    }
+    if header.block_access_list_hash.is_some() {
+        return Err(InvalidBlockHeaderError::BlockAccessListHashPresent);
     }
     Ok(())
 }

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -929,9 +929,12 @@ async fn handle_new_payload_v1_v2(
             "New payload requested but syncer is not initialized".to_string(),
         ));
     };
-    // Validate block hash
+    // Validate block hash. Per engine-API spec, a hash mismatch is a structural
+    // payload error (the sender's hash was computed over header fields the
+    // receiver doesn't know about, or vice versa) and surfaces as JSON-RPC
+    // -32602, not PayloadStatus.INVALID.
     if let Err(RpcErr::Internal(error_msg)) = validate_block_hash(payload, &block) {
-        return Ok(PayloadStatus::invalid_with_err(&error_msg));
+        return Err(RpcErr::WrongParam(error_msg));
     }
 
     // Check for invalid ancestors

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -192,6 +192,15 @@ impl RpcHandler for NewPayloadV4Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        // EIP-7928 / Amsterdam: V4 payloads MUST NOT include the BAL field — that
+        // field belongs to V5. Per engine-API spec, structurally-invalid payloads
+        // return JSON-RPC -32602 (Invalid params), not PayloadStatus.INVALID.
+        if self.payload.block_access_list.is_some() {
+            return Err(RpcErr::WrongParam(
+                "block_access_list not allowed in engine_newPayloadV4".to_string(),
+            ));
+        }
+
         // validate the received requests
         validate_execution_requests(&self.execution_requests)?;
 
@@ -211,6 +220,13 @@ impl RpcHandler for NewPayloadV4Request {
         };
 
         let chain_config = context.storage.get_chain_config();
+
+        // Amsterdam-active timestamps must use V5, not V4 (-32602 per engine-API spec).
+        if chain_config.is_amsterdam_activated(block.header.timestamp) {
+            return Err(RpcErr::WrongParam(
+                "engine_newPayloadV4 cannot accept Amsterdam timestamps".to_string(),
+            ));
+        }
 
         if !chain_config.is_prague_activated(block.header.timestamp) {
             return Err(RpcErr::UnsupportedFork(format!(
@@ -295,6 +311,15 @@ impl RpcHandler for NewPayloadV5Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        // EIP-7928 / Amsterdam: V5 payloads MUST include the BAL field — its
+        // absence is a structural error, not a block-validity failure. Per
+        // engine-API spec, this returns JSON-RPC -32602 (Invalid params).
+        if self.payload.block_access_list.is_none() {
+            return Err(RpcErr::WrongParam(
+                "block_access_list required in engine_newPayloadV5".to_string(),
+            ));
+        }
+
         validate_execution_payload_v4(&self.payload)?;
 
         // validate the received requests
@@ -322,11 +347,11 @@ impl RpcHandler for NewPayloadV5Request {
 
         let chain_config = context.storage.get_chain_config();
 
+        // Pre-Amsterdam timestamps must use V4, not V5 (-32602 per engine-API spec).
         if !chain_config.is_amsterdam_activated(block.header.timestamp) {
-            return Err(RpcErr::UnsupportedFork(format!(
-                "{:?}",
-                chain_config.get_fork(block.header.timestamp)
-            )));
+            return Err(RpcErr::WrongParam(
+                "engine_newPayloadV5 requires Amsterdam timestamp".to_string(),
+            ));
         }
 
         let bal = self.payload.block_access_list.clone();

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -221,11 +221,15 @@ impl RpcHandler for NewPayloadV4Request {
 
         let chain_config = context.storage.get_chain_config();
 
-        // Amsterdam-active timestamps must use V5, not V4 (-32602 per engine-API spec).
+        // Amsterdam-active timestamps must use V5, not V4. Per engine-API spec
+        // (amsterdam.md): "Client software MUST return -38005: Unsupported fork
+        // if the timestamp of payload is greater than or equal to the Amsterdam
+        // activation timestamp."
         if chain_config.is_amsterdam_activated(block.header.timestamp) {
-            return Err(RpcErr::WrongParam(
-                "engine_newPayloadV4 cannot accept Amsterdam timestamps".to_string(),
-            ));
+            return Err(RpcErr::UnsupportedFork(format!(
+                "{:?}",
+                chain_config.get_fork(block.header.timestamp)
+            )));
         }
 
         if !chain_config.is_prague_activated(block.header.timestamp) {

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -242,7 +242,9 @@ impl RpcHandler for NewPayloadV4Request {
         // EIP-7928 fork-boundary detector: V4 doesn't carry block_access_list_hash
         // in its header schema. If the payload's block_hash matches what a V5-style
         // header (with block_access_list_hash injected) would produce, the sender
-        // used the wrong API version — reject with -32602. Real value-mismatch
+        // used the wrong API version; reject with -32602 (InvalidParams) to match
+        // the EELS fixture test_invalid_pre_fork_block_with_bal_hash_field
+        // [fork_BPO2ToAmsterdamAtTime15k-blockchain_test_engine]. Real value-mismatch
         // tests don't match this alternate and fall through to PayloadStatus.INVALID.
         if block.hash() != self.payload.block_hash {
             let mut alt_header = block.header.clone();
@@ -369,18 +371,25 @@ impl RpcHandler for NewPayloadV5Request {
 
         let chain_config = context.storage.get_chain_config();
 
-        // Pre-Amsterdam timestamps must use V4, not V5 (-32602 per engine-API spec).
+        // Pre-Amsterdam timestamps must use V4, not V5. Per engine-API spec
+        // (amsterdam.md): "Client software MUST return -38005: Unsupported fork
+        // if the timestamp of the payload does not fall within the time frame of
+        // the Amsterdam activation." Symmetric with the V4+Amsterdam case above.
         if !chain_config.is_amsterdam_activated(block.header.timestamp) {
-            return Err(RpcErr::WrongParam(
-                "engine_newPayloadV5 requires Amsterdam timestamp".to_string(),
-            ));
+            return Err(RpcErr::UnsupportedFork(format!(
+                "{:?}",
+                chain_config.get_fork(block.header.timestamp)
+            )));
         }
 
         // EIP-7928 fork-boundary detector: V5 requires block_access_list_hash in
         // the header. If the payload's block_hash matches what a V4-style header
         // (without the field) would produce, the sender used the wrong API
-        // version — reject with -32602. Real value-mismatch tests don't match
-        // this alternate and fall through to PayloadStatus.INVALID.
+        // version; reject with -32602 (InvalidParams) to match the EELS fixture
+        // test_invalid_post_fork_block_without_bal_hash_field
+        // [fork_BPO2ToAmsterdamAtTime15k-blockchain_test_engine]. Real
+        // value-mismatch tests don't match this alternate and fall through to
+        // PayloadStatus.INVALID.
         if block.hash() != self.payload.block_hash {
             let mut alt_header = block.header.clone();
             alt_header.block_access_list_hash = None;

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -234,6 +234,24 @@ impl RpcHandler for NewPayloadV4Request {
                 chain_config.get_fork(block.header.timestamp)
             )));
         }
+
+        // EIP-7928 fork-boundary detector: V4 doesn't carry block_access_list_hash
+        // in its header schema. If the payload's block_hash matches what a V5-style
+        // header (with block_access_list_hash injected) would produce, the sender
+        // used the wrong API version — reject with -32602. Real value-mismatch
+        // tests don't match this alternate and fall through to PayloadStatus.INVALID.
+        if block.hash() != self.payload.block_hash {
+            let mut alt_header = block.header.clone();
+            alt_header.block_access_list_hash = Some(H256::zero());
+            let alt_hash = alt_header.compute_block_hash(&ethrex_crypto::NativeCrypto);
+            if alt_hash == self.payload.block_hash {
+                return Err(RpcErr::WrongParam(
+                    "engine_newPayloadV4 received header with Amsterdam block_access_list_hash field"
+                        .to_string(),
+                ));
+            }
+        }
+
         // We use v3 since the execution payload remains the same.
         validate_execution_payload_v3(&self.payload)?;
         let payload_status = handle_new_payload_v3(
@@ -352,6 +370,23 @@ impl RpcHandler for NewPayloadV5Request {
             return Err(RpcErr::WrongParam(
                 "engine_newPayloadV5 requires Amsterdam timestamp".to_string(),
             ));
+        }
+
+        // EIP-7928 fork-boundary detector: V5 requires block_access_list_hash in
+        // the header. If the payload's block_hash matches what a V4-style header
+        // (without the field) would produce, the sender used the wrong API
+        // version — reject with -32602. Real value-mismatch tests don't match
+        // this alternate and fall through to PayloadStatus.INVALID.
+        if block.hash() != self.payload.block_hash {
+            let mut alt_header = block.header.clone();
+            alt_header.block_access_list_hash = None;
+            let alt_hash = alt_header.compute_block_hash(&ethrex_crypto::NativeCrypto);
+            if alt_hash == self.payload.block_hash {
+                return Err(RpcErr::WrongParam(
+                    "engine_newPayloadV5 received header missing block_access_list_hash field"
+                        .to_string(),
+                ));
+            }
         }
 
         let bal = self.payload.block_access_list.clone();

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -929,12 +929,9 @@ async fn handle_new_payload_v1_v2(
             "New payload requested but syncer is not initialized".to_string(),
         ));
     };
-    // Validate block hash. Per engine-API spec, a hash mismatch is a structural
-    // payload error (the sender's hash was computed over header fields the
-    // receiver doesn't know about, or vice versa) and surfaces as JSON-RPC
-    // -32602, not PayloadStatus.INVALID.
+    // Validate block hash
     if let Err(RpcErr::Internal(error_msg)) = validate_block_hash(payload, &block) {
-        return Err(RpcErr::WrongParam(error_msg));
+        return Ok(PayloadStatus::invalid_with_err(&error_msg));
     }
 
     // Check for invalid ancestors

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -287,21 +287,9 @@ pub struct CallFrame {
     pub ret_size: usize,
     /// If true then transfer value from caller to callee
     pub should_transfer_value: bool,
-    /// EIP-8037: snapshot of VM.state_gas_used at the start of this frame (for revert restoration)
-    pub state_gas_used_snapshot: u64,
-    /// EIP-8037 clamp-and-spill: amount of state gas that has been credited back to this frame.
-    /// Used to compute the unrefunded local charge when clamping a refund against this frame.
-    pub state_gas_refund: u64,
-    /// EIP-8037 clamp-and-spill: snapshot of VM.state_gas_refund_pending at the start of this
-    /// frame. Restored on revert so reverted children don't contribute pending refunds.
-    pub state_gas_refund_pending_snapshot: u64,
-    /// EIP-8037 clamp-and-spill: snapshot of VM.state_gas_refund_absorbed at the start of this
-    /// frame. Restored on revert so reverted children don't contribute absorbed refunds.
-    pub state_gas_refund_absorbed_snapshot: u64,
-    /// EIP-8037: snapshot of VM.state_gas_spill_outstanding at the start of this frame.
-    /// Baseline for `credit_state_gas_refund`'s
-    /// `applied_to_spill = min(clamped, frame_outstanding_delta)` clamp.
-    pub state_gas_spill_outstanding_snapshot: u64,
+    /// EIP-8037 v7.2.0: snapshot of VM.state_gas_used (signed) at child-frame entry.
+    /// Used to restore parent's state_gas_used on child revert.
+    pub state_gas_used_at_entry: i64,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
@@ -406,11 +394,7 @@ impl CallFrame {
             output: Bytes::default(),
             pc: 0,
             sub_return_data: Bytes::default(),
-            state_gas_used_snapshot: 0,
-            state_gas_refund: 0,
-            state_gas_refund_pending_snapshot: 0,
-            state_gas_refund_absorbed_snapshot: 0,
-            state_gas_spill_outstanding_snapshot: 0,
+            state_gas_used_at_entry: 0,
         }
     }
 

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -287,7 +287,7 @@ pub struct CallFrame {
     pub ret_size: usize,
     /// If true then transfer value from caller to callee
     pub should_transfer_value: bool,
-    /// EIP-8037 v7.2.0: snapshot of VM.state_gas_used (signed) at child-frame entry.
+    /// EIP-8037: snapshot of VM.state_gas_used (signed) at child-frame entry.
     /// Used to restore parent's state_gas_used on child revert.
     pub state_gas_used_at_entry: i64,
 }

--- a/crates/vm/levm/src/constants.rs
+++ b/crates/vm/levm/src/constants.rs
@@ -20,7 +20,7 @@ pub const MEMORY_EXPANSION_QUOTIENT: u64 = 512;
 // Dedicated gas limit for system calls according to EIPs 2935, 4788, 7002 and 7251
 pub const SYS_CALL_GAS_LIMIT: u64 = 30000000;
 
-// EIP-8037 bal-devnet-7 (execution-specs commit 7b3e8016): system transactions
+// EIP-8037: system transactions
 // receive an extra state-gas reservoir of
 // `STATE_BYTES_PER_STORAGE_SET * cost_per_state_byte * SYSTEM_MAX_SSTORES_PER_CALL`
 // on top of `SYS_CALL_GAS_LIMIT`, so SSTORE-heavy system contracts (EIP-2935,

--- a/crates/vm/levm/src/execution_handlers.rs
+++ b/crates/vm/levm/src/execution_handlers.rs
@@ -131,7 +131,7 @@ impl<'a> VM<'a> {
         let new_account = self.get_account_mut(new_contract_address)?;
 
         if new_account.create_would_collide() {
-            // Per EIP-684 + EELS bal-devnet-7: a tx-level CREATE collision burns the
+            // Per EIP-684: a tx-level CREATE collision burns the
             // full forwarded execution gas as `regular_gas_used`. Zero `gas_remaining`
             // so `raw_consumed = gas_limit` for the downstream regular-gas formula in
             // `default_hook::refund_sender`; otherwise the post-intrinsic leftover

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -167,8 +167,8 @@ pub const STATE_BYTES_PER_STORAGE_SET: u64 = 64;
 pub const STATE_BYTES_PER_AUTH_BASE: u64 = 23; // 23-byte delegation indicator slot
 pub const STATE_BYTES_PER_AUTH_TOTAL: u64 = 143; // 120 account + 23 auth-specific
 
-/// EIP-8037 cost_per_state_byte. Pinned to the bal-devnet-7 fixed value 1530
-/// (execution-specs#2827). The dynamic formula derived from the block gas limit
+/// EIP-8037 cost_per_state_byte. Pinned to the fixed value 1530.
+/// The dynamic formula derived from the block gas limit
 /// is not active.
 pub fn cost_per_state_byte(_block_gas_limit: u64) -> u64 {
     1530

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -153,17 +153,14 @@ impl Hook for DefaultHook {
         // calldata_floor). The user does NOT lose the whole gas_limit.
         if vm.env.config.fork >= Fork::Amsterdam && ctx_result.is_collision() {
             let gas_limit = vm.env.gas_limit;
-            // `vm.finalize_execution` already bumped state_gas_refund_absorbed by
-            // new_account_refund (for the CREATE-failure intrinsic refund), and
-            // state_refund carries any EIP-7702 auth refund. Subtract both so the
-            // state dimension lands at 0.
-            let exec_refund = vm
-                .state_gas_refund_absorbed
-                .saturating_add(vm.state_gas_refund_pending);
+            // v7.2.0: state_gas_used is already net (signed, inline refunds applied).
+            // state_refund carries the EIP-7702 auth refund and CREATE-failure intrinsic
+            // (added by vm.finalize_execution). Clamp at zero per spec PR #2863.
+            #[expect(clippy::as_conversions, reason = "value is clamped to >=0 by .max(0)")]
             let state_gas = vm
                 .state_gas_used
-                .saturating_sub(exec_refund)
-                .saturating_sub(vm.state_refund);
+                .saturating_sub(i64::try_from(vm.state_refund).unwrap_or(i64::MAX))
+                .max(0) as u64;
             let floor = vm.get_min_gas_used()?;
             // Regular gas = gas_limit - state_gas_left, where state_gas_left =
             // reservoir (PRESERVED across collision in EELS, with new_account_refund
@@ -245,39 +242,25 @@ pub fn refund_sender(
     if vm.env.config.fork >= Fork::Amsterdam {
         // EIP-7623 floor applies to the regular (non-state) gas component only.
         let floor = vm.get_min_gas_used()?;
-        // EELS block accounting per fork.py:
-        //   tx_regular_gas = intrinsic_regular + regular_gas_used
-        //   tx_state_gas   = intrinsic_state   + state_gas_used (net after refunds)
-        // Reservoir activity (auth refunds, SSTORE 0→N→0 credits) is NEUTRAL to
-        // block accounting — it only affects sender refund. To derive tx_regular_gas
-        // from our raw gas consumption, subtract intrinsic_state, the initial
-        // reservoir (pre-consumed from gas_remaining in add_intrinsic_gas), and any
-        // state-gas spills that reduced gas_remaining (EELS charge_state_gas spills
-        // don't count as regular_gas_used).
-        let execution_state_gas_refund = vm
-            .state_gas_refund_absorbed
-            .saturating_add(vm.state_gas_refund_pending);
-        // EELS PR #2816 (bal-devnet-7): subtract `state_refund` (EIP-7702
-        // existing-authority refund channel) from the state dimension. Lives separately
-        // from `state_gas_refund_absorbed/pending` because it bypasses per-frame
-        // accounting and survives revert/halt/OOG (it's a tx-level refund, not a
-        // frame-local credit). Matches EELS
-        // `tx_state_gas = intrinsic_state + state_gas_used - state_refund`.
+        // EIP-8037 v7.2.0: state_gas_used is already net (signed, credits applied inline).
+        // Subtract state_refund (EIP-7702 tx-level channel) and clamp at zero per PR #2863.
+        #[expect(clippy::as_conversions, reason = "value is clamped to >=0 by .max(0)")]
         let state_gas = vm
             .state_gas_used
-            .saturating_sub(execution_state_gas_refund)
-            .saturating_sub(vm.state_refund);
+            .saturating_sub(i64::try_from(vm.state_refund).unwrap_or(i64::MAX))
+            .max(0) as u64;
         // Compute raw consumption from scratch (gas_limit minus gas_remaining)
         // to avoid interference from any reservoir-current subtraction baked
         // into the caller's pre-refund number.
         #[expect(clippy::as_conversions, reason = "gas_remaining is >= 0 here")]
         let gas_remaining = vm.current_call_frame.gas_remaining.max(0) as u64;
         let raw_consumed = vm.env.gas_limit.saturating_sub(gas_remaining);
-        // EIP-8037 (PR #2815, Policy A): state-gas spills are refunded via the reservoir
-        // (finalize_execution adds the execution portion back). Subtract every spill so it
-        // does not count toward the regular dimension; no reclassification term needed.
+        // Subtract intrinsic_state (pre-consumed from gas_remaining as part of total intrinsic),
+        // the initial reservoir (pre-consumed from gas_remaining), and state-gas spills
+        // (EELS charge_state_gas spills don't count as regular_gas_used).
+        let intrinsic_state_gas = vm.get_intrinsic_gas()?.1;
         let regular_gas = raw_consumed
-            .saturating_sub(vm.intrinsic_state_gas_charged)
+            .saturating_sub(intrinsic_state_gas)
             .saturating_sub(vm.state_gas_reservoir_initial)
             .saturating_sub(vm.state_gas_spill);
         let effective_regular = regular_gas.max(floor);

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -143,7 +143,7 @@ impl Hook for DefaultHook {
             undo_value_transfer(vm)?;
         }
 
-        // EIP-8037 (Amsterdam+, bal-devnet-7): CREATE-tx address collision.
+        // EIP-8037 (Amsterdam+): CREATE-tx address collision.
         // Per EELS process_message_call (interpreter.py:120-145) the collision
         // returns `state_gas_left = message.state_gas_reservoir` (reservoir is
         // PRESERVED, not burned). The failure block in fork.py:1086-1094 then
@@ -153,9 +153,9 @@ impl Hook for DefaultHook {
         // calldata_floor). The user does NOT lose the whole gas_limit.
         if vm.env.config.fork >= Fork::Amsterdam && ctx_result.is_collision() {
             let gas_limit = vm.env.gas_limit;
-            // v7.2.0: state_gas_used is already net (signed, inline refunds applied).
+            // state_gas_used is already net (signed, inline refunds applied).
             // state_refund carries the EIP-7702 auth refund and CREATE-failure intrinsic
-            // (added by vm.finalize_execution). Clamp at zero per spec PR #2863.
+            // (added by vm.finalize_execution). Clamp at zero.
             let state_refund_signed =
                 i64::try_from(vm.state_refund).map_err(|_| InternalError::Overflow)?;
             let state_gas: u64 =
@@ -242,8 +242,8 @@ pub fn refund_sender(
     if vm.env.config.fork >= Fork::Amsterdam {
         // EIP-7623 floor applies to the regular (non-state) gas component only.
         let floor = vm.get_min_gas_used()?;
-        // EIP-8037 v7.2.0: state_gas_used is already net (signed, credits applied inline).
-        // Subtract state_refund (EIP-7702 tx-level channel) and clamp at zero per PR #2863.
+        // EIP-8037: state_gas_used is already net (signed, credits applied inline).
+        // Subtract state_refund (EIP-7702 tx-level channel) and clamp at zero.
         let state_refund_signed =
             i64::try_from(vm.state_refund).map_err(|_| InternalError::Overflow)?;
         let state_gas: u64 =

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -156,11 +156,11 @@ impl Hook for DefaultHook {
             // v7.2.0: state_gas_used is already net (signed, inline refunds applied).
             // state_refund carries the EIP-7702 auth refund and CREATE-failure intrinsic
             // (added by vm.finalize_execution). Clamp at zero per spec PR #2863.
-            #[expect(clippy::as_conversions, reason = "value is clamped to >=0 by .max(0)")]
-            let state_gas = vm
-                .state_gas_used
-                .saturating_sub(i64::try_from(vm.state_refund).unwrap_or(i64::MAX))
-                .max(0) as u64;
+            let state_refund_signed =
+                i64::try_from(vm.state_refund).map_err(|_| InternalError::Overflow)?;
+            let state_gas: u64 =
+                u64::try_from(vm.state_gas_used.saturating_sub(state_refund_signed).max(0))
+                    .map_err(|_| InternalError::Overflow)?;
             let floor = vm.get_min_gas_used()?;
             // Regular gas = gas_limit - state_gas_left, where state_gas_left =
             // reservoir (PRESERVED across collision in EELS, with new_account_refund
@@ -244,11 +244,11 @@ pub fn refund_sender(
         let floor = vm.get_min_gas_used()?;
         // EIP-8037 v7.2.0: state_gas_used is already net (signed, credits applied inline).
         // Subtract state_refund (EIP-7702 tx-level channel) and clamp at zero per PR #2863.
-        #[expect(clippy::as_conversions, reason = "value is clamped to >=0 by .max(0)")]
-        let state_gas = vm
-            .state_gas_used
-            .saturating_sub(i64::try_from(vm.state_refund).unwrap_or(i64::MAX))
-            .max(0) as u64;
+        let state_refund_signed =
+            i64::try_from(vm.state_refund).map_err(|_| InternalError::Overflow)?;
+        let state_gas: u64 =
+            u64::try_from(vm.state_gas_used.saturating_sub(state_refund_signed).max(0))
+                .map_err(|_| InternalError::Overflow)?;
         // Compute raw consumption from scratch (gas_limit minus gas_remaining)
         // to avoid interference from any reservoir-current subtraction baked
         // into the caller's pre-refund number.

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -258,9 +258,8 @@ pub fn refund_sender(
         // Subtract intrinsic_state (pre-consumed from gas_remaining as part of total intrinsic),
         // the initial reservoir (pre-consumed from gas_remaining), and state-gas spills
         // (EELS charge_state_gas spills don't count as regular_gas_used).
-        let intrinsic_state_gas = vm.get_intrinsic_gas()?.1;
         let regular_gas = raw_consumed
-            .saturating_sub(intrinsic_state_gas)
+            .saturating_sub(vm.intrinsic_state_gas)
             .saturating_sub(vm.state_gas_reservoir_initial)
             .saturating_sub(vm.state_gas_spill);
         let effective_regular = regular_gas.max(floor);

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -818,6 +818,9 @@ impl<'a> VM<'a> {
         );
         // Store BAL checkpoint in the call frame's backup for restoration on revert
         new_call_frame.call_frame_backup.bal_checkpoint = bal_checkpoint;
+        // Snapshot AFTER the CREATE account state-gas charge has landed in
+        // `vm.state_gas_used`, so the revert restore in `handle_return_create`
+        // keeps the parent's pre-CREATE intrinsic without re-refunding it.
         new_call_frame.state_gas_used_at_entry = self.state_gas_used;
 
         self.add_callframe(new_call_frame);
@@ -1144,27 +1147,7 @@ impl<'a> VM<'a> {
                 // No pending flush needed — credits were applied inline.
             }
             TxResult::Revert(_) => {
-                // EIP-8037 incorporate_child_on_error:
-                //   parent.state_gas_left += child.state_gas_used + child.state_gas_left
-                // In ethrex's shared-VM model the child holds the whole reservoir
-                // during execution, so `child.state_gas_left == self.state_gas_reservoir`
-                // at revert (absolute, not a delta against entry).
-                let child_state_gas_used = self
-                    .state_gas_used
-                    .checked_sub(state_gas_used_at_entry)
-                    .ok_or(InternalError::Underflow)?;
-                let child_state_gas_left =
-                    i64::try_from(self.state_gas_reservoir).map_err(|_| InternalError::Overflow)?;
-                self.state_gas_used = state_gas_used_at_entry;
-                // child_state_gas_used may be negative when inline refunds exceed gross charges.
-                let net_return = child_state_gas_used
-                    .checked_add(child_state_gas_left)
-                    .ok_or(InternalError::Overflow)?;
-                // net_return < 0 would mean the child returned less gas than it consumed AND
-                // the inline-refund accounting underflowed — impossible by the spec invariant.
-                self.state_gas_reservoir =
-                    u64::try_from(net_return.max(0)).map_err(|_| InternalError::Overflow)?;
-
+                self.incorporate_child_state_gas_on_revert(state_gas_used_at_entry)?;
                 self.current_call_frame.stack.push(FAIL)?;
             }
         };
@@ -1216,20 +1199,7 @@ impl<'a> VM<'a> {
                 // No pending flush needed — credits were applied inline.
             }
             TxResult::Revert(err) => {
-                // EIP-8037 incorporate_child_on_error: see
-                // handle_return_call for the derivation.
-                let child_state_gas_used = self
-                    .state_gas_used
-                    .checked_sub(state_gas_used_at_entry)
-                    .ok_or(InternalError::Underflow)?;
-                let child_state_gas_left =
-                    i64::try_from(self.state_gas_reservoir).map_err(|_| InternalError::Overflow)?;
-                self.state_gas_used = state_gas_used_at_entry;
-                let net_return = child_state_gas_used
-                    .checked_add(child_state_gas_left)
-                    .ok_or(InternalError::Overflow)?;
-                self.state_gas_reservoir =
-                    u64::try_from(net_return.max(0)).map_err(|_| InternalError::Overflow)?;
+                self.incorporate_child_state_gas_on_revert(state_gas_used_at_entry)?;
 
                 // EIP-8037: CREATE's account state gas was charged in the parent before
                 // the child frame began; no account was created, so refund it per EELS

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -25,7 +25,6 @@ use crate::{
 use bytes::Bytes;
 use ethrex_common::{Address, H256, U256, evm::calculate_create_address, types::Fork};
 use ethrex_common::{tracing::CallType, types::Code};
-use std::mem;
 
 pub struct OpCallHandler;
 impl OpcodeHandler for OpCallHandler {
@@ -777,9 +776,6 @@ impl<'a> VM<'a> {
         // Increment sender nonce (irreversible change)
         self.increment_account_nonce(deployer)?;
 
-        // EIP-8037: Save snapshot AFTER charging CREATE's account state gas
-        let create_state_gas_used_snapshot = self.state_gas_used;
-
         // Deployment will fail (consuming all gas) if the contract already exists.
         let new_account = self.get_account_mut(new_address)?;
         if new_account.create_would_collide() {
@@ -822,10 +818,7 @@ impl<'a> VM<'a> {
         );
         // Store BAL checkpoint in the call frame's backup for restoration on revert
         new_call_frame.call_frame_backup.bal_checkpoint = bal_checkpoint;
-        new_call_frame.state_gas_used_snapshot = create_state_gas_used_snapshot;
-        new_call_frame.state_gas_refund_pending_snapshot = self.state_gas_refund_pending;
-        new_call_frame.state_gas_refund_absorbed_snapshot = self.state_gas_refund_absorbed;
-        new_call_frame.state_gas_spill_outstanding_snapshot = self.state_gas_spill_outstanding;
+        new_call_frame.state_gas_used_at_entry = self.state_gas_used;
 
         self.add_callframe(new_call_frame);
 
@@ -1040,10 +1033,7 @@ impl<'a> VM<'a> {
             );
             // Store BAL checkpoint in the call frame's backup for restoration on revert
             new_call_frame.call_frame_backup.bal_checkpoint = bal_checkpoint;
-            new_call_frame.state_gas_used_snapshot = self.state_gas_used;
-            new_call_frame.state_gas_refund_pending_snapshot = self.state_gas_refund_pending;
-            new_call_frame.state_gas_refund_absorbed_snapshot = self.state_gas_refund_absorbed;
-            new_call_frame.state_gas_spill_outstanding_snapshot = self.state_gas_spill_outstanding;
+            new_call_frame.state_gas_used_at_entry = self.state_gas_used;
 
             self.add_callframe(new_call_frame);
 
@@ -1110,9 +1100,7 @@ impl<'a> VM<'a> {
             ret_offset,
             ret_size,
             memory: old_callframe_memory,
-            state_gas_used_snapshot,
-            state_gas_refund_pending_snapshot,
-            state_gas_refund_absorbed_snapshot,
+            state_gas_used_at_entry,
             call_frame_backup,
             stack,
             ..
@@ -1151,50 +1139,31 @@ impl<'a> VM<'a> {
             TxResult::Success => {
                 self.current_call_frame.stack.push(SUCCESS)?;
                 self.merge_call_frame_backup_with_parent(&call_frame_backup)?;
-
-                // EIP-8037 clamp-and-spill: on successful child return, flush any pending
-                // state gas refund into the parent frame (which may absorb all, part, or none).
-                if self.state_gas_refund_pending > 0 {
-                    let pending = mem::replace(&mut self.state_gas_refund_pending, 0);
-                    self.credit_state_gas_refund(pending)?;
-                }
+                // EIP-8037 v7.2.0: on success, child's state_gas_used is already
+                // accumulated into the VM-level field (signed sum handles refunds).
+                // No pending flush needed — credits were applied inline.
             }
             TxResult::Revert(_) => {
-                // EELS PR #2823 (bal-devnet-7) incorporate_child_on_error:
+                // EIP-8037 v7.2.0 (PR #2863) incorporate_child_on_error:
                 //   parent.state_gas_left += child.state_gas_used + child.state_gas_left
-                // where EELS `credit_state_gas_refund` decrements the child's
-                // `state_gas_used` (applied = min(amount, state_gas_used);
-                // state_gas_used -= applied). So `child.state_gas_used` here is
-                // already NET of any inline credits the child applied.
-                //
-                // ethrex bookkeeping: gross charges live in `state_gas_used`, the
-                // matching deduction lives in `state_gas_refund_absorbed`. The
-                // EELS-equivalent net is therefore (used − absorbed) accumulated
-                // during the child:
-                //   new_res = current_res + (used_delta − absorbed_delta)
-                // The pre-child reservoir is preserved implicitly because the
-                // child's reservoir mutations are layered on top of the parent's
-                // current value.
-                //
-                // `state_gas_refund_absorbed` is restored to snapshot so the child's
-                // absorbed credit (which targeted its own rolled-back charge) does
-                // not discount the parent's later block-accounted charges.
-                let used_delta = self.state_gas_used.saturating_sub(state_gas_used_snapshot);
-                let absorbed_delta = self
-                    .state_gas_refund_absorbed
-                    .saturating_sub(state_gas_refund_absorbed_snapshot);
-                let child_net_used = used_delta.saturating_sub(absorbed_delta);
-
-                self.state_gas_used = state_gas_used_snapshot;
-                self.state_gas_refund_pending = state_gas_refund_pending_snapshot;
-                self.state_gas_refund_absorbed = state_gas_refund_absorbed_snapshot;
-                self.state_gas_reservoir = self.state_gas_reservoir.saturating_add(child_net_used);
-                // `state_gas_credit_against_drain`: NOT restored (left elevated per
-                // Policy A so its burn propagates up the cascade).
-                // `state_gas_spill_outstanding`: NOT restored — its baseline lives
-                // on the parent's snapshot (vm.rs `credit_state_gas_refund`) so
-                // the child's outstanding contribution stays visible to the
-                // parent's clamp.
+                // In ethrex's shared-VM model the child holds the whole reservoir
+                // during execution, so `child.state_gas_left == self.state_gas_reservoir`
+                // at revert (absolute, not a delta against entry).
+                let child_state_gas_used = self
+                    .state_gas_used
+                    .checked_sub(state_gas_used_at_entry)
+                    .ok_or(InternalError::Underflow)?;
+                let child_state_gas_left =
+                    i64::try_from(self.state_gas_reservoir).map_err(|_| InternalError::Overflow)?;
+                self.state_gas_used = state_gas_used_at_entry;
+                // child_state_gas_used may be negative when inline refunds exceed gross charges.
+                let net_return = child_state_gas_used
+                    .checked_add(child_state_gas_left)
+                    .ok_or(InternalError::Overflow)?;
+                // net_return < 0 would mean the child returned less gas than it consumed AND
+                // the inline-refund accounting underflowed — impossible by the spec invariant.
+                self.state_gas_reservoir =
+                    u64::try_from(net_return.max(0)).map_err(|_| InternalError::Overflow)?;
 
                 self.current_call_frame.stack.push(FAIL)?;
             }
@@ -1220,9 +1189,7 @@ impl<'a> VM<'a> {
             to,
             call_frame_backup,
             memory: old_callframe_memory,
-            state_gas_used_snapshot,
-            state_gas_refund_pending_snapshot,
-            state_gas_refund_absorbed_snapshot,
+            state_gas_used_at_entry,
             stack,
             ..
         } = executed_call_frame;
@@ -1244,28 +1211,25 @@ impl<'a> VM<'a> {
             TxResult::Success => {
                 self.current_call_frame.stack.push(address_to_word(to))?;
                 self.merge_call_frame_backup_with_parent(&call_frame_backup)?;
-
-                // EIP-8037 clamp-and-spill: on successful child return, flush any pending
-                // state gas refund into the parent frame (which may absorb all, part, or none).
-                if self.state_gas_refund_pending > 0 {
-                    let pending = mem::replace(&mut self.state_gas_refund_pending, 0);
-                    self.credit_state_gas_refund(pending)?;
-                }
+                // EIP-8037 v7.2.0: on success, child's state_gas_used is already
+                // accumulated into the VM-level field (signed sum handles refunds).
+                // No pending flush needed — credits were applied inline.
             }
             TxResult::Revert(err) => {
-                // EELS PR #2823 (bal-devnet-7): see handle_return_call for the full
-                // derivation. new_reservoir = current_reservoir + (used_delta −
-                // absorbed_delta) where deltas are child's effective net charges.
-                let used_delta = self.state_gas_used.saturating_sub(state_gas_used_snapshot);
-                let absorbed_delta = self
-                    .state_gas_refund_absorbed
-                    .saturating_sub(state_gas_refund_absorbed_snapshot);
-                let child_net_used = used_delta.saturating_sub(absorbed_delta);
-
-                self.state_gas_used = state_gas_used_snapshot;
-                self.state_gas_refund_pending = state_gas_refund_pending_snapshot;
-                self.state_gas_refund_absorbed = state_gas_refund_absorbed_snapshot;
-                self.state_gas_reservoir = self.state_gas_reservoir.saturating_add(child_net_used);
+                // EIP-8037 v7.2.0 (PR #2863) incorporate_child_on_error: see
+                // handle_return_call for the derivation.
+                let child_state_gas_used = self
+                    .state_gas_used
+                    .checked_sub(state_gas_used_at_entry)
+                    .ok_or(InternalError::Underflow)?;
+                let child_state_gas_left =
+                    i64::try_from(self.state_gas_reservoir).map_err(|_| InternalError::Overflow)?;
+                self.state_gas_used = state_gas_used_at_entry;
+                let net_return = child_state_gas_used
+                    .checked_add(child_state_gas_left)
+                    .ok_or(InternalError::Overflow)?;
+                self.state_gas_reservoir =
+                    u64::try_from(net_return.max(0)).map_err(|_| InternalError::Overflow)?;
 
                 // EIP-8037: CREATE's account state gas was charged in the parent before
                 // the child frame began; no account was created, so refund it per EELS

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1139,12 +1139,12 @@ impl<'a> VM<'a> {
             TxResult::Success => {
                 self.current_call_frame.stack.push(SUCCESS)?;
                 self.merge_call_frame_backup_with_parent(&call_frame_backup)?;
-                // EIP-8037 v7.2.0: on success, child's state_gas_used is already
+                // EIP-8037: on success, child's state_gas_used is already
                 // accumulated into the VM-level field (signed sum handles refunds).
                 // No pending flush needed — credits were applied inline.
             }
             TxResult::Revert(_) => {
-                // EIP-8037 v7.2.0 (PR #2863) incorporate_child_on_error:
+                // EIP-8037 incorporate_child_on_error:
                 //   parent.state_gas_left += child.state_gas_used + child.state_gas_left
                 // In ethrex's shared-VM model the child holds the whole reservoir
                 // during execution, so `child.state_gas_left == self.state_gas_reservoir`
@@ -1211,12 +1211,12 @@ impl<'a> VM<'a> {
             TxResult::Success => {
                 self.current_call_frame.stack.push(address_to_word(to))?;
                 self.merge_call_frame_backup_with_parent(&call_frame_backup)?;
-                // EIP-8037 v7.2.0: on success, child's state_gas_used is already
+                // EIP-8037: on success, child's state_gas_used is already
                 // accumulated into the VM-level field (signed sum handles refunds).
                 // No pending flush needed — credits were applied inline.
             }
             TxResult::Revert(err) => {
-                // EIP-8037 v7.2.0 (PR #2863) incorporate_child_on_error: see
+                // EIP-8037 incorporate_child_on_error: see
                 // handle_return_call for the derivation.
                 let child_state_gas_used = self
                     .state_gas_used

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -346,7 +346,7 @@ impl<'a> VM<'a> {
             // An account can exist in the trie but be empty (e.g., has non-empty storage root).
             if authority_exists {
                 if self.env.config.fork >= Fork::Amsterdam {
-                    // EELS PR #2816 (bal-devnet-7): refund
+                    // EIP-7702: refund
                     // `STATE_BYTES_PER_NEW_ACCOUNT * cpsb` for each existing authority via
                     // two independent channels:
                     //   1. `state_gas_reservoir += refund` — sender gets the gas back via
@@ -372,7 +372,7 @@ impl<'a> VM<'a> {
                 }
             }
 
-            // EELS PR #2836 + #2848 (bal-devnet-7, tests-bal@v7.1.1): refill the
+            // EIP-7702: refill the
             // `STATE_BYTES_PER_AUTH_BASE * cpsb` portion of intrinsic state gas
             // when no new delegation indicator bytes are written. That covers
             // two cases:
@@ -459,7 +459,7 @@ impl<'a> VM<'a> {
         // the reservoir for drawing state gas without consuming regular gas_remaining.
         if self.env.config.fork >= Fork::Amsterdam {
             if self.env.is_system_call {
-                // EIP-8037 bal-devnet-7 (execution-specs commit 7b3e8016): system
+                // EIP-8037: system
                 // transactions get a dedicated state-gas reservoir of
                 // `state_gas_storage_set * SYSTEM_MAX_SSTORES_PER_CALL` ON TOP of
                 // the full SYS_CALL_GAS_LIMIT regular budget — so SSTORE-heavy

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -447,6 +447,11 @@ impl<'a> VM<'a> {
             .state_gas_used
             .checked_add(i64::try_from(state_gas).map_err(|_| InternalError::Overflow)?)
             .ok_or(InternalError::Overflow)?;
+        // Remember the intrinsic split so we can leave it in state_gas_used on top-level
+        // error (matches EELS `tx_env.intrinsic_state_gas`, which is kept separate from
+        // `tx_output.state_gas_used` and never refunded).
+        debug_assert_eq!(self.intrinsic_state_gas, 0, "intrinsic_state_gas set twice");
+        self.intrinsic_state_gas = state_gas;
 
         // EIP-8037 (Amsterdam+): compute state gas reservoir from excess gas_limit.
         // execution_gas = what remains after all intrinsic gas; regular_gas_budget = how much

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -354,10 +354,8 @@ impl<'a> VM<'a> {
                     //   2. `state_refund += refund` — block-level state-gas accounting
                     //      subtracts this at refund_sender (mirrors EELS
                     //      `MessageCallOutput.state_refund`).
-                    // `state_gas_used` and `intrinsic_state_gas_charged` are intentionally
-                    // NOT decremented: spec keeps them immutable after validation so
-                    // Policy A's `execution_portion` math and refund_sender's regular-gas
-                    // formula stay correct on revert/halt/OOG paths.
+                    // `state_gas_used` is NOT decremented here: the refund goes through
+                    // `state_refund` (tx-level channel) so block-level accounting subtracts it.
                     let refund = self.state_gas_new_account;
                     self.state_gas_reservoir = self
                         .state_gas_reservoir
@@ -444,20 +442,11 @@ impl<'a> VM<'a> {
             .increase_consumed_gas(total_gas)
             .map_err(|_| TxValidationError::IntrinsicGasTooLow)?;
 
+        // state_gas_used is i64; intrinsic state gas is bounded by tx gas limit (< i64::MAX).
         self.state_gas_used = self
             .state_gas_used
-            .checked_add(state_gas)
+            .checked_add(i64::try_from(state_gas).map_err(|_| InternalError::Overflow)?)
             .ok_or(InternalError::Overflow)?;
-
-        // EIP-8037: Capture the intrinsic state gas charged so refund_sender's
-        // Policy A `execution_portion = state_gas_used − intrinsic − absorbed − pending`
-        // formula stays correct after revert/halt/OOG (where state_gas_used and
-        // intrinsic_state_gas_charged are intentionally not decremented).
-        debug_assert_eq!(
-            self.intrinsic_state_gas_charged, 0,
-            "intrinsic_state_gas_charged set twice"
-        );
-        self.intrinsic_state_gas_charged = self.state_gas_used;
 
         // EIP-8037 (Amsterdam+): compute state gas reservoir from excess gas_limit.
         // execution_gas = what remains after all intrinsic gas; regular_gas_budget = how much

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -481,6 +481,12 @@ pub struct VM<'a> {
     /// state-gas at the end of `refund_sender`. Survives revert/halt/OOG since it lives
     /// on the VM, not in any call-frame backup.
     pub state_refund: u64,
+    /// EIP-8037: intrinsic state gas (`tx_env.intrinsic_state_gas` in EELS). Captured at
+    /// `add_intrinsic_gas` time. ethrex lumps intrinsic + execution into `state_gas_used`,
+    /// so on top-level error this field is what we leave behind when refunding the
+    /// execution portion to the reservoir — block accounting then bills the intrinsic
+    /// (matches EELS `tx_state_gas = intrinsic_state_gas + tx_output.state_gas_used`).
+    pub intrinsic_state_gas: u64,
     /// The opcode table mapping opcodes to opcode handlers for fast lookup.
     /// Build dynamically according to the given fork config.
     pub(crate) opcode_table: [OpCodeFn; 256],
@@ -549,6 +555,7 @@ impl<'a> VM<'a> {
             state_gas_auth_total,
             state_gas_auth_base,
             state_refund: 0,
+            intrinsic_state_gas: 0,
             current_call_frame: CallFrame::new(
                 env.origin,
                 callee,
@@ -874,17 +881,27 @@ impl<'a> VM<'a> {
         mut ctx_result: ContextResult,
     ) -> Result<ExecutionReport, VMError> {
         // EIP-8037 v7.2.0 (PR #2863): On top-level tx failure (REVERT, ExceptionalHalt, or OOG),
-        // restore reservoir via the `state_gas_left + state_gas_used` invariant.
-        // With signed `state_gas_used`, `max(0, state_gas_used)` safely handles negative values
-        // (which arise when inline refunds exceed gross charges in this frame).
+        // refund only the EXECUTION portion of state gas to the reservoir; the intrinsic
+        // stays in `state_gas_used` so block accounting bills it. EELS keeps these in
+        // separate fields (`tx_output.state_gas_used` vs `tx_env.intrinsic_state_gas`);
+        // ethrex lumps them so we split on the way out:
+        //   tx_output.state_gas_left += tx_output.state_gas_used
+        //   tx_output.state_gas_used  = 0
+        // becomes in lumped form (with intrinsic preserved):
+        //   reservoir   += signed(state_gas_used − intrinsic)   [clamped at 0]
+        //   state_gas_used = intrinsic
         // Collision is handled separately in the hook.
         if self.env.config.fork >= Fork::Amsterdam && !ctx_result.is_success() {
             if !ctx_result.is_collision() {
-                #[expect(clippy::as_conversions, reason = "value is clamped to >=0 by .max(0)")]
-                let execution_portion = self.state_gas_used.max(0) as u64;
+                let intrinsic_signed =
+                    i64::try_from(self.intrinsic_state_gas).map_err(|_| InternalError::Overflow)?;
+                let execution_state_gas_used = self.state_gas_used.saturating_sub(intrinsic_signed);
+                let reservoir_signed = i64::try_from(self.state_gas_reservoir)
+                    .map_err(|_| InternalError::Overflow)?
+                    .saturating_add(execution_state_gas_used);
                 self.state_gas_reservoir =
-                    self.state_gas_reservoir.saturating_add(execution_portion);
-                self.state_gas_used = 0;
+                    u64::try_from(reservoir_signed.max(0)).map_err(|_| InternalError::Overflow)?;
+                self.state_gas_used = intrinsic_signed;
             }
 
             // EIP-8037 bal-devnet-7 (EELS PR #2823): on ANY top-level CREATE-tx

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -447,7 +447,7 @@ pub struct VM<'a> {
     pub vm_type: VMType,
     /// EIP-8037: Accumulated state gas for this transaction (Amsterdam+).
     /// Signed: goes negative when inline refunds exceed gross charges in the local frame
-    /// (e.g. SSTORE 0→x→0 restoration matching an ancestor's charge). PR #2863.
+    /// (e.g. SSTORE 0→x→0 restoration matching an ancestor's charge).
     pub state_gas_used: i64,
     /// EIP-8037: State gas reservoir pre-funded from excess gas_limit (Amsterdam+).
     pub state_gas_reservoir: u64,
@@ -471,10 +471,10 @@ pub struct VM<'a> {
     /// EIP-8037: State gas for the 23-byte EIP-7702 delegation indicator
     /// (STATE_BYTES_PER_AUTH_BASE * cost_per_state_byte). Refunded by
     /// `set_delegation` when no new delegation indicator bytes are written —
-    /// either the authority's code slot already holds an indicator (EELS PR
-    /// #2836) or the auth clears against an empty authority (EELS PR #2848).
+    /// either the authority's code slot already holds an indicator or the
+    /// auth clears against an empty authority.
     pub state_gas_auth_base: u64,
-    /// EIP-8037 bal-devnet-7 (EELS PR #2816): state-gas refund channel.
+    /// EIP-8037: state-gas refund channel.
     /// Mirrors EELS `MessageCallOutput.state_refund` — a separate, monotonic accumulator
     /// for refunds that bypass per-frame `state_gas_used` accounting. Populated by
     /// `set_delegation` for existing-authority refunds, subtracted from block-level
@@ -644,8 +644,8 @@ impl<'a> VM<'a> {
         Ok(())
     }
 
-    /// EIP-8037 v7.2.0: credit `amount` directly to the local frame's reservoir; `state_gas_used`
-    /// may go negative when the matching charge lives in an ancestor frame (PR #2863).
+    /// EIP-8037: credit `amount` directly to the local frame's reservoir; `state_gas_used`
+    /// may go negative when the matching charge lives in an ancestor frame.
     ///
     /// Must only be called for Amsterdam+ forks.
     pub fn credit_state_gas_refund(&mut self, amount: u64) -> Result<(), VMError> {
@@ -880,7 +880,7 @@ impl<'a> VM<'a> {
         &mut self,
         mut ctx_result: ContextResult,
     ) -> Result<ExecutionReport, VMError> {
-        // EIP-8037 v7.2.0 (PR #2863): On top-level tx failure (REVERT, ExceptionalHalt, or OOG),
+        // EIP-8037: On top-level tx failure (REVERT, ExceptionalHalt, or OOG),
         // refund only the EXECUTION portion of state gas to the reservoir; the intrinsic
         // stays in `state_gas_used` so block accounting bills it. EELS keeps these in
         // separate fields (`tx_output.state_gas_used` vs `tx_env.intrinsic_state_gas`);
@@ -904,7 +904,7 @@ impl<'a> VM<'a> {
                 self.state_gas_used = intrinsic_signed;
             }
 
-            // EIP-8037 bal-devnet-7 (EELS PR #2823): on ANY top-level CREATE-tx
+            // EIP-8037: on ANY top-level CREATE-tx
             // failure (revert / halt / OOG / collision), refund the intrinsic
             // `STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte` charge to the reservoir.
             // Also add to `state_refund` so block-level accounting subtracts it.
@@ -936,7 +936,7 @@ impl<'a> VM<'a> {
             Vec::new()
         };
 
-        // EIP-8037 v7.2.0 (PR #2863): `state_gas_used` is already net (signed; credits
+        // EIP-8037: `state_gas_used` is already net (signed; credits
         // decrement it inline). Subtract `state_refund` (EIP-7702 tx-level channel) and
         // clamp at zero for block accounting — `state_gas_used` may be negative when inline
         // refunds exceed gross charges.

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -660,7 +660,39 @@ impl<'a> VM<'a> {
         self.state_gas_used = self
             .state_gas_used
             .checked_sub(i64::try_from(amount).map_err(|_| InternalError::Overflow)?)
-            .ok_or(InternalError::Underflow)?;
+            .ok_or(InternalError::Overflow)?;
+        Ok(())
+    }
+
+    /// EIP-8037 `incorporate_child_on_error`: on child revert, restore the parent's
+    /// `state_gas_used` to its pre-child value and refund the child's net
+    /// `(state_gas_used + state_gas_left)` back into the parent's reservoir.
+    ///
+    /// In ethrex's shared-VM model the child holds the entire reservoir during its
+    /// execution, so `child.state_gas_left == self.state_gas_reservoir` (absolute,
+    /// not a delta against entry). `child.state_gas_used` can be negative when
+    /// inline refunds inside the child exceeded its gross charges.
+    pub fn incorporate_child_state_gas_on_revert(
+        &mut self,
+        state_gas_used_at_entry: i64,
+    ) -> Result<(), VMError> {
+        let child_state_gas_used = self
+            .state_gas_used
+            .checked_sub(state_gas_used_at_entry)
+            .ok_or(InternalError::Overflow)?;
+        let child_state_gas_left =
+            i64::try_from(self.state_gas_reservoir).map_err(|_| InternalError::Overflow)?;
+        self.state_gas_used = state_gas_used_at_entry;
+        let net_return = child_state_gas_used
+            .checked_add(child_state_gas_left)
+            .ok_or(InternalError::Overflow)?;
+        // net_return is always >= 0 by the spec invariant (reservoir conservation
+        // means a child cannot refund more than its ancestors charged); clamp
+        // defensively and cast — `as u64` is sound because of the `.max(0)`.
+        #[expect(clippy::as_conversions, reason = ".max(0) proves non-negativity")]
+        {
+            self.state_gas_reservoir = net_return.max(0) as u64;
+        }
         Ok(())
     }
 
@@ -915,9 +947,14 @@ impl<'a> VM<'a> {
             //       tx_output.state_refund   += new_account_refund
             if self.is_create()? {
                 let new_account_refund = self.state_gas_new_account;
-                self.state_gas_reservoir =
-                    self.state_gas_reservoir.saturating_add(new_account_refund);
-                self.state_refund = self.state_refund.saturating_add(new_account_refund);
+                self.state_gas_reservoir = self
+                    .state_gas_reservoir
+                    .checked_add(new_account_refund)
+                    .ok_or(InternalError::Overflow)?;
+                self.state_refund = self
+                    .state_refund
+                    .checked_add(new_account_refund)
+                    .ok_or(InternalError::Overflow)?;
             }
         }
 

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -446,7 +446,9 @@ pub struct VM<'a> {
     /// VM type (L1 or L2 with fee config).
     pub vm_type: VMType,
     /// EIP-8037: Accumulated state gas for this transaction (Amsterdam+).
-    pub state_gas_used: u64,
+    /// Signed: goes negative when inline refunds exceed gross charges in the local frame
+    /// (e.g. SSTORE 0→x→0 restoration matching an ancestor's charge). PR #2863.
+    pub state_gas_used: i64,
     /// EIP-8037: State gas reservoir pre-funded from excess gas_limit (Amsterdam+).
     pub state_gas_reservoir: u64,
     /// EIP-8037: Initial reservoir at tx start (before any execution). Captured in
@@ -458,21 +460,6 @@ pub struct VM<'a> {
     /// regular gas for block accounting — EELS charge_state_gas spills don't
     /// increment regular_gas_used.
     pub state_gas_spill: u64,
-    /// EIP-8037: Outstanding spill — the portion of `state_gas_spill` not yet cancelled
-    /// by an inline credit (SSTORE 0→N→0 or CREATE failure). Decremented inside
-    /// `credit_state_gas_refund` when the clamped credit matches the current frame's
-    /// own spill delta. Used by `incorporate_child_on_error` math at revert so a
-    /// reverting sub-frame's locally-cancelled spills don't leak into the grandparent's
-    /// reservoir refund (cf. `sstore_restoration_create_init_revert`). NOT restored on
-    /// revert — outstanding spill from a reverting child legitimately propagates up.
-    pub state_gas_spill_outstanding: u64,
-    /// EIP-8037: Cumulative credits that went toward cancelling drains (not spills).
-    /// Incremented inside `credit_state_gas_refund` by the portion of the clamped
-    /// credit that was not matched to outstanding spill. Used at revert boundaries in
-    /// place of `state_gas_refund_absorbed` so the reservoir math (`R_snap + spill -
-    /// credit`) stays consistent after the spill side is split between "still outstanding"
-    /// and "already cancelled by local credit". Restored from snapshot on child revert.
-    pub state_gas_credit_against_drain: u64,
     /// EIP-8037: Dynamic cost per state byte (computed from block_gas_limit, Amsterdam+).
     pub cost_per_state_byte: u64,
     /// EIP-8037: State gas for new account creation (STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte).
@@ -487,19 +474,6 @@ pub struct VM<'a> {
     /// either the authority's code slot already holds an indicator (EELS PR
     /// #2836) or the auth clears against an empty authority (EELS PR #2848).
     pub state_gas_auth_base: u64,
-    /// EIP-8037 clamp-and-spill: state gas refund amount that has been clamped by child frames but
-    /// not yet absorbed by an ancestor frame. Flushed into the current frame on successful sub-call
-    /// return, and restored from snapshot on revert.
-    pub state_gas_refund_pending: u64,
-    /// EIP-8037 clamp-and-spill: cumulative total of state gas refunds absorbed by any frame so
-    /// far in this transaction (across all depths). Used at finalization to compute net
-    /// state_gas_used. Restored from snapshot on child revert.
-    pub state_gas_refund_absorbed: u64,
-    /// EIP-8037: snapshot of state_gas_used taken immediately after intrinsic gas is charged.
-    /// On top-level tx failure (Policy A, EELS PR #2815), the execution portion
-    /// (state_gas_used − intrinsic_state_gas_charged − absorbed − pending) is refilled into
-    /// the reservoir while state_gas_used itself stays elevated for block-accounting.
-    pub intrinsic_state_gas_charged: u64,
     /// EIP-8037 bal-devnet-7 (EELS PR #2816): state-gas refund channel.
     /// Mirrors EELS `MessageCallOutput.state_refund` — a separate, monotonic accumulator
     /// for refunds that bypass per-frame `state_gas_used` accounting. Populated by
@@ -569,16 +543,11 @@ impl<'a> VM<'a> {
             state_gas_reservoir: 0,
             state_gas_reservoir_initial: 0,
             state_gas_spill: 0,
-            state_gas_spill_outstanding: 0,
-            state_gas_credit_against_drain: 0,
             cost_per_state_byte: cpsb,
             state_gas_new_account,
             state_gas_storage_set,
             state_gas_auth_total,
             state_gas_auth_base,
-            state_gas_refund_pending: 0,
-            state_gas_refund_absorbed: 0,
-            intrinsic_state_gas_charged: 0,
             state_refund: 0,
             current_call_frame: CallFrame::new(
                 env.origin,
@@ -653,34 +622,23 @@ impl<'a> VM<'a> {
         }
         // Safe: from_reservoir = min(reservoir, gas) so reservoir >= from_reservoir
         self.state_gas_reservoir -= from_reservoir;
-        // Only increment state_gas_used AFTER the charge succeeds
+        // Only increment state_gas_used AFTER the charge succeeds.
+        // state_gas_used is i64; tx gas_limit caps charges well below i64::MAX.
         self.state_gas_used = self
             .state_gas_used
-            .checked_add(gas)
+            .checked_add(i64::try_from(gas).map_err(|_| InternalError::Overflow)?)
             .ok_or(InternalError::Overflow)?;
-        // Track the spill amount for block-accounting: EELS charge_state_gas spills
+        // Track the spill for block-accounting: EELS charge_state_gas spills
         // don't count toward regular_gas_used for the regular dimension.
         self.state_gas_spill = self
             .state_gas_spill
             .checked_add(spill)
             .ok_or(InternalError::Overflow)?;
-        // Mirror the increment on `state_gas_spill_outstanding` — `credit_state_gas_refund`
-        // may cancel part of this later; the remainder is what the revert math sees.
-        self.state_gas_spill_outstanding = self
-            .state_gas_spill_outstanding
-            .checked_add(spill)
-            .ok_or(InternalError::Overflow)?;
         Ok(())
     }
 
-    /// EIP-8037 clamp-and-spill: credit `amount` of state gas refund to the current frame.
-    ///
-    /// The refund is clamped to the unrefunded local charge of the current frame. Any
-    /// remainder that cannot be absorbed here is added to `state_gas_refund_pending` for
-    /// the parent frame to absorb on successful return.
-    ///
-    /// The absorbed portion is also added to `state_gas_refund_absorbed`, the VM-level
-    /// running total used at finalization to compute net `state_gas_used`.
+    /// EIP-8037 v7.2.0: credit `amount` directly to the local frame's reservoir; `state_gas_used`
+    /// may go negative when the matching charge lives in an ancestor frame (PR #2863).
     ///
     /// Must only be called for Amsterdam+ forks.
     pub fn credit_state_gas_refund(&mut self, amount: u64) -> Result<(), VMError> {
@@ -688,77 +646,14 @@ impl<'a> VM<'a> {
             self.env.config.fork >= Fork::Amsterdam,
             "credit_state_gas_refund called pre-Amsterdam"
         );
-        // Local charge = what this frame has put into state_gas_used minus what it has
-        // already had refunded back. The snapshot captures state_gas_used at frame entry.
-        let local_charged = self
-            .state_gas_used
-            .saturating_sub(self.current_call_frame.state_gas_used_snapshot);
-        let already_refunded = self.current_call_frame.state_gas_refund;
-        debug_assert!(
-            already_refunded <= local_charged,
-            "state refund invariant violated: already_refunded > local_charged"
-        );
-        let local_unrefunded = local_charged
-            .checked_sub(already_refunded)
-            .ok_or(InternalError::Underflow)?;
-        let clamped = amount.min(local_unrefunded);
-        // clamped = amount.min(...) so amount - clamped cannot underflow.
-        #[expect(
-            clippy::arithmetic_side_effects,
-            reason = "clamped <= amount by construction"
-        )]
-        let spill = amount - clamped;
-        self.current_call_frame.state_gas_refund = self
-            .current_call_frame
-            .state_gas_refund
-            .checked_add(clamped)
-            .ok_or(InternalError::Overflow)?;
-        self.state_gas_refund_pending = self
-            .state_gas_refund_pending
-            .checked_add(spill)
-            .ok_or(InternalError::Overflow)?;
-        self.state_gas_refund_absorbed = self
-            .state_gas_refund_absorbed
-            .checked_add(clamped)
-            .ok_or(InternalError::Overflow)?;
-        // Split the clamped credit between "cancels this frame's outstanding spill" and
-        // "cancels a drain". The first portion decrements `state_gas_spill_outstanding`
-        // so a grandparent revert's reservoir math sees only un-cancelled spill. The
-        // second portion accumulates into `state_gas_credit_against_drain` and appears
-        // in the revert formula as the subtraction term.
-        //
-        // Invariant (crucial for reservoir correctness):
-        //   `state_gas_spill_outstanding - snapshot` counts only spill increments that
-        //   happened INSIDE the current frame (or its subtree, propagated up on revert).
-        //   It excludes the parent's pre-child spills because those are baked into the
-        //   snapshot captured at child-frame entry. Therefore `applied_to_spill` never
-        //   double-cancels a spill that's already been accounted for at a grandparent
-        //   boundary. Changing this subtraction, or reading `state_gas_spill` instead,
-        //   breaks `sstore_restoration_create_init_revert`.
-        let frame_outstanding_delta = self
-            .state_gas_spill_outstanding
-            .saturating_sub(self.current_call_frame.state_gas_spill_outstanding_snapshot);
-        let applied_to_spill = clamped.min(frame_outstanding_delta);
-        // clamped >= applied_to_spill by construction.
-        #[expect(
-            clippy::arithmetic_side_effects,
-            reason = "applied_to_spill <= clamped by construction"
-        )]
-        let applied_to_drain = clamped - applied_to_spill;
-        self.state_gas_spill_outstanding = self
-            .state_gas_spill_outstanding
-            .checked_sub(applied_to_spill)
-            .ok_or(InternalError::Underflow)?;
-        self.state_gas_credit_against_drain = self
-            .state_gas_credit_against_drain
-            .checked_add(applied_to_drain)
-            .ok_or(InternalError::Overflow)?;
-        // Refill the reservoir with the absorbed portion so subsequent state-gas charges
-        // in the same tx can draw from it — matches EELS `state_gas_left += applied`.
         self.state_gas_reservoir = self
             .state_gas_reservoir
-            .checked_add(clamped)
+            .checked_add(amount)
             .ok_or(InternalError::Overflow)?;
+        self.state_gas_used = self
+            .state_gas_used
+            .checked_sub(i64::try_from(amount).map_err(|_| InternalError::Overflow)?)
+            .ok_or(InternalError::Underflow)?;
         Ok(())
     }
 
@@ -978,48 +873,24 @@ impl<'a> VM<'a> {
         &mut self,
         mut ctx_result: ContextResult,
     ) -> Result<ExecutionReport, VMError> {
-        // EIP-8037 (PR #2815): On top-level tx failure (REVERT, ExceptionalHalt, or OOG),
-        // refill the reservoir with the execution portion of state-gas so the user gets
-        // back both the entry reservoir and any spill that decremented `gas_remaining`.
-        // Matches EELS fork.py::process_transaction lines 1076-1077:
-        //   `tx_output.state_gas_left += tx_output.state_gas_used` on any non-success.
-        // Halt, OOG, and REVERT all take the same path (Policy A). Collision is handled
-        // separately in the hook.
+        // EIP-8037 v7.2.0 (PR #2863): On top-level tx failure (REVERT, ExceptionalHalt, or OOG),
+        // restore reservoir via the `state_gas_left + state_gas_used` invariant.
+        // With signed `state_gas_used`, `max(0, state_gas_used)` safely handles negative values
+        // (which arise when inline refunds exceed gross charges in this frame).
+        // Collision is handled separately in the hook.
         if self.env.config.fork >= Fork::Amsterdam && !ctx_result.is_success() {
-            // Policy A (REVERT / ExceptionalHalt / OOG, but NOT collision): refill
-            // reservoir with the execution portion of state-gas. Collision burns the
-            // forwarded gas wholesale — there is no execution state-gas to recover.
             if !ctx_result.is_collision() {
-                debug_assert!(
-                    self.state_gas_used >= self.intrinsic_state_gas_charged,
-                    "invariant: intrinsic is a floor on state_gas_used ({} >= {})",
-                    self.state_gas_used,
-                    self.intrinsic_state_gas_charged
-                );
-                let execution_portion = self
-                    .state_gas_used
-                    .saturating_sub(self.intrinsic_state_gas_charged)
-                    .saturating_sub(self.state_gas_refund_absorbed)
-                    .saturating_sub(self.state_gas_refund_pending);
-                self.state_gas_refund_absorbed = self
-                    .state_gas_refund_absorbed
-                    .saturating_add(execution_portion);
+                #[expect(clippy::as_conversions, reason = "value is clamped to >=0 by .max(0)")]
+                let execution_portion = self.state_gas_used.max(0) as u64;
                 self.state_gas_reservoir =
                     self.state_gas_reservoir.saturating_add(execution_portion);
+                self.state_gas_used = 0;
             }
 
             // EIP-8037 bal-devnet-7 (EELS PR #2823): on ANY top-level CREATE-tx
             // failure (revert / halt / OOG / collision), refund the intrinsic
-            // `STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte` charge to the
-            // reservoir, mirroring the inner-CREATE rule. Routed through
-            // `state_gas_refund_absorbed` so block-level `state_gas_used` is reduced
-            // (matches EELS `tx_output.state_refund`). Collision specifically is the
-            // 7th of qu0b's table — handled here since it's another tx-CREATE
-            // failure variant that the spec wants refunded.
-            // `intrinsic_state_gas_charged` is left intact: `refund_sender`'s
-            // regular-gas formula subtracts it from `raw_consumed`, which keeps the
-            // intrinsic burn out of the regular dimension. The user gets the gas
-            // back via the reservoir, and neither dimension counts it.
+            // `STATE_BYTES_PER_NEW_ACCOUNT * cost_per_state_byte` charge to the reservoir.
+            // Also add to `state_refund` so block-level accounting subtracts it.
             // EELS reference: fork.py::process_transaction:
             //   if isinstance(tx.to, Bytes0):
             //       new_account_refund = STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE
@@ -1029,9 +900,7 @@ impl<'a> VM<'a> {
                 let new_account_refund = self.state_gas_new_account;
                 self.state_gas_reservoir =
                     self.state_gas_reservoir.saturating_add(new_account_refund);
-                self.state_gas_refund_absorbed = self
-                    .state_gas_refund_absorbed
-                    .saturating_add(new_account_refund);
+                self.state_refund = self.state_refund.saturating_add(new_account_refund);
             }
         }
 
@@ -1050,21 +919,18 @@ impl<'a> VM<'a> {
             Vec::new()
         };
 
-        // EIP-8037 clamp-and-spill: subtract execution state gas refunds.
-        // `state_gas_refund_absorbed` + `state_gas_refund_pending` cover in-execution
-        // credits (SSTORE through-zero, inner-CREATE silent failure, etc.). `state_refund`
-        // mirrors EELS `MessageCallOutput.state_refund` — the tx-level channel used by
-        // EIP-7702 set_delegation refunds and the CREATE-tx-failure intrinsic NEW_ACCOUNT
-        // refund. EELS fork.py:1199-1205 subtracts state_refund from tx_state_gas at
-        // block aggregation; we mirror that subtraction here so block-level
-        // `block_state_gas_used` matches spec.
-        let execution_state_gas_refund = self
-            .state_gas_refund_absorbed
-            .saturating_add(self.state_gas_refund_pending);
-        let net_state_gas_used = self
-            .state_gas_used
-            .saturating_sub(execution_state_gas_refund)
-            .saturating_sub(self.state_refund);
+        // EIP-8037 v7.2.0 (PR #2863): `state_gas_used` is already net (signed; credits
+        // decrement it inline). Subtract `state_refund` (EIP-7702 tx-level channel) and
+        // clamp at zero for block accounting — `state_gas_used` may be negative when inline
+        // refunds exceed gross charges.
+        let state_refund_signed =
+            i64::try_from(self.state_refund).map_err(|_| InternalError::Overflow)?;
+        let net_state_gas_used: u64 = u64::try_from(
+            self.state_gas_used
+                .saturating_sub(state_refund_signed)
+                .max(0),
+        )
+        .map_err(|_| InternalError::Overflow)?;
 
         let report = ExecutionReport {
             result: ctx_result.result.clone(),

--- a/tooling/ef_tests/blockchain/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/blockchain/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.1.1/fixtures_bal.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.2.0/fixtures_bal.tar.gz

--- a/tooling/ef_tests/state/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/state/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.1.1/fixtures_bal.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.2.0/fixtures_bal.tar.gz


### PR DESCRIPTION
Aligns ethrex with bal-devnet-7 v7.2.0.

Tracking: lambdaclass/ethrex#6583 (item 10).

## Changes

- Port ethereum/execution-specs#2863: inline `state_gas` refunds (SSTORE `0→x→0`, CREATE collision/revert, EIP-7702 auth refills) credit the local frame's reservoir immediately. `state_gas_used` becomes `i64`; the clamp-and-spill scaffolding (`state_gas_refund_pending`, `state_gas_refund_absorbed`, `state_gas_spill_outstanding`, `state_gas_credit_against_drain`, intrinsic-tracking field + frame snapshots) is removed.
- Bump fixtures and `eels_commit` to `tests-bal@v7.2.0` / `a3e5201a5`.
- Preserve intrinsic state gas on top-level error: split out a dedicated `vm.intrinsic_state_gas` so the error path refunds only the execution portion. Without this, EIP-7702 set-code reverts and CREATE-tx reverts underbilled `block_state_gas_used` by `AUTH_TOTAL × CPSB` / `NEW_ACCOUNT × CPSB`.
- `default_hook.rs` `state_refund` i64 cast: propagate `InternalError::Overflow` instead of silently saturating (match `vm.rs`).
- `engine_newPayloadV{4,5}`: return JSON-RPC `-32602` on fork/field mismatch (V4 with BAL field or Amsterdam timestamp; V5 missing BAL field or pre-Amsterdam timestamp). Was returning `PayloadStatus.INVALID`.

## Test plan

- `cargo check`, `clippy`, `fmt`: clean across `ethrex-levm`, `ethrex-rpc`, `ethrex-vm`, `ethrex-blockchain`, `ethrex-l2`.
- `make -C tooling/ef_tests/blockchain test-levm` against `tests-bal@v7.2.0`: 8726 passed, 0 failed.
- Hive `eels/consume-engine` Amsterdam: pending re-run; engine-API fix targets the 2 remaining `test_fork_transition` failures.
