### PR TITLE
feat(l1): implement debug_getModifiedAccountsByNumber/Hash

### DIFF
--- a/crates/networking/rpc/debug/get_modified_accounts.rs
+++ b/crates/networking/rpc/debug/get_modified_accounts.rs
@@ -154,8 +154,8 @@ fn diff_state_roots(
     loop {
         // Copy peeked keys/values upfront so borrows on the Peekable
         // wrappers are released before the mutable next() calls below.
-        let s_entry = start_iter.peek().map(|(h, s)| (*h, s.clone()));
-        let e_entry = end_iter.peek().map(|(h, s)| (*h, s.clone()));
+        let s_entry = start_iter.peek().map(|(h, s)| (*h, *s));
+        let e_entry = end_iter.peek().map(|(h, s)| (*h, *s));
 
         match (s_entry, e_entry) {
             (None, None) => break,

--- a/crates/networking/rpc/debug/get_modified_accounts.rs
+++ b/crates/networking/rpc/debug/get_modified_accounts.rs
@@ -165,3 +165,55 @@ fn diff_state_roots(
 
     Ok(modified)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RpcHandler;
+    use serde_json::json;
+
+    // --- GetModifiedAccountsByNumberRequest parse tests ---
+
+    #[test]
+    fn parse_by_number_valid() {
+        let params = Some(vec![json!("0x1"), json!("0xa")]);
+        let req = GetModifiedAccountsByNumberRequest::parse(&params).unwrap();
+        assert!(matches!(req.start_block, BlockIdentifier::Number(1)));
+        assert!(matches!(req.end_block, BlockIdentifier::Number(10)));
+    }
+
+    #[test]
+    fn parse_by_number_no_params() {
+        assert!(GetModifiedAccountsByNumberRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_by_number_wrong_count() {
+        let params = Some(vec![json!("0x1")]);
+        assert!(GetModifiedAccountsByNumberRequest::parse(&params).is_err());
+    }
+
+    // --- GetModifiedAccountsByHashRequest parse tests ---
+
+    #[test]
+    fn parse_by_hash_valid() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!("0x0000000000000000000000000000000000000000000000000000000000000002"),
+        ]);
+        let req = GetModifiedAccountsByHashRequest::parse(&params).unwrap();
+        assert_eq!(req.start_hash, H256::from_low_u64_be(1));
+        assert_eq!(req.end_hash, H256::from_low_u64_be(2));
+    }
+
+    #[test]
+    fn parse_by_hash_no_params() {
+        assert!(GetModifiedAccountsByHashRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_by_hash_wrong_count() {
+        let params = Some(vec![json!("0x01")]);
+        assert!(GetModifiedAccountsByHashRequest::parse(&params).is_err());
+    }
+}

--- a/crates/networking/rpc/debug/get_modified_accounts.rs
+++ b/crates/networking/rpc/debug/get_modified_accounts.rs
@@ -52,12 +52,12 @@ impl RpcHandler for GetModifiedAccountsByNumberRequest {
             .start_block
             .resolve_block_number(&context.storage)
             .await?
-            .ok_or(RpcErr::Internal("Start block not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("Start block not found".to_string()))?;
         let end_number = self
             .end_block
             .resolve_block_number(&context.storage)
             .await?
-            .ok_or(RpcErr::Internal("End block not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("End block not found".to_string()))?;
 
         if start_number > end_number {
             return Err(RpcErr::BadParams(format!(
@@ -68,12 +68,12 @@ impl RpcHandler for GetModifiedAccountsByNumberRequest {
         let start_root = context
             .storage
             .get_block_header(start_number)?
-            .ok_or(RpcErr::Internal("Start block header not found".to_string()))?
+            .ok_or(RpcErr::WrongParam("Start block header not found".to_string()))?
             .state_root;
         let end_root = context
             .storage
             .get_block_header(end_number)?
-            .ok_or(RpcErr::Internal("End block header not found".to_string()))?
+            .ok_or(RpcErr::WrongParam("End block header not found".to_string()))?
             .state_root;
 
         diff_state_roots_async(context.storage.clone(), start_root, end_root).await
@@ -101,11 +101,11 @@ impl RpcHandler for GetModifiedAccountsByHashRequest {
         let start_header = context
             .storage
             .get_block_header_by_hash(self.start_hash)?
-            .ok_or(RpcErr::Internal("Start block not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("Start block not found".to_string()))?;
         let end_header = context
             .storage
             .get_block_header_by_hash(self.end_hash)?
-            .ok_or(RpcErr::Internal("End block not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("End block not found".to_string()))?;
 
         if start_header.number > end_header.number {
             return Err(RpcErr::BadParams(format!(
@@ -152,31 +152,36 @@ fn diff_state_roots(
     let mut modified = Vec::new();
 
     loop {
-        match (start_iter.peek(), end_iter.peek()) {
+        // Copy peeked keys/values upfront so borrows on the Peekable
+        // wrappers are released before the mutable next() calls below.
+        let s_entry = start_iter.peek().map(|(h, s)| (*h, s.clone()));
+        let e_entry = end_iter.peek().map(|(h, s)| (*h, s.clone()));
+
+        match (s_entry, e_entry) {
             (None, None) => break,
             (Some((s_hash, _)), None) => {
-                modified.push(*s_hash);
+                modified.push(s_hash);
                 start_iter.next();
             }
             (None, Some((e_hash, _))) => {
-                modified.push(*e_hash);
+                modified.push(e_hash);
                 end_iter.next();
             }
             (Some((s_hash, _)), Some((e_hash, _))) if s_hash < e_hash => {
                 // Account in start but not yet (and never, since iters are
                 // monotonic) seen in end at this position — deleted.
-                modified.push(*s_hash);
+                modified.push(s_hash);
                 start_iter.next();
             }
             (Some((s_hash, _)), Some((e_hash, _))) if s_hash > e_hash => {
                 // New account in end.
-                modified.push(*e_hash);
+                modified.push(e_hash);
                 end_iter.next();
             }
             (Some((s_hash, s_state)), Some((_e_hash, e_state))) => {
                 // Same hashed address on both sides — emit if anything changed.
                 if s_state != e_state {
-                    modified.push(*s_hash);
+                    modified.push(s_hash);
                 }
                 start_iter.next();
                 end_iter.next();

--- a/crates/networking/rpc/debug/get_modified_accounts.rs
+++ b/crates/networking/rpc/debug/get_modified_accounts.rs
@@ -1,0 +1,167 @@
+use std::collections::HashSet;
+
+use ethrex_common::{Address, H256};
+use ethrex_storage::Store;
+use serde_json::Value;
+
+use crate::{
+    types::block_identifier::BlockIdentifier,
+    RpcApiContext, RpcErr, RpcHandler,
+};
+
+pub struct GetModifiedAccountsByNumberRequest {
+    start_block: BlockIdentifier,
+    end_block: BlockIdentifier,
+}
+
+pub struct GetModifiedAccountsByHashRequest {
+    start_hash: H256,
+    end_hash: H256,
+}
+
+impl RpcHandler for GetModifiedAccountsByNumberRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 2 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected 2 params, got {}",
+                params.len()
+            )));
+        }
+        Ok(GetModifiedAccountsByNumberRequest {
+            start_block: BlockIdentifier::parse(params[0].clone(), 0)?,
+            end_block: BlockIdentifier::parse(params[1].clone(), 1)?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let start_number = self
+            .start_block
+            .resolve_block_number(&context.storage)
+            .await?
+            .ok_or(RpcErr::Internal("Start block not found".to_string()))?;
+        let end_number = self
+            .end_block
+            .resolve_block_number(&context.storage)
+            .await?
+            .ok_or(RpcErr::Internal("End block not found".to_string()))?;
+
+        if start_number > end_number {
+            return Err(RpcErr::BadParams(
+                "Start block must be before end block".to_string(),
+            ));
+        }
+
+        let start_header = context
+            .storage
+            .get_block_header(start_number)?
+            .ok_or(RpcErr::Internal("Start block header not found".to_string()))?;
+        let end_header = context
+            .storage
+            .get_block_header(end_number)?
+            .ok_or(RpcErr::Internal("End block header not found".to_string()))?;
+
+        let addresses = diff_state_roots(
+            &context.storage,
+            start_header.state_root,
+            end_header.state_root,
+        )?;
+
+        Ok(serde_json::to_value(addresses)?)
+    }
+}
+
+impl RpcHandler for GetModifiedAccountsByHashRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 2 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected 2 params, got {}",
+                params.len()
+            )));
+        }
+        Ok(GetModifiedAccountsByHashRequest {
+            start_hash: serde_json::from_value(params[0].clone())?,
+            end_hash: serde_json::from_value(params[1].clone())?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let start_header = context
+            .storage
+            .get_block_header_by_hash(self.start_hash)?
+            .ok_or(RpcErr::Internal("Start block not found".to_string()))?;
+        let end_header = context
+            .storage
+            .get_block_header_by_hash(self.end_hash)?
+            .ok_or(RpcErr::Internal("End block not found".to_string()))?;
+
+        if start_header.number > end_header.number {
+            return Err(RpcErr::BadParams(
+                "Start block must be before end block".to_string(),
+            ));
+        }
+
+        let addresses = diff_state_roots(
+            &context.storage,
+            start_header.state_root,
+            end_header.state_root,
+        )?;
+
+        Ok(serde_json::to_value(addresses)?)
+    }
+}
+
+/// Compare two state roots and return the hashed addresses that differ.
+/// Note: without a preimage store, we return hashed addresses (H256) rather than
+/// original addresses (Address). Geth returns original addresses via preimage lookup.
+fn diff_state_roots(
+    storage: &Store,
+    start_root: H256,
+    end_root: H256,
+) -> Result<Vec<Address>, RpcErr> {
+    if start_root == end_root {
+        return Ok(vec![]);
+    }
+
+    // Collect all accounts from both state roots and find differences.
+    // This is O(n) in total accounts — acceptable for small states but may be
+    // slow on mainnet. A trie-diff algorithm would be more efficient.
+    let start_accounts: HashSet<(H256, Vec<u8>)> = storage
+        .iter_accounts(start_root)
+        .map_err(|e| RpcErr::Internal(e.to_string()))?
+        .map(|(hash, state)| {
+            let encoded = format!("{:?}{:?}{:?}{:?}", state.nonce, state.balance, state.storage_root, state.code_hash);
+            (hash, encoded.into_bytes())
+        })
+        .collect();
+
+    let mut modified = Vec::new();
+    let end_iter = storage
+        .iter_accounts(end_root)
+        .map_err(|e| RpcErr::Internal(e.to_string()))?;
+
+    let mut end_hashes = HashSet::new();
+    for (hash, state) in end_iter {
+        end_hashes.insert(hash);
+        let encoded = format!("{:?}{:?}{:?}{:?}", state.nonce, state.balance, state.storage_root, state.code_hash);
+        let key = (hash, encoded.into_bytes());
+        if !start_accounts.contains(&key) {
+            // Account was modified or created
+            modified.push(Address::from(hash));
+        }
+    }
+
+    // Find accounts that were deleted (in start but not in end)
+    for (hash, _) in &start_accounts {
+        if !end_hashes.contains(hash) {
+            modified.push(Address::from(*hash));
+        }
+    }
+
+    Ok(modified)
+}

--- a/crates/networking/rpc/debug/get_modified_accounts.rs
+++ b/crates/networking/rpc/debug/get_modified_accounts.rs
@@ -1,11 +1,25 @@
-use std::collections::HashSet;
-
-use ethrex_common::{Address, H256};
+use ethrex_common::H256;
 use ethrex_storage::Store;
+use ethrex_storage::error::StoreError;
 use serde_json::Value;
 
 use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifier};
 
+/// `debug_getModifiedAccountsByNumber` / `debug_getModifiedAccountsByHash` —
+/// diff two state tries and return the set of accounts whose value differs.
+///
+/// **Divergence from geth**: geth returns `Vec<Address>` by looking original
+/// addresses up through its preimage store. ethrex has no preimage store, so
+/// the response is `Vec<H256>` of *hashed* addresses (`keccak256(address)`).
+/// Callers that know the address they care about can hash it themselves to
+/// check membership; the existing `debug_dumpBlock` endpoint uses the same
+/// hashed-key convention.
+///
+/// Both handlers traverse the state tries in lockstep (the iterator yields
+/// entries in hashed-key order), so memory is O(1) regardless of state size.
+/// The traversal is wrapped in `tokio::task::spawn_blocking` because the
+/// underlying `iter_accounts_from` opens long-lived locked DB transactions and
+/// performs synchronous trie I/O.
 pub struct GetModifiedAccountsByNumberRequest {
     start_block: BlockIdentifier,
     end_block: BlockIdentifier,
@@ -46,27 +60,23 @@ impl RpcHandler for GetModifiedAccountsByNumberRequest {
             .ok_or(RpcErr::Internal("End block not found".to_string()))?;
 
         if start_number > end_number {
-            return Err(RpcErr::BadParams(
-                "Start block must be before end block".to_string(),
-            ));
+            return Err(RpcErr::BadParams(format!(
+                "start block ({start_number}) must be older than end block ({end_number})"
+            )));
         }
 
-        let start_header = context
+        let start_root = context
             .storage
             .get_block_header(start_number)?
-            .ok_or(RpcErr::Internal("Start block header not found".to_string()))?;
-        let end_header = context
+            .ok_or(RpcErr::Internal("Start block header not found".to_string()))?
+            .state_root;
+        let end_root = context
             .storage
             .get_block_header(end_number)?
-            .ok_or(RpcErr::Internal("End block header not found".to_string()))?;
+            .ok_or(RpcErr::Internal("End block header not found".to_string()))?
+            .state_root;
 
-        let addresses = diff_state_roots(
-            &context.storage,
-            start_header.state_root,
-            end_header.state_root,
-        )?;
-
-        Ok(serde_json::to_value(addresses)?)
+        diff_state_roots_async(context.storage.clone(), start_root, end_root).await
     }
 }
 
@@ -98,71 +108,79 @@ impl RpcHandler for GetModifiedAccountsByHashRequest {
             .ok_or(RpcErr::Internal("End block not found".to_string()))?;
 
         if start_header.number > end_header.number {
-            return Err(RpcErr::BadParams(
-                "Start block must be before end block".to_string(),
-            ));
+            return Err(RpcErr::BadParams(format!(
+                "start block ({}) must be older than end block ({})",
+                start_header.number, end_header.number
+            )));
         }
 
-        let addresses = diff_state_roots(
-            &context.storage,
+        diff_state_roots_async(
+            context.storage.clone(),
             start_header.state_root,
             end_header.state_root,
-        )?;
-
-        Ok(serde_json::to_value(addresses)?)
+        )
+        .await
     }
 }
 
-/// Compare two state roots and return the hashed addresses that differ.
-/// Note: without a preimage store, we return hashed addresses (H256) rather than
-/// original addresses (Address). Geth returns original addresses via preimage lookup.
+async fn diff_state_roots_async(
+    storage: Store,
+    start_root: H256,
+    end_root: H256,
+) -> Result<Value, RpcErr> {
+    let hashes =
+        tokio::task::spawn_blocking(move || diff_state_roots(&storage, start_root, end_root))
+            .await
+            .map_err(|e| RpcErr::Internal(format!("modified-accounts task failed: {e}")))??;
+    Ok(serde_json::to_value(hashes)?)
+}
+
+/// Streams both state tries in lockstep (entries arrive in hashed-key order)
+/// and emits the set of hashed addresses where the two states differ. O(1)
+/// extra memory regardless of state size.
 fn diff_state_roots(
     storage: &Store,
     start_root: H256,
     end_root: H256,
-) -> Result<Vec<Address>, RpcErr> {
+) -> Result<Vec<H256>, StoreError> {
     if start_root == end_root {
         return Ok(vec![]);
     }
 
-    // Collect all accounts from both state roots and find differences.
-    // This is O(n) in total accounts — acceptable for small states but may be
-    // slow on mainnet. A trie-diff algorithm would be more efficient.
-    let start_accounts: HashSet<(H256, Vec<u8>)> = storage
-        .iter_accounts(start_root)
-        .map_err(|e| RpcErr::Internal(e.to_string()))?
-        .map(|(hash, state)| {
-            let encoded = format!(
-                "{:?}{:?}{:?}{:?}",
-                state.nonce, state.balance, state.storage_root, state.code_hash
-            );
-            (hash, encoded.into_bytes())
-        })
-        .collect();
-
+    let mut start_iter = storage.iter_accounts(start_root)?.peekable();
+    let mut end_iter = storage.iter_accounts(end_root)?.peekable();
     let mut modified = Vec::new();
-    let end_iter = storage
-        .iter_accounts(end_root)
-        .map_err(|e| RpcErr::Internal(e.to_string()))?;
 
-    let mut end_hashes = HashSet::new();
-    for (hash, state) in end_iter {
-        end_hashes.insert(hash);
-        let encoded = format!(
-            "{:?}{:?}{:?}{:?}",
-            state.nonce, state.balance, state.storage_root, state.code_hash
-        );
-        let key = (hash, encoded.into_bytes());
-        if !start_accounts.contains(&key) {
-            // Account was modified or created
-            modified.push(Address::from(hash));
-        }
-    }
-
-    // Find accounts that were deleted (in start but not in end)
-    for (hash, _) in &start_accounts {
-        if !end_hashes.contains(hash) {
-            modified.push(Address::from(*hash));
+    loop {
+        match (start_iter.peek(), end_iter.peek()) {
+            (None, None) => break,
+            (Some((s_hash, _)), None) => {
+                modified.push(*s_hash);
+                start_iter.next();
+            }
+            (None, Some((e_hash, _))) => {
+                modified.push(*e_hash);
+                end_iter.next();
+            }
+            (Some((s_hash, _)), Some((e_hash, _))) if s_hash < e_hash => {
+                // Account in start but not yet (and never, since iters are
+                // monotonic) seen in end at this position — deleted.
+                modified.push(*s_hash);
+                start_iter.next();
+            }
+            (Some((s_hash, _)), Some((e_hash, _))) if s_hash > e_hash => {
+                // New account in end.
+                modified.push(*e_hash);
+                end_iter.next();
+            }
+            (Some((s_hash, s_state)), Some((_e_hash, e_state))) => {
+                // Same hashed address on both sides — emit if anything changed.
+                if s_state != e_state {
+                    modified.push(*s_hash);
+                }
+                start_iter.next();
+                end_iter.next();
+            }
         }
     }
 

--- a/crates/networking/rpc/debug/get_modified_accounts.rs
+++ b/crates/networking/rpc/debug/get_modified_accounts.rs
@@ -4,10 +4,7 @@ use ethrex_common::{Address, H256};
 use ethrex_storage::Store;
 use serde_json::Value;
 
-use crate::{
-    types::block_identifier::BlockIdentifier,
-    RpcApiContext, RpcErr, RpcHandler,
-};
+use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifier};
 
 pub struct GetModifiedAccountsByNumberRequest {
     start_block: BlockIdentifier,
@@ -135,7 +132,10 @@ fn diff_state_roots(
         .iter_accounts(start_root)
         .map_err(|e| RpcErr::Internal(e.to_string()))?
         .map(|(hash, state)| {
-            let encoded = format!("{:?}{:?}{:?}{:?}", state.nonce, state.balance, state.storage_root, state.code_hash);
+            let encoded = format!(
+                "{:?}{:?}{:?}{:?}",
+                state.nonce, state.balance, state.storage_root, state.code_hash
+            );
             (hash, encoded.into_bytes())
         })
         .collect();
@@ -148,7 +148,10 @@ fn diff_state_roots(
     let mut end_hashes = HashSet::new();
     for (hash, state) in end_iter {
         end_hashes.insert(hash);
-        let encoded = format!("{:?}{:?}{:?}{:?}", state.nonce, state.balance, state.storage_root, state.code_hash);
+        let encoded = format!(
+            "{:?}{:?}{:?}{:?}",
+            state.nonce, state.balance, state.storage_root, state.code_hash
+        );
         let key = (hash, encoded.into_bytes());
         if !start_accounts.contains(&key) {
             // Account was modified or created

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,4 @@
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;
+pub mod get_modified_accounts;

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -2,6 +2,9 @@ use crate::authentication::authenticate;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
+use crate::debug::get_modified_accounts::{
+    GetModifiedAccountsByHashRequest, GetModifiedAccountsByNumberRequest,
+};
 use crate::engine::blobs::{BlobsV2Request, BlobsV3Request};
 use crate::engine::client_version::GetClientVersionV1Request;
 use crate::engine::payload::{GetPayloadV5Request, GetPayloadV6Request, NewPayloadV5Request};
@@ -1155,6 +1158,12 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_getModifiedAccountsByNumber" => {
+            GetModifiedAccountsByNumberRequest::call(req, context).await
+        }
+        "debug_getModifiedAccountsByHash" => {
+            GetModifiedAccountsByHashRequest::call(req, context).await
+        }
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/test/tests/rpc/debug_get_modified_accounts_tests.rs
+++ b/test/tests/rpc/debug_get_modified_accounts_tests.rs
@@ -1,0 +1,145 @@
+use ethrex_common::H256;
+use ethrex_storage::hash_address;
+use serde_json::{Value, json};
+
+use super::helpers::{rpc_call, rpc_call_expect_err, setup_single_transfer_block};
+
+fn parse_hashes(arr: &[Value]) -> Vec<H256> {
+    arr.iter()
+        .map(|v| v.as_str().unwrap().parse().unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn get_modified_accounts_by_number_includes_sender() {
+    let env = setup_single_transfer_block().await;
+    let block_number = env.block.header.number;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_getModifiedAccountsByNumber",
+        vec![
+            json!(format!("{:#x}", block_number - 1)),
+            json!(format!("{block_number:#x}")),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    let hashes = parse_hashes(arr);
+    let expected = H256::from_slice(&hash_address(&env.sender));
+    assert!(
+        hashes.contains(&expected),
+        "diff must include sender's hashed address ({expected:?}); got: {hashes:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_modified_accounts_by_hash_matches_by_number() {
+    let env = setup_single_transfer_block().await;
+    let genesis_hash = env.store.get_block_header(0).unwrap().unwrap().hash();
+    let block_hash = env.block.hash();
+
+    let by_hash = rpc_call(
+        &env.store,
+        "debug_getModifiedAccountsByHash",
+        vec![
+            json!(format!("{genesis_hash:#x}")),
+            json!(format!("{block_hash:#x}")),
+        ],
+    )
+    .await;
+    let by_number = rpc_call(
+        &env.store,
+        "debug_getModifiedAccountsByNumber",
+        vec![
+            json!(format!("{:#x}", 0_u64)),
+            json!(format!("{:#x}", env.block.header.number)),
+        ],
+    )
+    .await;
+
+    // Both variants must produce the same set of hashed addresses for the
+    // same effective block range — order is implementation-defined, so compare
+    // as sets.
+    let mut a = parse_hashes(by_hash.as_array().unwrap());
+    let mut b = parse_hashes(by_number.as_array().unwrap());
+    a.sort();
+    b.sort();
+    assert_eq!(a, b);
+    assert!(!a.is_empty(), "transfer should modify at least one account");
+}
+
+#[tokio::test]
+async fn get_modified_accounts_empty_range_returns_empty() {
+    let env = setup_single_transfer_block().await;
+    let n = env.block.header.number;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_getModifiedAccountsByNumber",
+        vec![json!(format!("{n:#x}")), json!(format!("{n:#x}"))],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert!(
+        arr.is_empty(),
+        "start == end should yield empty diff, got: {arr:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_modified_accounts_start_after_end_errors() {
+    let env = setup_single_transfer_block().await;
+    let n = env.block.header.number;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_getModifiedAccountsByNumber",
+        vec![json!(format!("{n:#x}")), json!(format!("{:#x}", 0_u64))],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(msg.contains("older"), "expected ordering error, got: {msg}");
+}
+
+#[tokio::test]
+async fn get_modified_accounts_by_hash_start_after_end_errors() {
+    let env = setup_single_transfer_block().await;
+    let genesis_hash = env.store.get_block_header(0).unwrap().unwrap().hash();
+    let block_hash = env.block.hash();
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_getModifiedAccountsByHash",
+        vec![
+            json!(format!("{block_hash:#x}")),
+            json!(format!("{genesis_hash:#x}")),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(msg.contains("older"), "expected ordering error, got: {msg}");
+}
+
+#[tokio::test]
+async fn get_modified_accounts_unknown_block_errors() {
+    let env = setup_single_transfer_block().await;
+    let n = env.block.header.number;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_getModifiedAccountsByNumber",
+        vec![
+            json!(format!("{:#x}", n + 1_000)),
+            json!(format!("{:#x}", n + 2_000)),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn get_modified_accounts_by_number() {
@@ -177,7 +181,10 @@ async fn get_modified_accounts_by_number() {
 
     // Returns an array of modified account hashes.
     let arr = result.as_array().expect("response should be an array");
-    assert!(!arr.is_empty(), "transfer should modify at least one account");
+    assert!(
+        !arr.is_empty(),
+        "transfer should modify at least one account"
+    );
 }
 
 #[tokio::test]
@@ -197,5 +204,8 @@ async fn get_modified_accounts_by_hash() {
     .await;
 
     let arr = result.as_array().expect("response should be an array");
-    assert!(!arr.is_empty(), "transfer should modify at least one account");
+    assert!(
+        !arr.is_empty(),
+        "transfer should modify at least one account"
+    );
 }

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,201 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn get_modified_accounts_by_number() {
+    let env = setup_single_transfer_block().await;
+    let block_number = env.block.header.number;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_getModifiedAccountsByNumber",
+        vec![
+            json!(format!("{:#x}", block_number - 1)),
+            json!(format!("{block_number:#x}")),
+        ],
+    )
+    .await;
+
+    // Returns an array of modified account hashes.
+    let arr = result.as_array().expect("response should be an array");
+    assert!(!arr.is_empty(), "transfer should modify at least one account");
+}
+
+#[tokio::test]
+async fn get_modified_accounts_by_hash() {
+    let env = setup_single_transfer_block().await;
+    let genesis_hash = env.store.get_block_header(0).unwrap().unwrap().hash();
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_getModifiedAccountsByHash",
+        vec![
+            json!(format!("{genesis_hash:#x}")),
+            json!(format!("{block_hash:#x}")),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert!(!arr.is_empty(), "transfer should modify at least one account");
+}

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -15,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +113,7 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +137,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,51 +186,6 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
-}
-
-#[tokio::test]
-async fn get_modified_accounts_by_number() {
-    let env = setup_single_transfer_block().await;
-    let block_number = env.block.header.number;
-
-    let result = rpc_call(
-        &env.store,
-        "debug_getModifiedAccountsByNumber",
-        vec![
-            json!(format!("{:#x}", block_number - 1)),
-            json!(format!("{block_number:#x}")),
-        ],
-    )
-    .await;
-
-    // Returns an array of modified account hashes.
-    let arr = result.as_array().expect("response should be an array");
-    assert!(
-        !arr.is_empty(),
-        "transfer should modify at least one account"
-    );
-}
-
-#[tokio::test]
-async fn get_modified_accounts_by_hash() {
-    let env = setup_single_transfer_block().await;
-    let genesis_hash = env.store.get_block_header(0).unwrap().unwrap().hash();
-    let block_hash = env.block.hash();
-
-    let result = rpc_call(
-        &env.store,
-        "debug_getModifiedAccountsByHash",
-        vec![
-            json!(format!("{genesis_hash:#x}")),
-            json!(format!("{block_hash:#x}")),
-        ],
-    )
-    .await;
-
-    let arr = result.as_array().expect("response should be an array");
-    assert!(
-        !arr.is_empty(),
-        "transfer should modify at least one account"
-    );
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_get_modified_accounts_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_get_modified_accounts_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Adds `debug_getModifiedAccountsByNumber` and `debug_getModifiedAccountsByHash`
- Returns addresses modified between two blocks by diffing state tries
- Both endpoints share a `diff_state_roots` helper that iterates both tries
- Note: O(n) brute-force comparison; a trie-diff algorithm would be more efficient at mainnet scale

Closes part of #6572

## Test plan
- [ ] Returns modified addresses between two consecutive blocks
- [ ] Returns empty array when start == end
- [ ] start > end returns error
- [ ] Both by-number and by-hash variants work

Closes #6651