### PR TITLE
feat(l1): log block hash in per-block execution metric line

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2064,11 +2064,11 @@ impl Blockchain {
             block.header.number,
             block.body.transactions.len(),
         );
+        let block_hash = block.hash();
 
         if let Some(logger) = logger
             && let Some(account_updates) = accumulated_updates
         {
-            let block_hash = block.hash();
             let witness = self.generate_witness_from_account_updates(
                 account_updates,
                 &block,
@@ -2083,11 +2083,10 @@ impl Blockchain {
         // On the parallel Amsterdam validation path the BAL is supplied via the header
         // and `produced_bal` is None, so fall back to the validated incoming `bal`.
         // Pre-Amsterdam blocks have no BAL on either source, so nothing is stored.
-        if let Some(bal) = produced_bal.as_ref().or(bal) {
-            let block_hash = block.hash();
-            if let Err(err) = self.storage.store_block_access_list(block_hash, bal) {
-                warn!("Failed to store block access list for block {block_hash}: {err}");
-            }
+        if let Some(bal) = produced_bal.as_ref().or(bal)
+            && let Err(err) = self.storage.store_block_access_list(block_hash, bal)
+        {
+            warn!("Failed to store block access list for block {block_hash}: {err}");
         }
 
         let result = self.store_block(block, account_updates_list, res);
@@ -2107,6 +2106,7 @@ impl Blockchain {
                 gas_used,
                 gas_limit,
                 block_number,
+                block_hash,
                 transactions_count,
                 merkle_queue_length,
                 warmer_duration,
@@ -2187,6 +2187,7 @@ impl Blockchain {
         gas_used: u64,
         gas_limit: u64,
         block_number: u64,
+        block_hash: H256,
         transactions_count: usize,
         merkle_queue_length: usize,
         warmer_duration: Duration,
@@ -2275,8 +2276,9 @@ impl Blockchain {
 
         // Format output
         let header = format!(
-            "[METRIC] BLOCK {} | {:.3} Ggas/s | {:.2} ms | {} txs | {:.0} Mgas ({}%)",
+            "[METRIC] BLOCK {} {:#x} | {:.3} Ggas/s | {:.2} ms | {} txs | {:.0} Mgas ({}%)",
             block_number,
+            block_hash,
             throughput,
             total_ms,
             transactions_count,


### PR DESCRIPTION
## Motivation

The per-block execution metric line emitted on the `engine_newPayload` / `add_block_pipeline` path logs the block number but not the block hash:

```
[METRIC] BLOCK 24358000 | 1.234 Ggas/s | 567.00 ms | 150 txs | 700 Mgas (93%)
```

The block number alone is not a stable key for correlating these metrics with a specific block: benchmarking and replay harnesses commonly roll back and re-import at the same height, so the same block number maps to many distinct blocks. The block hash is the only content-unique identifier.

This also helps [ethpandaops/benchmarkoor](https://github.com/ethpandaops/benchmarkoor), which captures client block logs and associates them with tests strictly by block hash (`{ "block": { "hash": "0x..." } }`). Without the hash on this line, ethrex runs there can't attach per-block metrics; with it, a log parser can match them. (benchmarkoor drives blocks via `engine_newPayload`, which goes through this exact pipeline log.)

## Change

Thread the already-available `block.hash()` into `print_add_block_pipeline_logs` and include it in the metric header:

```
[METRIC] BLOCK 24358000 0x<hash> | 1.234 Ggas/s | 567.00 ms | 150 txs | 700 Mgas (93%)
```

The hash was already computed in this function on the witness/BAL branches; it is now computed once before the block is moved into `store_block` and reused, so there is no extra hashing on the common path. Uses the existing `{:#x}` block-hash convention (see `dev/block_producer.rs`).

## Log-consumer check

Verified the existing in-tree log parsers are unaffected:

- `tooling/log_analysis/log_analysis.ipynb` — regex is hardcoded to the `BLOCK EXECUTION THROUGHPUT (N): ...` line (`print_add_block_logs`), a different line that this PR does not touch.
- `tooling/import_benchmark/parse_bench.py` — keys off the first `)` in the line; the hash is inserted before the trailing `(...%)`, so its parsing is unchanged.

No other consumers of this line exist in the repo (Grafana panels read Prometheus metrics, not logs).
