### PR TITLE
fix(l1): remove stray `v` prefix from finalized hash in FCU log

### DIFF
--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -221,7 +221,7 @@ async fn handle_forkchoice(
         version = %format!("v{}", version),
         head = %format!("{:#x}", fork_choice_state.head_block_hash),
         safe = %format!("{:#x}", fork_choice_state.safe_block_hash),
-        finalized = %format!("v{:#x}", fork_choice_state.finalized_block_hash),
+        finalized = %format!("{:#x}", fork_choice_state.finalized_block_hash),
         "New fork choice update",
     );
 


### PR DESCRIPTION
## Summary
- The `finalized` field in the FCU debug log was being formatted as `v0x...` due to a stray `v` prefix copied from the adjacent `version` field.
- Now it formats consistently with `head` and `safe` as `0x...`.

## Test plan
- [x] Trigger an FCU and verify the debug log shows `finalized=0x...` (no leading `v`).