### PR TITLE
feat(l1): implement noopTracer for debug trace endpoints

### DIFF
--- a/crates/blockchain/tracing.rs
+++ b/crates/blockchain/tracing.rs
@@ -218,6 +218,58 @@ impl Blockchain {
         Ok(traces)
     }
 
+    /// Re-executes the target transaction (and any preceding txs in its block) with no
+    /// tracer attached, then discards the result. Used by `noopTracer` so the RPC layer
+    /// validates that the tx exists and replays it through the EVM without paying any
+    /// tracing collection cost, matching the benchmarking purpose of geth's `noopTracer`.
+    /// May need to re-execute blocks in order to rebuild the transaction's prestate, up
+    /// to the amount given by `reexec`.
+    pub async fn noop_trace_transaction(
+        &self,
+        tx_hash: H256,
+        reexec: u32,
+        timeout: Duration,
+    ) -> Result<(), ChainError> {
+        let Some((_, block_hash, tx_index)) =
+            self.storage.get_transaction_location(tx_hash).await?
+        else {
+            return Err(ChainError::Custom("Transaction not Found".to_string()));
+        };
+        let tx_index = tx_index as usize;
+        let Some(block) = self.storage.get_block_by_hash(block_hash).await? else {
+            return Err(ChainError::Custom("Block not Found".to_string()));
+        };
+        let mut vm = self
+            .rebuild_parent_state(block.header.parent_hash, reexec)
+            .await?;
+        // Run every tx up to AND including the target — no tracer attached.
+        let stop = tx_index.saturating_add(1);
+        timeout_trace_operation(timeout, move || vm.rerun_block(&block, Some(stop))).await
+    }
+
+    /// Re-executes every transaction in the block with no tracer attached and returns the
+    /// transaction hashes in order. Used by `noopTracer` for `debug_traceBlockByNumber` so
+    /// the RPC layer can emit `{txHash, result: {}}` per tx without paying tracing cost.
+    /// May need to re-execute blocks in order to rebuild the block's prestate, up to the
+    /// amount given by `reexec`.
+    pub async fn noop_trace_block(
+        &self,
+        block: Block,
+        reexec: u32,
+        timeout: Duration,
+    ) -> Result<Vec<H256>, ChainError> {
+        let mut vm = self
+            .rebuild_parent_state(block.header.parent_hash, reexec)
+            .await?;
+        let block = Arc::new(block);
+        let block_for_exec = block.clone();
+        timeout_trace_operation(timeout, move || {
+            vm.rerun_block(block_for_exec.as_ref(), None)
+        })
+        .await?;
+        Ok(block.body.transactions.iter().map(|tx| tx.hash()).collect())
+    }
+
     /// Rebuild the parent state for a block given its parent hash, returning an `Evm` instance with all changes cached
     /// Will re-execute all ancestor block's which's state is not stored up to a maximum given by `reexec`
     async fn rebuild_parent_state(

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -59,9 +59,10 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
-    /// No-op tracer that returns an empty JSON object `{}`. Useful for
-    /// benchmarking execution overhead without tracing cost.
-    /// Selected via `"tracer": "noopTracer"`.
+    /// No-op tracer that re-executes the transaction(s) through the EVM with no tracer
+    /// attached and returns empty JSON objects, matching geth's `noopTracer`. Useful for
+    /// benchmarking raw execution overhead without tracing cost. Any `tracerConfig` is
+    /// ignored. Selected via `"tracer": "noopTracer"`.
     NoopTracer,
 }
 
@@ -215,11 +216,11 @@ impl RpcHandler for TraceTransactionRequest {
             }
             TracerType::NoopTracer => {
                 // Like geth, noopTracer still executes the transaction (validating
-                // it exists and that parent state can be rebuilt) but discards the
-                // trace result, returning an empty object.
+                // it exists and that parent state can be rebuilt) but with no tracer
+                // attached — so we pay only the raw execution cost, then return {}.
                 context
                     .blockchain
-                    .trace_transaction_calls(self.tx_hash, reexec, timeout, true, false)
+                    .noop_trace_transaction(self.tx_hash, reexec, timeout)
                     .await
                     .map_err(|err| RpcErr::Internal(err.to_string()))?;
                 Ok(serde_json::json!({}))
@@ -371,16 +372,16 @@ impl RpcHandler for TraceBlockByNumberRequest {
                 Ok(serde_json::to_value(block_trace)?)
             }
             TracerType::NoopTracer => {
-                // Like geth, noopTracer still re-executes every transaction in
-                // the block but discards the trace data, returning {} per tx.
-                let call_traces = context
+                // Like geth, noopTracer re-executes every transaction in the block
+                // with no tracer attached, then emits {} per tx.
+                let tx_hashes = context
                     .blockchain
-                    .trace_block_calls(block, reexec, timeout, true, false)
+                    .noop_trace_block(block, reexec, timeout)
                     .await
                     .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                let block_trace: BlockTrace<Value> = call_traces
+                let block_trace: BlockTrace<Value> = tx_hashes
                     .into_iter()
-                    .map(|(hash, _)| (hash, serde_json::json!({})).into())
+                    .map(|hash| (hash, serde_json::json!({})).into())
                     .collect();
                 Ok(serde_json::to_value(block_trace)?)
             }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -59,10 +59,12 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
-    /// No-op tracer that re-executes the transaction(s) through the EVM with no tracer
-    /// attached and returns empty JSON objects, matching geth's `noopTracer`. Useful for
-    /// benchmarking raw execution overhead without tracing cost. Any `tracerConfig` is
-    /// ignored. Selected via `"tracer": "noopTracer"`.
+    /// No-op tracer: re-executes the transaction(s) through the EVM with no tracer
+    /// attached and returns empty JSON objects. The output shape matches geth's
+    /// `noopTracer` (`{}` per tx), but the mechanism differs: geth runs an
+    /// empty-hook tracer (paying per-opcode dispatch), whereas ethrex skips tracer
+    /// hooks entirely, isolating raw execution cost. Any `tracerConfig` is ignored.
+    /// Selected via `"tracer": "noopTracer"`.
     NoopTracer,
 }
 

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -378,3 +378,88 @@ impl RpcHandler for TraceBlockByNumberRequest {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::RpcHandler;
+    use serde_json::json;
+
+    // --- TraceTransactionRequest parse tests ---
+
+    #[test]
+    fn parse_trace_tx_with_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert_eq!(req.tx_hash, H256::from_low_u64_be(1));
+    }
+
+    #[test]
+    fn parse_trace_tx_with_config() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!({"tracer": "callTracer", "tracerConfig": {"onlyTopCall": true}}),
+        ]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert!(matches!(req.trace_config.tracer, TracerType::CallTracer));
+    }
+
+    #[test]
+    fn parse_trace_tx_no_params() {
+        assert!(TraceTransactionRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_trace_tx_too_many_params() {
+        let params = Some(vec![json!("0x01"), json!({}), json!("extra")]);
+        assert!(TraceTransactionRequest::parse(&params).is_err());
+    }
+
+    // --- TracerType deserialization tests ---
+
+    #[test]
+    fn deserialize_tracer_type_noop() {
+        let t: TracerType = serde_json::from_value(json!("noopTracer")).unwrap();
+        assert!(matches!(t, TracerType::NoopTracer));
+    }
+
+    #[test]
+    fn deserialize_tracer_type_unknown_fails() {
+        assert!(serde_json::from_value::<TracerType>(json!("unknownTracer")).is_err());
+    }
+
+    // --- TraceConfig deserialization tests ---
+
+    #[test]
+    fn deserialize_trace_config_defaults() {
+        let cfg: TraceConfig = serde_json::from_value(json!({})).unwrap();
+        assert!(matches!(cfg.tracer, TracerType::CallTracer));
+        assert!(cfg.timeout.is_none());
+        assert!(cfg.reexec.is_none());
+    }
+
+    // --- PrestateTracerConfig validation tests ---
+
+    #[test]
+    fn prestate_config_diff_mode_and_include_empty_is_invalid() {
+        let cfg = PrestateTracerConfig {
+            diff_mode: true,
+            include_empty: true,
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    // --- noopTracer parse test ---
+
+    #[test]
+    fn parse_trace_tx_noop_tracer() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!({"tracer": "noopTracer"}),
+        ]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert!(matches!(req.trace_config.tracer, TracerType::NoopTracer));
+    }
+}

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -59,6 +59,10 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
+    /// No-op tracer that returns an empty JSON object `{}`. Useful for
+    /// benchmarking execution overhead without tracing cost.
+    /// Selected via `"tracer": "noopTracer"`.
+    NoopTracer,
 }
 
 #[derive(Deserialize, Default)]
@@ -209,6 +213,7 @@ impl RpcHandler for TraceTransactionRequest {
                     emit,
                 })?)
             }
+            TracerType::NoopTracer => Ok(serde_json::json!({})),
         }
     }
 }
@@ -353,6 +358,21 @@ impl RpcHandler for TraceBlockByNumberRequest {
                         })
                     })
                     .collect::<Result<_, serde_json::Error>>()?;
+                Ok(serde_json::to_value(block_trace)?)
+            }
+            TracerType::NoopTracer => {
+                // Return one empty object per transaction in the block, matching
+                // geth's behaviour where noopTracer produces {} for each tx.
+                let tx_hashes: Vec<H256> = block
+                    .body
+                    .transactions
+                    .iter()
+                    .map(|tx| tx.hash())
+                    .collect();
+                let block_trace: BlockTrace<Value> = tx_hashes
+                    .into_iter()
+                    .map(|hash| (hash, serde_json::json!({})).into())
+                    .collect();
                 Ok(serde_json::to_value(block_trace)?)
             }
         }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -213,7 +213,17 @@ impl RpcHandler for TraceTransactionRequest {
                     emit,
                 })?)
             }
-            TracerType::NoopTracer => Ok(serde_json::json!({})),
+            TracerType::NoopTracer => {
+                // Like geth, noopTracer still executes the transaction (validating
+                // it exists and that parent state can be rebuilt) but discards the
+                // trace result, returning an empty object.
+                context
+                    .blockchain
+                    .trace_transaction_calls(self.tx_hash, reexec, timeout, true, false)
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                Ok(serde_json::json!({}))
+            }
         }
     }
 }
@@ -361,17 +371,16 @@ impl RpcHandler for TraceBlockByNumberRequest {
                 Ok(serde_json::to_value(block_trace)?)
             }
             TracerType::NoopTracer => {
-                // Return one empty object per transaction in the block, matching
-                // geth's behaviour where noopTracer produces {} for each tx.
-                let tx_hashes: Vec<H256> = block
-                    .body
-                    .transactions
-                    .iter()
-                    .map(|tx| tx.hash())
-                    .collect();
-                let block_trace: BlockTrace<Value> = tx_hashes
+                // Like geth, noopTracer still re-executes every transaction in
+                // the block but discards the trace data, returning {} per tx.
+                let call_traces = context
+                    .blockchain
+                    .trace_block_calls(block, reexec, timeout, true, false)
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                let block_trace: BlockTrace<Value> = call_traces
                     .into_iter()
-                    .map(|hash| (hash, serde_json::json!({})).into())
+                    .map(|(hash, _)| (hash, serde_json::json!({})).into())
                     .collect();
                 Ok(serde_json::to_value(block_trace)?)
             }

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn trace_tx_noop_tracer() {

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,180 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn trace_tx_noop_tracer() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", env.tx_hash)),
+            json!({"tracer": "noopTracer"}),
+        ],
+    )
+    .await;
+
+    // noopTracer returns an empty object {}.
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.is_empty(), "noopTracer should return empty object");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -182,3 +182,58 @@ async fn trace_tx_noop_tracer() {
     let obj = result.as_object().expect("response should be an object");
     assert!(obj.is_empty(), "noopTracer should return empty object");
 }
+
+#[tokio::test]
+async fn trace_tx_noop_tracer_unknown_hash_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": "debug_traceTransaction",
+        "params": [
+            json!(format!("{:#x}", H256::from_low_u64_be(0xdeadbeef))),
+            json!({"tracer": "noopTracer"}),
+        ],
+        "id": 1,
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(env.store.clone()).await;
+    let err = map_http_requests(&request, context)
+        .await
+        .expect_err("missing tx should error, not return {}");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Transaction not Found"),
+        "expected tx-not-found error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn trace_block_noop_tracer() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceBlockByNumber",
+        vec![
+            json!(format!("{:#x}", env.block.header.number)),
+            json!({"tracer": "noopTracer"}),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1, "one tx in block");
+    let entry = arr[0].as_object().expect("entry should be an object");
+    assert_eq!(
+        entry["txHash"].as_str().unwrap().to_lowercase(),
+        format!("{:#x}", env.tx_hash).to_lowercase()
+    );
+    assert!(
+        entry["result"]
+            .as_object()
+            .expect("result should be an object")
+            .is_empty(),
+        "noopTracer should return empty object per tx"
+    );
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,4 +1,5 @@
 mod authrpc_batch_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Adds `noopTracer` variant to the tracer type enum
- Returns `{}` for `debug_traceTransaction`, and `{txHash, result: {}}` per tx for `debug_traceBlockByNumber`
- Useful for benchmarking raw execution overhead without tracing cost
- Matches [geth's noopTracer](https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/noop.go)

Closes part of #6572

## Test plan
- [ ] `debug_traceTransaction` with `{"tracer": "noopTracer"}` returns `{}`
- [ ] `debug_traceBlockByNumber` with `{"tracer": "noopTracer"}` returns array of `{txHash, result: {}}`

Closes #6645