### PR TITLE
feat(l1): bal prometheus instruments, dashboard panels, and localnet fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Ethrex Changelog
 
+## Observability
+
+### 2026-05-27
+
+- Add BAL (EIP-7928) Prometheus instruments (`bal_blocks_total`, `bal_size_bytes`, `bal_size_bytes_histogram`, `bal_account_count`, `bal_slot_count`) and a BAL row in the `ethrex_l1_perf` Grafana dashboard [#6678](https://github.com/lambdaclass/ethrex/pull/6678)
+
 ## Perf
 
 ### 2026-05-19

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -111,6 +111,8 @@ use tokio_util::sync::CancellationToken;
 use vm::StoreVmDatabase;
 
 #[cfg(feature = "metrics")]
+use ethrex_metrics::bal::METRICS_BAL;
+#[cfg(feature = "metrics")]
 use ethrex_metrics::blocks::METRICS_BLOCKS;
 
 #[cfg(feature = "c-kzg")]
@@ -1980,14 +1982,15 @@ impl Blockchain {
             );
         }
 
-        metrics!(if let Some(bal) = produced_bal.as_ref().or(bal) {
-            let account_count = bal.accounts().len() as u64;
-            let slot_count = bal.item_count().saturating_sub(account_count);
-            let size_bytes = bal.length() as f64;
-            METRICS_BLOCKS.inc_bal_blocks_total();
-            METRICS_BLOCKS.set_bal_size_bytes(size_bytes);
-            METRICS_BLOCKS.set_bal_account_count(account_count as i64);
-            METRICS_BLOCKS.set_bal_slot_count(slot_count as i64);
+        metrics!(if let Some(bal_ref) = produced_bal.as_ref().or(bal) {
+            let account_count = bal_ref.accounts().len() as u64;
+            let slot_count = bal_ref.item_count().saturating_sub(account_count);
+            let size_bytes = bal_ref.length() as f64;
+            METRICS_BAL.blocks_total.inc();
+            METRICS_BAL.size_bytes.set(size_bytes);
+            METRICS_BAL.size_bytes_histogram.observe(size_bytes);
+            METRICS_BAL.account_count.set(account_count as i64);
+            METRICS_BAL.slot_count.set(slot_count as i64);
         });
 
         Ok((produced_bal, result))

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1980,6 +1980,16 @@ impl Blockchain {
             );
         }
 
+        metrics!(if let Some(bal) = produced_bal.as_ref().or(bal) {
+            let account_count = bal.accounts().len() as u64;
+            let slot_count = bal.item_count().saturating_sub(account_count);
+            let size_bytes = bal.length() as f64;
+            METRICS_BLOCKS.inc_bal_blocks_total();
+            METRICS_BLOCKS.set_bal_size_bytes(size_bytes);
+            METRICS_BLOCKS.set_bal_account_count(account_count as i64);
+            METRICS_BLOCKS.set_bal_slot_count(slot_count as i64);
+        });
+
         Ok((produced_bal, result))
     }
 

--- a/crates/blockchain/metrics/bal.rs
+++ b/crates/blockchain/metrics/bal.rs
@@ -1,0 +1,76 @@
+use prometheus::{
+    Gauge, Histogram, IntCounter, IntGauge, register_gauge, register_histogram,
+    register_int_counter, register_int_gauge,
+};
+use std::sync::LazyLock;
+
+// Metrics defined in this module register into the Prometheus default registry.
+// The metrics API exposes them via `gather_default_metrics()`.
+
+pub static METRICS_BAL: LazyLock<MetricsBal> = LazyLock::new(MetricsBal::default);
+
+// Histogram bucket layout for RLP-encoded BAL sizes: 1 KiB base, doubling, 16
+// buckets -> 1 KiB, 2 KiB, 4 KiB, ..., 32 MiB. Observed sizes are always >= 1
+// byte (the smallest BAL RLP-encodes to a non-empty list), so there is no zero
+// floor bucket.
+const BAL_SIZE_BUCKET_START_BYTES: f64 = 1024.0;
+const BAL_SIZE_BUCKET_FACTOR: f64 = 2.0;
+const BAL_SIZE_BUCKET_COUNT: usize = 16;
+
+#[derive(Debug, Clone)]
+pub struct MetricsBal {
+    /// Cumulative count of BAL-carrying blocks processed (post-Amsterdam).
+    pub blocks_total: IntCounter,
+    /// RLP-encoded size of the most recent BAL, in bytes (per-block snapshot).
+    pub size_bytes: Gauge,
+    /// Distribution of RLP-encoded BAL sizes in bytes.
+    pub size_bytes_histogram: Histogram,
+    /// Number of accounts in the most recent BAL (per-block snapshot).
+    pub account_count: IntGauge,
+    /// Unique storage slots (writes + reads) in the most recent BAL (per-block snapshot).
+    pub slot_count: IntGauge,
+}
+
+impl Default for MetricsBal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricsBal {
+    pub fn new() -> Self {
+        MetricsBal {
+            blocks_total: register_int_counter!(
+                "bal_blocks_total",
+                "Cumulative count of Block Access List (EIP-7928) carrying blocks processed"
+            )
+            .expect("Failed to create bal_blocks_total metric"),
+            size_bytes: register_gauge!(
+                "bal_size_bytes",
+                "RLP-encoded size of the most recent Block Access List, in bytes"
+            )
+            .expect("Failed to create bal_size_bytes metric"),
+            size_bytes_histogram: register_histogram!(
+                "bal_size_bytes_histogram",
+                "Distribution of RLP-encoded Block Access List sizes in bytes",
+                prometheus::exponential_buckets(
+                    BAL_SIZE_BUCKET_START_BYTES,
+                    BAL_SIZE_BUCKET_FACTOR,
+                    BAL_SIZE_BUCKET_COUNT,
+                )
+                .expect("Invalid BAL histogram bucket params")
+            )
+            .expect("Failed to create bal_size_bytes_histogram metric"),
+            account_count: register_int_gauge!(
+                "bal_account_count",
+                "Number of accounts in the most recent Block Access List"
+            )
+            .expect("Failed to create bal_account_count metric"),
+            slot_count: register_int_gauge!(
+                "bal_slot_count",
+                "Unique storage slots (writes + reads) in the most recent BAL"
+            )
+            .expect("Failed to create bal_slot_count metric"),
+        }
+    }
+}

--- a/crates/blockchain/metrics/blocks.rs
+++ b/crates/blockchain/metrics/blocks.rs
@@ -1,6 +1,6 @@
 use prometheus::Histogram;
 use prometheus::HistogramOpts;
-use prometheus::{Encoder, Gauge, IntGauge, Registry, TextEncoder};
+use prometheus::{Encoder, Gauge, IntCounter, IntGauge, Registry, TextEncoder};
 use std::sync::LazyLock;
 
 use crate::MetricsError;
@@ -37,6 +37,17 @@ pub struct MetricsBlocks {
     warmer_ms: Gauge,
     /// Warmer finished early (positive) or late (negative) relative to exec, in ms
     warmer_early_ms: Gauge,
+    // BAL (EIP-7928) metrics.
+    /// Cumulative count of BAL-carrying blocks processed (post-Amsterdam).
+    bal_blocks_total: IntCounter,
+    /// RLP-encoded size of the most recent BAL, in bytes.
+    bal_size_bytes: Gauge,
+    /// Distribution of RLP-encoded BAL sizes in bytes.
+    bal_size_bytes_histogram: Histogram,
+    /// Number of accounts in the most recent BAL.
+    bal_account_count: IntGauge,
+    /// Unique storage slots (writes + reads) in the most recent BAL.
+    bal_slot_count: IntGauge,
 }
 
 impl Default for MetricsBlocks {
@@ -157,6 +168,40 @@ impl MetricsBlocks {
                 "Warmer finished early (positive) or late (negative) relative to exec in milliseconds",
             )
             .expect("Failed to create warmer_early_ms metric"),
+            bal_blocks_total: IntCounter::new(
+                "bal_blocks_total",
+                "Cumulative count of Block Access List (EIP-7928) carrying blocks processed",
+            )
+            .expect("Failed to create bal_blocks_total metric"),
+            bal_size_bytes: Gauge::new(
+                "bal_size_bytes",
+                "RLP-encoded size of the most recent Block Access List, in bytes",
+            )
+            .expect("Failed to create bal_size_bytes metric"),
+            bal_size_bytes_histogram: Histogram::with_opts(
+                HistogramOpts::new(
+                    "bal_size_bytes_histogram",
+                    "Distribution of RLP-encoded Block Access List sizes in bytes",
+                )
+                .buckets({
+                    let mut buckets =
+                        prometheus::exponential_buckets(1024.0, 2.0, 16)
+                            .expect("Invalid bucket params");
+                    buckets.insert(0, 0.0);
+                    buckets
+                }),
+            )
+            .expect("Failed to create bal_size_bytes_histogram metric"),
+            bal_account_count: IntGauge::new(
+                "bal_account_count",
+                "Number of accounts in the most recent Block Access List",
+            )
+            .expect("Failed to create bal_account_count metric"),
+            bal_slot_count: IntGauge::new(
+                "bal_slot_count",
+                "Unique storage slots (writes + reads) in the most recent BAL",
+            )
+            .expect("Failed to create bal_slot_count metric"),
         }
     }
 
@@ -233,6 +278,23 @@ impl MetricsBlocks {
         self.warmer_early_ms.set(warmer_early_ms);
     }
 
+    pub fn inc_bal_blocks_total(&self) {
+        self.bal_blocks_total.inc();
+    }
+
+    pub fn set_bal_size_bytes(&self, size_bytes: f64) {
+        self.bal_size_bytes.set(size_bytes);
+        self.bal_size_bytes_histogram.observe(size_bytes);
+    }
+
+    pub fn set_bal_account_count(&self, account_count: i64) {
+        self.bal_account_count.set(account_count);
+    }
+
+    pub fn set_bal_slot_count(&self, slot_count: i64) {
+        self.bal_slot_count.set(slot_count);
+    }
+
     pub fn gather_metrics(&self) -> Result<String, MetricsError> {
         if self.block_number.get() <= 0 {
             return Ok(String::new());
@@ -277,6 +339,16 @@ impl MetricsBlocks {
         r.register(Box::new(self.warmer_ms.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
         r.register(Box::new(self.warmer_early_ms.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.bal_blocks_total.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.bal_size_bytes.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.bal_size_bytes_histogram.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.bal_account_count.clone()))
+            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
+        r.register(Box::new(self.bal_slot_count.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
 
         let encoder = TextEncoder::new();

--- a/crates/blockchain/metrics/blocks.rs
+++ b/crates/blockchain/metrics/blocks.rs
@@ -1,6 +1,6 @@
 use prometheus::Histogram;
 use prometheus::HistogramOpts;
-use prometheus::{Encoder, Gauge, IntCounter, IntGauge, Registry, TextEncoder};
+use prometheus::{Encoder, Gauge, IntGauge, Registry, TextEncoder};
 use std::sync::LazyLock;
 
 use crate::MetricsError;
@@ -37,17 +37,6 @@ pub struct MetricsBlocks {
     warmer_ms: Gauge,
     /// Warmer finished early (positive) or late (negative) relative to exec, in ms
     warmer_early_ms: Gauge,
-    // BAL (EIP-7928) metrics.
-    /// Cumulative count of BAL-carrying blocks processed (post-Amsterdam).
-    bal_blocks_total: IntCounter,
-    /// RLP-encoded size of the most recent BAL, in bytes.
-    bal_size_bytes: Gauge,
-    /// Distribution of RLP-encoded BAL sizes in bytes.
-    bal_size_bytes_histogram: Histogram,
-    /// Number of accounts in the most recent BAL.
-    bal_account_count: IntGauge,
-    /// Unique storage slots (writes + reads) in the most recent BAL.
-    bal_slot_count: IntGauge,
 }
 
 impl Default for MetricsBlocks {
@@ -168,40 +157,6 @@ impl MetricsBlocks {
                 "Warmer finished early (positive) or late (negative) relative to exec in milliseconds",
             )
             .expect("Failed to create warmer_early_ms metric"),
-            bal_blocks_total: IntCounter::new(
-                "bal_blocks_total",
-                "Cumulative count of Block Access List (EIP-7928) carrying blocks processed",
-            )
-            .expect("Failed to create bal_blocks_total metric"),
-            bal_size_bytes: Gauge::new(
-                "bal_size_bytes",
-                "RLP-encoded size of the most recent Block Access List, in bytes",
-            )
-            .expect("Failed to create bal_size_bytes metric"),
-            bal_size_bytes_histogram: Histogram::with_opts(
-                HistogramOpts::new(
-                    "bal_size_bytes_histogram",
-                    "Distribution of RLP-encoded Block Access List sizes in bytes",
-                )
-                .buckets({
-                    let mut buckets =
-                        prometheus::exponential_buckets(1024.0, 2.0, 16)
-                            .expect("Invalid bucket params");
-                    buckets.insert(0, 0.0);
-                    buckets
-                }),
-            )
-            .expect("Failed to create bal_size_bytes_histogram metric"),
-            bal_account_count: IntGauge::new(
-                "bal_account_count",
-                "Number of accounts in the most recent Block Access List",
-            )
-            .expect("Failed to create bal_account_count metric"),
-            bal_slot_count: IntGauge::new(
-                "bal_slot_count",
-                "Unique storage slots (writes + reads) in the most recent BAL",
-            )
-            .expect("Failed to create bal_slot_count metric"),
         }
     }
 
@@ -278,23 +233,6 @@ impl MetricsBlocks {
         self.warmer_early_ms.set(warmer_early_ms);
     }
 
-    pub fn inc_bal_blocks_total(&self) {
-        self.bal_blocks_total.inc();
-    }
-
-    pub fn set_bal_size_bytes(&self, size_bytes: f64) {
-        self.bal_size_bytes.set(size_bytes);
-        self.bal_size_bytes_histogram.observe(size_bytes);
-    }
-
-    pub fn set_bal_account_count(&self, account_count: i64) {
-        self.bal_account_count.set(account_count);
-    }
-
-    pub fn set_bal_slot_count(&self, slot_count: i64) {
-        self.bal_slot_count.set(slot_count);
-    }
-
     pub fn gather_metrics(&self) -> Result<String, MetricsError> {
         if self.block_number.get() <= 0 {
             return Ok(String::new());
@@ -339,16 +277,6 @@ impl MetricsBlocks {
         r.register(Box::new(self.warmer_ms.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
         r.register(Box::new(self.warmer_early_ms.clone()))
-            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
-        r.register(Box::new(self.bal_blocks_total.clone()))
-            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
-        r.register(Box::new(self.bal_size_bytes.clone()))
-            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
-        r.register(Box::new(self.bal_size_bytes_histogram.clone()))
-            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
-        r.register(Box::new(self.bal_account_count.clone()))
-            .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
-        r.register(Box::new(self.bal_slot_count.clone()))
             .map_err(|e| MetricsError::PrometheusErr(e.to_string()))?;
 
         let encoder = TextEncoder::new();

--- a/crates/blockchain/metrics/mod.rs
+++ b/crates/blockchain/metrics/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "api")]
 pub mod api;
 #[cfg(any(feature = "api", feature = "metrics"))]
+pub mod bal;
+#[cfg(any(feature = "api", feature = "metrics"))]
 pub mod blocks;
 #[cfg(feature = "api")]
 pub mod l2;

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -1629,9 +1629,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 8,
+            "w": 6,
             "x": 0,
-            "y": 0
+            "y": 27
           },
           "id": 301,
           "interval": "10s",
@@ -1734,9 +1734,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 8,
-            "x": 8,
-            "y": 0
+            "w": 6,
+            "x": 6,
+            "y": 27
           },
           "id": 302,
           "interval": "10s",
@@ -1773,90 +1773,6 @@
           ],
           "title": "BAL Size (bytes)",
           "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "Distribution of BAL sizes (heatmap of histogram buckets).",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 8,
-            "x": 16,
-            "y": 0
-          },
-          "id": 303,
-          "interval": "10s",
-          "options": {
-            "calculate": false,
-            "cellGap": 1,
-            "color": {
-              "exponent": 0.5,
-              "fill": "dark-orange",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Oranges",
-              "steps": 64
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-09
-            },
-            "legend": {
-              "show": true
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "mode": "single",
-              "showColorScale": false,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "bytes"
-            }
-          },
-          "pluginVersion": "12.2.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "sum by (le)(rate(bal_size_bytes_histogram_bucket{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}[$__rate_interval]))",
-              "format": "heatmap",
-              "instant": false,
-              "legendFormat": "{{le}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "BAL Size Distribution",
-          "type": "heatmap"
         },
         {
           "datasource": {
@@ -1923,9 +1839,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 8
+            "w": 6,
+            "x": 12,
+            "y": 27
           },
           "id": 304,
           "interval": "10s",
@@ -2028,9 +1944,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 8
+            "w": 6,
+            "x": 18,
+            "y": 27
           },
           "id": 305,
           "interval": "10s",
@@ -2067,6 +1983,90 @@
           ],
           "title": "BAL Slot Count",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Distribution of BAL sizes (heatmap of histogram buckets).",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 303,
+          "interval": "10s",
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-09
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "bytes"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (le)(rate(bal_size_bytes_histogram_bucket{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}[$__rate_interval]))",
+              "format": "heatmap",
+              "instant": false,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "BAL Size Distribution",
+          "type": "heatmap"
         }
       ],
       "title": "BAL (EIP-7928)",

--- a/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
+++ b/metrics/provisioning/grafana/dashboards/common_dashboards/ethrex_l1_perf.json
@@ -1560,6 +1560,524 @@
         "h": 1,
         "w": 24,
         "x": 0,
+        "y": 26
+      },
+      "id": 300,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Rate of EIP-7928 BAL-carrying blocks processed.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 0
+          },
+          "id": 301,
+          "interval": "10s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(bal_blocks_total{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}[$__rate_interval])",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "BAL Blocks Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "RLP-encoded size of the most recent BAL.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 0
+          },
+          "id": 302,
+          "interval": "10s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "bal_size_bytes{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "BAL Size (bytes)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Distribution of BAL sizes (heatmap of histogram buckets).",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 0
+          },
+          "id": 303,
+          "interval": "10s",
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-09
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "bytes"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (le)(rate(bal_size_bytes_histogram_bucket{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}[$__rate_interval]))",
+              "format": "heatmap",
+              "instant": false,
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "BAL Size Distribution",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Number of accounts in the most recent BAL.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 304,
+          "interval": "10s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "bal_account_count{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "BAL Account Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Unique storage slots (writes + reads) in the most recent BAL.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 305,
+          "interval": "10s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "bal_slot_count{job=\"$job\", instance=~\"$instance(:\\\\d+)?$\"}",
+              "instant": false,
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "BAL Slot Count",
+          "type": "timeseries"
+        }
+      ],
+      "title": "BAL (EIP-7928)",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
         "y": 27
       },
       "id": 110,
@@ -4195,7 +4713,7 @@
           "refId": "B"
         }
       ],
-      "title": "Host Ram (GiB) — Used vs Total",
+      "title": "Host Ram (GiB) \u2014 Used vs Total",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Summary

Adds Prometheus instruments for EIP-7928 Block Access Lists and a "BAL (EIP-7928)" row in `ethrex_l1_perf.json` to surface them. Aligns with the metrics subset of the cross-client BAL OTel spec (<https://notes.ethereum.org/@ethpandaops/bal-otel>); OTel span tracing is a separate follow-up.

The instruments live in `crates/blockchain/metrics/bal.rs` using the `register_*` macro / default-registry pattern (same shape as `sync.rs`), so they surface via `gather_default_metrics()` with no `api.rs` coupling. Metric names are bare `bal_*` (no client prefix) to match the cross-client spec.

## Instruments

| name | type | description |
|---|---|---|
| `bal_blocks_total` | IntCounter | cumulative BAL-carrying blocks processed |
| `bal_size_bytes` + `bal_size_bytes_histogram` | Gauge + Histogram | RLP-encoded BAL size and distribution (exponential buckets 1 KiB, 2 KiB, ..., 32 MiB) |
| `bal_account_count` | IntGauge | account count in the latest BAL |
| `bal_slot_count` | IntGauge | unique storage slots (writes + reads), via `BlockAccessList::item_count()` minus per-address rows |

## Dashboard panels

| panel | type | promql |
|---|---|---|
| BAL Blocks Rate | timeseries | `rate(bal_blocks_total[$__rate_interval])` |
| BAL Size (bytes) | timeseries | `bal_size_bytes` |
| BAL Size Distribution | heatmap | `sum by (le)(rate(bal_size_bytes_histogram_bucket[$__rate_interval]))` |
| BAL Account Count | timeseries | `bal_account_count` |
| BAL Slot Count | timeseries | `bal_slot_count` |

The `ethereum-package/src/grafana/ethrex_l1_perf.json` copy is regenerated by `make localnet` from the canonical file.

## Test plan

- [x] `cargo check --bin ethrex`
- [x] `cargo check -p ethrex-blockchain --no-default-features`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] Confirmed live: dev node with an Amsterdam-active genesis (`--dev --network fixtures/genesis/l1-bal.json --metrics`) producing blocks; `curl /metrics` shows all 5 `bal_*` series populating (`bal_blocks_total` incrementing per block, histogram lowest bucket `le="1024"` with no `le=0` bucket). Dev-mode Amsterdam block production required #6731.
