### PR TITLE
[DNM] glamsterdam-devnet-4 rebased on main (CI only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 2026-05-19
 
 - Lazy BAL cursor for per-tx parallel execution [#6669](https://github.com/lambdaclass/ethrex/pull/6669)
+- Move per-tx BAL validation into the rayon par_iter closure on the parallel execution path [#6677](https://github.com/lambdaclass/ethrex/pull/6677)
 
 ### 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Prefetch all BAL storage synchronously before execution [#6732](https://github.com/lambdaclass/ethrex/pull/6732)
 
+### 2026-05-22
+
+- Batch account-state prefetch via rocksdb `multi_get_cf` on the flat key-value table [#6712](https://github.com/lambdaclass/ethrex/pull/6712)
+
 ### 2026-05-19
 
 - Lazy BAL cursor for per-tx parallel execution [#6669](https://github.com/lambdaclass/ethrex/pull/6669)

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -117,6 +117,13 @@ impl BuildPayloadArgs {
         if let Some(beacon_root) = self.beacon_root {
             hasher.update(beacon_root);
         }
+        // execution-apis#796 / glamsterdam-devnet-4: hash slot_number and
+        // gas_ceil so two FCUs that differ only in CL-supplied
+        // targetGasLimit (or in slot_number) do not collide on payload_id.
+        if let Some(slot_number) = self.slot_number {
+            hasher.update(slot_number.to_be_bytes());
+        }
+        hasher.update(self.gas_ceil.to_be_bytes());
         let res = &mut hasher.finalize()[..8];
         res[0] = self.version;
         Ok(u64::from_be_bytes(res.try_into().map_err(|_| {
@@ -194,7 +201,6 @@ pub fn create_payload(
 }
 
 pub fn calc_gas_limit(parent_gas_limit: u64, builder_gas_ceil: u64) -> u64 {
-    // TODO: check where we should get builder values from
     let delta = parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1;
     let mut limit = parent_gas_limit;
     let desired_limit = max(builder_gas_ceil, MIN_GAS_LIMIT);
@@ -1092,5 +1098,83 @@ impl Ord for HeadTransaction {
 impl PartialOrd for HeadTransaction {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BuildPayloadArgs, calc_gas_limit};
+    use crate::constants::GAS_LIMIT_BOUND_DIVISOR;
+    use ethrex_common::{Address, H256};
+
+    fn base_args() -> BuildPayloadArgs {
+        BuildPayloadArgs {
+            parent: H256::repeat_byte(0xAA),
+            timestamp: 100,
+            fee_recipient: Address::repeat_byte(0xBB),
+            random: H256::repeat_byte(0xCC),
+            withdrawals: None,
+            beacon_root: None,
+            slot_number: Some(42),
+            version: 4,
+            elasticity_multiplier: 2,
+            gas_ceil: 60_000_000,
+        }
+    }
+
+    #[test]
+    fn payload_id_distinguishes_different_gas_ceil() {
+        // execution-apis#796: two FCUs differing only in CL-supplied
+        // targetGasLimit must produce different payload IDs.
+        let mut a = base_args();
+        let mut b = base_args();
+        a.gas_ceil = 30_000_000;
+        b.gas_ceil = 60_000_000;
+        assert_ne!(a.id().unwrap(), b.id().unwrap());
+    }
+
+    #[test]
+    fn payload_id_distinguishes_different_slot_number() {
+        // Latent bug pre-glamsterdam-devnet-4: slot_number was not hashed,
+        // so two attribute sets that differed only in slot collided.
+        let mut a = base_args();
+        let mut b = base_args();
+        a.slot_number = Some(100);
+        b.slot_number = Some(101);
+        assert_ne!(a.id().unwrap(), b.id().unwrap());
+    }
+
+    #[test]
+    fn payload_id_stable_when_inputs_match() {
+        let a = base_args();
+        let b = base_args();
+        assert_eq!(a.id().unwrap(), b.id().unwrap());
+    }
+
+    #[test]
+    fn gas_limit_steps_up_toward_higher_target() {
+        // execution-apis#796: CL-supplied target above parent → one
+        // EIP-1559 1/1024 step upward, capped at the target.
+        let parent = 30_000_000u64;
+        let target = 50_000_000u64;
+        let step = parent / GAS_LIMIT_BOUND_DIVISOR - 1;
+        assert_eq!(calc_gas_limit(parent, target), parent + step);
+    }
+
+    #[test]
+    fn gas_limit_steps_down_toward_lower_target() {
+        // CL-supplied target below parent → one EIP-1559 step downward.
+        let parent = 60_000_000u64;
+        let target = 45_000_000u64;
+        let step = parent / GAS_LIMIT_BOUND_DIVISOR - 1;
+        assert_eq!(calc_gas_limit(parent, target), parent - step);
+    }
+
+    #[test]
+    fn gas_limit_clamps_to_target_when_step_overshoots() {
+        // If target is within one step, we land exactly on it.
+        let parent = 30_000_000u64;
+        let target = parent + 100;
+        assert_eq!(calc_gas_limit(parent, target), target);
     }
 }

--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -163,7 +163,11 @@ impl VmDatabase for StoreVmDatabase {
             .get_account_states_batch_by_root(self.state_root, &miss_addrs)
             .map_err(|e| EvmError::DB(e.to_string()))?;
 
-        // Populate the per-DB cache and assemble results.
+        // Populate the per-DB cache and assemble results. `insert` (vs `or_insert`)
+        // is intentional: `state_root` is fixed for this `StoreVmDatabase`, so a
+        // concurrent populator can only have written the same value for the same
+        // address — overwriting is a no-op, and the unconditional insert avoids
+        // the extra `entry`-API lookup.
         let mut cache = self
             .account_state_cache
             .write()

--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -124,6 +124,68 @@ impl VmDatabase for StoreVmDatabase {
 
     #[instrument(
         level = "trace",
+        name = "Account read batch",
+        skip_all,
+        fields(namespace = "block_execution", n = addresses.len())
+    )]
+    fn get_account_states_batch(
+        &self,
+        addresses: &[Address],
+    ) -> Result<Vec<Option<AccountState>>, EvmError> {
+        // Split into cached / uncached so the rocksdb multi_get only fires for
+        // addresses we haven't memoized yet on this StoreVmDatabase.
+        let mut results: Vec<Option<AccountState>> = vec![None; addresses.len()];
+        let mut miss_idx: Vec<usize> = Vec::new();
+        let mut miss_addrs: Vec<Address> = Vec::new();
+        {
+            let cache = self
+                .account_state_cache
+                .read()
+                .map_err(|_| EvmError::Custom("LockError".to_string()))?;
+            for (i, addr) in addresses.iter().enumerate() {
+                match cache.get(addr) {
+                    Some(Some(entry)) => results[i] = Some(entry.state),
+                    Some(None) => results[i] = None,
+                    None => {
+                        miss_idx.push(i);
+                        miss_addrs.push(*addr);
+                    }
+                }
+            }
+        }
+
+        if miss_addrs.is_empty() {
+            return Ok(results);
+        }
+
+        let fetched = self
+            .store
+            .get_account_states_batch_by_root(self.state_root, &miss_addrs)
+            .map_err(|e| EvmError::DB(e.to_string()))?;
+
+        // Populate the per-DB cache and assemble results.
+        let mut cache = self
+            .account_state_cache
+            .write()
+            .map_err(|_| EvmError::Custom("LockError".to_string()))?;
+        for ((slot, addr), state) in miss_idx
+            .iter()
+            .zip(miss_addrs.iter())
+            .zip(fetched.into_iter())
+        {
+            let cached = state.map(|state| AccountStateCacheEntry {
+                state,
+                hashed_address: H256::from(keccak_hash(addr.to_fixed_bytes())),
+            });
+            cache.insert(*addr, cached);
+            results[*slot] = cached.map(|e| e.state);
+        }
+
+        Ok(results)
+    }
+
+    #[instrument(
+        level = "trace",
         name = "Storage read",
         skip_all,
         fields(namespace = "block_execution")

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -60,6 +60,7 @@ use spawned_concurrency::{
 use spawned_rt::tasks::BroadcastStream;
 use std::{
     collections::HashMap,
+    io::ErrorKind,
     net::SocketAddr,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
@@ -369,8 +370,16 @@ impl PeerConnectionServer {
             }
             Err(err) => {
                 // Handshake failed, just log a debug message.
-                // No connection was established so no need to perform any other action
-                debug!("Failed Handshake on RLPx connection {err}");
+                // No connection was established so no need to perform any other action.
+                // `early eof` during the RLPx handshake is expected on
+                // simultaneous-dial races (both peers initiate, one connection
+                // wins), so demote it to trace to avoid noise.
+                match &err {
+                    PeerConnectionError::IoError(e) if e.kind() == ErrorKind::UnexpectedEof => {
+                        trace!(error = %err, "RLPx handshake aborted (likely simultaneous dial)");
+                    }
+                    _ => debug!(error = %err, "RLPx handshake failed"),
+                }
                 self.state = ConnectionState::HandshakeFailed;
                 ctx.stop();
             }
@@ -1078,15 +1087,18 @@ where
             if negotiated_eth_version == 0 {
                 return Err(PeerConnectionError::NoMatchingCapabilities);
             }
-            debug!("Negotatied eth version: eth/{}", negotiated_eth_version);
             state.negotiated_eth_capability = Some(Capability::eth(negotiated_eth_version));
-
             if negotiated_snap_version != 0 {
-                debug!("Negotatied snap version: snap/{}", negotiated_snap_version);
                 state.negotiated_snap_capability = Some(Capability::snap(negotiated_snap_version));
             }
-
             state.node.version = Some(hello_message.client_id);
+
+            debug!(
+                peer = %state.node,
+                eth = negotiated_eth_version,
+                snap = negotiated_snap_version,
+                "RLPx capabilities negotiated",
+            );
 
             Ok(())
         }

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -533,6 +533,13 @@ fn validate_attributes_v4(
             "V4 payload attributes missing parent_beacon_block_root".to_string(),
         ));
     }
+    // execution-apis#796: required field. The paired CL on
+    // glamsterdam-devnet-4 ships consensus-specs#5235 and supplies it.
+    if attributes.target_gas_limit.is_none() {
+        return Err(RpcErr::InvalidPayloadAttributes(
+            "V4 payload attributes missing target_gas_limit".to_string(),
+        ));
+    }
     validate_timestamp_v4(attributes, head_block)
 }
 
@@ -553,6 +560,11 @@ async fn build_payload_v4(
     context: RpcApiContext,
     fork_choice_state: &ForkChoiceState,
 ) -> Result<u64, RpcErr> {
+    // validate_attributes_v4 guarantees target_gas_limit.is_some() before
+    // we reach this point (execution-apis#796).
+    let gas_ceil = attributes.target_gas_limit.ok_or_else(|| {
+        RpcErr::Internal("build_payload_v4 reached with no target_gas_limit".to_string())
+    })?;
     let args = BuildPayloadArgs {
         parent: fork_choice_state.head_block_hash,
         timestamp: attributes.timestamp,
@@ -563,7 +575,7 @@ async fn build_payload_v4(
         slot_number: Some(attributes.slot_number),
         version: 4,
         elasticity_multiplier: ELASTICITY_MULTIPLIER,
-        gas_ceil: context.gas_ceil,
+        gas_ceil,
     };
     let payload_id = args
         .id()
@@ -572,6 +584,7 @@ async fn build_payload_v4(
     info!(
         id = payload_id,
         slot = attributes.slot_number,
+        gas_ceil,
         "Fork choice updated V4 includes payload attributes. Creating a new payload"
     );
     let payload = match create_payload(&args, &context.storage, context.node_data.extra_data) {
@@ -589,8 +602,137 @@ async fn build_payload_v4(
 #[cfg(test)]
 mod tests {
     use super::{validate_attributes_v2, validate_attributes_v2_pre_shanghai};
-    use crate::types::fork_choice::PayloadAttributesV3;
+    use crate::types::fork_choice::{PayloadAttributesV3, PayloadAttributesV4};
     use ethrex_common::types::{BlockHeader, Withdrawal};
+
+    #[test]
+    fn payload_attributes_v4_parses_target_gas_limit_when_present() {
+        // execution-apis#796: targetGasLimit field is a hex QUANTITY.
+        let json = serde_json::json!({
+            "timestamp": "0x65",
+            "prevRandao": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "suggestedFeeRecipient": "0x0000000000000000000000000000000000000002",
+            "withdrawals": [],
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "slotNumber": "0x10",
+            "targetGasLimit": "0x2faf080",
+        });
+        let attrs: PayloadAttributesV4 = serde_json::from_value(json).unwrap();
+        assert_eq!(attrs.target_gas_limit, Some(50_000_000));
+        assert_eq!(attrs.slot_number, 0x10);
+    }
+
+    #[test]
+    fn payload_attributes_v4_accepts_missing_target_gas_limit() {
+        // Deserialization is permissive: an absent `targetGasLimit` parses to
+        // `None`. The strict spec contract is enforced separately in
+        // `validate_attributes_v4` (see `v4_rejects_target_gas_limit_absent`),
+        // which rejects such requests with `RpcErr::InvalidPayloadAttributes`.
+        let json = serde_json::json!({
+            "timestamp": "0x65",
+            "prevRandao": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "suggestedFeeRecipient": "0x0000000000000000000000000000000000000002",
+            "withdrawals": [],
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "slotNumber": "0x10",
+        });
+        let attrs: PayloadAttributesV4 = serde_json::from_value(json).unwrap();
+        assert!(attrs.target_gas_limit.is_none());
+    }
+
+    #[test]
+    fn payload_attributes_v4_parses_explicit_null_target_gas_limit() {
+        let json = serde_json::json!({
+            "timestamp": "0x65",
+            "prevRandao": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "suggestedFeeRecipient": "0x0000000000000000000000000000000000000002",
+            "withdrawals": [],
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000003",
+            "slotNumber": "0x10",
+            "targetGasLimit": null,
+        });
+        let attrs: PayloadAttributesV4 = serde_json::from_value(json).unwrap();
+        assert!(attrs.target_gas_limit.is_none());
+    }
+
+    /// Async validator coverage. Builds an in-memory store from a custom
+    /// genesis with Amsterdam (= upstream "Glamsterdam") activated at t=0
+    /// so we can exercise the V4 validator paths added by
+    /// execution-apis#796.
+    mod validator {
+        use super::super::validate_attributes_v4;
+        use crate::test_utils::default_context_with_storage;
+        use crate::types::fork_choice::PayloadAttributesV4;
+        use crate::utils::RpcErr;
+        use ethrex_common::H256;
+        use ethrex_common::types::{BlockHeader, Genesis};
+        use ethrex_storage::{EngineType, Store};
+
+        async fn amsterdam_active_context() -> crate::rpc::RpcApiContext {
+            let mut genesis: Genesis =
+                serde_json::from_str(include_str!("../../../../fixtures/genesis/l1.json"))
+                    .expect("test genesis fixture should parse");
+            genesis.config.amsterdam_time = Some(0);
+            let mut store =
+                Store::new("amsterdam-test-store", EngineType::InMemory).expect("in-memory store");
+            store.add_initial_state(genesis).await.unwrap();
+            default_context_with_storage(store).await
+        }
+
+        fn amsterdam_attributes(target_gas_limit: Option<u64>) -> PayloadAttributesV4 {
+            PayloadAttributesV4 {
+                timestamp: 2,
+                prev_randao: H256::zero(),
+                suggested_fee_recipient: Default::default(),
+                withdrawals: Some(Vec::new()),
+                parent_beacon_block_root: Some(H256::zero()),
+                slot_number: 1,
+                target_gas_limit,
+            }
+        }
+
+        #[tokio::test]
+        async fn v4_accepts_target_gas_limit_present() {
+            let context = amsterdam_active_context().await;
+            let head = BlockHeader {
+                timestamp: 1,
+                ..Default::default()
+            };
+            let attrs = amsterdam_attributes(Some(50_000_000));
+            assert!(validate_attributes_v4(&attrs, &head, &context).is_ok());
+        }
+
+        #[tokio::test]
+        async fn v4_rejects_target_gas_limit_absent() {
+            // execution-apis#796: targetGasLimit is required on V4.
+            let context = amsterdam_active_context().await;
+            let head = BlockHeader {
+                timestamp: 1,
+                ..Default::default()
+            };
+            let attrs = amsterdam_attributes(None);
+            let err = validate_attributes_v4(&attrs, &head, &context).unwrap_err();
+            let RpcErr::InvalidPayloadAttributes(msg) = err else {
+                panic!("expected InvalidPayloadAttributes, got {:?}", err);
+            };
+            assert!(msg.contains("target_gas_limit"), "got: {msg}");
+        }
+
+        #[tokio::test]
+        async fn v4_rejects_pre_amsterdam_unchanged() {
+            // Default fixture has no amsterdam_time set; V4 attributes must
+            // still be rejected outright for pre-Amsterdam timestamps.
+            let storage = crate::test_utils::setup_store().await;
+            let context = default_context_with_storage(storage).await;
+            let head = BlockHeader {
+                timestamp: 1,
+                ..Default::default()
+            };
+            let attrs = amsterdam_attributes(Some(50_000_000));
+            let err = validate_attributes_v4(&attrs, &head, &context).unwrap_err();
+            assert!(matches!(err, RpcErr::InvalidPayloadAttributes(_)));
+        }
+    }
 
     #[test]
     fn forkchoice_updated_v2_returns_invalid_payload_attributes_when_withdrawals_missing() {

--- a/crates/networking/rpc/types/fork_choice.rs
+++ b/crates/networking/rpc/types/fork_choice.rs
@@ -35,6 +35,11 @@ pub struct PayloadAttributesV4 {
     pub parent_beacon_block_root: Option<H256>,
     #[serde(with = "serde_utils::u64::hex_str")]
     pub slot_number: u64,
+    // execution-apis#796: CL-supplied target gas limit for local payload
+    // building. Required when Amsterdam (= upstream "Glamsterdam") is
+    // active; kept Option so the EL still accepts pre-rollout CLs.
+    #[serde(default, with = "serde_utils::u64::hex_str_opt")]
+    pub target_gas_limit: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/storage/api/mod.rs
+++ b/crates/storage/api/mod.rs
@@ -62,7 +62,10 @@ pub trait StorageReadView: Send + Sync {
     /// Retrieves multiple values by key from the specified table.
     /// Returns results in the same order as the input keys.
     /// Backends that support batched reads (e.g. RocksDB `multi_get_cf`)
-    /// should override this for better throughput.
+    /// should override this for better throughput. Callers should not
+    /// assume `multi_get` is asymptotically faster than `get`; on backends
+    /// without a batched read primitive (e.g. the in-memory backend) the
+    /// default impl below is equivalent to N independent `get` calls.
     fn multi_get(
         &self,
         table: &'static str,

--- a/crates/storage/api/mod.rs
+++ b/crates/storage/api/mod.rs
@@ -59,6 +59,18 @@ pub trait StorageReadView: Send + Sync {
     /// Retrieves a value by key from the specified table.
     fn get(&self, table: &'static str, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError>;
 
+    /// Retrieves multiple values by key from the specified table.
+    /// Returns results in the same order as the input keys.
+    /// Backends that support batched reads (e.g. RocksDB `multi_get_cf`)
+    /// should override this for better throughput.
+    fn multi_get(
+        &self,
+        table: &'static str,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<Vec<u8>>, StoreError>> {
+        keys.iter().map(|k| self.get(table, k)).collect()
+    }
+
     /// Returns an iterator over all key-value pairs with the given prefix.
     fn prefix_iterator(
         &self,

--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -313,6 +313,28 @@ impl StorageReadView for RocksDBReadTx {
             .map_err(|e| StoreError::Custom(format!("Failed to get from {}: {}", table, e)))
     }
 
+    fn multi_get(
+        &self,
+        table: &'static str,
+        keys: &[&[u8]],
+    ) -> Vec<Result<Option<Vec<u8>>, StoreError>> {
+        let Some(cf) = self.db.cf_handle(table) else {
+            let err = StoreError::Custom(format!("Table {} not found", table));
+            return (0..keys.len())
+                .map(|_| Err(StoreError::Custom(err.to_string())))
+                .collect();
+        };
+        // `sorted_input=false`: rocksdb sorts internally. Caller may pass arbitrary order.
+        self.db
+            .batched_multi_get_cf(&cf, keys.iter().copied(), false)
+            .into_iter()
+            .map(|res| {
+                res.map(|opt| opt.map(|slice| slice.to_vec()))
+                    .map_err(|e| StoreError::Custom(format!("multi_get {}: {}", table, e)))
+            })
+            .collect()
+    }
+
     fn prefix_iterator(
         &self,
         table: &'static str,

--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -319,9 +319,9 @@ impl StorageReadView for RocksDBReadTx {
         keys: &[&[u8]],
     ) -> Vec<Result<Option<Vec<u8>>, StoreError>> {
         let Some(cf) = self.db.cf_handle(table) else {
-            let err = StoreError::Custom(format!("Table {} not found", table));
+            let err_msg = format!("Table {} not found", table);
             return (0..keys.len())
-                .map(|_| Err(StoreError::Custom(err.to_string())))
+                .map(|_| Err(StoreError::Custom(err_msg.clone())))
                 .collect();
         };
         // `sorted_input=false`: rocksdb sorts internally. Caller may pass arbitrary order.

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2522,21 +2522,24 @@ impl Store {
 
         let mut fkv_indices: Vec<usize> = Vec::new();
         let mut trie_indices: Vec<usize> = Vec::new();
-        let mut diff_hits: usize = 0;
 
+        // Match `BackendTrieDB::flatkeyvalue_computed` semantics: a path is
+        // covered by FKV iff `last_written >= path` as raw nibble bytes. This
+        // is the same check `Trie::get` uses; the related helper
+        // `Store::flatkeyvalue_computed_with_last_written` slices `[0..64]`
+        // and is intentionally more conservative — using that here would
+        // unnecessarily fall back to the trie when the cursor sits inside an
+        // account's storage sweep (the account leaf is already in FKV at that
+        // point; see `flatkeyvalue_generator`).
+        let fkv_cursor = Nibbles::from_hex(last_written.clone());
         for (i, path) in leaf_paths.iter().enumerate() {
             if let Some(value) = trie_cache.get(state_root, path.as_slice()) {
                 if !value.is_empty() {
                     results[i] = Some(AccountState::decode(&value)?);
                 }
-                diff_hits += 1;
                 continue;
             }
-            // Reuse the trie's FKV-cursor check semantics via the leaf path.
             let path_nibbles = Nibbles::from_hex(path.clone());
-            // `last_computed_flatkeyvalue >= path` ⇒ FKV row is authoritative
-            // (either present with value, or absent meaning the account does not exist).
-            let fkv_cursor = Nibbles::from_hex(last_written.clone());
             if fkv_cursor >= path_nibbles {
                 fkv_indices.push(i);
             } else {
@@ -2569,7 +2572,6 @@ impl Store {
             }
         }
 
-        let _ = diff_hits; // surface via tracing if needed.
         Ok(results)
     }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2531,7 +2531,7 @@ impl Store {
         // unnecessarily fall back to the trie when the cursor sits inside an
         // account's storage sweep (the account leaf is already in FKV at that
         // point; see `flatkeyvalue_generator`).
-        let fkv_cursor = Nibbles::from_hex(last_written.clone());
+        let fkv_cursor = Nibbles::from_hex(last_written);
         for (i, path) in leaf_paths.iter().enumerate() {
             if let Some(value) = trie_cache.get(state_root, path.as_slice()) {
                 if !value.is_empty() {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -41,6 +41,7 @@ use ethrex_rlp::{
 use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, Trie, TrieLogger, TrieNode, TrieWitness};
 use ethrex_trie::{Node, NodeRLP};
 use lru::LruCache;
+use rayon::prelude::*;
 use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -2531,7 +2532,7 @@ impl Store {
         // unnecessarily fall back to the trie when the cursor sits inside an
         // account's storage sweep (the account leaf is already in FKV at that
         // point; see `flatkeyvalue_generator`).
-        let fkv_cursor = Nibbles::from_hex(last_written);
+        let fkv_cursor: &[u8] = last_written.as_slice();
         for (i, path) in leaf_paths.iter().enumerate() {
             if let Some(value) = trie_cache.get(state_root, path.as_slice()) {
                 if !value.is_empty() {
@@ -2539,8 +2540,7 @@ impl Store {
                 }
                 continue;
             }
-            let path_nibbles = Nibbles::from_hex(path.clone());
-            if fkv_cursor >= path_nibbles {
+            if fkv_cursor >= path.as_slice() {
                 fkv_indices.push(i);
             } else {
                 trie_indices.push(i);
@@ -2565,10 +2565,20 @@ impl Store {
 
         if !trie_indices.is_empty() {
             // Fall back to the regular trie path for any addresses whose path
-            // hasn't been swept by the FKV generator yet.
+            // hasn't been swept by the FKV generator yet. Parallelized to
+            // recover the per-address fan-out the pre-batch `par_iter` path
+            // had, which matters during initial sync when most addresses
+            // miss FKV.
             let state_trie = self.open_state_trie(state_root)?;
-            for &i in &trie_indices {
-                results[i] = self.get_account_state_from_trie(&state_trie, addresses[i])?;
+            let fetched: Result<Vec<(usize, Option<AccountState>)>, StoreError> = trie_indices
+                .par_iter()
+                .map(|&i| {
+                    self.get_account_state_from_trie(&state_trie, addresses[i])
+                        .map(|s| (i, s))
+                })
+                .collect();
+            for (i, s) in fetched? {
+                results[i] = s;
             }
         }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2486,6 +2486,93 @@ impl Store {
         Ok(Some(AccountState::decode(&encoded_state)?))
     }
 
+    /// Batch lookup of account states by address against a given state root.
+    ///
+    /// Fast path: for addresses whose hashed path falls within the FKV cursor
+    /// (and which are not present in the in-memory diff-layer cache), values
+    /// are fetched in a single `multi_get` on `ACCOUNT_FLATKEYVALUE`. Other
+    /// addresses fall back to per-address trie walks.
+    ///
+    /// Results are returned in the same order as the input addresses.
+    pub fn get_account_states_batch_by_root(
+        &self,
+        state_root: H256,
+        addresses: &[Address],
+    ) -> Result<Vec<Option<AccountState>>, StoreError> {
+        if addresses.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let last_written = self.last_written()?;
+        let trie_cache = self
+            .trie_cache
+            .read()
+            .map_err(|_| StoreError::LockError)?
+            .clone();
+
+        let mut results: Vec<Option<AccountState>> = vec![None; addresses.len()];
+        // Per-address leaf paths (nibbles + leaf flag). Length 65.
+        let leaf_paths: Vec<Vec<u8>> = addresses
+            .iter()
+            .map(|addr| {
+                let hashed = hash_address_fixed(addr);
+                Nibbles::from_bytes(hashed.as_bytes()).into_vec()
+            })
+            .collect();
+
+        let mut fkv_indices: Vec<usize> = Vec::new();
+        let mut trie_indices: Vec<usize> = Vec::new();
+        let mut diff_hits: usize = 0;
+
+        for (i, path) in leaf_paths.iter().enumerate() {
+            if let Some(value) = trie_cache.get(state_root, path.as_slice()) {
+                if !value.is_empty() {
+                    results[i] = Some(AccountState::decode(&value)?);
+                }
+                diff_hits += 1;
+                continue;
+            }
+            // Reuse the trie's FKV-cursor check semantics via the leaf path.
+            let path_nibbles = Nibbles::from_hex(path.clone());
+            // `last_computed_flatkeyvalue >= path` ⇒ FKV row is authoritative
+            // (either present with value, or absent meaning the account does not exist).
+            let fkv_cursor = Nibbles::from_hex(last_written.clone());
+            if fkv_cursor >= path_nibbles {
+                fkv_indices.push(i);
+            } else {
+                trie_indices.push(i);
+            }
+        }
+
+        if !fkv_indices.is_empty() {
+            let read_view = self.backend.begin_read()?;
+            let keys: Vec<&[u8]> = fkv_indices
+                .iter()
+                .map(|&i| leaf_paths[i].as_slice())
+                .collect();
+            let raw = read_view.multi_get(ACCOUNT_FLATKEYVALUE, &keys);
+            for (slot, res) in fkv_indices.iter().zip(raw.into_iter()) {
+                let Some(encoded) = res? else { continue };
+                if encoded.is_empty() {
+                    continue;
+                }
+                results[*slot] = Some(AccountState::decode(&encoded)?);
+            }
+        }
+
+        if !trie_indices.is_empty() {
+            // Fall back to the regular trie path for any addresses whose path
+            // hasn't been swept by the FKV generator yet.
+            let state_trie = self.open_state_trie(state_root)?;
+            for &i in &trie_indices {
+                results[i] = self.get_account_state_from_trie(&state_trie, addresses[i])?;
+            }
+        }
+
+        let _ = diff_hits; // surface via tracing if needed.
+        Ok(results)
+    }
+
     /// Constructs a merkle proof for the given account address against a given state.
     /// If storage_keys are provided, also constructs the storage proofs for those keys.
     ///

--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -93,6 +93,18 @@ impl LevmDatabase for DynVmDatabase {
         Ok(acc_state)
     }
 
+    fn get_account_states_batch(
+        &self,
+        addresses: &[CoreAddress],
+    ) -> Result<Vec<AccountState>, DatabaseError> {
+        let states = <dyn VmDatabase>::get_account_states_batch(self.as_ref(), addresses)
+            .map_err(|e| DatabaseError::Custom(e.to_string()))?;
+        Ok(states
+            .into_iter()
+            .map(|opt| opt.unwrap_or_default())
+            .collect())
+    }
+
     fn get_storage_value(
         &self,
         address: CoreAddress,

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -1137,7 +1137,13 @@ impl LEVM {
                 // storage from the final state, so destroyed accounts
                 // satisfy ALL their BAL storage_reads regardless of which
                 // slots remain in `current_state`.
-                let mut reads_satisfied: Vec<(Address, H256)> = Vec::new();
+                // Rough avg storage slots per touched account; over-allocation
+                // is cheap compared to 2-3 reallocations on the hot path.
+                let mut reads_satisfied: Vec<(Address, H256)> =
+                    Vec::with_capacity(current_state.len() * 4);
+                // `destroyed` stays empty on the typical block (selfdestruct
+                // is rare post-EIP-6780), so `Vec::new()` (no allocation) is
+                // optimal here.
                 let mut destroyed: Vec<Address> = Vec::new();
                 for (addr, acct) in &current_state {
                     if matches!(
@@ -1223,7 +1229,12 @@ impl LEVM {
 
         let mut exec_results = exec_results?;
 
-        // Sort so gas accounting and error surfacing happen in tx order.
+        // `IndexedParallelIterator` (via `(0..n_txs).into_par_iter()`) preserves
+        // source-index order through `.map().collect()`, so `exec_results` is
+        // already sorted. The sort is kept as a defensive guard against a future
+        // refactor swapping in an unordered iterator; `sort_unstable_by_key` on
+        // an already-sorted slice is near-linear via pdqsort, so the cost is
+        // negligible.
         exec_results.sort_unstable_by_key(|(idx, _, _, _, _, _, _)| *idx);
 
         // 3. Gas limit check — must happen BEFORE BAL validation errors so that

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -1052,17 +1052,26 @@ impl LEVM {
         let arc_idx = Arc::new(validation_index.clone());
 
         // 2. Execute all txs in parallel (embarrassingly parallel, BAL-seeded).
-        //    BAL validation is deferred to after the gas limit check (step 3) so that
-        //    blocks exceeding gas limit produce GAS_USED_OVERFLOW before BAL mismatch.
+        //    BAL validation runs INSIDE the par_iter closure (parallel) but its
+        //    errors are deferred via Option<EvmError> so the post-par_iter
+        //    gas-limit check still takes priority (GAS_USED_OVERFLOW must beat
+        //    BAL mismatch on blocks exceeding the gas limit; the BAL is built
+        //    assuming rejected txs, so miner balance in the BAL won't match
+        //    execution that ran all txs).
+        //
+        //    The closure also precomputes the small (Vec<(Address, H256)>,
+        //    Vec<Address>) inputs needed to update the shared
+        //    `unread_storage_reads` / `unaccessed_pure_accounts` sets, so the
+        //    serial pass after par_iter is just hash-set ops; current_state
+        //    and codes never cross the rayon boundary.
         type TxExecResult = (
             usize,
             TxType,
             ExecutionReport,
-            FxHashMap<Address, LevmAccount>,
-            FxHashMap<H256, ethrex_common::types::Code>,
             FxHashSet<Address>,   // accessed_accounts tracker (coarse)
-            Vec<Address>,         // shadow recorder touched_addresses (EIP-7928 exact)
-            Vec<(Address, U256)>, // shadow recorder storage_reads (EIP-7928 exact)
+            Vec<(Address, H256)>, // reads_satisfied: (addr, slot) loaded during this tx
+            Vec<Address>,         // destroyed: accounts selfdestructed during this tx
+            Option<EvmError>,     // deferred BAL validation error
         );
 
         let exec_results: Result<Vec<TxExecResult>, EvmError> = (0..n_txs)
@@ -1122,37 +1131,109 @@ impl LEVM {
                     .take()
                     .map(|mut r| (r.take_touched_addresses(), r.take_storage_reads()))
                     .unwrap_or_default();
+
+                // Precompute the per-tx inputs the serial pass uses to update
+                // the shared unread_storage_reads set. Selfdestruct clears
+                // storage from the final state, so destroyed accounts
+                // satisfy ALL their BAL storage_reads regardless of which
+                // slots remain in `current_state`.
+                let mut reads_satisfied: Vec<(Address, H256)> = Vec::new();
+                let mut destroyed: Vec<Address> = Vec::new();
+                for (addr, acct) in &current_state {
+                    if matches!(
+                        acct.status,
+                        AccountStatus::Destroyed | AccountStatus::DestroyedModified
+                    ) {
+                        destroyed.push(*addr);
+                    } else {
+                        for key in acct.storage.keys() {
+                            reads_satisfied.push((*addr, *key));
+                        }
+                    }
+                }
+
+                // Run BAL validation inline. Errors are DEFERRED: stored in
+                // Option<EvmError> so the serial gas-limit check below still
+                // takes priority. Borrow current_state / codes during the
+                // validation closure, then drop them before returning so
+                // they don't cross the rayon boundary.
+                let deferred_bal_err: Option<EvmError> = (|| -> Result<(), EvmError> {
+                    let bal_idx = u32::try_from(tx_idx + 1).unwrap_or(u32::MAX);
+                    let seed_idx = u32::try_from(tx_idx).unwrap_or(u32::MAX);
+                    Self::validate_tx_execution(
+                        bal_idx,
+                        seed_idx,
+                        &current_state,
+                        &codes,
+                        bal,
+                        validation_index,
+                        &system_seed,
+                        &store,
+                    )
+                    .map_err(|e| {
+                        EvmError::Custom(format!("BAL validation failed for tx {tx_idx}: {e}"))
+                    })?;
+
+                    // EIP-7928 (Group B): missing-access detection via shadow recorder.
+                    for addr in &shadow_touched {
+                        if !validation_index.addr_to_idx.contains_key(addr) {
+                            return Err(EvmError::Custom(format!(
+                                "BAL validation failed for tx {tx_idx}: account {addr:?} was \
+                                 accessed during execution but is missing from BAL"
+                            )));
+                        }
+                    }
+                    for (addr, slot) in &shadow_reads {
+                        let Some(&bal_acct_idx) = validation_index.addr_to_idx.get(addr) else {
+                            // Already caught by the touched-address check above.
+                            continue;
+                        };
+                        let acct = &bal.accounts()[bal_acct_idx];
+                        let in_changes = acct
+                            .storage_changes
+                            .binary_search_by(|sc| sc.slot.cmp(slot))
+                            .is_ok();
+                        let in_reads = acct.storage_reads.contains(slot);
+                        if !in_changes && !in_reads {
+                            return Err(EvmError::Custom(format!(
+                                "BAL validation failed for tx {tx_idx}: storage slot {slot} of \
+                                 account {addr:?} was read during execution but is missing from \
+                                 BAL (no storage_changes or storage_reads entry)"
+                            )));
+                        }
+                    }
+                    Ok(())
+                })()
+                .err();
+
+                drop(current_state);
+                drop(codes);
+
                 Ok((
                     tx_idx,
                     tx.tx_type(),
                     report,
-                    current_state,
-                    codes,
                     tracked,
-                    shadow_touched,
-                    shadow_reads,
+                    reads_satisfied,
+                    destroyed,
+                    deferred_bal_err,
                 ))
             })
             .collect();
 
         let mut exec_results = exec_results?;
 
-        // Sort so gas accounting and validation happen in tx order.
-        exec_results.sort_unstable_by_key(|(idx, _, _, _, _, _, _, _)| *idx);
+        // Sort so gas accounting and error surfacing happen in tx order.
+        exec_results.sort_unstable_by_key(|(idx, _, _, _, _, _, _)| *idx);
 
-        // 3. Gas limit check — must happen BEFORE BAL validation so that blocks
-        //    exceeding the gas limit produce GAS_USED_OVERFLOW instead of a BAL
-        //    mismatch error (the BAL is built assuming rejected txs, so the miner
-        //    balance in the BAL won't match execution that ran all txs).
-        //
-        //    EIP-8037 PR #2703: also enforce the per-tx 2D inclusion check
-        //    against running block totals. A tx whose worst-case regular or
-        //    state contribution exceeds the remaining budget at its inclusion
-        //    position invalidates the block with GAS_ALLOWANCE_EXCEEDED.
+        // 3. Gas limit check — must happen BEFORE BAL validation errors so that
+        //    blocks exceeding the gas limit produce GAS_USED_OVERFLOW instead of
+        //    a BAL mismatch error. EIP-8037 PR #2703: also enforce the per-tx
+        //    2D inclusion check against running block totals.
         let mut block_regular_gas_used = 0_u64;
         let mut block_state_gas_used = 0_u64;
         let mut tx_gas_breakdowns: Vec<TxGasBreakdown> = Vec::with_capacity(exec_results.len());
-        for (tx_idx, _, report, _, _, _, _, _) in &exec_results {
+        for (tx_idx, _, report, _, _, _, _) in &exec_results {
             let (tx, _) = txs_with_sender
                 .get(*tx_idx)
                 .ok_or_else(|| EvmError::Custom(format!("tx index {tx_idx} out of bounds")))?;
@@ -1183,48 +1264,25 @@ impl LEVM {
             )));
         }
 
-        // 4. Per-tx BAL validation — now safe to run after gas limit is confirmed OK.
-        //    Also mark off storage_reads that appear in per-tx execution state.
-        for (tx_idx, _, _, current_state, codes, tracked_accounts, shadow_touched, shadow_reads) in
-            &exec_results
-        {
-            let bal_idx = u32::try_from(*tx_idx + 1).unwrap_or(u32::MAX);
-            let seed_idx = u32::try_from(*tx_idx).unwrap_or(u32::MAX);
-            Self::validate_tx_execution(
-                bal_idx,
-                seed_idx,
-                current_state,
-                codes,
-                bal,
-                validation_index,
-                &system_seed,
-                &store,
-            )
-            .map_err(|e| EvmError::Custom(format!("BAL validation failed for tx {tx_idx}: {e}")))?;
+        // 4. Surface the first deferred BAL validation error (in tx order) now
+        //    that the gas-limit check has passed.
+        for (_, _, _, _, _, _, deferred) in &mut exec_results {
+            if let Some(err) = deferred.take() {
+                return Err(err);
+            }
+        }
 
-            // Mark storage_reads that were actually loaded during this tx.
-            // storage_reads slots are NOT in storage_changes (conflict check ensures this),
-            // so they're not seeded. If a slot appears in the per-tx state's storage,
-            // the tx genuinely read it via SLOAD.
-            // Special case: selfdestruct clears storage from the final state, so reads
-            // that happened before destruction are no longer visible. For destroyed
-            // accounts, mark ALL their BAL storage_reads as satisfied.
+        // 5. Apply per-tx reads_satisfied / destroyed / tracked to the shared
+        //    sets (cheap hash-set ops; preserves prior semantics).
+        for (_, _, _, tracked_accounts, reads_satisfied, destroyed, _) in &exec_results {
             if !unread_storage_reads.is_empty() {
-                for (addr, acct) in current_state {
-                    if matches!(
-                        acct.status,
-                        AccountStatus::Destroyed | AccountStatus::DestroyedModified
-                    ) {
-                        unread_storage_reads.retain(|&(a, _)| a != *addr);
-                    } else {
-                        for key in acct.storage.keys() {
-                            unread_storage_reads.remove(&(*addr, *key));
-                        }
-                    }
+                for addr in destroyed {
+                    unread_storage_reads.retain(|&(a, _)| a != *addr);
+                }
+                for pair in reads_satisfied {
+                    unread_storage_reads.remove(pair);
                 }
             }
-
-            // Mark pure-access accounts that were accessed during this tx.
             // The coinbase is always accessed during fee finalization (geth's
             // readerTracker records it), even when the miner fee is zero and
             // ethrex skips the load_account call.
@@ -1234,44 +1292,12 @@ impl LEVM {
                     unaccessed_pure_accounts.remove(addr);
                 }
             }
-
-            // EIP-7928 (Group B): missing-access detection using the shadow recorder.
-            // For each address the per-tx shadow recorder marked as touched, the header
-            // BAL must contain an entry for it. For each storage read, the header BAL
-            // must carry the slot either in storage_changes or storage_reads.
-            for addr in shadow_touched {
-                if !validation_index.addr_to_idx.contains_key(addr) {
-                    return Err(EvmError::Custom(format!(
-                        "BAL validation failed for tx {tx_idx}: account {addr:?} was \
-                         accessed during execution but is missing from BAL"
-                    )));
-                }
-            }
-            for (addr, slot) in shadow_reads {
-                let Some(&bal_acct_idx) = validation_index.addr_to_idx.get(addr) else {
-                    // Already caught by the touched-address check above.
-                    continue;
-                };
-                let acct = &bal.accounts()[bal_acct_idx];
-                let in_changes = acct
-                    .storage_changes
-                    .binary_search_by(|sc| sc.slot.cmp(slot))
-                    .is_ok();
-                let in_reads = acct.storage_reads.contains(slot);
-                if !in_changes && !in_reads {
-                    return Err(EvmError::Custom(format!(
-                        "BAL validation failed for tx {tx_idx}: storage slot {slot} of \
-                         account {addr:?} was read during execution but is missing from \
-                         BAL (no storage_changes or storage_reads entry)"
-                    )));
-                }
-            }
         }
 
-        // 5. Build receipts in tx order.
+        // 6. Build receipts in tx order.
         let mut receipts = Vec::with_capacity(n_txs);
         let mut cumulative_gas_used = 0_u64;
-        for (_, tx_type, report, _, _, _, _, _) in exec_results {
+        for (_, tx_type, report, _, _, _, _) in exec_results {
             cumulative_gas_used += report.gas_spent;
             let receipt = Receipt::new(
                 tx_type,

--- a/crates/vm/db.rs
+++ b/crates/vm/db.rs
@@ -12,6 +12,19 @@ pub trait VmDatabase: Send + Sync + DynClone {
     fn get_chain_config(&self) -> Result<ChainConfig, EvmError>;
     fn get_account_code(&self, code_hash: H256) -> Result<Code, EvmError>;
     fn get_code_metadata(&self, code_hash: H256) -> Result<CodeMetadata, EvmError>;
+
+    /// Batch account-state lookup. Default impl loops `get_account_state`.
+    /// Backends that can amortize per-key cost (e.g. rocksdb `multi_get_cf` on
+    /// the flat key-value table) should override this.
+    fn get_account_states_batch(
+        &self,
+        addresses: &[Address],
+    ) -> Result<Vec<Option<AccountState>>, EvmError> {
+        addresses
+            .iter()
+            .map(|a| self.get_account_state(*a))
+            .collect()
+    }
 }
 
 dyn_clone::clone_trait_object!(VmDatabase);

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -26,6 +26,18 @@ pub trait Database: Send + Sync {
     fn precompile_cache(&self) -> Option<&PrecompileCache> {
         None
     }
+    /// Batch lookup. Default: loop. Backends with a batched read path (e.g. rocksdb
+    /// `multi_get_cf` on the flat key-value table) should override this and the
+    /// caching layer above will dispatch to it.
+    fn get_account_states_batch(
+        &self,
+        addresses: &[Address],
+    ) -> Result<Vec<AccountState>, DatabaseError> {
+        addresses
+            .iter()
+            .map(|a| self.get_account_state(*a))
+            .collect()
+    }
     /// Prefetch a batch of accounts into the cache. Default: sequential fallback.
     fn prefetch_accounts(&self, addresses: &[Address]) -> Result<(), DatabaseError> {
         for &addr in addresses {
@@ -182,13 +194,24 @@ impl Database for CachingDatabase {
 
     #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
     fn prefetch_accounts(&self, addresses: &[Address]) -> Result<(), DatabaseError> {
-        // Fetch from inner in parallel (no lock contention), then single write-lock to populate cache.
-        let fetched: Vec<(Address, AccountState)> = addresses
-            .par_iter()
-            .map(|&addr| self.inner.get_account_state(addr).map(|s| (addr, s)))
-            .collect::<Result<_, _>>()?;
+        // Filter out already-cached addresses before issuing the batch read.
+        let missing: Vec<Address> = {
+            let cache = self.read_accounts()?;
+            addresses
+                .iter()
+                .copied()
+                .filter(|a| !cache.contains_key(a))
+                .collect()
+        };
+        if missing.is_empty() {
+            return Ok(());
+        }
+        // Dispatch to inner's batch path. For the rocksdb-backed StoreVmDatabase
+        // this collapses into a single multi_get on ACCOUNT_FLATKEYVALUE for the
+        // FKV-covered subset; default impl loops for other backends.
+        let states = self.inner.get_account_states_batch(&missing)?;
         let mut cache = self.write_accounts()?;
-        for (addr, state) in fetched {
+        for (addr, state) in missing.into_iter().zip(states.into_iter()) {
             cache.entry(addr).or_insert(state);
         }
         Ok(())


### PR DESCRIPTION
**[DNM] — Do Not Merge.** Opened to run CI on the rebased `glamsterdam-devnet-4` branch.

This branch was rebased onto `main` via cherry-pick. 5 commits already present on `main` were dropped (FCU finalized-ancestor work via #6676; BAL storage prefetch via #6732). The 10 commits below are the net-new work:

- perf(l1): per-tx BAL validation in the par_iter closure
- perf(l1): batch account-state prefetch via rocksdb `multi_get_cf` (#6712)
- perf(l1): parallelize trie fallback in account batch lookup
- perf(l1): tighten batch prefetch + drop redundant clone in `get_account_state_multi`
- engine_forkchoiceUpdatedV4 `targetGasLimit` (execution-apis#796)
- chore(p2p): clean up RLPx handshake logs
- docs(changelog) entries

Not for merge; tracking CI only.
