### PR TITLE
fix(l1): accept number-encoded terminalTotalDifficulty in genesis

### DIFF
--- a/crates/common/serde_utils.rs
+++ b/crates/common/serde_utils.rs
@@ -317,6 +317,13 @@ pub mod u128 {
         }
     }
 
+    /// Deserializes an `Option<u128>` from either a `0x`-hex string or a bare
+    /// JSON number, for geth/reth genesis compatibility.
+    ///
+    /// **Precision**: bare numbers above `u64::MAX` are read through an `f64`
+    /// cast, losing ~3 decimal digits. Acceptable for sentinel-only fields like
+    /// `terminalTotalDifficulty`; if you need bit-exact `u128` here, add a new
+    /// deserializer rather than reusing this one.
     pub mod hex_str_opt {
         use serde::Serialize;
 
@@ -348,7 +355,9 @@ pub mod u128 {
                         // "PoS active" for TTD; reject them above instead.
                         f as u128
                     } else {
-                        return Err(D::Error::custom("Failed to deserialize u128 number"));
+                        return Err(D::Error::custom(format!(
+                            "u128 value must be a finite, non-negative number; got {n}"
+                        )));
                     };
                     Ok(Some(v))
                 }

--- a/crates/common/serde_utils.rs
+++ b/crates/common/serde_utils.rs
@@ -343,7 +343,9 @@ pub mod u128 {
                     // used as a post-merge sentinel, so f64 imprecision is moot).
                     let v = if let Some(u) = n.as_u64() {
                         u as u128
-                    } else if let Some(f) = n.as_f64() {
+                    } else if let Some(f) = n.as_f64().filter(|f| f.is_finite() && *f >= 0.0) {
+                        // `f as u128` saturates negatives to 0, which would mean
+                        // "PoS active" for TTD; reject them above instead.
                         f as u128
                     } else {
                         return Err(D::Error::custom("Failed to deserialize u128 number"));

--- a/crates/common/serde_utils.rs
+++ b/crates/common/serde_utils.rs
@@ -335,11 +335,21 @@ pub mod u128 {
         {
             let value: Option<serde_json::Value> = Option::deserialize(d)?;
             match value {
-                Some(serde_json::Value::Number(n)) => n
-                    .to_string()
-                    .parse::<u128>()
-                    .map(Some)
-                    .map_err(|_| D::Error::custom("Failed to deserialize u128 number")),
+                Some(serde_json::Value::Number(n)) => {
+                    // Values above u64::MAX (e.g. mainnet's TTD) are stored by
+                    // serde_json as f64, so `n.to_string()` can be "5.875e22",
+                    // which won't parse as u128. Read the integer directly and
+                    // fall back to f64 for the out-of-u64-range case (TTD is only
+                    // used as a post-merge sentinel, so f64 imprecision is moot).
+                    let v = if let Some(u) = n.as_u64() {
+                        u as u128
+                    } else if let Some(f) = n.as_f64() {
+                        f as u128
+                    } else {
+                        return Err(D::Error::custom("Failed to deserialize u128 number"));
+                    };
+                    Ok(Some(v))
+                }
                 Some(serde_json::Value::String(s)) if !s.is_empty() => {
                     u128::from_str_radix(s.trim_start_matches("0x"), 16)
                         .map_err(|_| D::Error::custom("Failed to deserialize u128 value"))

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -795,7 +795,12 @@ mod tests {
             r#"{{"chainId":1,"terminalTotalDifficulty":58750000000000000000000,{dca}}}"#
         ))
         .expect("number-encoded TTD should parse");
-        assert!(from_number.terminal_total_difficulty.is_some());
+        // f64 cast is lossy above u64::MAX; assert the known, stable
+        // approximation so a regression to Some(0) can't silently pass.
+        assert_eq!(
+            from_number.terminal_total_difficulty,
+            Some(58749999999999996329984u128)
+        );
 
         let from_hex: ChainConfig = serde_json::from_str(&format!(
             r#"{{"chainId":1,"terminalTotalDifficulty":"0xc70d808a128d7380000",{dca}}}"#
@@ -811,6 +816,12 @@ mod tests {
         ))
         .expect("small number TTD should parse");
         assert_eq!(small.terminal_total_difficulty, Some(17000000000000000u128));
+
+        // A negative bare number must error, not silently saturate to Some(0).
+        let negative = serde_json::from_str::<ChainConfig>(&format!(
+            r#"{{"chainId":1,"terminalTotalDifficulty":-1,{dca}}}"#
+        ));
+        assert!(negative.is_err(), "negative TTD must be rejected");
     }
 
     #[test]

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -785,6 +785,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn terminal_total_difficulty_accepts_number_or_hex_string() {
+        // geth/reth-style genesis files encode terminalTotalDifficulty as a
+        // bare decimal number that exceeds u64::MAX; ethrex must accept it as
+        // well as the 0x-hex-string form.
+        let dca = r#""depositContractAddress":"0x00000000219ab540356cbb839cbe05303d7705fa""#;
+
+        let from_number: ChainConfig = serde_json::from_str(&format!(
+            r#"{{"chainId":1,"terminalTotalDifficulty":58750000000000000000000,{dca}}}"#
+        ))
+        .expect("number-encoded TTD should parse");
+        assert!(from_number.terminal_total_difficulty.is_some());
+
+        let from_hex: ChainConfig = serde_json::from_str(&format!(
+            r#"{{"chainId":1,"terminalTotalDifficulty":"0xc70d808a128d7380000",{dca}}}"#
+        ))
+        .expect("hex-string TTD should parse");
+        assert_eq!(
+            from_hex.terminal_total_difficulty,
+            Some(58750000000000000000000u128)
+        );
+
+        let small: ChainConfig = serde_json::from_str(&format!(
+            r#"{{"chainId":1,"terminalTotalDifficulty":17000000000000000,{dca}}}"#
+        ))
+        .expect("small number TTD should parse");
+        assert_eq!(small.terminal_total_difficulty, Some(17000000000000000u128));
+    }
+
+    #[test]
     fn deserialize_genesis_file() {
         // Deserialize genesis file
         let file = File::open("../../fixtures/genesis/kurtosis.json")

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -821,7 +821,11 @@ mod tests {
         let negative = serde_json::from_str::<ChainConfig>(&format!(
             r#"{{"chainId":1,"terminalTotalDifficulty":-1,{dca}}}"#
         ));
-        assert!(negative.is_err(), "negative TTD must be rejected");
+        let err = negative.expect_err("negative TTD must be rejected");
+        assert!(
+            err.to_string().contains("finite, non-negative"),
+            "error should name the sign/finiteness cause, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`ChainConfig::terminal_total_difficulty` failed to deserialize when a genesis file encodes `terminalTotalDifficulty` as a bare decimal number (geth/reth style), e.g. `58750000000000000000000`. Genesis loading aborts with `Failed to deserialize u128 number`.

## Why

The value exceeds `u64::MAX`, so serde_json (default features) stores it as `f64`. The old code did `n.to_string().parse::<u128>()`, where `to_string()` yields `"5.875e22"`, which doesn't parse as `u128`. Hex-string form (`"0x..."`) worked; bare numbers didn't.

This reads the integer directly: exact via `as_u64()` for `<= u64::MAX`, with an `as_f64()` cast fallback above that. Hex-string form is unchanged.

## Precision

The `as_f64()` cast is lossy above `u64::MAX` (`58750000000000000000000` → `58749999999999996329984`). This is acceptable because `terminal_total_difficulty` is only used as a post-merge sentinel (`!= Some(0)` to detect PoS); it never enters block hashing, execution, or consensus arithmetic, so the approximation is functionally identical.

## Why not a bit-exact parser

serde_json discards the precision before any custom code runs:
- `deserialize_any` (and `Value`) downcast `> u64::MAX` integers to `f64` (verified: it calls `visit_f64`, never `visit_u128`).
- `deserialize_u128` is exact but errors on strings, so it can't also accept the hex-string form.
- `raw_value` (read the raw token) is exact but breaks `from_reader`/`from_value` for the field; genesis is loaded via `from_reader`.
- `arbitrary_precision` is exact but global, and breaks `#[serde(flatten)]` / `#[serde(untagged)]` with numbers — both used across transaction and RPC types here.

For a sentinel field, none of those is worth the blast radius.
