### PR TITLE
feat(l1): implement debug_dumpBlock endpoint

### DIFF
--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -100,11 +100,11 @@ impl RpcHandler for DumpBlockRequest {
             .block
             .resolve_block_number(&context.storage)
             .await?
-            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("Block not found".to_string()))?;
         let header = context
             .storage
             .get_block_header(block_number)?
-            .ok_or(RpcErr::Internal("Block header not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("Block header not found".to_string()))?;
 
         let state_root = header.state_root;
         let start = self.config.start.unwrap_or_else(H256::zero);

--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -7,11 +7,16 @@ use serde_json::Value;
 
 use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifier};
 
-/// Default cap on accounts emitted by `debug_dumpBlock` when the caller does
-/// not specify `maxResults`. Picked to bound response size on large states —
-/// geth's `debug_dumpBlock` is unbounded; ethrex diverges here to protect the
-/// RPC server. Callers wanting more can paginate via the config object.
+/// Default number of accounts emitted by `debug_dumpBlock` when the caller does
+/// not specify `maxResults`. Callers wanting more can paginate via the `start`
+/// cursor in the config object.
 const DEFAULT_MAX_RESULTS: usize = 100_000;
+
+/// Hard ceiling on `maxResults` — callers cannot exceed this even via an
+/// explicit parameter. Picked to bound response size on large states; geth's
+/// `debug_dumpBlock` is unbounded, ethrex diverges here to protect the RPC
+/// server from unbounded in-memory responses.
+const MAX_RESULTS_CEILING: usize = 100_000;
 
 /// `debug_dumpBlock` — geth-compatible state-trie dump at a given block.
 ///
@@ -30,7 +35,7 @@ const DEFAULT_MAX_RESULTS: usize = 100_000;
 ///   `eth_getStorageAt` for those.
 /// - `balance` is serialized as a hex string (`"0x..."`) whereas geth uses a
 ///   decimal string. Callers parsing the balance field should handle both.
-/// - `maxResults` is clamped to [`DEFAULT_MAX_RESULTS`] even if the caller
+/// - `maxResults` is clamped to [`MAX_RESULTS_CEILING`] even if the caller
 ///   provides a larger value, to protect the RPC server from unbounded
 ///   responses. Pass `{"start": ..., "maxResults": ...}` to page through
 ///   larger states.
@@ -112,7 +117,7 @@ impl RpcHandler for DumpBlockRequest {
             .config
             .max_results
             .unwrap_or(DEFAULT_MAX_RESULTS)
-            .min(DEFAULT_MAX_RESULTS);
+            .min(MAX_RESULTS_CEILING);
         let storage = context.storage.clone();
 
         // The trie iterator opens long-lived locked DB transactions and walks

--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -1,0 +1,82 @@
+use std::collections::BTreeMap;
+
+use ethrex_common::{H256, U256};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{
+    types::block_identifier::BlockIdentifier,
+    RpcApiContext, RpcErr, RpcHandler,
+};
+
+pub struct DumpBlockRequest {
+    block: BlockIdentifier,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DumpResult {
+    root: H256,
+    accounts: BTreeMap<H256, DumpAccount>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DumpAccount {
+    balance: U256,
+    nonce: u64,
+    root: H256,
+    code_hash: H256,
+}
+
+impl RpcHandler for DumpBlockRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected 1 param, got {}",
+                params.len()
+            )));
+        }
+        Ok(DumpBlockRequest {
+            block: BlockIdentifier::parse(params[0].clone(), 0)?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let block_number = self
+            .block
+            .resolve_block_number(&context.storage)
+            .await?
+            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+        let header = context
+            .storage
+            .get_block_header(block_number)?
+            .ok_or(RpcErr::Internal("Block header not found".to_string()))?;
+
+        let iter = context
+            .storage
+            .iter_accounts(header.state_root)
+            .map_err(|e| RpcErr::Internal(e.to_string()))?;
+
+        let mut accounts = BTreeMap::new();
+        for (hashed_addr, account_state) in iter {
+            accounts.insert(
+                hashed_addr,
+                DumpAccount {
+                    balance: account_state.balance,
+                    nonce: account_state.nonce,
+                    root: account_state.storage_root,
+                    code_hash: account_state.code_hash,
+                },
+            );
+        }
+
+        Ok(serde_json::to_value(DumpResult {
+            root: header.state_root,
+            accounts,
+        })?)
+    }
+}

--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -80,3 +80,38 @@ impl RpcHandler for DumpBlockRequest {
         })?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RpcHandler;
+    use serde_json::json;
+
+    #[test]
+    fn parse_block_number() {
+        let params = Some(vec![json!("0xa")]);
+        let req = DumpBlockRequest::parse(&params).unwrap();
+        assert!(matches!(req.block, BlockIdentifier::Number(10)));
+    }
+
+    #[test]
+    fn parse_latest_tag() {
+        let params = Some(vec![json!("latest")]);
+        let req = DumpBlockRequest::parse(&params).unwrap();
+        assert!(matches!(
+            req.block,
+            BlockIdentifier::Tag(crate::types::block_identifier::BlockTag::Latest)
+        ));
+    }
+
+    #[test]
+    fn parse_no_params() {
+        assert!(DumpBlockRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_too_many_params() {
+        let params = Some(vec![json!("0x1"), json!("extra")]);
+        assert!(DumpBlockRequest::parse(&params).is_err());
+    }
+}

--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -28,8 +28,12 @@ const DEFAULT_MAX_RESULTS: usize = 100_000;
 /// - Emits hashed keys only; addresses and trie preimages are not exposed.
 /// - `code` and `storage` are not included. Use `eth_getCode` /
 ///   `eth_getStorageAt` for those.
-/// - Default `maxResults` is [`DEFAULT_MAX_RESULTS`] rather than unbounded;
-///   pass `{"start": ..., "maxResults": ...}` to page through larger states.
+/// - `balance` is serialized as a hex string (`"0x..."`) whereas geth uses a
+///   decimal string. Callers parsing the balance field should handle both.
+/// - `maxResults` is clamped to [`DEFAULT_MAX_RESULTS`] even if the caller
+///   provides a larger value, to protect the RPC server from unbounded
+///   responses. Pass `{"start": ..., "maxResults": ...}` to page through
+///   larger states.
 ///
 /// Iteration caveat: `Store::iter_accounts_from` silently stops on a node
 /// decode failure (see `crates/storage/store.rs`). A truncated response with
@@ -104,7 +108,11 @@ impl RpcHandler for DumpBlockRequest {
 
         let state_root = header.state_root;
         let start = self.config.start.unwrap_or_else(H256::zero);
-        let max_results = self.config.max_results.unwrap_or(DEFAULT_MAX_RESULTS);
+        let max_results = self
+            .config
+            .max_results
+            .unwrap_or(DEFAULT_MAX_RESULTS)
+            .min(DEFAULT_MAX_RESULTS);
         let storage = context.storage.clone();
 
         // The trie iterator opens long-lived locked DB transactions and walks

--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -1,13 +1,54 @@
 use std::collections::BTreeMap;
 
 use ethrex_common::{H256, U256};
-use serde::Serialize;
+use ethrex_storage::error::StoreError;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifier};
 
+/// Default cap on accounts emitted by `debug_dumpBlock` when the caller does
+/// not specify `maxResults`. Picked to bound response size on large states —
+/// geth's `debug_dumpBlock` is unbounded; ethrex diverges here to protect the
+/// RPC server. Callers wanting more can paginate via the config object.
+const DEFAULT_MAX_RESULTS: usize = 100_000;
+
+/// `debug_dumpBlock` — geth-compatible state-trie dump at a given block.
+///
+/// Response shape:
+/// ```text
+/// {
+///   "root":     <state-root>,
+///   "accounts": { <keccak(address)>: { balance, nonce, root, codeHash }, ... },
+///   "next":     <keccak(address)>   // present only if more accounts remain
+/// }
+/// ```
+///
+/// Divergences from geth:
+/// - Emits hashed keys only; addresses and trie preimages are not exposed.
+/// - `code` and `storage` are not included. Use `eth_getCode` /
+///   `eth_getStorageAt` for those.
+/// - Default `maxResults` is [`DEFAULT_MAX_RESULTS`] rather than unbounded;
+///   pass `{"start": ..., "maxResults": ...}` to page through larger states.
+///
+/// Iteration caveat: `Store::iter_accounts_from` silently stops on a node
+/// decode failure (see `crates/storage/store.rs`). A truncated response with
+/// `next` absent is therefore ambiguous with a complete dump — a fix at the
+/// storage layer is needed to distinguish them.
 pub struct DumpBlockRequest {
     block: BlockIdentifier,
+    config: DumpConfig,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DumpConfig {
+    /// Inclusive starting hashed address. Defaults to the start of the trie.
+    #[serde(default)]
+    start: Option<H256>,
+    /// Maximum accounts to emit. Defaults to [`DEFAULT_MAX_RESULTS`].
+    #[serde(default)]
+    max_results: Option<usize>,
 }
 
 #[derive(Serialize)]
@@ -15,6 +56,10 @@ pub struct DumpBlockRequest {
 struct DumpResult {
     root: H256,
     accounts: BTreeMap<H256, DumpAccount>,
+    /// Set to the next hashed address to query when iteration was truncated by
+    /// `maxResults`. Pass it as `start` in a follow-up call to continue.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next: Option<H256>,
 }
 
 #[derive(Serialize)]
@@ -31,15 +76,19 @@ impl RpcHandler for DumpBlockRequest {
         let params = params
             .as_ref()
             .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
-        if params.len() != 1 {
+        if params.is_empty() || params.len() > 2 {
             return Err(RpcErr::BadParams(format!(
-                "Expected 1 param, got {}",
+                "Expected 1 or 2 params, got {}",
                 params.len()
             )));
         }
-        Ok(DumpBlockRequest {
-            block: BlockIdentifier::parse(params[0].clone(), 0)?,
-        })
+        let block = BlockIdentifier::parse(params[0].clone(), 0)?;
+        let config = if params.len() == 2 {
+            serde_json::from_value(params[1].clone())?
+        } else {
+            DumpConfig::default()
+        };
+        Ok(DumpBlockRequest { block, config })
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
@@ -53,27 +102,41 @@ impl RpcHandler for DumpBlockRequest {
             .get_block_header(block_number)?
             .ok_or(RpcErr::Internal("Block header not found".to_string()))?;
 
-        let iter = context
-            .storage
-            .iter_accounts(header.state_root)
-            .map_err(|e| RpcErr::Internal(e.to_string()))?;
+        let state_root = header.state_root;
+        let start = self.config.start.unwrap_or_else(H256::zero);
+        let max_results = self.config.max_results.unwrap_or(DEFAULT_MAX_RESULTS);
+        let storage = context.storage.clone();
 
-        let mut accounts = BTreeMap::new();
-        for (hashed_addr, account_state) in iter {
-            accounts.insert(
-                hashed_addr,
-                DumpAccount {
-                    balance: account_state.balance,
-                    nonce: account_state.nonce,
-                    root: account_state.storage_root,
-                    code_hash: account_state.code_hash,
-                },
-            );
-        }
+        // The trie iterator opens long-lived locked DB transactions and walks
+        // the state synchronously — must run off the async runtime.
+        let (accounts, next) = tokio::task::spawn_blocking(move || {
+            let iter = storage.iter_accounts_from(state_root, start)?;
+            let mut accounts: BTreeMap<H256, DumpAccount> = BTreeMap::new();
+            let mut next = None;
+            for (hashed_addr, account_state) in iter {
+                if accounts.len() >= max_results {
+                    next = Some(hashed_addr);
+                    break;
+                }
+                accounts.insert(
+                    hashed_addr,
+                    DumpAccount {
+                        balance: account_state.balance,
+                        nonce: account_state.nonce,
+                        root: account_state.storage_root,
+                        code_hash: account_state.code_hash,
+                    },
+                );
+            }
+            Ok::<_, StoreError>((accounts, next))
+        })
+        .await
+        .map_err(|e| RpcErr::Internal(format!("dumpBlock task failed: {e}")))??;
 
         Ok(serde_json::to_value(DumpResult {
-            root: header.state_root,
+            root: state_root,
             accounts,
+            next,
         })?)
     }
 }
@@ -89,6 +152,8 @@ mod tests {
         let params = Some(vec![json!("0xa")]);
         let req = DumpBlockRequest::parse(&params).unwrap();
         assert!(matches!(req.block, BlockIdentifier::Number(10)));
+        assert!(req.config.start.is_none());
+        assert!(req.config.max_results.is_none());
     }
 
     #[test]
@@ -102,13 +167,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_with_config() {
+        let params = Some(vec![
+            json!("0xa"),
+            json!({
+                "start": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                "maxResults": 42_u64,
+            }),
+        ]);
+        let req = DumpBlockRequest::parse(&params).unwrap();
+        assert_eq!(req.config.start, Some(H256::from_low_u64_be(5)));
+        assert_eq!(req.config.max_results, Some(42));
+    }
+
+    #[test]
     fn parse_no_params() {
         assert!(DumpBlockRequest::parse(&None).is_err());
     }
 
     #[test]
     fn parse_too_many_params() {
-        let params = Some(vec![json!("0x1"), json!("extra")]);
+        let params = Some(vec![json!("0x1"), json!({}), json!("extra")]);
+        assert!(DumpBlockRequest::parse(&params).is_err());
+    }
+
+    #[test]
+    fn parse_empty_params() {
+        let params: Option<Vec<Value>> = Some(vec![]);
         assert!(DumpBlockRequest::parse(&params).is_err());
     }
 }

--- a/crates/networking/rpc/debug/dump_block.rs
+++ b/crates/networking/rpc/debug/dump_block.rs
@@ -4,10 +4,7 @@ use ethrex_common::{H256, U256};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::{
-    types::block_identifier::BlockIdentifier,
-    RpcApiContext, RpcErr, RpcHandler,
-};
+use crate::{RpcApiContext, RpcErr, RpcHandler, types::block_identifier::BlockIdentifier};
 
 pub struct DumpBlockRequest {
     block: BlockIdentifier,

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,4 @@
 pub mod chain_config;
+pub mod dump_block;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1,5 +1,6 @@
 use crate::authentication::authenticate;
 use crate::debug::chain_config::ChainConfigRequest;
+use crate::debug::dump_block::DumpBlockRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
 use crate::engine::blobs::{BlobsV2Request, BlobsV3Request};
@@ -1155,6 +1156,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_dumpBlock" => DumpBlockRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/test/tests/rpc/debug_dump_block_tests.rs
+++ b/test/tests/rpc/debug_dump_block_tests.rs
@@ -1,0 +1,136 @@
+use ethrex_common::{H256, U256};
+use ethrex_storage::hash_address;
+use serde_json::{Value, json};
+
+use super::helpers::{rpc_call, rpc_call_expect_err, setup_single_transfer_block};
+
+#[tokio::test]
+async fn dump_block_returns_state_at_block() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_dumpBlock",
+        vec![json!(format!("{:#x}", env.block.header.number))],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    let root = obj["root"].as_str().expect("root should be a string");
+    assert_eq!(
+        root.to_lowercase(),
+        format!("{:#x}", env.block.header.state_root).to_lowercase()
+    );
+    assert!(
+        obj.get("next").is_none() || obj["next"].is_null(),
+        "small dev chain should not be truncated"
+    );
+
+    let accounts = obj["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(!accounts.is_empty(), "should have accounts in state dump");
+
+    // Sender appears with the expected post-transfer state. Lookup is by
+    // hashed-address since dumpBlock keys accounts on `keccak(address)`.
+    let sender_key = format!("{:#x}", H256::from_slice(&hash_address(&env.sender)));
+    let entry = accounts
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(&sender_key))
+        .map(|(_, v)| v)
+        .expect("sender should appear in the dump");
+    let nonce = entry["nonce"].as_u64().expect("nonce must be a number");
+    assert_eq!(nonce, 1, "sender nonce after one tx should be 1");
+    let balance_str = entry["balance"]
+        .as_str()
+        .expect("balance must be a hex string");
+    let balance =
+        U256::from_str_radix(balance_str.trim_start_matches("0x"), 16).expect("hex balance");
+    assert!(
+        balance < U256::from(10).pow(U256::from(20)),
+        "sender balance should be reduced after the transfer"
+    );
+}
+
+#[tokio::test]
+async fn dump_block_unknown_block_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_dumpBlock",
+        vec![json!(format!("{:#x}", env.block.header.number + 1_000))],
+    )
+    .await;
+
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Block not found") || msg.contains("Block header not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn dump_block_latest_tag_resolves() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(&env.store, "debug_dumpBlock", vec![json!("latest")]).await;
+
+    let root = result["root"].as_str().expect("root should be a string");
+    assert_eq!(
+        root.to_lowercase(),
+        format!("{:#x}", env.block.header.state_root).to_lowercase(),
+        "`latest` should resolve to the head block's state root"
+    );
+}
+
+#[tokio::test]
+async fn dump_block_paginates_via_max_results_and_next() {
+    let env = setup_single_transfer_block().await;
+
+    let first: Value = rpc_call(
+        &env.store,
+        "debug_dumpBlock",
+        vec![
+            json!(format!("{:#x}", env.block.header.number)),
+            json!({ "maxResults": 1_u64 }),
+        ],
+    )
+    .await;
+
+    let accounts = first["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert_eq!(accounts.len(), 1, "maxResults=1 should yield one account");
+    let first_key = accounts.keys().next().unwrap().clone();
+    let next = first["next"]
+        .as_str()
+        .expect("truncated response must include `next`")
+        .to_owned();
+
+    let second: Value = rpc_call(
+        &env.store,
+        "debug_dumpBlock",
+        vec![
+            json!(format!("{:#x}", env.block.header.number)),
+            json!({ "start": next, "maxResults": 1_000_000_u64 }),
+        ],
+    )
+    .await;
+
+    let second_accounts = second["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
+    assert!(
+        !second_accounts.is_empty(),
+        "continuation page should return remaining accounts"
+    );
+    assert!(
+        !second_accounts.contains_key(&first_key),
+        "continuation page should not repeat the first page's account"
+    );
+    assert!(
+        second.get("next").is_none() || second["next"].is_null(),
+        "second page should complete the dump on a tiny dev chain"
+    );
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn dump_block() {
@@ -176,6 +180,8 @@ async fn dump_block() {
     assert!(obj.contains_key("root"), "should have 'root'");
     assert!(obj.contains_key("accounts"), "should have 'accounts'");
 
-    let accounts = obj["accounts"].as_object().expect("accounts should be an object");
+    let accounts = obj["accounts"]
+        .as_object()
+        .expect("accounts should be an object");
     assert!(!accounts.is_empty(), "should have accounts in state dump");
 }

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,181 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn dump_block() {
+    let env = setup_single_transfer_block().await;
+    let block_number = env.block.header.number;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_dumpBlock",
+        vec![json!(format!("{block_number:#x}"))],
+    )
+    .await;
+
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.contains_key("root"), "should have 'root'");
+    assert!(obj.contains_key("accounts"), "should have 'accounts'");
+
+    let accounts = obj["accounts"].as_object().expect("accounts should be an object");
+    assert!(!accounts.is_empty(), "should have accounts in state dump");
+}

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -15,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +113,7 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +137,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,27 +186,6 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
-}
-
-#[tokio::test]
-async fn dump_block() {
-    let env = setup_single_transfer_block().await;
-    let block_number = env.block.header.number;
-
-    let result = rpc_call(
-        &env.store,
-        "debug_dumpBlock",
-        vec![json!(format!("{block_number:#x}"))],
-    )
-    .await;
-
-    let obj = result.as_object().expect("response should be an object");
-    assert!(obj.contains_key("root"), "should have 'root'");
-    assert!(obj.contains_key("accounts"), "should have 'accounts'");
-
-    let accounts = obj["accounts"]
-        .as_object()
-        .expect("accounts should be an object");
-    assert!(!accounts.is_empty(), "should have accounts in state dump");
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_dump_block_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_dump_block_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Implement `debug_dumpBlock` RPC endpoint that dumps the entire state at a given block
- Returns the state root and all accounts with their balance, nonce, storage root, and code hash
- Uses `iter_accounts` to iterate the state trie at the block's state root

Closes part of #6572

Closes #6650