### PR TITLE
feat(l1): implement debug_traceBlock RPC endpoint

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -44,7 +44,7 @@ use crate::eth::{
     },
 };
 use crate::subscription_manager::{SubscriptionManager, SubscriptionManagerProtocol};
-use crate::tracing::{TraceBlockByNumberRequest, TraceTransactionRequest};
+use crate::tracing::{TraceBlockByNumberRequest, TraceBlockRequest, TraceTransactionRequest};
 use crate::types::transaction::SendRawTransactionRequest;
 use crate::utils::{
     RpcErr, RpcErrorMetadata, RpcErrorResponse, RpcNamespace, RpcRequest, RpcRequestId,
@@ -1155,6 +1155,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_traceBlock" => TraceBlockRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -252,12 +252,12 @@ impl RpcHandler for TraceBlockByNumberRequest {
             .block
             .resolve_block_number(&context.storage)
             .await?
-            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+            .ok_or(RpcErr::BadParams("Block not Found".to_string()))?;
         let block = context
             .storage
             .get_block_by_number(block_number)
             .await?
-            .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
+            .ok_or(RpcErr::BadParams("Block not Found".to_string()))?;
         trace_block(block, &self.trace_config, &context).await
     }
 }
@@ -270,8 +270,14 @@ impl RpcHandler for TraceBlockRequest {
         if params.is_empty() || params.len() > 2 {
             return Err(RpcErr::BadParams("Expected 1 or 2 params".to_owned()));
         }
-        // First param is hex-encoded RLP block
+        // First param is hex-encoded RLP block.
+        // Cap input size to 5 MB of hex (≈ 2.5 MB decoded) to prevent OOM on
+        // absurdly large payloads.  A mainnet block's RLP is well under 2 MB.
+        const MAX_HEX_LEN: usize = 5 * 1024 * 1024;
         let hex_str: String = serde_json::from_value(params[0].clone())?;
+        if hex_str.len() > MAX_HEX_LEN {
+            return Err(RpcErr::TooLargeRequest);
+        }
         let hex_str = hex_str.strip_prefix("0x").ok_or(RpcErr::BadParams(
             "Block data must be 0x-prefixed".to_owned(),
         ))?;

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -405,3 +405,76 @@ async fn trace_block(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::RpcHandler;
+    use serde_json::json;
+
+    // --- TraceTransactionRequest parse tests ---
+
+    #[test]
+    fn parse_trace_tx_with_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert_eq!(req.tx_hash, H256::from_low_u64_be(1));
+    }
+
+    #[test]
+    fn parse_trace_tx_no_params() {
+        assert!(TraceTransactionRequest::parse(&None).is_err());
+    }
+
+    // --- TraceBlockRequest (RLP) parse tests ---
+
+    #[test]
+    fn parse_trace_block_rlp_missing_0x_prefix() {
+        let params = Some(vec![json!("deadbeef")]);
+        let result = TraceBlockRequest::parse(&params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_trace_block_rlp_invalid_hex() {
+        let params = Some(vec![json!("0xZZZZ")]);
+        let result = TraceBlockRequest::parse(&params);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_trace_block_rlp_no_params() {
+        assert!(TraceBlockRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_trace_block_rlp_empty_params() {
+        assert!(TraceBlockRequest::parse(&Some(vec![])).is_err());
+    }
+
+    #[test]
+    fn parse_trace_block_rlp_too_many_params() {
+        let params = Some(vec![json!("0x00"), json!({}), json!("extra")]);
+        assert!(TraceBlockRequest::parse(&params).is_err());
+    }
+
+    // --- TracerType deserialization tests ---
+
+    #[test]
+    fn deserialize_tracer_type_unknown_fails() {
+        assert!(serde_json::from_value::<TracerType>(json!("unknownTracer")).is_err());
+    }
+
+    // --- PrestateTracerConfig validation ---
+
+    #[test]
+    fn prestate_config_diff_mode_and_include_empty_is_invalid() {
+        let cfg = PrestateTracerConfig {
+            diff_mode: true,
+            include_empty: true,
+        };
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -11,7 +11,9 @@ use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{rpc::RpcApiContext, rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
+use crate::{
+    rpc::RpcApiContext, rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr,
+};
 
 /// Default max amount of blocks to re-excute if it is not given
 const DEFAULT_REEXEC: u32 = 128;
@@ -270,9 +272,9 @@ impl RpcHandler for TraceBlockRequest {
         }
         // First param is hex-encoded RLP block
         let hex_str: String = serde_json::from_value(params[0].clone())?;
-        let hex_str = hex_str
-            .strip_prefix("0x")
-            .ok_or(RpcErr::BadParams("Block data must be 0x-prefixed".to_owned()))?;
+        let hex_str = hex_str.strip_prefix("0x").ok_or(RpcErr::BadParams(
+            "Block data must be 0x-prefixed".to_owned(),
+        ))?;
         let rlp_bytes =
             hex::decode(hex_str).map_err(|e| RpcErr::BadParams(format!("Invalid hex: {e}")))?;
         let block = Block::decode(&rlp_bytes)
@@ -338,12 +340,11 @@ async fn trace_block(
             Ok(serde_json::to_value(block_trace)?)
         }
         TracerType::PrestateTracer => {
-            let config: PrestateTracerConfig =
-                if let Some(value) = &trace_config.tracer_config {
-                    serde_json::from_value(value.clone())?
-                } else {
-                    PrestateTracerConfig::default()
-                };
+            let config: PrestateTracerConfig = if let Some(value) = &trace_config.tracer_config {
+                serde_json::from_value(value.clone())?
+            } else {
+                PrestateTracerConfig::default()
+            };
             config.validate()?;
             let prestate_traces = context
                 .blockchain

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -4,12 +4,14 @@ use ethrex_common::H256;
 use ethrex_common::{
     serde_utils,
     tracing::{CallTraceFrame, PrestateResult, StructLoggerEmit, StructLoggerResult},
+    types::Block,
 };
+use ethrex_rlp::decode::RLPDecode;
 use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
+use crate::{rpc::RpcApiContext, rpc::RpcHandler, types::block_identifier::BlockIdentifier, utils::RpcErr};
 
 /// Default max amount of blocks to re-excute if it is not given
 const DEFAULT_REEXEC: u32 = 128;
@@ -23,6 +25,11 @@ pub struct TraceTransactionRequest {
 
 pub struct TraceBlockByNumberRequest {
     block: BlockIdentifier,
+    trace_config: TraceConfig,
+}
+
+pub struct TraceBlockRequest {
+    block: Block,
     trace_config: TraceConfig,
 }
 
@@ -249,112 +256,152 @@ impl RpcHandler for TraceBlockByNumberRequest {
             .get_block_by_number(block_number)
             .await?
             .ok_or(RpcErr::Internal("Block not Found".to_string()))?;
-        let reexec = self.trace_config.reexec.unwrap_or(DEFAULT_REEXEC);
-        let timeout = self.trace_config.timeout.unwrap_or(DEFAULT_TIMEOUT);
-        match self.trace_config.tracer {
-            TracerType::CallTracer => {
-                // Parse tracer config now that we know the type
-                let config = if let Some(value) = &self.trace_config.tracer_config {
+        trace_block(block, &self.trace_config, &context).await
+    }
+}
+
+impl RpcHandler for TraceBlockRequest {
+    fn parse(params: &Option<Vec<serde_json::Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.is_empty() || params.len() > 2 {
+            return Err(RpcErr::BadParams("Expected 1 or 2 params".to_owned()));
+        }
+        // First param is hex-encoded RLP block
+        let hex_str: String = serde_json::from_value(params[0].clone())?;
+        let hex_str = hex_str
+            .strip_prefix("0x")
+            .ok_or(RpcErr::BadParams("Block data must be 0x-prefixed".to_owned()))?;
+        let rlp_bytes =
+            hex::decode(hex_str).map_err(|e| RpcErr::BadParams(format!("Invalid hex: {e}")))?;
+        let block = Block::decode(&rlp_bytes)
+            .map_err(|e| RpcErr::BadParams(format!("Invalid RLP block: {e}")))?;
+        let trace_config = if params.len() == 2 {
+            serde_json::from_value(params[1].clone())?
+        } else {
+            TraceConfig::default()
+        };
+        Ok(TraceBlockRequest {
+            block,
+            trace_config,
+        })
+    }
+
+    async fn handle(
+        &self,
+        context: crate::rpc::RpcApiContext,
+    ) -> Result<serde_json::Value, crate::utils::RpcErr> {
+        trace_block(self.block.clone(), &self.trace_config, &context).await
+    }
+}
+
+/// Shared block tracing logic used by `debug_traceBlockByNumber`, `debug_traceBlockByHash`,
+/// and `debug_traceBlock` (raw RLP).
+async fn trace_block(
+    block: Block,
+    trace_config: &TraceConfig,
+    context: &RpcApiContext,
+) -> Result<Value, RpcErr> {
+    let reexec = trace_config.reexec.unwrap_or(DEFAULT_REEXEC);
+    let timeout = trace_config.timeout.unwrap_or(DEFAULT_TIMEOUT);
+    match trace_config.tracer {
+        TracerType::CallTracer => {
+            let config = if let Some(value) = &trace_config.tracer_config {
+                serde_json::from_value(value.clone())?
+            } else {
+                CallTracerConfig::default()
+            };
+            let call_traces = context
+                .blockchain
+                .trace_block_calls(
+                    block,
+                    reexec,
+                    timeout,
+                    config.only_top_call,
+                    config.with_log,
+                )
+                .await
+                .map_err(|err| RpcErr::Internal(err.to_string()))?;
+            // Unwrap each CallTrace (Vec<CallTraceFrame>) to a single
+            // CallTraceFrame to match geth's callTracer response format.
+            let block_trace: BlockTrace<CallTraceFrame> = call_traces
+                .into_iter()
+                .map(|(hash, trace)| {
+                    let frame = trace
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
+                    Ok((hash, frame).into())
+                })
+                .collect::<Result<_, RpcErr>>()?;
+            Ok(serde_json::to_value(block_trace)?)
+        }
+        TracerType::PrestateTracer => {
+            let config: PrestateTracerConfig =
+                if let Some(value) = &trace_config.tracer_config {
                     serde_json::from_value(value.clone())?
                 } else {
-                    CallTracerConfig::default()
+                    PrestateTracerConfig::default()
                 };
-                let call_traces = context
-                    .blockchain
-                    .trace_block_calls(
-                        block,
-                        reexec,
-                        timeout,
-                        config.only_top_call,
-                        config.with_log,
-                    )
-                    .await
-                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                // Unwrap each CallTrace (Vec<CallTraceFrame>) to a single
-                // CallTraceFrame to match geth's callTracer response format.
-                let block_trace: BlockTrace<CallTraceFrame> = call_traces
-                    .into_iter()
-                    .map(|(hash, trace)| {
-                        let frame = trace
-                            .into_iter()
-                            .next()
-                            .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
-                        Ok((hash, frame).into())
-                    })
-                    .collect::<Result<_, RpcErr>>()?;
-                Ok(serde_json::to_value(block_trace)?)
-            }
-            TracerType::PrestateTracer => {
-                let config: PrestateTracerConfig =
-                    if let Some(value) = &self.trace_config.tracer_config {
-                        serde_json::from_value(value.clone())?
-                    } else {
-                        PrestateTracerConfig::default()
+            config.validate()?;
+            let prestate_traces = context
+                .blockchain
+                .trace_block_prestate(
+                    block,
+                    reexec,
+                    timeout,
+                    config.diff_mode,
+                    config.include_empty,
+                )
+                .await
+                .map_err(|err| RpcErr::Internal(err.to_string()))?;
+            let block_trace: Vec<serde_json::Value> = prestate_traces
+                .into_iter()
+                .map(|(hash, result)| {
+                    let trace_value = match result {
+                        PrestateResult::Prestate(trace) => serde_json::to_value(trace)?,
+                        PrestateResult::Diff(diff) => serde_json::to_value(diff)?,
                     };
-                config.validate()?;
-                let prestate_traces = context
-                    .blockchain
-                    .trace_block_prestate(
-                        block,
-                        reexec,
-                        timeout,
-                        config.diff_mode,
-                        config.include_empty,
-                    )
-                    .await
-                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                // Each trace result is already the correct variant (Prestate or Diff)
-                // based on the diff_mode flag, so we serialize directly.
-                let block_trace: Vec<serde_json::Value> = prestate_traces
-                    .into_iter()
-                    .map(|(hash, result)| {
-                        let trace_value = match result {
-                            PrestateResult::Prestate(trace) => serde_json::to_value(trace)?,
-                            PrestateResult::Diff(diff) => serde_json::to_value(diff)?,
-                        };
-                        serde_json::to_value(BlockTraceComponent {
-                            tx_hash: hash,
-                            result: trace_value,
-                        })
+                    serde_json::to_value(BlockTraceComponent {
+                        tx_hash: hash,
+                        result: trace_value,
                     })
-                    .collect::<Result<_, serde_json::Error>>()?;
-                Ok(serde_json::to_value(block_trace)?)
-            }
-            TracerType::OpcodeTracer => {
-                let cfg: OpcodeTracerConfig = self
-                    .trace_config
-                    .tracer_config
-                    .as_ref()
-                    .map(|v| serde_json::from_value(v.clone()))
-                    .transpose()?
-                    .unwrap_or_default();
-                let emit = StructLoggerEmit {
-                    mem_size: cfg.enable_memory,
-                    return_data: cfg.enable_return_data,
-                    refund: false,
-                };
-                let opcode_traces = context
-                    .blockchain
-                    .trace_block_opcodes(block, reexec, timeout, cfg)
-                    .await
-                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
-                // Wrap each result with StructLoggerResult so it serializes in the
-                // geth-RPC shape expected by `debug_traceBlockByNumber` consumers.
-                let block_trace: Vec<serde_json::Value> = opcode_traces
-                    .into_iter()
-                    .map(|(hash, result)| {
-                        let wrapped = serde_json::to_value(StructLoggerResult {
-                            result: &result,
-                            emit,
-                        })?;
-                        serde_json::to_value(BlockTraceComponent {
-                            tx_hash: hash,
-                            result: wrapped,
-                        })
+                })
+                .collect::<Result<_, serde_json::Error>>()?;
+            Ok(serde_json::to_value(block_trace)?)
+        }
+        TracerType::OpcodeTracer => {
+            let cfg: OpcodeTracerConfig = trace_config
+                .tracer_config
+                .as_ref()
+                .map(|v| serde_json::from_value(v.clone()))
+                .transpose()?
+                .unwrap_or_default();
+            let emit = StructLoggerEmit {
+                mem_size: cfg.enable_memory,
+                return_data: cfg.enable_return_data,
+                refund: false,
+            };
+            let opcode_traces = context
+                .blockchain
+                .trace_block_opcodes(block, reexec, timeout, cfg)
+                .await
+                .map_err(|err| RpcErr::Internal(err.to_string()))?;
+            let block_trace: Vec<serde_json::Value> = opcode_traces
+                .into_iter()
+                .map(|(hash, result)| {
+                    let wrapped = serde_json::to_value(StructLoggerResult {
+                        result: &result,
+                        emit,
+                    })?;
+                    serde_json::to_value(BlockTraceComponent {
+                        tx_hash: hash,
+                        result: wrapped,
                     })
-                    .collect::<Result<_, serde_json::Error>>()?;
-                Ok(serde_json::to_value(block_trace)?)
-            }
+                })
+                .collect::<Result<_, serde_json::Error>>()?;
+            Ok(serde_json::to_value(block_trace)?)
         }
     }
 }

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,185 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rlp::encode::RLPEncode;
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block }
+}
+
+// ─── debug_traceBlock (raw RLP input) ────────────────────────────────────
+
+#[tokio::test]
+async fn trace_block_rlp() {
+    let env = setup_single_transfer_block().await;
+
+    // RLP-encode the executed block and pass it as hex to debug_traceBlock.
+    let rlp_hex = format!("0x{}", hex::encode(env.block.encode_to_vec()));
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceBlock",
+        vec![json!(rlp_hex)],
+    )
+    .await;
+
+    // Response is an array of {txHash, result} objects (callTracer by default).
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1, "block has 1 tx so should have 1 trace");
+
+    let entry = arr[0].as_object().expect("entry should be an object");
+    assert!(entry.contains_key("txHash"), "entry should have 'txHash'");
+    assert!(entry.contains_key("result"), "entry should have 'result'");
+    assert_eq!(entry["result"]["type"].as_str().unwrap(), "CALL");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -21,8 +21,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -117,7 +116,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -167,12 +168,7 @@ async fn trace_block_rlp() {
     // RLP-encode the executed block and pass it as hex to debug_traceBlock.
     let rlp_hex = format!("0x{}", hex::encode(env.block.encode_to_vec()));
 
-    let result = rpc_call(
-        &env.store,
-        "debug_traceBlock",
-        vec![json!(rlp_hex)],
-    )
-    .await;
+    let result = rpc_call(&env.store, "debug_traceBlock", vec![json!(rlp_hex)]).await;
 
     // Response is an array of {txHash, result} objects (callTracer by default).
     let arr = result.as_array().expect("response should be an array");

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Adds `debug_traceBlock` which accepts a hex-encoded RLP block, decodes it, and traces all transactions
- Extracts shared block tracing logic into a `trace_block` helper used by both `traceBlockByNumber` and `traceBlock`
- Supports all existing tracers: `callTracer`, `prestateTracer`, `opcodeTracer`
- Matches [geth's debug_traceBlock](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-traceblock)

Closes #6642
Closes part of #6572

## Test plan
- [ ] `debug_traceBlock` with valid RLP block returns traces
- [ ] Invalid RLP returns proper error
- [ ] Non-hex-prefixed input returns proper error