### PR TITLE
feat(l1): add CLI toggles for BAL parallel exec, prefetch, and optimistic trie

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -167,6 +167,22 @@ pub struct Options {
     )]
     pub no_precompile_cache: bool,
     #[arg(
+        long = "no-bal-parallel-exec",
+        action = ArgAction::SetTrue,
+        help = "Disable BAL-driven parallel transaction execution on Amsterdam+ blocks (falls back to sequential).",
+        help_heading = "Node options",
+        env = "ETHREX_NO_BAL_PARALLEL_EXEC"
+    )]
+    pub no_bal_parallel_exec: bool,
+    #[arg(
+        long = "no-bal-prefetch",
+        action = ArgAction::SetTrue,
+        help = "Disable the BAL-driven state prefetch warmer thread on Amsterdam+ blocks.",
+        help_heading = "Node options",
+        env = "ETHREX_NO_BAL_PREFETCH"
+    )]
+    pub no_bal_prefetch: bool,
+    #[arg(
         long = "log.dir",
         value_name = "LOG_DIR",
         help = "Directory to store log files.",
@@ -473,6 +489,8 @@ impl Default for Options {
             precompute_witnesses: false,
             no_migrate: false,
             no_precompile_cache: false,
+            no_bal_parallel_exec: false,
+            no_bal_prefetch: false,
         }
     }
 }
@@ -684,6 +702,8 @@ impl Subcommand {
                         r#type: blockchain_type,
                         perf_logs_enabled: true,
                         precompile_cache_enabled: !opts.no_precompile_cache,
+                        bal_parallel_exec_enabled: !opts.no_bal_parallel_exec,
+                        bal_prefetch_enabled: !opts.no_bal_prefetch,
                         ..Default::default()
                     },
                     export_bal.as_deref(),

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -499,6 +499,7 @@ impl Default for Options {
             no_precompile_cache: false,
             no_bal_parallel_exec: false,
             no_bal_prefetch: false,
+            no_bal_parallel_trie: false,
         }
     }
 }

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -183,6 +183,14 @@ pub struct Options {
     )]
     pub no_bal_prefetch: bool,
     #[arg(
+        long = "no-bal-parallel-trie",
+        action = ArgAction::SetTrue,
+        help = "Disable BAL-driven optimistic trie merkleization on Amsterdam+ blocks (falls back to streaming AccountUpdates from the executor).",
+        help_heading = "Node options",
+        env = "ETHREX_NO_BAL_PARALLEL_TRIE"
+    )]
+    pub no_bal_parallel_trie: bool,
+    #[arg(
         long = "log.dir",
         value_name = "LOG_DIR",
         help = "Directory to store log files.",
@@ -704,6 +712,7 @@ impl Subcommand {
                         precompile_cache_enabled: !opts.no_precompile_cache,
                         bal_parallel_exec_enabled: !opts.no_bal_parallel_exec,
                         bal_prefetch_enabled: !opts.no_bal_prefetch,
+                        bal_parallel_trie_enabled: !opts.no_bal_parallel_trie,
                         ..Default::default()
                     },
                     export_bal.as_deref(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -574,6 +574,8 @@ pub async fn init_l1(
             max_blobs_per_block: opts.max_blobs_per_block,
             precompute_witnesses: opts.precompute_witnesses,
             precompile_cache_enabled: !opts.no_precompile_cache,
+            bal_parallel_exec_enabled: !opts.no_bal_parallel_exec,
+            bal_prefetch_enabled: !opts.no_bal_prefetch,
         },
     );
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -576,6 +576,7 @@ pub async fn init_l1(
             precompile_cache_enabled: !opts.no_precompile_cache,
             bal_parallel_exec_enabled: !opts.no_bal_parallel_exec,
             bal_prefetch_enabled: !opts.no_bal_prefetch,
+            bal_parallel_trie_enabled: !opts.no_bal_parallel_trie,
         },
     );
 

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -230,6 +230,7 @@ pub async fn init_l2(
         precompile_cache_enabled: true,
         bal_parallel_exec_enabled: true,
         bal_prefetch_enabled: true,
+        bal_parallel_trie_enabled: true,
     };
 
     let blockchain = init_blockchain(store.clone(), blockchain_opts.clone());

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -228,6 +228,8 @@ pub async fn init_l2(
         max_blobs_per_block: None, // L2 doesn't support blob transactions
         precompute_witnesses: opts.node_opts.precompute_witnesses,
         precompile_cache_enabled: true,
+        bal_parallel_exec_enabled: true,
+        bal_prefetch_enabled: true,
     };
 
     let blockchain = init_blockchain(store.clone(), blockchain_opts.clone());

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -515,15 +515,28 @@ impl Blockchain {
                         // Precompile cache lives inside CachingDatabase, shared automatically.
                         let start = Instant::now();
                         if let Some(bal) = bal {
-                            // Amsterdam+: BAL-based precise prefetching (no tx re-execution).
-                            // Skipped when --no-bal-prefetch is set; we don't fall back to
-                            // speculative warm_block here because tx replay would be wasted
-                            // work when the header BAL already drives execution.
-                            if bal_prefetch_enabled
-                                && let Err(e) =
+                            if bal_prefetch_enabled {
+                                // Amsterdam+: BAL-based precise prefetching (no tx re-execution).
+                                if let Err(e) =
                                     LEVM::warm_block_from_bal(bal, caching_store, cancelled_ref)
-                            {
-                                debug!("BAL warming failed (non-fatal): {e}");
+                                {
+                                    debug!("BAL warming failed (non-fatal): {e}");
+                                }
+                            } else if !bal_parallel_exec_enabled {
+                                // --no-bal-prefetch combined with --no-bal-parallel-exec:
+                                // mirror the pre-Amsterdam setup where a parallel speculative
+                                // warmer races ahead of the serial executor. With parallel
+                                // exec still on, we skip warming instead — two parallel passes
+                                // over the same txs would just fight for cores.
+                                if let Err(e) = LEVM::warm_block(
+                                    block,
+                                    caching_store,
+                                    vm_type,
+                                    &NativeCrypto,
+                                    cancelled_ref,
+                                ) {
+                                    debug!("Block warming failed (non-fatal): {e}");
+                                }
                             }
                         } else {
                             // Pre-Amsterdam / P2P sync: speculative tx re-execution

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -233,6 +233,14 @@ pub struct BlockchainOptions {
     /// warmer thread and the executor. Set to false (via `--no-precompile-cache`) to
     /// disable the cache for benchmarking purposes.
     pub precompile_cache_enabled: bool,
+    /// If true (default), Amsterdam+ validation runs transactions in parallel
+    /// using the header BAL to seed per-tx databases. Set to false (via
+    /// `--no-bal-parallel-exec`) to fall back to sequential execution.
+    pub bal_parallel_exec_enabled: bool,
+    /// If true (default), Amsterdam+ validation spawns a warmer thread that
+    /// prefetches accounts, storage slots, and codes listed in the header BAL.
+    /// Set to false (via `--no-bal-prefetch`) to skip prefetching on the BAL path.
+    pub bal_prefetch_enabled: bool,
 }
 
 impl Default for BlockchainOptions {
@@ -244,6 +252,8 @@ impl Default for BlockchainOptions {
             max_blobs_per_block: None,
             precompute_witnesses: false,
             precompile_cache_enabled: true,
+            bal_parallel_exec_enabled: true,
+            bal_prefetch_enabled: true,
         }
     }
 }
@@ -471,6 +481,8 @@ impl Blockchain {
         vm.db.store = caching_store.clone();
 
         let cancelled = AtomicBool::new(false);
+        let bal_parallel_exec_enabled = self.options.bal_parallel_exec_enabled;
+        let bal_prefetch_enabled = self.options.bal_prefetch_enabled;
 
         // Synthesize BAL updates pre-scope so the merkleizer thread can start
         // trie work immediately, in parallel with execution.
@@ -503,9 +515,13 @@ impl Blockchain {
                         // Precompile cache lives inside CachingDatabase, shared automatically.
                         let start = Instant::now();
                         if let Some(bal) = bal {
-                            // Amsterdam+: BAL-based precise prefetching (no tx re-execution)
-                            if let Err(e) =
-                                LEVM::warm_block_from_bal(bal, caching_store, cancelled_ref)
+                            // Amsterdam+: BAL-based precise prefetching (no tx re-execution).
+                            // Skipped when --no-bal-prefetch is set; we don't fall back to
+                            // speculative warm_block here because tx replay would be wasted
+                            // work when the header BAL already drives execution.
+                            if bal_prefetch_enabled
+                                && let Err(e) =
+                                    LEVM::warm_block_from_bal(bal, caching_store, cancelled_ref)
                             {
                                 debug!("BAL warming failed (non-fatal): {e}");
                             }
@@ -540,7 +556,13 @@ impl Blockchain {
                 let execution_handle = std::thread::Builder::new()
                     .name("block_executor_execution".to_string())
                     .spawn_scoped(s, move || -> Result<_, ChainError> {
-                        let result = vm.execute_block_pipeline(block, tx, queue_length_ref, bal);
+                        let result = vm.execute_block_pipeline(
+                            block,
+                            tx,
+                            queue_length_ref,
+                            bal,
+                            bal_parallel_exec_enabled,
+                        );
                         cancelled_ref.store(true, Ordering::Relaxed);
                         let (execution_result, produced_bal) = result?;
 

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -482,7 +482,6 @@ impl Blockchain {
 
         let cancelled = AtomicBool::new(false);
         let bal_parallel_exec_enabled = self.options.bal_parallel_exec_enabled;
-        let bal_prefetch_enabled = self.options.bal_prefetch_enabled;
 
         // Synthesize BAL updates pre-scope so the merkleizer thread can start
         // trie work immediately, in parallel with execution.
@@ -507,6 +506,8 @@ impl Blockchain {
                 #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
                 let vm_type = vm.vm_type;
                 let cancelled_ref = &cancelled;
+                #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+                let bal_prefetch_enabled = self.options.bal_prefetch_enabled;
                 #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
                 let warm_handle = std::thread::Builder::new()
                     .name("block_executor_warmer".to_string())

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -241,6 +241,11 @@ pub struct BlockchainOptions {
     /// prefetches accounts, storage slots, and codes listed in the header BAL.
     /// Set to false (via `--no-bal-prefetch`) to skip prefetching on the BAL path.
     pub bal_prefetch_enabled: bool,
+    /// If true (default), Amsterdam+ validation merkleizes optimistically from
+    /// `synthesize_bal_updates` in parallel with execution. Set to false (via
+    /// `--no-bal-parallel-trie`) to fall back to streaming `AccountUpdate`s from
+    /// the executor and merkleizing post-execution.
+    pub bal_parallel_trie_enabled: bool,
 }
 
 impl Default for BlockchainOptions {
@@ -254,6 +259,7 @@ impl Default for BlockchainOptions {
             precompile_cache_enabled: true,
             bal_parallel_exec_enabled: true,
             bal_prefetch_enabled: true,
+            bal_parallel_trie_enabled: true,
         }
     }
 }
@@ -485,8 +491,15 @@ impl Blockchain {
 
         // Synthesize BAL updates pre-scope so the merkleizer thread can start
         // trie work immediately, in parallel with execution.
+        // `--no-bal-parallel-trie` opts out: leave `optimistic_updates = None` so
+        // the merkleizer takes the streaming branch (fed by the EVM-side
+        // `bal_to_account_updates` send over the channel below).
         let optimistic_updates: Option<FxHashMap<Address, BalSynthesisItem>> =
-            bal.map(synthesize_bal_updates);
+            if self.options.bal_parallel_trie_enabled {
+                bal.map(synthesize_bal_updates)
+            } else {
+                None
+            };
         let optimistic_witness: Option<Vec<AccountUpdate>> = if self.options.precompute_witnesses {
             optimistic_updates.as_ref().map(|m| {
                 m.iter()
@@ -557,10 +570,12 @@ impl Blockchain {
                         ChainError::Custom(format!("Failed to spawn warmer thread: {e}"))
                     })?;
                 let max_queue_length_ref = &mut max_queue_length;
-                // Channel only exists on the streaming (non-BAL) path. On the BAL path the
-                // EVM merkleizes nothing on its own (the synthesized map drives merkleization),
+                // Channel exists whenever the merkleizer takes the streaming branch:
+                // pre-Amsterdam (no BAL) and `--no-bal-parallel-trie` on the BAL path.
+                // When optimistic merkleization runs, the synthesized map drives the
+                // merkleizer and the EVM-side `bal_to_account_updates` send is skipped,
                 // so no Sender / drain thread are needed.
-                let (tx, rx_for_merkle) = if bal.is_some() {
+                let (tx, rx_for_merkle) = if optimistic_updates.is_some() {
                     (None, None)
                 } else {
                     let (tx, rx) = channel();

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -570,17 +570,22 @@ impl Blockchain {
                         ChainError::Custom(format!("Failed to spawn warmer thread: {e}"))
                     })?;
                 let max_queue_length_ref = &mut max_queue_length;
-                // Channel exists whenever the merkleizer takes the streaming branch:
-                // pre-Amsterdam (no BAL) and `--no-bal-parallel-trie` on the BAL path.
-                // When optimistic merkleization runs, the synthesized map drives the
-                // merkleizer and the EVM-side `bal_to_account_updates` send is skipped,
-                // so no Sender / drain thread are needed.
-                let (tx, rx_for_merkle) = if optimistic_updates.is_some() {
-                    (None, None)
-                } else {
-                    let (tx, rx) = channel();
-                    (Some(tx), Some(rx))
-                };
+                // Channel is needed whenever the merkleizer takes the streaming
+                // branch OR LEVM falls into the sequential path:
+                // - sequential LEVM (`!bal_parallel_exec_enabled`) sends per-tx
+                //   updates via `send_state_transitions_tx`; errors if Sender is None.
+                // - streaming merkleizer (`!bal_parallel_trie_enabled` or no BAL)
+                //   reads updates from `rx`.
+                // Only the default `bal=Some && parallel_exec && parallel_trie` case
+                // can skip both: parallel LEVM doesn't stream when its Sender is None,
+                // and the merkleizer uses the synthesized optimistic map directly.
+                let (tx, rx_for_merkle) =
+                    if optimistic_updates.is_some() && bal_parallel_exec_enabled {
+                        (None, None)
+                    } else {
+                        let (tx, rx) = channel();
+                        (Some(tx), Some(rx))
+                    };
 
                 let execution_handle = std::thread::Builder::new()
                     .name("block_executor_execution".to_string())

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -360,6 +360,7 @@ impl LEVM {
     /// `merkleizer` is `Some` on the streaming (non-BAL) path; the BAL validation path
     /// passes `None` because the caller merkleizes optimistically from the input BAL and
     /// the EVM-side `bal_to_account_updates` send is then redundant work.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute_block_pipeline(
         block: &Block,
         db: &mut GeneralizedDatabase,
@@ -368,6 +369,7 @@ impl LEVM {
         queue_length: &AtomicUsize,
         crypto: &dyn Crypto,
         header_bal: Option<&BlockAccessList>,
+        bal_parallel_exec_enabled: bool,
     ) -> Result<(BlockExecutionResult, Option<BlockAccessList>), EvmError> {
         let chain_config = db.store.get_chain_config()?;
         let is_amsterdam = chain_config.is_amsterdam_activated(block.header.timestamp);
@@ -389,14 +391,16 @@ impl LEVM {
         #[cfg(any(feature = "eip-8025", not(feature = "rayon")))]
         // `eip-8025` does not call `execute_block_pipeline` it uses
         // `execute_block` instead. Adding dummy let to avoid unused warnings.
-        let _ = header_bal;
+        let _ = (header_bal, bal_parallel_exec_enabled);
         #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
         // When BAL is provided (Amsterdam+ validation path): use parallel execution.
         // The `is_amsterdam` gate is required: `execute_block_parallel` (and the
         // optimistic merkleization it feeds) is only correct on Amsterdam+; a
         // pre-Amsterdam call here in release would skip the inner debug_assert.
+        // `--no-bal-parallel-exec` opts out and falls through to the sequential pipeline below.
         if let Some(bal) = header_bal
             && is_amsterdam
+            && bal_parallel_exec_enabled
         {
             // Validate header BAL structural properties before execution.
             // This catches index-out-of-bounds early, before wasting execution time.

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -112,6 +112,7 @@ impl Evm {
         merkleizer: Option<Sender<Vec<AccountUpdate>>>,
         queue_length: &AtomicUsize,
         bal: Option<&BlockAccessList>,
+        bal_parallel_exec_enabled: bool,
     ) -> Result<(BlockExecutionResult, Option<BlockAccessList>), EvmError> {
         LEVM::execute_block_pipeline(
             block,
@@ -121,6 +122,7 @@ impl Evm {
             queue_length,
             self.crypto.as_ref(),
             bal,
+            bal_parallel_exec_enabled,
         )
     }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -80,6 +80,16 @@ Node options:
           
           [env: ETHREX_NO_PRECOMPILE_CACHE=]
 
+      --no-bal-parallel-exec
+          Disable BAL-driven parallel transaction execution on Amsterdam+ blocks (falls back to sequential).
+          
+          [env: ETHREX_NO_BAL_PARALLEL_EXEC=]
+
+      --no-bal-prefetch
+          Disable the BAL-driven state prefetch warmer thread on Amsterdam+ blocks.
+          
+          [env: ETHREX_NO_BAL_PREFETCH=]
+
       --log.dir <LOG_DIR>
           Directory to store log files.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -90,6 +90,11 @@ Node options:
           
           [env: ETHREX_NO_BAL_PREFETCH=]
 
+      --no-bal-parallel-trie
+          Disable BAL-driven optimistic trie merkleization on Amsterdam+ blocks (falls back to streaming AccountUpdates from the executor).
+          
+          [env: ETHREX_NO_BAL_PARALLEL_TRIE=]
+
       --log.dir <LOG_DIR>
           Directory to store log files.
 


### PR DESCRIPTION
## Summary
Adds three CLI flags so operators can disable the BAL-driven optimizations on Amsterdam+ validation, for benchmarking and A/B comparison against other clients:

- `--no-bal-parallel-exec` / `ETHREX_NO_BAL_PARALLEL_EXEC` — disable BAL-driven parallel transaction execution; falls through to the sequential pipeline.
- `--no-bal-prefetch` / `ETHREX_NO_BAL_PREFETCH` — disable the BAL-driven warmer thread.
- `--no-bal-parallel-trie` / `ETHREX_NO_BAL_PARALLEL_TRIE` — disable BAL-driven optimistic trie merkleization; falls back to streaming `AccountUpdate`s from the executor.

Default behavior is unchanged: all three optimizations stay on. Closes #6684.

### Plumbing
- New fields `bal_parallel_exec_enabled`, `bal_prefetch_enabled`, and `bal_parallel_trie_enabled` on `BlockchainOptions` (each default `true`).
- `--no-bal-parallel-exec` is threaded as a bool through `Evm::execute_block_pipeline` → `LEVM::execute_block_pipeline`, where it ANDs into the `if let Some(bal) = header_bal` gate so the function falls through to the existing sequential path (which already handles `is_amsterdam` by recording its own BAL; the caller validates against the header).
- `--no-bal-prefetch` is read in `Blockchain::execute_block_pipeline` and selects the warmer strategy based on both toggles:

| `--no-bal-prefetch` | `--no-bal-parallel-exec` | Warmer does |
|---|---|---|
| off (default) | * | `warm_block_from_bal` (cheap; helps both serial and parallel executor) |
| on | off | skip warming (parallel warmer would just compete with parallel executor) |
| on | on | `warm_block` speculative replay (mirrors pre-Amsterdam: serial executor + parallel warmer = proven win) |

- `--no-bal-parallel-trie` is read in `Blockchain::execute_block_pipeline` and gates the `synthesize_bal_updates` call: when disabled, `optimistic_updates` stays `None`, so the merkleizer thread takes the streaming `handle_merkleization` branch fed by the EVM-side `bal_to_account_updates` send.

### Channel allocation (BAL path)
Two consumers want the streaming channel: the merkleizer thread when `parallel_trie` is off, and `LEVM`'s sequential path when `parallel_exec` is off (its `send_state_transitions_tx` requires a Sender). The channel is now allocated whenever **either** side needs it; only the all-defaults cell can skip it.

| `parallel_exec` | `parallel_trie` | LEVM path | Merkleizer | Channel |
|:---:|:---:|---|---|:---:|
| on | on | parallel; no streaming | optimistic (uses synthesized map) | None |
| on | off | parallel; sends one `bal_to_account_updates` batch | streaming (reads `rx`) | Some |
| off | on | sequential; per-tx `send_state_transitions_tx` | optimistic (channel batch dropped at scope exit) | Some |
| off | off | sequential; per-tx `send_state_transitions_tx` | streaming | Some |

The `off / on` cell was a pre-existing latent bug: the channel was keyed only on whether the merkleizer wanted streaming, so `--no-bal-parallel-exec` alone hit the sequential path's `merkleizer.is_none()` error on Amsterdam+ BAL blocks. Now fixed.

### Context
Part of a wider effort to surface per-optimization toggles for the BAL devnets (see the [bal-devnet-6 feature-flags notes](https://notes.ethereum.org/@ethpandaops/bal-devnet-6#Feature-flags) for what other clients expose: reth's `--engine.disable-bal-parallel-state-root`; geth's `--bal.executionmode=sequential|nobatchio`).

The optimistic-trie path (`synthesize_bal_updates` + `handle_merkleization_bal_from_updates`) landed on main via #6655, which unblocked the third toggle and #6684.

## Test plan
- [ ] `cargo check --workspace --all-targets` (verified locally)
- [ ] `cargo clippy -p ethrex-blockchain -p ethrex-vm -p ethrex` clean (verified locally)
- [ ] `cargo fmt --all -- --check` (verified locally)
- [ ] Manual: run a sync with `--no-bal-parallel-exec` alone and confirm Amsterdam+ blocks still validate (sequential fallback uses the Sender; merkleizer still goes optimistic).
- [ ] Manual: run with `--no-bal-prefetch` alone on an Amsterdam block and confirm the warmer thread no-ops.
- [ ] Manual: run with `--no-bal-prefetch --no-bal-parallel-exec` and confirm `warm_block` speculative replay runs.
- [ ] Manual: run with `--no-bal-parallel-trie` on an Amsterdam block and confirm merkleization takes the streaming path (channel-fed) and the state root still matches the header.
- [ ] Manual: run with all three `--no-*` flags and confirm sequential exec + streaming merkleization + speculative warmer all engage.
- [ ] Hive \`bal-quick\` green with defaults (no regression).