### PR TITLE
chore(l1): bump zkevm fixtures to tests-zkevm@v0.4.1

### DIFF
--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -4,29 +4,31 @@ Tests intentionally excluded from CI. Source of truth for the **Known
 Issues** section the L1 workflow appends to each ef-tests job summary
 and posts as a sticky PR comment.
 
-## EF Tests — Stateless coverage narrowed to EIP-8025 optional-proofs
+## EF Tests — Stateless `stateless_input_invalid_public_key_is_rejected` skipped
 
-`make -C tooling/ef_tests/blockchain test` calls `test-stateless-zkevm`
-instead of `test-stateless`. The zkevm@v0.3.3 fixtures are filled against
-bal@v5.6.1, out of sync with current bal spec; the broad target trips ~549
-fixtures. Re-broaden once the zkevm bundle is regenerated.
+The single fixture
+`tests/amsterdam/eip8025_optional_proofs/test_stateless_input_validation.py::test_stateless_input_invalid_public_key_is_rejected`
+is filtered out of `test-stateless`. All other ~2864 stateless fixtures
+from `tests-zkevm@v0.4.1` (bal@v7.2.0 baseline) pass.
 
 <details>
 <summary>Why and resolution path</summary>
 
-[PR #6527](https://github.com/lambdaclass/ethrex/pull/6527) broadened
-`test-stateless` to extract the entire `for_amsterdam/` tree from the
-zkevm bundle and run all of it under `--features stateless`; combined with
-this branch's bal-devnet-7 semantics that scope produces ~549
-`GasUsedMismatch` / `ReceiptsRootMismatch` /
-`BlockAccessListHashMismatch` failures.
+`tests-zkevm@v0.4.x` introduces the v0.4 stateless wire format: a new
+schema-id prefix and a populated `public_keys` field on
+`StatelessInput`. Two gaps prevent the wrong-pubkey rejection from
+being observable end-to-end in ethrex's harness:
 
-`test-stateless-zkevm` filters cargo to the `eip8025_optional_proofs`
-suite, which still validates the stateless harness without the bal-version
-mismatch.
+1. `decode_eip8025` still parses the v0.3 framing (no schema-id, old
+   `ChainConfig` shape), so v0.4 canonical bytes don't round-trip.
+2. The blockchain ef_test runner consumes JSON `executionWitness`
+   instead of the canonical `statelessInputBytes`, bypassing the
+   `public_keys` check entirely.
 
-Re-broaden by switching `test:` back to `test-stateless` in
-`tooling/ef_tests/blockchain/Makefile` once the zkevm bundle is regenerated
-against the current bal spec.
+Resolution: update `decode_eip8025` for the v0.4 schema-id + reshaped
+`ChainConfig`, then route the stateless test runner through
+`execution_program(bytes)` (or replicate the public-keys check against
+the canonical input). The skip site in
+`tooling/ef_tests/blockchain/tests/all.rs` carries the same note.
 
 </details>

--- a/tooling/ef_tests/blockchain/.fixtures_url_zkevm
+++ b/tooling/ef_tests/blockchain/.fixtures_url_zkevm
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/zkevm%40v0.3.3/fixtures_zkevm.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.4.1/fixtures_zkevm.tar.gz

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -16,10 +16,9 @@ AMSTERDAM_FIXTURES_FILE := .fixtures_url_amsterdam
 AMSTERDAM_ARTIFACT := amsterdam-tests.tar.gz
 AMSTERDAM_URL := $(shell cat $(AMSTERDAM_FIXTURES_FILE))
 
-# zkevm@v0.3.3 ships fixtures filled against an older Amsterdam base
-# (bal@v5.6.1). Extracting them on top of the bal-devnet-7 tree would
-# clobber the newer fixtures with stale gas-accounting expectations, so we
-# keep them in a separate root and only the stateless harness reads from it.
+# Keep the zkevm bundle in a separate root. The zkevm release cadence trails
+# the bal cadence, so during a divergence window extracting it over the
+# bal-devnet tree would clobber the newer fixtures with stale expectations.
 ZKEVM_VECTORS_ROOT := vectors_zkevm
 ZKEVM_VECTORS_DIR := $(ZKEVM_VECTORS_ROOT)/eest
 ZKEVM_FIXTURES_FILE := .fixtures_url_zkevm
@@ -79,16 +78,6 @@ test-sp1: $(VECTORS_TARGETS) amsterdam-vectors
 test-stateless: zkevm-vectors
 	cargo test --profile release-with-debug --features stateless
 
-test-stateless-zkevm: zkevm-vectors
-	cargo test --profile release-with-debug --features stateless -- eip8025_optional_proofs
-
 test: ## 🧪 Run blockchain tests with LEVM both with state and stateless
 	$(MAKE) test-levm
-	# Narrow stateless coverage to the EIP-8025 optional-proofs suite. The
-	# zkevm@v0.3.3 fixtures are filled against bal@v5.6.1, which is out of
-	# sync with this branch's bal-devnet-6+ (and bal-devnet-7-prep) gas
-	# accounting; the broader `test-stateless` invocation introduced by
-	# #6527 trips ~549 of those fixtures with `GasUsedMismatch` /
-	# `ReceiptsRootMismatch` / `BlockAccessListHashMismatch`. Re-broaden
-	# once the zkevm bundle is regenerated against the current bal spec.
-	$(MAKE) test-stateless-zkevm
+	$(MAKE) test-stateless

--- a/tooling/ef_tests/blockchain/tests/all.rs
+++ b/tooling/ef_tests/blockchain/tests/all.rs
@@ -6,10 +6,11 @@ use std::path::Path;
 #[cfg(all(feature = "sp1", feature = "stateless"))]
 compile_error!("Only one of `sp1` and `stateless` can be enabled at a time.");
 
-// test-levm / test-sp1 read snobal-devnet-6 + legacy from `vectors/`.
-// test-stateless reads zkevm@v0.3.3 (the only bundle that ships executionWitness)
-// from a separate `vectors_zkevm/` so its older bal@v5.6.1 base never overlays
-// the snobal fixtures used by the other suites.
+// test-levm / test-sp1 read bal-devnet-N + legacy from `vectors/`.
+// test-stateless reads the zkevm bundle (the only one that ships
+// executionWitness) from a separate `vectors_zkevm/`. The zkevm cadence trails
+// the bal cadence, so keeping the trees isolated prevents a stale zkvm bundle
+// from overlaying current bal fixtures during the gap.
 #[cfg(feature = "stateless")]
 const TEST_FOLDER: &str = "vectors_zkevm/";
 #[cfg(not(feature = "stateless"))]
@@ -25,46 +26,6 @@ const SKIPPED_BASE: &[&str] = &[
     "ValueOverflowParis",
     // Skip because it's a "Create" Blob Transaction, which doesn't actually exist. It never reaches the EVM because we can't even parse it as an actual Transaction.
     "createBlobhashTx",
-    // EIP-8025 optional-proofs fixtures filled against bal@v5.6.1 (devnets/bal/3),
-    // which predates EELS PR #2711 "immutable intrinsic_state_gas for EIP-7702".
-    // Expected gas assumes the auth refund still deducts from block-accounted state
-    // gas; our devnet-4 (bal@v5.7.0) impl correctly keeps intrinsic_state_gas
-    // immutable and routes the refund to the reservoir only. Re-enable once the
-    // zkevm@v0.4.x release ships fixtures regenerated against devnet-4.
-    "witness_codes_redelegation_old_marker_included_new_marker_excluded",
-    "witness_codes_reset_delegation",
-    "witness_codes_reverted_transaction",
-    "witness_codes_failed_create_includes_factory",
-    "witness_codes_reverted_create_same_hash_then_read",
-    "witness_codes_create_then_selfdestruct_same_tx",
-    // Additional EIP-8025 optional-proofs fixtures whose expected gas magnitudes
-    // disagree with bal-devnet-7 (bal@v7.1.1) state-gas accounting. Same root
-    // cause as the block above: zkevm@v0.3.3 bundle is pinned at an older bal
-    // spec (storage_set / new_account / cpsb constants pre-recalibration plus
-    // earlier refund-channel semantics) and the broader fork.py changes from
-    // EELS PRs #2815/#2816/#2823/#2827/#2828. Re-enable once the zkevm bundle
-    // is regenerated against bal-7.
-    "witness_codes_delegation_set_in_same_block",
-    "witness_codes_auth_nonce_mismatch",
-    "witness_codes_dedup_identical_bytecode",
-    "witness_codes_create2_excludes_new_bytecode",
-    "witness_codes_reverted_inner_call",
-    "witness_codes_create_same_hash_then_read",
-    "witness_codes_create_then_call_same_block",
-    "witness_codes_create_then_call_same_tx",
-    "witness_codes_failed_create_after_initcode_read",
-    "witness_codes_initcode_calls_existing_contract",
-    "witness_excludes_bytecode_created_in_same_block",
-    "witness_keeps_prestate_code_read_even_if_later_created_with_same_hash",
-    "witness_codes_selfdestruct_in_initcode",
-    "witness_codes_selfdestruct_beneficiary_no_code",
-    "witness_state_delete_with_new_dirty_sibling_omits_post_state_node",
-    "witness_state_block_diff_delete_insert_before_delete_order",
-    "witness_state_delete_then_insert_uses_insert_before_delete_order",
-    "witness_state_sstore_into_empty_storage_omits_post_state_nodes",
-    "witness_state_sstore_new_slot_omits_post_state_nodes",
-    "validation_state_missing_absent_slot_proof_leaf_node",
-    "validation_state_missing_storage_proof_node",
 ];
 
 // Extra skips added only for prover backends.
@@ -77,31 +38,39 @@ const EXTRA_SKIPS: &[&str] = &[
 ];
 #[cfg(feature = "stateless")]
 const EXTRA_SKIPS: &[&str] = &[
-    // zkevm@v0.3.3 tolerance tests: the fixture's `statelessOutputBytes` declares `valid = 1`
-    // because the executed path does not actually consume the malformed/extra/missing witness
-    // entry, but our RpcExecutionWitness conversion eagerly validates the full witness and
-    // rejects it. Re-enable once the witness conversion is lazy per EIP-8025 §Tolerance.
+    // tolerance tests: the fixture's `statelessOutputBytes` declares `valid = 1`
+    // because the executed path does not actually consume the malformed/extra/missing
+    // witness entry, but our RpcExecutionWitness conversion eagerly validates the
+    // full witness and rejects it. Re-enable once the witness conversion is lazy per
+    // EIP-8025 §Tolerance.
     "validation_headers_malformed_rlp_header",
     "validation_headers_missing_oldest_blockhash_ancestor",
     "validation_headers_missing_parent_header",
     "validation_state_extra_unused_trie_node",
-    // zkevm@v0.3.3 rejection tests: `statelessOutputBytes` declares `valid = 0` so the guest
-    // program must reject the deliberately-incomplete witness, but our stateless path runs
-    // to completion instead of detecting the missing entry. Re-enable once the witness
-    // completeness checks land (missing delegation/external-code bytecodes, non-contiguous
-    // header chain detection).
+    // rejection tests: `statelessOutputBytes` declares `valid = 0` so the guest
+    // program must reject the deliberately-incomplete witness, but our stateless
+    // path runs to completion instead of detecting the missing entry. Re-enable
+    // once the witness completeness checks land (missing delegation/external-code
+    // bytecodes, non-contiguous header chain detection).
     "validation_codes_missing_delegated_code_on_insufficient_balance_call",
     "validation_codes_missing_external_code_read_target",
     "validation_codes_missing_redelegation_old_marker",
     "validation_codes_missing_sender_delegation_marker",
     "validation_headers_non_contiguous_chain",
-    // zkevm@v0.3.3 conversion-time rejection: `statelessOutputBytes` declares `valid = 0` and
-    // our `into_execution_witness` correctly rejects the witness because it can't extract the
-    // initial state root without the parent header. Since 5a597e67d the runner treats
-    // conversion errors as unconditional regressions, so this correct-rejection-at-the-wrong-
-    // stage trips the test. Re-enable once conversion is lazy enough to defer the parent-
-    // header check to execution.
+    // conversion-time rejection: `statelessOutputBytes` declares `valid = 0` and
+    // our `into_execution_witness` correctly rejects the witness because it can't
+    // extract the initial state root without the parent header. The runner treats
+    // conversion errors as unconditional regressions, so this correct-rejection-
+    // at-the-wrong-stage trips the test. Re-enable once conversion is lazy enough
+    // to defer the parent-header check to execution.
     "validation_headers_empty_block_missing_mandatory_parent",
+    // zkevm@v0.4.x introduces a filled `public_keys` field on the canonical
+    // StatelessInput. The test runner consumes JSON `executionWitness` and never
+    // decodes `statelessInputBytes`, so the wrong-pubkey rejection is invisible
+    // and execution completes successfully. Re-enable once the runner exercises
+    // the canonical SSZ path (which also requires updating decode_eip8025 for the
+    // v0.4 schema-id wire format).
+    "stateless_input_invalid_public_key_is_rejected",
 ];
 #[cfg(not(any(feature = "sp1", feature = "stateless")))]
 const EXTRA_SKIPS: &[&str] = &[];


### PR DESCRIPTION
## Summary

- Bump `.fixtures_url_zkevm` to `tests-zkevm@v0.4.1` (based on bal@v7.2.0, matching our current bal pin).
- Drop ~30 EIP-8025 fixture-mismatch skips that v0.3.3 (bal@v5.6.1) required, and re-enable broad `test-stateless` coverage in the default `make test` target.
- Skip one new test (`stateless_input_invalid_public_key_is_rejected`) with an inline comment.

The single skip exists because v0.4+ also ships a new schema-id wire format and a filled `public_keys` field on `StatelessInput`. Our `decode_eip8025` still parses the v0.3 framing, and the ef_test runner consumes JSON `executionWitness` rather than the canonical `statelessInputBytes`, so the wrong-pubkey rejection is invisible end-to-end. Wiring this up needs:
1. Update `decode_eip8025` for the v0.4 schema-id prefix + reshaped `ChainConfig`.
2. Route the stateless test runner through `execution_program(bytes)` (or replicate the public_keys check against the canonical input).

Both are out of scope here; the skip comment in `tests/all.rs` documents the gap.

Result: 2864 stateless tests pass, 1 documented skip (up from a narrow ~50-fixture EIP-8025-only run on v0.3.3).

## Test plan
- [x] `make zkevm-vectors` downloads the v0.4.1 bundle cleanly.
- [x] `cargo test --profile release-with-debug --features stateless` → 2864 passed, 0 failed.
- [x] `cargo check` (default features) passes.
- [x] `cargo fmt --check` clean.
- [ ] CI green on bal-devnet and stateless jobs.