### PR TITLE
fix(l2): fix critical bugs in bench_metrics.sh

### DIFF
--- a/scripts/bench_metrics.sh
+++ b/scripts/bench_metrics.sh
@@ -135,15 +135,25 @@ gpu=$(detect_gpu)
     done
 
     # Summary stats.
-    count=0; total=0; min=999999999; max=0; total_gas=0; total_txs=0
+    if [[ ${#ms_arr[@]} -eq 0 ]]; then
+        echo "No batches to summarize." >&2
+        exit 0
+    fi
+
+    min=${ms_arr[0]}
+    max=${ms_arr[0]}
+    count=0
+    total=0
+    total_gas=0
+    total_txs=0
     for i in "${!batches[@]}"; do
         ms=${ms_arr[$i]}
         gas=${gas_arr[$i]}
         txs=${txs_arr[$i]}
         count=$((count + 1))
         total=$((total + ms))
-        ((ms < min)) && min=$ms
-        ((ms > max)) && max=$ms
+        if (( ms < min )); then min=$ms; fi
+        if (( ms > max )); then max=$ms; fi
         [[ "$gas" != "-" && -n "$gas" ]] && total_gas=$((total_gas + ${gas%%.*}))
         [[ "$txs" != "-" && -n "$txs" ]] && total_txs=$((total_txs + ${txs%%.*}))
     done

--- a/scripts/bench_metrics.sh
+++ b/scripts/bench_metrics.sh
@@ -49,7 +49,7 @@ gas_arr=()
 txs_arr=()
 blocks_arr=()
 
-while read -r line; do
+while IFS= read -r line; do
     if echo "$line" | grep -q 'proving_time_ms='; then
         batch=$(echo "$line" | grep -o 'batch=[0-9]*' | head -1 | cut -d= -f2)
         secs=$(echo "$line" | grep -o 'proving_time_s=[0-9]*' | cut -d= -f2)
@@ -135,30 +135,24 @@ gpu=$(detect_gpu)
     done
 
     # Summary stats.
-    if [[ ${#ms_arr[@]} -eq 0 ]]; then
-        echo "No batches to summarize." >&2
-        exit 0
-    fi
-
-    min=${ms_arr[0]}
-    max=${ms_arr[0]}
-    count=0
-    total=0
-    total_gas=0
-    total_txs=0
-    for i in "${!batches[@]}"; do
-        ms=${ms_arr[$i]}
-        gas=${gas_arr[$i]}
-        txs=${txs_arr[$i]}
-        count=$((count + 1))
-        total=$((total + ms))
-        if (( ms < min )); then min=$ms; fi
-        if (( ms > max )); then max=$ms; fi
-        [[ "$gas" != "-" && -n "$gas" ]] && total_gas=$((total_gas + ${gas%%.*}))
-        [[ "$txs" != "-" && -n "$txs" ]] && total_txs=$((total_txs + ${txs%%.*}))
-    done
-
-    if [[ $count -gt 0 ]]; then
+    if [[ ${#ms_arr[@]} -gt 0 ]]; then
+        min=${ms_arr[0]}
+        max=${ms_arr[0]}
+        count=0
+        total=0
+        total_gas=0
+        total_txs=0
+        for i in "${!batches[@]}"; do
+            ms=${ms_arr[$i]}
+            gas=${gas_arr[$i]}
+            txs=${txs_arr[$i]}
+            count=$((count + 1))
+            total=$((total + ms))
+            if (( ms < min )); then min=$ms; fi
+            if (( ms > max )); then max=$ms; fi
+            [[ "$gas" != "-" && -n "$gas" ]] && total_gas=$((total_gas + ${gas%%.*}))
+            [[ "$txs" != "-" && -n "$txs" ]] && total_txs=$((total_txs + ${txs%%.*}))
+        done
         avg=$((total / count))
         echo ""
         echo "## Summary"


### PR DESCRIPTION
Fix three bugs in scripts/bench_metrics.sh: replace ((ms < min)) && min=$ms and ((ms > max)) && max=$ms with if (( )); then fi to prevent silent crashes under set -e when the arithmetic condition evaluates to false; replace the magic sentinel min=999999999 with min=${ms_arr[0]} to avoid incorrect results for large proving times; and add a local guard before min/max initialization to make the non-empty array invariant explicit rather than relying on a distant check earlier in the script.
