### PR TITLE
feat(l1): implement debug_intermediateRoots endpoint

### DIFF
--- a/crates/blockchain/tracing.rs
+++ b/crates/blockchain/tracing.rs
@@ -218,6 +218,58 @@ impl Blockchain {
         Ok(traces)
     }
 
+    /// Computes the intermediate state root after each transaction in the given block.
+    /// Returns one H256 per transaction.
+    pub async fn compute_intermediate_roots(
+        &self,
+        block: Block,
+        reexec: u32,
+        timeout: Duration,
+    ) -> Result<Vec<H256>, ChainError> {
+        let parent_header = self
+            .storage
+            .get_block_header_by_hash(block.header.parent_hash)?
+            .ok_or(ChainError::ParentNotFound)?;
+        let parent_state_root = parent_header.state_root;
+
+        // Rebuild parent state and run system calls (stop before tx 0)
+        let mut vm = self
+            .rebuild_parent_state(block.header.parent_hash, reexec)
+            .await?;
+        vm.rerun_block(&block, Some(0))?;
+
+        let store = self.storage.clone();
+
+        timeout_trace_operation(timeout, move || {
+            let tx_count = block.body.transactions.len();
+            let mut roots = Vec::with_capacity(tx_count);
+
+            for index in 0..tx_count {
+                vm.execute_tx_by_index(&block, index)?;
+
+                // Peek at cumulative state transitions (non-destructive)
+                let updates = vm.db.peek_state_transitions().map_err(|e| {
+                    EvmError::Custom(format!("Failed to get state transitions: {e}"))
+                })?;
+
+                // Apply cumulative updates to a fresh trie from the parent state root
+                let mut state_trie = store.open_state_trie(parent_state_root).map_err(|e| {
+                    EvmError::Custom(format!("Failed to open state trie: {e}"))
+                })?;
+                let result = store
+                    .apply_account_updates_from_trie_batch(&mut state_trie, &updates)
+                    .map_err(|e| {
+                        EvmError::Custom(format!("Failed to apply account updates: {e}"))
+                    })?;
+
+                roots.push(result.state_trie_hash);
+            }
+
+            Ok(roots)
+        })
+        .await
+    }
+
     /// Rebuild the parent state for a block given its parent hash, returning an `Evm` instance with all changes cached
     /// Will re-execute all ancestor block's which's state is not stored up to a maximum given by `reexec`
     async fn rebuild_parent_state(

--- a/crates/blockchain/tracing.rs
+++ b/crates/blockchain/tracing.rs
@@ -253,9 +253,9 @@ impl Blockchain {
                 })?;
 
                 // Apply cumulative updates to a fresh trie from the parent state root
-                let mut state_trie = store.open_state_trie(parent_state_root).map_err(|e| {
-                    EvmError::Custom(format!("Failed to open state trie: {e}"))
-                })?;
+                let mut state_trie = store
+                    .open_state_trie(parent_state_root)
+                    .map_err(|e| EvmError::Custom(format!("Failed to open state trie: {e}")))?;
                 let result = store
                     .apply_account_updates_from_trie_batch(&mut state_trie, &updates)
                     .map_err(|e| {

--- a/crates/blockchain/tracing.rs
+++ b/crates/blockchain/tracing.rs
@@ -252,7 +252,11 @@ impl Blockchain {
                     EvmError::Custom(format!("Failed to get state transitions: {e}"))
                 })?;
 
-                // Apply cumulative updates to a fresh trie from the parent state root
+                // TODO: this is O(N^2) — each iteration opens a fresh trie and
+                // re-applies ALL cumulative updates from tx 0..=index. For a block
+                // with N txs, total work is ~N*(N+1)/2 trie mutations. An incremental
+                // approach (reuse the trie, apply only per-tx deltas) would make this
+                // O(N) but requires a delta-tracking API in peek_state_transitions.
                 let mut state_trie = store
                     .open_state_trie(parent_state_root)
                     .map_err(|e| EvmError::Custom(format!("Failed to open state trie: {e}")))?;

--- a/crates/networking/rpc/debug/intermediate_roots.rs
+++ b/crates/networking/rpc/debug/intermediate_roots.rs
@@ -63,3 +63,48 @@ impl RpcHandler for IntermediateRootsRequest {
         Ok(serde_json::to_value(roots)?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RpcHandler;
+    use serde_json::json;
+
+    #[test]
+    fn parse_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = IntermediateRootsRequest::parse(&params).unwrap();
+        assert_eq!(req.block_hash, H256::from_low_u64_be(1));
+        assert_eq!(req.timeout, DEFAULT_TIMEOUT);
+        assert_eq!(req.reexec, DEFAULT_REEXEC);
+    }
+
+    #[test]
+    fn parse_with_config() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!({"timeout": "10s", "reexec": 256}),
+        ]);
+        let req = IntermediateRootsRequest::parse(&params).unwrap();
+        assert_eq!(req.timeout, Duration::from_secs(10));
+        assert_eq!(req.reexec, 256);
+    }
+
+    #[test]
+    fn parse_no_params() {
+        assert!(IntermediateRootsRequest::parse(&None).is_err());
+    }
+
+    #[test]
+    fn parse_empty_params() {
+        assert!(IntermediateRootsRequest::parse(&Some(vec![])).is_err());
+    }
+
+    #[test]
+    fn parse_too_many_params() {
+        let params = Some(vec![json!("0x01"), json!({}), json!("extra")]);
+        assert!(IntermediateRootsRequest::parse(&params).is_err());
+    }
+}

--- a/crates/networking/rpc/debug/intermediate_roots.rs
+++ b/crates/networking/rpc/debug/intermediate_roots.rs
@@ -52,7 +52,7 @@ impl RpcHandler for IntermediateRootsRequest {
             .storage
             .get_block_by_hash(self.block_hash)
             .await?
-            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+            .ok_or(RpcErr::WrongParam("Block not found".to_string()))?;
 
         let roots = context
             .blockchain

--- a/crates/networking/rpc/debug/intermediate_roots.rs
+++ b/crates/networking/rpc/debug/intermediate_roots.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use ethrex_common::{H256, serde_utils};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{RpcApiContext, RpcErr, RpcHandler};
+
+const DEFAULT_REEXEC: u32 = 128;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct IntermediateRootsRequest {
+    block_hash: H256,
+    timeout: Duration,
+    reexec: u32,
+}
+
+#[derive(Deserialize, Default)]
+struct IntermediateRootsConfig {
+    #[serde(default, with = "serde_utils::duration::opt")]
+    timeout: Option<Duration>,
+    #[serde(default)]
+    reexec: Option<u32>,
+}
+
+impl RpcHandler for IntermediateRootsRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.is_empty() || params.len() > 2 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected 1-2 params, got {}",
+                params.len()
+            )));
+        }
+        let block_hash: H256 = serde_json::from_value(params[0].clone())?;
+        let config: IntermediateRootsConfig = if params.len() > 1 {
+            serde_json::from_value(params[1].clone())?
+        } else {
+            IntermediateRootsConfig::default()
+        };
+        Ok(IntermediateRootsRequest {
+            block_hash,
+            timeout: config.timeout.unwrap_or(DEFAULT_TIMEOUT),
+            reexec: config.reexec.unwrap_or(DEFAULT_REEXEC),
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let block = context
+            .storage
+            .get_block_by_hash(self.block_hash)
+            .await?
+            .ok_or(RpcErr::Internal("Block not found".to_string()))?;
+
+        let roots = context
+            .blockchain
+            .compute_intermediate_roots(block, self.reexec, self.timeout)
+            .await
+            .map_err(|e| RpcErr::Internal(e.to_string()))?;
+
+        Ok(serde_json::to_value(roots)?)
+    }
+}

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,4 @@
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;
+pub mod intermediate_roots;

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -2,6 +2,7 @@ use crate::authentication::authenticate;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
+use crate::debug::intermediate_roots::IntermediateRootsRequest;
 use crate::engine::blobs::{BlobsV2Request, BlobsV3Request};
 use crate::engine::client_version::GetClientVersionV1Request;
 use crate::engine::payload::{GetPayloadV5Request, GetPayloadV6Request, NewPayloadV5Request};
@@ -1155,6 +1156,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
+        "debug_intermediateRoots" => IntermediateRootsRequest::call(req, context).await,
         unknown_debug_method => Err(RpcErr::MethodNotFound(unknown_debug_method.to_owned())),
     }
 }

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -661,6 +661,92 @@ impl GeneralizedDatabase {
         Ok(account_updates)
     }
 
+    /// Non-destructive version of `get_state_transitions`.
+    /// Returns cumulative account updates (current vs initial) without clearing the caches.
+    /// Used by `debug_intermediateRoots` to compute state roots after each transaction
+    /// while allowing execution to continue.
+    pub fn peek_state_transitions(&self) -> Result<Vec<AccountUpdate>, VMError> {
+        let mut account_updates: Vec<AccountUpdate> = vec![];
+        for (address, new_state_account) in self.current_accounts_state.iter() {
+            if new_state_account.is_unmodified() {
+                continue;
+            }
+            let initial_state_account =
+                self.initial_accounts_state.get(address).ok_or_else(|| {
+                    VMError::Internal(InternalError::Custom(format!(
+                        "Failed to get account {address} from immutable cache",
+                    )))
+                })?;
+
+            let mut acc_info_updated = false;
+            let mut storage_updated = false;
+
+            if initial_state_account.info.balance != new_state_account.info.balance {
+                acc_info_updated = true;
+            }
+
+            if initial_state_account.info.nonce != new_state_account.info.nonce {
+                acc_info_updated = true;
+            }
+
+            let code = if initial_state_account.info.code_hash != new_state_account.info.code_hash {
+                acc_info_updated = true;
+                Some(
+                    self.codes
+                        .get(&new_state_account.info.code_hash)
+                        .ok_or_else(|| {
+                            VMError::Internal(InternalError::Custom(format!(
+                                "Failed to get code for account {address}"
+                            )))
+                        })?,
+                )
+            } else {
+                None
+            };
+
+            let was_destroyed = new_state_account.status == AccountStatus::DestroyedModified;
+            let removed_storage = was_destroyed && initial_state_account.has_storage;
+
+            let mut added_storage: FxHashMap<_, _> = Default::default();
+
+            for (key, new_value) in &new_state_account.storage {
+                let old_value = if !was_destroyed {
+                    initial_state_account.storage.get(key).ok_or_else(|| { VMError::Internal(InternalError::Custom(format!("Failed to get old value from account's initial storage for address: {address:?}. For key: {key:?}")))})?
+                } else {
+                    &ZERO_U256
+                };
+
+                if new_value != old_value {
+                    added_storage.insert(*key, *new_value);
+                    storage_updated = true;
+                }
+            }
+
+            let info = if acc_info_updated {
+                Some(new_state_account.info.clone())
+            } else {
+                None
+            };
+
+            let was_empty = initial_state_account.is_empty();
+            let removed = new_state_account.is_empty() && !was_empty;
+
+            if !removed && !acc_info_updated && !storage_updated && !removed_storage {
+                continue;
+            }
+
+            account_updates.push(AccountUpdate {
+                address: *address,
+                removed,
+                info,
+                code: code.cloned(),
+                added_storage,
+                removed_storage,
+            });
+        }
+        Ok(account_updates)
+    }
+
     pub fn get_state_transitions_tx(&mut self) -> Result<Vec<AccountUpdate>, VMError> {
         let mut account_updates: Vec<AccountUpdate> = vec![];
         for (address, new_state_account) in self.current_accounts_state.drain() {

--- a/crates/vm/tracing.rs
+++ b/crates/vm/tracing.rs
@@ -90,6 +90,34 @@ impl Evm {
         )
     }
 
+    /// Executes a single transaction in a block by index without any tracer.
+    /// Assumes that the DB already reflects all prior txs in the block.
+    pub fn execute_tx_by_index(
+        &mut self,
+        block: &Block,
+        tx_index: usize,
+    ) -> Result<(), EvmError> {
+        let tx = block
+            .body
+            .transactions
+            .get(tx_index)
+            .ok_or(EvmError::Custom(
+                "Missing Transaction for Execution".to_string(),
+            ))?;
+        let sender = tx.sender(self.crypto.as_ref()).map_err(|e| {
+            EvmError::Transaction(format!("Couldn't recover sender: {e}"))
+        })?;
+        LEVM::execute_tx(
+            tx,
+            sender,
+            &block.header,
+            &mut self.db,
+            self.vm_type,
+            self.crypto.as_ref(),
+        )?;
+        Ok(())
+    }
+
     /// Reruns the given block, saving the changes on the state, doesn't output any results or receipts.
     /// If the optional argument `stop_index` is set, the run will stop just before executing the transaction at that index
     /// and won't process the withdrawals afterwards.

--- a/crates/vm/tracing.rs
+++ b/crates/vm/tracing.rs
@@ -92,11 +92,7 @@ impl Evm {
 
     /// Executes a single transaction in a block by index without any tracer.
     /// Assumes that the DB already reflects all prior txs in the block.
-    pub fn execute_tx_by_index(
-        &mut self,
-        block: &Block,
-        tx_index: usize,
-    ) -> Result<(), EvmError> {
+    pub fn execute_tx_by_index(&mut self, block: &Block, tx_index: usize) -> Result<(), EvmError> {
         let tx = block
             .body
             .transactions
@@ -104,9 +100,9 @@ impl Evm {
             .ok_or(EvmError::Custom(
                 "Missing Transaction for Execution".to_string(),
             ))?;
-        let sender = tx.sender(self.crypto.as_ref()).map_err(|e| {
-            EvmError::Transaction(format!("Couldn't recover sender: {e}"))
-        })?;
+        let sender = tx
+            .sender(self.crypto.as_ref())
+            .map_err(|e| EvmError::Transaction(format!("Couldn't recover sender: {e}")))?;
         LEVM::execute_tx(
             tx,
             sender,

--- a/test/tests/rpc/debug_intermediate_roots_tests.rs
+++ b/test/tests/rpc/debug_intermediate_roots_tests.rs
@@ -1,0 +1,110 @@
+use ethrex_common::H256;
+use serde_json::json;
+
+use super::helpers::{
+    rpc_call, rpc_call_expect_err, setup_multi_transfer_block, setup_single_transfer_block,
+};
+
+fn parse_roots(arr: &[serde_json::Value]) -> Vec<H256> {
+    arr.iter()
+        .map(|v| v.as_str().unwrap().parse().unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn intermediate_roots_single_tx_matches_block_state_root() {
+    // For a block with one tx and empty withdrawals, the only intermediate
+    // root (after that single tx) must equal `block.header.state_root` — this
+    // is the strong correctness check that distinguishes a real
+    // implementation from one that just returns plausible-looking hashes.
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+    let expected_state_root = env.block.header.state_root;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_intermediateRoots",
+        vec![json!(format!("{block_hash:#x}"))],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    let roots = parse_roots(arr);
+    assert_eq!(roots.len(), 1, "one tx → one intermediate root");
+    assert_eq!(
+        roots[0], expected_state_root,
+        "intermediate root after the only tx must equal the block's state_root \
+         (empty withdrawals, so no post-tx changes)"
+    );
+}
+
+#[tokio::test]
+async fn intermediate_roots_multi_tx_progress_and_match_final() {
+    // Block with three transfers from the same sender. The PR's algorithm
+    // emits the *cumulative* state root after each tx (parent + system_calls
+    // + txs[0..=i]). Sequential txs from the same sender mutate the sender's
+    // nonce and balance every time, so each intermediate root must differ
+    // from the previous one. The last root must equal `block.state_root`.
+    let env = setup_multi_transfer_block(3).await;
+    let block_hash = env.block.hash();
+    let expected_final_root = env.block.header.state_root;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_intermediateRoots",
+        vec![json!(format!("{block_hash:#x}"))],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    let roots = parse_roots(arr);
+    assert_eq!(roots.len(), 3, "three txs → three intermediate roots");
+    assert_ne!(
+        roots[0], roots[1],
+        "tx[0] and tx[1] must yield different roots"
+    );
+    assert_ne!(
+        roots[1], roots[2],
+        "tx[1] and tx[2] must yield different roots"
+    );
+    assert_eq!(
+        roots[2], expected_final_root,
+        "final intermediate root must equal the block's state_root"
+    );
+}
+
+#[tokio::test]
+async fn intermediate_roots_accepts_config_object() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_intermediateRoots",
+        vec![
+            json!(format!("{block_hash:#x}")),
+            json!({"timeout": "10s", "reexec": 256}),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1);
+}
+
+#[tokio::test]
+async fn intermediate_roots_unknown_block_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_intermediateRoots",
+        vec![json!(format!("{:#x}", H256::from_low_u64_be(0xdeadbeef)))],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Block not found"),
+        "expected block-not-found error, got: {msg}"
+    );
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,182 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn intermediate_roots() {
+    let env = setup_single_transfer_block().await;
+    let block_hash = env.block.hash();
+
+    let result = rpc_call(
+        &env.store,
+        "debug_intermediateRoots",
+        vec![json!(format!("{block_hash:#x}"))],
+    )
+    .await;
+
+    // Returns an array of intermediate state roots (one per tx).
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1, "block has 1 tx so should have 1 intermediate root");
+
+    // Each root should be a 0x-prefixed hex string.
+    let root_str = arr[0].as_str().expect("root should be a string");
+    assert!(root_str.starts_with("0x"), "root should be hex");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn intermediate_roots() {
@@ -174,7 +178,11 @@ async fn intermediate_roots() {
 
     // Returns an array of intermediate state roots (one per tx).
     let arr = result.as_array().expect("response should be an array");
-    assert_eq!(arr.len(), 1, "block has 1 tx so should have 1 intermediate root");
+    assert_eq!(
+        arr.len(),
+        1,
+        "block has 1 tx so should have 1 intermediate root"
+    );
 
     // Each root should be a 0x-prefixed hex string.
     let root_str = arr[0].as_str().expect("root should be a string");

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -15,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +113,7 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +137,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,30 +186,33 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
 }
 
-#[tokio::test]
-async fn intermediate_roots() {
-    let env = setup_single_transfer_block().await;
-    let block_hash = env.block.hash();
-
-    let result = rpc_call(
-        &env.store,
-        "debug_intermediateRoots",
-        vec![json!(format!("{block_hash:#x}"))],
-    )
-    .await;
-
-    // Returns an array of intermediate state roots (one per tx).
-    let arr = result.as_array().expect("response should be an array");
-    assert_eq!(
-        arr.len(),
-        1,
-        "block has 1 tx so should have 1 intermediate root"
-    );
-
-    // Each root should be a 0x-prefixed hex string.
-    let root_str = arr[0].as_str().expect("root should be a string");
-    assert!(root_str.starts_with("0x"), "root should be hex");
+/// Multi-tx variant: builds a block containing `tx_count` value transfers from
+/// the sender to incrementing recipient addresses. Used by tests that need to
+/// observe per-tx state progression.
+pub async fn setup_multi_transfer_block(tx_count: u64) -> TestEnv {
+    assert!(tx_count >= 1);
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let value = U256::from(1_000_000_000_000_000_u64); // 0.001 ETH per tx
+    let mut txs = Vec::with_capacity(tx_count as usize);
+    for i in 0..tx_count {
+        let recipient = Address::from_low_u64_be(0xAA + i);
+        txs.push(create_transfer_tx(chain_id, i, recipient, value, &signer).await);
+    }
+    let first_hash = txs[0].hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, txs).await;
+    TestEnv {
+        store,
+        block,
+        tx_hash: first_hash,
+        sender,
+    }
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_intermediate_roots_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_intermediate_roots_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Implement `debug_intermediateRoots` RPC endpoint that returns the intermediate state root after each transaction in a block
- Adds `GeneralizedDatabase::peek_state_transitions()` — a non-destructive read of cumulative state transitions
- Adds `Evm::execute_tx_by_index()` for single-transaction execution without tracing
- Adds `Blockchain::compute_intermediate_roots()` with timeout support
- For each tx: re-executes the block progressively, computes cumulative account updates, then applies them to a fresh state trie from the parent root

Closes part of #6572

Closes #6643