### PR TITLE
feat(l1): revert MAX_WITHDRAWALS_PER_PAYLOAD to 16

### DIFF
--- a/crates/common/types/eip8025_ssz.rs
+++ b/crates/common/types/eip8025_ssz.rs
@@ -17,11 +17,7 @@ use super::requests::EncodedRequests;
 /// `MAX_TRANSACTIONS_PER_PAYLOAD` (Electra).
 const MAX_TRANSACTIONS_PER_PAYLOAD: usize = 1_048_576;
 /// `MAX_WITHDRAWALS_PER_PAYLOAD` (Electra).
-/// TODO: the specs have a non-compliant value compared to consensus
-/// specs. Whenever the specs can resolve an underlying issue,
-/// this value should be updated.
-/// See https://github.com/ethereum/execution-specs/blob/ec23140720d6a9257a907c470ba1874623bd7b50/src/ethereum/forks/amsterdam/stateless_ssz.py#L40-L43
-const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 65536;
+const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 16;
 /// `MAX_BYTES_PER_TRANSACTION`.
 const MAX_BYTES_PER_TRANSACTION: usize = 1_073_741_824;
 /// `MAX_EXTRA_DATA_BYTES`.


### PR DESCRIPTION

Revert `MAX_WITHDRAWALS_PER_PAYLOAD` from `65536` to `16`, so the `hash_tree_root` result is compatible with  fixtures after `tests-zkevm@v0.4.0` (that includes [this commit](https://github.com/ethereum/execution-specs/commit/73427c2c2a7344fa0b5d04ab9d2d118d0f67fef6#diff-6ee7a579e66e9190afd89b1bcec94a23ed6fdefcf45028239874fe856697ed15) of `execution-specs` reverting the value)

(Not strictly) depends on #6715, since the test runner doesn't check whether the `new_payload_request_root` matches the one of test fixture or not ([only `valid` bool is checked](https://github.com/lambdaclass/ethrex/blob/main/tooling/ef_tests/blockchain/test_runner.rs#L611)).
