### PR TITLE
feat(l1): implement debug_accountRange RPC endpoint

### DIFF
--- a/crates/networking/rpc/debug/account_range.rs
+++ b/crates/networking/rpc/debug/account_range.rs
@@ -80,6 +80,11 @@ impl RpcHandler for AccountRangeRequest {
             .map_err(|e| RpcErr::BadParams(format!("invalid start hash: {e}")))?;
         let max_results: usize = serde_json::from_value(params[3].clone())
             .map_err(|e| RpcErr::BadParams(format!("invalid maxResults: {e}")))?;
+        if max_results == 0 {
+            return Err(RpcErr::BadParams(
+                "maxResults must be greater than 0".to_owned(),
+            ));
+        }
         Ok(AccountRangeRequest {
             block,
             tx_index,
@@ -93,7 +98,7 @@ impl RpcHandler for AccountRangeRequest {
             .block
             .resolve_block_header(&context.storage)
             .await?
-            .ok_or_else(|| RpcErr::Internal("Block not found".to_string()))?;
+            .ok_or_else(|| RpcErr::WrongParam("Block not found".to_string()))?;
 
         // `tx_index` is parsed and validated but not honoured yet. Negative
         // values (geth's `-1` "end of block" sentinel) and any value >= the

--- a/crates/networking/rpc/debug/account_range.rs
+++ b/crates/networking/rpc/debug/account_range.rs
@@ -1,0 +1,93 @@
+use std::collections::BTreeMap;
+
+use ethrex_common::{H256, U256};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{RpcApiContext, RpcErr, RpcHandler};
+
+pub struct AccountRangeRequest {
+    block_hash: H256,
+    tx_index: usize,
+    start: H256,
+    max_results: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AccountRangeResult {
+    accounts: BTreeMap<H256, AccountEntry>,
+    #[serde(rename = "next")]
+    next: H256,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AccountEntry {
+    balance: U256,
+    nonce: u64,
+    root: H256,
+    code_hash: H256,
+    /// The original (unhashed) address. Null when preimage is not available.
+    key: Option<H256>,
+}
+
+impl RpcHandler for AccountRangeRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 4 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected 4 params, got {}",
+                params.len()
+            )));
+        }
+        let block_hash: H256 = serde_json::from_value(params[0].clone())?;
+        let tx_index: usize = serde_json::from_value(params[1].clone())?;
+        let start: H256 = serde_json::from_value(params[2].clone())?;
+        let max_results: usize = serde_json::from_value(params[3].clone())?;
+        Ok(AccountRangeRequest {
+            block_hash,
+            tx_index,
+            start,
+            max_results,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let header = context
+            .storage
+            .get_block_header_by_hash(self.block_hash)?
+            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+
+        let _ = self.tx_index; // TODO: re-execute up to tx_index for precise state
+
+        let iter = context
+            .storage
+            .iter_accounts_from(header.state_root, self.start)
+            .map_err(|e| RpcErr::Internal(e.to_string()))?;
+
+        let mut accounts = BTreeMap::new();
+        let mut next = H256::zero();
+
+        for (hashed_addr, account_state) in iter {
+            if accounts.len() >= self.max_results {
+                next = hashed_addr;
+                break;
+            }
+            accounts.insert(
+                hashed_addr,
+                AccountEntry {
+                    balance: account_state.balance,
+                    nonce: account_state.nonce,
+                    root: account_state.storage_root,
+                    code_hash: account_state.code_hash,
+                    key: None, // preimage not available
+                },
+            );
+        }
+
+        Ok(serde_json::to_value(AccountRangeResult { accounts, next })?)
+    }
+}

--- a/crates/networking/rpc/debug/account_range.rs
+++ b/crates/networking/rpc/debug/account_range.rs
@@ -6,6 +6,8 @@ use ethrex_storage::error::StoreError;
 use serde::Serialize;
 use serde_json::Value;
 
+use tracing::warn;
+
 use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifierOrHash};
 
 /// `debug_accountRange` — paginated iteration over the state trie at a block,
@@ -59,6 +61,7 @@ struct AccountEntry {
     root: H256,
     code_hash: H256,
     /// Original (unhashed) address. Always `null` — ethrex has no preimage store.
+    #[serde(skip_serializing_if = "Option::is_none")]
     key: Option<H256>,
 }
 
@@ -100,12 +103,16 @@ impl RpcHandler for AccountRangeRequest {
             .await?
             .ok_or_else(|| RpcErr::WrongParam("Block not found".to_string()))?;
 
-        // `tx_index` is parsed and validated but not honoured yet. Negative
-        // values (geth's `-1` "end of block" sentinel) and any value >= the
-        // block's tx count are equivalent to "end of block" — which is what
-        // we always return, so no error needed. Other values would require
-        // mid-block state reconstruction; documented on the type.
-        let _ = self.tx_index;
+        // `tx_index` is parsed but not honoured yet — we always return end-of-block
+        // state. Negative values (geth's `-1` sentinel) and values >= the block's tx
+        // count are equivalent, so no error. For non-negative values that would
+        // require mid-block state reconstruction we emit a warning.
+        if self.tx_index >= 0 {
+            warn!(
+                tx_index = self.tx_index,
+                "debug_accountRange: txIndex is not yet supported, returning end-of-block state"
+            );
+        }
 
         let state_root = header.state_root;
         let start = self.start;

--- a/crates/networking/rpc/debug/account_range.rs
+++ b/crates/networking/rpc/debug/account_range.rs
@@ -1,14 +1,43 @@
 use std::collections::BTreeMap;
 
 use ethrex_common::{H256, U256};
+use ethrex_storage::Store;
+use ethrex_storage::error::StoreError;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::{RpcApiContext, RpcErr, RpcHandler};
+use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifierOrHash};
 
+/// `debug_accountRange` — paginated iteration over the state trie at a block,
+/// matching the shape documented at
+/// https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-accountrange.
+///
+/// Params: `[blockNrOrHash, txIndex, start, maxResults]`. The first parameter
+/// accepts a block number, a tag (`latest` / `earliest` / etc.), a 32-byte
+/// hash, or the EIP-1898 object form `{"blockHash": ...}` /
+/// `{"blockNumber": ...}`.
+///
+/// **Known divergences from geth**:
+///
+/// - `txIndex` is currently ignored — the response is always the state at the
+///   *end* of the given block (equivalent to geth's `txIndex == -1`). Returning
+///   the state immediately after the Nth transaction requires rebuilding the
+///   state trie root from an in-memory VM cache, which is a deferred feature.
+///   `code` / `storage` of the accounts are also not emitted; use `eth_getCode`
+///   / `eth_getStorageAt` for those. Consequently geth's `nocode`, `nostorage`,
+///   and `incompletes` booleans (params 5–7) are not implemented and not
+///   accepted — passing more than four parameters errors.
+/// - Account entries always have `key: null` because ethrex has no preimage
+///   store; callers wanting the original address must hash it themselves to
+///   look up by hashed address.
+///
+/// The trie traversal is wrapped in `tokio::task::spawn_blocking` because
+/// `iter_accounts_from` opens long-lived locked DB transactions and performs
+/// synchronous trie I/O.
 pub struct AccountRangeRequest {
-    block_hash: H256,
-    tx_index: usize,
+    block: BlockIdentifierOrHash,
+    /// Currently ignored — see type-level doc.
+    tx_index: i64,
     start: H256,
     max_results: usize,
 }
@@ -17,7 +46,8 @@ pub struct AccountRangeRequest {
 #[serde(rename_all = "camelCase")]
 struct AccountRangeResult {
     accounts: BTreeMap<H256, AccountEntry>,
-    #[serde(rename = "next")]
+    /// First hashed address NOT included in this page. All zeroes means the
+    /// iteration is complete (matches geth's sentinel).
     next: H256,
 }
 
@@ -28,7 +58,7 @@ struct AccountEntry {
     nonce: u64,
     root: H256,
     code_hash: H256,
-    /// The original (unhashed) address. Null when preimage is not available.
+    /// Original (unhashed) address. Always `null` — ethrex has no preimage store.
     key: Option<H256>,
 }
 
@@ -43,12 +73,15 @@ impl RpcHandler for AccountRangeRequest {
                 params.len()
             )));
         }
-        let block_hash: H256 = serde_json::from_value(params[0].clone())?;
-        let tx_index: usize = serde_json::from_value(params[1].clone())?;
-        let start: H256 = serde_json::from_value(params[2].clone())?;
-        let max_results: usize = serde_json::from_value(params[3].clone())?;
+        let block = BlockIdentifierOrHash::parse(params[0].clone(), 0)?;
+        let tx_index: i64 = serde_json::from_value(params[1].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid txIndex: {e}")))?;
+        let start: H256 = serde_json::from_value(params[2].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid start hash: {e}")))?;
+        let max_results: usize = serde_json::from_value(params[3].clone())
+            .map_err(|e| RpcErr::BadParams(format!("invalid maxResults: {e}")))?;
         Ok(AccountRangeRequest {
-            block_hash,
+            block,
             tx_index,
             start,
             max_results,
@@ -56,50 +89,71 @@ impl RpcHandler for AccountRangeRequest {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        let header = context
-            .storage
-            .get_block_header_by_hash(self.block_hash)?
-            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+        let header = self
+            .block
+            .resolve_block_header(&context.storage)
+            .await?
+            .ok_or_else(|| RpcErr::Internal("Block not found".to_string()))?;
 
-        let _ = self.tx_index; // TODO: re-execute up to tx_index for precise state
+        // `tx_index` is parsed and validated but not honoured yet. Negative
+        // values (geth's `-1` "end of block" sentinel) and any value >= the
+        // block's tx count are equivalent to "end of block" — which is what
+        // we always return, so no error needed. Other values would require
+        // mid-block state reconstruction; documented on the type.
+        let _ = self.tx_index;
 
-        let iter = context
-            .storage
-            .iter_accounts_from(header.state_root, self.start)
-            .map_err(|e| RpcErr::Internal(e.to_string()))?;
+        let state_root = header.state_root;
+        let start = self.start;
+        let max_results = self.max_results;
+        let storage = context.storage.clone();
 
-        let mut accounts = BTreeMap::new();
-        let mut next = H256::zero();
-
-        for (hashed_addr, account_state) in iter {
-            if accounts.len() >= self.max_results {
-                next = hashed_addr;
-                break;
-            }
-            accounts.insert(
-                hashed_addr,
-                AccountEntry {
-                    balance: account_state.balance,
-                    nonce: account_state.nonce,
-                    root: account_state.storage_root,
-                    code_hash: account_state.code_hash,
-                    key: None, // preimage not available
-                },
-            );
-        }
+        let (accounts, next) = tokio::task::spawn_blocking(move || {
+            collect_account_range(&storage, state_root, start, max_results)
+        })
+        .await
+        .map_err(|e| RpcErr::Internal(format!("accountRange task failed: {e}")))??;
 
         Ok(serde_json::to_value(AccountRangeResult { accounts, next })?)
     }
+}
+
+fn collect_account_range(
+    storage: &Store,
+    state_root: H256,
+    start: H256,
+    max_results: usize,
+) -> Result<(BTreeMap<H256, AccountEntry>, H256), StoreError> {
+    let iter = storage.iter_accounts_from(state_root, start)?;
+    let mut accounts = BTreeMap::new();
+    let mut next = H256::zero();
+    for (hashed_addr, account_state) in iter {
+        if accounts.len() >= max_results {
+            next = hashed_addr;
+            break;
+        }
+        accounts.insert(
+            hashed_addr,
+            AccountEntry {
+                balance: account_state.balance,
+                nonce: account_state.nonce,
+                root: account_state.storage_root,
+                code_hash: account_state.code_hash,
+                key: None,
+            },
+        );
+    }
+    Ok((accounts, next))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::RpcHandler;
+    use crate::types::block_identifier::BlockIdentifier;
     use serde_json::json;
 
     #[test]
-    fn parse_valid_params() {
+    fn parse_valid_params_by_hash() {
         let params = Some(vec![
             json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
             json!(0),
@@ -107,10 +161,38 @@ mod tests {
             json!(64),
         ]);
         let req = AccountRangeRequest::parse(&params).unwrap();
-        assert_eq!(req.block_hash, H256::from_low_u64_be(1));
+        assert!(matches!(req.block, BlockIdentifierOrHash::Hash(_)));
         assert_eq!(req.tx_index, 0);
         assert_eq!(req.start, H256::zero());
         assert_eq!(req.max_results, 64);
+    }
+
+    #[test]
+    fn parse_valid_params_by_number() {
+        let params = Some(vec![
+            json!("0xa"),
+            json!(-1),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(64),
+        ]);
+        let req = AccountRangeRequest::parse(&params).unwrap();
+        assert!(matches!(
+            req.block,
+            BlockIdentifierOrHash::Identifier(BlockIdentifier::Number(10))
+        ));
+        assert_eq!(req.tx_index, -1);
+    }
+
+    #[test]
+    fn parse_valid_params_by_tag() {
+        let params = Some(vec![
+            json!("latest"),
+            json!(0),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(64),
+        ]);
+        let req = AccountRangeRequest::parse(&params).unwrap();
+        assert!(matches!(req.block, BlockIdentifierOrHash::Identifier(_)));
     }
 
     #[test]

--- a/crates/networking/rpc/debug/account_range.rs
+++ b/crates/networking/rpc/debug/account_range.rs
@@ -91,3 +91,48 @@ impl RpcHandler for AccountRangeRequest {
         Ok(serde_json::to_value(AccountRangeResult { accounts, next })?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RpcHandler;
+    use serde_json::json;
+
+    #[test]
+    fn parse_valid_params() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!(0),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(64),
+        ]);
+        let req = AccountRangeRequest::parse(&params).unwrap();
+        assert_eq!(req.block_hash, H256::from_low_u64_be(1));
+        assert_eq!(req.tx_index, 0);
+        assert_eq!(req.start, H256::zero());
+        assert_eq!(req.max_results, 64);
+    }
+
+    #[test]
+    fn parse_no_params() {
+        assert!(AccountRangeRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_wrong_param_count() {
+        let params = Some(vec![json!("0x01"), json!(0)]);
+        assert!(AccountRangeRequest::parse(&params).is_err());
+    }
+
+    #[test]
+    fn parse_too_many_params() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!(0),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000000"),
+            json!(64),
+            json!("extra"),
+        ]);
+        assert!(AccountRangeRequest::parse(&params).is_err());
+    }
+}

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,5 @@
+pub mod account_range;
+pub mod block_access_list;
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,5 +1,4 @@
 pub mod account_range;
-pub mod block_access_list;
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1,6 +1,5 @@
 use crate::authentication::authenticate;
 use crate::debug::account_range::AccountRangeRequest;
-use crate::debug::block_access_list::BlockAccessListRequest;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1,4 +1,6 @@
 use crate::authentication::authenticate;
+use crate::debug::account_range::AccountRangeRequest;
+use crate::debug::block_access_list::BlockAccessListRequest;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
@@ -1155,6 +1157,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_accountRange" => AccountRangeRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/test/tests/rpc/debug_account_range_tests.rs
+++ b/test/tests/rpc/debug_account_range_tests.rs
@@ -1,0 +1,224 @@
+use ethrex_common::H256;
+use ethrex_storage::hash_address;
+use serde_json::{Value, json};
+
+use super::helpers::{rpc_call, rpc_call_expect_err, setup_single_transfer_block};
+
+async fn call_range(
+    store: &ethrex_storage::Store,
+    block_arg: Value,
+    start: H256,
+    max: u64,
+) -> Value {
+    rpc_call(
+        store,
+        "debug_accountRange",
+        vec![
+            block_arg,
+            json!(0),
+            json!(format!("{start:#x}")),
+            json!(max),
+        ],
+    )
+    .await
+}
+
+#[tokio::test]
+async fn account_range_returns_accounts_by_hash() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!(format!("{block_hash:#x}")),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            json!(1_000_u64),
+        ],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    let accounts = obj["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(!accounts.is_empty(), "should return accounts from state");
+
+    // Sender appears with its hashed address as key, and `key: null` per type doc.
+    let sender_hash = format!("{:#x}", H256::from_slice(&hash_address(&env.sender)));
+    let entry = accounts
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(&sender_hash))
+        .map(|(_, v)| v)
+        .expect("sender should appear in account range");
+    assert!(entry["key"].is_null(), "preimage is not stored");
+    assert!(entry["balance"].is_string());
+    assert!(entry["nonce"].is_number());
+}
+
+#[tokio::test]
+async fn account_range_by_block_number() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!(format!("{:#x}", env.block.header.number)),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            json!(1_000_u64),
+        ],
+    )
+    .await;
+
+    let accounts = result["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(!accounts.is_empty(), "block-number form should resolve");
+}
+
+#[tokio::test]
+async fn account_range_by_latest_tag() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!("latest"),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            json!(1_000_u64),
+        ],
+    )
+    .await;
+
+    let accounts = result["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(!accounts.is_empty(), "`latest` tag should resolve");
+}
+
+#[tokio::test]
+async fn account_range_completes_with_zero_next() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!(format!("{block_hash:#x}")),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            // Far more than any genesis state — must terminate.
+            json!(1_000_000_u64),
+        ],
+    )
+    .await;
+
+    let next = result["next"].as_str().expect("next must be a string");
+    assert_eq!(
+        next,
+        format!("{:#x}", H256::zero()),
+        "complete iteration must report all-zero next"
+    );
+}
+
+#[tokio::test]
+async fn account_range_paginates_via_next() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let first = call_range(
+        &env.store,
+        json!(format!("{block_hash:#x}")),
+        H256::zero(),
+        1,
+    )
+    .await;
+    let first_accounts = first["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert_eq!(first_accounts.len(), 1, "max=1 yields exactly one entry");
+    let next_str = first["next"].as_str().expect("next should be a string");
+    assert_ne!(
+        next_str,
+        format!("{:#x}", H256::zero()),
+        "truncated page must have non-zero next"
+    );
+    let next_hash: H256 = next_str.parse().unwrap();
+    let first_key = first_accounts.keys().next().unwrap().clone();
+
+    // Continue from the cursor.
+    let second = call_range(
+        &env.store,
+        json!(format!("{block_hash:#x}")),
+        next_hash,
+        1_000_000,
+    )
+    .await;
+    let second_accounts = second["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(
+        !second_accounts.is_empty(),
+        "continuation page must return remaining accounts"
+    );
+    assert!(
+        !second_accounts.contains_key(&first_key),
+        "continuation must not repeat the first page's account"
+    );
+    assert_eq!(
+        second["next"].as_str().unwrap(),
+        format!("{:#x}", H256::zero()),
+        "second page should complete the iteration"
+    );
+}
+
+#[tokio::test]
+async fn account_range_invalid_block_hash_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!(format!("{:#x}", H256::from_low_u64_be(0xdeadbeef))),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            json!(1_u64),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Block not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn account_range_unknown_block_number_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!(format!("{:#x}", env.block.header.number + 1_000)),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            json!(1_u64),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Block not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,186 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn account_range() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_accountRange",
+        vec![
+            json!(format!("{block_hash:#x}")),
+            json!(0),
+            json!(format!("{:#x}", H256::zero())),
+            json!(10),
+        ],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.contains_key("accounts"), "should have 'accounts'");
+    assert!(obj.contains_key("next"), "should have 'next'");
+
+    let accounts = obj["accounts"].as_object().expect("accounts should be an object");
+    assert!(!accounts.is_empty(), "should return some accounts from genesis state");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn account_range() {
@@ -181,6 +185,11 @@ async fn account_range() {
     assert!(obj.contains_key("accounts"), "should have 'accounts'");
     assert!(obj.contains_key("next"), "should have 'next'");
 
-    let accounts = obj["accounts"].as_object().expect("accounts should be an object");
-    assert!(!accounts.is_empty(), "should return some accounts from genesis state");
+    let accounts = obj["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(
+        !accounts.is_empty(),
+        "should return some accounts from genesis state"
+    );
 }

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -15,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +113,7 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +137,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,35 +186,6 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
-}
-
-#[tokio::test]
-async fn account_range() {
-    let env = setup_single_transfer_block().await;
-    let block_hash = env.block.hash();
-
-    let result = rpc_call(
-        &env.store,
-        "debug_accountRange",
-        vec![
-            json!(format!("{block_hash:#x}")),
-            json!(0),
-            json!(format!("{:#x}", H256::zero())),
-            json!(10),
-        ],
-    )
-    .await;
-
-    let obj = result.as_object().expect("response should be an object");
-    assert!(obj.contains_key("accounts"), "should have 'accounts'");
-    assert!(obj.contains_key("next"), "should have 'next'");
-
-    let accounts = obj["accounts"]
-        .as_object()
-        .expect("accounts should be an object");
-    assert!(
-        !accounts.is_empty(),
-        "should return some accounts from genesis state"
-    );
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_account_range_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_account_range_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Adds `debug_accountRange` which iterates accounts in the state trie from a given starting hash
- Returns up to `maxResults` entries with a `next` hash for pagination
- Each entry includes balance, nonce, storage root, and code hash
- Uses block's final state root; txIndex-based reconstruction is a future enhancement
- Matches [geth's debug_accountRange](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debug-accountrange)

Closes part of #6572

## Test plan
- [ ] Returns account entries starting from a given hash
- [ ] Pagination via `next` field works correctly
- [ ] Returns all-zero `next` when no more accounts
- [ ] Invalid block hash returns error

Closes #6649