### PR TITLE
feat(l1): implement debug_traceCall RPC endpoint

### DIFF
--- a/crates/blockchain/tracing.rs
+++ b/crates/blockchain/tracing.rs
@@ -6,7 +6,7 @@ use std::{
 use ethrex_common::{
     H256,
     tracing::{CallTrace, OpcodeTraceResult, PrestateResult},
-    types::Block,
+    types::{Block, BlockHeader, GenericTransaction},
 };
 use ethrex_storage::Store;
 use ethrex_vm::tracing::OpcodeTracerConfig;
@@ -216,6 +216,59 @@ impl Blockchain {
             traces.push((tx_hash, result));
         }
         Ok(traces)
+    }
+
+    /// Traces an arbitrary call with the callTracer at the state of the given block header.
+    pub async fn trace_call_calls(
+        &self,
+        header: &BlockHeader,
+        tx: &GenericTransaction,
+        timeout: Duration,
+        only_top_call: bool,
+        with_log: bool,
+    ) -> Result<CallTrace, ChainError> {
+        let vm_db = StoreVmDatabase::new(self.storage.clone(), header.clone())?;
+        let mut vm = self.new_evm(vm_db)?;
+        let tx = tx.clone();
+        let header = header.clone();
+        timeout_trace_operation(timeout, move || {
+            vm.trace_call_calls(&header, &tx, only_top_call, with_log)
+        })
+        .await
+    }
+
+    /// Traces an arbitrary call with the prestateTracer at the state of the given block header.
+    pub async fn trace_call_prestate(
+        &self,
+        header: &BlockHeader,
+        tx: &GenericTransaction,
+        timeout: Duration,
+        diff_mode: bool,
+        include_empty: bool,
+    ) -> Result<PrestateResult, ChainError> {
+        let vm_db = StoreVmDatabase::new(self.storage.clone(), header.clone())?;
+        let mut vm = self.new_evm(vm_db)?;
+        let tx = tx.clone();
+        let header = header.clone();
+        timeout_trace_operation(timeout, move || {
+            vm.trace_call_prestate(&header, &tx, diff_mode, include_empty)
+        })
+        .await
+    }
+
+    /// Traces an arbitrary call with the opcodeTracer at the state of the given block header.
+    pub async fn trace_call_opcodes(
+        &self,
+        header: &BlockHeader,
+        tx: &GenericTransaction,
+        timeout: Duration,
+        cfg: OpcodeTracerConfig,
+    ) -> Result<OpcodeTraceResult, ChainError> {
+        let vm_db = StoreVmDatabase::new(self.storage.clone(), header.clone())?;
+        let mut vm = self.new_evm(vm_db)?;
+        let tx = tx.clone();
+        let header = header.clone();
+        timeout_trace_operation(timeout, move || vm.trace_call_opcodes(&header, &tx, cfg)).await
     }
 
     /// Rebuild the parent state for a block given its parent hash, returning an `Evm` instance with all changes cached

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -44,7 +44,7 @@ use crate::eth::{
     },
 };
 use crate::subscription_manager::{SubscriptionManager, SubscriptionManagerProtocol};
-use crate::tracing::{TraceBlockByNumberRequest, TraceTransactionRequest};
+use crate::tracing::{TraceBlockByNumberRequest, TraceCallRequest, TraceTransactionRequest};
 use crate::types::transaction::SendRawTransactionRequest;
 use crate::utils::{
     RpcErr, RpcErrorMetadata, RpcErrorResponse, RpcNamespace, RpcRequest, RpcRequestId,
@@ -1155,6 +1155,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_traceCall" => TraceCallRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -9,7 +9,13 @@ use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
+use ethrex_common::types::GenericTransaction;
+
+use crate::{
+    rpc::RpcHandler,
+    types::block_identifier::{BlockIdentifier, BlockIdentifierOrHash},
+    utils::RpcErr,
+};
 
 /// Default max amount of blocks to re-excute if it is not given
 const DEFAULT_REEXEC: u32 = 128;
@@ -23,6 +29,12 @@ pub struct TraceTransactionRequest {
 
 pub struct TraceBlockByNumberRequest {
     block: BlockIdentifier,
+    trace_config: TraceConfig,
+}
+
+pub struct TraceCallRequest {
+    transaction: GenericTransaction,
+    block: Option<BlockIdentifierOrHash>,
     trace_config: TraceConfig,
 }
 
@@ -354,6 +366,119 @@ impl RpcHandler for TraceBlockByNumberRequest {
                     })
                     .collect::<Result<_, serde_json::Error>>()?;
                 Ok(serde_json::to_value(block_trace)?)
+            }
+        }
+    }
+}
+
+impl RpcHandler for TraceCallRequest {
+    fn parse(params: &Option<Vec<serde_json::Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.is_empty() || params.len() > 3 {
+            return Err(RpcErr::BadParams("Expected 1 to 3 params".to_owned()));
+        }
+        let transaction: GenericTransaction = serde_json::from_value(params[0].clone())?;
+        let block = params
+            .get(1)
+            .map(|v| BlockIdentifierOrHash::parse(v.clone(), 1))
+            .transpose()?;
+        let trace_config = if let Some(v) = params.get(2) {
+            serde_json::from_value(v.clone())?
+        } else {
+            TraceConfig::default()
+        };
+        Ok(TraceCallRequest {
+            transaction,
+            block,
+            trace_config,
+        })
+    }
+
+    async fn handle(
+        &self,
+        context: crate::rpc::RpcApiContext,
+    ) -> Result<serde_json::Value, crate::utils::RpcErr> {
+        let block = self
+            .block
+            .clone()
+            .unwrap_or(BlockIdentifierOrHash::Identifier(BlockIdentifier::default()));
+        let header = block
+            .resolve_block_header(&context.storage)
+            .await?
+            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+        let timeout = self.trace_config.timeout.unwrap_or(DEFAULT_TIMEOUT);
+        match self.trace_config.tracer {
+            TracerType::CallTracer => {
+                let config = if let Some(value) = &self.trace_config.tracer_config {
+                    serde_json::from_value(value.clone())?
+                } else {
+                    CallTracerConfig::default()
+                };
+                let call_trace = context
+                    .blockchain
+                    .trace_call_calls(
+                        &header,
+                        &self.transaction,
+                        timeout,
+                        config.only_top_call,
+                        config.with_log,
+                    )
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                let top_frame = call_trace
+                    .into_iter()
+                    .next()
+                    .ok_or(RpcErr::Internal("Empty call trace".to_string()))?;
+                Ok(serde_json::to_value(top_frame)?)
+            }
+            TracerType::PrestateTracer => {
+                let config: PrestateTracerConfig =
+                    if let Some(value) = &self.trace_config.tracer_config {
+                        serde_json::from_value(value.clone())?
+                    } else {
+                        PrestateTracerConfig::default()
+                    };
+                config.validate()?;
+                let result = context
+                    .blockchain
+                    .trace_call_prestate(
+                        &header,
+                        &self.transaction,
+                        timeout,
+                        config.diff_mode,
+                        config.include_empty,
+                    )
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                match result {
+                    PrestateResult::Prestate(trace) => Ok(serde_json::to_value(trace)?),
+                    PrestateResult::Diff(diff) => Ok(serde_json::to_value(diff)?),
+                }
+            }
+            TracerType::OpcodeTracer => {
+                let cfg: OpcodeTracerConfig = self
+                    .trace_config
+                    .tracer_config
+                    .as_ref()
+                    .map(|v| serde_json::from_value(v.clone()))
+                    .transpose()?
+                    .unwrap_or_default();
+                let emit = StructLoggerEmit {
+                    mem_size: cfg.enable_memory,
+                    return_data: cfg.enable_return_data,
+                    refund: false,
+                };
+                let result = context
+                    .blockchain
+                    .trace_call_opcodes(&header, &self.transaction, timeout, cfg)
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                Ok(serde_json::to_value(StructLoggerResult {
+                    result: &result,
+                    emit,
+                })?)
             }
         }
     }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -32,6 +32,24 @@ pub struct TraceBlockByNumberRequest {
     trace_config: TraceConfig,
 }
 
+/// `debug_traceCall` — trace an arbitrary call against the state at a given
+/// block, matching geth's [debug_traceCall][geth]. The call is executed in
+/// memory only; nothing is persisted.
+///
+/// Params: `[callObject, blockIdOrHash?, traceConfig?]`. Omitting the block
+/// defaults to `"latest"`. The call object follows the `eth_call` shape; the
+/// trace config follows the same shape used by `debug_traceTransaction`.
+///
+/// **Known divergence from geth**: geth's `traceConfig` accepts
+/// `stateOverrides` and `blockOverrides` for hypothetical-state debugging.
+/// ethrex does not yet honour either — they are silently ignored. Pass-through
+/// support requires applying overrides at the VM layer before execution.
+///
+/// State is sourced from `header.state_root` (i.e. the state **after** the
+/// block has been applied), matching geth. Pruned nodes that don't have the
+/// state will get an "Internal: state root missing" error.
+///
+/// [geth]: https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-tracecall
 pub struct TraceCallRequest {
     transaction: GenericTransaction,
     block: Option<BlockIdentifierOrHash>,
@@ -400,14 +418,13 @@ impl RpcHandler for TraceCallRequest {
         &self,
         context: crate::rpc::RpcApiContext,
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
-        let block = self
-            .block
-            .clone()
-            .unwrap_or(BlockIdentifierOrHash::Identifier(BlockIdentifier::default()));
+        // Omitted block parameter defaults to `latest` (matches geth).
+        let default_block = BlockIdentifierOrHash::Identifier(BlockIdentifier::default());
+        let block = self.block.as_ref().unwrap_or(&default_block);
         let header = block
             .resolve_block_header(&context.storage)
             .await?
-            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+            .ok_or_else(|| RpcErr::Internal("Block not found".to_string()))?;
         let timeout = self.trace_config.timeout.unwrap_or(DEFAULT_TIMEOUT);
         match self.trace_config.tracer {
             TracerType::CallTracer => {
@@ -430,7 +447,7 @@ impl RpcHandler for TraceCallRequest {
                 let top_frame = call_trace
                     .into_iter()
                     .next()
-                    .ok_or(RpcErr::Internal("Empty call trace".to_string()))?;
+                    .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
                 Ok(serde_json::to_value(top_frame)?)
             }
             TracerType::PrestateTracer => {

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -45,6 +45,10 @@ pub struct TraceBlockByNumberRequest {
 /// ethrex does not yet honour either — they are silently ignored. Pass-through
 /// support requires applying overrides at the VM layer before execution.
 ///
+/// The `reexec` field in `traceConfig` is also accepted but has no effect:
+/// state is read directly from the block header's state root rather than
+/// being rebuilt by re-executing ancestor blocks.
+///
 /// State is sourced from `header.state_root` (i.e. the state **after** the
 /// block has been applied), matching geth. Pruned nodes that don't have the
 /// state will get an "Internal: state root missing" error.

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -483,3 +483,103 @@ impl RpcHandler for TraceCallRequest {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::RpcHandler;
+    use serde_json::json;
+
+    // --- TraceTransactionRequest parse tests ---
+
+    #[test]
+    fn parse_trace_tx_with_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert_eq!(req.tx_hash, H256::from_low_u64_be(1));
+    }
+
+    #[test]
+    fn parse_trace_tx_no_params() {
+        assert!(TraceTransactionRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_trace_tx_too_many_params() {
+        let params = Some(vec![json!("0x01"), json!({}), json!("extra")]);
+        assert!(TraceTransactionRequest::parse(&params).is_err());
+    }
+
+    // --- TraceCallRequest parse tests ---
+
+    #[test]
+    fn parse_trace_call_minimal() {
+        let params = Some(vec![json!({
+            "from": "0x0000000000000000000000000000000000000001",
+            "to": "0x0000000000000000000000000000000000000002"
+        })]);
+        let req = TraceCallRequest::parse(&params).unwrap();
+        assert!(req.block.is_none());
+        assert!(matches!(req.trace_config.tracer, TracerType::CallTracer));
+    }
+
+    #[test]
+    fn parse_trace_call_with_block() {
+        let params = Some(vec![
+            json!({"from": "0x0000000000000000000000000000000000000001"}),
+            json!("latest"),
+        ]);
+        let req = TraceCallRequest::parse(&params).unwrap();
+        assert!(req.block.is_some());
+    }
+
+    #[test]
+    fn parse_trace_call_with_config() {
+        let params = Some(vec![
+            json!({"from": "0x0000000000000000000000000000000000000001"}),
+            json!("latest"),
+            json!({"tracer": "prestateTracer"}),
+        ]);
+        let req = TraceCallRequest::parse(&params).unwrap();
+        assert!(matches!(
+            req.trace_config.tracer,
+            TracerType::PrestateTracer
+        ));
+    }
+
+    #[test]
+    fn parse_trace_call_no_params() {
+        assert!(TraceCallRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_trace_call_empty_params() {
+        assert!(TraceCallRequest::parse(&Some(vec![])).is_err());
+    }
+
+    #[test]
+    fn parse_trace_call_too_many_params() {
+        let params = Some(vec![json!({}), json!("latest"), json!({}), json!("extra")]);
+        assert!(TraceCallRequest::parse(&params).is_err());
+    }
+
+    // --- TracerType deserialization tests ---
+
+    #[test]
+    fn deserialize_tracer_type_unknown_fails() {
+        assert!(serde_json::from_value::<TracerType>(json!("unknownTracer")).is_err());
+    }
+
+    // --- PrestateTracerConfig validation ---
+
+    #[test]
+    fn prestate_config_diff_mode_and_include_empty_is_invalid() {
+        let cfg = PrestateTracerConfig {
+            diff_mode: true,
+            include_empty: true,
+        };
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -8,6 +8,7 @@ use ethrex_common::{
 use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::warn;
 
 use ethrex_common::types::GenericTransaction;
 
@@ -406,7 +407,18 @@ impl RpcHandler for TraceCallRequest {
             .get(1)
             .map(|v| BlockIdentifierOrHash::parse(v.clone(), 1))
             .transpose()?;
-        let trace_config = if let Some(v) = params.get(2) {
+        let trace_config: TraceConfig = if let Some(v) = params.get(2) {
+            // Warn when callers pass overrides we don't yet honour, so the
+            // ignored fields surface in node logs rather than being silently
+            // swallowed.
+            if let Some(obj) = v.as_object() {
+                if obj.contains_key("stateOverrides") {
+                    warn!("debug_traceCall: stateOverrides present but not yet supported — ignored");
+                }
+                if obj.contains_key("blockOverrides") {
+                    warn!("debug_traceCall: blockOverrides present but not yet supported — ignored");
+                }
+            }
             serde_json::from_value(v.clone())?
         } else {
             TraceConfig::default()
@@ -448,6 +460,12 @@ impl RpcHandler for TraceCallRequest {
                     )
                     .await
                     .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                // A single call always produces exactly one top-level frame.
+                debug_assert_eq!(
+                    call_trace.len(),
+                    1,
+                    "trace_call_calls should return exactly one frame"
+                );
                 let top_frame = call_trace
                     .into_iter()
                     .next()

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2767,14 +2767,11 @@ pub(crate) fn env_from_generic(
     })
 }
 
-fn vm_from_generic<'a>(
-    tx: &GenericTransaction,
-    env: Environment,
-    db: &'a mut GeneralizedDatabase,
-    vm_type: VMType,
-    crypto: &'a dyn Crypto,
-) -> Result<VM<'a>, VMError> {
-    let tx = match &tx.authorization_list {
+/// Convert a `GenericTransaction` (eth_call / debug_traceCall shape) into the
+/// concrete `Transaction` enum consumed by the VM. Shared by both
+/// `vm_from_generic` and `vm_from_generic_with_tracer`.
+fn generic_to_transaction(tx: &GenericTransaction) -> Result<Transaction, VMError> {
+    let transaction = match &tx.authorization_list {
         Some(authorization_list) => Transaction::EIP7702Transaction(EIP7702Transaction {
             to: match tx.to {
                 TxKind::Call(to) => to,
@@ -2807,7 +2804,17 @@ fn vm_from_generic<'a>(
             ..Default::default()
         }),
     };
+    Ok(transaction)
+}
 
+fn vm_from_generic<'a>(
+    tx: &GenericTransaction,
+    env: Environment,
+    db: &'a mut GeneralizedDatabase,
+    vm_type: VMType,
+    crypto: &'a dyn Crypto,
+) -> Result<VM<'a>, VMError> {
+    let tx = generic_to_transaction(tx)?;
     let vm_type = adjust_disabled_l2_fees(&env, vm_type);
     VM::new(env, db, &tx, LevmCallTracer::disabled(), vm_type, crypto)
 }
@@ -2821,40 +2828,7 @@ pub(crate) fn vm_from_generic_with_tracer<'a>(
     crypto: &'a dyn Crypto,
     tracer: LevmCallTracer,
 ) -> Result<VM<'a>, VMError> {
-    let tx = match &tx.authorization_list {
-        Some(authorization_list) => Transaction::EIP7702Transaction(EIP7702Transaction {
-            to: match tx.to {
-                TxKind::Call(to) => to,
-                TxKind::Create => {
-                    return Err(InternalError::msg("Generic Tx cannot be create type").into());
-                }
-            },
-            value: tx.value,
-            data: tx.input.clone(),
-            access_list: tx
-                .access_list
-                .iter()
-                .map(|list| (list.address, list.storage_keys.clone()))
-                .collect(),
-            authorization_list: authorization_list
-                .iter()
-                .map(|auth| Into::<AuthorizationTuple>::into(auth.clone()))
-                .collect(),
-            ..Default::default()
-        }),
-        None => Transaction::EIP1559Transaction(EIP1559Transaction {
-            to: tx.to.clone(),
-            value: tx.value,
-            data: tx.input.clone(),
-            access_list: tx
-                .access_list
-                .iter()
-                .map(|list| (list.address, list.storage_keys.clone()))
-                .collect(),
-            ..Default::default()
-        }),
-    };
-
+    let tx = generic_to_transaction(tx)?;
     let vm_type = adjust_disabled_l2_fees(&env, vm_type);
     VM::new(env, db, &tx, tracer, vm_type, crypto)
 }

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2680,7 +2680,7 @@ pub fn calculate_gas_price_for_tx(
 /// When basefee tracking is disabled  (ie. env.disable_base_fee = true; env.disable_block_gas_limit = true;)
 /// and no gas prices were specified, lower the basefee to 0 to avoid breaking EVM invariants (basefee < feecap)
 /// See https://github.com/ethereum/go-ethereum/blob/00294e9d28151122e955c7db4344f06724295ec5/core/vm/evm.go#L137
-fn adjust_disabled_base_fee(env: &mut Environment) {
+pub(crate) fn adjust_disabled_base_fee(env: &mut Environment) {
     if env.gas_price == U256::zero() {
         env.base_fee_per_gas = U256::zero();
     }
@@ -2707,7 +2707,7 @@ fn adjust_disabled_l2_fees(env: &Environment, vm_type: VMType) -> VMType {
     vm_type
 }
 
-fn env_from_generic(
+pub(crate) fn env_from_generic(
     tx: &GenericTransaction,
     header: &BlockHeader,
     db: &GeneralizedDatabase,
@@ -2810,6 +2810,53 @@ fn vm_from_generic<'a>(
 
     let vm_type = adjust_disabled_l2_fees(&env, vm_type);
     VM::new(env, db, &tx, LevmCallTracer::disabled(), vm_type, crypto)
+}
+
+/// Like `vm_from_generic` but accepts a custom `LevmCallTracer`.
+pub(crate) fn vm_from_generic_with_tracer<'a>(
+    tx: &GenericTransaction,
+    env: Environment,
+    db: &'a mut GeneralizedDatabase,
+    vm_type: VMType,
+    crypto: &'a dyn Crypto,
+    tracer: LevmCallTracer,
+) -> Result<VM<'a>, VMError> {
+    let tx = match &tx.authorization_list {
+        Some(authorization_list) => Transaction::EIP7702Transaction(EIP7702Transaction {
+            to: match tx.to {
+                TxKind::Call(to) => to,
+                TxKind::Create => {
+                    return Err(InternalError::msg("Generic Tx cannot be create type").into());
+                }
+            },
+            value: tx.value,
+            data: tx.input.clone(),
+            access_list: tx
+                .access_list
+                .iter()
+                .map(|list| (list.address, list.storage_keys.clone()))
+                .collect(),
+            authorization_list: authorization_list
+                .iter()
+                .map(|auth| Into::<AuthorizationTuple>::into(auth.clone()))
+                .collect(),
+            ..Default::default()
+        }),
+        None => Transaction::EIP1559Transaction(EIP1559Transaction {
+            to: tx.to.clone(),
+            value: tx.value,
+            data: tx.input.clone(),
+            access_list: tx
+                .access_list
+                .iter()
+                .map(|list| (list.address, list.storage_keys.clone()))
+                .collect(),
+            ..Default::default()
+        }),
+    };
+
+    let vm_type = adjust_disabled_l2_fees(&env, vm_type);
+    VM::new(env, db, &tx, tracer, vm_type, crypto)
 }
 
 pub fn get_max_allowed_gas_limit(block_gas_limit: u64, fork: Fork) -> u64 {

--- a/crates/vm/backends/levm/tracing.rs
+++ b/crates/vm/backends/levm/tracing.rs
@@ -171,6 +171,8 @@ impl LEVM {
         crypto: &dyn Crypto,
     ) -> Result<CallTrace, EvmError> {
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
+        // Simulate outside the parent block's gas budget (same as eth_call);
+        // geth uses `evm.GasPool = MaxUint64` for the same reason.
         env.block_gas_limit = i64::MAX as u64;
         adjust_disabled_base_fee(&mut env);
         let mut vm = vm_from_generic_with_tracer(
@@ -199,6 +201,8 @@ impl LEVM {
         let pre_snapshot: CacheDB = db.current_accounts_state.clone();
 
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
+        // Simulate outside the parent block's gas budget (same as eth_call);
+        // geth uses `evm.GasPool = MaxUint64` for the same reason.
         env.block_gas_limit = i64::MAX as u64;
         adjust_disabled_base_fee(&mut env);
         let mut vm =
@@ -237,6 +241,8 @@ impl LEVM {
         crypto: &dyn Crypto,
     ) -> Result<OpcodeTraceResult, EvmError> {
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
+        // Simulate outside the parent block's gas budget (same as eth_call);
+        // geth uses `evm.GasPool = MaxUint64` for the same reason.
         env.block_gas_limit = i64::MAX as u64;
         adjust_disabled_base_fee(&mut env);
         let mut vm =

--- a/crates/vm/backends/levm/tracing.rs
+++ b/crates/vm/backends/levm/tracing.rs
@@ -201,14 +201,8 @@ impl LEVM {
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
         env.block_gas_limit = i64::MAX as u64;
         adjust_disabled_base_fee(&mut env);
-        let mut vm = vm_from_generic_with_tracer(
-            tx,
-            env,
-            db,
-            vm_type,
-            crypto,
-            LevmCallTracer::disabled(),
-        )?;
+        let mut vm =
+            vm_from_generic_with_tracer(tx, env, db, vm_type, crypto, LevmCallTracer::disabled())?;
         vm.execute()?;
 
         preload_touched_codes(&pre_snapshot, db)?;
@@ -245,14 +239,8 @@ impl LEVM {
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
         env.block_gas_limit = i64::MAX as u64;
         adjust_disabled_base_fee(&mut env);
-        let mut vm = vm_from_generic_with_tracer(
-            tx,
-            env,
-            db,
-            vm_type,
-            crypto,
-            LevmCallTracer::disabled(),
-        )?;
+        let mut vm =
+            vm_from_generic_with_tracer(tx, env, db, vm_type, crypto, LevmCallTracer::disabled())?;
         vm.opcode_tracer = LevmOpcodeTracer::new(cfg);
         vm.execute()?;
         Ok(vm.opcode_tracer.take_result())

--- a/crates/vm/backends/levm/tracing.rs
+++ b/crates/vm/backends/levm/tracing.rs
@@ -1,6 +1,6 @@
 use ethrex_common::constants::EMPTY_KECCACK_HASH;
 use ethrex_common::tracing::{PrePostState, PrestateAccountState, PrestateResult, PrestateTrace};
-use ethrex_common::types::{Block, Transaction};
+use ethrex_common::types::{Block, GenericTransaction, Transaction};
 use ethrex_common::{
     Address, BigEndianHash, H256, U256,
     tracing::{CallTrace, OpcodeTraceResult},
@@ -16,6 +16,7 @@ use ethrex_levm::{
     vm::VM,
 };
 
+use super::{adjust_disabled_base_fee, env_from_generic, vm_from_generic_with_tracer};
 use crate::{EvmError, backends::levm::LEVM};
 
 impl LEVM {
@@ -157,6 +158,104 @@ impl LEVM {
 
         // We only return the top call because a transaction only has one call with subcalls
         Ok(vec![callframe])
+    }
+
+    /// Trace a `GenericTransaction` (arbitrary call) with the callTracer.
+    pub fn trace_call_calls(
+        db: &mut GeneralizedDatabase,
+        block_header: &BlockHeader,
+        tx: &GenericTransaction,
+        only_top_call: bool,
+        with_log: bool,
+        vm_type: VMType,
+        crypto: &dyn Crypto,
+    ) -> Result<CallTrace, EvmError> {
+        let mut env = env_from_generic(tx, block_header, db, vm_type)?;
+        env.block_gas_limit = i64::MAX as u64;
+        adjust_disabled_base_fee(&mut env);
+        let mut vm = vm_from_generic_with_tracer(
+            tx,
+            env,
+            db,
+            vm_type,
+            crypto,
+            LevmCallTracer::new(only_top_call, with_log),
+        )?;
+        vm.execute()?;
+        let callframe = vm.get_trace_result()?;
+        Ok(vec![callframe])
+    }
+
+    /// Trace a `GenericTransaction` (arbitrary call) with the prestateTracer.
+    pub fn trace_call_prestate(
+        db: &mut GeneralizedDatabase,
+        block_header: &BlockHeader,
+        tx: &GenericTransaction,
+        diff_mode: bool,
+        include_empty: bool,
+        vm_type: VMType,
+        crypto: &dyn Crypto,
+    ) -> Result<PrestateResult, EvmError> {
+        let pre_snapshot: CacheDB = db.current_accounts_state.clone();
+
+        let mut env = env_from_generic(tx, block_header, db, vm_type)?;
+        env.block_gas_limit = i64::MAX as u64;
+        adjust_disabled_base_fee(&mut env);
+        let mut vm = vm_from_generic_with_tracer(
+            tx,
+            env,
+            db,
+            vm_type,
+            crypto,
+            LevmCallTracer::disabled(),
+        )?;
+        vm.execute()?;
+
+        preload_touched_codes(&pre_snapshot, db)?;
+
+        let mut pre_map = build_pre_state_map(&pre_snapshot, &db.current_accounts_state, db)?;
+
+        if diff_mode {
+            let (post_map, kept) =
+                build_post_state_map(&pre_snapshot, &db.current_accounts_state, db)?;
+            filter_diff_pre_storage(&mut pre_map, &db.current_accounts_state);
+            pre_map.retain(|addr, _| kept.contains(addr));
+            pre_map.retain(|_, state| !state.is_empty());
+            Ok(PrestateResult::Diff(PrePostState {
+                pre: pre_map,
+                post: post_map,
+            }))
+        } else {
+            if !include_empty {
+                pre_map.retain(|_, state| !state.is_empty());
+            }
+            Ok(PrestateResult::Prestate(pre_map))
+        }
+    }
+
+    /// Trace a `GenericTransaction` (arbitrary call) with the opcodeTracer (EIP-3155).
+    pub fn trace_call_opcodes(
+        db: &mut GeneralizedDatabase,
+        block_header: &BlockHeader,
+        tx: &GenericTransaction,
+        cfg: OpcodeTracerConfig,
+        vm_type: VMType,
+        crypto: &dyn Crypto,
+    ) -> Result<OpcodeTraceResult, EvmError> {
+        let mut env = env_from_generic(tx, block_header, db, vm_type)?;
+        env.block_gas_limit = i64::MAX as u64;
+        adjust_disabled_base_fee(&mut env);
+        let mut vm = vm_from_generic_with_tracer(
+            tx,
+            env,
+            db,
+            vm_type,
+            crypto,
+            LevmCallTracer::disabled(),
+        )?;
+        vm.opcode_tracer = LevmOpcodeTracer::new(cfg);
+        vm.execute()?;
+        Ok(vm.opcode_tracer.take_result())
     }
 }
 

--- a/crates/vm/tracing.rs
+++ b/crates/vm/tracing.rs
@@ -1,6 +1,6 @@
 use crate::backends::levm::LEVM;
 use ethrex_common::tracing::{CallTrace, OpcodeTraceResult, PrestateResult};
-use ethrex_common::types::Block;
+use ethrex_common::types::{Block, BlockHeader, GenericTransaction};
 pub use ethrex_levm::tracing::OpcodeTracerConfig;
 
 use crate::{Evm, EvmError};
@@ -83,6 +83,61 @@ impl Evm {
         LEVM::trace_tx_opcodes(
             &mut self.db,
             &block.header,
+            tx,
+            cfg,
+            self.vm_type,
+            self.crypto.as_ref(),
+        )
+    }
+
+    /// Traces an arbitrary call (GenericTransaction) with the callTracer.
+    pub fn trace_call_calls(
+        &mut self,
+        header: &BlockHeader,
+        tx: &GenericTransaction,
+        only_top_call: bool,
+        with_log: bool,
+    ) -> Result<CallTrace, EvmError> {
+        LEVM::trace_call_calls(
+            &mut self.db,
+            header,
+            tx,
+            only_top_call,
+            with_log,
+            self.vm_type,
+            self.crypto.as_ref(),
+        )
+    }
+
+    /// Traces an arbitrary call (GenericTransaction) with the prestateTracer.
+    pub fn trace_call_prestate(
+        &mut self,
+        header: &BlockHeader,
+        tx: &GenericTransaction,
+        diff_mode: bool,
+        include_empty: bool,
+    ) -> Result<PrestateResult, EvmError> {
+        LEVM::trace_call_prestate(
+            &mut self.db,
+            header,
+            tx,
+            diff_mode,
+            include_empty,
+            self.vm_type,
+            self.crypto.as_ref(),
+        )
+    }
+
+    /// Traces an arbitrary call (GenericTransaction) with the opcodeTracer (EIP-3155).
+    pub fn trace_call_opcodes(
+        &mut self,
+        header: &BlockHeader,
+        tx: &GenericTransaction,
+        cfg: OpcodeTracerConfig,
+    ) -> Result<OpcodeTraceResult, EvmError> {
+        LEVM::trace_call_opcodes(
+            &mut self.db,
+            header,
             tx,
             cfg,
             self.vm_type,

--- a/test/tests/rpc/debug_trace_call_tests.rs
+++ b/test/tests/rpc/debug_trace_call_tests.rs
@@ -1,0 +1,175 @@
+use ethrex_common::Address;
+use serde_json::{Value, json};
+
+use super::helpers::{
+    rpc_call, rpc_call_expect_err, setup_genesis_only, setup_single_transfer_block,
+};
+
+fn transfer_call(sender: Address, recipient: Address) -> Value {
+    transfer_call_with_nonce(sender, recipient, 0)
+}
+
+/// Like [`transfer_call`] but pins the call's `nonce` to match what the
+/// account already has in state. ethrex's VM enforces nonce equality even on
+/// simulated calls (same behaviour as `eth_call`), so post-block tests must
+/// either pre-fund the sender fresh or pass an explicit nonce.
+fn transfer_call_with_nonce(sender: Address, recipient: Address, nonce: u64) -> Value {
+    json!({
+        "from": format!("{sender:#x}"),
+        "to": format!("{recipient:#x}"),
+        "value": "0xde0b6b3a7640000",
+        "nonce": format!("{nonce:#x}"),
+    })
+}
+
+#[tokio::test]
+async fn trace_call_default_call_tracer_at_latest() {
+    let env = setup_genesis_only().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceCall",
+        vec![transfer_call(env.sender, recipient), json!("latest")],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert_eq!(obj["type"].as_str().unwrap(), "CALL");
+    assert_eq!(
+        obj["from"].as_str().unwrap().to_lowercase(),
+        format!("{:#x}", env.sender).to_lowercase()
+    );
+    assert_eq!(
+        obj["to"].as_str().unwrap().to_lowercase(),
+        format!("{recipient:#x}").to_lowercase()
+    );
+    assert!(obj.contains_key("gas"), "missing 'gas'");
+}
+
+#[tokio::test]
+async fn trace_call_defaults_block_to_latest() {
+    let env = setup_genesis_only().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    // Omitting the second parameter should be equivalent to passing "latest".
+    let result = rpc_call(
+        &env.store,
+        "debug_traceCall",
+        vec![transfer_call(env.sender, recipient)],
+    )
+    .await;
+    let obj = result.as_object().expect("response should be an object");
+    assert_eq!(obj["type"].as_str().unwrap(), "CALL");
+}
+
+#[tokio::test]
+async fn trace_call_by_block_number() {
+    // Trace against state *after* a tx was applied — sender nonce is 1.
+    let env = setup_single_transfer_block().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceCall",
+        vec![
+            transfer_call_with_nonce(env.sender, recipient, 1),
+            json!(format!("{:#x}", env.block.header.number)),
+        ],
+    )
+    .await;
+    let obj = result.as_object().expect("response should be an object");
+    assert_eq!(obj["type"].as_str().unwrap(), "CALL");
+}
+
+#[tokio::test]
+async fn trace_call_by_block_hash_eip1898() {
+    let env = setup_single_transfer_block().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceCall",
+        vec![
+            transfer_call_with_nonce(env.sender, recipient, 1),
+            json!({ "blockHash": format!("{:#x}", env.block.hash()) }),
+        ],
+    )
+    .await;
+    let obj = result.as_object().expect("response should be an object");
+    assert_eq!(obj["type"].as_str().unwrap(), "CALL");
+}
+
+#[tokio::test]
+async fn trace_call_prestate_tracer() {
+    let env = setup_genesis_only().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceCall",
+        vec![
+            transfer_call(env.sender, recipient),
+            json!("latest"),
+            json!({"tracer": "prestateTracer"}),
+        ],
+    )
+    .await;
+    // prestateTracer returns an object keyed by address with {balance, nonce, ...}.
+    let obj = result.as_object().expect("response should be an object");
+    let sender_key = format!("{:#x}", env.sender).to_lowercase();
+    let entry = obj
+        .iter()
+        .find(|(k, _)| k.to_lowercase() == sender_key)
+        .map(|(_, v)| v)
+        .expect("sender must appear in prestate");
+    assert!(entry["balance"].is_string());
+}
+
+#[tokio::test]
+async fn trace_call_opcode_tracer() {
+    let env = setup_genesis_only().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceCall",
+        vec![
+            transfer_call(env.sender, recipient),
+            json!("latest"),
+            json!({"tracer": "opcodeTracer"}),
+        ],
+    )
+    .await;
+    // opcodeTracer emits the structLogger wrapper: {failed, gas, returnValue, structLogs}.
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.contains_key("failed"));
+    assert!(obj.contains_key("gas"));
+    assert!(obj.contains_key("structLogs"));
+}
+
+#[tokio::test]
+async fn trace_call_unknown_block_errors() {
+    let env = setup_genesis_only().await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_traceCall",
+        vec![transfer_call(env.sender, recipient), json!("0x10000")],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Block not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn trace_call_empty_params_errors() {
+    let env = setup_genesis_only().await;
+    let err = rpc_call_expect_err(&env.store, "debug_traceCall", vec![]).await;
+    let msg = format!("{err:?}");
+    assert!(msg.contains("params"), "expected BadParams, got: {msg}");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -22,8 +22,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -118,7 +117,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -158,9 +159,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn trace_call() {

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,192 @@
+#![allow(dead_code)]
+
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn trace_call() {
+    // Use genesis state directly (nonce=0) so the simulated call is valid.
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let (store, _) = setup_store(sender).await;
+    let recipient = Address::from_low_u64_be(0xBB);
+
+    let result = rpc_call(
+        &store,
+        "debug_traceCall",
+        vec![
+            json!({
+                "from": format!("{sender:#x}"),
+                "to": format!("{recipient:#x}"),
+                "value": "0xde0b6b3a7640000"
+            }),
+            json!("latest"),
+        ],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert_eq!(obj["type"].as_str().unwrap(), "CALL");
+    assert!(obj.contains_key("from"), "missing 'from'");
+    assert!(obj.contains_key("to"), "missing 'to'");
+    assert!(obj.contains_key("gas"), "missing 'gas'");
+}

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,8 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
 #![allow(dead_code)]
 
 use std::{fs::File, io::BufReader, path::PathBuf};
@@ -17,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -34,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -63,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -81,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -103,7 +113,7 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -127,27 +137,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -163,34 +186,22 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
 }
 
-#[tokio::test]
-async fn trace_call() {
-    // Use genesis state directly (nonce=0) so the simulated call is valid.
+/// `TestEnv`-shaped wrapper for tests that operate against a genesis-only
+/// store. `block` is the genesis block; `tx_hash` is zero (no tx was sent).
+/// Used by `debug_traceCall`, which needs only a state-root anchor.
+pub async fn setup_genesis_only() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let (store, _) = setup_store(sender).await;
-    let recipient = Address::from_low_u64_be(0xBB);
-
-    let result = rpc_call(
-        &store,
-        "debug_traceCall",
-        vec![
-            json!({
-                "from": format!("{sender:#x}"),
-                "to": format!("{recipient:#x}"),
-                "value": "0xde0b6b3a7640000"
-            }),
-            json!("latest"),
-        ],
-    )
-    .await;
-
-    let obj = result.as_object().expect("response should be an object");
-    assert_eq!(obj["type"].as_str().unwrap(), "CALL");
-    assert!(obj.contains_key("from"), "missing 'from'");
-    assert!(obj.contains_key("to"), "missing 'to'");
-    assert!(obj.contains_key("gas"), "missing 'gas'");
+    let genesis = store.get_block_by_number(0).await.unwrap().unwrap();
+    TestEnv {
+        store,
+        block: genesis,
+        tx_hash: H256::zero(),
+        sender,
+    }
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_call_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_trace_call_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;


### PR DESCRIPTION
## Summary
- Adds `debug_traceCall` which traces an arbitrary call at a given block state without creating a transaction on-chain
- Supports all existing tracers: `callTracer`, `prestateTracer`, `opcodeTracer`
- Adds trace-call infrastructure at each layer (LEVM → Evm → Blockchain → RPC)
- Accepts the same call object format as `eth_call` plus an optional trace config
- Matches [geth's debug_traceCall](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-tracecall)

Closes part of #6572

## Test plan
- [ ] `debug_traceCall` with callTracer returns nested call frames
- [ ] `debug_traceCall` with prestateTracer returns pre/post state
- [ ] `debug_traceCall` with opcodeTracer returns EIP-3155 step trace
- [ ] Block identifier parameter works (latest, specific number, hash)
- [ ] Default block (latest) works when block param omitted

Closes #6641