### PR TITLE
perf(l1): prefetch all BAL storage synchronously before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Perf
 
+### 2026-05-27
+
+- Prefetch all BAL storage synchronously before execution [#6732](https://github.com/lambdaclass/ethrex/pull/6732)
+
 ### 2026-05-19
 
 - Lazy BAL cursor for per-tx parallel execution [#6669](https://github.com/lambdaclass/ethrex/pull/6669)

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -544,12 +544,12 @@ impl Blockchain {
         // prefetching, skip the synchronous storage warm too. The warmer thread
         // below already honors the same toggle.
         #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
-        if self.options.bal_prefetch_enabled {
-            if let Some(bal) = bal {
-                let slots = LEVM::bal_storage_slots(bal);
-                if !slots.is_empty() {
-                    let _ = caching_store.prefetch_storage(&slots);
-                }
+        if self.options.bal_prefetch_enabled
+            && let Some(bal) = bal
+        {
+            let slots = LEVM::bal_storage_slots(bal);
+            if !slots.is_empty() {
+                let _ = caching_store.prefetch_storage(&slots);
             }
         }
 

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -539,11 +539,17 @@ impl Blockchain {
         // block) it adds serial latency the old overlapped warmer would have hidden.
         // The benchmarks above are cold-cache batch import, not single-block live
         // tail latency; the tradeoff is deliberate and favors throughput.
+        //
+        // Gated by `--no-bal-prefetch`: when the operator disables BAL-driven
+        // prefetching, skip the synchronous storage warm too. The warmer thread
+        // below already honors the same toggle.
         #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
-        if let Some(bal) = bal {
-            let slots = LEVM::bal_storage_slots(bal);
-            if !slots.is_empty() {
-                let _ = caching_store.prefetch_storage(&slots);
+        if self.options.bal_prefetch_enabled {
+            if let Some(bal) = bal {
+                let slots = LEVM::bal_storage_slots(bal);
+                if !slots.is_empty() {
+                    let _ = caching_store.prefetch_storage(&slots);
+                }
             }
         }
 

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -514,6 +514,39 @@ impl Blockchain {
             None
         };
 
+        // Synchronously warm all BAL storage slots before the executor thread starts.
+        //
+        // The warmer and executor share one CachingDatabase; `prefetch_storage`
+        // populates the cache only after its whole parallel fetch completes, so when
+        // the warmer ran storage concurrently the executor raced it to the trie for
+        // SSTORE original values and lost (~22% of CPU on cold-cache import-bench).
+        // Doing the storage prefetch up front (parallel, on all cores) lets execution
+        // run fully warm and removes the warmer's CPU/lock contention with it.
+        //
+        // Measured on bal-devnet-7-mainnet-mix-460 (import-bench --with-bal, vs main):
+        //   - concurrent storage warming (any ordering/chunking): ~ -7% to -13%
+        //   - this synchronous full-storage prefetch:             ~ -24%
+        // DO NOT move storage back into the concurrent warmer; the race is the whole
+        // problem. DO NOT add account prefetch here too: that regressed (~ +150 ms),
+        // because account reads already overlap exec well and a synchronous pass both
+        // adds serial latency and double-fetches against the warmer's Phase 1. Slots
+        // are warmed in natural account order; an execution-order sort gave no benefit
+        // once every slot is warm before exec.
+        //
+        // Live-node tradeoff: this prefetch is on the critical path before exec, no
+        // longer overlapped with it. With a warm cache the reads hit and it is a
+        // no-op; on a genuinely cold block (first slot after restart, account-heavy
+        // block) it adds serial latency the old overlapped warmer would have hidden.
+        // The benchmarks above are cold-cache batch import, not single-block live
+        // tail latency; the tradeoff is deliberate and favors throughput.
+        #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+        if let Some(bal) = bal {
+            let slots = LEVM::bal_storage_slots(bal);
+            if !slots.is_empty() {
+                let _ = caching_store.prefetch_storage(&slots);
+            }
+        }
+
         let (execution_result, merkleization_result, warmer_duration) =
             std::thread::scope(|s| -> Result<_, ChainError> {
                 #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2091,14 +2091,27 @@ impl LEVM {
         Ok(())
     }
 
-    /// Pre-warms state by loading all accounts and storage slots listed in the
-    /// Block Access List directly, without speculative re-execution.
+    /// Flattened (address, slot) storage worklist for a BAL, in natural account
+    /// order (slots grouped per account for storage-trie locality).
+    #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+    pub fn bal_storage_slots(bal: &BlockAccessList) -> Vec<(Address, H256)> {
+        bal.accounts()
+            .iter()
+            .flat_map(|ac| {
+                ac.all_storage_slots()
+                    .map(move |slot| (ac.address, H256::from_uint(&slot)))
+            })
+            .collect()
+    }
+
+    /// Concurrent block warmer for the BAL path: prefetches account states and
+    /// contract code while execution runs.
     ///
-    /// Two-phase approach:
-    /// - Phase 1: Load all account states (parallel via rayon) -> warms CachingDatabase
-    ///   account cache AND trie layer cache nodes
-    /// - Phase 2: Load all storage slots (parallel via rayon, per-slot) + contract code
-    ///   (parallel via rayon, per-account) -> benefits from trie nodes cached in Phase 1
+    /// Storage slots are deliberately NOT warmed here. They are prefetched
+    /// synchronously before the executor starts (see `bal_storage_slots` and the
+    /// call site in `blockchain.rs`); warming them concurrently here let the
+    /// executor race the warmer to the trie for SSTORE original values and cost
+    /// ~22% of CPU. Keep storage warming synchronous and up front.
     #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
     pub fn warm_block_from_bal(
         bal: &BlockAccessList,
@@ -2111,8 +2124,10 @@ impl LEVM {
         }
 
         // Phase 1: Prefetch all account states — parallel inner fetch + single write-lock.
-        // This warms the CachingDatabase account cache and the TrieLayerCache
-        // with state trie nodes, so Phase 2 storage reads benefit from cached lookups.
+        // This warms the CachingDatabase account cache and the TrieLayerCache with
+        // state trie nodes. Storage slots are prefetched synchronously before the
+        // executor starts (see `bal_storage_slots` at the call site), so this warmer
+        // only needs to cover account states and contract code, which overlap exec.
         let account_addresses: Vec<Address> = accounts.iter().map(|ac| ac.address).collect();
         store
             .prefetch_accounts(&account_addresses)
@@ -2122,27 +2137,7 @@ impl LEVM {
             return Ok(());
         }
 
-        // Phase 2: Prefetch storage slots in batch — parallel inner fetch + single write-lock.
-        // Storage is flattened to (address, slot) pairs so rayon can distribute
-        // work across threads regardless of how many slots each account has.
-        // Without flattening, a hot contract with hundreds of slots (e.g. a DEX
-        // pool) would monopolize a single thread while others go idle.
-        let slots: Vec<(Address, ethrex_common::H256)> = accounts
-            .iter()
-            .flat_map(|ac| {
-                ac.all_storage_slots()
-                    .map(move |slot| (ac.address, ethrex_common::H256::from_uint(&slot)))
-            })
-            .collect();
-        store
-            .prefetch_storage(&slots)
-            .map_err(|e| EvmError::Custom(format!("prefetch_storage: {e}")))?;
-
-        if cancelled.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-
-        // Phase 3: Code prefetch — collect code hashes from Phase 1 account states
+        // Phase 2: Code prefetch — collect code hashes from Phase 1 account states
         // (already cached after Phase 1 prefetch), then batch-fetch codes in parallel.
         // Uses par_iter for collection since blocks can have thousands of accounts.
         let code_hashes: Vec<ethrex_common::H256> = accounts


### PR DESCRIPTION
## What

The BAL warmer and the parallel executor run concurrently, sharing one `CachingDatabase`. The warmer prefetched the block's storage slots from a background thread, and `prefetch_storage` only populates the cache after its whole parallel fetch completes. So the executor started against a cold cache and raced the warmer to the trie for its SSTORE original values, losing for the early transactions. A perf-record profile on the fixture below showed those SSTORE original-value trie walks were ~22% of total CPU, with ~72% of `CachingDatabase` storage reads falling through to the trie.

This change prefetches all BAL storage slots synchronously, before the executor thread starts. The prefetch is parallel (one `par_iter` across all cores), so it is fast, and it lets execution run fully warm with no trie fallthrough for storage and no warmer contending with the executor for CPU and the cache lock. The concurrent warmer is reduced to account states and contract code, which overlap execution well.

Storage is warmed in natural account order (slots grouped per account for storage-trie locality). Account prefetch is intentionally left concurrent: warming accounts synchronously too was measured slower, since account reads already overlap execution and a synchronous pass adds serial latency plus a double-fetch against the warmer.

## Why synchronous, not on the concurrent warmer?

The question is not "warmer thread vs exec thread", it is synchronous (before exec) vs concurrent (racing exec). The warmer and executor are spawned together and start at the same instant; `prefetch_storage` publishes to the cache only after its whole parallel fetch completes (a single write-lock at the end, no incremental visibility). So while the warmer is fetching, the executor sees a cold cache and reaches the trie itself for early-transaction SSTORE original values, paying a synchronous trie walk on the critical path.

Because the executor always starts with zero lead over the warmer, no ordering or chunking of the concurrent prefetch removes that race; concurrent variants topped out around -7% to -13%. The two threads also compete for CPU cores and the cache `RwLock`. Doing the storage prefetch up front, fully in parallel, costs only a few ms/block and lets exec run against a fully warm cache with no contention, for ~ -24%.

The intuition that overlapping the warmer with exec is free does not hold here: on this workload the overlap was a net loss (race plus contention). Only storage is moved; accounts and code stay on the concurrent warmer because they already overlap exec well (moving accounts synchronously regressed).

Tradeoff to note: on a live single-block `newPayload` the prefetch is now on the critical path before exec, so it can add a little latency versus the fully overlapped warmer; it is parallel and removes more fallthrough than it adds, so it should still net positive, and import / sync (back-to-back blocks) clearly win.

## Benchmark

Fixture: `bal-devnet-7-mainnet-mix-460` (460 blocks, ~30 Ggas, transfer/EVM mix). `release-with-debug`, `import-bench --with-bal`. Baseline = `main`. 4 runs each.

| metric         | baseline (main) | this PR   | delta              |
|----------------|-----------------|-----------|--------------------|
| wall time      | 4687.9 ms       | 3577.9 ms | -1110 ms (-23.7%)  |
| exec total     | 4263.2 ms       | 3166.4 ms | -1097 ms (-25.7%)  |
| warmer total   | 3148.3 ms       | 864.8 ms  | warmer now covers accounts + code only |
| warmer overlap | 97.0%           | 97.8%     | preserved          |

## Correctness

The prefetch only fills a read cache with values fetched from the underlying DB (`or_insert`, never overwriting executor writes); any cache miss falls through to the trie as before. Per EIP-7928 the BAL covers every storage slot accessed during the block, so coverage is complete. import-bench validates each block's state root and ran clean.

Related: #6729.
