### PR TITLE
fix(l1): announce local IP when --p2p.addr is unspecified

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -360,27 +360,27 @@ pub fn get_signer(datadir: &Path) -> SecretKey {
     }
 }
 
-pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkConfig) {
-    let tcp_port = opts.p2p_port.parse().expect("Failed to parse p2p port");
-    let udp_port = opts
-        .discovery_port
-        .parse()
-        .expect("Failed to parse discovery port");
-
-    let local_public_key = public_key_from_signing_key(signer);
-
-    // Determine bind and external addresses.
-    //
-    // --nat.extip sets the address announced to peers (for nodes behind NAT).
-    // --p2p.addr sets the bind address (defaults to the auto-detected local IP
-    //   when --nat.extip is not given, or to the unspecified address when it is:
-    //   0.0.0.0 for IPv4, :: for IPv6).
-    let (bind_addr, external_addr): (IpAddr, IpAddr) = match (&opts.p2p_addr, &opts.nat_extip) {
+/// Decide the bind and externally-announced addresses for the P2P endpoint.
+///
+/// Precedence:
+/// - `--nat.extip` wins for the announced address; bind comes from `--p2p.addr` if given,
+///   else the unspecified address of the matching family.
+/// - `--p2p.addr` alone is used for both bind and announce, except when it's an unspecified
+///   address (`0.0.0.0` / `::`). In that case the announced address falls back to the
+///   auto-detected local IP of the matching family; this avoids advertising `0.0.0.0` in
+///   the ENR, which would make the node unreachable for inbound connections. Operators
+///   behind NAT still need `--nat.extip` for that case to resolve correctly.
+/// - With neither flag set, the auto-detected local IP is used for both bind and announce.
+fn resolve_p2p_endpoints(
+    p2p_addr: Option<&str>,
+    nat_extip: Option<&str>,
+    local_v4: Option<IpAddr>,
+    local_v6: Option<IpAddr>,
+) -> (IpAddr, IpAddr) {
+    match (p2p_addr, nat_extip) {
         (_, Some(extip)) => {
             let external: IpAddr = extip.parse().expect("Failed to parse --nat.extip address");
-            let bind: IpAddr = opts
-                .p2p_addr
-                .as_deref()
+            let bind: IpAddr = p2p_addr
                 .map(|a| {
                     let addr: IpAddr = a.parse().expect("Failed to parse p2p address");
                     assert!(
@@ -399,16 +399,60 @@ pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkC
             (bind, external)
         }
         (Some(addr), None) => {
-            let ip: IpAddr = addr.parse().expect("Failed to parse p2p address");
-            (ip, ip)
+            let bind: IpAddr = addr.parse().expect("Failed to parse p2p address");
+            if bind.is_unspecified() {
+                let external = if bind.is_ipv6() {
+                    local_v6.or(local_v4)
+                } else {
+                    local_v4.or(local_v6)
+                };
+                match external {
+                    Some(ext) => {
+                        info!(
+                            announced = %ext,
+                            bind = %bind,
+                            "--p2p.addr is unspecified; announcing auto-detected local IP. Set --nat.extip to override."
+                        );
+                        (bind, ext)
+                    }
+                    None => {
+                        warn!(
+                            bind = %bind,
+                            "--p2p.addr is unspecified and no local IP could be detected; \
+                             announcing the unspecified address. Inbound peer connections will fail. \
+                             Set --nat.extip to fix this."
+                        );
+                        (bind, bind)
+                    }
+                }
+            } else {
+                (bind, bind)
+            }
         }
         (None, None) => {
-            let ip = local_ip().unwrap_or_else(|_| {
-                local_ipv6().expect("Neither ipv4 nor ipv6 local address found")
-            });
+            let ip = local_v4
+                .or(local_v6)
+                .expect("Neither ipv4 nor ipv6 local address found");
             (ip, ip)
         }
-    };
+    }
+}
+
+pub fn get_local_p2p_node(opts: &Options, signer: &SecretKey) -> (Node, NetworkConfig) {
+    let tcp_port = opts.p2p_port.parse().expect("Failed to parse p2p port");
+    let udp_port = opts
+        .discovery_port
+        .parse()
+        .expect("Failed to parse discovery port");
+
+    let local_public_key = public_key_from_signing_key(signer);
+
+    let (bind_addr, external_addr) = resolve_p2p_endpoints(
+        opts.p2p_addr.as_deref(),
+        opts.nat_extip.as_deref(),
+        local_ip().ok(),
+        local_ipv6().ok(),
+    );
 
     let node = Node::new(external_addr, udp_port, tcp_port, local_public_key);
     let network_config = NetworkConfig {
@@ -811,4 +855,64 @@ pub async fn regenerate_head_state(
     info!("Finished regenerating state");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_p2p_endpoints;
+    use std::net::IpAddr;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn p2p_addr_unspecified_v4_announces_local_ip() {
+        let local = ip("10.0.0.5");
+        let (bind, ext) = resolve_p2p_endpoints(Some("0.0.0.0"), None, Some(local), None);
+        assert_eq!(bind, ip("0.0.0.0"));
+        assert_eq!(ext, local);
+    }
+
+    #[test]
+    fn p2p_addr_unspecified_without_local_ip_keeps_unspecified() {
+        let (bind, ext) = resolve_p2p_endpoints(Some("0.0.0.0"), None, None, None);
+        assert_eq!(bind, ip("0.0.0.0"));
+        assert_eq!(ext, ip("0.0.0.0"));
+    }
+
+    #[test]
+    fn extip_overrides_unspecified_bind() {
+        let (bind, ext) = resolve_p2p_endpoints(
+            Some("0.0.0.0"),
+            Some("203.0.113.5"),
+            Some(ip("10.0.0.5")),
+            None,
+        );
+        assert_eq!(bind, ip("0.0.0.0"));
+        assert_eq!(ext, ip("203.0.113.5"));
+    }
+
+    #[test]
+    fn specific_p2p_addr_used_for_both() {
+        let (bind, ext) =
+            resolve_p2p_endpoints(Some("10.0.0.5"), None, Some(ip("192.168.1.1")), None);
+        assert_eq!(bind, ip("10.0.0.5"));
+        assert_eq!(ext, ip("10.0.0.5"));
+    }
+
+    #[test]
+    fn no_flags_uses_local_v4_when_available() {
+        let local = ip("10.0.0.5");
+        let (bind, ext) = resolve_p2p_endpoints(None, None, Some(local), Some(ip("fe80::1")));
+        assert_eq!(bind, local);
+        assert_eq!(ext, local);
+    }
+
+    #[test]
+    fn extip_only_uses_unspecified_bind() {
+        let (bind, ext) = resolve_p2p_endpoints(None, Some("203.0.113.5"), None, None);
+        assert_eq!(bind, ip("0.0.0.0"));
+        assert_eq!(ext, ip("203.0.113.5"));
+    }
 }

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -401,11 +401,10 @@ fn resolve_p2p_endpoints(
         (Some(addr), None) => {
             let bind: IpAddr = addr.parse().expect("Failed to parse p2p address");
             if bind.is_unspecified() {
-                let external = if bind.is_ipv6() {
-                    local_v6.or(local_v4)
-                } else {
-                    local_v4.or(local_v6)
-                };
+                // Stay in the same address family: an IPv4 socket can't accept
+                // inbound IPv6 connections (and vice versa), so falling back
+                // across families would just advertise an unreachable address.
+                let external = if bind.is_ipv6() { local_v6 } else { local_v4 };
                 match external {
                     Some(ext) => {
                         info!(
@@ -420,7 +419,7 @@ fn resolve_p2p_endpoints(
                             bind = %bind,
                             "--p2p.addr is unspecified and no local IP could be detected; \
                              announcing the unspecified address. Inbound peer connections will fail. \
-                             Set --nat.extip to fix this."
+                             Set --nat.extip=<ip> or --p2p.addr=<ip> to fix."
                         );
                         (bind, bind)
                     }
@@ -914,5 +913,19 @@ mod tests {
         let (bind, ext) = resolve_p2p_endpoints(None, Some("203.0.113.5"), None, None);
         assert_eq!(bind, ip("0.0.0.0"));
         assert_eq!(ext, ip("203.0.113.5"));
+    }
+
+    #[test]
+    fn p2p_addr_unspecified_v6_announces_local_ipv6() {
+        let local6 = ip("fe80::1");
+        let (bind, ext) = resolve_p2p_endpoints(Some("::"), None, None, Some(local6));
+        assert_eq!(bind, ip("::"));
+        assert_eq!(ext, local6);
+    }
+
+    #[test]
+    #[should_panic(expected = "--p2p.addr and --nat.extip must use the same address family")]
+    fn family_mismatch_panics() {
+        let _ = resolve_p2p_endpoints(Some("0.0.0.0"), Some("::1"), None, None);
     }
 }


### PR DESCRIPTION
## Summary

When ethrex is launched with `--p2p.addr=0.0.0.0` (or `::`) and no `--nat.extip`, the announce/enode/ENR address ended up as the bind address verbatim, i.e. `enode://…@0.0.0.0:30303`. Peers cannot dial back to that, so the node sits at 0 inbound peers. Spotted on bal-devnet-7 (the deployment passes `--p2p.addr=0.0.0.0` without `--nat.extip`).

This patch:

- Factors the address-resolution logic out of `get_local_p2p_node` into a small pure function `resolve_p2p_endpoints`, so it can be unit-tested.
- When `--p2p.addr` is given and resolves to an unspecified address, the announced address now falls back to the auto-detected local IP (the same `local_ip()` / `local_ipv6()` call the no-flag branch already used). `--nat.extip` still overrides; specific bind addresses are unchanged.
- If no local IP can be detected, emits a loud warning rather than silently advertising the unspecified address.

This is the minimal fix. A follow-up could implement devp2p endpoint prediction (learning the external IP from the `to` field on incoming PINGs/PONGs, à la geth's `UDPEndpointStatement`), which would remove the need for operators to set `--nat.extip` at all on cloud hosts. Out of scope for this PR.

## Test plan

- [x] `cargo fmt -p ethrex`
- [x] `cargo clippy -p ethrex --all-targets -- -D warnings`
- [x] `cargo test -p ethrex --lib initializers::` — 6 new unit tests pass
- [ ] Deploy onto a bal-devnet ethrex node with `--p2p.addr=0.0.0.0` and confirm `admin_nodeInfo` reports the host IP in the enode/ENR and inbound peers > 0.