### PR TITLE
fix(l1): lock cargo cache mounts to fix concurrent docker build race

### DIFF
--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/main_prover.yaml"
+      - "Dockerfile"
+      - ".dockerignore"
+      - "crates/l2/docker-compose*.yaml"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/main_prover.yaml
+++ b/.github/workflows/main_prover.yaml
@@ -31,6 +31,11 @@ env:
   # Work around frequent libgit2/submodule fetch flakiness in CI.
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   CARGO_NET_RETRY: "10"
+  # Image metadata for the compose-built images (consumed by docker-compose.yaml
+  # build args). Without these, compose-built images bake revision=unknown/version=dev.
+  GIT_SHA: ${{ github.sha }}
+  GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+  VERSION: dev-${{ github.sha }}
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Install cargo-chef via prebuilt binary (cargo-binstall) — avoids ~2 min source build.
 # cargo-binstall pinned for reproducibility; bump deliberately.
 ARG CARGO_BINSTALL_VERSION=v1.19.1
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     # uname -m (NOT $TARGETARCH): cargo-chef is a build-platform tool, must match
     # the stage's execution arch, not the target image arch.
     curl -fsSL https://github.com/cargo-bins/cargo-binstall/releases/download/${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-musl.tgz \
@@ -69,9 +69,9 @@ ENV VERGEN_GIT_BRANCH=$GIT_BRANCH \
 
 COPY --from=planner --link /ethrex/recipe.json recipe.json
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/ethrex/target,id=ethrex-target-${TARGETARCH} \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/ethrex/target,id=ethrex-target-${TARGETARCH},sharing=locked \
     cargo chef cook --profile $PROFILE --recipe-path recipe.json $BUILD_FLAGS
 
 # Fetch solc using buildx's TARGETARCH (no shell uname).
@@ -100,9 +100,9 @@ COPY --link fixtures/keys ./fixtures/keys
 ENV COMPILE_CONTRACTS=true
 
 # Combine build + extract in one RUN so the target cache mount is still mounted.
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/ethrex/target,id=ethrex-target-${TARGETARCH} \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/ethrex/target,id=ethrex-target-${TARGETARCH},sharing=locked \
     cargo build --profile $PROFILE $BUILD_FLAGS \
     && mkdir -p /ethrex/bin \
     && cp /ethrex/target/${PROFILE}/ethrex /ethrex/bin/ethrex

--- a/crates/l2/Makefile
+++ b/crates/l2/Makefile
@@ -6,6 +6,12 @@
 
 .DEFAULT_GOAL := help
 
+# Image metadata baked into the compose-built images (consumed by
+# docker-compose.yaml build args). Mirrors the root Makefile's build-image.
+GIT_SHA    := $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+VERSION    := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
 # ==============================================================================
 # Top-Level Targets
 # ==============================================================================
@@ -237,6 +243,7 @@ integration-test: rm-db-l2 rm-db-l1 # We create an empty .env file simply becaus
 	docker compose down
 	DOCKER_ETHREX_WORKDIR=${DOCKER_ETHREX_WORKDIR} \
 	ETHREX_L2_VALIDIUM=${ETHREX_L2_VALIDIUM} \
+	GIT_SHA=$(GIT_SHA) GIT_BRANCH=$(GIT_BRANCH) VERSION=$(VERSION) \
 	docker compose up --detach --build
 	RUST_LOG=info,ethrex_l2_prover=debug make init-prover-exec & \
 	ETHREX_WATCHER_BRIDGE_ADDRESS=$(shell make bridge-address) \
@@ -251,6 +258,7 @@ integration-test-gpu: rm-db-l2 rm-db-l1
 	docker compose down
 	DOCKER_ETHREX_WORKDIR=${DOCKER_ETHREX_WORKDIR} \
 	ETHREX_BLOCK_PRODUCER_BLOCK_TIME=${ETHREX_BLOCK_PRODUCER_BLOCK_TIME} \
+	GIT_SHA=$(GIT_SHA) GIT_BRANCH=$(GIT_BRANCH) VERSION=$(VERSION) \
 	docker compose up --detach --build
 
 	RUST_LOG=info,ethrex_l2_prover=debug GPU=true make init-prover-sp1 & \

--- a/crates/l2/build.rs
+++ b/crates/l2/build.rs
@@ -11,7 +11,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-env=VERGEN_GIT_SHA={}", sha.trim());
         return Ok(());
     }
-    let git2 = Git2Builder::default().sha(true).build()?;
+    // Emit the full SHA, not the abbreviated form: it must match the
+    // VERGEN_GIT_SHA build-arg (full github.sha) baked into the docker image so
+    // a source-built component and a docker-built one agree on the commit hash
+    // used for the prover version check. git's and libgit2's short-SHA lengths
+    // diverge by repo size, so the abbreviated form can't be compared reliably.
+    let git2 = Git2Builder::default().sha(false).build()?;
 
     Emitter::default().add_instructions(&git2)?.emit()?;
     Ok(())

--- a/crates/l2/docker-compose-l2-shared-bridge.overrides.yaml
+++ b/crates/l2/docker-compose-l2-shared-bridge.overrides.yaml
@@ -25,6 +25,9 @@ services:
       context: ../../
       args:
         - BUILD_FLAGS=--features l2,l2-sql
+        - GIT_SHA=${GIT_SHA:-unknown}
+        - GIT_BRANCH=${GIT_BRANCH:-unknown}
+        - VERSION=${VERSION:-dev}
     ports:
       # RPC
       - 127.0.0.1:1730:1730

--- a/crates/l2/docker-compose.yaml
+++ b/crates/l2/docker-compose.yaml
@@ -5,7 +5,12 @@ services:
   ethrex_l1:
     container_name: ethrex_l1
     image: "ethrex:main"
-    build: ../../
+    build:
+      context: ../../
+      args:
+        - GIT_SHA=${GIT_SHA:-unknown}
+        - GIT_BRANCH=${GIT_BRANCH:-unknown}
+        - VERSION=${VERSION:-dev}
     ports:
       - 127.0.0.1:8545:8545
     environment:
@@ -22,6 +27,9 @@ services:
       context: ../../
       args:
         - BUILD_FLAGS=--features l2,l2-sql
+        - GIT_SHA=${GIT_SHA:-unknown}
+        - GIT_BRANCH=${GIT_BRANCH:-unknown}
+        - VERSION=${VERSION:-dev}
     volumes:
       # NOTE: DOCKER_ETHREX_WORKDIR is defined in crates/l2/Makefile
       - ./contracts:${DOCKER_ETHREX_WORKDIR}/contracts
@@ -79,6 +87,9 @@ services:
       context: ../../
       args:
         - BUILD_FLAGS=--features l2,l2-sql
+        - GIT_SHA=${GIT_SHA:-unknown}
+        - GIT_BRANCH=${GIT_BRANCH:-unknown}
+        - VERSION=${VERSION:-dev}
     ports:
       # RPC
       - 127.0.0.1:1729:1729
@@ -134,6 +145,9 @@ services:
       context: ../../
       args:
         - BUILD_FLAGS=--features l2,l2-sql
+        - GIT_SHA=${GIT_SHA:-unknown}
+        - GIT_BRANCH=${GIT_BRANCH:-unknown}
+        - VERSION=${VERSION:-dev}
     command: >
       l2 prover
       --backend exec

--- a/crates/l2/tee/quote-gen/build.rs
+++ b/crates/l2/tee/quote-gen/build.rs
@@ -11,7 +11,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-env=VERGEN_GIT_SHA={}", sha.trim());
         return Ok(());
     }
-    let git2 = Git2Builder::default().sha(true).build()?;
+    // Emit the full SHA, not the abbreviated form: it must match the
+    // VERGEN_GIT_SHA build-arg (full github.sha) baked into the docker image so
+    // a source-built component and a docker-built one agree on the commit hash
+    // used for the prover version check. git's and libgit2's short-SHA lengths
+    // diverge by repo size, so the abbreviated form can't be compared reliably.
+    let git2 = Git2Builder::default().sha(false).build()?;
 
     Emitter::default().add_instructions(&git2)?.emit()?;
     Ok(())


### PR DESCRIPTION
## What

Fix the concurrent Docker build race introduced by #6725, plus harden the surrounding CI/build setup so it can't regress silently.

- **`Dockerfile`**: add `sharing=locked` to the cargo (`registry`, `git`) and `target` BuildKit cache mounts.
- **`.github/workflows/main_prover.yaml`**: run the SP1 backend integration test on PRs that touch `Dockerfile`, `.dockerignore`, or `crates/l2/docker-compose*.yaml`; export image-metadata env for the compose builds.
- **`crates/l2/docker-compose*.yaml`**: thread `GIT_SHA`/`GIT_BRANCH`/`VERSION` build args through every service build.
- **`crates/l2/Makefile`**: derive and export the same metadata for the local `integration-test` / `integration-test-gpu` compose builds.

## Why

`docker compose up --build contract_deployer` (used by the `L2 (SP1 Backend)` test and the L2 Makefile integration targets) builds `ethrex_l1` and `contract_deployer` from the same Dockerfile concurrently. Since #6725 those builds share BuildKit cache mounts left at the default `sharing=shared`, so both run `cargo chef cook` at once and race on the shared cargo git cache, corrupting the checkout:

```
failed to rename lockfile to '/usr/local/cargo/git/checkouts/openvm-.../69373ff/.git/index': No such file or directory
```

`sharing=locked` serializes concurrent access to these mounts (same pattern already used for the apt mounts), so the two builds no longer clobber the cache.

Seen on main: https://github.com/lambdaclass/ethrex/actions/runs/26945935971/job/79498785477

## Safeguards for the future

**Why PR CI missed it.** The only workflow exercising the racy `docker compose up --build` path is `main_prover.yaml`, which previously only ran on push-to-main (and on PRs only when its own file changed). PR-time L2 image builds go through the `build-docker` action in separate, serial jobs (one image per job), and `pr-main_l2_prover.yaml` builds with cargo (no Docker) — so no PR-time job ever built two images concurrently. The bug could only surface post-merge.

Safeguards added here:

1. **Catch it pre-merge.** `main_prover.yaml` now triggers on PRs touching `Dockerfile` / `.dockerignore` / `crates/l2/docker-compose*.yaml`, so the concurrent-build path is exercised before merge. (Still gated to in-org PRs; it runs on a GPU self-hosted runner.)
2. **Correct image metadata for compose builds.** Compose build args (`${GIT_SHA:-unknown}` etc.) only carry real values if the caller exports them. The compose files now accept these args, and both compose callers now provide them: `main_prover.yaml` exports `GIT_SHA`/`GIT_BRANCH`/`VERSION` from the `github` context (matching the `build-docker` action), and `crates/l2/Makefile` derives them via `git rev-parse`/`git describe` (matching the root `Makefile`). Previously, without `.git` in the build context, compose-built images baked `revision=unknown`/`version=dev` with no way to inject real values.

## Verified safe (no further regression from #6725)

- No `include_str!`/`include_bytes!`/build.rs reference to any path excluded by the new `.dockerignore` (`fixtures/blockchain|blobs|cache|rsp|hive`, `vectors_zkevm`). Only `fixtures/genesis` + `fixtures/keys` are read at build time, and both are copied in.
- Contract sources (`crates/l2/contracts/src`) live under `crates/`, which is fully copied.
- Workspace path-deps are only `tooling/repl` + `tooling/monitor`, both copied.
