### PR TITLE
refactor(l1): key TRANSACTION_LOCATIONS by tx hash

### DIFF
--- a/crates/storage/api/tables.rs
+++ b/crates/storage/api/tables.rs
@@ -43,13 +43,12 @@ pub const RECEIPTS: &str = "receipts";
 pub const RECEIPTS_V2: &str = "receipts_v2";
 
 /// Transaction locations column family: [`Vec<u8>`] => [`Vec<u8>`]
-/// - [`Vec<u8>`] = Composite key
-///    ```rust,no_run
-///     // let mut composite_key = Vec::with_capacity(64);
-///     // composite_key.extend_from_slice(transaction_hash.as_bytes());
-///     // composite_key.extend_from_slice(block_hash.as_bytes());
-///    ```
-/// - [`Vec<u8>`] = `(block_number, block_hash, index).encode_to_vec()`
+/// - Key: `transaction_hash.as_bytes()` (32 bytes)
+/// - Value: `Vec<(block_number, block_hash, index)>.encode_to_vec()`
+///
+/// The value is a list because, in the rare case of a reorg, the same
+/// transaction may appear in multiple blocks. Readers must filter by the
+/// canonical chain to pick the right `(block_number, block_hash, index)`.
 pub const TRANSACTION_LOCATIONS: &str = "transaction_locations";
 
 /// Chain data column family: [`Vec<u8>`] => [`Vec<u8>`]

--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -85,7 +85,7 @@ pub use store::{
 /// When bumping this version, add a corresponding migration function to
 /// `migrations::MIGRATIONS`. The migration framework will automatically
 /// upgrade existing databases instead of requiring a full resync.
-pub const STORE_SCHEMA_VERSION: u64 = 2;
+pub const STORE_SCHEMA_VERSION: u64 = 3;
 
 /// Name of the file storing the metadata about the database.
 ///

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -1,14 +1,16 @@
 use std::io::Write;
 use std::path::Path;
 
-use crate::api::StorageBackend;
-use crate::api::tables::{RECEIPTS, RECEIPTS_V2};
+use ethrex_common::H256;
+use ethrex_common::types::{BlockHash, BlockNumber, Index};
+use ethrex_rlp::decode::RLPDecode;
+use ethrex_rlp::encode::RLPEncode;
+
+use crate::api::tables::{RECEIPTS, RECEIPTS_V2, TRANSACTION_LOCATIONS};
+use crate::api::{StorageBackend, StorageWriteBatch};
 use crate::error::StoreError;
 use crate::store::receipt_key;
 use crate::{STORE_METADATA_FILENAME, STORE_SCHEMA_VERSION};
-
-use ethrex_common::H256;
-use ethrex_rlp::decode::RLPDecode;
 
 use super::store::StoreMetadata;
 
@@ -27,7 +29,7 @@ pub type MigrationFn = fn(backend: &dyn StorageBackend) -> Result<(), StoreError
 ///
 /// **Invariant**: `MIGRATIONS.len() == (STORE_SCHEMA_VERSION - 1) as usize`
 /// (empty when `STORE_SCHEMA_VERSION == 1`, one entry when it's 2, etc.)
-pub const MIGRATIONS: &[MigrationFn] = &[migrate_1_to_2];
+pub const MIGRATIONS: &[MigrationFn] = &[migrate_1_to_2, migrate_2_to_3];
 
 // Compile-time check: the number of migration functions must match the number
 // of version gaps (i.e. STORE_SCHEMA_VERSION - 1).
@@ -158,6 +160,101 @@ fn migrate_1_to_2(backend: &dyn StorageBackend) -> Result<(), StoreError> {
     Ok(())
 }
 
+type TxLocation = (BlockNumber, BlockHash, Index);
+
+/// Rewrites `TRANSACTION_LOCATIONS` from the v2 composite-key schema
+/// (`key = tx_hash || block_hash`, `value = (block_number, block_hash, index)`)
+/// to the v3 schema (`key = tx_hash`, `value = Vec<(block_number, block_hash, index)>`).
+///
+/// Streams the old table in lex order, grouping consecutive entries by tx_hash
+/// (composite keys with the same 32-byte prefix are adjacent). Flushes each
+/// group as an atomic write batch (put new key + delete old composite keys),
+/// chunking commits to bound memory. Skips any already-migrated 32-byte keys
+/// it encounters, so partial-crash resume re-runs cleanly.
+fn migrate_2_to_3(backend: &dyn StorageBackend) -> Result<(), StoreError> {
+    const GROUPS_PER_COMMIT: usize = 50_000;
+
+    let read = backend.begin_read()?;
+    let iter = read.prefix_iterator(TRANSACTION_LOCATIONS, &[])?;
+
+    let mut write_batch = backend.begin_write()?;
+    let mut groups_in_batch: usize = 0;
+    let mut current: Option<(H256, Vec<TxLocation>, Vec<Vec<u8>>)> = None;
+    let mut total_groups: u64 = 0;
+    let mut total_old_entries: u64 = 0;
+
+    for result in iter {
+        let (key, value) = result?;
+
+        // Already-migrated entries (32-byte tx_hash keys, from a prior partial run): skip.
+        if key.len() == 32 {
+            continue;
+        }
+        if key.len() != 64 {
+            return Err(StoreError::Custom(format!(
+                "unexpected TRANSACTION_LOCATIONS key length {} during migration",
+                key.len()
+            )));
+        }
+
+        total_old_entries += 1;
+
+        let tx_hash = H256::from_slice(&key[..32]);
+        let location = TxLocation::decode(&value)?;
+        let key_vec = key.into_vec();
+
+        match &mut current {
+            Some((h, locs, keys_to_delete)) if *h == tx_hash => {
+                locs.push(location);
+                keys_to_delete.push(key_vec);
+            }
+            _ => {
+                if let Some((h, locs, keys_to_delete)) = current.take() {
+                    flush_tx_location_group(&mut *write_batch, h, locs, keys_to_delete)?;
+                    total_groups += 1;
+                    groups_in_batch += 1;
+                    if groups_in_batch >= GROUPS_PER_COMMIT {
+                        write_batch.commit()?;
+                        groups_in_batch = 0;
+                    }
+                }
+                current = Some((tx_hash, vec![location], vec![key_vec]));
+            }
+        }
+    }
+
+    if let Some((h, locs, keys_to_delete)) = current {
+        flush_tx_location_group(&mut *write_batch, h, locs, keys_to_delete)?;
+        total_groups += 1;
+    }
+
+    write_batch.commit()?;
+
+    tracing::info!(
+        "TRANSACTION_LOCATIONS migration: rewrote {} composite-key entries into {} tx-hash-keyed entries",
+        total_old_entries,
+        total_groups
+    );
+    Ok(())
+}
+
+fn flush_tx_location_group(
+    write_batch: &mut dyn StorageWriteBatch,
+    tx_hash: H256,
+    locations: Vec<TxLocation>,
+    composite_keys: Vec<Vec<u8>>,
+) -> Result<(), StoreError> {
+    write_batch.put(
+        TRANSACTION_LOCATIONS,
+        tx_hash.as_bytes(),
+        &locations.encode_to_vec(),
+    )?;
+    for key in composite_keys {
+        write_batch.delete(TRANSACTION_LOCATIONS, &key)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,6 +350,149 @@ mod tests {
                 txn.get(RECEIPTS, &old_key).unwrap().is_some(),
                 "old key should still exist in RECEIPTS (dropped after migration)"
             );
+        }
+    }
+
+    /// Seeds the backend with one entry under the v2 composite-key schema:
+    /// `key = tx_hash || block_hash`, `value = (block_number, block_hash, index)`.
+    fn seed_old_entry(
+        backend: &dyn StorageBackend,
+        tx_hash: H256,
+        block_number: BlockNumber,
+        block_hash: BlockHash,
+        index: Index,
+    ) {
+        let mut composite_key = Vec::with_capacity(64);
+        composite_key.extend_from_slice(tx_hash.as_bytes());
+        composite_key.extend_from_slice(block_hash.as_bytes());
+        let value = (block_number, block_hash, index).encode_to_vec();
+
+        let mut batch = backend.begin_write().unwrap();
+        batch
+            .put(TRANSACTION_LOCATIONS, &composite_key, &value)
+            .unwrap();
+        batch.commit().unwrap();
+    }
+
+    fn read_new_entry(
+        backend: &dyn StorageBackend,
+        tx_hash: H256,
+    ) -> Option<Vec<(BlockNumber, BlockHash, Index)>> {
+        let read = backend.begin_read().unwrap();
+        let bytes = read.get(TRANSACTION_LOCATIONS, tx_hash.as_bytes()).unwrap()?;
+        Some(<Vec<(BlockNumber, BlockHash, Index)>>::decode(&bytes).unwrap())
+    }
+
+    fn h256(byte: u8) -> H256 {
+        H256::from_low_u64_be(byte as u64)
+    }
+
+    #[test]
+    fn migrate_2_to_3_empty_table() {
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+        migrate_2_to_3(&backend).unwrap();
+        // Nothing to assert other than no error and no spurious entries.
+        assert!(read_new_entry(&backend, h256(1)).is_none());
+    }
+
+    #[test]
+    fn migrate_2_to_3_single_entry_per_hash() {
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+        seed_old_entry(&backend, h256(1), 100, h256(0x10), 0);
+        seed_old_entry(&backend, h256(2), 101, h256(0x11), 5);
+        seed_old_entry(&backend, h256(3), 102, h256(0x12), 7);
+
+        migrate_2_to_3(&backend).unwrap();
+
+        assert_eq!(
+            read_new_entry(&backend, h256(1)).unwrap(),
+            vec![(100u64, h256(0x10), 0u64)]
+        );
+        assert_eq!(
+            read_new_entry(&backend, h256(2)).unwrap(),
+            vec![(101u64, h256(0x11), 5u64)]
+        );
+        assert_eq!(
+            read_new_entry(&backend, h256(3)).unwrap(),
+            vec![(102u64, h256(0x12), 7u64)]
+        );
+
+        // Old composite-key entries are gone.
+        let read = backend.begin_read().unwrap();
+        let iter = read.prefix_iterator(TRANSACTION_LOCATIONS, &[]).unwrap();
+        for entry in iter {
+            let (key, _) = entry.unwrap();
+            assert_eq!(key.len(), 32, "leftover non-migrated key: {:?}", key);
+        }
+    }
+
+    #[test]
+    fn migrate_2_to_3_multi_block_per_hash() {
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+        // Same tx hash appears in three different blocks (reorg scenario).
+        seed_old_entry(&backend, h256(0xAA), 100, h256(0x10), 3);
+        seed_old_entry(&backend, h256(0xAA), 100, h256(0x11), 4);
+        seed_old_entry(&backend, h256(0xAA), 101, h256(0x12), 5);
+
+        migrate_2_to_3(&backend).unwrap();
+
+        let mut got = read_new_entry(&backend, h256(0xAA)).unwrap();
+        got.sort();
+        let mut expected = vec![
+            (100u64, h256(0x10), 3u64),
+            (100u64, h256(0x11), 4u64),
+            (101u64, h256(0x12), 5u64),
+        ];
+        expected.sort();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn migrate_2_to_3_is_idempotent_on_partial_state() {
+        // Simulate a crash-resume: the backend already has a v3 32-byte entry
+        // for one tx hash (from a previously-completed chunk), and v2 composite
+        // entries for another tx hash (still pending).
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+
+        // Already-migrated v3 entry for h256(1).
+        {
+            let v3_value: Vec<(BlockNumber, BlockHash, Index)> =
+                vec![(100, h256(0x10), 0), (100, h256(0x11), 0)];
+            let mut batch = backend.begin_write().unwrap();
+            batch
+                .put(
+                    TRANSACTION_LOCATIONS,
+                    h256(1).as_bytes(),
+                    &v3_value.encode_to_vec(),
+                )
+                .unwrap();
+            batch.commit().unwrap();
+        }
+        // Pending v2 entries for h256(2).
+        seed_old_entry(&backend, h256(2), 200, h256(0x20), 0);
+        seed_old_entry(&backend, h256(2), 200, h256(0x21), 1);
+
+        migrate_2_to_3(&backend).unwrap();
+
+        // h256(1)'s already-migrated entry is unchanged.
+        assert_eq!(
+            read_new_entry(&backend, h256(1)).unwrap(),
+            vec![(100u64, h256(0x10), 0u64), (100u64, h256(0x11), 0u64)]
+        );
+
+        // h256(2) is now migrated.
+        let mut got = read_new_entry(&backend, h256(2)).unwrap();
+        got.sort();
+        let mut expected = vec![(200u64, h256(0x20), 0u64), (200u64, h256(0x21), 1u64)];
+        expected.sort();
+        assert_eq!(got, expected);
+
+        // No leftover 64-byte keys.
+        let read = backend.begin_read().unwrap();
+        let iter = read.prefix_iterator(TRANSACTION_LOCATIONS, &[]).unwrap();
+        for entry in iter {
+            let (key, _) = entry.unwrap();
+            assert_eq!(key.len(), 32);
         }
     }
 }

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -215,6 +215,11 @@ fn migrate_2_to_3(backend: &dyn StorageBackend) -> Result<(), StoreError> {
                     groups_in_batch += 1;
                     if groups_in_batch >= GROUPS_PER_COMMIT {
                         write_batch.commit()?;
+                        // Re-acquire instead of relying on post-commit reuse
+                        // of the trait object (works today via mem::take in
+                        // RocksDB and a no-op InMemory commit, but it's not
+                        // a documented contract on `StorageWriteBatch`).
+                        write_batch = backend.begin_write()?;
                         groups_in_batch = 0;
                     }
                 }
@@ -228,6 +233,9 @@ fn migrate_2_to_3(backend: &dyn StorageBackend) -> Result<(), StoreError> {
         total_groups += 1;
     }
 
+    // Final commit. `groups_in_batch` is not bumped/reset here intentionally
+    // — the post-loop flush is followed immediately by a commit, after which
+    // the variable goes out of scope.
     write_batch.commit()?;
 
     tracing::info!(

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -379,7 +379,9 @@ mod tests {
         tx_hash: H256,
     ) -> Option<Vec<(BlockNumber, BlockHash, Index)>> {
         let read = backend.begin_read().unwrap();
-        let bytes = read.get(TRANSACTION_LOCATIONS, tx_hash.as_bytes()).unwrap()?;
+        let bytes = read
+            .get(TRANSACTION_LOCATIONS, tx_hash.as_bytes())
+            .unwrap()?;
         Some(<Vec<(BlockNumber, BlockHash, Index)>>::decode(&bytes).unwrap())
     }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -269,6 +269,39 @@ pub struct AccountUpdatesList {
     pub code_updates: Vec<(H256, Code)>,
 }
 
+/// Read-modify-write helper for the TRANSACTION_LOCATIONS table.
+///
+/// The table is keyed by tx hash and stores `Vec<(BlockNumber, BlockHash, Index)>` —
+/// one entry per block the tx appears in (multiple only in case of reorgs). The
+/// caller stages updates in `pending`, lazily seeded from disk on first touch
+/// of each tx hash. Re-touching the same hash within the batch (e.g. two blocks
+/// in the same batch containing the same tx) replaces any prior entry for the
+/// same `block_hash`, preserving the dedupe semantics of the previous composite-key
+/// schema.
+fn stage_tx_location(
+    read: &dyn StorageReadView,
+    pending: &mut HashMap<H256, Vec<(BlockNumber, BlockHash, Index)>>,
+    tx_hash: H256,
+    block_number: BlockNumber,
+    block_hash: BlockHash,
+    index: Index,
+) -> Result<(), StoreError> {
+    let list = match pending.entry(tx_hash) {
+        Entry::Occupied(e) => e.into_mut(),
+        Entry::Vacant(e) => {
+            let existing = read
+                .get(TRANSACTION_LOCATIONS, tx_hash.as_bytes())?
+                .map(|bytes| <Vec<(BlockNumber, BlockHash, Index)>>::decode(&bytes))
+                .transpose()?
+                .unwrap_or_default();
+            e.insert(existing)
+        }
+    };
+    list.retain(|(_, bh, _)| *bh != block_hash);
+    list.push((block_number, block_hash, index));
+    Ok(())
+}
+
 impl Store {
     /// Block until the trie-update background worker has drained every prior
     /// message and is waiting for new work — i.e. Phase 2 (disk write of the
@@ -304,6 +337,9 @@ impl Store {
     pub async fn add_blocks(&self, blocks: Vec<Block>) -> Result<(), StoreError> {
         let db = self.backend.clone();
         tokio::task::spawn_blocking(move || {
+            let read = db.begin_read()?;
+            let mut tx_locations: HashMap<H256, Vec<(BlockNumber, BlockHash, Index)>> =
+                HashMap::new();
             let mut tx = db.begin_write()?;
 
             // TODO: Same logic in apply_updates
@@ -321,15 +357,25 @@ impl Store {
                 tx.put(BLOCK_NUMBERS, &hash_key, &block_number.to_le_bytes())?;
 
                 for (index, transaction) in block.body.transactions.iter().enumerate() {
-                    let tx_hash = transaction.hash();
-                    // Key: tx_hash + block_hash
-                    let mut composite_key = Vec::with_capacity(64);
-                    composite_key.extend_from_slice(tx_hash.as_bytes());
-                    composite_key.extend_from_slice(block_hash.as_bytes());
-                    let location_value = (block_number, block_hash, index as u64).encode_to_vec();
-                    tx.put(TRANSACTION_LOCATIONS, &composite_key, &location_value)?;
+                    stage_tx_location(
+                        &*read,
+                        &mut tx_locations,
+                        transaction.hash(),
+                        block_number,
+                        block_hash,
+                        index as u64,
+                    )?;
                 }
             }
+
+            for (tx_hash, locations) in tx_locations {
+                tx.put(
+                    TRANSACTION_LOCATIONS,
+                    tx_hash.as_bytes(),
+                    &locations.encode_to_vec(),
+                )?;
+            }
+
             tx.commit()
         })
         .await
@@ -572,14 +618,13 @@ impl Store {
         block_hash: BlockHash,
         index: Index,
     ) -> Result<(), StoreError> {
-        // FIXME: Use dupsort table
-        let mut composite_key = Vec::with_capacity(64);
-        composite_key.extend_from_slice(transaction_hash.as_bytes());
-        composite_key.extend_from_slice(block_hash.as_bytes());
-        let location_value = (block_number, block_hash, index).encode_to_vec();
-
-        self.write_async(TRANSACTION_LOCATIONS, composite_key, location_value)
-            .await
+        self.add_transaction_locations(vec![(
+            transaction_hash,
+            block_number,
+            block_hash,
+            index,
+        )])
+        .await
     }
 
     /// Store transaction locations in batch (one db transaction for all)
@@ -587,19 +632,35 @@ impl Store {
         &self,
         locations: Vec<(H256, BlockNumber, BlockHash, Index)>,
     ) -> Result<(), StoreError> {
-        let batch_items: Vec<_> = locations
-            .iter()
-            .map(|(tx_hash, block_number, block_hash, index)| {
-                let mut composite_key = Vec::with_capacity(64);
-                composite_key.extend_from_slice(tx_hash.as_bytes());
-                composite_key.extend_from_slice(block_hash.as_bytes());
-                let location_value = (*block_number, *block_hash, *index).encode_to_vec();
-                (composite_key, location_value)
-            })
-            .collect();
+        let db = self.backend.clone();
+        tokio::task::spawn_blocking(move || {
+            let read = db.begin_read()?;
+            let mut tx_locations: HashMap<H256, Vec<(BlockNumber, BlockHash, Index)>> =
+                HashMap::new();
 
-        self.write_batch_async(TRANSACTION_LOCATIONS, batch_items)
-            .await
+            for (tx_hash, block_number, block_hash, index) in locations {
+                stage_tx_location(
+                    &*read,
+                    &mut tx_locations,
+                    tx_hash,
+                    block_number,
+                    block_hash,
+                    index,
+                )?;
+            }
+
+            let mut tx = db.begin_write()?;
+            for (tx_hash, locs) in tx_locations {
+                tx.put(
+                    TRANSACTION_LOCATIONS,
+                    tx_hash.as_bytes(),
+                    &locs.encode_to_vec(),
+                )?;
+            }
+            tx.commit()
+        })
+        .await
+        .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?
     }
 
     /// Obtain transaction location (block hash and index)
@@ -609,37 +670,22 @@ impl Store {
     ) -> Result<Option<(BlockNumber, BlockHash, Index)>, StoreError> {
         let db = self.backend.clone();
         tokio::task::spawn_blocking(move || {
-            let tx_hash_bytes = transaction_hash.as_bytes();
             let tx = db.begin_read()?;
-
-            // rust-rocksdb's prefix_iterator_cf seeks but does not bound iteration —
-            // caller must stop on the first prefix mismatch.
-            let mut iter = tx.prefix_iterator(TRANSACTION_LOCATIONS, tx_hash_bytes)?;
-            let mut transaction_locations = Vec::new();
-
-            while let Some(Ok((key, value))) = iter.next() {
-                // Key is tx_hash (32) + block_hash (32) = 64 bytes.
-                if key.len() == 64 && &key[0..32] == tx_hash_bytes {
-                    transaction_locations.push(<(BlockNumber, BlockHash, Index)>::decode(&value)?);
-                } else {
-                    break;
-                }
-            }
-
-            if transaction_locations.is_empty() {
+            let Some(bytes) = tx.get(TRANSACTION_LOCATIONS, transaction_hash.as_bytes())? else {
                 return Ok(None);
-            }
+            };
+            let locations = <Vec<(BlockNumber, BlockHash, Index)>>::decode(&bytes)?;
 
-            // If there are multiple locations, filter by the canonical chain
-            for (block_number, block_hash, index) in transaction_locations {
-                let canonical_hash = {
-                    tx.get(
+            // In the absence of reorgs, locations has exactly one entry.
+            // If multiple, filter by the canonical chain.
+            for (block_number, block_hash, index) in locations {
+                let canonical_hash = tx
+                    .get(
                         CANONICAL_BLOCK_HASHES,
                         block_number.to_le_bytes().as_slice(),
                     )?
                     .map(|bytes| H256::decode(bytes.as_slice()))
-                    .transpose()?
-                };
+                    .transpose()?;
 
                 if canonical_hash == Some(block_hash) {
                     return Ok(Some((block_number, block_hash, index)));
@@ -1465,6 +1511,8 @@ impl Store {
             .map_err(|e| {
                 StoreError::Custom(format!("failed to read new trie layer notification: {e}"))
             })?;
+        let read = db.begin_read()?;
+        let mut tx_locations: HashMap<H256, Vec<(BlockNumber, BlockHash, Index)>> = HashMap::new();
         let mut tx = db.begin_write()?;
 
         for block in update_batch.blocks {
@@ -1481,14 +1529,23 @@ impl Store {
             tx.put(BLOCK_NUMBERS, &hash_key, &block_number.to_le_bytes())?;
 
             for (index, transaction) in block.body.transactions.iter().enumerate() {
-                let tx_hash = transaction.hash();
-                // Key: tx_hash + block_hash
-                let mut composite_key = Vec::with_capacity(64);
-                composite_key.extend_from_slice(tx_hash.as_bytes());
-                composite_key.extend_from_slice(block_hash.as_bytes());
-                let location_value = (block_number, block_hash, index as u64).encode_to_vec();
-                tx.put(TRANSACTION_LOCATIONS, &composite_key, &location_value)?;
+                stage_tx_location(
+                    &*read,
+                    &mut tx_locations,
+                    transaction.hash(),
+                    block_number,
+                    block_hash,
+                    index as u64,
+                )?;
             }
+        }
+
+        for (tx_hash, locations) in tx_locations {
+            tx.put(
+                TRANSACTION_LOCATIONS,
+                tx_hash.as_bytes(),
+                &locations.encode_to_vec(),
+            )?;
         }
 
         for (block_hash, receipts) in update_batch.receipts {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -278,6 +278,18 @@ pub struct AccountUpdatesList {
 /// in the same batch containing the same tx) replaces any prior entry for the
 /// same `block_hash`, preserving the dedupe semantics of the previous composite-key
 /// schema.
+///
+/// # Concurrency invariant
+///
+/// Callers MUST be serialized at the application layer: the read snapshot and
+/// the write batch are separate, so two concurrent writers on the same tx hash
+/// would both see the pre-write state and the last commit wins — silently
+/// losing the other's entry. In ethrex the blockchain pipeline is sequential
+/// (fork-choice and block import run one block at a time), so this holds
+/// today. If that ever changes, this helper needs an exclusive lock around
+/// the read+stage+write sequence for the TRANSACTION_LOCATIONS slot. The
+/// previous composite-key schema avoided this question by giving concurrent
+/// writers different keys; the new schema can't.
 fn stage_tx_location(
     read: &dyn StorageReadView,
     pending: &mut HashMap<H256, Vec<(BlockNumber, BlockHash, Index)>>,
@@ -618,13 +630,8 @@ impl Store {
         block_hash: BlockHash,
         index: Index,
     ) -> Result<(), StoreError> {
-        self.add_transaction_locations(vec![(
-            transaction_hash,
-            block_number,
-            block_hash,
-            index,
-        )])
-        .await
+        self.add_transaction_locations(vec![(transaction_hash, block_number, block_hash, index)])
+            .await
     }
 
     /// Store transaction locations in batch (one db transaction for all)

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -290,6 +290,8 @@ pub struct AccountUpdatesList {
 /// the read+stage+write sequence for the TRANSACTION_LOCATIONS slot. The
 /// previous composite-key schema avoided this question by giving concurrent
 /// writers different keys; the new schema can't.
+///
+/// Tracked in [#6727](https://github.com/lambdaclass/ethrex/issues/6727).
 fn stage_tx_location(
     read: &dyn StorageReadView,
     pending: &mut HashMap<H256, Vec<(BlockNumber, BlockHash, Index)>>,


### PR DESCRIPTION
**Motivation**

Follow-up to [#6688](https://github.com/lambdaclass/ethrex/issues/6688). The minimal `break`-on-prefix-mismatch fix in [#6702](https://github.com/lambdaclass/ethrex/pull/6702) made `eth_getTransactionByHash` sub-millisecond again, but the underlying schema (composite key `tx_hash || block_hash` over a table that holds a one-to-many relationship) is the reason a prefix iterator was needed in the first place. The original author left a `// FIXME: Use dupsort table` on the write helper. This PR follows through on that.

Reads now do a single `get_cf` on a fixed 32-byte key — `O(1)`, no iteration, no dependency on bounded-iterator hygiene. Future call sites can't accidentally reintroduce the unbounded-scan footgun from #6688 on this table.

**Description**

Schema change for the `TRANSACTION_LOCATIONS` column family (v2 → v3, on top of the receipts migration from [#6598](https://github.com/lambdaclass/ethrex/pull/6598)):

| | Before (v2) | After (v3) |
|---|---|---|
| Key | `tx_hash ‖ block_hash` (64 bytes) | `tx_hash` (32 bytes) |
| Value | `(BlockNumber, BlockHash, Index)` | `Vec<(BlockNumber, BlockHash, Index)>` |
| Read path | `prefix_iterator` + per-entry filter | single `get` + decode |

The value is a `Vec` because, in the rare reorg case, the same tx hash may appear in multiple blocks. The canonical-chain filter (the second half of `get_transaction_location`) is unchanged.

**Write paths.** The four write sites (`add_blocks`, `store_block_updates`, `add_transaction_location`, `add_transaction_locations`) now go through a small `stage_tx_location` helper that does read-modify-write into a `HashMap<H256, Vec<location>>`. Within a batch, re-touching the same tx hash replaces any prior entry with the same `block_hash` — preserving the dedupe semantics that the old composite key gave us for free. The codebase already implicitly serializes writers to this table (the blockchain pipeline is sequential), and the new RMW preserves that assumption; it doesn't introduce a new concurrency requirement.

**Migration.** A new `migrate_2_to_3` is registered as the second entry in the migration framework's `MIGRATIONS` array (the receipts migration from #6598 stays as entry 0, v1→v2). It streams the v2 table in lex order (composite keys with the same 32-byte prefix are adjacent), groups them by tx hash, and flushes each group as an atomic `put (32-byte key) + delete (64-byte keys)` batch. Commits are chunked (50k groups per commit) to bound memory. Per-tx atomicity means crash-resume sees either a fully-migrated tx hash (32-byte key present, 64-byte keys absent) or a still-pending one (32-byte key absent, 64-byte keys present) — never a mix — so resuming after a crash just re-runs cleanly.

`TRANSACTION_LOCATIONS` is ~150–200 GB on a fully-synced mainnet node; first restart after upgrade will be unavailable for the duration of the migration. This should be flagged in release notes.

**Secondary benefits.**
- 32-byte fixed keys work cleanly with RocksDB's standard block-based bloom filter — negative lookups (tx not present) get O(1) bloom-filter rejection. Adding the filter is out of scope for this PR but is now an easy follow-up.
- ~24% smaller per-entry storage in the common single-block case.

**Tests.** Four new migration unit tests (empty table, single-entry-per-hash, multi-block-per-hash for reorg, idempotent partial-restart). All existing storage and RPC tests pass.

Closes #6708

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
