### PR TITLE
feat(l1): implement debug_traceBlockByHash RPC endpoint

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -44,7 +44,7 @@ use crate::eth::{
     },
 };
 use crate::subscription_manager::{SubscriptionManager, SubscriptionManagerProtocol};
-use crate::tracing::{TraceBlockByNumberRequest, TraceTransactionRequest};
+use crate::tracing::{TraceBlockByHashRequest, TraceBlockByNumberRequest, TraceTransactionRequest};
 use crate::types::transaction::SendRawTransactionRequest;
 use crate::utils::{
     RpcErr, RpcErrorMetadata, RpcErrorResponse, RpcNamespace, RpcRequest, RpcRequestId,
@@ -1155,6 +1155,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_traceBlockByHash" => TraceBlockByHashRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -4,12 +4,13 @@ use ethrex_common::H256;
 use ethrex_common::{
     serde_utils,
     tracing::{CallTraceFrame, PrestateResult, StructLoggerEmit, StructLoggerResult},
+    types::Block,
 };
 use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
+use crate::{rpc::RpcApiContext, rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
 
 /// Default max amount of blocks to re-excute if it is not given
 const DEFAULT_REEXEC: u32 = 128;
@@ -23,6 +24,11 @@ pub struct TraceTransactionRequest {
 
 pub struct TraceBlockByNumberRequest {
     block: BlockIdentifier,
+    trace_config: TraceConfig,
+}
+
+pub struct TraceBlockByHashRequest {
+    block_hash: H256,
     trace_config: TraceConfig,
 }
 
@@ -213,6 +219,120 @@ impl RpcHandler for TraceTransactionRequest {
     }
 }
 
+/// Shared block tracing logic used by both `debug_traceBlockByNumber` and
+/// `debug_traceBlockByHash`.
+async fn trace_block(
+    block: Block,
+    trace_config: &TraceConfig,
+    context: &RpcApiContext,
+) -> Result<Value, RpcErr> {
+    let reexec = trace_config.reexec.unwrap_or(DEFAULT_REEXEC);
+    let timeout = trace_config.timeout.unwrap_or(DEFAULT_TIMEOUT);
+    match trace_config.tracer {
+        TracerType::CallTracer => {
+            let config = if let Some(value) = &trace_config.tracer_config {
+                serde_json::from_value(value.clone())?
+            } else {
+                CallTracerConfig::default()
+            };
+            let call_traces = context
+                .blockchain
+                .trace_block_calls(
+                    block,
+                    reexec,
+                    timeout,
+                    config.only_top_call,
+                    config.with_log,
+                )
+                .await
+                .map_err(|err| RpcErr::Internal(err.to_string()))?;
+            // Unwrap each CallTrace (Vec<CallTraceFrame>) to a single
+            // CallTraceFrame to match geth's callTracer response format.
+            let block_trace: BlockTrace<CallTraceFrame> = call_traces
+                .into_iter()
+                .map(|(hash, trace)| {
+                    let frame = trace
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
+                    Ok((hash, frame).into())
+                })
+                .collect::<Result<_, RpcErr>>()?;
+            Ok(serde_json::to_value(block_trace)?)
+        }
+        TracerType::PrestateTracer => {
+            let config: PrestateTracerConfig =
+                if let Some(value) = &trace_config.tracer_config {
+                    serde_json::from_value(value.clone())?
+                } else {
+                    PrestateTracerConfig::default()
+                };
+            config.validate()?;
+            let prestate_traces = context
+                .blockchain
+                .trace_block_prestate(
+                    block,
+                    reexec,
+                    timeout,
+                    config.diff_mode,
+                    config.include_empty,
+                )
+                .await
+                .map_err(|err| RpcErr::Internal(err.to_string()))?;
+            // Each trace result is already the correct variant (Prestate or Diff)
+            // based on the diff_mode flag, so we serialize directly.
+            let block_trace: Vec<serde_json::Value> = prestate_traces
+                .into_iter()
+                .map(|(hash, result)| {
+                    let trace_value = match result {
+                        PrestateResult::Prestate(trace) => serde_json::to_value(trace)?,
+                        PrestateResult::Diff(diff) => serde_json::to_value(diff)?,
+                    };
+                    serde_json::to_value(BlockTraceComponent {
+                        tx_hash: hash,
+                        result: trace_value,
+                    })
+                })
+                .collect::<Result<_, serde_json::Error>>()?;
+            Ok(serde_json::to_value(block_trace)?)
+        }
+        TracerType::OpcodeTracer => {
+            let cfg: OpcodeTracerConfig = trace_config
+                .tracer_config
+                .as_ref()
+                .map(|v| serde_json::from_value(v.clone()))
+                .transpose()?
+                .unwrap_or_default();
+            let emit = StructLoggerEmit {
+                mem_size: cfg.enable_memory,
+                return_data: cfg.enable_return_data,
+                refund: false,
+            };
+            let opcode_traces = context
+                .blockchain
+                .trace_block_opcodes(block, reexec, timeout, cfg)
+                .await
+                .map_err(|err| RpcErr::Internal(err.to_string()))?;
+            // Wrap each result with StructLoggerResult so it serializes in the
+            // geth-RPC shape expected by `debug_traceBlock*` consumers.
+            let block_trace: Vec<serde_json::Value> = opcode_traces
+                .into_iter()
+                .map(|(hash, result)| {
+                    let wrapped = serde_json::to_value(StructLoggerResult {
+                        result: &result,
+                        emit,
+                    })?;
+                    serde_json::to_value(BlockTraceComponent {
+                        tx_hash: hash,
+                        result: wrapped,
+                    })
+                })
+                .collect::<Result<_, serde_json::Error>>()?;
+            Ok(serde_json::to_value(block_trace)?)
+        }
+    }
+}
+
 impl RpcHandler for TraceBlockByNumberRequest {
     fn parse(params: &Option<Vec<serde_json::Value>>) -> Result<Self, RpcErr> {
         let params = params
@@ -249,112 +369,39 @@ impl RpcHandler for TraceBlockByNumberRequest {
             .get_block_by_number(block_number)
             .await?
             .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
-        let reexec = self.trace_config.reexec.unwrap_or(DEFAULT_REEXEC);
-        let timeout = self.trace_config.timeout.unwrap_or(DEFAULT_TIMEOUT);
-        match self.trace_config.tracer {
-            TracerType::CallTracer => {
-                // Parse tracer config now that we know the type
-                let config = if let Some(value) = &self.trace_config.tracer_config {
-                    serde_json::from_value(value.clone())?
-                } else {
-                    CallTracerConfig::default()
-                };
-                let call_traces = context
-                    .blockchain
-                    .trace_block_calls(
-                        block,
-                        reexec,
-                        timeout,
-                        config.only_top_call,
-                        config.with_log,
-                    )
-                    .await
-                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                // Unwrap each CallTrace (Vec<CallTraceFrame>) to a single
-                // CallTraceFrame to match geth's callTracer response format.
-                let block_trace: BlockTrace<CallTraceFrame> = call_traces
-                    .into_iter()
-                    .map(|(hash, trace)| {
-                        let frame = trace
-                            .into_iter()
-                            .next()
-                            .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
-                        Ok((hash, frame).into())
-                    })
-                    .collect::<Result<_, RpcErr>>()?;
-                Ok(serde_json::to_value(block_trace)?)
-            }
-            TracerType::PrestateTracer => {
-                let config: PrestateTracerConfig =
-                    if let Some(value) = &self.trace_config.tracer_config {
-                        serde_json::from_value(value.clone())?
-                    } else {
-                        PrestateTracerConfig::default()
-                    };
-                config.validate()?;
-                let prestate_traces = context
-                    .blockchain
-                    .trace_block_prestate(
-                        block,
-                        reexec,
-                        timeout,
-                        config.diff_mode,
-                        config.include_empty,
-                    )
-                    .await
-                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                // Each trace result is already the correct variant (Prestate or Diff)
-                // based on the diff_mode flag, so we serialize directly.
-                let block_trace: Vec<serde_json::Value> = prestate_traces
-                    .into_iter()
-                    .map(|(hash, result)| {
-                        let trace_value = match result {
-                            PrestateResult::Prestate(trace) => serde_json::to_value(trace)?,
-                            PrestateResult::Diff(diff) => serde_json::to_value(diff)?,
-                        };
-                        serde_json::to_value(BlockTraceComponent {
-                            tx_hash: hash,
-                            result: trace_value,
-                        })
-                    })
-                    .collect::<Result<_, serde_json::Error>>()?;
-                Ok(serde_json::to_value(block_trace)?)
-            }
-            TracerType::OpcodeTracer => {
-                let cfg: OpcodeTracerConfig = self
-                    .trace_config
-                    .tracer_config
-                    .as_ref()
-                    .map(|v| serde_json::from_value(v.clone()))
-                    .transpose()?
-                    .unwrap_or_default();
-                let emit = StructLoggerEmit {
-                    mem_size: cfg.enable_memory,
-                    return_data: cfg.enable_return_data,
-                    refund: false,
-                };
-                let opcode_traces = context
-                    .blockchain
-                    .trace_block_opcodes(block, reexec, timeout, cfg)
-                    .await
-                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                // Wrap each result with StructLoggerResult so it serializes in the
-                // geth-RPC shape expected by `debug_traceBlockByNumber` consumers.
-                let block_trace: Vec<serde_json::Value> = opcode_traces
-                    .into_iter()
-                    .map(|(hash, result)| {
-                        let wrapped = serde_json::to_value(StructLoggerResult {
-                            result: &result,
-                            emit,
-                        })?;
-                        serde_json::to_value(BlockTraceComponent {
-                            tx_hash: hash,
-                            result: wrapped,
-                        })
-                    })
-                    .collect::<Result<_, serde_json::Error>>()?;
-                Ok(serde_json::to_value(block_trace)?)
-            }
-        }
+        trace_block(block, &self.trace_config, &context).await
+    }
+}
+
+impl RpcHandler for TraceBlockByHashRequest {
+    fn parse(params: &Option<Vec<serde_json::Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 && params.len() != 2 {
+            return Err(RpcErr::BadParams("Expected 1 or 2 params".to_owned()));
+        };
+        let trace_config = if params.len() == 2 {
+            serde_json::from_value(params[1].clone())?
+        } else {
+            TraceConfig::default()
+        };
+
+        Ok(TraceBlockByHashRequest {
+            block_hash: serde_json::from_value(params[0].clone())?,
+            trace_config,
+        })
+    }
+
+    async fn handle(
+        &self,
+        context: crate::rpc::RpcApiContext,
+    ) -> Result<serde_json::Value, crate::utils::RpcErr> {
+        let block = context
+            .storage
+            .get_block_by_hash(self.block_hash)
+            .await?
+            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+        trace_block(block, &self.trace_config, &context).await
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -405,3 +405,195 @@ impl RpcHandler for TraceBlockByHashRequest {
         trace_block(block, &self.trace_config, &context).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::RpcHandler;
+    use serde_json::json;
+
+    // --- TraceTransactionRequest parse tests ---
+
+    #[test]
+    fn parse_trace_tx_with_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert_eq!(req.tx_hash, H256::from_low_u64_be(1));
+    }
+
+    #[test]
+    fn parse_trace_tx_with_config() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!({"tracer": "callTracer", "tracerConfig": {"onlyTopCall": true}}),
+        ]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert_eq!(req.tx_hash, H256::from_low_u64_be(1));
+        assert!(matches!(req.trace_config.tracer, TracerType::CallTracer));
+    }
+
+    #[test]
+    fn parse_trace_tx_no_params() {
+        let result = TraceTransactionRequest::parse(&None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_trace_tx_too_many_params() {
+        let params = Some(vec![json!("0x01"), json!({}), json!("extra")]);
+        let result = TraceTransactionRequest::parse(&params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_trace_tx_default_tracer_is_call_tracer() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert!(matches!(req.trace_config.tracer, TracerType::CallTracer));
+    }
+
+    // --- TraceBlockByNumberRequest parse tests ---
+
+    #[test]
+    fn parse_trace_block_by_number_latest() {
+        let params = Some(vec![json!("latest")]);
+        let req = TraceBlockByNumberRequest::parse(&params).unwrap();
+        assert!(matches!(
+            req.block,
+            BlockIdentifier::Tag(crate::types::block_identifier::BlockTag::Latest)
+        ));
+    }
+
+    #[test]
+    fn parse_trace_block_by_number_hex() {
+        let params = Some(vec![json!("0xa")]);
+        let req = TraceBlockByNumberRequest::parse(&params).unwrap();
+        assert!(matches!(req.block, BlockIdentifier::Number(10)));
+    }
+
+    #[test]
+    fn parse_trace_block_by_number_with_config() {
+        let params = Some(vec![
+            json!("0x1"),
+            json!({"tracer": "prestateTracer"}),
+        ]);
+        let req = TraceBlockByNumberRequest::parse(&params).unwrap();
+        assert!(matches!(
+            req.trace_config.tracer,
+            TracerType::PrestateTracer
+        ));
+    }
+
+    #[test]
+    fn parse_trace_block_by_number_no_params() {
+        let result = TraceBlockByNumberRequest::parse(&None);
+        assert!(result.is_err());
+    }
+
+    // --- TraceBlockByHashRequest parse tests ---
+
+    #[test]
+    fn parse_trace_block_by_hash_with_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000abc"
+        )]);
+        let req = TraceBlockByHashRequest::parse(&params).unwrap();
+        assert_eq!(req.block_hash, H256::from_low_u64_be(0xabc));
+    }
+
+    #[test]
+    fn parse_trace_block_by_hash_with_config() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000abc"),
+            json!({"tracer": "opcodeTracer"}),
+        ]);
+        let req = TraceBlockByHashRequest::parse(&params).unwrap();
+        assert_eq!(req.block_hash, H256::from_low_u64_be(0xabc));
+        assert!(matches!(req.trace_config.tracer, TracerType::OpcodeTracer));
+    }
+
+    #[test]
+    fn parse_trace_block_by_hash_no_params() {
+        let result = TraceBlockByHashRequest::parse(&None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_trace_block_by_hash_too_many_params() {
+        let params = Some(vec![json!("0x01"), json!({}), json!("extra")]);
+        let result = TraceBlockByHashRequest::parse(&params);
+        assert!(result.is_err());
+    }
+
+    // --- TracerType deserialization tests ---
+
+    #[test]
+    fn deserialize_tracer_type_call_tracer() {
+        let t: TracerType = serde_json::from_value(json!("callTracer")).unwrap();
+        assert!(matches!(t, TracerType::CallTracer));
+    }
+
+    #[test]
+    fn deserialize_tracer_type_prestate_tracer() {
+        let t: TracerType = serde_json::from_value(json!("prestateTracer")).unwrap();
+        assert!(matches!(t, TracerType::PrestateTracer));
+    }
+
+    #[test]
+    fn deserialize_tracer_type_opcode_tracer() {
+        let t: TracerType = serde_json::from_value(json!("opcodeTracer")).unwrap();
+        assert!(matches!(t, TracerType::OpcodeTracer));
+    }
+
+    #[test]
+    fn deserialize_tracer_type_unknown_fails() {
+        let result = serde_json::from_value::<TracerType>(json!("unknownTracer"));
+        assert!(result.is_err());
+    }
+
+    // --- TraceConfig deserialization tests ---
+
+    #[test]
+    fn deserialize_trace_config_defaults() {
+        let cfg: TraceConfig = serde_json::from_value(json!({})).unwrap();
+        assert!(matches!(cfg.tracer, TracerType::CallTracer));
+        assert!(cfg.tracer_config.is_none());
+        assert!(cfg.timeout.is_none());
+        assert!(cfg.reexec.is_none());
+    }
+
+    #[test]
+    fn deserialize_trace_config_with_timeout() {
+        let cfg: TraceConfig =
+            serde_json::from_value(json!({"timeout": "10s"})).unwrap();
+        assert_eq!(cfg.timeout, Some(Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn deserialize_trace_config_with_reexec() {
+        let cfg: TraceConfig =
+            serde_json::from_value(json!({"reexec": 256})).unwrap();
+        assert_eq!(cfg.reexec, Some(256));
+    }
+
+    // --- PrestateTracerConfig validation tests ---
+
+    #[test]
+    fn prestate_config_default_is_valid() {
+        let cfg = PrestateTracerConfig::default();
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn prestate_config_diff_mode_and_include_empty_is_invalid() {
+        let cfg = PrestateTracerConfig {
+            diff_mode: true,
+            include_empty: true,
+        };
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -10,7 +10,9 @@ use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{rpc::RpcApiContext, rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
+use crate::{
+    rpc::RpcApiContext, rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr,
+};
 
 /// Default max amount of blocks to re-excute if it is not given
 const DEFAULT_REEXEC: u32 = 128;
@@ -261,12 +263,11 @@ async fn trace_block(
             Ok(serde_json::to_value(block_trace)?)
         }
         TracerType::PrestateTracer => {
-            let config: PrestateTracerConfig =
-                if let Some(value) = &trace_config.tracer_config {
-                    serde_json::from_value(value.clone())?
-                } else {
-                    PrestateTracerConfig::default()
-                };
+            let config: PrestateTracerConfig = if let Some(value) = &trace_config.tracer_config {
+                serde_json::from_value(value.clone())?
+            } else {
+                PrestateTracerConfig::default()
+            };
             config.validate()?;
             let prestate_traces = context
                 .blockchain
@@ -477,10 +478,7 @@ mod tests {
 
     #[test]
     fn parse_trace_block_by_number_with_config() {
-        let params = Some(vec![
-            json!("0x1"),
-            json!({"tracer": "prestateTracer"}),
-        ]);
+        let params = Some(vec![json!("0x1"), json!({"tracer": "prestateTracer"})]);
         let req = TraceBlockByNumberRequest::parse(&params).unwrap();
         assert!(matches!(
             req.trace_config.tracer,
@@ -568,15 +566,13 @@ mod tests {
 
     #[test]
     fn deserialize_trace_config_with_timeout() {
-        let cfg: TraceConfig =
-            serde_json::from_value(json!({"timeout": "10s"})).unwrap();
+        let cfg: TraceConfig = serde_json::from_value(json!({"timeout": "10s"})).unwrap();
         assert_eq!(cfg.timeout, Some(Duration::from_secs(10)));
     }
 
     #[test]
     fn deserialize_trace_config_with_reexec() {
-        let cfg: TraceConfig =
-            serde_json::from_value(json!({"reexec": 256})).unwrap();
+        let cfg: TraceConfig = serde_json::from_value(json!({"reexec": 256})).unwrap();
         assert_eq!(cfg.reexec, Some(256));
     }
 

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -363,12 +363,12 @@ impl RpcHandler for TraceBlockByNumberRequest {
             .block
             .resolve_block_number(&context.storage)
             .await?
-            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+            .ok_or(RpcErr::BadParams("Block not Found".to_string()))?;
         let block = context
             .storage
             .get_block_by_number(block_number)
             .await?
-            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+            .ok_or(RpcErr::BadParams("Block not Found".to_string()))?;
         trace_block(block, &self.trace_config, &context).await
     }
 }
@@ -401,7 +401,7 @@ impl RpcHandler for TraceBlockByHashRequest {
             .storage
             .get_block_by_hash(self.block_hash)
             .await?
-            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+            .ok_or(RpcErr::BadParams("Block not Found".to_string()))?;
         trace_block(block, &self.trace_config, &context).await
     }
 }

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn trace_block_by_hash() {

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,182 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn trace_block_by_hash() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceBlockByHash",
+        vec![json!(format!("{block_hash:#x}"))],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1, "block has 1 tx so should have 1 trace");
+
+    let entry = arr[0].as_object().expect("entry should be an object");
+    assert!(entry.contains_key("txHash"), "entry should have 'txHash'");
+    assert!(entry.contains_key("result"), "entry should have 'result'");
+    assert_eq!(entry["result"]["type"].as_str().unwrap(), "CALL");
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/tooling/repl/src/commands/debug.rs
+++ b/tooling/repl/src/commands/debug.rs
@@ -99,7 +99,14 @@ pub fn commands() -> Vec<CommandDef> {
             name: "traceBlockByNumber",
             rpc_method: "debug_traceBlockByNumber",
             params: BLOCK_OPTIONS,
-            description: "Traces all transactions in a block",
+            description: "Traces all transactions in a block by number",
+        },
+        CommandDef {
+            namespace: "debug",
+            name: "traceBlockByHash",
+            rpc_method: "debug_traceBlockByHash",
+            params: HASH_OPTIONS,
+            description: "Traces all transactions in a block by hash",
         },
     ]
 }


### PR DESCRIPTION
## Summary
- Adds `debug_traceBlockByHash` which traces all transactions in a block identified by its hash
- Extracts shared block tracing logic into a `trace_block` helper used by both `traceBlockByNumber` and `traceBlockByHash`, eliminating code duplication
- Supports all existing tracers: `callTracer`, `prestateTracer`, `opcodeTracer`

Closes #6642
Closes part of #6572

## Test plan
- [ ] Verify `debug_traceBlockByHash` returns same results as `debug_traceBlockByNumber` for the same block
- [ ] Test with each tracer type (callTracer, prestateTracer, opcodeTracer)
- [ ] Test with invalid/unknown block hash returns proper error