### PR TITLE
perf(l1): replace index based jump targets with bit vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
 
 - Two-CF receipts migration: copy old RLP-keyed receipts to `receipts_v2` with fixed-width keys; old CF auto-dropped on restart [#6598](https://github.com/lambdaclass/ethrex/pull/6598)
 
+### 2026-05-21
+
+- Two-CF receipts migration: copy old RLP-keyed receipts to `receipts_v2` with fixed-width keys; old CF auto-dropped on restart [#6598](https://github.com/lambdaclass/ethrex/pull/6598)
+
 ### 2026-04-27
 
 - Reduce peak disk usage during snap sync by moving SST files into the temp DB instead of copying [#6532](https://github.com/lambdaclass/ethrex/pull/6532)

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -34,7 +34,7 @@ pub struct Code {
     pub hash: H256,
     pub bytecode: Bytes,
     // Jump targets stored as a bit vector: bit i is set iff position i is a valid JUMPDEST
-    // The size is exactly the bytecode length
+    // The size is ceil(bytecode.len() / 8) bytes
     pub jump_targets: Vec<u8>,
 }
 

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -33,13 +33,9 @@ pub struct Code {
     // endpoints to access that hash, saving one expensive Keccak hash.
     pub hash: H256,
     pub bytecode: Bytes,
-    // `Arc<[u32]>` so cloning `Code` (hot: every message-call resolves and clones
-    // the callee's code) is a refcount bump instead of deep-copying the table.
-    // Serializes via serde's `rc` feature (enabled workspace-wide).
-    // The valid addresses are 32-bit because, despite EIP-3860 restricting initcode size,
-    // this does not apply to previous forks. This is tested in the EEST tests, which would
-    // panic in debug mode.
-    pub jump_targets: Arc<[u32]>,
+    // Jump targets stored as a bit vector: bit i is set iff position i is a valid JUMPDEST
+    // The size is exactly the bytecode length
+    pub jump_targets: Vec<u8>,
 }
 
 impl Code {
@@ -64,16 +60,16 @@ impl Code {
         }
     }
 
-    fn compute_jump_targets(code: &[u8]) -> Arc<[u32]> {
-        debug_assert!(code.len() <= u32::MAX as usize);
-        let mut targets = Vec::new();
+    fn compute_jump_targets(code: &[u8]) -> Vec<u8> {
+        let bitset_len = code.len().saturating_add(7) / 8;
+        let mut targets = vec![0u8; bitset_len];
         let mut i = 0;
         while i < code.len() {
             // TODO: we don't use the constants from the vm module to avoid a circular dependency
             match code[i] {
                 // OP_JUMPDEST
                 0x5B => {
-                    targets.push(i as u32);
+                    targets[i / 8] |= 1 << (i % 8);
                 }
                 // OP_PUSH1..32
                 c @ 0x60..0x80 => {
@@ -93,6 +89,13 @@ impl Code {
         }
     }
 
+    #[inline(always)]
+    pub fn is_valid_jump_target(&self, target: usize) -> bool {
+        self.jump_targets
+            .get(target / 8)
+            .is_some_and(|byte| byte & (1 << (target % 8)) != 0)
+    }
+
     /// Estimates the size of the Code struct in bytes
     /// (including stack size and heap allocation).
     ///
@@ -104,7 +107,7 @@ impl Code {
     pub fn size(&self) -> usize {
         let hash_size = size_of::<H256>();
         let bytes_size = size_of::<Bytes>();
-        let vec_size = size_of::<Arc<[u32]>>() + self.jump_targets.len() * size_of::<u32>();
+        let vec_size = size_of::<Vec<u8>>() + self.jump_targets.len();
         hash_size + bytes_size + vec_size
     }
 }

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -22,7 +22,7 @@ use crate::constants::{EMPTY_KECCAK_HASH, EMPTY_TRIE_HASH};
 /// `JUMPDEST` clone this (a refcount bump) instead of allocating a fresh empty
 /// `Arc` header each time. This matters because the per-tx `Code::default()`
 /// placeholder and every EOA / empty-code load would otherwise each allocate.
-static EMPTY_JUMP_TARGETS: LazyLock<Arc<[u32]>> = LazyLock::new(|| Arc::from(Vec::new()));
+static EMPTY_JUMP_TARGETS: LazyLock<Arc<[u8]>> = LazyLock::new(|| Arc::from(Vec::new()));
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Code {
@@ -35,7 +35,7 @@ pub struct Code {
     pub bytecode: Bytes,
     // Jump targets stored as a bit vector: bit i is set iff position i is a valid JUMPDEST
     // The size is ceil(bytecode.len() / 8) bytes
-    pub jump_targets: Vec<u8>,
+    pub jump_targets: Arc<[u8]>,
 }
 
 impl Code {
@@ -60,7 +60,7 @@ impl Code {
         }
     }
 
-    fn compute_jump_targets(code: &[u8]) -> Vec<u8> {
+    fn compute_jump_targets(code: &[u8]) -> Arc<[u8]> {
         let bitset_len = code.len().saturating_add(7) / 8;
         let mut targets = vec![0u8; bitset_len];
         let mut i = 0;
@@ -107,7 +107,7 @@ impl Code {
     pub fn size(&self) -> usize {
         let hash_size = size_of::<H256>();
         let bytes_size = size_of::<Bytes>();
-        let vec_size = size_of::<Vec<u8>>() + self.jump_targets.len();
+        let vec_size = size_of::<Arc<[u8]>>() + self.jump_targets.len();
         hash_size + bytes_size + vec_size
     }
 }

--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -85,7 +85,7 @@ pub use store::{
 /// When bumping this version, add a corresponding migration function to
 /// `migrations::MIGRATIONS`. The migration framework will automatically
 /// upgrade existing databases instead of requiring a full resync.
-pub const STORE_SCHEMA_VERSION: u64 = 3;
+pub const STORE_SCHEMA_VERSION: u64 = 4;
 
 /// Name of the file storing the metadata about the database.
 ///

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -14,7 +14,10 @@ use crate::store::receipt_key;
 use crate::{STORE_METADATA_FILENAME, STORE_SCHEMA_VERSION};
 
 use ethrex_common::H256;
-use ethrex_rlp::decode::RLPDecode;
+use ethrex_rlp::decode::{RLPDecode, decode_bytes};
+use ethrex_rlp::encode::RLPEncode;
+use bytes::Bytes;
+use ethrex_common::types::Code;
 
 use super::store::StoreMetadata;
 
@@ -323,6 +326,54 @@ fn flush_tx_location_group(
     for key in composite_keys {
         write_batch.delete(TRANSACTION_LOCATIONS, &key)?;
     }
+    Ok(())
+}
+
+/// Migrates from index-based Vec<u32> JUMPDEST to the Vec<u8> bitvec, 
+/// where bit i is set iff position i is a valid JUMPDEST
+fn migrate_2_to_3(backend: &dyn StorageBackend) -> Result<(), StoreError> {
+    const BATCH_SIZE: usize = 10_000;
+
+    let txn = backend.begin_read()?;
+    let iter = txn.prefix_iterator(ACCOUNT_CODES, &[])?;
+
+    let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
+    let mut migrated: u64 = 0;
+
+    for result in iter {
+        let (key, val) = result?;
+        let bytes = Bytes::from(val.to_vec());
+        let (bytecode_slice, _targets) = decode_bytes(&bytes)?;
+        let bytecode = bytes.slice_ref(bytecode_slice);
+
+        let code = Code::from_bytecode_unchecked(bytecode, H256::from_slice(&key));
+        let mut buf = Vec::with_capacity(6 + code.bytecode.len() + code.jump_targets.len());
+        code.bytecode.encode(&mut buf);
+        code.jump_targets.encode(&mut buf);
+        batch.push((key.to_vec(), buf));
+
+        if batch.len() >= BATCH_SIZE {
+            let count = batch.len() as u64;
+            let mut tx = backend.begin_write()?;
+            tx.put_batch(ACCOUNT_CODES, std::mem::take(&mut batch))?;
+            tx.commit()?;
+            migrated += count;
+            if migrated.is_multiple_of(100_000) {
+                tracing::info!("Migration v2→v3: migrated {migrated} ACCOUNT_CODES entries so far");
+            }
+        }
+    }
+
+    // Flush remaining entries.
+    if !batch.is_empty() {
+        let count = batch.len() as u64;
+        let mut tx = backend.begin_write()?;
+        tx.put_batch(ACCOUNT_CODES, batch)?;
+        tx.commit()?;
+        migrated += count;
+    }
+
+    tracing::info!("Migration v2→v3 complete: migrated {migrated} ACCOUNT_CODES entries total");
     Ok(())
 }
 

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -13,6 +13,9 @@ use crate::error::StoreError;
 use crate::store::receipt_key;
 use crate::{STORE_METADATA_FILENAME, STORE_SCHEMA_VERSION};
 
+use ethrex_common::H256;
+use ethrex_rlp::decode::RLPDecode;
+
 use super::store::StoreMetadata;
 
 /// A migration function that upgrades the database schema by one version.

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -694,35 +694,39 @@ mod tests {
     }
 }
 #[test]
-    fn migrate_3_to_4_jumpless_bytecode_produces_empty_bitvec() {
-        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+fn migrate_3_to_4_jumpless_bytecode_produces_empty_bitvec() {
+    let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
 
-        // No JUMPDEST opcodes — old targets empty, bitvec must also be empty.
-        let bytecode = Bytes::from(vec![0x60u8, 0x00, 0x50]); // PUSH1 0x00 POP
-        let old_targets: Vec<u32> = vec![];
-        let code_hash = H256::random();
+    // No JUMPDEST opcodes — old targets empty, bitvec must also be empty.
+    let bytecode = Bytes::from(vec![0x60u8, 0x00, 0x50]); // PUSH1 0x00 POP
+    let old_targets: Vec<u32> = vec![];
+    let code_hash = H256::random();
 
-        {
-            let mut buf = Vec::new();
-            bytecode.encode(&mut buf);
-            old_targets.encode(&mut buf);
-            let mut txn = backend.begin_write().unwrap();
-            txn.put(ACCOUNT_CODES, code_hash.as_bytes(), &buf).unwrap();
-            txn.commit().unwrap();
-        }
-
-        migrate_3_to_4(&backend).unwrap();
-
-        let txn = backend.begin_read().unwrap();
-        let val = txn
-            .get(ACCOUNT_CODES, code_hash.as_bytes())
-            .unwrap()
-            .expect("entry must still exist after migration");
-        let bytes = Bytes::from(val.to_vec());
-        let (bytecode_slice, targets_tail) = decode_bytes(&bytes).unwrap();
-        let new_bytecode = bytes.slice_ref(bytecode_slice);
-        let new_targets = <Vec<u8>>::decode(targets_tail).unwrap();
-
-        assert_eq!(new_bytecode, bytecode, "bytecode unchanged");
-        assert_eq!(new_targets, vec![0x00u8], "jumpless bytecode produces zeroed bitvec");
+    {
+        let mut buf = Vec::new();
+        bytecode.encode(&mut buf);
+        old_targets.encode(&mut buf);
+        let mut txn = backend.begin_write().unwrap();
+        txn.put(ACCOUNT_CODES, code_hash.as_bytes(), &buf).unwrap();
+        txn.commit().unwrap();
     }
+
+    migrate_3_to_4(&backend).unwrap();
+
+    let txn = backend.begin_read().unwrap();
+    let val = txn
+        .get(ACCOUNT_CODES, code_hash.as_bytes())
+        .unwrap()
+        .expect("entry must still exist after migration");
+    let bytes = Bytes::from(val.to_vec());
+    let (bytecode_slice, targets_tail) = decode_bytes(&bytes).unwrap();
+    let new_bytecode = bytes.slice_ref(bytecode_slice);
+    let new_targets = <Vec<u8>>::decode(targets_tail).unwrap();
+
+    assert_eq!(new_bytecode, bytecode, "bytecode unchanged");
+    assert_eq!(
+        new_targets,
+        vec![0x00u8],
+        "jumpless bytecode produces zeroed bitvec"
+    );
+}

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -13,12 +13,6 @@ use crate::error::StoreError;
 use crate::store::receipt_key;
 use crate::{STORE_METADATA_FILENAME, STORE_SCHEMA_VERSION};
 
-use ethrex_common::H256;
-use ethrex_rlp::decode::{RLPDecode, decode_bytes};
-use ethrex_rlp::encode::RLPEncode;
-use bytes::Bytes;
-use ethrex_common::types::Code;
-
 use super::store::StoreMetadata;
 
 /// A migration function that upgrades the database schema by one version.
@@ -326,54 +320,6 @@ fn flush_tx_location_group(
     for key in composite_keys {
         write_batch.delete(TRANSACTION_LOCATIONS, &key)?;
     }
-    Ok(())
-}
-
-/// Migrates from index-based Vec<u32> JUMPDEST to the Vec<u8> bitvec, 
-/// where bit i is set iff position i is a valid JUMPDEST
-fn migrate_2_to_3(backend: &dyn StorageBackend) -> Result<(), StoreError> {
-    const BATCH_SIZE: usize = 10_000;
-
-    let txn = backend.begin_read()?;
-    let iter = txn.prefix_iterator(ACCOUNT_CODES, &[])?;
-
-    let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
-    let mut migrated: u64 = 0;
-
-    for result in iter {
-        let (key, val) = result?;
-        let bytes = Bytes::from(val.to_vec());
-        let (bytecode_slice, _targets) = decode_bytes(&bytes)?;
-        let bytecode = bytes.slice_ref(bytecode_slice);
-
-        let code = Code::from_bytecode_unchecked(bytecode, H256::from_slice(&key));
-        let mut buf = Vec::with_capacity(6 + code.bytecode.len() + code.jump_targets.len());
-        code.bytecode.encode(&mut buf);
-        code.jump_targets.encode(&mut buf);
-        batch.push((key.to_vec(), buf));
-
-        if batch.len() >= BATCH_SIZE {
-            let count = batch.len() as u64;
-            let mut tx = backend.begin_write()?;
-            tx.put_batch(ACCOUNT_CODES, std::mem::take(&mut batch))?;
-            tx.commit()?;
-            migrated += count;
-            if migrated.is_multiple_of(100_000) {
-                tracing::info!("Migration v2→v3: migrated {migrated} ACCOUNT_CODES entries so far");
-            }
-        }
-    }
-
-    // Flush remaining entries.
-    if !batch.is_empty() {
-        let count = batch.len() as u64;
-        let mut tx = backend.begin_write()?;
-        tx.put_batch(ACCOUNT_CODES, batch)?;
-        tx.commit()?;
-        migrated += count;
-    }
-
-    tracing::info!("Migration v2→v3 complete: migrated {migrated} ACCOUNT_CODES entries total");
     Ok(())
 }
 

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -2,12 +2,13 @@ use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
 use ethrex_common::H256;
-use ethrex_common::types::{BlockHash, BlockNumber, Index};
-use ethrex_rlp::decode::RLPDecode;
+use ethrex_common::types::{BlockHash, BlockNumber, Code, Index};
+use ethrex_rlp::decode::{RLPDecode, decode_bytes};
 use ethrex_rlp::encode::RLPEncode;
 
-use crate::api::tables::{RECEIPTS, RECEIPTS_V2, TRANSACTION_LOCATIONS};
+use crate::api::tables::{ACCOUNT_CODES, RECEIPTS, RECEIPTS_V2, TRANSACTION_LOCATIONS};
 use crate::api::{StorageBackend, StorageWriteBatch};
 use crate::error::StoreError;
 use crate::store::receipt_key;
@@ -30,7 +31,7 @@ pub type MigrationFn = fn(backend: &dyn StorageBackend) -> Result<(), StoreError
 ///
 /// **Invariant**: `MIGRATIONS.len() == (STORE_SCHEMA_VERSION - 1) as usize`
 /// (empty when `STORE_SCHEMA_VERSION == 1`, one entry when it's 2, etc.)
-pub const MIGRATIONS: &[MigrationFn] = &[migrate_1_to_2, migrate_2_to_3];
+pub const MIGRATIONS: &[MigrationFn] = &[migrate_1_to_2, migrate_2_to_3, migrate_3_to_4];
 
 // Compile-time check: the number of migration functions must match the number
 // of version gaps (i.e. STORE_SCHEMA_VERSION - 1).
@@ -320,6 +321,55 @@ fn flush_tx_location_group(
     for key in composite_keys {
         write_batch.delete(TRANSACTION_LOCATIONS, &key)?;
     }
+    Ok(())
+}
+
+/// Migrates from index-based Vec<u32> JUMPDEST to the Vec<u8> bitvec, 
+/// where bit i is set iff position i is a valid JUMPDEST
+fn migrate_3_to_4(backend: &dyn StorageBackend) -> Result<(), StoreError> {
+    const BATCH_SIZE: usize = 10_000;
+
+    let txn = backend.begin_read()?;
+    let iter = txn.prefix_iterator(ACCOUNT_CODES, &[])?;
+
+    let mut batch: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(BATCH_SIZE);
+    let mut migrated: u64 = 0;
+
+    for result in iter {
+        let (key, val) = result?;
+        let bytes = Bytes::from(val.to_vec());
+        let (bytecode_slice, _old_targets) = decode_bytes(&bytes)?;
+        let bytecode = bytes.slice_ref(bytecode_slice);
+
+        let code = Code::from_bytecode_unchecked(bytecode, H256::from_slice(&key));
+        let mut buf = Vec::with_capacity(6 + code.bytecode.len() + code.jump_targets.len());
+        code.bytecode.encode(&mut buf);
+        code.jump_targets.to_vec().encode(&mut buf);
+        batch.push((key.into(), buf));
+
+        if batch.len() >= BATCH_SIZE {
+            let count = batch.len() as u64;
+            let mut tx = backend.begin_write()?;
+            tx.put_batch(ACCOUNT_CODES, std::mem::take(&mut batch))?;
+            tx.commit()?;
+            migrated += count;
+            if migrated.is_multiple_of(100_000) {
+                tracing::info!(
+                    "Schema migration v3 → v4: {migrated} account code entries migrated so far"
+                );
+            }
+        }
+    }
+
+    if !batch.is_empty() {
+        let count = batch.len() as u64;
+        let mut tx = backend.begin_write()?;
+        tx.put_batch(ACCOUNT_CODES, batch)?;
+        tx.commit()?;
+        migrated += count;
+    }
+
+    tracing::info!("Schema migration v3 → v4: migrated {migrated} account code entries in total");
     Ok(())
 }
 

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -324,7 +324,7 @@ fn flush_tx_location_group(
     Ok(())
 }
 
-/// Migrates from index-based Vec<u32> JUMPDEST to the Vec<u8> bitvec, 
+/// Migrates from index-based Vec<u32> JUMPDEST to the Vec<u8> bitvec,
 /// where bit i is set iff position i is a valid JUMPDEST
 fn migrate_3_to_4(backend: &dyn StorageBackend) -> Result<(), StoreError> {
     const BATCH_SIZE: usize = 10_000;
@@ -658,4 +658,71 @@ mod tests {
             "merge must union, not overwrite, on mixed state"
         );
     }
+
+    #[test]
+    fn migrate_3_to_4_converts_jumpdest_indices_to_bitvec() {
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+
+        // Old jump targets: [0, 3], expected bitvec [1, 0, 0, 1]
+        let bytecode = Bytes::from(vec![0x5Bu8, 0x00, 0x00, 0x5B]);
+        let old_targets: Vec<u32> = vec![0, 3];
+        let code_hash = H256::random();
+
+        {
+            let mut buf = Vec::new();
+            bytecode.encode(&mut buf);
+            old_targets.encode(&mut buf);
+            let mut txn = backend.begin_write().unwrap();
+            txn.put(ACCOUNT_CODES, code_hash.as_bytes(), &buf).unwrap();
+            txn.commit().unwrap();
+        }
+
+        migrate_3_to_4(&backend).unwrap();
+
+        let txn = backend.begin_read().unwrap();
+        let val = txn
+            .get(ACCOUNT_CODES, code_hash.as_bytes())
+            .unwrap()
+            .expect("entry must still exist after migration");
+        let bytes = Bytes::from(val.to_vec());
+        let (bytecode_slice, targets_tail) = decode_bytes(&bytes).unwrap();
+        let new_bytecode = bytes.slice_ref(bytecode_slice);
+        let new_targets = <Vec<u8>>::decode(targets_tail).unwrap();
+
+        assert_eq!(new_bytecode, bytecode);
+        assert_eq!(new_targets, vec![0x09u8]);
+    }
 }
+#[test]
+    fn migrate_3_to_4_jumpless_bytecode_produces_empty_bitvec() {
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+
+        // No JUMPDEST opcodes — old targets empty, bitvec must also be empty.
+        let bytecode = Bytes::from(vec![0x60u8, 0x00, 0x50]); // PUSH1 0x00 POP
+        let old_targets: Vec<u32> = vec![];
+        let code_hash = H256::random();
+
+        {
+            let mut buf = Vec::new();
+            bytecode.encode(&mut buf);
+            old_targets.encode(&mut buf);
+            let mut txn = backend.begin_write().unwrap();
+            txn.put(ACCOUNT_CODES, code_hash.as_bytes(), &buf).unwrap();
+            txn.commit().unwrap();
+        }
+
+        migrate_3_to_4(&backend).unwrap();
+
+        let txn = backend.begin_read().unwrap();
+        let val = txn
+            .get(ACCOUNT_CODES, code_hash.as_bytes())
+            .unwrap()
+            .expect("entry must still exist after migration");
+        let bytes = Bytes::from(val.to_vec());
+        let (bytecode_slice, targets_tail) = decode_bytes(&bytes).unwrap();
+        let new_bytecode = bytes.slice_ref(bytecode_slice);
+        let new_targets = <Vec<u8>>::decode(targets_tail).unwrap();
+
+        assert_eq!(new_bytecode, bytecode, "bytecode unchanged");
+        assert_eq!(new_targets, vec![0x00u8], "jumpless bytecode produces zeroed bitvec");
+    }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -851,7 +851,7 @@ impl Store {
         let code = Code {
             hash: code_hash,
             bytecode,
-            jump_targets: <Vec<u8>>::decode(targets)?,
+            jump_targets: Arc::from(<Vec<u8>>::decode(targets)?),
         };
 
         // insert into cache and evict if needed

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -851,7 +851,7 @@ impl Store {
         let code = Code {
             hash: code_hash,
             bytecode,
-            jump_targets: <Vec<u32>>::decode(targets)?.into(),
+            jump_targets: <Vec<u8>>::decode(targets)?,
         };
 
         // insert into cache and evict if needed
@@ -3527,9 +3527,7 @@ pub fn receipt_key(block_hash: &BlockHash, index: u64) -> Vec<u8> {
 }
 
 fn encode_code(code: &Code) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(
-        6 + code.bytecode.len() + std::mem::size_of_val::<[u32]>(&code.jump_targets),
-    );
+    let mut buf = Vec::with_capacity(6 + code.bytecode.len() + code.jump_targets.len());
     code.bytecode.encode(&mut buf);
     // `Arc<[u32]>` (the in-memory share) has no `RLPEncode` impl; encode through an
     // owned `Vec` on this cold DB-write path (code is persisted once per hash).

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -434,21 +434,7 @@ fn jump(vm: &mut VM<'_>, target: usize, parent_gas_cost: u64) -> Result<(), VMEr
     //   - Target bytecode has to be a JUMPDEST.
     //   - Target address must not be blacklisted (aka. the JUMPDEST must not be part of a literal).
     #[expect(clippy::as_conversions, reason = "safe")]
-    if vm
-        .current_call_frame
-        .bytecode
-        .bytecode
-        .get(target)
-        .is_some_and(|&value| {
-            value == Opcode::JUMPDEST as u8
-                && vm
-                    .current_call_frame
-                    .bytecode
-                    .jump_targets
-                    .binary_search(&(target as u32))
-                    .is_ok()
-        })
-    {
+    if vm.current_call_frame.bytecode.is_valid_jump_target(target) {
         if vm.opcode_tracer.active {
             // Override the parent JUMP/JUMPI's gasCost so the dispatch loop
             // doesn't roll the upcoming JUMPDEST charge into it.

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -433,7 +433,6 @@ fn jump(vm: &mut VM<'_>, target: usize, parent_gas_cost: u64) -> Result<(), VMEr
     // Check target address validity.
     //   - Target bytecode has to be a JUMPDEST.
     //   - Target address must not be blacklisted (aka. the JUMPDEST must not be part of a literal).
-    #[expect(clippy::as_conversions, reason = "safe")]
     if vm.current_call_frame.bytecode.is_valid_jump_target(target) {
         if vm.opcode_tracer.active {
             // Override the parent JUMP/JUMPI's gasCost so the dispatch loop

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -433,6 +433,7 @@ fn jump(vm: &mut VM<'_>, target: usize, parent_gas_cost: u64) -> Result<(), VMEr
     // Check target address validity.
     //   - Target bytecode has to be a JUMPDEST.
     //   - Target address must not be blacklisted (aka. the JUMPDEST must not be part of a literal).
+    #[expect(clippy::as_conversions, reason = "safe")]
     if vm.current_call_frame.bytecode.is_valid_jump_target(target) {
         if vm.opcode_tracer.active {
             // Override the parent JUMP/JUMPI's gasCost so the dispatch loop


### PR DESCRIPTION
**Motivation**
The motivation for this PR are EEST tests, that crash because of exceeding memory limits on zkVM.
```
test_jumpdest_analysis[fork_Osaka-blockchain_test-5b-benchmark-gas-value_60M]
test_jumpdest_analysis[fork_Osaka-blockchain_test-605b5b-benchmark-gas-value_60M]
```
Currently the jump targets are stored as a vector of `u32` indices, this change switches to storing it as a bit vector.

**Description**

This change fixes the crashing tests. However the test is constructed in an unrealistic adversarial setting where most of the operations are just jumps. The question is whether this is actually practical for normal execution. 

I check the storage required for `jump_target` on 500 blocks 20260424 - 24950286, by counting the jump instructions compared to length of bytecode. The total storage for index-based `jump_target` across all contracts is 21.37MB which is ~10% higher than 19.29MB for the bit vector approach. There are contracts for which bit vector consumes more storage but on average it seems to be more efficient. 

In addition, the bit vector is faster because lookups are constant time, compared to binary search. I benchmarked the costs on Zisk, and there is a slight ~2% improvement. But primarily, the point of this change is to resolve the possible attack vector.

It is worth mentioning that other clients also seem to use the bit vector approach:
- [JumpTable](https://docs.rs/revm-bytecode/11.0.0/revm_bytecode/struct.JumpTable.html) in Reth
- [BitVec](https://github.com/ethereum/go-ethereum/blob/efe58eac003940e736717ab2207f6db22fdbd2e6/core/vm/analysis_legacy.go#L28-L31) in Geth

The new format defined by `encode_code` is breaking! It might be reasonable to recompute and store `Vec<u32>` for backwards compatibility. I leave this up to discussion.
