### PR TITLE
fix(l1): break out of prefix iterator on mismatch in get_transaction_location

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -589,15 +589,17 @@ impl Store {
             let tx_hash_bytes = transaction_hash.as_bytes();
             let tx = db.begin_read()?;
 
-            // Use prefix iterator to find all entries with this transaction hash
+            // rust-rocksdb's prefix_iterator_cf seeks but does not bound iteration —
+            // caller must stop on the first prefix mismatch.
             let mut iter = tx.prefix_iterator(TRANSACTION_LOCATIONS, tx_hash_bytes)?;
             let mut transaction_locations = Vec::new();
 
             while let Some(Ok((key, value))) = iter.next() {
-                // Ensure key is exactly tx_hash + block_hash (32 + 32 = 64 bytes)
-                // and starts with our exact tx_hash
+                // Key is tx_hash (32) + block_hash (32) = 64 bytes.
                 if key.len() == 64 && &key[0..32] == tx_hash_bytes {
                     transaction_locations.push(<(BlockNumber, BlockHash, Index)>::decode(&value)?);
+                } else {
+                    break;
                 }
             }
 


### PR DESCRIPTION
**Motivation**

`Store::get_transaction_location` was performing an unbounded RocksDB scan on every `eth_getTransactionByHash` call. On mainnet, this meant each call scanned hundreds of GB of compressed SSTs taking seconds per request, and under modest concurrent load (a few hundred persistent connections), it cascaded into multi-hour latencies and full saturation of the Tokio blocking pool — see [#6688](https://github.com/lambdaclass/ethrex/issues/6688) for the full incident write-up.

**Description**

`rust-rocksdb`'s `prefix_iterator_cf` seeks to the prefix but iterates forward indefinitely; the caller must break manually when the key no longer matches. The previous loop in `crates/storage/store.rs:596-602` used an `if` filter that correctly ignored non-matching keys but didn't stop iteration, so every call scanned from the seek point to the end of the `TRANSACTION_LOCATIONS` column family.

Fix is one line: `else { break; }`. RocksDB stores keys in lexicographic order and all entries sharing a `tx_hash` prefix are contiguous; once we see a non-matching key, no further matches can appear ahead. Iteration is now bounded to `(matches + 1)` reads — typically 1-2 entries.

**Verification on mainnet-10 (fresh sync, hot OS cache)**

Single-call latency, identical reproducer to the issue body:

| Position | Hash | Before | After | Speedup |
|---|---|---|---|---|
| Low (0x00…) | `0x0000…001` | 39 ms | **0.37 ms** | **105×** |
| Mid | `0x8000…000` | 15 ms | **0.40 ms** | 37× |
| Real | `0x454a…b611` | 21 ms | **0.55 ms** | 38× |
| High (0xff…) | `0xfff…ffe` | 0.20 ms | **0.18 ms** | 1× |

The linear-with-position pattern disappears entirely — all calls flat at sub-millisecond.

Persistent-connection storm (`oha -z 3m -c 200 --no-tui` against worst-case low hash, same as the reproduction in [issue #6688](https://github.com/lambdaclass/ethrex/issues/6688#issuecomment-4507659014)):

| Metric | Before | After | Improvement |
|---|---|---|---|
| Total requests in 3 min | 39,368 | **47,611,407** | **1,210×** |
| Throughput | 218 req/s | **264,504 req/s** | **1,213×** |
| Mean latency | ~900 ms | **0.75 ms** | **1,200×** |
| p50 | 877 ms | **0.70 ms** | **1,253×** |
| p95 | 1,517 ms | **1.37 ms** | **1,107×** |
| p99 | 1,843 ms | **1.82 ms** | **1,012×** |
| Slowest | 2,870 ms | **59.7 ms** | 48× |
| Errors | 0 | 188 of 47.6M (deadline race at storm end) | ≈0% |

99.98% of requests now complete in <6 ms. The 22× bandwidth-contention amplifier observed under storm conditions is gone — the node finds a stable operating point at 264K req/s with no thread-pool saturation. The mathematical model from the issue (Little's Law-based queue growth) cleanly explains why eliminating the per-call O(table) cost defuses the entire cascade.

**Follow-up improvements (separate PRs)**

These are referenced in #6688 but worth restating:

- **Iterator upper bound at API level.** Extend the `prefix_iterator` storage trait method to construct iterators with `set_iterate_upper_bound(prefix + 1)` so RocksDB itself stops at the bound. Removes the dependence on caller discipline. The same-PR fix here is sufficient for correctness, but a typed bounded-iterator API would prevent recurrence in any future call site.
- **Bloom filter on `TRANSACTION_LOCATIONS`** for negative-lookup speedup. Only helps after compaction rewrites existing SSTs.
- **Schema redesign.** Key by `tx_hash` only with the value being a `Vec<(BlockNumber, BlockHash, Index)>`. Reduces this from a prefix scan to a single `get_cf`. Best long-term option.
- **Cancellation propagation for `spawn_blocking`.** Independent of this bug: orphaned blocking tasks from cancelled futures kept the pool saturated even after the rogue IP was blocked on mainnet-1.

**Checklist**

Closes #6688
