### PR TITLE
fix(l1): use 0x80 sentinel for missing eth/71 BAL per EIP-8159

### DIFF
--- a/crates/networking/p2p/rlpx/eth/block_access_lists.rs
+++ b/crates/networking/p2p/rlpx/eth/block_access_lists.rs
@@ -23,9 +23,9 @@ pub const BLOCK_ACCESS_LIST_LIMIT: usize = 1024;
 /// empty string is the only sentinel that can never alias a real BAL.
 /// `Some(bal)` is encoded as the BAL's normal RLP list encoding.
 ///
-/// INVARIANT: `BlockAccessList` always encodes as an RLP list (first byte
-/// >= 0xc0), so `0x80` is unambiguously the `None` sentinel; keep this true
-/// if `BlockAccessList`'s encoding is ever refactored.
+/// INVARIANT: `BlockAccessList` always encodes as an RLP list (first byte is
+/// `0xc0` or greater), so `0x80` is unambiguously the `None` sentinel; keep
+/// this true if `BlockAccessList`'s encoding is ever refactored.
 #[derive(Debug, Clone)]
 struct OptionalBal(Option<BlockAccessList>);
 

--- a/crates/networking/p2p/rlpx/eth/block_access_lists.rs
+++ b/crates/networking/p2p/rlpx/eth/block_access_lists.rs
@@ -26,8 +26,12 @@ pub const BLOCK_ACCESS_LIST_LIMIT: usize = 1024;
 /// INVARIANT: `BlockAccessList` always encodes as an RLP list (first byte is
 /// `0xc0` or greater), so `0x80` is unambiguously the `None` sentinel; keep
 /// this true if `BlockAccessList`'s encoding is ever refactored.
+///
+/// Public so the byte-level sentinel encoding can be asserted from the test
+/// crate (`test/tests/p2p/rlpx/block_access_lists_tests.rs`); message-level
+/// roundtrips run the bytes through snappy and can't see the raw `0x80`.
 #[derive(Debug, Clone)]
-struct OptionalBal(Option<BlockAccessList>);
+pub struct OptionalBal(pub Option<BlockAccessList>);
 
 impl RLPEncode for OptionalBal {
     fn encode(&self, buf: &mut dyn BufMut) {
@@ -251,19 +255,5 @@ mod tests {
         msg.encode(&mut buf).unwrap();
         let decoded = BlockAccessLists::decode(&buf).unwrap();
         assert_eq!(decoded.block_access_lists.len(), BLOCK_ACCESS_LIST_LIMIT);
-    }
-
-    /// Locks the EIP-8159 §"BlockAccessLists (0x13)" sentinel at the unit
-    /// level: a missing BAL encodes as exactly the RLP empty string (`0x80`),
-    /// never the empty list (`0xc0`, a valid empty BAL). geth uses the same
-    /// sentinel (`rlp.EmptyString` in `eth/protocols/eth/handlers.go`); any
-    /// drift here is silent interop breakage. Message-level roundtrip coverage
-    /// lives in `test/tests/p2p/rlpx/block_access_lists_tests.rs` (the private
-    /// `OptionalBal` wrapper asserted here is unreachable from that crate).
-    #[test]
-    fn optional_bal_none_encodes_as_0x80_sentinel() {
-        let mut bytes = Vec::new();
-        OptionalBal(None).encode(&mut bytes);
-        assert_eq!(bytes, vec![0x80]);
     }
 }

--- a/crates/networking/p2p/rlpx/eth/block_access_lists.rs
+++ b/crates/networking/p2p/rlpx/eth/block_access_lists.rs
@@ -22,6 +22,10 @@ pub const BLOCK_ACCESS_LIST_LIMIT: usize = 1024;
 /// (`0xc0`) is a valid BAL encoding (block with no state changes), so the
 /// empty string is the only sentinel that can never alias a real BAL.
 /// `Some(bal)` is encoded as the BAL's normal RLP list encoding.
+///
+/// INVARIANT: `BlockAccessList` always encodes as an RLP list (first byte
+/// >= 0xc0), so `0x80` is unambiguously the `None` sentinel; keep this true
+/// if `BlockAccessList`'s encoding is ever refactored.
 #[derive(Debug, Clone)]
 struct OptionalBal(Option<BlockAccessList>);
 
@@ -143,7 +147,6 @@ impl RLPxMessage for BlockAccessLists {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rlpx::utils::snappy_decompress;
     use ethereum_types::Address;
     use ethrex_common::types::block_access_list::{AccountChanges, BalanceChange};
 
@@ -250,30 +253,17 @@ mod tests {
         assert_eq!(decoded.block_access_lists.len(), BLOCK_ACCESS_LIST_LIMIT);
     }
 
-    /// Locks EIP-8159 §"BlockAccessLists (0x13)" sentinel: missing BALs encode
-    /// as RLP empty string (`0x80`), NOT empty list (`0xc0`). Empty list is a
-    /// valid BAL encoding (block with no state changes), so the empty string
-    /// is the only byte that can't alias a real BAL. geth uses the same
+    /// Locks the EIP-8159 §"BlockAccessLists (0x13)" sentinel at the unit
+    /// level: a missing BAL encodes as exactly the RLP empty string (`0x80`),
+    /// never the empty list (`0xc0`, a valid empty BAL). geth uses the same
     /// sentinel (`rlp.EmptyString` in `eth/protocols/eth/handlers.go`); any
-    /// drift here is silent interop breakage.
+    /// drift here is silent interop breakage. Message-level roundtrip coverage
+    /// lives in `test/tests/p2p/rlpx/block_access_lists_tests.rs` (the private
+    /// `OptionalBal` wrapper asserted here is unreachable from that crate).
     #[test]
-    fn block_access_lists_none_uses_0x80_sentinel() {
-        let msg = BlockAccessLists::new(0, vec![None]);
-        let mut buf = Vec::new();
-        msg.encode(&mut buf).unwrap();
-        let decompressed = snappy_decompress(&buf).unwrap();
-        assert!(
-            decompressed.contains(&0x80),
-            "decompressed payload must contain the 0x80 None sentinel"
-        );
-        assert!(
-            !decompressed.contains(&0xc0),
-            "decompressed payload must not contain the 0xc0 empty-list sentinel"
-        );
-
-        // Roundtrip must preserve the None.
-        let decoded = BlockAccessLists::decode(&buf).unwrap();
-        assert_eq!(decoded.block_access_lists.len(), 1);
-        assert!(decoded.block_access_lists[0].is_none());
+    fn optional_bal_none_encodes_as_0x80_sentinel() {
+        let mut bytes = Vec::new();
+        OptionalBal(None).encode(&mut bytes);
+        assert_eq!(bytes, vec![0x80]);
     }
 }

--- a/crates/networking/p2p/rlpx/eth/block_access_lists.rs
+++ b/crates/networking/p2p/rlpx/eth/block_access_lists.rs
@@ -16,7 +16,11 @@ use ethrex_rlp::{
 pub const BLOCK_ACCESS_LIST_LIMIT: usize = 1024;
 
 /// Wrapper for optional BAL in eth/71 protocol messages.
-/// `None` (BAL unavailable) is encoded as an empty RLP list (0xc0).
+///
+/// Per EIP-8159 §"BlockAccessLists (0x13)": "The RLP empty string (`0x80`)
+/// is returned for blocks where the BAL is unavailable." An empty list
+/// (`0xc0`) is a valid BAL encoding (block with no state changes), so the
+/// empty string is the only sentinel that can never alias a real BAL.
 /// `Some(bal)` is encoded as the BAL's normal RLP list encoding.
 #[derive(Debug, Clone)]
 struct OptionalBal(Option<BlockAccessList>);
@@ -24,14 +28,14 @@ struct OptionalBal(Option<BlockAccessList>);
 impl RLPEncode for OptionalBal {
     fn encode(&self, buf: &mut dyn BufMut) {
         match &self.0 {
-            None => buf.put_u8(0xc0),
+            None => buf.put_u8(0x80),
             Some(bal) => bal.encode(buf),
         }
     }
 
     fn length(&self) -> usize {
         match &self.0 {
-            None => 1, // empty list = 0xc0
+            None => 1, // empty string = 0x80 per EIP-8159
             Some(bal) => bal.length(),
         }
     }
@@ -39,7 +43,7 @@ impl RLPEncode for OptionalBal {
 
 impl RLPDecode for OptionalBal {
     fn decode_unfinished(rlp: &[u8]) -> Result<(Self, &[u8]), RLPDecodeError> {
-        if rlp.first() == Some(&0xc0) {
+        if rlp.first() == Some(&0x80) {
             return Ok((OptionalBal(None), &rlp[1..]));
         }
         let (bal, rest) = BlockAccessList::decode_unfinished(rlp)?;
@@ -139,6 +143,7 @@ impl RLPxMessage for BlockAccessLists {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rlpx::utils::snappy_decompress;
     use ethereum_types::Address;
     use ethrex_common::types::block_access_list::{AccountChanges, BalanceChange};
 
@@ -243,5 +248,32 @@ mod tests {
         msg.encode(&mut buf).unwrap();
         let decoded = BlockAccessLists::decode(&buf).unwrap();
         assert_eq!(decoded.block_access_lists.len(), BLOCK_ACCESS_LIST_LIMIT);
+    }
+
+    /// Locks EIP-8159 §"BlockAccessLists (0x13)" sentinel: missing BALs encode
+    /// as RLP empty string (`0x80`), NOT empty list (`0xc0`). Empty list is a
+    /// valid BAL encoding (block with no state changes), so the empty string
+    /// is the only byte that can't alias a real BAL. geth uses the same
+    /// sentinel (`rlp.EmptyString` in `eth/protocols/eth/handlers.go`); any
+    /// drift here is silent interop breakage.
+    #[test]
+    fn block_access_lists_none_uses_0x80_sentinel() {
+        let msg = BlockAccessLists::new(0, vec![None]);
+        let mut buf = Vec::new();
+        msg.encode(&mut buf).unwrap();
+        let decompressed = snappy_decompress(&buf).unwrap();
+        assert!(
+            decompressed.contains(&0x80),
+            "decompressed payload must contain the 0x80 None sentinel"
+        );
+        assert!(
+            !decompressed.contains(&0xc0),
+            "decompressed payload must not contain the 0xc0 empty-list sentinel"
+        );
+
+        // Roundtrip must preserve the None.
+        let decoded = BlockAccessLists::decode(&buf).unwrap();
+        assert_eq!(decoded.block_access_lists.len(), 1);
+        assert!(decoded.block_access_lists[0].is_none());
     }
 }

--- a/crates/networking/p2p/rlpx/eth/mod.rs
+++ b/crates/networking/p2p/rlpx/eth/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod block_access_lists;
+pub mod block_access_lists;
 pub mod blocks;
 pub mod eth68;
 mod eth69;

--- a/test/tests/p2p/rlpx/block_access_lists_tests.rs
+++ b/test/tests/p2p/rlpx/block_access_lists_tests.rs
@@ -1,5 +1,9 @@
 use ethrex_common::types::block_access_list::BlockAccessList;
-use ethrex_p2p::rlpx::{eth::block_access_lists::BlockAccessLists, message::RLPxMessage};
+use ethrex_p2p::rlpx::{
+    eth::block_access_lists::{BlockAccessLists, OptionalBal},
+    message::RLPxMessage,
+};
+use ethrex_rlp::encode::RLPEncode;
 
 // ── BlockAccessLists (0x13, eth/71) ──
 //
@@ -43,4 +47,17 @@ fn present_empty_bal_roundtrips_as_some() {
     let decoded = BlockAccessLists::decode(&buf).unwrap();
     assert_eq!(decoded.block_access_lists.len(), 1);
     assert!(decoded.block_access_lists[0].is_some());
+}
+
+/// Locks the EIP-8159 §"BlockAccessLists (0x13)" sentinel: a missing BAL
+/// encodes as exactly the RLP empty string (`0x80`), never the empty list
+/// (`0xc0`, a valid empty BAL). geth uses the same sentinel (`rlp.EmptyString`
+/// in `eth/protocols/eth/handlers.go`); any drift here is silent interop
+/// breakage. Asserts the raw byte directly on the `OptionalBal` wrapper, which
+/// the message-level tests can't see (their bytes go through snappy).
+#[test]
+fn optional_bal_none_encodes_as_0x80_sentinel() {
+    let mut bytes = Vec::new();
+    OptionalBal(None).encode(&mut bytes);
+    assert_eq!(bytes, vec![0x80]);
 }

--- a/test/tests/p2p/rlpx/block_access_lists_tests.rs
+++ b/test/tests/p2p/rlpx/block_access_lists_tests.rs
@@ -1,0 +1,46 @@
+use ethrex_common::types::block_access_list::BlockAccessList;
+use ethrex_p2p::rlpx::{eth::block_access_lists::BlockAccessLists, message::RLPxMessage};
+
+// ── BlockAccessLists (0x13, eth/71) ──
+//
+// EIP-8159 says a missing BAL is the RLP empty string (`0x80`), while a
+// present-but-empty BAL (block with no state changes) is the RLP empty list
+// (`0xc0`). The two must never alias, otherwise an upgraded node silently
+// confuses "BAL unavailable" with "valid empty BAL" (interop break with geth).
+
+#[test]
+fn missing_bal_is_distinct_from_present_empty_bal() {
+    let missing = BlockAccessLists::new(1, vec![None]);
+    let empty = BlockAccessLists::new(1, vec![Some(BlockAccessList::from_accounts(vec![]))]);
+
+    let mut missing_buf = Vec::new();
+    missing.encode(&mut missing_buf).unwrap();
+    let mut empty_buf = Vec::new();
+    empty.encode(&mut empty_buf).unwrap();
+
+    // 0x80 sentinel must not collapse onto the 0xc0 empty-list encoding.
+    assert_ne!(missing_buf, empty_buf);
+}
+
+#[test]
+fn missing_bal_roundtrips_as_none() {
+    let msg = BlockAccessLists::new(7, vec![None]);
+    let mut buf = Vec::new();
+    msg.encode(&mut buf).unwrap();
+
+    let decoded = BlockAccessLists::decode(&buf).unwrap();
+    assert_eq!(decoded.id, 7);
+    assert_eq!(decoded.block_access_lists.len(), 1);
+    assert!(decoded.block_access_lists[0].is_none());
+}
+
+#[test]
+fn present_empty_bal_roundtrips_as_some() {
+    let msg = BlockAccessLists::new(7, vec![Some(BlockAccessList::from_accounts(vec![]))]);
+    let mut buf = Vec::new();
+    msg.encode(&mut buf).unwrap();
+
+    let decoded = BlockAccessLists::decode(&buf).unwrap();
+    assert_eq!(decoded.block_access_lists.len(), 1);
+    assert!(decoded.block_access_lists[0].is_some());
+}

--- a/test/tests/p2p/rlpx/mod.rs
+++ b/test/tests/p2p/rlpx/mod.rs
@@ -1,3 +1,4 @@
+mod block_access_lists_tests;
 mod blocks_tests;
 mod handshake_tests;
 mod p2p_tests;


### PR DESCRIPTION
## Summary

eth/71 `BlockAccessLists` (0x13) returns the wrong sentinel byte for missing BALs. EIP-8159 §\"BlockAccessLists (0x13)\" mandates the RLP empty string (\`0x80\`); our implementation emitted the RLP empty list (\`0xc0\`).

\`0xc0\` is a valid encoding for an empty \`BlockAccessList\` (a block with no state changes), so using it as the \"unavailable\" sentinel makes \"missing BAL\" indistinguishable from \"valid empty BAL\" on the wire. The spec uses \`0x80\` because it can never alias a real BAL.

## Why this matters

go-ethereum's eth/71 handler uses \`rlp.EmptyString\` (= \`0x80\`) at \`eth/protocols/eth/handlers.go:693\`, with the comment:

> The signal for missing BAL is the empty string, because an empty list is also a valid BAL.

With ethrex on \`0xc0\` and geth on \`0x80\`:

- **ethrex → geth**: geth decodes our \`0xc0\` as a zero-element list, interprets the slot as a valid empty BAL. Silent data confusion.
- **geth → ethrex**: ethrex's decode checks for \`0xc0\`, falls through to \`BlockAccessList::decode_unfinished\` which errors on \`0x80\`.

Found while cross-checking the snap/2 (EIP-8189) PR against go-ethereum.

## Changes

- \`crates/networking/p2p/rlpx/eth/block_access_lists.rs\`: \`OptionalBal\` encode and decode now use \`0x80\`.
- Added \`block_access_lists_none_uses_0x80_sentinel\` test asserting \`0x80\` is present and \`0xc0\` absent in a single-None response payload.

## Test plan

- [x] \`cargo test -p ethrex-p2p --lib block_access_lists\` — 8 passed (7 existing + 1 new).
- [x] \`cargo test -p ethrex-p2p --lib\` — 35 passed.
- [x] \`cargo clippy -p ethrex-p2p -- -D warnings\` — clean.
- [x] \`cargo fmt --all\` — clean.