### PR TITLE
fix(l1): re-enable rayon on ethrex-common

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -45,7 +45,7 @@ libssz-derive = { workspace = true, optional = true }
 default = ["secp256k1", "rayon"]
 c-kzg = ["ethrex-crypto/c-kzg"]
 rayon = ["dep:rayon"]
-secp256k1 = ["dep:secp256k1", "ethrex-crypto/secp256k1"]
+secp256k1 = ["dep:secp256k1", "ethrex-crypto/secp256k1", "rayon"]
 eip-8025 = ["dep:libssz", "dep:libssz-types", "dep:libssz-merkle", "dep:libssz-derive"]
 
 risc0 = ["ethrex-crypto/risc0"]

--- a/crates/guest-program/bin/sp1/Cargo.lock
+++ b/crates/guest-program/bin/sp1/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "libssz-types",
  "lru",
  "once_cell",
+ "rayon",
  "rkyv",
  "rustc-hash",
  "secp256k1",

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "libc",
  "lru",
  "once_cell",
+ "rayon",
  "rkyv",
  "rustc-hash",
  "secp256k1",


### PR DESCRIPTION
**Motivation**

On #6560 we disabled rayon for zkVMs by gating it's usage, but we forgot to enable it on the blockchain crate outside zkVMs. This causes a small performance regression which caused it to be overlooked while re-enabling the feature on ethrex-blockchain (#6662).

**Description**

We enable it when secp256k1 is enabled, mirroring what ethrex-vm does.
