### PR TITLE
feat(l1): add --skip-genesis-validation to trust a pre-existing datadir

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -159,6 +159,14 @@ pub struct Options {
     )]
     pub no_migrate: bool,
     #[arg(
+        long = "skip-genesis-validation",
+        action = ArgAction::SetTrue,
+        help = "Trust a pre-existing datadir's genesis instead of recomputing the genesis state root from the genesis alloc. Use only when booting against a database produced out-of-band (e.g. by a state generator) whose state root you vouch for; has no effect on a fresh datadir.",
+        help_heading = "Node options",
+        env = "ETHREX_SKIP_GENESIS_VALIDATION"
+    )]
+    pub skip_genesis_validation: bool,
+    #[arg(
         long = "no-precompile-cache",
         action = ArgAction::SetTrue,
         help = "Disable the per-block precompile result cache (benchmarking only).",
@@ -496,6 +504,7 @@ impl Default for Options {
             max_blobs_per_block: None,
             precompute_witnesses: false,
             no_migrate: false,
+            skip_genesis_validation: false,
             no_precompile_cache: false,
             no_bal_parallel_exec: false,
             no_bal_prefetch: false,

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -150,6 +150,17 @@ pub async fn init_store(datadir: impl AsRef<Path>, genesis: Genesis) -> Result<S
     Ok(store)
 }
 
+/// Like [`init_store`], but trusts a pre-existing datadir's genesis instead of
+/// validating it against `genesis`. See [`Store::add_initial_state_skip_validation`].
+pub async fn init_store_trusting(
+    datadir: impl AsRef<Path>,
+    genesis: Genesis,
+) -> Result<Store, StoreError> {
+    let mut store = open_store(datadir.as_ref())?;
+    store.add_initial_state_skip_validation(genesis).await?;
+    Ok(store)
+}
+
 /// Initializes a pre-existing Store
 pub async fn load_store(datadir: &Path) -> Result<Store, StoreError> {
     let store = open_store(datadir)?;
@@ -542,7 +553,12 @@ pub async fn init_l1(
     debug!("Preloading KZG trusted setup");
     ethrex_crypto::kzg::warm_up_trusted_setup();
 
-    let store = match init_store(&datadir, genesis).await {
+    let store_result = if opts.skip_genesis_validation {
+        init_store_trusting(&datadir, genesis).await
+    } else {
+        init_store(&datadir, genesis).await
+    };
+    let store = match store_result {
         Ok(store) => store,
         Err(err @ StoreError::IncompatibleDBVersion { .. })
         | Err(err @ StoreError::NotFoundDBVersion) => {

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -152,7 +152,7 @@ pub async fn init_store(datadir: impl AsRef<Path>, genesis: Genesis) -> Result<S
 
 /// Like [`init_store`], but trusts a pre-existing datadir's genesis instead of
 /// validating it against `genesis`. See [`Store::add_initial_state_skip_validation`].
-pub async fn init_store_trusting(
+pub async fn init_store_skip_validation(
     datadir: impl AsRef<Path>,
     genesis: Genesis,
 ) -> Result<Store, StoreError> {
@@ -554,7 +554,7 @@ pub async fn init_l1(
     ethrex_crypto::kzg::warm_up_trusted_setup();
 
     let store_result = if opts.skip_genesis_validation {
-        init_store_trusting(&datadir, genesis).await
+        init_store_skip_validation(&datadir, genesis).await
     } else {
         init_store(&datadir, genesis).await
     };

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2270,6 +2270,30 @@ impl Store {
     }
 
     pub async fn add_initial_state(&mut self, genesis: Genesis) -> Result<(), StoreError> {
+        self.add_initial_state_inner(genesis, false).await
+    }
+
+    /// Like [`Store::add_initial_state`], but trusts a pre-existing datadir
+    /// instead of validating it against the provided genesis. If a genesis
+    /// header is already stored, it is kept as-is rather than recomputing the
+    /// genesis state root from `genesis.alloc` and rejecting on mismatch.
+    ///
+    /// Intended for booting a datadir produced out-of-band (e.g. by a state
+    /// generator that writes the state trie directly and emits a genesis file
+    /// with an empty `alloc`), where the operator vouches for the stored state
+    /// root. Has no effect on a fresh datadir: the genesis is built normally.
+    pub async fn add_initial_state_skip_validation(
+        &mut self,
+        genesis: Genesis,
+    ) -> Result<(), StoreError> {
+        self.add_initial_state_inner(genesis, true).await
+    }
+
+    async fn add_initial_state_inner(
+        &mut self,
+        genesis: Genesis,
+        skip_genesis_validation: bool,
+    ) -> Result<(), StoreError> {
         debug!("Storing initial state from genesis");
 
         // Obtain genesis block
@@ -2290,6 +2314,13 @@ impl Store {
         }
 
         match self.load_block_header(genesis_block_number)? {
+            Some(header) if skip_genesis_validation => {
+                info!(
+                    stored_genesis = %header.hash(),
+                    "Skipping genesis validation; trusting the genesis already stored in the datadir"
+                );
+                return Ok(());
+            }
             Some(header) if header.hash() == genesis_hash => {
                 info!("Received genesis file matching a previously stored one, nothing to do");
                 return Ok(());

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2273,10 +2273,11 @@ impl Store {
         self.add_initial_state_inner(genesis, false).await
     }
 
-    /// Like [`Store::add_initial_state`], but trusts a pre-existing datadir
-    /// instead of validating it against the provided genesis. If a genesis
+    /// Like [`Store::add_initial_state`], but trusts a pre-existing datadir's
+    /// state instead of validating it against the provided genesis. If a genesis
     /// header is already stored, it is kept as-is rather than recomputing the
-    /// genesis state root from `genesis.alloc` and rejecting on mismatch.
+    /// genesis state root from `genesis.alloc` and rejecting on mismatch. The
+    /// chain config from the genesis file is still applied either way.
     ///
     /// Intended for booting a datadir produced out-of-band (e.g. by a state
     /// generator that writes the state trie directly and emits a genesis file
@@ -2304,17 +2305,13 @@ impl Store {
 
         let stored_genesis_header = self.load_block_header(genesis_block_number)?;
 
-        // In skip-validation mode with a genesis already in the datadir, trust
-        // the stored state wholesale: leave the chain config untouched too,
-        // rather than overwriting it from the supplied (possibly stripped)
-        // genesis file. Overwriting could silently swap the fork schedule or
-        // chainId out from under a datadir we were told to trust.
-        let trust_stored = skip_genesis_validation && stored_genesis_header.is_some();
-
-        // Set chain config
-        if !trust_stored {
-            self.set_chain_config(&genesis.config).await?;
-        }
+        // Always set the chain config from the genesis file. The in-memory
+        // `chain_config` starts at `Default::default()` on every boot and is
+        // not reloaded from the datadir, so skipping this would leave the store
+        // with the wrong chainId and an empty fork schedule. Skip-validation
+        // only waives the genesis state-root/header check; the `config` section
+        // of the genesis file is still authoritative and must be applied.
+        self.set_chain_config(&genesis.config).await?;
 
         // The cache can't be empty
         if let Some(number) = self.load_latest_block_number().await? {
@@ -2328,7 +2325,7 @@ impl Store {
             Some(header) if skip_genesis_validation => {
                 info!(
                     stored_genesis = %header.hash(),
-                    "Skipping genesis validation; trusting the genesis and chain config already stored in the datadir"
+                    "Skipping genesis state validation; trusting the genesis header and state already stored in the datadir"
                 );
                 return Ok(());
             }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2302,8 +2302,19 @@ impl Store {
 
         let genesis_hash = genesis_block.hash();
 
+        let stored_genesis_header = self.load_block_header(genesis_block_number)?;
+
+        // In skip-validation mode with a genesis already in the datadir, trust
+        // the stored state wholesale: leave the chain config untouched too,
+        // rather than overwriting it from the supplied (possibly stripped)
+        // genesis file. Overwriting could silently swap the fork schedule or
+        // chainId out from under a datadir we were told to trust.
+        let trust_stored = skip_genesis_validation && stored_genesis_header.is_some();
+
         // Set chain config
-        self.set_chain_config(&genesis.config).await?;
+        if !trust_stored {
+            self.set_chain_config(&genesis.config).await?;
+        }
 
         // The cache can't be empty
         if let Some(number) = self.load_latest_block_number().await? {
@@ -2313,11 +2324,11 @@ impl Store {
             self.latest_block_header.update(latest_block_header);
         }
 
-        match self.load_block_header(genesis_block_number)? {
+        match stored_genesis_header {
             Some(header) if skip_genesis_validation => {
                 info!(
                     stored_genesis = %header.hash(),
-                    "Skipping genesis validation; trusting the genesis already stored in the datadir"
+                    "Skipping genesis validation; trusting the genesis and chain config already stored in the datadir"
                 );
                 return Ok(());
             }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,14 +28,14 @@ Options:
 Node options:
       --network <GENESIS_FILE_PATH>
           Alternatively, the name of a known network can be provided instead to use its preset genesis file and include its preset bootnodes. The networks currently supported include sepolia, hoodi and mainnet. If not specified, defaults to mainnet.
-
+          
           [env: ETHREX_NETWORK=]
 
       --datadir <DATABASE_DIRECTORY>
           Base directory for the database. For public networks a subdirectory named after the network is appended (e.g. ~/.local/share/ethrex/mainnet). If the value is `memory`, the InMemory Engine is used instead.
-
+          
           [env: ETHREX_DATADIR=]
-          [default: /home/runner/.local/share/ethrex]
+          [default: /home/edgar/.local/share/ethrex]
 
       --force
           Delete the database without confirmation.
@@ -50,30 +50,35 @@ Node options:
 
       --metrics
           Enable metrics collection and exposition
-
+          
           [env: ETHREX_METRICS=]
 
       --dev
           If set it will be considered as `true`. If `--network` is not specified, it will default to a custom local devnet. The Binary has to be built with the `dev` feature enabled.
-
+          
           [env: ETHREX_DEV=]
 
       --log.level <LOG_LEVEL>
           Possible values: info, debug, trace, warn, error
-
+          
           [env: ETHREX_LOG_LEVEL=]
           [default: INFO]
 
       --log.color <LOG_COLOR>
           Possible values: auto, always, never
-
+          
           [env: ETHREX_LOG_COLOR=]
           [default: auto]
 
       --no-migrate
           Do not migrate an existing database to the network-specific subdirectory.
-
+          
           [env: ETHREX_NO_MIGRATE=]
+
+      --skip-genesis-validation
+          Trust a pre-existing datadir's genesis instead of recomputing the genesis state root from the genesis alloc. Use only when booting against a database produced out-of-band (e.g. by a state generator) whose state root you vouch for; has no effect on a fresh datadir.
+          
+          [env: ETHREX_SKIP_GENESIS_VALIDATION=]
 
       --no-precompile-cache
           Disable the per-block precompile result cache (benchmarking only).
@@ -97,29 +102,29 @@ Node options:
 
       --log.dir <LOG_DIR>
           Directory to store log files.
-
+          
           [env: ETHREX_LOG_DIR=]
 
       --mempool.maxsize <MEMPOOL_MAX_SIZE>
           Maximum size of the mempool in number of transactions
-
+          
           [env: ETHREX_MEMPOOL_MAX_SIZE=]
           [default: 10000]
 
       --precompute-witnesses
           Once synced, computes execution witnesses upon receiving newPayload messages and stores them in local storage
-
+          
           [env: ETHREX_PRECOMPUTE_WITNESSES=]
 
 P2P options:
       --bootnodes <BOOTNODE_LIST>...
           Comma separated enode URLs for P2P discovery bootstrap.
-
+          
           [env: ETHREX_BOOTNODES=]
 
       --syncmode <SYNC_MODE>
           Can be either "full" or "snap" with "snap" as default value.
-
+          
           [env: ETHREX_SYNCMODE=]
           [default: snap]
 
@@ -128,126 +133,126 @@ P2P options:
 
       --p2p.addr <ADDRESS>
           The address to bind P2P sockets to. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
-
+          
           [env: ETHREX_P2P_ADDR=]
 
       --nat.extip <IP>
           The IP address advertised to other nodes via discovery and ENR. Use this when the node is behind NAT and --p2p.addr is a private/unspecified address. Defaults to the value of --p2p.addr (or the auto-detected local IP if neither is set).
-
+          
           [env: ETHREX_P2P_NAT_EXTIP=]
 
       --p2p.port <PORT>
           TCP port for the P2P protocol.
-
+          
           [env: ETHREX_P2P_PORT=]
           [default: 30303]
 
       --discovery.port <PORT>
           UDP port for P2P discovery.
-
+          
           [env: ETHREX_P2P_DISCOVERY_PORT=]
           [default: 30303]
 
       --p2p.discv4 <DISCV4_ENABLED>
           Enable discv4 discovery.
-
+          
           [default: true]
           [possible values: true, false]
 
       --p2p.discv5 <DISCV5_ENABLED>
           Enable discv5 discovery.
-
+          
           [default: true]
           [possible values: true, false]
 
       --p2p.tx-broadcasting-interval <INTERVAL_MS>
           Transaction Broadcasting Time Interval (ms) for batching transactions before broadcasting them.
-
+          
           [env: ETHREX_P2P_TX_BROADCASTING_INTERVAL=]
           [default: 1000]
 
       --p2p.target-peers <MAX_PEERS>
           Max amount of connected peers.
-
+          
           [env: ETHREX_P2P_TARGET_PEERS=]
           [default: 100]
 
       --p2p.lookup-interval <INITIAL_LOOKUP_INTERVAL>
           Initial Lookup Time Interval (ms) to trigger each Discovery lookup message and RLPx connection attempt.
-
+          
           [env: ETHREX_P2P_LOOKUP_INTERVAL=]
           [default: 100]
 
 RPC options:
       --http.addr <ADDRESS>
           Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).
-
+          
           [env: ETHREX_HTTP_ADDR=]
           [default: 127.0.0.1]
 
       --http.port <PORT>
           Listening port for the http rpc server.
-
+          
           [env: ETHREX_HTTP_PORT=]
           [default: 8545]
 
       --http.api <NAMESPACES>
           Comma-separated list of JSON-RPC namespaces exposed on the public HTTP and WebSocket endpoints. Defaults to `eth,net,web3`. Enable `admin`, `debug` or `txpool` only when needed; the `engine` namespace is served on the authenticated RPC port and cannot be toggled here.
-
+          
           [env: ETHREX_HTTP_API=]
           [default: eth,net,web3]
 
       --ws.enabled
           Enable websocket rpc server. Disabled by default.
-
+          
           [env: ETHREX_ENABLE_WS=]
 
       --ws.addr <ADDRESS>
           Listening address for the websocket rpc server.
-
+          
           [env: ETHREX_WS_ADDR=]
           [default: 0.0.0.0]
 
       --ws.port <PORT>
           Listening port for the websocket rpc server.
-
+          
           [env: ETHREX_WS_PORT=]
           [default: 8546]
 
       --authrpc.addr <ADDRESS>
           Listening address for the authenticated rpc server.
-
+          
           [env: ETHREX_AUTHRPC_ADDR=]
           [default: 127.0.0.1]
 
       --authrpc.port <PORT>
           Listening port for the authenticated rpc server.
-
+          
           [env: ETHREX_AUTHRPC_PORT=]
           [default: 8551]
 
       --authrpc.jwtsecret <JWTSECRET_PATH>
           Receives the jwt secret used for authenticated rpc requests.
-
+          
           [env: ETHREX_AUTHRPC_JWTSECRET_PATH=]
           [default: jwt.hex]
 
 Block building options:
       --builder.extra-data <EXTRA_DATA>
           Block extra data message.
-
+          
           [env: ETHREX_BUILDER_EXTRA_DATA=]
           [default: "ethrex 15.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
-
+          
           [env: ETHREX_BUILDER_GAS_LIMIT=]
           [default: 60000000]
 
       --builder.max-blobs <MAX_BLOBS>
           EIP-7872: Maximum blobs per block for local building. Minimum of 1. Defaults to protocol max.
-
+          
           [env: ETHREX_BUILDER_MAX_BLOBS=]
 ```
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,14 +28,14 @@ Options:
 Node options:
       --network <GENESIS_FILE_PATH>
           Alternatively, the name of a known network can be provided instead to use its preset genesis file and include its preset bootnodes. The networks currently supported include sepolia, hoodi and mainnet. If not specified, defaults to mainnet.
-          
+
           [env: ETHREX_NETWORK=]
 
       --datadir <DATABASE_DIRECTORY>
           Base directory for the database. For public networks a subdirectory named after the network is appended (e.g. ~/.local/share/ethrex/mainnet). If the value is `memory`, the InMemory Engine is used instead.
-          
+
           [env: ETHREX_DATADIR=]
-          [default: /home/edgar/.local/share/ethrex]
+          [default: /home/runner/.local/share/ethrex]
 
       --force
           Delete the database without confirmation.
@@ -50,34 +50,34 @@ Node options:
 
       --metrics
           Enable metrics collection and exposition
-          
+
           [env: ETHREX_METRICS=]
 
       --dev
           If set it will be considered as `true`. If `--network` is not specified, it will default to a custom local devnet. The Binary has to be built with the `dev` feature enabled.
-          
+
           [env: ETHREX_DEV=]
 
       --log.level <LOG_LEVEL>
           Possible values: info, debug, trace, warn, error
-          
+
           [env: ETHREX_LOG_LEVEL=]
           [default: INFO]
 
       --log.color <LOG_COLOR>
           Possible values: auto, always, never
-          
+
           [env: ETHREX_LOG_COLOR=]
           [default: auto]
 
       --no-migrate
           Do not migrate an existing database to the network-specific subdirectory.
-          
+
           [env: ETHREX_NO_MIGRATE=]
 
       --skip-genesis-validation
           Trust a pre-existing datadir's genesis instead of recomputing the genesis state root from the genesis alloc. Use only when booting against a database produced out-of-band (e.g. by a state generator) whose state root you vouch for; has no effect on a fresh datadir.
-          
+
           [env: ETHREX_SKIP_GENESIS_VALIDATION=]
 
       --no-precompile-cache
@@ -102,29 +102,29 @@ Node options:
 
       --log.dir <LOG_DIR>
           Directory to store log files.
-          
+
           [env: ETHREX_LOG_DIR=]
 
       --mempool.maxsize <MEMPOOL_MAX_SIZE>
           Maximum size of the mempool in number of transactions
-          
+
           [env: ETHREX_MEMPOOL_MAX_SIZE=]
           [default: 10000]
 
       --precompute-witnesses
           Once synced, computes execution witnesses upon receiving newPayload messages and stores them in local storage
-          
+
           [env: ETHREX_PRECOMPUTE_WITNESSES=]
 
 P2P options:
       --bootnodes <BOOTNODE_LIST>...
           Comma separated enode URLs for P2P discovery bootstrap.
-          
+
           [env: ETHREX_BOOTNODES=]
 
       --syncmode <SYNC_MODE>
           Can be either "full" or "snap" with "snap" as default value.
-          
+
           [env: ETHREX_SYNCMODE=]
           [default: snap]
 
@@ -133,126 +133,126 @@ P2P options:
 
       --p2p.addr <ADDRESS>
           The address to bind P2P sockets to. Defaults to the local IP. Use 0.0.0.0 (IPv4) or :: (IPv6) to listen on all interfaces. See also --nat.extip to announce a different external address.
-          
+
           [env: ETHREX_P2P_ADDR=]
 
       --nat.extip <IP>
           The IP address advertised to other nodes via discovery and ENR. Use this when the node is behind NAT and --p2p.addr is a private/unspecified address. Defaults to the value of --p2p.addr (or the auto-detected local IP if neither is set).
-          
+
           [env: ETHREX_P2P_NAT_EXTIP=]
 
       --p2p.port <PORT>
           TCP port for the P2P protocol.
-          
+
           [env: ETHREX_P2P_PORT=]
           [default: 30303]
 
       --discovery.port <PORT>
           UDP port for P2P discovery.
-          
+
           [env: ETHREX_P2P_DISCOVERY_PORT=]
           [default: 30303]
 
       --p2p.discv4 <DISCV4_ENABLED>
           Enable discv4 discovery.
-          
+
           [default: true]
           [possible values: true, false]
 
       --p2p.discv5 <DISCV5_ENABLED>
           Enable discv5 discovery.
-          
+
           [default: true]
           [possible values: true, false]
 
       --p2p.tx-broadcasting-interval <INTERVAL_MS>
           Transaction Broadcasting Time Interval (ms) for batching transactions before broadcasting them.
-          
+
           [env: ETHREX_P2P_TX_BROADCASTING_INTERVAL=]
           [default: 1000]
 
       --p2p.target-peers <MAX_PEERS>
           Max amount of connected peers.
-          
+
           [env: ETHREX_P2P_TARGET_PEERS=]
           [default: 100]
 
       --p2p.lookup-interval <INITIAL_LOOKUP_INTERVAL>
           Initial Lookup Time Interval (ms) to trigger each Discovery lookup message and RLPx connection attempt.
-          
+
           [env: ETHREX_P2P_LOOKUP_INTERVAL=]
           [default: 100]
 
 RPC options:
       --http.addr <ADDRESS>
           Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).
-          
+
           [env: ETHREX_HTTP_ADDR=]
           [default: 127.0.0.1]
 
       --http.port <PORT>
           Listening port for the http rpc server.
-          
+
           [env: ETHREX_HTTP_PORT=]
           [default: 8545]
 
       --http.api <NAMESPACES>
           Comma-separated list of JSON-RPC namespaces exposed on the public HTTP and WebSocket endpoints. Defaults to `eth,net,web3`. Enable `admin`, `debug` or `txpool` only when needed; the `engine` namespace is served on the authenticated RPC port and cannot be toggled here.
-          
+
           [env: ETHREX_HTTP_API=]
           [default: eth,net,web3]
 
       --ws.enabled
           Enable websocket rpc server. Disabled by default.
-          
+
           [env: ETHREX_ENABLE_WS=]
 
       --ws.addr <ADDRESS>
           Listening address for the websocket rpc server.
-          
+
           [env: ETHREX_WS_ADDR=]
           [default: 0.0.0.0]
 
       --ws.port <PORT>
           Listening port for the websocket rpc server.
-          
+
           [env: ETHREX_WS_PORT=]
           [default: 8546]
 
       --authrpc.addr <ADDRESS>
           Listening address for the authenticated rpc server.
-          
+
           [env: ETHREX_AUTHRPC_ADDR=]
           [default: 127.0.0.1]
 
       --authrpc.port <PORT>
           Listening port for the authenticated rpc server.
-          
+
           [env: ETHREX_AUTHRPC_PORT=]
           [default: 8551]
 
       --authrpc.jwtsecret <JWTSECRET_PATH>
           Receives the jwt secret used for authenticated rpc requests.
-          
+
           [env: ETHREX_AUTHRPC_JWTSECRET_PATH=]
           [default: jwt.hex]
 
 Block building options:
       --builder.extra-data <EXTRA_DATA>
           Block extra data message.
-          
+
           [env: ETHREX_BUILDER_EXTRA_DATA=]
           [default: "ethrex 15.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
-          
+
           [env: ETHREX_BUILDER_GAS_LIMIT=]
           [default: 60000000]
 
       --builder.max-blobs <MAX_BLOBS>
           EIP-7872: Maximum blobs per block for local building. Minimum of 1. Defaults to protocol max.
-          
+
           [env: ETHREX_BUILDER_MAX_BLOBS=]
 ```
 

--- a/test/tests/storage/store_tests.rs
+++ b/test/tests/storage/store_tests.rs
@@ -155,11 +155,8 @@ async fn test_genesis_block(mut store: Store) {
         .await
         .expect("skip-validation trusts the stored genesis");
 
-    // Symmetric trust: BOTH the stored genesis block and the stored chain
-    // config are kept as-is. The supplied (hive) genesis must not leak into
-    // either — neither the genesis header nor the chain config is overwritten.
-    // (Asserted before the rejection case below, whose set_chain_config runs
-    // before erroring and would otherwise pollute the stored config.)
+    // The stored genesis block/state is trusted and kept as-is: the supplied
+    // (hive) genesis header must not overwrite the stored kurtosis one.
     let stored_header = store
         .get_block_header(0)
         .expect("load genesis header")
@@ -169,10 +166,13 @@ async fn test_genesis_block(mut store: Store) {
         kurtosis_hash,
         "skip-validation must preserve the stored genesis block"
     );
+    // The chain config, however, is always applied from the supplied genesis
+    // file. `chain_config` is not reloaded from the datadir on boot, so it must
+    // come from the genesis file or it would be left at its (wrong) default.
     assert_eq!(
         store.get_chain_config(),
-        kurtosis_config,
-        "skip-validation must preserve the stored chain config"
+        hive_config,
+        "skip-validation must apply the chain config from the supplied genesis"
     );
 
     // Without skip-validation, a mismatching genesis is rejected.

--- a/test/tests/storage/store_tests.rs
+++ b/test/tests/storage/store_tests.rs
@@ -131,6 +131,14 @@ async fn test_genesis_block(mut store: Store) {
     let genesis_kurtosis: Genesis =
         serde_json::from_str(GENESIS_KURTOSIS).expect("deserialize kurtosis.json");
     let genesis_hive: Genesis = serde_json::from_str(GENESIS_HIVE).expect("deserialize hive.json");
+
+    let kurtosis_hash = genesis_kurtosis.get_block().hash();
+    let kurtosis_config = genesis_kurtosis.config;
+    let hive_hash = genesis_hive.get_block().hash();
+    let hive_config = genesis_hive.config;
+    assert_ne!(kurtosis_hash, hive_hash);
+    assert_ne!(kurtosis_config, hive_config);
+
     store
         .add_initial_state(genesis_kurtosis.clone())
         .await
@@ -139,17 +147,56 @@ async fn test_genesis_block(mut store: Store) {
         .add_initial_state(genesis_kurtosis)
         .await
         .expect("second genesis with same block");
+
+    // With validation skipped, the mismatching genesis is trusted instead of
+    // rejected: the call returns Ok rather than IncompatibleChainConfig.
+    store
+        .add_initial_state_skip_validation(genesis_hive.clone())
+        .await
+        .expect("skip-validation trusts the stored genesis");
+
+    // Symmetric trust: BOTH the stored genesis block and the stored chain
+    // config are kept as-is. The supplied (hive) genesis must not leak into
+    // either — neither the genesis header nor the chain config is overwritten.
+    // (Asserted before the rejection case below, whose set_chain_config runs
+    // before erroring and would otherwise pollute the stored config.)
+    let stored_header = store
+        .get_block_header(0)
+        .expect("load genesis header")
+        .expect("genesis header present");
+    assert_eq!(
+        stored_header.hash(),
+        kurtosis_hash,
+        "skip-validation must preserve the stored genesis block"
+    );
+    assert_eq!(
+        store.get_chain_config(),
+        kurtosis_config,
+        "skip-validation must preserve the stored chain config"
+    );
+
+    // Without skip-validation, a mismatching genesis is rejected.
     let result = store.add_initial_state(genesis_hive.clone()).await;
     assert!(result.is_err());
     assert!(matches!(result, Err(StoreError::IncompatibleChainConfig)));
 
-    // With validation skipped, the mismatching genesis is trusted instead of
-    // rejected: the stored (kurtosis) genesis is kept as-is and the call
-    // returns Ok rather than IncompatibleChainConfig.
-    store
+    // Fresh datadir: skip-validation has no genesis to trust, so it builds the
+    // supplied genesis normally rather than short-circuiting.
+    let mut fresh = Store::new("memory", EngineType::InMemory).expect("fresh in-memory store");
+    fresh
         .add_initial_state_skip_validation(genesis_hive)
         .await
-        .expect("skip-validation trusts the stored genesis");
+        .expect("skip-validation on a fresh datadir builds genesis");
+    assert_eq!(
+        fresh
+            .get_block_header(0)
+            .expect("load fresh genesis header")
+            .expect("fresh genesis header present")
+            .hash(),
+        hive_hash,
+        "skip-validation on a fresh datadir must build the supplied genesis"
+    );
+    assert_eq!(fresh.get_chain_config(), hive_config);
 }
 
 fn remove_test_dbs(path: &str) {

--- a/test/tests/storage/store_tests.rs
+++ b/test/tests/storage/store_tests.rs
@@ -139,9 +139,17 @@ async fn test_genesis_block(mut store: Store) {
         .add_initial_state(genesis_kurtosis)
         .await
         .expect("second genesis with same block");
-    let result = store.add_initial_state(genesis_hive).await;
+    let result = store.add_initial_state(genesis_hive.clone()).await;
     assert!(result.is_err());
     assert!(matches!(result, Err(StoreError::IncompatibleChainConfig)));
+
+    // With validation skipped, the mismatching genesis is trusted instead of
+    // rejected: the stored (kurtosis) genesis is kept as-is and the call
+    // returns Ok rather than IncompatibleChainConfig.
+    store
+        .add_initial_state_skip_validation(genesis_hive)
+        .await
+        .expect("skip-validation trusts the stored genesis");
 }
 
 fn remove_test_dbs(path: &str) {


### PR DESCRIPTION
## What

Adds `--skip-genesis-validation` (env `ETHREX_SKIP_GENESIS_VALIDATION`). When the datadir already contains a genesis header, ethrex trusts it instead of recomputing the genesis state root from the genesis `alloc` and rejecting on mismatch.

## Why

On boot, `init_store` → `add_initial_state` recomputes the genesis block hash from the `--network` file, where `state_root = compute_state_root(alloc)`, and compares it to the stored genesis header. If they differ it returns `IncompatibleChainConfig` and refuses to boot.

That blocks booting a datadir built out-of-band — e.g. a tool that writes the state trie straight into RocksDB and ships a genesis file with an empty `alloc` (so it doesn't have to materialize millions of accounts as JSON). The recomputed root is then `EMPTY_TRIE_HASH`, which never matches the real stored root, so ethrex always rejects it.

Reproduced against the current behavior: build a DB from a populated genesis, reopen with the same genesis but `alloc` emptied → `IncompatibleChainConfig`.

reth (`--debug.skip-genesis-validation`), besu (`--genesis-state-hash-cache-enabled`) and nethermind (`stateUnavailable: true`) all expose an equivalent "trust the stored state root" switch for this exact pattern; ethrex had none.

## How

- `Store::add_initial_state_skip_validation` — same as `add_initial_state` but, when a genesis header is already stored, returns early and trusts it. `set_chain_config` still runs; a fresh datadir is built normally.
- `init_store_trusting` + `init_l1` branches on the new flag.
- `--skip-genesis-validation` on `Options`.

The operator opts in explicitly and vouches for the datadir, so the safety check is waived rather than removed.

## Test

Extended `test_genesis_block`: the mismatching genesis that returns `IncompatibleChainConfig` under normal validation now returns `Ok` under skip-validation (stored genesis kept as-is).

## Notes

Draft — opening for early feedback on the flag name/shape before polishing. Happy to add a CHANGELOG entry once the section/format is confirmed.
