### PR TITLE
fix(l1): guard derive_legacy_chain_id against underflow on malformed v

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1527,11 +1527,11 @@ impl Transaction {
 
 fn derive_legacy_chain_id(v: U256) -> Option<u64> {
     let v = u64::try_from(v).ok()?;
-    if v == 27 || v == 28 {
-        None
-    } else {
-        Some((v - 35) / 2)
-    }
+    // EIP-155 encodes the chain id as `v = chain_id * 2 + 35` (or 36), so any
+    // replay-protected `v` is >= 35. Pre-EIP-155 txs use v=27/28, and malformed
+    // signatures (e.g. v=0 from an unsigned IL transaction) are < 35 too; none
+    // carry a chain id. Guard the subtraction to avoid an underflow panic.
+    if v < 35 { None } else { Some((v - 35) / 2) }
 }
 
 impl TxType {


### PR DESCRIPTION
`derive_legacy_chain_id` only guarded against `v == 27 || v == 28`, so any `v < 35` that wasn't 27/28 (e.g. `v = 0` from an unsigned tx) would hit `v - 35` and either panic in debug/test builds or wrap silently in release.

Fix replaces the 27/28 guard with `if v < 35 { None }`. This subsumes pre-EIP-155 values and rejects all sub-35 inputs, none of which carry an EIP-155 chain id (`v = chain_id*2 + 35/36` implies `v >= 35`).

Found via the EIP-7805 execution-spec test `block_with_invalid_signature_pending_il_tx_is_valid`, which passes a `v=0, r=0, s=0` legacy tx through the IL satisfaction check. The bug predates FOCIL (present since ~Oct 2024); this PR targets `main` independently.

`cargo test -p ethrex-common --lib` passes (79 tests).