### PR TITLE
ci(l1): free disk space in run-hive job

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -320,6 +320,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk
+
       - name: Download ethrex image artifact
         uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
## Summary
- The `run-hive` job (e.g. Hive - Consume Engine Amsterdam) ran out of disk while building the simulator image (`no space left on device`).
- Adds the existing `./.github/actions/free-disk` composite step right after checkout, matching what sibling jobs (`check-cargo-locks`, `reorg-tests`, etc.) already do.

## Test plan
- [ ] CI passes on this PR; the `Hive - Consume Engine Amsterdam` matrix entry no longer fails on disk space.