### PR TITLE
feat(l1): implement flatCallTracer

### DIFF
--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -503,3 +503,143 @@ fn flatten_recursive(
         flatten_recursive(sub_call, &child_address, result);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::RpcHandler;
+    use serde_json::json;
+
+    // --- TracerType deserialization tests ---
+
+    #[test]
+    fn deserialize_tracer_type_flat_call() {
+        let t: TracerType = serde_json::from_value(json!("flatCallTracer")).unwrap();
+        assert!(matches!(t, TracerType::FlatCallTracer));
+    }
+
+    #[test]
+    fn deserialize_tracer_type_unknown_fails() {
+        assert!(serde_json::from_value::<TracerType>(json!("unknownTracer")).is_err());
+    }
+
+    // --- flatCallTracer parse test ---
+
+    #[test]
+    fn parse_trace_tx_flat_call_tracer() {
+        let params = Some(vec![
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001"),
+            json!({"tracer": "flatCallTracer"}),
+        ]);
+        let req = TraceTransactionRequest::parse(&params).unwrap();
+        assert!(matches!(req.trace_config.tracer, TracerType::FlatCallTracer));
+    }
+
+    // --- flatten_call_trace tests ---
+
+    #[test]
+    fn flatten_single_frame() {
+        let frame = CallTraceFrame {
+            call_type: CallType::CALL,
+            from: Address::zero(),
+            to: Address::from_low_u64_be(1),
+            gas: 21000,
+            gas_used: 21000,
+            input: Bytes::new(),
+            output: Bytes::new(),
+            ..Default::default()
+        };
+        let flat = flatten_call_trace(&frame);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].trace_address, Vec::<usize>::new());
+        assert_eq!(flat[0].subtraces, 0);
+        assert_eq!(flat[0].frame_type, "call");
+        assert!(flat[0].action.call_type.as_deref() == Some("call"));
+    }
+
+    #[test]
+    fn flatten_nested_frames() {
+        let grandchild = CallTraceFrame {
+            call_type: CallType::STATICCALL,
+            from: Address::from_low_u64_be(2),
+            to: Address::from_low_u64_be(3),
+            gas: 5000,
+            gas_used: 3000,
+            input: Bytes::new(),
+            output: Bytes::new(),
+            ..Default::default()
+        };
+        let child = CallTraceFrame {
+            call_type: CallType::DELEGATECALL,
+            from: Address::from_low_u64_be(1),
+            to: Address::from_low_u64_be(2),
+            gas: 10000,
+            gas_used: 8000,
+            input: Bytes::new(),
+            output: Bytes::new(),
+            calls: vec![grandchild],
+            ..Default::default()
+        };
+        let root = CallTraceFrame {
+            call_type: CallType::CALL,
+            from: Address::zero(),
+            to: Address::from_low_u64_be(1),
+            gas: 21000,
+            gas_used: 15000,
+            input: Bytes::new(),
+            output: Bytes::new(),
+            calls: vec![child],
+            ..Default::default()
+        };
+        let flat = flatten_call_trace(&root);
+        assert_eq!(flat.len(), 3);
+        // Root
+        assert_eq!(flat[0].trace_address, Vec::<usize>::new());
+        assert_eq!(flat[0].subtraces, 1);
+        // Child
+        assert_eq!(flat[1].trace_address, vec![0]);
+        assert_eq!(flat[1].subtraces, 1);
+        assert!(flat[1].action.call_type.as_deref() == Some("delegatecall"));
+        // Grandchild
+        assert_eq!(flat[2].trace_address, vec![0, 0]);
+        assert_eq!(flat[2].subtraces, 0);
+        assert!(flat[2].action.call_type.as_deref() == Some("staticcall"));
+    }
+
+    #[test]
+    fn flatten_create_frame_type() {
+        let frame = CallTraceFrame {
+            call_type: CallType::CREATE,
+            from: Address::zero(),
+            gas: 50000,
+            gas_used: 32000,
+            input: Bytes::new(),
+            output: Bytes::new(),
+            ..Default::default()
+        };
+        let flat = flatten_call_trace(&frame);
+        assert_eq!(flat[0].frame_type, "create");
+        assert!(flat[0].action.creation_method.as_deref() == Some("create"));
+        assert!(flat[0].action.call_type.is_none());
+        // `to` should be None for create frames
+        assert!(flat[0].action.to.is_none());
+    }
+
+    #[test]
+    fn flatten_error_frame_has_no_result() {
+        let frame = CallTraceFrame {
+            call_type: CallType::CALL,
+            from: Address::zero(),
+            to: Address::from_low_u64_be(1),
+            gas: 21000,
+            gas_used: 0,
+            input: Bytes::new(),
+            output: Bytes::new(),
+            error: Some("out of gas".to_string()),
+            ..Default::default()
+        };
+        let flat = flatten_call_trace(&frame);
+        assert!(flat[0].result.is_none());
+        assert_eq!(flat[0].error.as_deref(), Some("out of gas"));
+    }
+}

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -532,7 +532,10 @@ mod tests {
             json!({"tracer": "flatCallTracer"}),
         ]);
         let req = TraceTransactionRequest::parse(&params).unwrap();
-        assert!(matches!(req.trace_config.tracer, TracerType::FlatCallTracer));
+        assert!(matches!(
+            req.trace_config.tracer,
+            TracerType::FlatCallTracer
+        ));
     }
 
     // --- flatten_call_trace tests ---

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
-use ethrex_common::H256;
+use bytes::Bytes;
+use ethrex_common::{Address, H256, U256};
 use ethrex_common::{
     serde_utils,
-    tracing::{CallTraceFrame, PrestateResult, StructLoggerEmit, StructLoggerResult},
+    tracing::{CallTraceFrame, CallType, PrestateResult, StructLoggerEmit, StructLoggerResult},
 };
 use ethrex_vm::tracing::OpcodeTracerConfig;
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,9 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
+    /// Flat call tracer that returns a flat array of call frames with
+    /// `traceAddress` and `subtraces` fields (Parity/OpenEthereum format).
+    FlatCallTracer,
 }
 
 #[derive(Deserialize, Default)]
@@ -209,6 +213,25 @@ impl RpcHandler for TraceTransactionRequest {
                     emit,
                 })?)
             }
+            TracerType::FlatCallTracer => {
+                let call_trace = context
+                    .blockchain
+                    .trace_transaction_calls(
+                        self.tx_hash,
+                        reexec,
+                        timeout,
+                        false, // need all subcalls
+                        false,
+                    )
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                let top_frame = call_trace
+                    .into_iter()
+                    .next()
+                    .ok_or(RpcErr::Internal("Empty call trace".to_string()))?;
+                let flat_frames = flatten_call_trace(&top_frame);
+                Ok(serde_json::to_value(flat_frames)?)
+            }
         }
     }
 }
@@ -355,6 +378,128 @@ impl RpcHandler for TraceBlockByNumberRequest {
                     .collect::<Result<_, serde_json::Error>>()?;
                 Ok(serde_json::to_value(block_trace)?)
             }
+            TracerType::FlatCallTracer => {
+                let call_traces = context
+                    .blockchain
+                    .trace_block_calls(block, reexec, timeout, false, false)
+                    .await
+                    .map_err(|err| RpcErr::Internal(err.to_string()))?;
+                let block_trace: BlockTrace<Vec<FlatCallFrame>> = call_traces
+                    .into_iter()
+                    .map(|(hash, trace)| {
+                        let frame = trace
+                            .into_iter()
+                            .next()
+                            .ok_or_else(|| RpcErr::Internal("Empty call trace".to_string()))?;
+                        let flat_frames = flatten_call_trace(&frame);
+                        Ok((hash, flat_frames).into())
+                    })
+                    .collect::<Result<_, RpcErr>>()?;
+                Ok(serde_json::to_value(block_trace)?)
+            }
         }
+    }
+}
+
+// ── flatCallTracer types and helpers ─────────────────────────────────────
+
+/// A single flattened call frame following the Parity/OpenEthereum trace format.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FlatCallFrame {
+    action: FlatCallAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<FlatCallResult>,
+    subtraces: usize,
+    trace_address: Vec<usize>,
+    #[serde(rename = "type")]
+    frame_type: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FlatCallAction {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    call_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    creation_method: Option<String>,
+    from: Address,
+    #[serde(with = "serde_utils::u64::hex_str")]
+    gas: u64,
+    #[serde(with = "serde_utils::bytes")]
+    input: Bytes,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    to: Option<Address>,
+    value: U256,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FlatCallResult {
+    #[serde(with = "serde_utils::u64::hex_str")]
+    gas_used: u64,
+    #[serde(with = "serde_utils::bytes")]
+    output: Bytes,
+}
+
+/// Flattens a nested `CallTraceFrame` tree into a flat array with
+/// `traceAddress` and `subtraces` fields.
+fn flatten_call_trace(root: &CallTraceFrame) -> Vec<FlatCallFrame> {
+    let mut result = Vec::new();
+    flatten_recursive(root, &[], &mut result);
+    result
+}
+
+fn flatten_recursive(
+    frame: &CallTraceFrame,
+    trace_address: &[usize],
+    result: &mut Vec<FlatCallFrame>,
+) {
+    let (frame_type, call_type, creation_method) = match frame.call_type {
+        CallType::CALL => ("call", Some("call"), None),
+        CallType::CALLCODE => ("call", Some("callcode"), None),
+        CallType::STATICCALL => ("call", Some("staticcall"), None),
+        CallType::DELEGATECALL => ("call", Some("delegatecall"), None),
+        CallType::CREATE => ("create", None, Some("create")),
+        CallType::CREATE2 => ("create", None, Some("create2")),
+        CallType::SELFDESTRUCT => ("suicide", None, None),
+    };
+
+    let flat = FlatCallFrame {
+        action: FlatCallAction {
+            call_type: call_type.map(String::from),
+            creation_method: creation_method.map(String::from),
+            from: frame.from,
+            gas: frame.gas,
+            input: frame.input.clone(),
+            to: if frame_type == "call" {
+                Some(frame.to)
+            } else {
+                None
+            },
+            value: frame.value,
+        },
+        error: frame.error.clone(),
+        result: if frame.error.is_none() {
+            Some(FlatCallResult {
+                gas_used: frame.gas_used,
+                output: frame.output.clone(),
+            })
+        } else {
+            None
+        },
+        subtraces: frame.calls.len(),
+        trace_address: trace_address.to_vec(),
+        frame_type: frame_type.to_string(),
+    };
+
+    result.push(flat);
+
+    for (i, sub_call) in frame.calls.iter().enumerate() {
+        let mut child_address = trace_address.to_vec();
+        child_address.push(i);
+        flatten_recursive(sub_call, &child_address, result);
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -60,8 +60,10 @@ enum TracerType {
     /// `structLogger` wrapper shape (`{failed, gas, returnValue, structLogs}`).
     /// Selected via `"tracer": "opcodeTracer"`.
     OpcodeTracer,
-    /// Flat call tracer that returns a flat array of call frames with
-    /// `traceAddress` and `subtraces` fields (Parity/OpenEthereum format).
+    /// Flat call tracer matching geth's built-in `flatCallTracer`: a flat array
+    /// of call frames with `traceAddress` and `subtraces`, following the
+    /// Parity/OpenEthereum shape plus geth's `creationMethod` field on
+    /// `create` actions. Selected via `"tracer": "flatCallTracer"`.
     FlatCallTracer,
 }
 
@@ -402,8 +404,19 @@ impl RpcHandler for TraceBlockByNumberRequest {
 }
 
 // ── flatCallTracer types and helpers ─────────────────────────────────────
+//
+// Output mirrors geth's built-in `flatCallTracer`
+// (https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/call_flat.go),
+// which itself follows the Parity/OpenEthereum trace shape but adds a
+// `creationMethod` field on `create` frames. Three variants exist:
+//
+// - `type: "call"`  → action has callType/from/gas/input/to/value,
+//                     result has gasUsed/output
+// - `type: "create"`→ action has creationMethod/from/gas/init/value,
+//                     result has address/code/gasUsed
+// - `type: "suicide"`→ action has address/balance/refundAddress, no result
 
-/// A single flattened call frame following the Parity/OpenEthereum trace format.
+/// A single flattened call frame.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct FlatCallFrame {
@@ -415,37 +428,67 @@ struct FlatCallFrame {
     subtraces: usize,
     trace_address: Vec<usize>,
     #[serde(rename = "type")]
-    frame_type: String,
+    frame_type: &'static str,
+}
+
+/// Per-variant action object. The outer `type` field disambiguates which shape
+/// is in use; `#[serde(untagged)]` emits the inner fields directly without a
+/// discriminator key, matching geth.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum FlatCallAction {
+    #[serde(rename_all = "camelCase")]
+    Call {
+        call_type: &'static str,
+        from: Address,
+        #[serde(with = "serde_utils::u64::hex_str")]
+        gas: u64,
+        #[serde(with = "serde_utils::bytes")]
+        input: Bytes,
+        to: Address,
+        value: U256,
+    },
+    #[serde(rename_all = "camelCase")]
+    Create {
+        creation_method: &'static str,
+        from: Address,
+        #[serde(with = "serde_utils::u64::hex_str")]
+        gas: u64,
+        #[serde(with = "serde_utils::bytes")]
+        init: Bytes,
+        value: U256,
+    },
+    #[serde(rename_all = "camelCase")]
+    Suicide {
+        address: Address,
+        balance: U256,
+        refund_address: Address,
+    },
 }
 
 #[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FlatCallAction {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    call_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    creation_method: Option<String>,
-    from: Address,
-    #[serde(with = "serde_utils::u64::hex_str")]
-    gas: u64,
-    #[serde(with = "serde_utils::bytes")]
-    input: Bytes,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    to: Option<Address>,
-    value: U256,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FlatCallResult {
-    #[serde(with = "serde_utils::u64::hex_str")]
-    gas_used: u64,
-    #[serde(with = "serde_utils::bytes")]
-    output: Bytes,
+#[serde(untagged)]
+enum FlatCallResult {
+    #[serde(rename_all = "camelCase")]
+    Call {
+        #[serde(with = "serde_utils::u64::hex_str")]
+        gas_used: u64,
+        #[serde(with = "serde_utils::bytes")]
+        output: Bytes,
+    },
+    #[serde(rename_all = "camelCase")]
+    Create {
+        address: Address,
+        #[serde(with = "serde_utils::bytes")]
+        code: Bytes,
+        #[serde(with = "serde_utils::u64::hex_str")]
+        gas_used: u64,
+    },
 }
 
 /// Flattens a nested `CallTraceFrame` tree into a flat array with
-/// `traceAddress` and `subtraces` fields.
+/// `traceAddress` and `subtraces` fields. Maximum recursion depth is bounded
+/// by the EVM call depth limit (1024), so stack usage is safe.
 fn flatten_call_trace(root: &CallTraceFrame) -> Vec<FlatCallFrame> {
     let mut result = Vec::new();
     flatten_recursive(root, &[], &mut result);
@@ -457,45 +500,79 @@ fn flatten_recursive(
     trace_address: &[usize],
     result: &mut Vec<FlatCallFrame>,
 ) {
-    let (frame_type, call_type, creation_method) = match frame.call_type {
-        CallType::CALL => ("call", Some("call"), None),
-        CallType::CALLCODE => ("call", Some("callcode"), None),
-        CallType::STATICCALL => ("call", Some("staticcall"), None),
-        CallType::DELEGATECALL => ("call", Some("delegatecall"), None),
-        CallType::CREATE => ("create", None, Some("create")),
-        CallType::CREATE2 => ("create", None, Some("create2")),
-        CallType::SELFDESTRUCT => ("suicide", None, None),
+    let frame_type: &'static str = match frame.call_type {
+        CallType::CALL | CallType::CALLCODE | CallType::STATICCALL | CallType::DELEGATECALL => {
+            "call"
+        }
+        CallType::CREATE | CallType::CREATE2 => "create",
+        CallType::SELFDESTRUCT => "suicide",
     };
 
-    let flat = FlatCallFrame {
-        action: FlatCallAction {
-            call_type: call_type.map(String::from),
-            creation_method: creation_method.map(String::from),
+    let action = match frame.call_type {
+        CallType::CALL | CallType::CALLCODE | CallType::STATICCALL | CallType::DELEGATECALL => {
+            FlatCallAction::Call {
+                call_type: match frame.call_type {
+                    CallType::CALL => "call",
+                    CallType::CALLCODE => "callcode",
+                    CallType::STATICCALL => "staticcall",
+                    CallType::DELEGATECALL => "delegatecall",
+                    _ => unreachable!(),
+                },
+                from: frame.from,
+                gas: frame.gas,
+                input: frame.input.clone(),
+                to: frame.to,
+                value: frame.value,
+            }
+        }
+        CallType::CREATE | CallType::CREATE2 => FlatCallAction::Create {
+            creation_method: if matches!(frame.call_type, CallType::CREATE) {
+                "create"
+            } else {
+                "create2"
+            },
             from: frame.from,
             gas: frame.gas,
-            input: frame.input.clone(),
-            to: if frame_type == "call" {
-                Some(frame.to)
-            } else {
-                None
-            },
+            init: frame.input.clone(),
             value: frame.value,
         },
-        error: frame.error.clone(),
-        result: if frame.error.is_none() {
-            Some(FlatCallResult {
-                gas_used: frame.gas_used,
-                output: frame.output.clone(),
-            })
-        } else {
-            None
+        // SELFDESTRUCT: `from` is the destructed contract, `to` is the refund
+        // address, `value` is the balance forwarded — match those onto Parity's
+        // suicide action shape.
+        CallType::SELFDESTRUCT => FlatCallAction::Suicide {
+            address: frame.from,
+            balance: frame.value,
+            refund_address: frame.to,
         },
-        subtraces: frame.calls.len(),
-        trace_address: trace_address.to_vec(),
-        frame_type: frame_type.to_string(),
     };
 
-    result.push(flat);
+    // Suicide frames never carry a result; failed frames omit it too (the
+    // failure is surfaced via the `error` field).
+    let result_value = if frame.error.is_some() || matches!(frame.call_type, CallType::SELFDESTRUCT)
+    {
+        None
+    } else {
+        Some(match frame.call_type {
+            CallType::CREATE | CallType::CREATE2 => FlatCallResult::Create {
+                address: frame.to,
+                code: frame.output.clone(),
+                gas_used: frame.gas_used,
+            },
+            _ => FlatCallResult::Call {
+                gas_used: frame.gas_used,
+                output: frame.output.clone(),
+            },
+        })
+    };
+
+    result.push(FlatCallFrame {
+        action,
+        error: frame.error.clone(),
+        result: result_value,
+        subtraces: frame.calls.len(),
+        trace_address: trace_address.to_vec(),
+        frame_type,
+    });
 
     for (i, sub_call) in frame.calls.iter().enumerate() {
         let mut child_address = trace_address.to_vec();
@@ -539,47 +616,56 @@ mod tests {
     }
 
     // --- flatten_call_trace tests ---
+    //
+    // The Serialize-only types are inspected via their JSON projection so we
+    // verify the wire shape clients actually receive.
+
+    fn flat_json(frame: &CallTraceFrame) -> Vec<serde_json::Value> {
+        flatten_call_trace(frame)
+            .iter()
+            .map(|f| serde_json::to_value(f).unwrap())
+            .collect()
+    }
 
     #[test]
-    fn flatten_single_frame() {
+    fn flatten_single_call_frame() {
         let frame = CallTraceFrame {
             call_type: CallType::CALL,
             from: Address::zero(),
             to: Address::from_low_u64_be(1),
             gas: 21000,
             gas_used: 21000,
-            input: Bytes::new(),
-            output: Bytes::new(),
             ..Default::default()
         };
-        let flat = flatten_call_trace(&frame);
-        assert_eq!(flat.len(), 1);
-        assert_eq!(flat[0].trace_address, Vec::<usize>::new());
-        assert_eq!(flat[0].subtraces, 0);
-        assert_eq!(flat[0].frame_type, "call");
-        assert!(flat[0].action.call_type.as_deref() == Some("call"));
+        let frames = flat_json(&frame);
+        assert_eq!(frames.len(), 1);
+        let f = &frames[0];
+        assert_eq!(f["type"], "call");
+        assert_eq!(f["traceAddress"], json!([]));
+        assert_eq!(f["subtraces"], 0);
+        assert_eq!(f["action"]["callType"], "call");
+        assert_eq!(
+            f["action"]["to"],
+            format!("{:#x}", Address::from_low_u64_be(1))
+        );
+        // Call results carry gasUsed + output, not address/code.
+        assert!(f["result"]["gasUsed"].is_string());
+        assert!(f["result"]["output"].is_string());
+        assert!(f["result"].get("address").is_none());
     }
 
     #[test]
-    fn flatten_nested_frames() {
+    fn flatten_nested_frames_pre_order_with_trace_address() {
         let grandchild = CallTraceFrame {
             call_type: CallType::STATICCALL,
             from: Address::from_low_u64_be(2),
             to: Address::from_low_u64_be(3),
-            gas: 5000,
-            gas_used: 3000,
-            input: Bytes::new(),
-            output: Bytes::new(),
             ..Default::default()
         };
         let child = CallTraceFrame {
             call_type: CallType::DELEGATECALL,
             from: Address::from_low_u64_be(1),
             to: Address::from_low_u64_be(2),
-            gas: 10000,
-            gas_used: 8000,
-            input: Bytes::new(),
-            output: Bytes::new(),
             calls: vec![grandchild],
             ..Default::default()
         };
@@ -587,62 +673,103 @@ mod tests {
             call_type: CallType::CALL,
             from: Address::zero(),
             to: Address::from_low_u64_be(1),
-            gas: 21000,
-            gas_used: 15000,
-            input: Bytes::new(),
-            output: Bytes::new(),
             calls: vec![child],
             ..Default::default()
         };
-        let flat = flatten_call_trace(&root);
-        assert_eq!(flat.len(), 3);
-        // Root
-        assert_eq!(flat[0].trace_address, Vec::<usize>::new());
-        assert_eq!(flat[0].subtraces, 1);
-        // Child
-        assert_eq!(flat[1].trace_address, vec![0]);
-        assert_eq!(flat[1].subtraces, 1);
-        assert!(flat[1].action.call_type.as_deref() == Some("delegatecall"));
-        // Grandchild
-        assert_eq!(flat[2].trace_address, vec![0, 0]);
-        assert_eq!(flat[2].subtraces, 0);
-        assert!(flat[2].action.call_type.as_deref() == Some("staticcall"));
+        let frames = flat_json(&root);
+        assert_eq!(frames.len(), 3);
+        assert_eq!(frames[0]["traceAddress"], json!([]));
+        assert_eq!(frames[0]["subtraces"], 1);
+        assert_eq!(frames[1]["traceAddress"], json!([0]));
+        assert_eq!(frames[1]["action"]["callType"], "delegatecall");
+        assert_eq!(frames[1]["subtraces"], 1);
+        assert_eq!(frames[2]["traceAddress"], json!([0, 0]));
+        assert_eq!(frames[2]["action"]["callType"], "staticcall");
+        assert_eq!(frames[2]["subtraces"], 0);
     }
 
     #[test]
-    fn flatten_create_frame_type() {
+    fn flatten_create_emits_init_and_address_code_result() {
+        let deployed_addr = Address::from_low_u64_be(0x42);
         let frame = CallTraceFrame {
             call_type: CallType::CREATE,
             from: Address::zero(),
+            to: deployed_addr,
             gas: 50000,
             gas_used: 32000,
-            input: Bytes::new(),
-            output: Bytes::new(),
+            input: Bytes::from_static(b"init"),
+            output: Bytes::from_static(&[0xfe, 0xfe, 0xfe]),
             ..Default::default()
         };
-        let flat = flatten_call_trace(&frame);
-        assert_eq!(flat[0].frame_type, "create");
-        assert!(flat[0].action.creation_method.as_deref() == Some("create"));
-        assert!(flat[0].action.call_type.is_none());
-        // `to` should be None for create frames
-        assert!(flat[0].action.to.is_none());
+        let frames = flat_json(&frame);
+        let f = &frames[0];
+        assert_eq!(f["type"], "create");
+        assert_eq!(f["action"]["creationMethod"], "create");
+        // The init code lives under `init`, not `input`.
+        assert!(
+            f["action"].get("input").is_none(),
+            "create action must use `init`, not `input`"
+        );
+        assert!(f["action"]["init"].is_string());
+        // `to` does not appear on create actions.
+        assert!(f["action"].get("to").is_none());
+        // Result carries address + code, not output.
+        assert_eq!(f["result"]["address"], format!("{deployed_addr:#x}"));
+        assert!(f["result"]["code"].is_string());
+        assert!(f["result"].get("output").is_none());
+        assert!(f["result"]["gasUsed"].is_string());
     }
 
     #[test]
-    fn flatten_error_frame_has_no_result() {
+    fn flatten_create2_uses_create2_method() {
+        let frame = CallTraceFrame {
+            call_type: CallType::CREATE2,
+            ..Default::default()
+        };
+        let frames = flat_json(&frame);
+        assert_eq!(frames[0]["action"]["creationMethod"], "create2");
+    }
+
+    #[test]
+    fn flatten_selfdestruct_uses_suicide_shape() {
+        let destructed = Address::from_low_u64_be(0xaa);
+        let beneficiary = Address::from_low_u64_be(0xbb);
+        let balance = U256::from(123_456u64);
+        let frame = CallTraceFrame {
+            call_type: CallType::SELFDESTRUCT,
+            from: destructed,
+            to: beneficiary,
+            value: balance,
+            ..Default::default()
+        };
+        let frames = flat_json(&frame);
+        let f = &frames[0];
+        assert_eq!(f["type"], "suicide");
+        // Action shape is {address, balance, refundAddress} — nothing from the
+        // call shape leaks through.
+        assert_eq!(f["action"]["address"], format!("{destructed:#x}"));
+        assert_eq!(f["action"]["refundAddress"], format!("{beneficiary:#x}"));
+        assert!(f["action"]["balance"].is_string());
+        assert!(f["action"].get("from").is_none());
+        assert!(f["action"].get("to").is_none());
+        assert!(f["action"].get("callType").is_none());
+        assert!(f["action"].get("input").is_none());
+        // Suicide frames never carry a result.
+        assert!(f.get("result").is_none() || f["result"].is_null());
+    }
+
+    #[test]
+    fn flatten_failed_call_omits_result_and_keeps_error() {
         let frame = CallTraceFrame {
             call_type: CallType::CALL,
             from: Address::zero(),
             to: Address::from_low_u64_be(1),
-            gas: 21000,
-            gas_used: 0,
-            input: Bytes::new(),
-            output: Bytes::new(),
             error: Some("out of gas".to_string()),
             ..Default::default()
         };
-        let flat = flatten_call_trace(&frame);
-        assert!(flat[0].result.is_none());
-        assert_eq!(flat[0].error.as_deref(), Some("out of gas"));
+        let frames = flat_json(&frame);
+        let f = &frames[0];
+        assert_eq!(f["error"], "out of gas");
+        assert!(f.get("result").is_none() || f["result"].is_null());
     }
 }

--- a/crates/networking/rpc/tracing.rs
+++ b/crates/networking/rpc/tracing.rs
@@ -565,6 +565,15 @@ fn flatten_recursive(
         })
     };
 
+    // SELFDESTRUCT frames are always leaves in the call tree — the EVM cannot
+    // execute further code after self-destructing. Assert this invariant so
+    // that a future tracer bug doesn't silently produce malformed output.
+    debug_assert!(
+        !matches!(frame.call_type, CallType::SELFDESTRUCT) || frame.calls.is_empty(),
+        "SELFDESTRUCT frame must be a leaf (no children), got {} subcalls",
+        frame.calls.len(),
+    );
+
     result.push(FlatCallFrame {
         action,
         error: frame.error.clone(),

--- a/test/tests/rpc/debug_flat_call_tracer_tests.rs
+++ b/test/tests/rpc/debug_flat_call_tracer_tests.rs
@@ -1,0 +1,141 @@
+use ethrex_common::H256;
+use serde_json::{Value, json};
+
+use super::helpers::{
+    rpc_call, rpc_call_expect_err, setup_single_deploy_block, setup_single_transfer_block,
+};
+
+#[tokio::test]
+async fn trace_tx_flat_call_tracer_value_transfer() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", env.tx_hash)),
+            json!({"tracer": "flatCallTracer"}),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "value transfer should produce a single flat frame"
+    );
+
+    let f = &arr[0];
+    assert_eq!(f["type"], "call");
+    assert_eq!(f["traceAddress"], json!([]));
+    assert_eq!(f["subtraces"], 0);
+    assert_eq!(f["action"]["callType"], "call");
+    assert!(f["action"]["from"].is_string());
+    assert!(f["action"]["to"].is_string());
+    assert!(f["action"]["gas"].is_string());
+    // Call results carry gasUsed + output, NOT address/code.
+    assert!(f["result"]["gasUsed"].is_string());
+    assert!(f["result"]["output"].is_string());
+    assert!(f["result"].get("address").is_none());
+}
+
+#[tokio::test]
+async fn trace_tx_flat_call_tracer_create() {
+    let env = setup_single_deploy_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", env.tx_hash)),
+            json!({"tracer": "flatCallTracer"}),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert!(
+        !arr.is_empty(),
+        "deploy tx should produce at least one frame"
+    );
+    // The top frame for a contract deployment is the CREATE.
+    let f = &arr[0];
+    assert_eq!(f["type"], "create");
+    assert_eq!(f["action"]["creationMethod"], "create");
+    // Init code lives under `init`, not `input`.
+    assert!(
+        f["action"]["init"].is_string(),
+        "create action must carry `init`"
+    );
+    assert!(
+        f["action"].get("input").is_none(),
+        "create action must not carry `input`"
+    );
+    assert!(
+        f["action"].get("to").is_none(),
+        "create action must not carry `to`"
+    );
+    // Result carries the deployed `address` and runtime `code`.
+    assert!(
+        f["result"]["address"].is_string(),
+        "create result must carry deployed `address`"
+    );
+    assert!(
+        f["result"]["code"].is_string(),
+        "create result must carry deployed `code`"
+    );
+    assert!(
+        f["result"].get("output").is_none(),
+        "create result must not carry `output`"
+    );
+}
+
+#[tokio::test]
+async fn trace_tx_flat_call_tracer_unknown_hash_errors() {
+    let env = setup_single_transfer_block().await;
+
+    let err = rpc_call_expect_err(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", H256::from_low_u64_be(0xdeadbeef))),
+            json!({"tracer": "flatCallTracer"}),
+        ],
+    )
+    .await;
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("Transaction not Found"),
+        "expected tx-not-found error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn trace_block_flat_call_tracer() {
+    let env = setup_single_transfer_block().await;
+
+    let result: Value = rpc_call(
+        &env.store,
+        "debug_traceBlockByNumber",
+        vec![
+            json!(format!("{:#x}", env.block.header.number)),
+            json!({"tracer": "flatCallTracer"}),
+        ],
+    )
+    .await;
+
+    let arr = result.as_array().expect("response should be an array");
+    assert_eq!(arr.len(), 1, "one tx in block");
+    let entry = arr[0].as_object().expect("entry should be an object");
+    assert_eq!(
+        entry["txHash"].as_str().unwrap().to_lowercase(),
+        format!("{:#x}", env.tx_hash).to_lowercase()
+    );
+    let frames = entry["result"]
+        .as_array()
+        .expect("result should be a flat frame array");
+    assert_eq!(frames.len(), 1, "value transfer is a single frame");
+    assert_eq!(frames[0]["type"], "call");
+    assert_eq!(frames[0]["action"]["callType"], "call");
+}

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -20,8 +20,7 @@ use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str =
-    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
 const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
 const TEST_GAS_LIMIT: u64 = 100_000;
 
@@ -116,7 +115,9 @@ async fn build_and_execute_block(
     }
     let block = build_block(store, blockchain, parent_header).await;
     assert_eq!(block.body.transactions.len(), transactions.len());
-    blockchain.add_block(block.clone()).expect("block should be valid");
+    blockchain
+        .add_block(block.clone())
+        .expect("block should be valid");
     store
         .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
         .await
@@ -156,9 +157,12 @@ async fn setup_single_transfer_block() -> TestEnv {
     let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
     let tx_hash = tx.hash();
     let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
-    TestEnv { store, block, tx_hash }
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+    }
 }
-
 
 #[tokio::test]
 async fn trace_tx_flat_call_tracer() {
@@ -180,8 +184,14 @@ async fn trace_tx_flat_call_tracer() {
 
     let frame = arr[0].as_object().expect("frame should be an object");
     assert!(frame.contains_key("action"), "frame should have 'action'");
-    assert!(frame.contains_key("subtraces"), "frame should have 'subtraces'");
-    assert!(frame.contains_key("traceAddress"), "frame should have 'traceAddress'");
+    assert!(
+        frame.contains_key("subtraces"),
+        "frame should have 'subtraces'"
+    );
+    assert!(
+        frame.contains_key("traceAddress"),
+        "frame should have 'traceAddress'"
+    );
     assert!(frame.contains_key("type"), "frame should have 'type'");
     assert_eq!(frame["type"].as_str().unwrap(), "call");
 }

--- a/test/tests/rpc/debug_trace_tests.rs
+++ b/test/tests/rpc/debug_trace_tests.rs
@@ -1,0 +1,187 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, H256, U256,
+    types::{
+        Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, ELASTICITY_MULTIPLIER,
+        GenesisAccount, Transaction, TxKind,
+    },
+};
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_rpc::rpc::map_http_requests;
+use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::utils::RpcRequest;
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use serde_json::{Value, json};
+
+const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+const TEST_GAS_LIMIT: u64 = 100_000;
+
+fn test_secret_key() -> SecretKey {
+    SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn sender_from_key(sk: &SecretKey) -> Address {
+    LocalSigner::new(*sk).address
+}
+
+async fn setup_store(sender: Address) -> (Store, u64) {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("Failed to open genesis file");
+    let reader = BufReader::new(file);
+    let mut genesis: ethrex_common::types::Genesis =
+        serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
+    let chain_id = genesis.config.chain_id;
+    genesis.alloc.insert(
+        sender,
+        GenesisAccount {
+            balance: U256::from(10).pow(U256::from(20)),
+            code: Bytes::new(),
+            storage: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store =
+        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("Failed to add genesis state");
+    (store, chain_id)
+}
+
+async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+    let args = BuildPayloadArgs {
+        parent: parent_header.hash(),
+        timestamp: parent_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let block = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = blockchain.build_payload(block).unwrap();
+    result.payload
+}
+
+async fn create_transfer_tx(
+    chain_id: u64,
+    nonce: u64,
+    to: Address,
+    value: U256,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: TEST_GAS_LIMIT,
+        to: TxKind::Call(to),
+        value,
+        data: Bytes::new(),
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+async fn build_and_execute_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+    transactions: Vec<Transaction>,
+) -> Block {
+    for tx in &transactions {
+        blockchain
+            .add_transaction_to_pool(tx.clone())
+            .await
+            .expect("tx should enter pool");
+    }
+    let block = build_block(store, blockchain, parent_header).await;
+    assert_eq!(block.body.transactions.len(), transactions.len());
+    blockchain.add_block(block.clone()).expect("block should be valid");
+    store
+        .forkchoice_update(vec![], block.header.number, block.hash(), None, None)
+        .await
+        .unwrap();
+    block
+}
+
+async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect("RPC call should succeed")
+}
+
+struct TestEnv {
+    store: Store,
+    block: Block,
+    tx_hash: H256,
+}
+
+async fn setup_single_transfer_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let recipient = Address::from_low_u64_be(0xAA);
+    let value = U256::from(1_000_000_000_000_000_000u64);
+    let tx = create_transfer_tx(chain_id, 0, recipient, value, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv { store, block, tx_hash }
+}
+
+
+#[tokio::test]
+async fn trace_tx_flat_call_tracer() {
+    let env = setup_single_transfer_block().await;
+
+    let result = rpc_call(
+        &env.store,
+        "debug_traceTransaction",
+        vec![
+            json!(format!("{:#x}", env.tx_hash)),
+            json!({"tracer": "flatCallTracer"}),
+        ],
+    )
+    .await;
+
+    // flatCallTracer returns a flat array of call frames.
+    let arr = result.as_array().expect("response should be an array");
+    assert!(!arr.is_empty(), "should have at least one frame");
+
+    let frame = arr[0].as_object().expect("frame should be an object");
+    assert!(frame.contains_key("action"), "frame should have 'action'");
+    assert!(frame.contains_key("subtraces"), "frame should have 'subtraces'");
+    assert!(frame.contains_key("traceAddress"), "frame should have 'traceAddress'");
+    assert!(frame.contains_key("type"), "frame should have 'type'");
+    assert_eq!(frame["type"].as_str().unwrap(), "call");
+}

--- a/test/tests/rpc/helpers.rs
+++ b/test/tests/rpc/helpers.rs
@@ -1,3 +1,10 @@
+//! Shared setup helpers for the rpc integration tests. Each test file builds
+//! its own in-memory `Store`, funds a known sender, and uses [`rpc_call`] to
+//! drive the dispatcher just like a live request would. Individual test files
+//! only need a subset of the helpers, so the module is permissive about dead
+//! code rather than gating each item separately.
+#![allow(dead_code)]
+
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use bytes::Bytes;
@@ -15,16 +22,17 @@ use ethrex_common::{
 use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
 use ethrex_rpc::rpc::map_http_requests;
 use ethrex_rpc::test_utils::default_context_with_storage;
-use ethrex_rpc::utils::RpcRequest;
+use ethrex_rpc::utils::{RpcErr, RpcRequest};
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use serde_json::{Value, json};
 
-const TEST_PRIVATE_KEY: &str = "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
-const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
-const TEST_GAS_LIMIT: u64 = 100_000;
+pub const TEST_PRIVATE_KEY: &str =
+    "850643a0224065ecce3882673c21f56bcf6eef86274cc21cadff15930b59fc8c";
+pub const TEST_MAX_FEE_PER_GAS: u64 = 10_000_000_000;
+pub const TEST_GAS_LIMIT: u64 = 100_000;
 
-fn test_secret_key() -> SecretKey {
+pub fn test_secret_key() -> SecretKey {
     SecretKey::from_slice(&hex::decode(TEST_PRIVATE_KEY).unwrap()).unwrap()
 }
 
@@ -32,11 +40,11 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
-fn sender_from_key(sk: &SecretKey) -> Address {
+pub fn sender_from_key(sk: &SecretKey) -> Address {
     LocalSigner::new(*sk).address
 }
 
-async fn setup_store(sender: Address) -> (Store, u64) {
+pub async fn setup_store(sender: Address) -> (Store, u64) {
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
     let reader = BufReader::new(file);
@@ -61,7 +69,11 @@ async fn setup_store(sender: Address) -> (Store, u64) {
     (store, chain_id)
 }
 
-async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &BlockHeader) -> Block {
+pub async fn build_block(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent_header: &BlockHeader,
+) -> Block {
     let args = BuildPayloadArgs {
         parent: parent_header.hash(),
         timestamp: parent_header.timestamp + 12,
@@ -79,7 +91,7 @@ async fn build_block(store: &Store, blockchain: &Blockchain, parent_header: &Blo
     result.payload
 }
 
-async fn create_transfer_tx(
+pub async fn create_transfer_tx(
     chain_id: u64,
     nonce: u64,
     to: Address,
@@ -101,7 +113,28 @@ async fn create_transfer_tx(
     tx
 }
 
-async fn build_and_execute_block(
+pub async fn create_deploy_tx(
+    chain_id: u64,
+    nonce: u64,
+    init_code: Bytes,
+    signer: &Signer,
+) -> Transaction {
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas: 0,
+        max_fee_per_gas: TEST_MAX_FEE_PER_GAS,
+        gas_limit: 1_000_000,
+        to: TxKind::Create,
+        value: U256::zero(),
+        data: init_code,
+        ..Default::default()
+    });
+    tx.sign_inplace(signer).await.unwrap();
+    tx
+}
+
+pub async fn build_and_execute_block(
     store: &Store,
     blockchain: &Blockchain,
     parent_header: &BlockHeader,
@@ -125,27 +158,40 @@ async fn build_and_execute_block(
     block
 }
 
-async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-    let request: RpcRequest = serde_json::from_value(body).expect("valid RPC request");
+pub async fn rpc_call(store: &Store, method: &str, params: Vec<Value>) -> Value {
+    let request = build_rpc_request(method, params);
     let context = default_context_with_storage(store.clone()).await;
     map_http_requests(&request, context)
         .await
         .expect("RPC call should succeed")
 }
 
-struct TestEnv {
-    store: Store,
-    block: Block,
-    tx_hash: H256,
+pub async fn rpc_call_expect_err(store: &Store, method: &str, params: Vec<Value>) -> RpcErr {
+    let request = build_rpc_request(method, params);
+    let context = default_context_with_storage(store.clone()).await;
+    map_http_requests(&request, context)
+        .await
+        .expect_err("RPC call should fail")
 }
 
-async fn setup_single_transfer_block() -> TestEnv {
+fn build_rpc_request(method: &str, params: Vec<Value>) -> RpcRequest {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1,
+    });
+    serde_json::from_value(body).expect("valid RPC request")
+}
+
+pub struct TestEnv {
+    pub store: Store,
+    pub block: Block,
+    pub tx_hash: H256,
+    pub sender: Address,
+}
+
+pub async fn setup_single_transfer_block() -> TestEnv {
     let sk = test_secret_key();
     let sender = sender_from_key(&sk);
     let signer: Signer = LocalSigner::new(sk).into();
@@ -161,37 +207,39 @@ async fn setup_single_transfer_block() -> TestEnv {
         store,
         block,
         tx_hash,
+        sender,
     }
 }
 
-#[tokio::test]
-async fn trace_tx_flat_call_tracer() {
-    let env = setup_single_transfer_block().await;
-
-    let result = rpc_call(
-        &env.store,
-        "debug_traceTransaction",
-        vec![
-            json!(format!("{:#x}", env.tx_hash)),
-            json!({"tracer": "flatCallTracer"}),
-        ],
-    )
-    .await;
-
-    // flatCallTracer returns a flat array of call frames.
-    let arr = result.as_array().expect("response should be an array");
-    assert!(!arr.is_empty(), "should have at least one frame");
-
-    let frame = arr[0].as_object().expect("frame should be an object");
-    assert!(frame.contains_key("action"), "frame should have 'action'");
-    assert!(
-        frame.contains_key("subtraces"),
-        "frame should have 'subtraces'"
-    );
-    assert!(
-        frame.contains_key("traceAddress"),
-        "frame should have 'traceAddress'"
-    );
-    assert!(frame.contains_key("type"), "frame should have 'type'");
-    assert_eq!(frame["type"].as_str().unwrap(), "call");
+/// Same as [`setup_single_transfer_block`] but the single tx is a contract
+/// deployment whose runtime code is the trivial `STOP` opcode. Useful for
+/// exercising `CREATE` paths in tracers.
+pub async fn setup_single_deploy_block() -> TestEnv {
+    let sk = test_secret_key();
+    let sender = sender_from_key(&sk);
+    let signer: Signer = LocalSigner::new(sk).into();
+    let (store, chain_id) = setup_store(sender).await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    // init code: PUSH1 0x01 PUSH1 0x00 MSTORE8 PUSH1 0x01 PUSH1 0x00 RETURN —
+    // deploys runtime bytecode `0x01` (a single byte). The actual byte doesn't
+    // matter; what matters is that runtime code is non-empty so we can verify
+    // it round-trips through the tracer's `result.code` field.
+    let init_code = Bytes::from_static(&[
+        0x60, 0x01, // PUSH1 0x01
+        0x60, 0x00, // PUSH1 0x00
+        0x53, // MSTORE8
+        0x60, 0x01, // PUSH1 0x01
+        0x60, 0x00, // PUSH1 0x00
+        0xF3, // RETURN
+    ]);
+    let tx = create_deploy_tx(chain_id, 0, init_code, &signer).await;
+    let tx_hash = tx.hash();
+    let block = build_and_execute_block(&store, &blockchain, &genesis_header, vec![tx]).await;
+    TestEnv {
+        store,
+        block,
+        tx_hash,
+        sender,
+    }
 }

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,7 +1,9 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_flat_call_tracer_tests;
 mod debug_trace_tests;
 mod fork_choice_tests;
+mod helpers;
 mod http_batch_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -2,7 +2,6 @@ mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
 mod debug_flat_call_tracer_tests;
-mod debug_trace_tests;
 mod fork_choice_tests;
 mod helpers;
 mod http_batch_tests;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod debug_trace_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod subscription_manager_tests;


### PR DESCRIPTION
## Summary
- Add `flatCallTracer` tracer type for `debug_traceTransaction` and block tracing endpoints
- Returns a flat array of call frames following the Parity/OpenEthereum trace format
- Each frame includes `traceAddress` (position in call tree as array of indices) and `subtraces` (direct child count)
- Uses the `action`/`result` sub-object structure: `action.callType`, `action.from`, `action.to`, etc.
- Supports frame types: `"call"`, `"create"`, and `"suicide"`
- Implemented by post-processing the existing call tracer output (depth-first recursive flattening)

Closes part of #6572

Closes #6647