### PR TITLE
fix(l2): override Nix daemon User-Agent so crates.io stops 403ing the TDX image build

### DIFF
--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -530,6 +530,16 @@ jobs:
 
       - name: Set up Nix
         uses: cachix/install-nix-action@v31
+        with:
+          # crates.io 403s any User-Agent containing "curl/", which is what Nix's
+          # fetchurl sends by default, breaking crate downloads during the image
+          # build. In multi-user (daemon) mode the FOD builds run under the
+          # nix-daemon and don't see the caller's environment, so override the
+          # User-Agent via impure-env (honored because the runner is a trusted
+          # user). Single token (=-form) so it survives word-splitting.
+          extra_nix_config: |
+            extra-experimental-features = configurable-impure-env
+            impure-env = NIX_CURL_FLAGS=--user-agent=ethrex-ci+https://github.com/lambdaclass/ethrex
 
       - name: Set up QEMU
         run: |

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -536,10 +536,12 @@ jobs:
           # build. In multi-user (daemon) mode the FOD builds run under the
           # nix-daemon and don't see the caller's environment, so override the
           # User-Agent via impure-env (honored because the runner is a trusted
-          # user). Single token (=-form) so it survives word-splitting.
+          # user). Use curl's glued short option `-A<value>`: a single space-free
+          # token that survives impure-env's space-separated parsing and
+          # fetchurl's unquoted word-split (curl rejects the --user-agent=value form).
           extra_nix_config: |
             extra-experimental-features = configurable-impure-env
-            impure-env = NIX_CURL_FLAGS=--user-agent=ethrex-ci+https://github.com/lambdaclass/ethrex
+            impure-env = NIX_CURL_FLAGS=-Aethrex-ci+https://github.com/lambdaclass/ethrex
 
       - name: Set up QEMU
         run: |

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -55,10 +55,12 @@ jobs:
           # build. In multi-user (daemon) mode the FOD builds run under the
           # nix-daemon and don't see the caller's environment, so override the
           # User-Agent via impure-env (honored because the runner is a trusted
-          # user). Single token (=-form) so it survives word-splitting.
+          # user). Use curl's glued short option `-A<value>`: a single space-free
+          # token that survives impure-env's space-separated parsing and
+          # fetchurl's unquoted word-split (curl rejects the --user-agent=value form).
           extra_nix_config: |
             extra-experimental-features = configurable-impure-env
-            impure-env = NIX_CURL_FLAGS=--user-agent=ethrex-ci+https://github.com/lambdaclass/ethrex
+            impure-env = NIX_CURL_FLAGS=-Aethrex-ci+https://github.com/lambdaclass/ethrex
 
       - name: Build image
         run: |

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -49,6 +49,16 @@ jobs:
 
       - name: Set up Nix
         uses: cachix/install-nix-action@v31
+        with:
+          # crates.io 403s any User-Agent containing "curl/", which is what Nix's
+          # fetchurl sends by default, breaking crate downloads during the image
+          # build. In multi-user (daemon) mode the FOD builds run under the
+          # nix-daemon and don't see the caller's environment, so override the
+          # User-Agent via impure-env (honored because the runner is a trusted
+          # user). Single token (=-form) so it survives word-splitting.
+          extra_nix_config: |
+            extra-experimental-features = configurable-impure-env
+            impure-env = NIX_CURL_FLAGS=--user-agent=ethrex-ci+https://github.com/lambdaclass/ethrex
 
       - name: Build image
         run: |

--- a/crates/l2/tee/quote-gen/Makefile
+++ b/crates/l2/tee/quote-gen/Makefile
@@ -6,22 +6,13 @@ NIXPKGS_URL = https://github.com/NixOS/nixpkgs/archive/3fcbdcfc707e0aa42c541b774
 GIT_REV := $(shell git rev-parse --short=7 HEAD)
 NIX_BUILD_ARGS = --no-out-link -I nixpkgs=$(NIXPKGS_URL) --argstr gitRev "$(GIT_REV)"
 
-# crates.io returns HTTP 403 for any User-Agent containing "curl/", which is what
-# Nix's fetchurl sends by default (`curl/<ver> Nixpkgs/<ver>`). That breaks every
-# crate download during the image build. fetchurl appends $NIX_CURL_FLAGS to its
-# curl invocation (last --user-agent wins) and passes it into the fixed-output
-# derivation sandbox via impureEnvVars, so we override the User-Agent with one
-# crates.io accepts. Set inline on the nix-build command rather than via `export`
-# because GNU Make's $(shell ...) does not inherit exported variables.
-NIX_ENV = NIX_CURL_FLAGS="--user-agent ethrex-ci+https://github.com/lambdaclass/ethrex"
-
 image.raw:
-	$(eval IMAGE := $(shell $(NIX_ENV) nix-build image.nix ${NIX_BUILD_ARGS})/${IMAGE_NAME})
+	$(eval IMAGE := $(shell nix-build image.nix ${NIX_BUILD_ARGS})/${IMAGE_NAME})
 	cp $(IMAGE) image.raw
 	chmod u+rw image.raw
 
 run: image.raw
-	$(eval RUN_QEMU := $(shell $(NIX_ENV) nix-build hypervisor.nix ${NIX_BUILD_ARGS})/bin/run-qemu)
+	$(eval RUN_QEMU := $(shell nix-build hypervisor.nix ${NIX_BUILD_ARGS})/bin/run-qemu)
 	$(RUN_QEMU) image.raw
 
 clean:

--- a/crates/l2/tee/quote-gen/Makefile
+++ b/crates/l2/tee/quote-gen/Makefile
@@ -6,13 +6,22 @@ NIXPKGS_URL = https://github.com/NixOS/nixpkgs/archive/3fcbdcfc707e0aa42c541b774
 GIT_REV := $(shell git rev-parse --short=7 HEAD)
 NIX_BUILD_ARGS = --no-out-link -I nixpkgs=$(NIXPKGS_URL) --argstr gitRev "$(GIT_REV)"
 
+# crates.io returns HTTP 403 for any User-Agent containing "curl/", which is what
+# Nix's fetchurl sends by default (`curl/<ver> Nixpkgs/<ver>`). That breaks every
+# crate download during the image build. fetchurl appends $NIX_CURL_FLAGS to its
+# curl invocation (last --user-agent wins) and passes it into the fixed-output
+# derivation sandbox via impureEnvVars, so we override the User-Agent with one
+# crates.io accepts. Set inline on the nix-build command rather than via `export`
+# because GNU Make's $(shell ...) does not inherit exported variables.
+NIX_ENV = NIX_CURL_FLAGS="--user-agent ethrex-ci+https://github.com/lambdaclass/ethrex"
+
 image.raw:
-	$(eval IMAGE := $(shell nix-build image.nix ${NIX_BUILD_ARGS})/${IMAGE_NAME})
+	$(eval IMAGE := $(shell $(NIX_ENV) nix-build image.nix ${NIX_BUILD_ARGS})/${IMAGE_NAME})
 	cp $(IMAGE) image.raw
 	chmod u+rw image.raw
 
 run: image.raw
-	$(eval RUN_QEMU := $(shell nix-build hypervisor.nix ${NIX_BUILD_ARGS})/bin/run-qemu)
+	$(eval RUN_QEMU := $(shell $(NIX_ENV) nix-build hypervisor.nix ${NIX_BUILD_ARGS})/bin/run-qemu)
 	$(RUN_QEMU) image.raw
 
 clean:


### PR DESCRIPTION
**Motivation**

The TDX image build (`make image.raw`, in the **L2 TDX build** and **L2 (without proving)** workflows) is failing on `main` and on every PR. crates.io now returns **HTTP 403** to any request whose `User-Agent` contains the substring `curl/`. Nix's `fetchurl` — used by `rustPlatform.importCargoLock` to vendor crates for the TDX `quote-gen` image — sends `User-Agent: curl/<ver> Nixpkgs/<ver>`, so every crate download 403s and the build fails:

```
> trying https://crates.io/api/v1/crates/ark-ec/0.5.0/download
> curl: (22) The requested URL returned error: 403
error: cannot download crate-ark-ec-0.5.0.tar.gz from any mirror
```

It's an external crates.io policy change, which is why it breaks `main` and all PRs at once.

**Description**

`install-nix-action` runs Nix in **multi-user (daemon) mode**, so the crate fixed-output derivations are built by the `nix-daemon`, which does **not** inherit the caller's environment. The fix therefore has to reach the daemon, via Nix's [`impure-env`](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-impure-env) setting — the documented mechanism for passing environment into fixed-output derivations in a multi-user install (its canonical use is `https_proxy` for the daemon). It is honored because the CI runner is a trusted user.

`fetchurl` appends `$NIX_CURL_FLAGS` to its `curl` invocation (curl honors the last `--user-agent`), so we set it to a `curl/`-free User-Agent. The `--user-agent=<value>` form keeps it a single token through `impure-env`'s space-separated parsing and `fetchurl`'s unquoted word-split.

Applied to both workflows that run `make image.raw`. The earlier Makefile-level `NIX_CURL_FLAGS` override is reverted — it was inert in daemon mode (only single-user/local Nix would have seen it).

**How to Test**

```
# crates.io blocks the curl/ UA, accepts the override:
curl -sS -o /dev/null -w '%{http_code}\n' -A 'curl/8.7.1'                                    -L https://crates.io/api/v1/crates/ark-ec/0.5.0/download   # 403
curl -sS -o /dev/null -w '%{http_code}\n' -A 'ethrex-ci+https://github.com/lambdaclass/ethrex' -L https://crates.io/api/v1/crates/ark-ec/0.5.0/download   # 200
```

Verified end-to-end via CI on this PR (the **L2 TDX build** check).