### PR TITLE
feat(l1): implement 4byteTracer

### DIFF
--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -416,3 +416,123 @@ fn collect_four_byte_selectors(frame: &CallTraceFrame, selectors: &mut HashMap<S
         collect_four_byte_selectors(sub_call, selectors);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use crate::rpc::RpcHandler;
+    use serde_json::json;
+
+    // --- TraceTransactionRequest parse tests ---
+
+    #[test]
+    fn parse_trace_tx_with_hash_only() {
+        let params = Some(vec![json!(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        )]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert_eq!(req.tx_hash, H256::from_low_u64_be(1));
+    }
+
+    #[test]
+    fn parse_trace_tx_no_params() {
+        assert!(TraceTransactionRequest::parse(&None).is_err());
+    }
+
+    // --- TracerType deserialization tests ---
+
+    #[test]
+    fn deserialize_tracer_type_four_byte() {
+        let t: TracerType = serde_json::from_value(json!("4byteTracer")).unwrap();
+        assert!(matches!(t, TracerType::FourByteTracer));
+    }
+
+    #[test]
+    fn deserialize_tracer_type_unknown_fails() {
+        assert!(serde_json::from_value::<TracerType>(json!("unknownTracer")).is_err());
+    }
+
+    // --- 4byteTracer parse test ---
+
+    #[test]
+    fn parse_trace_tx_four_byte_tracer() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!({"tracer": "4byteTracer"}),
+        ]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert!(matches!(req.trace_config.tracer, TracerType::FourByteTracer));
+    }
+
+    // --- collect_four_byte_selectors tests ---
+
+    #[test]
+    fn four_byte_selectors_empty_input() {
+        let frame = CallTraceFrame {
+            input: Bytes::new(),
+            ..Default::default()
+        };
+        let mut selectors = HashMap::new();
+        collect_four_byte_selectors(&frame, &mut selectors);
+        assert!(selectors.is_empty());
+    }
+
+    #[test]
+    fn four_byte_selectors_short_input_ignored() {
+        let frame = CallTraceFrame {
+            input: Bytes::from_static(&[0xa9, 0x05, 0x9c]),
+            ..Default::default()
+        };
+        let mut selectors = HashMap::new();
+        collect_four_byte_selectors(&frame, &mut selectors);
+        assert!(selectors.is_empty());
+    }
+
+    #[test]
+    fn four_byte_selectors_single_call() {
+        let frame = CallTraceFrame {
+            input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0x00, 0x01]),
+            ..Default::default()
+        };
+        let mut selectors = HashMap::new();
+        collect_four_byte_selectors(&frame, &mut selectors);
+        assert_eq!(selectors.len(), 1);
+        assert_eq!(selectors["0xa9059cbb-6"], 1);
+    }
+
+    #[test]
+    fn four_byte_selectors_nested_calls() {
+        let child = CallTraceFrame {
+            input: Bytes::from_static(&[0x23, 0xb8, 0x72, 0xdd, 0x01, 0x02, 0x03]),
+            ..Default::default()
+        };
+        let frame = CallTraceFrame {
+            input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0xaa]),
+            calls: vec![child],
+            ..Default::default()
+        };
+        let mut selectors = HashMap::new();
+        collect_four_byte_selectors(&frame, &mut selectors);
+        assert_eq!(selectors.len(), 2);
+        assert_eq!(selectors["0xa9059cbb-5"], 1);
+        assert_eq!(selectors["0x23b872dd-7"], 1);
+    }
+
+    #[test]
+    fn four_byte_selectors_duplicate_calls_counted() {
+        let child = CallTraceFrame {
+            input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0xaa]),
+            ..Default::default()
+        };
+        let frame = CallTraceFrame {
+            input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0xaa]),
+            calls: vec![child],
+            ..Default::default()
+        };
+        let mut selectors = HashMap::new();
+        collect_four_byte_selectors(&frame, &mut selectors);
+        assert_eq!(selectors.len(), 1);
+        assert_eq!(selectors["0xa9059cbb-5"], 2);
+    }
+}

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -420,8 +420,8 @@ fn collect_four_byte_selectors(frame: &CallTraceFrame, selectors: &mut HashMap<S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
     use crate::rpc::RpcHandler;
+    use bytes::Bytes;
     use serde_json::json;
 
     // --- TraceTransactionRequest parse tests ---
@@ -462,7 +462,10 @@ mod tests {
             json!({"tracer": "4byteTracer"}),
         ]);
         let req = TraceTransactionRequest::parse(&params).unwrap();
-        assert!(matches!(req.trace_config.tracer, TracerType::FourByteTracer));
+        assert!(matches!(
+            req.trace_config.tracer,
+            TracerType::FourByteTracer
+        ));
     }
 
     // --- collect_four_byte_selectors tests ---

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use ethrex_common::H256;
@@ -59,6 +60,11 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
+    /// Records 4-byte function selectors and calldata sizes for every call.
+    /// Returns a map of `"0xSELECTOR-SIZE" -> count`.
+    /// Selected via `"tracer": "4byteTracer"`.
+    #[serde(rename = "4byteTracer")]
+    FourByteTracer,
 }
 
 #[derive(Deserialize, Default)]
@@ -209,6 +215,26 @@ impl RpcHandler for TraceTransactionRequest {
                     emit,
                 })?)
             }
+            TracerType::FourByteTracer => {
+                let call_trace = context
+                    .blockchain
+                    .trace_transaction_calls(
+                        self.tx_hash,
+                        reexec,
+                        timeout,
+                        false, // need all subcalls
+                        false,
+                    )
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                let top_frame = call_trace
+                    .into_iter()
+                    .next()
+                    .ok_or(RpcErr::Internal("Empty call trace".to_string()))?;
+                let mut selectors = HashMap::new();
+                collect_four_byte_selectors(&top_frame, &mut selectors);
+                Ok(serde_json::to_value(selectors)?)
+            }
         }
     }
 }
@@ -355,6 +381,38 @@ impl RpcHandler for TraceBlockByNumberRequest {
                     .collect::<Result<_, serde_json::Error>>()?;
                 Ok(serde_json::to_value(block_trace)?)
             }
+            TracerType::FourByteTracer => {
+                let call_traces = context
+                    .blockchain
+                    .trace_block_calls(block, reexec, timeout, false, false)
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                let block_trace: BlockTrace<HashMap<String, u64>> = call_traces
+                    .into_iter()
+                    .map(|(hash, trace)| {
+                        let frame = trace
+                            .into_iter()
+                            .next()
+                            .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
+                        let mut selectors = HashMap::new();
+                        collect_four_byte_selectors(&frame, &mut selectors);
+                        Ok((hash, selectors).into())
+                    })
+                    .collect::<Result<_, RpcErr>>()?;
+                Ok(serde_json::to_value(block_trace)?)
+            }
         }
+    }
+}
+
+/// Recursively collects 4-byte function selectors and calldata sizes from a call trace tree.
+fn collect_four_byte_selectors(frame: &CallTraceFrame, selectors: &mut HashMap<String, u64>) {
+    if frame.input.len() >= 4 {
+        let selector = hex::encode(&frame.input[..4]);
+        let key = format!("0x{selector}-{}", frame.input.len());
+        *selectors.entry(key).or_insert(0) += 1;
+    }
+    for sub_call in &frame.calls {
+        collect_four_byte_selectors(sub_call, selectors);
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use ethrex_common::H256;
+use ethrex_common::{Address, H256};
 use ethrex_common::{
     serde_utils,
-    tracing::{CallTraceFrame, PrestateResult, StructLoggerEmit, StructLoggerResult},
+    tracing::{CallTraceFrame, CallType, PrestateResult, StructLoggerEmit, StructLoggerResult},
 };
 use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
@@ -60,9 +60,12 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
-    /// Records 4-byte function selectors and calldata sizes for every call.
-    /// Returns a map of `"0xSELECTOR-SIZE" -> count`.
-    /// Selected via `"tracer": "4byteTracer"`.
+    /// Records 4-byte function selectors and calldata sizes from CALL and
+    /// DELEGATECALL invocations matching geth's built-in `4byteTracer`. The
+    /// key shape is `"0xSELECTOR-N"` where `N` is `len(calldata) - 4` (the
+    /// argument-bytes length, not the full input length); the value is the
+    /// number of matching calls. The top-level transaction call and calls to
+    /// precompile addresses are skipped. Selected via `"tracer": "4byteTracer"`.
     #[serde(rename = "4byteTracer")]
     FourByteTracer,
 }
@@ -405,16 +408,57 @@ impl RpcHandler for TraceBlockByNumberRequest {
     }
 }
 
-/// Recursively collects 4-byte function selectors and calldata sizes from a call trace tree.
-fn collect_four_byte_selectors(frame: &CallTraceFrame, selectors: &mut HashMap<String, u64>) {
-    if frame.input.len() >= 4 {
+/// Collects 4-byte function selectors and calldata sizes from a call trace
+/// tree, matching geth's built-in `4byteTracer`
+/// (https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/4byte.go):
+///
+/// - The top-level transaction call is **not** counted; only nested calls are.
+/// - Only `CALL` and `DELEGATECALL` are counted. `STATICCALL`, `CALLCODE`,
+///   `CREATE`, `CREATE2`, and `SELFDESTRUCT` are skipped — geth's tracer
+///   filters on the opcode the same way.
+/// - Invocations targeting precompile addresses are skipped.
+/// - The reported size is `len(calldata) - 4` (the argument bytes), not the
+///   full input length.
+fn collect_four_byte_selectors(top_frame: &CallTraceFrame, selectors: &mut HashMap<String, u64>) {
+    for sub_call in &top_frame.calls {
+        collect_four_byte_recursive(sub_call, selectors);
+    }
+}
+
+fn collect_four_byte_recursive(frame: &CallTraceFrame, selectors: &mut HashMap<String, u64>) {
+    if matches!(frame.call_type, CallType::CALL | CallType::DELEGATECALL)
+        && frame.input.len() >= 4
+        && !is_precompile_address(&frame.to)
+    {
         let selector = hex::encode(&frame.input[..4]);
-        let key = format!("0x{selector}-{}", frame.input.len());
+        let arg_size = frame.input.len() - 4;
+        let key = format!("0x{selector}-{arg_size}");
         *selectors.entry(key).or_insert(0) += 1;
     }
     for sub_call in &frame.calls {
-        collect_four_byte_selectors(sub_call, selectors);
+        collect_four_byte_recursive(sub_call, selectors);
     }
+}
+
+/// Fork-agnostic precompile address check used by `4byteTracer`. Returns true
+/// for any address that maps to a precompile in some fork ethrex supports —
+/// see `crates/vm/levm/src/precompiles.rs` for the canonical table. This is
+/// slightly more aggressive than geth's per-fork check but defensible: every
+/// such address ends up routed through a precompile once that fork activates,
+/// so its calldata bytes are not a function selector.
+fn is_precompile_address(addr: &Address) -> bool {
+    let bytes = addr.as_bytes();
+    // L1 precompiles occupy 0x...01 through 0x...11 (BLAKE2F at 0x09, point
+    // evaluation at 0x0a, BLS12 family up to 0x11). 0x00 is intentionally not
+    // classified as a precompile.
+    if bytes[..19].iter().all(|&b| b == 0) && (1..=0x11).contains(&bytes[19]) {
+        return true;
+    }
+    // L2 P256VERIFY sits at 0x...0100.
+    if bytes[..18].iter().all(|&b| b == 0) && bytes[18] == 0x01 && bytes[19] == 0x00 {
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -470,72 +514,143 @@ mod tests {
 
     // --- collect_four_byte_selectors tests ---
 
-    #[test]
-    fn four_byte_selectors_empty_input() {
-        let frame = CallTraceFrame {
-            input: Bytes::new(),
+    /// `top_frame_call` builds a top-level frame with `calls` children. The
+    /// 4byteTracer skips the top frame itself, so the helper makes that
+    /// intent explicit in the test bodies.
+    fn top_frame_call(calls: Vec<CallTraceFrame>) -> CallTraceFrame {
+        CallTraceFrame {
+            call_type: CallType::CALL,
+            input: Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef, 0xff]),
+            calls,
             ..Default::default()
-        };
+        }
+    }
+
+    fn collect(top: &CallTraceFrame) -> HashMap<String, u64> {
         let mut selectors = HashMap::new();
-        collect_four_byte_selectors(&frame, &mut selectors);
-        assert!(selectors.is_empty());
+        collect_four_byte_selectors(top, &mut selectors);
+        selectors
     }
 
     #[test]
-    fn four_byte_selectors_short_input_ignored() {
-        let frame = CallTraceFrame {
+    fn four_byte_skips_top_level_call() {
+        // Top frame has a 4-byte selector but no children — the tracer must
+        // NOT record the top frame's selector (geth's tracer skips depth 0).
+        let top = top_frame_call(vec![]);
+        assert!(collect(&top).is_empty());
+    }
+
+    #[test]
+    fn four_byte_skips_short_calldata_subcall() {
+        let short = CallTraceFrame {
+            call_type: CallType::CALL,
             input: Bytes::from_static(&[0xa9, 0x05, 0x9c]),
             ..Default::default()
         };
-        let mut selectors = HashMap::new();
-        collect_four_byte_selectors(&frame, &mut selectors);
-        assert!(selectors.is_empty());
+        assert!(collect(&top_frame_call(vec![short])).is_empty());
     }
 
     #[test]
-    fn four_byte_selectors_single_call() {
-        let frame = CallTraceFrame {
+    fn four_byte_single_subcall_uses_arg_size_not_total_length() {
+        // 6 bytes total → selector + 2 arg bytes → key "0x...-2", not "-6".
+        let child = CallTraceFrame {
+            call_type: CallType::CALL,
             input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0x00, 0x01]),
             ..Default::default()
         };
-        let mut selectors = HashMap::new();
-        collect_four_byte_selectors(&frame, &mut selectors);
+        let selectors = collect(&top_frame_call(vec![child]));
         assert_eq!(selectors.len(), 1);
-        assert_eq!(selectors["0xa9059cbb-6"], 1);
+        assert_eq!(selectors["0xa9059cbb-2"], 1);
     }
 
     #[test]
-    fn four_byte_selectors_nested_calls() {
-        let child = CallTraceFrame {
+    fn four_byte_nested_subcalls() {
+        let grandchild = CallTraceFrame {
+            call_type: CallType::CALL,
             input: Bytes::from_static(&[0x23, 0xb8, 0x72, 0xdd, 0x01, 0x02, 0x03]),
             ..Default::default()
         };
-        let frame = CallTraceFrame {
+        let child = CallTraceFrame {
+            call_type: CallType::CALL,
             input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0xaa]),
-            calls: vec![child],
+            calls: vec![grandchild],
             ..Default::default()
         };
-        let mut selectors = HashMap::new();
-        collect_four_byte_selectors(&frame, &mut selectors);
+        let selectors = collect(&top_frame_call(vec![child]));
         assert_eq!(selectors.len(), 2);
-        assert_eq!(selectors["0xa9059cbb-5"], 1);
-        assert_eq!(selectors["0x23b872dd-7"], 1);
+        assert_eq!(selectors["0xa9059cbb-1"], 1);
+        assert_eq!(selectors["0x23b872dd-3"], 1);
     }
 
     #[test]
-    fn four_byte_selectors_duplicate_calls_counted() {
-        let child = CallTraceFrame {
+    fn four_byte_duplicate_subcalls_counted() {
+        let mk = || CallTraceFrame {
+            call_type: CallType::CALL,
             input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0xaa]),
             ..Default::default()
         };
-        let frame = CallTraceFrame {
-            input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0xaa]),
-            calls: vec![child],
-            ..Default::default()
-        };
-        let mut selectors = HashMap::new();
-        collect_four_byte_selectors(&frame, &mut selectors);
+        let selectors = collect(&top_frame_call(vec![mk(), mk()]));
         assert_eq!(selectors.len(), 1);
-        assert_eq!(selectors["0xa9059cbb-5"], 2);
+        assert_eq!(selectors["0xa9059cbb-1"], 2);
+    }
+
+    #[test]
+    fn four_byte_only_counts_call_and_delegatecall() {
+        // STATICCALL, CALLCODE, CREATE, CREATE2, SELFDESTRUCT all skipped.
+        let mk_with = |call_type: CallType| CallTraceFrame {
+            call_type,
+            input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0x01]),
+            ..Default::default()
+        };
+        let top = top_frame_call(vec![
+            mk_with(CallType::CALL),
+            mk_with(CallType::DELEGATECALL),
+            mk_with(CallType::STATICCALL),
+            mk_with(CallType::CALLCODE),
+            mk_with(CallType::CREATE),
+            mk_with(CallType::CREATE2),
+            mk_with(CallType::SELFDESTRUCT),
+        ]);
+        let selectors = collect(&top);
+        // Only the two valid ones contribute.
+        assert_eq!(selectors.len(), 1);
+        assert_eq!(selectors["0xa9059cbb-1"], 2);
+    }
+
+    #[test]
+    fn four_byte_skips_precompile_targets() {
+        let precompile_addrs = [
+            Address::from_low_u64_be(0x01),  // ECRECOVER
+            Address::from_low_u64_be(0x09),  // BLAKE2F
+            Address::from_low_u64_be(0x0a),  // POINT_EVALUATION
+            Address::from_low_u64_be(0x11),  // BLS12_MAP_FP2_TO_G2
+            Address::from_low_u64_be(0x100), // P256VERIFY (L2)
+        ];
+        let subcalls: Vec<_> = precompile_addrs
+            .iter()
+            .map(|addr| CallTraceFrame {
+                call_type: CallType::CALL,
+                to: *addr,
+                input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0x01]),
+                ..Default::default()
+            })
+            .collect();
+        assert!(collect(&top_frame_call(subcalls)).is_empty());
+    }
+
+    #[test]
+    fn is_precompile_address_boundaries() {
+        // First non-precompile slot above the BLS family.
+        assert!(!is_precompile_address(&Address::from_low_u64_be(0x12)));
+        assert!(!is_precompile_address(&Address::zero()));
+        // A regular contract address must never be classed as a precompile.
+        assert!(!is_precompile_address(
+            &"0x000000000000000000000000000000000000beef"
+                .parse()
+                .unwrap()
+        ));
+        // P256VERIFY at 0x100 is, but 0x101 isn't.
+        assert!(is_precompile_address(&Address::from_low_u64_be(0x100)));
+        assert!(!is_precompile_address(&Address::from_low_u64_be(0x101)));
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -413,9 +413,10 @@ impl RpcHandler for TraceBlockByNumberRequest {
 /// (https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/4byte.go):
 ///
 /// - The top-level transaction call is **not** counted; only nested calls are.
-/// - Only `CALL` and `DELEGATECALL` are counted. `STATICCALL`, `CALLCODE`,
-///   `CREATE`, `CREATE2`, and `SELFDESTRUCT` are skipped — geth's tracer
-///   filters on the opcode the same way.
+/// - `CALL`, `DELEGATECALL`, `STATICCALL`, and `CALLCODE` are counted
+///   (matching geth's `CaptureEnter`, which fires for all call types).
+///   `CREATE`, `CREATE2`, and `SELFDESTRUCT` are skipped because their
+///   input is init-code, not an ABI-encoded call.
 /// - Invocations targeting precompile addresses are skipped.
 /// - The reported size is `len(calldata) - 4` (the argument bytes), not the
 ///   full input length.
@@ -426,7 +427,7 @@ fn collect_four_byte_selectors(top_frame: &CallTraceFrame, selectors: &mut HashM
 }
 
 fn collect_four_byte_recursive(frame: &CallTraceFrame, selectors: &mut HashMap<String, u64>) {
-    if matches!(frame.call_type, CallType::CALL | CallType::DELEGATECALL)
+    if matches!(frame.call_type, CallType::CALL | CallType::DELEGATECALL | CallType::STATICCALL | CallType::CALLCODE)
         && frame.input.len() >= 4
         && !is_precompile_address(&frame.to)
     {
@@ -595,8 +596,9 @@ mod tests {
     }
 
     #[test]
-    fn four_byte_only_counts_call_and_delegatecall() {
-        // STATICCALL, CALLCODE, CREATE, CREATE2, SELFDESTRUCT all skipped.
+    fn four_byte_counts_all_call_types_except_create_and_selfdestruct() {
+        // CALL, DELEGATECALL, STATICCALL, CALLCODE are counted (matching geth).
+        // CREATE, CREATE2, SELFDESTRUCT are skipped (init-code, not ABI calls).
         let mk_with = |call_type: CallType| CallTraceFrame {
             call_type,
             input: Bytes::from_static(&[0xa9, 0x05, 0x9c, 0xbb, 0x01]),
@@ -612,9 +614,9 @@ mod tests {
             mk_with(CallType::SELFDESTRUCT),
         ]);
         let selectors = collect(&top);
-        // Only the two valid ones contribute.
+        // CALL + DELEGATECALL + STATICCALL + CALLCODE = 4 hits.
         assert_eq!(selectors.len(), 1);
-        assert_eq!(selectors["0xa9059cbb-1"], 2);
+        assert_eq!(selectors["0xa9059cbb-1"], 4);
     }
 
     #[test]

--- a/test/tests/rpc/debug_four_byte_tracer_tests.rs
+++ b/test/tests/rpc/debug_four_byte_tracer_tests.rs
@@ -1,0 +1,71 @@
+use ethrex_common::H256;
+use serde_json::{Value, json};
+
+use super::helpers::{rpc_call, rpc_call_expect_err, setup_single_transfer_block};
+
+#[tokio::test]
+async fn trace_tx_four_byte_tracer_value_transfer_is_empty() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", env.tx_hash)),
+            json!({"tracer": "4byteTracer"}),
+        ],
+    )
+    .await;
+
+    // A simple ETH transfer has no nested calls and the tracer skips the
+    // top-level call, so the result must be the empty map.
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.is_empty(), "simple transfer has no 4-byte selectors");
+}
+
+#[tokio::test]
+async fn trace_tx_four_byte_tracer_unknown_hash_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", H256::from_low_u64_be(0xdeadbeef))),
+            json!({"tracer": "4byteTracer"}),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Transaction not Found"),
+        "expected tx-not-found error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn trace_block_four_byte_tracer() {
+    let env = setup_single_transfer_block().await;
+
+    let result: Value = rpc_call(
+        &env.store,
+        "debug_traceBlockByNumber",
+        vec![
+            json!(format!("{:#x}", env.block.header.number)),
+            json!({"tracer": "4byteTracer"}),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1, "one tx in block");
+    let entry = arr[0].as_object().expect("entry should be an object");
+    assert_eq!(
+        entry["txHash"].as_str().unwrap().to_lowercase(),
+        format!("{:#x}", env.tx_hash).to_lowercase()
+    );
+    let selectors = entry["result"]
+        .as_object()
+        .expect("result should be a selector map");
+    assert!(selectors.is_empty(), "value transfer yields no selectors");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn trace_tx_four_byte_tracer() {

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,181 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn trace_tx_four_byte_tracer() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", env.tx_hash)),
+            json!({"tracer": "4byteTracer"}),
+        ],
+    )
+    .await;
+
+    // 4byteTracer returns an object mapping "selector-size" to call count.
+    // For a simple ETH transfer with no calldata the map should be empty.
+    let obj = result.as_object().expect("response should be an object");
+    assert!(obj.is_empty(), "simple transfer has no 4-byte selectors");
+}

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -15,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +113,7 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +137,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,25 +186,6 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
-}
-
-#[tokio::test]
-async fn trace_tx_four_byte_tracer() {
-    let env = setup_single_transfer_block().await;
-
-    let result = rpc_call(
-        &env.store,
-        "debug_traceTransaction",
-        vec![
-            json!(format!("{:#x}", env.tx_hash)),
-            json!({"tracer": "4byteTracer"}),
-        ],
-    )
-    .await;
-
-    // 4byteTracer returns an object mapping "selector-size" to call count.
-    // For a simple ETH transfer with no calldata the map should be empty.
-    let obj = result.as_object().expect("response should be an object");
-    assert!(obj.is_empty(), "simple transfer has no 4-byte selectors");
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_four_byte_tracer_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_four_byte_tracer_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Add `4byteTracer` tracer type for `debug_traceTransaction` and block tracing endpoints
- Records all function selectors (first 4 bytes of calldata) and their calldata sizes for every call in a transaction
- Returns a map of `"0xSELECTOR-SIZE" → count` (e.g. `{"0xa9059cbb-68": 1}`)
- Implemented by post-processing the existing call tracer output (walks the call trace tree to extract selectors)

Closes part of #6572

Closes #6644