### PR TITLE
feat(l1): implement debug_getBadBlocks RPC endpoint

### DIFF
--- a/crates/networking/rpc/debug/get_bad_blocks.rs
+++ b/crates/networking/rpc/debug/get_bad_blocks.rs
@@ -24,3 +24,37 @@ impl RpcHandler for GetBadBlocksRequest {
         Ok(Value::Array(vec![]))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RpcHandler;
+    use serde_json::json;
+
+    #[test]
+    fn parse_no_params() {
+        let result = GetBadBlocksRequest::parse(&None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_empty_params() {
+        let result = GetBadBlocksRequest::parse(&Some(vec![]));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_with_params_fails() {
+        let result = GetBadBlocksRequest::parse(&Some(vec![json!("extra")]));
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn handle_returns_empty_array() {
+        let req = GetBadBlocksRequest;
+        let storage = crate::test_utils::setup_store().await;
+        let context = crate::test_utils::default_context_with_storage(storage).await;
+        let result = req.handle(context).await.unwrap();
+        assert_eq!(result, Value::Array(vec![]));
+    }
+}

--- a/crates/networking/rpc/debug/get_bad_blocks.rs
+++ b/crates/networking/rpc/debug/get_bad_blocks.rs
@@ -1,0 +1,26 @@
+use serde_json::Value;
+
+use crate::{RpcApiContext, RpcErr, RpcHandler};
+
+pub struct GetBadBlocksRequest;
+
+impl RpcHandler for GetBadBlocksRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        if let Some(params) = params
+            && !params.is_empty()
+        {
+            return Err(RpcErr::BadParams(format!(
+                "Expected no params and {} were provided",
+                params.len()
+            )));
+        }
+        Ok(GetBadBlocksRequest)
+    }
+
+    async fn handle(&self, _context: RpcApiContext) -> Result<Value, RpcErr> {
+        // Geth maintains a ring buffer of bad blocks encountered during chain
+        // insertion. ethrex does not currently track bad blocks, so we return
+        // an empty array which is valid (a healthy node has no bad blocks).
+        Ok(Value::Array(vec![]))
+    }
+}

--- a/crates/networking/rpc/debug/get_bad_blocks.rs
+++ b/crates/networking/rpc/debug/get_bad_blocks.rs
@@ -18,9 +18,11 @@ impl RpcHandler for GetBadBlocksRequest {
     }
 
     async fn handle(&self, _context: RpcApiContext) -> Result<Value, RpcErr> {
-        // Geth maintains a ring buffer of bad blocks encountered during chain
-        // insertion. ethrex does not currently track bad blocks, so we return
-        // an empty array which is valid (a healthy node has no bad blocks).
+        // ethrex records rejected-block hashes in INVALID_CHAINS (hash ->
+        // latest_valid_hash) but does not persist the full block RLP / body /
+        // error reason that geth's debug_getBadBlocks response requires, so we
+        // return the spec-valid empty array. A real implementation needs a
+        // bad-block metadata table with eviction policy.
         Ok(Value::Array(vec![]))
     }
 }

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,4 @@
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;
+pub mod get_bad_blocks;

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -2,6 +2,7 @@ use crate::authentication::authenticate;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
+use crate::debug::get_bad_blocks::GetBadBlocksRequest;
 use crate::engine::blobs::{BlobsV2Request, BlobsV3Request};
 use crate::engine::client_version::GetClientVersionV1Request;
 use crate::engine::payload::{GetPayloadV5Request, GetPayloadV6Request, NewPayloadV5Request};
@@ -1155,6 +1156,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_getBadBlocks" => GetBadBlocksRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1141,8 +1141,9 @@ pub async fn map_eth_requests(req: &RpcRequest, context: RpcApiContext) -> Resul
 ///
 /// Handles debugging and introspection methods:
 /// - Raw data: `debug_getRawHeader`, `debug_getRawBlock`, `debug_getRawTransaction`, `debug_getRawReceipts`
-/// - Execution witness: `debug_executionWitness` (for stateless validation)
+/// - Execution witness: `debug_executionWitness`, `debug_executionWitnessByBlockHash`
 /// - Tracing: `debug_traceTransaction`, `debug_traceBlockByNumber`
+/// - Chain info: `debug_chainConfig`, `debug_getBlockAccessList`, `debug_getBadBlocks`
 pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "debug_getRawHeader" => GetRawHeaderRequest::call(req, context).await,

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn get_bad_blocks() {

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,174 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn get_bad_blocks() {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let (store, _) = setup_store(sender).await;
+
+    let result = rpc_call(&store, "debug_getBadBlocks", vec![]).await;
+
+    // ethrex returns an empty array (no bad blocks tracked).
+    let arr = result.as_array().expect("response should be an array");
+    assert!(arr.is_empty(), "should return empty array");
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
Adds the `debug_getBadBlocks` RPC endpoint as specified in the [execution-apis OpenRPC spec](https://github.com/ethereum/execution-apis/blob/main/src/debug/getters.yaml).

**This is a stub that always returns `[]`.** A full implementation is not currently possible because ethrex lacks the required storage infrastructure:

- Geth's response requires the full block RLP, header, body, and a human-readable error reason per bad block entry.
- ethrex only stores `(bad_block_hash → latest_valid_hash)` in the `INVALID_CHAINS` table (used by the fork-choice handler). It does **not** persist the full block data or the validation error when a block is rejected.
- Implementing this properly would require:
  1. A new storage table / ring buffer for bad block metadata (full block + error string).
  2. Writes at every block rejection site (engine fork-choice, full sync, etc.).
  3. An eviction policy (geth keeps the last N entries).

Returning `[]` is spec-valid — it's the correct response for a node that has not encountered any bad blocks. The endpoint is registered so that tooling that probes for it (e.g. Blockscout, hive tests) gets a well-formed response instead of a `method not found` error.

Part of #6572

## Test plan
- [x] `debug_getBadBlocks` returns `[]`
- [x] Calling with unexpected params returns error
- [x] e2e integration test (`trace_get_bad_blocks`)