### PR TITLE
fix(l1): support JSON-RPC batches on the auth RPC port

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -676,8 +676,8 @@ pub async fn handle_authrpc_request(
     auth_header: Option<TypedHeader<Authorization<Bearer>>>,
     body: String,
 ) -> Result<Json<Value>, StatusCode> {
-    let req: RpcRequest = match serde_json::from_str(&body) {
-        Ok(req) => req,
+    let wrapper: RpcRequestWrapper = match serde_json::from_str(&body) {
+        Ok(w) => w,
         Err(_) => {
             return Ok(Json(
                 rpc_response(
@@ -688,18 +688,41 @@ pub async fn handle_authrpc_request(
             ));
         }
     };
-    match authenticate(&service_context.node_data.jwt_secret, auth_header) {
-        Err(error) => Ok(Json(
-            rpc_response(req.id, Err(error)).map_err(|_| StatusCode::BAD_REQUEST)?,
-        )),
-        Ok(()) => {
-            // Proceed with the request
-            let res = map_authrpc_requests(&req, service_context).await;
-            Ok(Json(
-                rpc_response(req.id, res).map_err(|_| StatusCode::BAD_REQUEST)?,
-            ))
-        }
+
+    if let Err(error) = authenticate(&service_context.node_data.jwt_secret, auth_header) {
+        let id = match &wrapper {
+            RpcRequestWrapper::Single(req) => req.id.clone(),
+            RpcRequestWrapper::Multiple(_) => RpcRequestId::String("".to_string()),
+        };
+        return Ok(Json(
+            rpc_response(id, Err(error)).map_err(|_| StatusCode::BAD_REQUEST)?,
+        ));
     }
+
+    let res = match wrapper {
+        RpcRequestWrapper::Single(req) => {
+            let res = map_authrpc_requests(&req, service_context).await;
+            rpc_response(req.id, res).map_err(|_| StatusCode::BAD_REQUEST)?
+        }
+        RpcRequestWrapper::Multiple(requests) => {
+            if requests.is_empty() {
+                return Ok(Json(
+                    rpc_response(
+                        RpcRequestId::String("".to_string()),
+                        Err(RpcErr::BadParams("Invalid request body".to_string())),
+                    )
+                    .map_err(|_| StatusCode::BAD_REQUEST)?,
+                ));
+            }
+            let mut responses = Vec::with_capacity(requests.len());
+            for req in requests {
+                let res = map_authrpc_requests(&req, service_context.clone()).await;
+                responses.push(rpc_response(req.id, res).map_err(|_| StatusCode::BAD_REQUEST)?);
+            }
+            serde_json::to_value(responses).map_err(|_| StatusCode::BAD_REQUEST)?
+        }
+    };
+    Ok(Json(res))
 }
 
 /// Handle a WebSocket connection.
@@ -1663,5 +1686,110 @@ mod tests {
         });
         let expected_response = to_rpc_response_success_value(&json.to_string());
         assert_eq!(rpc_response.to_string(), expected_response.to_string())
+    }
+
+    /// Regression test for engine port batch parsing. Prior to the fix,
+    /// `handle_authrpc_request` deserialized directly into `RpcRequest` and
+    /// rejected JSON-RPC 2.0 batches with `Invalid request body`. Prysm's
+    /// `execution_payload_envelopes_by_root` handler batches `eth_getBlockByHash`
+    /// against the engine port, which caused glamsterdam-devnet-4 forking.
+    #[tokio::test]
+    async fn authrpc_accepts_batched_engine_requests() {
+        use axum::extract::State;
+        use axum_extra::TypedHeader;
+        use axum_extra::headers::Authorization;
+        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let context = default_context_with_storage(storage).await;
+
+        let iat = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = serde_json::json!({ "iat": iat });
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(&context.node_data.jwt_secret),
+        )
+        .unwrap();
+        let auth_header = Some(TypedHeader(Authorization::bearer(&token).unwrap()));
+
+        let body = r#"[
+            {"jsonrpc":"2.0","method":"engine_exchangeCapabilities","params":[[]],"id":1},
+            {"jsonrpc":"2.0","method":"engine_exchangeCapabilities","params":[[]],"id":2}
+        ]"#
+        .to_string();
+
+        let response = handle_authrpc_request(State(context), auth_header, body)
+            .await
+            .expect("handler should succeed");
+        let value = response.0;
+        let arr = value
+            .as_array()
+            .expect("batched auth response must be a JSON array");
+        assert_eq!(arr.len(), 2, "expected 2 responses, got {value}");
+        for (i, item) in arr.iter().enumerate() {
+            assert!(
+                item.get("result").is_some(),
+                "response {i} should have a result field, got {item}"
+            );
+            assert_eq!(
+                item.get("id").and_then(|v| v.as_u64()),
+                Some((i + 1) as u64)
+            );
+        }
+    }
+
+    /// JSON-RPC 2.0 §6: an empty batch is itself an Invalid Request.
+    #[tokio::test]
+    async fn authrpc_rejects_empty_batch() {
+        use axum::extract::State;
+        use axum_extra::TypedHeader;
+        use axum_extra::headers::Authorization;
+        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let context = default_context_with_storage(storage).await;
+
+        let iat = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let claims = serde_json::json!({ "iat": iat });
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(&context.node_data.jwt_secret),
+        )
+        .unwrap();
+        let auth_header = Some(TypedHeader(Authorization::bearer(&token).unwrap()));
+
+        let response = handle_authrpc_request(State(context), auth_header, "[]".to_string())
+            .await
+            .expect("handler should succeed");
+        let err = response
+            .0
+            .get("error")
+            .expect("empty batch must produce an error response");
+        assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32000));
+        assert!(
+            err.get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .contains("Invalid request body"),
+            "expected Invalid request body, got {err}"
+        );
     }
 }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -664,9 +664,10 @@ fn null_id_error(err: RpcErr) -> Value {
     })
 }
 
-/// Reject empty and oversize batches before they reach dispatch. Returns
-/// `Some(error_value)` to short-circuit, or `None` to proceed.
-fn reject_invalid_batch(wrapper: &RpcRequestWrapper) -> Option<Value> {
+/// Validate a batch envelope. Returns `Some(error_value)` for empty or
+/// oversize batches (short-circuits dispatch), `None` if the request is
+/// ok to process.
+fn validate_batch(wrapper: &RpcRequestWrapper) -> Option<Value> {
     let RpcRequestWrapper::Multiple(requests) = wrapper else {
         return None;
     };
@@ -701,7 +702,7 @@ pub(crate) async fn handle_http_request(
         }
     };
 
-    if let Some(err) = reject_invalid_batch(&wrapper) {
+    if let Some(err) = validate_batch(&wrapper) {
         return Ok(Json(err));
     }
 
@@ -738,7 +739,7 @@ pub async fn handle_authrpc_request(
 
     // Reject empty / oversize batches before any auth or dispatch work so a
     // 100k-request body can't burn JWT crypto or memory.
-    if let Some(err) = reject_invalid_batch(&wrapper) {
+    if let Some(err) = validate_batch(&wrapper) {
         return Ok(Json(err));
     }
 

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -646,28 +646,78 @@ pub async fn shutdown_signal() {
         .expect("failed to install Ctrl+C handler");
 }
 
-async fn handle_http_request(
+/// Maximum number of requests accepted in a single JSON-RPC batch on either
+/// the public HTTP port or the engine auth port. Matches geth's
+/// `--engine.batchitemlimit` default. Larger batches are rejected up front
+/// with `-32600 InvalidRequest` before any per-request work runs.
+const MAX_BATCH_SIZE: usize = 1000;
+
+/// JSON-RPC 2.0 §5.1: when the request body is not a valid Request object the
+/// response id MUST be null. Build these transport-level errors directly so we
+/// don't have to encode "no id" through `RpcRequestId`.
+fn null_id_error(err: RpcErr) -> Value {
+    let meta: RpcErrorMetadata = err.into();
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": Value::Null,
+        "error": meta,
+    })
+}
+
+/// Reject empty and oversize batches before they reach dispatch. Returns
+/// `Some(error_value)` to short-circuit, or `None` to proceed.
+fn reject_invalid_batch(wrapper: &RpcRequestWrapper) -> Option<Value> {
+    let RpcRequestWrapper::Multiple(requests) = wrapper else {
+        return None;
+    };
+    if requests.is_empty() {
+        return Some(null_id_error(RpcErr::InvalidRequest(
+            "empty batch is not a valid Request".to_string(),
+        )));
+    }
+    if requests.len() > MAX_BATCH_SIZE {
+        return Some(null_id_error(RpcErr::InvalidRequest(format!(
+            "batch too large: {} > {MAX_BATCH_SIZE}",
+            requests.len()
+        ))));
+    }
+    None
+}
+
+pub(crate) async fn handle_http_request(
     State(service_context): State<RpcApiContext>,
     body: String,
 ) -> Result<Json<Value>, StatusCode> {
-    let res = match serde_json::from_str::<RpcRequestWrapper>(&body) {
-        Ok(RpcRequestWrapper::Single(request)) => {
+    let wrapper: RpcRequestWrapper = match serde_json::from_str(&body) {
+        Ok(w) => w,
+        Err(_) => {
+            return Ok(Json(
+                rpc_response(
+                    RpcRequestId::String("".to_string()),
+                    Err(RpcErr::BadParams("Invalid request body".to_string())),
+                )
+                .map_err(|_| StatusCode::BAD_REQUEST)?,
+            ));
+        }
+    };
+
+    if let Some(err) = reject_invalid_batch(&wrapper) {
+        return Ok(Json(err));
+    }
+
+    let res = match wrapper {
+        RpcRequestWrapper::Single(request) => {
             let res = map_http_requests(&request, service_context).await;
             rpc_response(request.id, res).map_err(|_| StatusCode::BAD_REQUEST)?
         }
-        Ok(RpcRequestWrapper::Multiple(requests)) => {
-            let mut responses = Vec::new();
+        RpcRequestWrapper::Multiple(requests) => {
+            let mut responses = Vec::with_capacity(requests.len());
             for req in requests {
                 let res = map_http_requests(&req, service_context.clone()).await;
                 responses.push(rpc_response(req.id, res).map_err(|_| StatusCode::BAD_REQUEST)?);
             }
             serde_json::to_value(responses).map_err(|_| StatusCode::BAD_REQUEST)?
         }
-        Err(_) => rpc_response(
-            RpcRequestId::String("".to_string()),
-            Err(RpcErr::BadParams("Invalid request body".to_string())),
-        )
-        .map_err(|_| StatusCode::BAD_REQUEST)?,
     };
     Ok(Json(res))
 }
@@ -677,18 +727,6 @@ pub async fn handle_authrpc_request(
     auth_header: Option<TypedHeader<Authorization<Bearer>>>,
     body: String,
 ) -> Result<Json<Value>, StatusCode> {
-    // JSON-RPC 2.0: when the request body is not a valid Request object the
-    // response id MUST be null. Build these transport-level errors directly so
-    // we don't have to encode "no id" through `RpcRequestId`.
-    let null_id_error = |err: RpcErr| -> Value {
-        let meta: RpcErrorMetadata = err.into();
-        serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": Value::Null,
-            "error": meta,
-        })
-    };
-
     let wrapper: RpcRequestWrapper = match serde_json::from_str(&body) {
         Ok(w) => w,
         Err(_) => {
@@ -697,6 +735,12 @@ pub async fn handle_authrpc_request(
             ))));
         }
     };
+
+    // Reject empty / oversize batches before any auth or dispatch work so a
+    // 100k-request body can't burn JWT crypto or memory.
+    if let Some(err) = reject_invalid_batch(&wrapper) {
+        return Ok(Json(err));
+    }
 
     if let Err(error) = authenticate(&service_context.node_data.jwt_secret, auth_header) {
         // Auth failed: respond before dispatching anything. For batches, mirror
@@ -709,9 +753,6 @@ pub async fn handle_authrpc_request(
                 "id": req.id,
                 "error": error_meta,
             }),
-            RpcRequestWrapper::Multiple(requests) if requests.is_empty() => null_id_error(
-                RpcErr::InvalidRequest("empty batch is not a valid Request".to_string()),
-            ),
             RpcRequestWrapper::Multiple(requests) => {
                 let mut responses = Vec::with_capacity(requests.len());
                 for req in requests {
@@ -732,9 +773,6 @@ pub async fn handle_authrpc_request(
             let res = map_authrpc_requests(&req, service_context).await;
             rpc_response(req.id, res).map_err(|_| StatusCode::BAD_REQUEST)?
         }
-        RpcRequestWrapper::Multiple(requests) if requests.is_empty() => null_id_error(
-            RpcErr::InvalidRequest("empty batch is not a valid Request".to_string()),
-        ),
         RpcRequestWrapper::Multiple(requests) => {
             let mut responses = Vec::with_capacity(requests.len());
             for req in requests {

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -392,6 +392,7 @@ fn get_error_kind(err: &RpcErr) -> &'static str {
         RpcErr::MethodNotFound(_) => "MethodNotFound",
         RpcErr::WrongParam(_) => "WrongParam",
         RpcErr::BadParams(_) => "BadParams",
+        RpcErr::InvalidRequest(_) => "InvalidRequest",
         RpcErr::MissingParam(_) => "MissingParam",
         RpcErr::TooLargeRequest => "TooLargeRequest",
         RpcErr::BadHexFormat(_) => "BadHexFormat",
@@ -676,27 +677,54 @@ pub async fn handle_authrpc_request(
     auth_header: Option<TypedHeader<Authorization<Bearer>>>,
     body: String,
 ) -> Result<Json<Value>, StatusCode> {
+    // JSON-RPC 2.0: when the request body is not a valid Request object the
+    // response id MUST be null. Build these transport-level errors directly so
+    // we don't have to encode "no id" through `RpcRequestId`.
+    let null_id_error = |err: RpcErr| -> Value {
+        let meta: RpcErrorMetadata = err.into();
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": Value::Null,
+            "error": meta,
+        })
+    };
+
     let wrapper: RpcRequestWrapper = match serde_json::from_str(&body) {
         Ok(w) => w,
         Err(_) => {
-            return Ok(Json(
-                rpc_response(
-                    RpcRequestId::String("".to_string()),
-                    Err(RpcErr::BadParams("Invalid request body".to_string())),
-                )
-                .map_err(|_| StatusCode::BAD_REQUEST)?,
-            ));
+            return Ok(Json(null_id_error(RpcErr::InvalidRequest(
+                "could not parse JSON-RPC request body".to_string(),
+            ))));
         }
     };
 
     if let Err(error) = authenticate(&service_context.node_data.jwt_secret, auth_header) {
-        let id = match &wrapper {
-            RpcRequestWrapper::Single(req) => req.id.clone(),
-            RpcRequestWrapper::Multiple(_) => RpcRequestId::String("".to_string()),
+        // Auth failed: respond before dispatching anything. For batches, mirror
+        // the batch shape and emit one error response per request so clients
+        // can still correlate by id.
+        let error_meta: RpcErrorMetadata = error.into();
+        let res = match wrapper {
+            RpcRequestWrapper::Single(req) => serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": req.id,
+                "error": error_meta,
+            }),
+            RpcRequestWrapper::Multiple(requests) if requests.is_empty() => null_id_error(
+                RpcErr::InvalidRequest("empty batch is not a valid Request".to_string()),
+            ),
+            RpcRequestWrapper::Multiple(requests) => {
+                let mut responses = Vec::with_capacity(requests.len());
+                for req in requests {
+                    responses.push(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": req.id,
+                        "error": error_meta.clone(),
+                    }));
+                }
+                serde_json::to_value(responses).map_err(|_| StatusCode::BAD_REQUEST)?
+            }
         };
-        return Ok(Json(
-            rpc_response(id, Err(error)).map_err(|_| StatusCode::BAD_REQUEST)?,
-        ));
+        return Ok(Json(res));
     }
 
     let res = match wrapper {
@@ -704,16 +732,10 @@ pub async fn handle_authrpc_request(
             let res = map_authrpc_requests(&req, service_context).await;
             rpc_response(req.id, res).map_err(|_| StatusCode::BAD_REQUEST)?
         }
+        RpcRequestWrapper::Multiple(requests) if requests.is_empty() => null_id_error(
+            RpcErr::InvalidRequest("empty batch is not a valid Request".to_string()),
+        ),
         RpcRequestWrapper::Multiple(requests) => {
-            if requests.is_empty() {
-                return Ok(Json(
-                    rpc_response(
-                        RpcRequestId::String("".to_string()),
-                        Err(RpcErr::BadParams("Invalid request body".to_string())),
-                    )
-                    .map_err(|_| StatusCode::BAD_REQUEST)?,
-                ));
-            }
             let mut responses = Vec::with_capacity(requests.len());
             for req in requests {
                 let res = map_authrpc_requests(&req, service_context.clone()).await;
@@ -1686,110 +1708,5 @@ mod tests {
         });
         let expected_response = to_rpc_response_success_value(&json.to_string());
         assert_eq!(rpc_response.to_string(), expected_response.to_string())
-    }
-
-    /// Regression test for engine port batch parsing. Prior to the fix,
-    /// `handle_authrpc_request` deserialized directly into `RpcRequest` and
-    /// rejected JSON-RPC 2.0 batches with `Invalid request body`. Prysm's
-    /// `execution_payload_envelopes_by_root` handler batches `eth_getBlockByHash`
-    /// against the engine port, which caused glamsterdam-devnet-4 forking.
-    #[tokio::test]
-    async fn authrpc_accepts_batched_engine_requests() {
-        use axum::extract::State;
-        use axum_extra::TypedHeader;
-        use axum_extra::headers::Authorization;
-        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
-
-        let mut storage =
-            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
-        storage
-            .set_chain_config(&example_chain_config())
-            .await
-            .unwrap();
-        let context = default_context_with_storage(storage).await;
-
-        let iat = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let claims = serde_json::json!({ "iat": iat });
-        let token = encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &EncodingKey::from_secret(&context.node_data.jwt_secret),
-        )
-        .unwrap();
-        let auth_header = Some(TypedHeader(Authorization::bearer(&token).unwrap()));
-
-        let body = r#"[
-            {"jsonrpc":"2.0","method":"engine_exchangeCapabilities","params":[[]],"id":1},
-            {"jsonrpc":"2.0","method":"engine_exchangeCapabilities","params":[[]],"id":2}
-        ]"#
-        .to_string();
-
-        let response = handle_authrpc_request(State(context), auth_header, body)
-            .await
-            .expect("handler should succeed");
-        let value = response.0;
-        let arr = value
-            .as_array()
-            .expect("batched auth response must be a JSON array");
-        assert_eq!(arr.len(), 2, "expected 2 responses, got {value}");
-        for (i, item) in arr.iter().enumerate() {
-            assert!(
-                item.get("result").is_some(),
-                "response {i} should have a result field, got {item}"
-            );
-            assert_eq!(
-                item.get("id").and_then(|v| v.as_u64()),
-                Some((i + 1) as u64)
-            );
-        }
-    }
-
-    /// JSON-RPC 2.0 §6: an empty batch is itself an Invalid Request.
-    #[tokio::test]
-    async fn authrpc_rejects_empty_batch() {
-        use axum::extract::State;
-        use axum_extra::TypedHeader;
-        use axum_extra::headers::Authorization;
-        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
-
-        let mut storage =
-            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
-        storage
-            .set_chain_config(&example_chain_config())
-            .await
-            .unwrap();
-        let context = default_context_with_storage(storage).await;
-
-        let iat = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let claims = serde_json::json!({ "iat": iat });
-        let token = encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &EncodingKey::from_secret(&context.node_data.jwt_secret),
-        )
-        .unwrap();
-        let auth_header = Some(TypedHeader(Authorization::bearer(&token).unwrap()));
-
-        let response = handle_authrpc_request(State(context), auth_header, "[]".to_string())
-            .await
-            .expect("handler should succeed");
-        let err = response
-            .0
-            .get("error")
-            .expect("empty batch must produce an error response");
-        assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32000));
-        assert!(
-            err.get("message")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .contains("Invalid request body"),
-            "expected Invalid request body, got {err}"
-        );
     }
 }

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -8,8 +8,8 @@
 use crate::{
     eth::gas_tip_estimator::GasTipEstimator,
     rpc::{
-        ClientVersion, NodeData, RpcApiContext, handle_authrpc_request, start_api,
-        start_block_executor,
+        ClientVersion, NodeData, RpcApiContext, handle_authrpc_request, handle_http_request,
+        start_api, start_block_executor,
     },
     utils::RpcNamespace,
 };
@@ -401,5 +401,14 @@ pub async fn call_authrpc(
     handle_authrpc_request(State(context), auth_header, body)
         .await
         .expect("handle_authrpc_request should not return a status code error")
+        .0
+}
+
+/// Drive the public HTTP RPC handler without needing axum extractor types at
+/// the call site.
+pub async fn call_http(context: RpcApiContext, body: String) -> Value {
+    handle_http_request(State(context), body)
+        .await
+        .expect("handle_http_request should not return a status code error")
         .0
 }

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -7,9 +7,15 @@
 
 use crate::{
     eth::gas_tip_estimator::GasTipEstimator,
-    rpc::{ClientVersion, NodeData, RpcApiContext, start_api, start_block_executor},
+    rpc::{
+        ClientVersion, NodeData, RpcApiContext, handle_authrpc_request, start_api,
+        start_block_executor,
+    },
     utils::RpcNamespace,
 };
+use axum::extract::State;
+use axum_extra::TypedHeader;
+use axum_extra::headers::{Authorization, authorization::Bearer};
 use bytes::Bytes;
 use ethrex_blockchain::Blockchain;
 use ethrex_common::{
@@ -31,8 +37,11 @@ use ethrex_p2p::{
 };
 use ethrex_storage::{EngineType, Store};
 use hex_literal::hex;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use secp256k1::SecretKey;
+use serde_json::Value;
 use spawned_concurrency::tasks::ActorRef;
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashSet, net::SocketAddr, str::FromStr, sync::Arc};
 use tokio::sync::Mutex as TokioMutex;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -364,4 +373,33 @@ pub async fn dummy_p2p_context(peer_table: PeerTable) -> P2PContext {
         100.0,
     )
     .unwrap()
+}
+
+/// Mint a valid bearer header for the given context's JWT secret, with a
+/// fresh `iat` claim. For integration tests of the engine RPC port.
+pub fn jwt_auth_header_for(context: &RpcApiContext) -> Option<TypedHeader<Authorization<Bearer>>> {
+    let iat = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let token = encode(
+        &Header::new(Algorithm::HS256),
+        &serde_json::json!({ "iat": iat }),
+        &EncodingKey::from_secret(&context.node_data.jwt_secret),
+    )
+    .unwrap();
+    Some(TypedHeader(Authorization::bearer(&token).unwrap()))
+}
+
+/// Drive the auth RPC handler without needing axum extractor types at the
+/// call site.
+pub async fn call_authrpc(
+    context: RpcApiContext,
+    auth_header: Option<TypedHeader<Authorization<Bearer>>>,
+    body: String,
+) -> Value {
+    handle_authrpc_request(State(context), auth_header, body)
+        .await
+        .expect("handle_authrpc_request should not return a status code error")
+        .0
 }

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -50,6 +50,12 @@ pub enum RpcErr {
     Halt { reason: String, gas_used: u64 },
     #[error("Authentication error: {0:?}")]
     AuthenticationError(AuthenticationError),
+    /// JSON-RPC 2.0 §5.1: the JSON sent is not a valid Request object. Used
+    /// for malformed bodies on the auth port (e.g. empty batches) where we
+    /// also drop the request id (per spec, id MUST be null when it cannot
+    /// be detected).
+    #[error("Invalid Request: {0}")]
+    InvalidRequest(String),
     #[error("Invalid forkchoice state: {0}")]
     InvalidForkChoiceState(String),
     #[error("Invalid payload attributes: {0}")]
@@ -86,6 +92,11 @@ impl From<RpcErr> for RpcErrorMetadata {
                 code: -32000,
                 data: None,
                 message: format!("Invalid params: {context}"),
+            },
+            RpcErr::InvalidRequest(context) => RpcErrorMetadata {
+                code: -32600,
+                data: None,
+                message: format!("Invalid Request: {context}"),
             },
             RpcErr::MissingParam(parameter_name) => RpcErrorMetadata {
                 code: -32000,
@@ -334,7 +345,7 @@ impl Default for RpcRequest {
 ///
 /// Contains the error code, message, and optional additional data.
 /// Error codes follow the JSON-RPC 2.0 and Ethereum conventions.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RpcErrorMetadata {
     /// Numeric error code (negative for standard errors).
     pub code: i32,

--- a/test/tests/rpc/authrpc_batch_tests.rs
+++ b/test/tests/rpc/authrpc_batch_tests.rs
@@ -109,3 +109,26 @@ async fn authrpc_single_auth_failure_keeps_request_id() {
     let err = value.get("error").expect("auth failure must error");
     assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32000));
 }
+
+/// Batches larger than `MAX_BATCH_SIZE` (1000) must be rejected before any
+/// JWT-auth or dispatch work runs, to keep a 100k-request body from burning
+/// crypto or memory on the engine port. Matches geth's
+/// `--engine.batchitemlimit` default.
+#[tokio::test]
+async fn authrpc_rejects_oversize_batch() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+    let context = default_context_with_storage(storage).await;
+    let auth = jwt_auth_header_for(&context);
+
+    let reqs: Vec<String> = (0..1001)
+        .map(|i| format!(r#"{{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":{i}}}"#))
+        .collect();
+    let body = format!("[{}]", reqs.join(","));
+
+    let value = call_authrpc(context, auth, body).await;
+    let err = value
+        .get("error")
+        .expect("oversize batch must produce an error response");
+    assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32600));
+    assert!(value.get("id").map(|v| v.is_null()).unwrap_or(false));
+}

--- a/test/tests/rpc/authrpc_batch_tests.rs
+++ b/test/tests/rpc/authrpc_batch_tests.rs
@@ -1,0 +1,111 @@
+use ethrex_rpc::test_utils::{
+    call_authrpc, default_context_with_storage, jwt_auth_header_for, setup_store,
+};
+use ethrex_storage::{EngineType, Store};
+
+/// Regression test for engine-port batch parsing. Prior to the fix,
+/// `handle_authrpc_request` deserialized directly into `RpcRequest` and
+/// rejected JSON-RPC 2.0 batches with `Invalid request body`. Prysm's
+/// `execution_payload_envelopes_by_root` handler batches `eth_getBlockByHash`
+/// against the engine port (auth RPC also serves the `eth_*` namespace), which
+/// caused glamsterdam-devnet-4 forking. This test uses `eth_chainId` to
+/// exercise the same routing path (`map_authrpc_requests` -> `map_eth_requests`)
+/// that Prysm hits.
+#[tokio::test]
+async fn authrpc_accepts_batched_eth_requests() {
+    let storage = setup_store().await;
+    let context = default_context_with_storage(storage).await;
+    let auth = jwt_auth_header_for(&context);
+
+    let body = r#"[
+        {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1},
+        {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}
+    ]"#
+    .to_string();
+
+    let value = call_authrpc(context, auth, body).await;
+    let arr = value
+        .as_array()
+        .expect("batched auth response must be a JSON array");
+    assert_eq!(arr.len(), 2, "expected 2 responses, got {value}");
+    for (i, item) in arr.iter().enumerate() {
+        assert!(
+            item.get("result").is_some(),
+            "response {i} should have a result field, got {item}"
+        );
+        assert_eq!(
+            item.get("id").and_then(|v| v.as_u64()),
+            Some((i + 1) as u64)
+        );
+    }
+}
+
+/// JSON-RPC 2.0 §4.2: empty batch is itself an Invalid Request. Response code
+/// must be -32600, and per §5.1 the id must be null when the request can't be
+/// associated with a single object.
+#[tokio::test]
+async fn authrpc_rejects_empty_batch() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+    let context = default_context_with_storage(storage).await;
+    let auth = jwt_auth_header_for(&context);
+
+    let value = call_authrpc(context, auth, "[]".to_string()).await;
+    let err = value
+        .get("error")
+        .expect("empty batch must produce an error response");
+    assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32600));
+    assert!(value.get("id").map(|v| v.is_null()).unwrap_or(false));
+}
+
+/// Auth failure on a batched body must preserve the batch shape so clients can
+/// still correlate the failure with each original request id. Without this the
+/// caller sees a single error with a synthetic id and has no way to tell which
+/// of N requests triggered it.
+#[tokio::test]
+async fn authrpc_batch_auth_failure_preserves_ids() {
+    let storage = setup_store().await;
+    let context = default_context_with_storage(storage).await;
+
+    // No auth header at all: authenticate() returns MissingAuthentication.
+    let body = r#"[
+        {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1},
+        {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":7}
+    ]"#
+    .to_string();
+
+    let value = call_authrpc(context, None, body).await;
+    let arr = value
+        .as_array()
+        .expect("batched auth failure must return a JSON array, got {value:?}");
+    assert_eq!(arr.len(), 2);
+    let ids: Vec<u64> = arr
+        .iter()
+        .map(|item| item.get("id").and_then(|v| v.as_u64()).unwrap())
+        .collect();
+    assert_eq!(ids, vec![1, 7], "ids should match the request batch");
+    for item in arr {
+        let err = item.get("error").expect("each entry must be an error");
+        assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32000));
+        assert!(
+            err.get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .contains("Auth"),
+            "expected auth error message, got {err}"
+        );
+    }
+}
+
+/// Single-request auth failure still goes back as a single object (not wrapped
+/// in an array) and echoes the original id.
+#[tokio::test]
+async fn authrpc_single_auth_failure_keeps_request_id() {
+    let storage = setup_store().await;
+    let context = default_context_with_storage(storage).await;
+
+    let body = r#"{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":42}"#.to_string();
+    let value = call_authrpc(context, None, body).await;
+    assert_eq!(value.get("id").and_then(|v| v.as_u64()), Some(42));
+    let err = value.get("error").expect("auth failure must error");
+    assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32000));
+}

--- a/test/tests/rpc/http_batch_tests.rs
+++ b/test/tests/rpc/http_batch_tests.rs
@@ -1,0 +1,39 @@
+use ethrex_rpc::test_utils::{call_http, default_context_with_storage};
+use ethrex_storage::{EngineType, Store};
+
+/// JSON-RPC 2.0 §4.2: empty batch is itself an Invalid Request. The public
+/// HTTP port must reject `[]` the same way the engine auth port does;
+/// historically this returned `[]` and silently succeeded.
+#[tokio::test]
+async fn http_rejects_empty_batch() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+    let context = default_context_with_storage(storage).await;
+
+    let value = call_http(context, "[]".to_string()).await;
+    let err = value
+        .get("error")
+        .expect("empty batch must produce an error response");
+    assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32600));
+    assert!(value.get("id").map(|v| v.is_null()).unwrap_or(false));
+}
+
+/// Batches larger than `MAX_BATCH_SIZE` (1000) must be rejected before any
+/// dispatch work runs on the public HTTP port too. Matches geth's
+/// `--rpc.batch-request-limit` default.
+#[tokio::test]
+async fn http_rejects_oversize_batch() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+    let context = default_context_with_storage(storage).await;
+
+    let reqs: Vec<String> = (0..1001)
+        .map(|i| format!(r#"{{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":{i}}}"#))
+        .collect();
+    let body = format!("[{}]", reqs.join(","));
+
+    let value = call_http(context, body).await;
+    let err = value
+        .get("error")
+        .expect("oversize batch must produce an error response");
+    assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32600));
+    assert!(value.get("id").map(|v| v.is_null()).unwrap_or(false));
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,2 +1,3 @@
+mod authrpc_batch_tests;
 mod client_version_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,3 +1,4 @@
 mod authrpc_batch_tests;
 mod client_version_tests;
+mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary

- Engine RPC port (`:8551`) rejected JSON-RPC 2.0 batches with `Invalid request body` because `handle_authrpc_request` deserialized into `RpcRequest` instead of `RpcRequestWrapper`. The public HTTP and WS handlers already supported batches; the auth path was missed when batching was added in #2006.
- Prysm's `execution_payload_envelopes_by_root` handler batches `eth_getBlockByHash` calls to the EL. On glamsterdam-devnet-4, this returned an unmarshal error, lodestar downscored and booted the prysm peers, and many ethrex/prysm slots got orphaned (forking party).
- JWT authentication still runs once per HTTP body. Empty batches return `-32000` `Invalid request body` per JSON-RPC 2.0 §6.

## Test plan

- [x] `cargo test -p ethrex-rpc --lib` (69/69 pass)
- [x] New `authrpc_accepts_batched_engine_requests` regression test: mints a valid JWT, sends a batch of two `engine_exchangeCapabilities` calls, asserts an array of 2 responses with `result` fields and matching ids
- [x] New `authrpc_rejects_empty_batch` test: empty array body returns `-32000` `Invalid request body`
- [x] `cargo fmt` / `cargo clippy -p ethrex-rpc --lib --tests` clean
- [ ] Validate on glamsterdam-devnet-4 that ethrex/prysm pairs no longer orphan slots