### PR TITLE
feat(l1): implement debug_storageRangeAt RPC endpoint

### DIFF
--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,4 @@
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;
+pub mod storage_range_at;

--- a/crates/networking/rpc/debug/storage_range_at.rs
+++ b/crates/networking/rpc/debug/storage_range_at.rs
@@ -95,7 +95,7 @@ impl RpcHandler for StorageRangeAtRequest {
             .block
             .resolve_block_header(&context.storage)
             .await?
-            .ok_or_else(|| RpcErr::Internal("Block not found".to_string()))?;
+            .ok_or_else(|| RpcErr::WrongParam("Block not found".to_string()))?;
 
         // `tx_index` is accepted (geth's `-1` sentinel works since it's `i64`)
         // but not honoured — see type-level doc.

--- a/crates/networking/rpc/debug/storage_range_at.rs
+++ b/crates/networking/rpc/debug/storage_range_at.rs
@@ -104,3 +104,49 @@ impl RpcHandler for StorageRangeAtRequest {
         })?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RpcHandler;
+    use serde_json::json;
+
+    #[test]
+    fn parse_valid_params() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!(0),
+            json!("0x0000000000000000000000000000000000000001"),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(128),
+        ]);
+        let req = StorageRangeAtRequest::parse(&params).unwrap();
+        assert_eq!(req.block_hash, H256::from_low_u64_be(1));
+        assert_eq!(req.tx_index, 0);
+        assert_eq!(req.max_result, 128);
+    }
+
+    #[test]
+    fn parse_no_params() {
+        assert!(StorageRangeAtRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_wrong_param_count() {
+        let params = Some(vec![json!("0x01"), json!(0)]);
+        assert!(StorageRangeAtRequest::parse(&params).is_err());
+    }
+
+    #[test]
+    fn parse_too_many_params() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!(0),
+            json!("0x0000000000000000000000000000000000000001"),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(128),
+            json!("extra"),
+        ]);
+        assert!(StorageRangeAtRequest::parse(&params).is_err());
+    }
+}

--- a/crates/networking/rpc/debug/storage_range_at.rs
+++ b/crates/networking/rpc/debug/storage_range_at.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeMap;
+
+use ethrex_common::{Address, BigEndianHash, H256};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{RpcApiContext, RpcErr, RpcHandler};
+
+pub struct StorageRangeAtRequest {
+    block_hash: H256,
+    tx_index: usize,
+    address: Address,
+    start_key: H256,
+    max_result: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StorageRangeResult {
+    storage: BTreeMap<H256, StorageEntry>,
+    #[serde(rename = "nextKey")]
+    next_key: Option<H256>,
+}
+
+#[derive(Serialize)]
+struct StorageEntry {
+    /// The original (unhashed) key. Null when the preimage is not available.
+    key: Option<H256>,
+    value: H256,
+}
+
+impl RpcHandler for StorageRangeAtRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 5 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected 5 params, got {}",
+                params.len()
+            )));
+        }
+        let block_hash: H256 = serde_json::from_value(params[0].clone())?;
+        let tx_index: usize = serde_json::from_value(params[1].clone())?;
+        let address: Address = serde_json::from_value(params[2].clone())?;
+        let start_key: H256 = serde_json::from_value(params[3].clone())?;
+        let max_result: usize = serde_json::from_value(params[4].clone())?;
+        Ok(StorageRangeAtRequest {
+            block_hash,
+            tx_index,
+            address,
+            start_key,
+            max_result,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        // Get the block header to obtain the state root.
+        // Note: txIndex-based state reconstruction (re-executing up to txIndex)
+        // is not yet supported; we use the block's final state root.
+        let header = context
+            .storage
+            .get_block_header_by_hash(self.block_hash)?
+            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+
+        let _ = self.tx_index; // TODO: re-execute up to tx_index for precise state
+
+        let hashed_address = ethrex_common::utils::keccak(self.address);
+
+        let iter = context
+            .storage
+            .iter_storage_from(header.state_root, hashed_address, self.start_key)
+            .map_err(|e| RpcErr::Internal(e.to_string()))?;
+
+        let Some(iter) = iter else {
+            // Account not found in state
+            return Ok(serde_json::to_value(StorageRangeResult {
+                storage: BTreeMap::new(),
+                next_key: None,
+            })?);
+        };
+
+        let mut storage = BTreeMap::new();
+        let mut next_key = None;
+
+        for (hashed_slot, value) in iter {
+            if storage.len() >= self.max_result {
+                next_key = Some(hashed_slot);
+                break;
+            }
+            storage.insert(
+                hashed_slot,
+                StorageEntry {
+                    // ethrex does not store keccak preimages, so key is unavailable
+                    key: None,
+                    value: H256::from_uint(&value),
+                },
+            );
+        }
+
+        Ok(serde_json::to_value(StorageRangeResult {
+            storage,
+            next_key,
+        })?)
+    }
+}

--- a/crates/networking/rpc/debug/storage_range_at.rs
+++ b/crates/networking/rpc/debug/storage_range_at.rs
@@ -46,7 +46,6 @@ pub struct StorageRangeAtRequest {
 #[serde(rename_all = "camelCase")]
 struct StorageRangeResult {
     storage: BTreeMap<H256, StorageEntry>,
-    #[serde(rename = "nextKey")]
     next_key: Option<H256>,
 }
 
@@ -77,6 +76,11 @@ impl RpcHandler for StorageRangeAtRequest {
             .map_err(|e| RpcErr::BadParams(format!("invalid startKey: {e}")))?;
         let max_result: usize = serde_json::from_value(params[4].clone())
             .map_err(|e| RpcErr::BadParams(format!("invalid maxResult: {e}")))?;
+        if max_result == 0 {
+            return Err(RpcErr::BadParams(
+                "maxResult must be greater than 0".to_owned(),
+            ));
+        }
         Ok(StorageRangeAtRequest {
             block,
             tx_index,

--- a/crates/networking/rpc/debug/storage_range_at.rs
+++ b/crates/networking/rpc/debug/storage_range_at.rs
@@ -1,14 +1,42 @@
 use std::collections::BTreeMap;
 
-use ethrex_common::{Address, BigEndianHash, H256};
+use ethrex_common::{Address, BigEndianHash, H256, utils::keccak};
+use ethrex_storage::Store;
+use ethrex_storage::error::StoreError;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::{RpcApiContext, RpcErr, RpcHandler};
+use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifierOrHash};
 
+/// `debug_storageRangeAt` — paginated iteration over an account's storage trie
+/// at a block, matching the shape documented at
+/// https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-storagerangeat.
+///
+/// Params: `[blockNrOrHash, txIndex, contractAddress, startKey, maxResult]`.
+/// The first parameter accepts a block number, a tag (`latest` /
+/// `earliest` / etc.), a 32-byte hash, or the EIP-1898 object form.
+/// `startKey` is the hashed slot (`keccak256(slot_index)`), matching geth's
+/// convention; the iterator yields slots in hashed-key order.
+///
+/// **Known divergences from geth**:
+///
+/// - `txIndex` is currently ignored — the response is always the state at the
+///   *end* of the given block (equivalent to geth's `txIndex == -1`). Returning
+///   the state immediately after the Nth transaction requires mid-block
+///   trie-root reconstruction, which is a deferred feature.
+/// - `StorageEntry.key` (the unhashed slot index) is always `null` because
+///   ethrex has no preimage store.
+/// - When the contract address has no account in the state trie at this block
+///   (EOA, contract not yet deployed, or self-destructed), the response is
+///   `{storage: {}, nextKey: null}` rather than an error — matches geth.
+///
+/// The trie traversal is wrapped in `tokio::task::spawn_blocking` because
+/// `iter_storage_from` opens long-lived locked DB transactions and performs
+/// synchronous trie I/O.
 pub struct StorageRangeAtRequest {
-    block_hash: H256,
-    tx_index: usize,
+    block: BlockIdentifierOrHash,
+    /// Currently ignored — see type-level doc.
+    tx_index: i64,
     address: Address,
     start_key: H256,
     max_result: usize,
@@ -24,7 +52,7 @@ struct StorageRangeResult {
 
 #[derive(Serialize)]
 struct StorageEntry {
-    /// The original (unhashed) key. Null when the preimage is not available.
+    /// Original (unhashed) slot index. Always `null` — no preimage store.
     key: Option<H256>,
     value: H256,
 }
@@ -40,13 +68,17 @@ impl RpcHandler for StorageRangeAtRequest {
                 params.len()
             )));
         }
-        let block_hash: H256 = serde_json::from_value(params[0].clone())?;
-        let tx_index: usize = serde_json::from_value(params[1].clone())?;
-        let address: Address = serde_json::from_value(params[2].clone())?;
-        let start_key: H256 = serde_json::from_value(params[3].clone())?;
-        let max_result: usize = serde_json::from_value(params[4].clone())?;
+        let block = BlockIdentifierOrHash::parse(params[0].clone(), 0)?;
+        let tx_index: i64 = serde_json::from_value(params[1].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid txIndex: {e}")))?;
+        let address: Address = serde_json::from_value(params[2].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid contractAddress: {e}")))?;
+        let start_key: H256 = serde_json::from_value(params[3].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid startKey: {e}")))?;
+        let max_result: usize = serde_json::from_value(params[4].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid maxResult: {e}")))?;
         Ok(StorageRangeAtRequest {
-            block_hash,
+            block,
             tx_index,
             address,
             start_key,
@@ -55,64 +87,73 @@ impl RpcHandler for StorageRangeAtRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        // Get the block header to obtain the state root.
-        // Note: txIndex-based state reconstruction (re-executing up to txIndex)
-        // is not yet supported; we use the block's final state root.
-        let header = context
-            .storage
-            .get_block_header_by_hash(self.block_hash)?
-            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+        let header = self
+            .block
+            .resolve_block_header(&context.storage)
+            .await?
+            .ok_or_else(|| RpcErr::Internal("Block not found".to_string()))?;
 
-        let _ = self.tx_index; // TODO: re-execute up to tx_index for precise state
+        // `tx_index` is accepted (geth's `-1` sentinel works since it's `i64`)
+        // but not honoured — see type-level doc.
+        let _ = self.tx_index;
 
-        let hashed_address = ethrex_common::utils::keccak(self.address);
+        let state_root = header.state_root;
+        let hashed_address = keccak(self.address);
+        let start_key = self.start_key;
+        let max_result = self.max_result;
+        let storage = context.storage.clone();
 
-        let iter = context
-            .storage
-            .iter_storage_from(header.state_root, hashed_address, self.start_key)
-            .map_err(|e| RpcErr::Internal(e.to_string()))?;
-
-        let Some(iter) = iter else {
-            // Account not found in state
-            return Ok(serde_json::to_value(StorageRangeResult {
-                storage: BTreeMap::new(),
-                next_key: None,
-            })?);
-        };
-
-        let mut storage = BTreeMap::new();
-        let mut next_key = None;
-
-        for (hashed_slot, value) in iter {
-            if storage.len() >= self.max_result {
-                next_key = Some(hashed_slot);
-                break;
-            }
-            storage.insert(
-                hashed_slot,
-                StorageEntry {
-                    // ethrex does not store keccak preimages, so key is unavailable
-                    key: None,
-                    value: H256::from_uint(&value),
-                },
-            );
-        }
+        let (entries, next_key) = tokio::task::spawn_blocking(move || {
+            collect_storage_range(&storage, state_root, hashed_address, start_key, max_result)
+        })
+        .await
+        .map_err(|e| RpcErr::Internal(format!("storageRangeAt task failed: {e}")))??;
 
         Ok(serde_json::to_value(StorageRangeResult {
-            storage,
+            storage: entries,
             next_key,
         })?)
     }
+}
+
+fn collect_storage_range(
+    storage: &Store,
+    state_root: H256,
+    hashed_address: H256,
+    start_key: H256,
+    max_result: usize,
+) -> Result<(BTreeMap<H256, StorageEntry>, Option<H256>), StoreError> {
+    let Some(iter) = storage.iter_storage_from(state_root, hashed_address, start_key)? else {
+        // Account not present in state (EOA, undeployed, or destructed).
+        return Ok((BTreeMap::new(), None));
+    };
+    let mut entries = BTreeMap::new();
+    let mut next_key = None;
+    for (hashed_slot, value) in iter {
+        if entries.len() >= max_result {
+            next_key = Some(hashed_slot);
+            break;
+        }
+        entries.insert(
+            hashed_slot,
+            StorageEntry {
+                key: None,
+                value: H256::from_uint(&value),
+            },
+        );
+    }
+    Ok((entries, next_key))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::RpcHandler;
+    use crate::types::block_identifier::BlockIdentifier;
     use serde_json::json;
 
     #[test]
-    fn parse_valid_params() {
+    fn parse_valid_params_by_hash() {
         let params = Some(vec![
             json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
             json!(0),
@@ -121,9 +162,41 @@ mod tests {
             json!(128),
         ]);
         let req = StorageRangeAtRequest::parse(&params).unwrap();
-        assert_eq!(req.block_hash, H256::from_low_u64_be(1));
+        assert!(matches!(req.block, BlockIdentifierOrHash::Hash(_)));
         assert_eq!(req.tx_index, 0);
+        assert_eq!(req.address, Address::from_low_u64_be(1));
+        assert_eq!(req.start_key, H256::zero());
         assert_eq!(req.max_result, 128);
+    }
+
+    #[test]
+    fn parse_valid_params_by_number_and_neg_tx_index() {
+        let params = Some(vec![
+            json!("0xa"),
+            json!(-1),
+            json!("0x0000000000000000000000000000000000000001"),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(128),
+        ]);
+        let req = StorageRangeAtRequest::parse(&params).unwrap();
+        assert!(matches!(
+            req.block,
+            BlockIdentifierOrHash::Identifier(BlockIdentifier::Number(10))
+        ));
+        assert_eq!(req.tx_index, -1);
+    }
+
+    #[test]
+    fn parse_valid_params_by_tag() {
+        let params = Some(vec![
+            json!("latest"),
+            json!(0),
+            json!("0x0000000000000000000000000000000000000001"),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(128),
+        ]);
+        let req = StorageRangeAtRequest::parse(&params).unwrap();
+        assert!(matches!(req.block, BlockIdentifierOrHash::Identifier(_)));
     }
 
     #[test]

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -2,6 +2,7 @@ use crate::authentication::authenticate;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
+use crate::debug::storage_range_at::StorageRangeAtRequest;
 use crate::engine::blobs::{BlobsV2Request, BlobsV3Request};
 use crate::engine::client_version::GetClientVersionV1Request;
 use crate::engine::payload::{GetPayloadV5Request, GetPayloadV6Request, NewPayloadV5Request};
@@ -1155,6 +1156,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_storageRangeAt" => StorageRangeAtRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/test/tests/rpc/debug_storage_range_at_tests.rs
+++ b/test/tests/rpc/debug_storage_range_at_tests.rs
@@ -1,0 +1,223 @@
+use ethrex_common::{Address, H256, U256, utils::keccak};
+use serde_json::{Value, json};
+
+use super::helpers::{rpc_call, rpc_call_expect_err, setup_block_with_storage_contract};
+
+/// Hashed slot for a u256 slot index. Storage-trie entries are keyed by
+/// `keccak256(slot)`, so this is how callers locate a known slot in the
+/// `nextKey`-style response.
+fn hashed_slot(slot: u64) -> H256 {
+    let bytes = U256::from(slot).to_big_endian();
+    keccak(bytes)
+}
+
+async fn call_range(
+    store: &ethrex_storage::Store,
+    block: Value,
+    contract: Address,
+    start_key: H256,
+    max: u64,
+) -> Value {
+    rpc_call(
+        store,
+        "debug_storageRangeAt",
+        vec![
+            block,
+            json!(0),
+            json!(format!("{contract:#x}")),
+            json!(format!("{start_key:#x}")),
+            json!(max),
+        ],
+    )
+    .await
+}
+
+#[tokio::test]
+async fn storage_range_returns_contract_slots() {
+    let env = setup_block_with_storage_contract().await;
+    let block_hash = env.block.hash();
+
+    let result = call_range(
+        &env.store,
+        json!(format!("{block_hash:#x}")),
+        env.contract,
+        H256::zero(),
+        1_000,
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    let storage = obj["storage"]
+        .as_object()
+        .expect("storage should be an object");
+    assert_eq!(storage.len(), 3, "deployed contract has 3 storage slots");
+
+    // Verify each known slot appears under its hashed key with the expected
+    // value. The deploy code wrote slot 0 = 0x11, slot 1 = 0x22, slot 2 = 0x33.
+    for (slot_idx, expected_value) in [(0u64, 0x11u8), (1, 0x22), (2, 0x33)] {
+        let key = format!("{:#x}", hashed_slot(slot_idx));
+        let entry = storage
+            .get(&key)
+            .or_else(|| {
+                storage
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case(&key))
+                    .map(|(_, v)| v)
+            })
+            .unwrap_or_else(|| panic!("slot {slot_idx} (hashed: {key}) missing from response"));
+        assert!(
+            entry["key"].is_null(),
+            "preimage is not stored, key must be null"
+        );
+        let value = entry["value"].as_str().unwrap();
+        let v: U256 = U256::from_str_radix(value.trim_start_matches("0x"), 16).unwrap();
+        assert_eq!(
+            v,
+            U256::from(expected_value),
+            "slot {slot_idx} should be 0x{expected_value:02x}"
+        );
+    }
+    // Iteration complete — nextKey absent or null.
+    assert!(
+        obj.get("nextKey").is_none() || obj["nextKey"].is_null(),
+        "complete iteration must have null nextKey"
+    );
+}
+
+#[tokio::test]
+async fn storage_range_paginates_via_next_key() {
+    let env = setup_block_with_storage_contract().await;
+    let block_hash = env.block.hash();
+
+    // Three slots in trie-order. Request one at a time and walk via nextKey.
+    let mut cursor = H256::zero();
+    let mut seen = Vec::new();
+    for _ in 0..3 {
+        let page = call_range(
+            &env.store,
+            json!(format!("{block_hash:#x}")),
+            env.contract,
+            cursor,
+            1,
+        )
+        .await;
+        let storage = page["storage"].as_object().unwrap();
+        assert_eq!(storage.len(), 1, "max=1 page returns exactly one slot");
+        let key = storage.keys().next().unwrap().clone();
+        assert!(!seen.contains(&key), "page must not repeat a previous slot");
+        seen.push(key);
+        let next = &page["nextKey"];
+        if next.is_null() {
+            break;
+        }
+        cursor = next.as_str().unwrap().parse().unwrap();
+    }
+    assert_eq!(seen.len(), 3, "should have walked through all three slots");
+
+    // One more page from the post-last cursor must yield empty + null nextKey.
+    let final_page = call_range(
+        &env.store,
+        json!(format!("{block_hash:#x}")),
+        env.contract,
+        // Walk from the last seen key + 1 to be safe; use zero-cursor + max
+        // (effectively "give me all remaining" — already past).
+        H256::repeat_byte(0xFF),
+        1_000,
+    )
+    .await;
+    assert!(final_page["storage"].as_object().unwrap().is_empty());
+    assert!(
+        final_page["nextKey"].is_null(),
+        "exhausted iteration must have null nextKey"
+    );
+}
+
+#[tokio::test]
+async fn storage_range_unknown_address_returns_empty() {
+    let env = setup_block_with_storage_contract().await;
+    let block_hash = env.block.hash();
+
+    // Query a random non-existent account.
+    let result = call_range(
+        &env.store,
+        json!(format!("{block_hash:#x}")),
+        Address::from_low_u64_be(0xDEAD_BEEF),
+        H256::zero(),
+        1_000,
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert!(
+        obj["storage"].as_object().unwrap().is_empty(),
+        "unknown account must return empty storage"
+    );
+    assert!(
+        obj["nextKey"].is_null(),
+        "unknown account must have null nextKey"
+    );
+}
+
+#[tokio::test]
+async fn storage_range_eoa_returns_empty() {
+    // The sender is an EOA — has no storage trie. Should behave identically
+    // to "unknown address": empty + null nextKey, no error.
+    let env = setup_block_with_storage_contract().await;
+    let block_hash = env.block.hash();
+
+    let result = call_range(
+        &env.store,
+        json!(format!("{block_hash:#x}")),
+        env.sender,
+        H256::zero(),
+        1_000,
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj["storage"].as_object().unwrap().is_empty());
+    assert!(obj["nextKey"].is_null());
+}
+
+#[tokio::test]
+async fn storage_range_by_block_number() {
+    let env = setup_block_with_storage_contract().await;
+
+    let result = call_range(
+        &env.store,
+        json!(format!("{:#x}", env.block.header.number)),
+        env.contract,
+        H256::zero(),
+        1_000,
+    )
+    .await;
+    let storage = result["storage"].as_object().unwrap();
+    assert_eq!(
+        storage.len(),
+        3,
+        "block-number form must resolve the same state"
+    );
+}
+
+#[tokio::test]
+async fn storage_range_invalid_block_hash_errors() {
+    let env = setup_block_with_storage_contract().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_storageRangeAt",
+        vec![
+            json!(format!("{:#x}", H256::from_low_u64_be(0xdeadbeef))),
+            json!(0),
+            json!(format!("{:#x}", env.contract)),
+            json!(format!("{:#x}", H256::zero())),
+            json!(1_u64),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Block not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn storage_range_at() {

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,186 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn storage_range_at() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+    let sender = sender_from_key(&test_secret_key());
+
+    let result = rpc_call(
+        &env.store,
+        "debug_storageRangeAt",
+        vec![
+            json!(format!("{block_hash:#x}")),
+            json!(0),
+            json!(format!("{sender:#x}")),
+            json!(format!("{:#x}", H256::zero())),
+            json!(128),
+        ],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.contains_key("storage"), "should have 'storage'");
+    // nextKey can be null or a hash.
+    assert!(obj.contains_key("nextKey"), "should have 'nextKey'");
+}

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -7,6 +14,7 @@ use ethrex_blockchain::{
 };
 use ethrex_common::{
     Address, H160, H256, U256,
+    evm::calculate_create_address,
     types::{
         Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
         GenesisAccount, Transaction, TxKind,
@@ -15,16 +23,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +41,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +70,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +92,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +114,28 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn create_deploy_tx(
+    chain_id: u64,
+    nonce: u64,
+    init_code: Bytes,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: 1_000_000,
+        to: TxKind::Create,
+        value: U256::zero(),
+        data: init_code,
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +159,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,30 +208,43 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
 }
 
-#[tokio::test]
-async fn storage_range_at() {
-    let env = setup_single_transfer_block().await;
-    let block_hash = env.block.hash();
-    let sender = sender_from_key(&test_secret_key());
+pub struct DeployedEnv {
+    pub store: Store,
+    pub block: Block,
+    pub sender: Address,
+    /// Address of the contract deployed by the single tx in `block`.
+    pub contract: Address,
+}
 
-    let result = rpc_call(
-        &env.store,
-        "debug_storageRangeAt",
-        vec![
-            json!(format!("{block_hash:#x}")),
-            json!(0),
-            json!(format!("{sender:#x}")),
-            json!(format!("{:#x}", H256::zero())),
-            json!(128),
-        ],
-    )
-    .await;
-
-    let obj = result.as_object().expect("response should be an object");
-    assert!(obj.contains_key("storage"), "should have 'storage'");
-    // nextKey can be null or a hash.
-    assert!(obj.contains_key("nextKey"), "should have 'nextKey'");
+/// Deploys a tiny contract whose constructor writes three storage slots:
+/// slot 0 = 0x11, slot 1 = 0x22, slot 2 = 0x33. Used by storage-range tests
+/// to verify both content and pagination against real trie data.
+pub async fn setup_block_with_storage_contract() -> DeployedEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    // PUSH1 0x11 PUSH1 0x00 SSTORE   ; slot 0 = 0x11
+    // PUSH1 0x22 PUSH1 0x01 SSTORE   ; slot 1 = 0x22
+    // PUSH1 0x33 PUSH1 0x02 SSTORE   ; slot 2 = 0x33
+    // PUSH1 0x00 PUSH1 0x00 RETURN   ; deploy empty runtime
+    let init_code = Bytes::from_static(&[
+        0x60, 0x11, 0x60, 0x00, 0x55, 0x60, 0x22, 0x60, 0x01, 0x55, 0x60, 0x33, 0x60, 0x02, 0x55,
+        0x60, 0x00, 0x60, 0x00, 0xF3,
+    ]);
+    let tx = create_deploy_tx(chain_id, 0, init_code, &signer).await;
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    let contract = calculate_create_address(sender, 0);
+    DeployedEnv {
+        store,
+        block,
+        sender,
+        contract,
+    }
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_storage_range_at_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_storage_range_at_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Adds `debug_storageRangeAt` which iterates storage slots for a contract address starting from a given key
- Returns up to `maxResult` entries with a `nextKey` for pagination
- Uses the block's final state root; txIndex-based state reconstruction is a future enhancement
- Preimage lookup not yet available (original key field returned as null)
- Matches [geth's debug_storageRangeAt](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-storagerangeat)

Closes part of #6572

## Test plan
- [ ] Returns storage entries for a known contract
- [ ] Pagination via nextKey works correctly
- [ ] Unknown address returns empty result
- [ ] Invalid block hash returns error

Closes #6648