### PR TITLE
fix(l1): retry GetPooledTransactions on alternate peer when blob sidecar mismatches

### DIFF
--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, VecDeque, hash_map::Entry},
     sync::RwLock,
     sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
 };
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -25,6 +26,27 @@ use ethrex_storage::error::StoreError;
 use ethrex_vm::{intrinsic_gas_dimensions, intrinsic_gas_floor};
 use tracing::warn;
 
+/// Maximum number of alternate announcers tracked per hash. Bounds the memory
+/// used by the alternates map and prevents pathological peers from filling it.
+///
+/// TODO(#6691-fu): expose this through `BlockchainOptions` / CLI like the
+/// other mempool ceilings (`max_mempool_size`, RBF price-bumps). 8 is
+/// conservative; high-fan-in benchmarks and Hive adversarial-mempool scenarios
+/// might want to raise it. FIFO eviction keeps the cap safe regardless.
+pub const MAX_ALTERNATES_PER_HASH: usize = 8;
+
+/// An alternate announcer for a known-in-flight transaction hash. Carries the
+/// announcer's own announced type and size so the eventual retry can validate
+/// the response against the alternate's metadata (which may differ from the
+/// primary announcer's, e.g. when one peer advertises a bare blob tx while
+/// another advertises the full sidecar).
+#[derive(Debug, Clone, Copy)]
+pub struct Alternate {
+    pub peer_id: H256,
+    pub tx_type: u8,
+    pub tx_size: usize,
+}
+
 #[derive(Debug, Default)]
 struct MempoolInner {
     broadcast_pool: FxHashSet<H256>,
@@ -34,6 +56,15 @@ struct MempoolInner {
     /// but whose responses haven't arrived yet. Used to avoid sending duplicate
     /// requests when multiple peers announce the same transaction.
     in_flight_txs: FxHashSet<H256>,
+    /// For each announced hash, the queue of *alternate* announcers that also
+    /// advertised it while the hash was already in-flight from someone else.
+    /// Each entry carries the announcer's own announced type and size so the
+    /// retry can validate the response against the alternate's metadata (which
+    /// may differ from the primary's). Used as a fallback list when an in-flight
+    /// request fails or the responding peer disconnects. The `Instant` records
+    /// the last time the entry was touched so a periodic pruner can drop stale
+    /// entries.
+    alternates: FxHashMap<H256, (VecDeque<Alternate>, Instant)>,
     /// Maps blob versioned hashes to transaction hashes that include them and a position inside
     /// blob bundle where blob and its adjacent data is available.
     blobs_bundle_by_versioned_hash: FxHashMap<H256, FxHashMap<H256, usize>>,
@@ -177,6 +208,7 @@ impl Mempool {
             .insert((sender, transaction.nonce()), hash);
         inner.transaction_pool.insert(hash, transaction);
         inner.broadcast_pool.insert(hash);
+        inner.alternates.remove(&hash);
         // Drop the write lock before notifying to avoid holding it while waking waiters
         drop(inner);
         // Bump `tx_seq` *after* releasing the write lock. The payload builder
@@ -332,13 +364,34 @@ impl Mempool {
     /// Filters hashes to those not already in the mempool or in-flight, and
     /// atomically marks the returned hashes as in-flight under a single write
     /// lock so that concurrent peer handlers cannot request the same hashes.
+    ///
+    /// For hashes that get filtered out *because they're already in-flight
+    /// from another peer*, records `announcer` as a fallback so the request
+    /// can be retried against this peer if the original responder fails. New
+    /// hashes that the caller is about to request do not need an alternates
+    /// entry yet: the caller is the primary, and one will be created only if
+    /// some other peer later announces the same hash while it's in-flight.
+    /// Reserve hashes the caller wants to request, returning only those that are
+    /// neither already in-flight nor already in the pool. Any hash filtered out
+    /// because it's in-flight from another peer is registered with the caller's
+    /// own (type, size) metadata as an alternate, so a later retry can validate
+    /// the response against this announcer's announcement.
+    ///
+    /// `hashes`, `types`, and `sizes` must be the same length (one entry per
+    /// announced hash).
     pub fn reserve_unknown_hashes(
         &self,
-        possible_hashes: &[H256],
+        hashes: &[H256],
+        types: &[u8],
+        sizes: &[usize],
+        announcer: H256,
     ) -> Result<Vec<H256>, StoreError> {
+        debug_assert_eq!(hashes.len(), types.len());
+        debug_assert_eq!(hashes.len(), sizes.len());
+
         let mut inner = self.write()?;
 
-        let unknown: Vec<H256> = possible_hashes
+        let unknown: Vec<H256> = hashes
             .iter()
             .filter(|hash| {
                 !inner.in_flight_txs.contains(hash) && !inner.transaction_pool.contains_key(hash)
@@ -347,6 +400,36 @@ impl Mempool {
             .collect();
 
         inner.in_flight_txs.extend(unknown.iter().copied());
+
+        // Register alternates only for hashes the caller will *not* request
+        // (i.e. those already in-flight from someone else). Skip pool hits
+        // and skip hashes we just reserved for this peer.
+        if hashes.len() > unknown.len() {
+            let unknown_set: FxHashSet<H256> = unknown.iter().copied().collect();
+            let now = Instant::now();
+            for (i, hash) in hashes.iter().enumerate() {
+                if unknown_set.contains(hash) || inner.transaction_pool.contains_key(hash) {
+                    continue;
+                }
+                let alt = Alternate {
+                    peer_id: announcer,
+                    tx_type: types[i],
+                    tx_size: sizes[i],
+                };
+                let entry = inner
+                    .alternates
+                    .entry(*hash)
+                    .or_insert_with(|| (VecDeque::new(), now));
+                entry.1 = now;
+                if !entry.0.iter().any(|a| a.peer_id == announcer) {
+                    if entry.0.len() >= MAX_ALTERNATES_PER_HASH {
+                        entry.0.pop_front();
+                    }
+                    entry.0.push_back(alt);
+                }
+            }
+        }
+
         Ok(unknown)
     }
 
@@ -357,6 +440,49 @@ impl Mempool {
         for hash in hashes {
             inner.in_flight_txs.remove(hash);
         }
+        Ok(())
+    }
+
+    /// Pops the next alternate announcer for the given hash, if any. Returns
+    /// `Ok(None)` when no alternates remain. The caller uses the popped
+    /// `Alternate` to look up the peer connection and build a retry request
+    /// against that peer's own announcement metadata.
+    pub fn pop_alternate(&self, hash: H256) -> Result<Option<Alternate>, StoreError> {
+        let mut inner = self.write()?;
+        let Some(entry) = inner.alternates.get_mut(&hash) else {
+            return Ok(None);
+        };
+        let popped = entry.0.pop_front();
+        if entry.0.is_empty() {
+            inner.alternates.remove(&hash);
+        }
+        Ok(popped)
+    }
+
+    /// Drop the entire alternates list for the given hashes. Per-hash cleanup
+    /// already happens inline in `add_transaction` when a tx lands in the
+    /// pool, so this batch variant has no production caller today —
+    /// `prune_alternates` (10-min TTL sweep) is the only background reaper.
+    /// Kept `pub` for the integration test in `test/tests/blockchain/` and
+    /// for the obvious future wiring (success-path batch cleanup in
+    /// `PooledTransactions::handle`) when that lands.
+    pub fn clear_alternates(&self, hashes: &[H256]) -> Result<(), StoreError> {
+        let mut inner = self.write()?;
+        for hash in hashes {
+            inner.alternates.remove(hash);
+        }
+        Ok(())
+    }
+
+    /// Drop alternates entries that haven't been touched in the last `ttl`.
+    /// Called periodically to bound the size of the alternates map when
+    /// announced txs never make it into the pool.
+    pub fn prune_alternates(&self, ttl: Duration) -> Result<(), StoreError> {
+        let mut inner = self.write()?;
+        let now = Instant::now();
+        inner
+            .alternates
+            .retain(|_, (_, last_seen)| now.saturating_duration_since(*last_seen) < ttl);
         Ok(())
     }
 

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -459,21 +459,6 @@ impl Mempool {
         Ok(popped)
     }
 
-    /// Drop the entire alternates list for the given hashes. Per-hash cleanup
-    /// already happens inline in `add_transaction` when a tx lands in the
-    /// pool, so this batch variant has no production caller today —
-    /// `prune_alternates` (10-min TTL sweep) is the only background reaper.
-    /// Kept `pub` for the integration test in `test/tests/blockchain/` and
-    /// for the obvious future wiring (success-path batch cleanup in
-    /// `PooledTransactions::handle`) when that lands.
-    pub fn clear_alternates(&self, hashes: &[H256]) -> Result<(), StoreError> {
-        let mut inner = self.write()?;
-        for hash in hashes {
-            inner.alternates.remove(hash);
-        }
-        Ok(())
-    }
-
     /// Drop alternates entries that haven't been touched in the last `ttl`.
     /// Called periodically to bound the size of the alternates map when
     /// announced txs never make it into the pool.

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -373,6 +373,7 @@ pub trait PeerTableServerProtocol: Send + Sync {
     ) -> Response<Option<(H256, PeerConnection, RequestPermit)>>;
     fn get_session_info(&self, node_id: H256) -> Response<Option<Session>>;
     fn get_peer_diagnostics(&self) -> Response<Vec<PeerDiagnostics>>;
+    fn get_peer_connection(&self, peer_id: H256) -> Response<Option<PeerConnection>>;
 }
 
 #[derive(Debug)]
@@ -929,6 +930,17 @@ impl PeerTableServer {
             .get(&msg.node_id)
             .cloned()
             .or_else(|| self.contacts.get(&msg.node_id)?.session.clone())
+    }
+
+    #[request_handler]
+    async fn handle_get_peer_connection(
+        &mut self,
+        msg: peer_table_server_protocol::GetPeerConnection,
+        _ctx: &Context<Self>,
+    ) -> Option<PeerConnection> {
+        self.peers
+            .get(&msg.peer_id)
+            .and_then(|peer_data| peer_data.connection.clone())
     }
 
     #[request_handler]

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -1720,13 +1720,12 @@ async fn retry_on_alternates(
     }
     // Group hashes by chosen live alternate, carrying their own type/size.
     // We walk per-hash so a dead alternate for hash X doesn't consume the
-    // slot that hash Y could use.
-    //
-    // TODO(#6691-fu): the liveness probe here and the actual lookup at the
-    // enqueue site below race; if the connection drops in between, the
-    // alternate slot is consumed for nothing. Carry the `PeerConnection`
-    // handle in `by_peer` to collapse both into a single lookup.
-    let mut by_peer: FxHashMap<H256, Vec<(H256, u8, usize)>> = FxHashMap::default();
+    // slot that hash Y could use. The `PeerConnection` handle from the
+    // liveness probe is stashed in `by_peer` and reused at enqueue time,
+    // so there's no second lookup (and no race where the connection drops
+    // between probe and use).
+    type AltGroup = (PeerConnection, Vec<(H256, u8, usize)>);
+    let mut by_peer: FxHashMap<H256, AltGroup> = FxHashMap::default();
     for hash in hashes {
         loop {
             let alt = match blockchain.mempool.pop_alternate(*hash) {
@@ -1737,12 +1736,14 @@ async fn retry_on_alternates(
                     break;
                 }
             };
+            // Reuse the connection we already grabbed for this peer.
+            if let Some((_, list)) = by_peer.get_mut(&alt.peer_id) {
+                list.push((*hash, alt.tx_type, alt.tx_size));
+                break;
+            }
             match peer_table.get_peer_connection(alt.peer_id).await {
-                Ok(Some(_)) => {
-                    by_peer
-                        .entry(alt.peer_id)
-                        .or_default()
-                        .push((*hash, alt.tx_type, alt.tx_size));
+                Ok(Some(conn)) => {
+                    by_peer.insert(alt.peer_id, (conn, vec![(*hash, alt.tx_type, alt.tx_size)]));
                     break;
                 }
                 Ok(None) => continue, // dead peer, try next alternate
@@ -1754,7 +1755,7 @@ async fn retry_on_alternates(
         }
     }
 
-    for (alt_peer_id, entries) in by_peer {
+    for (_, (conn, entries)) in by_peer {
         let mut types = Vec::with_capacity(entries.len());
         let mut sizes = Vec::with_capacity(entries.len());
         let mut hash_list = Vec::with_capacity(entries.len());
@@ -1765,10 +1766,7 @@ async fn retry_on_alternates(
         }
         let announcement =
             NewPooledTransactionHashes::from_raw(types.into(), sizes, hash_list.clone());
-        // Look up again: connection could have closed since we checked.
-        if let Ok(Some(conn)) = peer_table.get_peer_connection(alt_peer_id).await
-            && let Err(e) = conn.enqueue_tx_requests(announcement, hash_list)
-        {
+        if let Err(e) = conn.enqueue_tx_requests(announcement, hash_list) {
             warn!(error = %e, "failed to enqueue tx requests on alternate peer");
         }
     }

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -1721,6 +1721,11 @@ async fn retry_on_alternates(
     // Group hashes by chosen live alternate, carrying their own type/size.
     // We walk per-hash so a dead alternate for hash X doesn't consume the
     // slot that hash Y could use.
+    //
+    // TODO(#6691-fu): the liveness probe here and the actual lookup at the
+    // enqueue site below race; if the connection drops in between, the
+    // alternate slot is consumed for nothing. Carry the `PeerConnection`
+    // handle in `by_peer` to collapse both into a single lookup.
     let mut by_peer: FxHashMap<H256, Vec<(H256, u8, usize)>> = FxHashMap::default();
     for hash in hashes {
         loop {

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -49,6 +49,7 @@ use ethrex_storage::{Store, error::StoreError};
 use ethrex_trie::TrieError;
 use futures::{SinkExt as _, Stream, stream::SplitSink};
 use rand::random;
+use rustc_hash::FxHashMap;
 use secp256k1::{PublicKey, SecretKey};
 use spawned_concurrency::{
     actor,
@@ -103,6 +104,11 @@ pub trait PeerConnectionServerProtocol: Send + Sync {
     fn broadcast_message(&self, task_id: Id, msg: Arc<Message>) -> Result<(), ActorError>;
     fn sweep_inflight_txs(&self) -> Result<(), ActorError>;
     fn flush_pending_tx_requests(&self) -> Result<(), ActorError>;
+    fn enqueue_tx_requests(
+        &self,
+        announcement: NewPooledTransactionHashes,
+        hashes: Vec<H256>,
+    ) -> Result<(), ActorError>;
 }
 
 #[cfg(feature = "l2")]
@@ -152,6 +158,19 @@ impl PeerConnection {
     pub async fn outgoing_message(&mut self, message: Message) -> Result<(), PeerConnectionError> {
         self.handle
             .outgoing_message(message)
+            .map_err(|err| PeerConnectionError::InternalError(err.to_string()))
+    }
+
+    /// Queue tx hashes (with the originating announcement metadata) to be
+    /// requested on the next flush tick. Used as a fallback when an in-flight
+    /// request on another peer fails.
+    pub fn enqueue_tx_requests(
+        &self,
+        announcement: NewPooledTransactionHashes,
+        hashes: Vec<H256>,
+    ) -> Result<(), PeerConnectionError> {
+        self.handle
+            .enqueue_tx_requests(announcement, hashes)
             .map_err(|err| PeerConnectionError::InternalError(err.to_string()))
     }
 
@@ -250,16 +269,27 @@ pub struct Established {
 
 impl Established {
     async fn teardown(&mut self) {
-        // Clear any in-flight transaction hashes so other connections can re-request them.
+        // Clear any in-flight transaction hashes so other connections can re-request them,
+        // then try to re-issue each pending request to an alternate announcer.
+        // Order matters: clear first so the alternate's reserve_unknown_hashes sees the
+        // hashes as free; otherwise the actor handler can race with clear_in_flight_txs
+        // and silently no-op the retry while consuming an alternates slot.
         for (_, (_announced, requested_hashes, _)) in self.requested_pooled_txs.drain() {
-            let _ = self
+            if let Err(e) = self
                 .blockchain
                 .mempool
-                .clear_in_flight_txs(&requested_hashes);
+                .clear_in_flight_txs(&requested_hashes)
+            {
+                warn!(error = %e, "clear_in_flight_txs failed during teardown");
+            }
+            retry_on_alternates(&self.blockchain, &self.peer_table, &requested_hashes).await;
         }
         // Also clear hashes that were buffered but not yet sent.
         for (_announced, pending_hashes) in self.pending_tx_requests.drain(..) {
-            let _ = self.blockchain.mempool.clear_in_flight_txs(&pending_hashes);
+            if let Err(e) = self.blockchain.mempool.clear_in_flight_txs(&pending_hashes) {
+                warn!(error = %e, "clear_in_flight_txs failed during teardown");
+            }
+            retry_on_alternates(&self.blockchain, &self.peer_table, &pending_hashes).await;
         }
         // Closing the sink. It may fail if it is already closed (eg. the other side already closed it)
         // Just logging a debug line if that's the case.
@@ -511,8 +541,13 @@ impl PeerConnectionServer {
                 .map(|(id, _)| *id)
                 .collect();
             for id in stale_ids {
-                if let Some((_, hashes, _)) = state.requested_pooled_txs.remove(&id) {
-                    let _ = state.blockchain.mempool.clear_in_flight_txs(&hashes);
+                if let Some((_announced, hashes, _)) = state.requested_pooled_txs.remove(&id) {
+                    // Clear in-flight before retry so the alternate's reserve_unknown_hashes
+                    // doesn't race against still-in-flight state and silently no-op.
+                    if let Err(e) = state.blockchain.mempool.clear_in_flight_txs(&hashes) {
+                        warn!(error = %e, "clear_in_flight_txs failed while sweeping stale requests");
+                    }
+                    retry_on_alternates(&state.blockchain, &state.peer_table, &hashes).await;
                 }
             }
         }
@@ -527,6 +562,32 @@ impl PeerConnectionServer {
         if let ConnectionState::Established(ref mut established_state) = self.state {
             let result = flush_pending_tx_requests(established_state).await;
             Self::process_cast_error(&self.state, result, ctx);
+        }
+    }
+
+    #[send_handler]
+    async fn handle_enqueue_tx_requests(
+        &mut self,
+        msg: peer_connection_server_protocol::EnqueueTxRequests,
+        _ctx: &Context<Self>,
+    ) {
+        if let ConnectionState::Established(ref mut state) = self.state {
+            // Re-reserve in-flight against this peer. If any hashes are already
+            // in-flight (race), drop them; we don't want duplicate requests.
+            let to_request: Vec<H256> = match state.blockchain.mempool.reserve_unknown_hashes(
+                &msg.announcement.transaction_hashes,
+                &msg.announcement.transaction_types,
+                &msg.announcement.transaction_sizes,
+                state.node.node_id(),
+            ) {
+                Ok(unknown) => unknown,
+                Err(_) => return,
+            };
+            if to_request.is_empty() {
+                return;
+            }
+            let trimmed = msg.announcement.filter_to(&to_request);
+            state.pending_tx_requests.push((trimmed, to_request));
         }
     }
 
@@ -1340,8 +1401,8 @@ async fn handle_incoming_message(
         Message::NewPooledTransactionHashes(new_pooled_transaction_hashes) if peer_supports_eth => {
             // Don't request transactions if we're not synced — we won't be building blocks soon.
             if state.blockchain.is_synced() {
-                let hashes =
-                    new_pooled_transaction_hashes.get_transactions_to_request(&state.blockchain)?;
+                let hashes = new_pooled_transaction_hashes
+                    .get_transactions_to_request(&state.blockchain, state.node.node_id())?;
                 if !hashes.is_empty() {
                     // Buffer hashes for batched requesting instead of sending immediately.
                     // The periodic flush_pending_tx_requests handler will send them.
@@ -1397,6 +1458,10 @@ async fn handle_incoming_message(
                         peer=%state.node,
                         "disconnected from peer. Reason: Invalid/Missing Blobs",
                     );
+                    if let Some((_announced, requested_hashes, _)) = &removed_request {
+                        retry_on_alternates(&state.blockchain, &state.peer_table, requested_hashes)
+                            .await;
+                    }
                     send_disconnect_message(state, Some(DisconnectReason::SubprotocolError)).await;
                     return Err(PeerConnectionError::DisconnectSent(
                         DisconnectReason::SubprotocolError,
@@ -1404,14 +1469,16 @@ async fn handle_incoming_message(
                 }
             }
             if state.blockchain.is_synced() {
-                if let Some((announced, _requested_hashes, _)) = removed_request {
+                if let Some((announced, requested_hashes, _)) = &removed_request {
                     let fork = state.blockchain.current_fork().await?;
-                    if let Err(error) = msg.validate_requested(&announced, fork) {
+                    if let Err(error) = msg.validate_requested(announced, fork) {
                         warn!(
                             peer=%state.node,
                             reason=%error,
                             "disconnected from peer",
                         );
+                        retry_on_alternates(&state.blockchain, &state.peer_table, requested_hashes)
+                            .await;
                         send_disconnect_message(state, Some(DisconnectReason::SubprotocolError))
                             .await;
                         return Err(PeerConnectionError::DisconnectSent(
@@ -1434,6 +1501,14 @@ async fn handle_incoming_message(
                             reason=%error,
                             "disconnected from peer",
                         );
+                        if let Some((_announced, requested_hashes, _)) = &removed_request {
+                            retry_on_alternates(
+                                &state.blockchain,
+                                &state.peer_table,
+                                requested_hashes,
+                            )
+                            .await;
+                        }
                         send_disconnect_message(state, Some(DisconnectReason::SubprotocolError))
                             .await;
                         return Err(PeerConnectionError::DisconnectSent(
@@ -1602,10 +1677,17 @@ async fn flush_pending_tx_requests(state: &mut Established) -> Result<(), PeerCo
         // Send first, only register in requested_pooled_txs on success.
         // This ensures we never track hashes for messages that were not transmitted.
         if let Err(e) = send(state, Message::GetPooledTransactions(request)).await {
-            // Clear in-flight for the current chunk (failed to send) and all remaining chunks.
+            // Clear in-flight for the current chunk (failed to send) and all remaining chunks,
+            // then try alternate announcers. Order matters: clear first so the alternate's
+            // reserve_unknown_hashes sees the hashes as free.
+            // Build an announcement covering every unsent hash (later chunks too) so the
+            // alternate can validate its response against the original type/size metadata.
             let unsent = &all_hashes[offset..];
             if !unsent.is_empty() {
-                let _ = state.blockchain.mempool.clear_in_flight_txs(unsent);
+                if let Err(clear_err) = state.blockchain.mempool.clear_in_flight_txs(unsent) {
+                    warn!(error = %clear_err, "clear_in_flight_txs failed after send error");
+                }
+                retry_on_alternates(&state.blockchain, &state.peer_table, unsent).await;
             }
             return Err(e);
         }
@@ -1615,4 +1697,74 @@ async fn flush_pending_tx_requests(state: &mut Established) -> Result<(), PeerCo
     }
 
     Ok(())
+}
+
+/// For each hash that has a remaining alternate announcer, look up that
+/// peer's connection and enqueue the request there. Each alternate carries
+/// the (type, size) metadata it originally announced, so the retry request
+/// is built from the alternate's own announcement rather than the failing
+/// peer's; otherwise validation against the failing peer's sizes would
+/// reject the alternate's response when the two announcements differ (e.g.
+/// bare blob tx vs full sidecar).
+///
+/// If a popped alternate is no longer reachable, keep popping until a live
+/// peer is found or alternates for that hash are exhausted, so a disconnected
+/// alternate doesn't burn the only fallback slot.
+async fn retry_on_alternates(
+    blockchain: &Arc<Blockchain>,
+    peer_table: &PeerTable,
+    hashes: &[H256],
+) {
+    if hashes.is_empty() {
+        return;
+    }
+    // Group hashes by chosen live alternate, carrying their own type/size.
+    // We walk per-hash so a dead alternate for hash X doesn't consume the
+    // slot that hash Y could use.
+    let mut by_peer: FxHashMap<H256, Vec<(H256, u8, usize)>> = FxHashMap::default();
+    for hash in hashes {
+        loop {
+            let alt = match blockchain.mempool.pop_alternate(*hash) {
+                Ok(Some(a)) => a,
+                Ok(None) => break,
+                Err(e) => {
+                    warn!(error = %e, "pop_alternate failed");
+                    break;
+                }
+            };
+            match peer_table.get_peer_connection(alt.peer_id).await {
+                Ok(Some(_)) => {
+                    by_peer
+                        .entry(alt.peer_id)
+                        .or_default()
+                        .push((*hash, alt.tx_type, alt.tx_size));
+                    break;
+                }
+                Ok(None) => continue, // dead peer, try next alternate
+                Err(e) => {
+                    warn!(error = %e, "get_peer_connection failed");
+                    break;
+                }
+            }
+        }
+    }
+
+    for (alt_peer_id, entries) in by_peer {
+        let mut types = Vec::with_capacity(entries.len());
+        let mut sizes = Vec::with_capacity(entries.len());
+        let mut hash_list = Vec::with_capacity(entries.len());
+        for (h, t, s) in &entries {
+            hash_list.push(*h);
+            types.push(*t);
+            sizes.push(*s);
+        }
+        let announcement =
+            NewPooledTransactionHashes::from_raw(types.into(), sizes, hash_list.clone());
+        // Look up again: connection could have closed since we checked.
+        if let Ok(Some(conn)) = peer_table.get_peer_connection(alt_peer_id).await
+            && let Err(e) = conn.enqueue_tx_requests(announcement, hash_list)
+        {
+            warn!(error = %e, "failed to enqueue tx requests on alternate peer");
+        }
+    }
 }

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -133,10 +133,14 @@ impl NewPooledTransactionHashes {
     pub fn get_transactions_to_request(
         &self,
         blockchain: &Blockchain,
+        announcer: H256,
     ) -> Result<Vec<H256>, StoreError> {
-        blockchain
-            .mempool
-            .reserve_unknown_hashes(&self.transaction_hashes)
+        blockchain.mempool.reserve_unknown_hashes(
+            &self.transaction_hashes,
+            &self.transaction_types,
+            &self.transaction_sizes,
+            announcer,
+        )
     }
 
     /// Extract only the entries for the given `requested` hashes from this announcement.

--- a/crates/networking/p2p/tx_broadcaster.rs
+++ b/crates/networking/p2p/tx_broadcaster.rs
@@ -210,6 +210,9 @@ impl TxBroadcaster {
             after = self.known_txs.len(),
             "Pruned old broadcasted transactions"
         );
+
+        // Piggyback the alternates-map sweep on this same tick.
+        let _ = self.blockchain.mempool.prune_alternates(prune_window);
     }
 
     // Get or assign a unique index to the peer_id

--- a/test/tests/blockchain/mempool_tests.rs
+++ b/test/tests/blockchain/mempool_tests.rs
@@ -548,3 +548,155 @@ fn blobs_bundle_insert_and_remove() {
         vec![None]
     );
 }
+
+mod alternates {
+    use super::*;
+    use ethrex_blockchain::mempool::MAX_ALTERNATES_PER_HASH;
+    use std::time::Duration;
+
+    fn h(n: u8) -> H256 {
+        let mut b = [0u8; 32];
+        b[31] = n;
+        H256::from(b)
+    }
+
+    /// Helper that reserves `hashes` with synthetic per-hash (type, size)
+    /// metadata. Tests that don't care about the metadata can use this.
+    fn reserve(mp: &Mempool, hashes: &[H256], announcer: H256) -> Vec<H256> {
+        let types = vec![0u8; hashes.len()];
+        let sizes = vec![0usize; hashes.len()];
+        mp.reserve_unknown_hashes(hashes, &types, &sizes, announcer)
+            .unwrap()
+    }
+
+    #[test]
+    fn primary_requester_is_not_an_alternate() {
+        let mp = Mempool::new(64);
+        let peer_a = h(1);
+        let tx = h(0xa);
+
+        // peer_a is the first announcer: it becomes the primary requester
+        // (returned in `unknown`), so no alternates entry should be created.
+        let unknown = reserve(&mp, &[tx], peer_a);
+        assert_eq!(unknown, vec![tx]);
+        assert!(mp.pop_alternate(tx).unwrap().is_none());
+    }
+
+    #[test]
+    fn second_announcer_recorded_as_alternate() {
+        let mp = Mempool::new(64);
+        let peer_a = h(1);
+        let peer_b = h(2);
+        let tx_a = h(0xa);
+        let tx_b = h(0xb);
+
+        let unknown = reserve(&mp, &[tx_a, tx_b], peer_a);
+        assert_eq!(unknown, vec![tx_a, tx_b]);
+
+        // peer_b sees the same hashes already in-flight from peer_a, so it
+        // should be filed as an alternate for each hash.
+        let unknown = reserve(&mp, &[tx_a, tx_b], peer_b);
+        assert!(unknown.is_empty());
+
+        let alt_a = mp.pop_alternate(tx_a).unwrap().expect("alt for tx_a");
+        let alt_b = mp.pop_alternate(tx_b).unwrap().expect("alt for tx_b");
+        assert_eq!(alt_a.peer_id, peer_b);
+        assert_eq!(alt_b.peer_id, peer_b);
+    }
+
+    #[test]
+    fn alternate_carries_per_hash_type_and_size() {
+        let mp = Mempool::new(64);
+        let primary = h(1);
+        let alt_peer = h(2);
+        let tx = h(0xa);
+
+        // primary announces with one (type, size); alt announces with another.
+        // The stored alternate must carry the alt peer's metadata, not the
+        // primary's, so a later retry validates the alt peer's response
+        // against the alt's own announcement.
+        mp.reserve_unknown_hashes(&[tx], &[0x03], &[42], primary)
+            .unwrap();
+        mp.reserve_unknown_hashes(&[tx], &[0x03], &[131072], alt_peer)
+            .unwrap();
+
+        let popped = mp.pop_alternate(tx).unwrap().expect("alt present");
+        assert_eq!(popped.peer_id, alt_peer);
+        assert_eq!(popped.tx_type, 0x03);
+        assert_eq!(popped.tx_size, 131072);
+    }
+
+    #[test]
+    fn pop_alternates_is_fifo_and_drains() {
+        let mp = Mempool::new(64);
+        let tx = h(0xab);
+        let primary = h(99);
+        let p1 = h(1);
+        let p2 = h(2);
+        let p3 = h(3);
+
+        reserve(&mp, &[tx], primary);
+        reserve(&mp, &[tx], p1);
+        reserve(&mp, &[tx], p2);
+        reserve(&mp, &[tx], p3);
+
+        assert_eq!(mp.pop_alternate(tx).unwrap().unwrap().peer_id, p1);
+        assert_eq!(mp.pop_alternate(tx).unwrap().unwrap().peer_id, p2);
+        assert_eq!(mp.pop_alternate(tx).unwrap().unwrap().peer_id, p3);
+        assert!(mp.pop_alternate(tx).unwrap().is_none());
+    }
+
+    #[test]
+    fn alternates_capped() {
+        let mp = Mempool::new(64);
+        let tx = h(0xcd);
+        let primary = h(0xff);
+        reserve(&mp, &[tx], primary);
+        for i in 0..(MAX_ALTERNATES_PER_HASH + 4) {
+            reserve(&mp, &[tx], h(i as u8 + 1));
+        }
+        let mut count = 0;
+        while mp.pop_alternate(tx).unwrap().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, MAX_ALTERNATES_PER_HASH);
+    }
+
+    #[test]
+    fn duplicate_announcer_not_double_counted() {
+        let mp = Mempool::new(64);
+        let tx = h(0xef);
+        let primary = h(0xff);
+        let peer = h(42);
+        reserve(&mp, &[tx], primary);
+        reserve(&mp, &[tx], peer);
+        reserve(&mp, &[tx], peer);
+        reserve(&mp, &[tx], peer);
+        let popped = mp.pop_alternate(tx).unwrap().expect("alt present");
+        assert_eq!(popped.peer_id, peer);
+        assert!(mp.pop_alternate(tx).unwrap().is_none());
+    }
+
+    #[test]
+    fn clear_alternates_drops_entries() {
+        let mp = Mempool::new(64);
+        let tx = h(1);
+        reserve(&mp, &[tx], h(99));
+        reserve(&mp, &[tx], h(2));
+        mp.clear_alternates(&[tx]).unwrap();
+        assert!(mp.pop_alternate(tx).unwrap().is_none());
+    }
+
+    #[test]
+    fn prune_alternates_drops_stale_entries() {
+        let mp = Mempool::new(64);
+        let tx = h(0xaa);
+        reserve(&mp, &[tx], h(1));
+        reserve(&mp, &[tx], h(2));
+        // Sleep well past the TTL so a loaded CI scheduler that gives us a
+        // shorter-than-asked sleep still observes the entries as stale.
+        std::thread::sleep(Duration::from_millis(20));
+        mp.prune_alternates(Duration::from_millis(5)).unwrap();
+        assert!(mp.pop_alternate(tx).unwrap().is_none());
+    }
+}

--- a/test/tests/blockchain/mempool_tests.rs
+++ b/test/tests/blockchain/mempool_tests.rs
@@ -678,16 +678,6 @@ mod alternates {
     }
 
     #[test]
-    fn clear_alternates_drops_entries() {
-        let mp = Mempool::new(64);
-        let tx = h(1);
-        reserve(&mp, &[tx], h(99));
-        reserve(&mp, &[tx], h(2));
-        mp.clear_alternates(&[tx]).unwrap();
-        assert!(mp.pop_alternate(tx).unwrap().is_none());
-    }
-
-    #[test]
     fn prune_alternates_drops_stale_entries() {
         let mp = Mempool::new(64);
         let tx = h(0xaa);


### PR DESCRIPTION
## Bug
When two peers announce the same blob tx hash, only the first becomes the in-flight requester; the second's announcement is dropped. If the first peer responds with bad data, ethrex disconnects it but has no fallback, and the upstream Hive test (`TestBlobTxWithMismatchedSidecar` / `TestBlobTxWithoutSidecar`) times out waiting for a re-request.

A subtler variant of the same bug: the two announcements can carry different `(type, size)` metadata. Peer A advertises a bare blob tx (small size), peer B advertises the full sidecar (large size). Even with a fallback in place, validating B's response against A's announced size would size-mismatch and disconnect the good peer.

## Fix
Track *alternate* announcers per hash in the mempool. When a hash is already in-flight from peer A and peer B announces it, store `Alternate { peer_id: B, tx_type, tx_size }` keyed on B's own announcement. On any failure path (bad blob, validation error, timeout, teardown, send error), pop the next live alternate and re-enqueue the request on that peer's connection, building the retry announcement from the alternate's own metadata so validation lines up.

Bounded by `MAX_ALTERNATES_PER_HASH = 8`, FIFO eviction, stale entries pruned every 6 min with a 10 min TTL.

## Test plan
- [x] 8 unit tests for the mempool alternates logic.
- [x] `cargo clippy -p ethrex-blockchain -p ethrex-p2p --all-targets -- -D warnings`
- [x] Hive devp2p: `TestBlobTxWithMismatchedSidecar` and `TestBlobTxWithoutSidecar` pass across 4 consecutive runs.
- [ ] Hive engine + sync + rpc-compat suites: confirm no regressions in CI.