### PR TITLE
fix(l1): persist BAL and serve V2 payload bodies from store

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2074,8 +2074,10 @@ impl Blockchain {
                 .store_witness(block_hash, block_number, witness)?;
         };
 
-        // Store the produced BAL (present on Amsterdam+ blocks) so peers can request it
-        if let Some(bal) = &produced_bal {
+        // Store the block's BAL so peers can request it later without re-execution.
+        // On the Amsterdam+ validation path the BAL is supplied via the header and
+        // `produced_bal` is None, so fall back to the validated incoming `bal`.
+        if let Some(bal) = produced_bal.as_ref().or(bal) {
             let block_hash = block.hash();
             if let Err(err) = self.storage.store_block_access_list(block_hash, bal) {
                 warn!("Failed to store block access list for block {block_hash}: {err}");

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1982,7 +1982,9 @@ impl Blockchain {
     }
 
     /// Same as [`add_block_pipeline`] but also returns the BAL produced during execution.
-    /// On Amsterdam+ blocks the returned value is `Some(bal)`, otherwise `None`.
+    /// On the Amsterdam+ validation path the BAL comes from the header and drives
+    /// execution rather than being rebuilt, so the returned value is `None`; the
+    /// pre-Amsterdam / streaming paths rebuild and return `Some(bal)`.
     pub fn add_block_pipeline_bal(
         &self,
         block: Block,

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -690,13 +690,14 @@ impl Blockchain {
                             &chain_config,
                             &execution_result.requests,
                         )?;
-                        // Amsterdam validation path uses the header BAL directly to drive
-                        // execution; it doesn't rebuild a BAL, so produced_bal is None.
+                        // The parallel Amsterdam validation path uses the header BAL directly
+                        // to drive execution; it doesn't rebuild a BAL, so produced_bal is None.
                         // BAL correctness on that path is enforced inside
                         // execute_block_pipeline (header-BAL index/size/withdrawal-index
                         // checks plus unread_storage_reads / unaccessed_pure_accounts).
-                        // Pre-Amsterdam / streaming paths return Some(produced_bal) and
-                        // the hash check below still runs.
+                        // The sequential Amsterdam path rebuilds a BAL and returns
+                        // Some(produced_bal), so the hash check below runs. Pre-Amsterdam
+                        // blocks never record a BAL, so produced_bal is None there too.
                         if let Some(bal) = &produced_bal {
                             validate_block_access_list_hash(
                                 &block.header,
@@ -1982,9 +1983,11 @@ impl Blockchain {
     }
 
     /// Same as [`add_block_pipeline`] but also returns the BAL produced during execution.
-    /// On the Amsterdam+ validation path the BAL comes from the header and drives
-    /// execution rather than being rebuilt, so the returned value is `None`; the
-    /// pre-Amsterdam / streaming paths rebuild and return `Some(bal)`.
+    /// A BAL only exists from Amsterdam onward. On the parallel validation path the BAL
+    /// comes from the header and drives execution rather than being rebuilt, so the
+    /// returned value is `None`; the sequential path (block production or
+    /// `--no-bal-parallel-exec`) rebuilds it and returns `Some(bal)`. Pre-Amsterdam blocks
+    /// never record a BAL, so the returned value is always `None`.
     pub fn add_block_pipeline_bal(
         &self,
         block: Block,
@@ -2077,8 +2080,9 @@ impl Blockchain {
         };
 
         // Store the block's BAL so peers can request it later without re-execution.
-        // On the Amsterdam+ validation path the BAL is supplied via the header and
-        // `produced_bal` is None, so fall back to the validated incoming `bal`.
+        // On the parallel Amsterdam validation path the BAL is supplied via the header
+        // and `produced_bal` is None, so fall back to the validated incoming `bal`.
+        // Pre-Amsterdam blocks have no BAL on either source, so nothing is stored.
         if let Some(bal) = produced_bal.as_ref().or(bal) {
             let block_hash = block.hash();
             if let Err(err) = self.storage.store_block_access_list(block_hash, bal) {

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -739,9 +739,10 @@ fn build_payload_body_response(bodies: Vec<Option<BlockBody>>) -> Result<Value, 
 
 /// Returns the block's BAL for V2 payload-body responses.
 ///
-/// Reads the persisted BAL first; only when it is absent (e.g. blocks predating
-/// BAL persistence) does it fall back to regenerating via re-execution, which
-/// requires the parent state trie and fails once that state has been pruned.
+/// Reads the persisted BAL first; only when it is absent (pre-Amsterdam blocks,
+/// or Amsterdam blocks processed before BAL persistence was added) does it fall
+/// back to regenerating via re-execution, which requires the parent state trie
+/// and fails on snap-synced nodes that don't hold that historical state.
 fn bal_for_block(
     context: &RpcApiContext,
     block: &Block,

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -737,6 +737,24 @@ fn build_payload_body_response(bodies: Vec<Option<BlockBody>>) -> Result<Value, 
     serde_json::to_value(response).map_err(|error| RpcErr::Internal(error.to_string()))
 }
 
+/// Returns the block's BAL for V2 payload-body responses.
+///
+/// Reads the persisted BAL first; only when it is absent (e.g. blocks predating
+/// BAL persistence) does it fall back to regenerating via re-execution, which
+/// requires the parent state trie and fails once that state has been pruned.
+fn bal_for_block(
+    context: &RpcApiContext,
+    block: &Block,
+) -> Result<Option<BlockAccessList>, RpcErr> {
+    if let Some(bal) = context.storage.get_block_access_list(block.hash())? {
+        return Ok(Some(bal));
+    }
+    context
+        .blockchain
+        .generate_bal_for_block(block)
+        .map_err(|e| RpcErr::Internal(e.to_string()))
+}
+
 // ==================== V2 Body Methods (EIP-7928) ====================
 
 pub struct GetPayloadBodiesByHashV2Request {
@@ -767,10 +785,7 @@ impl RpcHandler for GetPayloadBodiesByHashV2Request {
             let block = context.storage.get_block_by_hash(*hash).await?;
             let result = match block {
                 Some(block) => {
-                    let bal = context
-                        .blockchain
-                        .generate_bal_for_block(&block)
-                        .map_err(|e| RpcErr::Internal(e.to_string()))?;
+                    let bal = bal_for_block(&context, &block)?;
                     Some(ExecutionPayloadBodyV2::from_body_with_bal(block.body, bal))
                 }
                 None => None,
@@ -835,10 +850,7 @@ impl RpcHandler for GetPayloadBodiesByRangeV2Request {
                             })?;
                     let block = Block { header, body };
 
-                    let bal = context
-                        .blockchain
-                        .generate_bal_for_block(&block)
-                        .map_err(|e| RpcErr::Internal(e.to_string()))?;
+                    let bal = bal_for_block(&context, &block)?;
                     Some(ExecutionPayloadBodyV2::from_body_with_bal(block.body, bal))
                 }
                 None => None,

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -747,13 +747,24 @@ fn bal_for_block(
     context: &RpcApiContext,
     block: &Block,
 ) -> Result<Option<BlockAccessList>, RpcErr> {
-    if let Some(bal) = context.storage.get_block_access_list(block.hash())? {
+    let block_hash = block.hash();
+    if let Some(bal) = context.storage.get_block_access_list(block_hash)? {
         return Ok(Some(bal));
     }
-    context
+    let generated = context
         .blockchain
         .generate_bal_for_block(block)
-        .map_err(|e| RpcErr::Internal(e.to_string()))
+        .map_err(|e| RpcErr::Internal(e.to_string()))?;
+    // Write back so subsequent requests for this block are served from the
+    // store instead of re-executing every time. Regeneration only succeeds
+    // while the parent state is still in the retained window; the block has
+    // long been accepted, so the regenerated BAL is authoritative for serving.
+    if let Some(bal) = &generated
+        && let Err(err) = context.storage.store_block_access_list(block_hash, bal)
+    {
+        warn!("Failed to persist regenerated block access list for {block_hash}: {err}");
+    }
+    Ok(generated)
 }
 
 // ==================== V2 Body Methods (EIP-7928) ====================

--- a/test/tests/rpc/block_access_list_tests.rs
+++ b/test/tests/rpc/block_access_list_tests.rs
@@ -193,3 +193,40 @@ async fn payload_bodies_by_range_v2_serves_stored_bal() {
         ]);
     assert_eq!(got, expected);
 }
+
+// Fallback path: when no BAL is stored, the handler must not re-execute a block
+// whose parent state is unavailable. For a pre-Amsterdam block, regeneration
+// short-circuits to None, so a None-carrying body proves the response was
+// produced without touching (absent) historical state. This locks in the
+// snap-sync / aged-out-state safety the PR targets.
+#[tokio::test]
+async fn payload_bodies_by_hash_v2_pre_amsterdam_returns_none_without_re_execution() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+
+    // Pre-Amsterdam block (timestamp 0); no BAL stored and no state trie built.
+    let block = Block {
+        header: BlockHeader {
+            number: 1,
+            ..Default::default()
+        },
+        body: BlockBody::default(),
+    };
+    let block_hash = block.hash();
+    storage.add_block(block).await.expect("store block");
+
+    let context = default_context_with_storage(storage).await;
+    let request = GetPayloadBodiesByHashV2Request {
+        hashes: vec![block_hash],
+    };
+    let got = request.handle(context).await.expect("rpc ok");
+
+    let expected =
+        serde_json::json!([
+            serde_json::to_value(ExecutionPayloadBodyV2::from_body_with_bal(
+                BlockBody::default(),
+                None
+            ))
+            .unwrap()
+        ]);
+    assert_eq!(got, expected);
+}

--- a/test/tests/rpc/block_access_list_tests.rs
+++ b/test/tests/rpc/block_access_list_tests.rs
@@ -1,12 +1,27 @@
 use ethrex_common::types::block_access_list::{
     AccountChanges, BalanceChange, BlockAccessList, NonceChange, SlotChange, StorageChange,
 };
+use ethrex_common::types::{Block, BlockBody, BlockHeader};
 use ethrex_common::{Address, H256, U256};
+use ethrex_rpc::engine::payload::{
+    GetPayloadBodiesByHashV2Request, GetPayloadBodiesByRangeV2Request,
+};
 use ethrex_rpc::map_eth_requests;
+use ethrex_rpc::rpc::RpcHandler;
 use ethrex_rpc::test_utils::default_context_with_storage;
+use ethrex_rpc::types::payload::ExecutionPayloadBodyV2;
 use ethrex_rpc::utils::RpcRequest;
 use ethrex_storage::{EngineType, Store};
 use std::str::FromStr;
+
+// A small, structurally valid BAL used by the payload-body serving tests.
+fn sample_bal() -> BlockAccessList {
+    let address = Address::from_str("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b").unwrap();
+    let account = AccountChanges::new(address)
+        .with_nonce_changes(vec![NonceChange::new(0, 1)])
+        .with_balance_changes(vec![BalanceChange::new(0, U256::from(1u64))]);
+    BlockAccessList::from_accounts(vec![account])
+}
 
 // Mirrors the `eth_getBlockAccessList` example in
 // execution-apis/src/eth/block.yaml (schema at
@@ -93,4 +108,88 @@ async fn eth_get_block_access_list_unknown_hash_returns_null() {
 
     let got = map_eth_requests(&request, context).await.expect("rpc ok");
     assert_eq!(got, serde_json::Value::Null);
+}
+
+// engine_getPayloadBodiesByHashV2 must serve the persisted BAL straight from the
+// store, without re-executing the block. We store a block and its BAL but never
+// build the state trie, so a regeneration fallback would fail (or, for this
+// non-Amsterdam block, return None); a response carrying the stored BAL proves it
+// was read from the store. This is the path that was failing on snap-synced nodes.
+#[tokio::test]
+async fn payload_bodies_by_hash_v2_serves_stored_bal() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+
+    let block = Block {
+        header: BlockHeader {
+            number: 1,
+            ..Default::default()
+        },
+        body: BlockBody::default(),
+    };
+    let block_hash = block.hash();
+    storage.add_block(block).await.expect("store block");
+
+    let bal = sample_bal();
+    storage
+        .store_block_access_list(block_hash, &bal)
+        .expect("store BAL");
+
+    let context = default_context_with_storage(storage).await;
+    let request = GetPayloadBodiesByHashV2Request {
+        hashes: vec![block_hash],
+    };
+    let got = request.handle(context).await.expect("rpc ok");
+
+    let expected =
+        serde_json::json!([
+            serde_json::to_value(ExecutionPayloadBodyV2::from_body_with_bal(
+                BlockBody::default(),
+                Some(bal)
+            ))
+            .unwrap()
+        ]);
+    assert_eq!(got, expected);
+}
+
+// Same guarantee for the range variant: engine_getPayloadBodiesByRangeV2 returns
+// the persisted BAL from the store without re-execution.
+#[tokio::test]
+async fn payload_bodies_by_range_v2_serves_stored_bal() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+
+    let block = Block {
+        header: BlockHeader {
+            number: 1,
+            ..Default::default()
+        },
+        body: BlockBody::default(),
+    };
+    let block_hash = block.hash();
+    storage.add_block(block).await.expect("store block");
+    // Make the block canonical and the latest so the range handler can find it.
+    storage
+        .forkchoice_update(vec![(1, block_hash)], 1, block_hash, None, None)
+        .await
+        .expect("forkchoice update");
+
+    let bal = sample_bal();
+    storage
+        .store_block_access_list(block_hash, &bal)
+        .expect("store BAL");
+
+    let context = default_context_with_storage(storage).await;
+    // params: [start, count] = [block 1, 1 block]
+    let params = Some(vec![serde_json::json!("0x1"), serde_json::json!("0x1")]);
+    let request = GetPayloadBodiesByRangeV2Request::parse(&params).expect("parse");
+    let got = request.handle(context).await.expect("rpc ok");
+
+    let expected =
+        serde_json::json!([
+            serde_json::to_value(ExecutionPayloadBodyV2::from_body_with_bal(
+                BlockBody::default(),
+                Some(bal)
+            ))
+            .unwrap()
+        ]);
+    assert_eq!(got, expected);
 }


### PR DESCRIPTION
## Problem

On `bal-devnet-7`, Lighthouse logged ~15 errors/hr from a single node:

```
WARN Execution engine call failed
  error: ServerMessage { code: -32603, message: "Internal Error: EVM error: DB error: state root missing" }
```

Triggered during `beacon_blocks_by_range` payload reconstruction. The CL calls `engine_getPayloadBodiesByRangeV2`/`ByHashV2`, whose handlers regenerate each block's BAL by re-executing the block against its parent state (`generate_bal_for_block` -> `StoreVmDatabase::new`). A snap-synced node does not hold that historical state, so re-execution fails with `state root missing` and the CL can't serve blocks to peers.

The BAL is already validated at block execution and there is a `block_access_lists` table, but the persistence site only stored `produced_bal`, which is `None` on the Amsterdam header-driven path, so live blocks never got their BAL stored.

## Fix

- Persist the validated BAL at execution: `produced_bal.as_ref().or(bal)`, covering the Amsterdam path where `produced_bal` is `None`.
- Serve V2 payload bodies from the store via a `bal_for_block` helper that reads the persisted BAL first and only falls back to regeneration when absent.

Serving no longer re-executes, so it never depends on historical state.

## Notes

- BAL lifecycle stays coupled to the block body; no pruning added.
- Forward-looking: only blocks executed after this change get a stored BAL. Blocks pulled in purely via the non-final batch full-sync path (never live-executed) still lack a stored BAL; tracked in #6765.

## Test

`cargo test -p ethrex-test --test ethrex_tests block_access_list` passes.
