### PR TITLE
ci(l1): pin hive to #1530 merge (deposit contract address fix)

### DIFF
--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -164,15 +164,15 @@ jobs:
         with:
           simulator: ${{ matrix.test.simulation }}
           client: ethrex
-          # Pin hive to the commit BEFORE ethereum/hive#1507
-          # ("Source depositContractAddress from HIVE_DEPOSIT_CONTRACT_ADDRESS",
-          # merged 2026-06-04). That PR added an unparenthesized `//` alternative
-          # operator to clients/ethrex/mapper.jq, which is invalid in jq's
-          # object-value grammar (ExpD) and aborts the genesis mapper at compile
-          # time, so the ethrex container never starts (every test reports
-          # "could not start client ... terminated unexpectedly"). Unpin once the
-          # mapper is fixed upstream (wrap the value in parentheses).
-          hive_version: b61002ea0c876a0e29c0403d88f9f96fca104c21
+          # Pin hive to ethereum/hive#1530's merge commit, which fixes the
+          # clients/ethrex/mapper.jq depositContractAddress bug from #1507:
+          # #1524 wrapped the `//` value in parens (the unparenthesized form was
+          # a jq syntax error that stopped the client from starting), and #1530
+          # restored the mainnet deposit contract address as the fallback (the
+          # zero-address default made every eip6110 deposit / eip7685 request
+          # test fail). Also gives the daily report a reproducible hive version
+          # instead of floating on the action's default.
+          hive_version: 7c4c99ebb79955f23e1952fb0282a0dadcb6e181
           extra_flags: ${{ steps.hive-flags.outputs.flags }}
           workflow_artifact_upload: true
           workflow_artifact_prefix: ${{ matrix.test.file_name }}_daily

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -164,6 +164,15 @@ jobs:
         with:
           simulator: ${{ matrix.test.simulation }}
           client: ethrex
+          # Pin hive to the commit BEFORE ethereum/hive#1507
+          # ("Source depositContractAddress from HIVE_DEPOSIT_CONTRACT_ADDRESS",
+          # merged 2026-06-04). That PR added an unparenthesized `//` alternative
+          # operator to clients/ethrex/mapper.jq, which is invalid in jq's
+          # object-value grammar (ExpD) and aborts the genesis mapper at compile
+          # time, so the ethrex container never starts (every test reports
+          # "could not start client ... terminated unexpectedly"). Unpin once the
+          # mapper is fixed upstream (wrap the value in parentheses).
+          hive_version: b61002ea0c876a0e29c0403d88f9f96fca104c21
           extra_flags: ${{ steps.hive-flags.outputs.flags }}
           workflow_artifact_upload: true
           workflow_artifact_prefix: ${{ matrix.test.file_name }}_daily

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -387,7 +387,8 @@ jobs:
         uses: ethpandaops/hive-github-action@v0.5.0
         with:
           hive_repository: ethereum/hive
-          hive_version: 3b6bde032562a8733c8bfa0e928d900f91c06e82
+          # ethereum/hive#1530 merge (deposit contract address mapper fix)
+          hive_version: 7c4c99ebb79955f23e1952fb0282a0dadcb6e181
           simulator: ${{ matrix.simulation }}
           client: ethrex
           client_config: ${{ steps.client-config.outputs.config }}


### PR DESCRIPTION
Pins both hive jobs (daily report + pr-main L1) to `ethereum/hive` `7c4c99eb`, which carries the full fix for the `clients/ethrex/mapper.jq` `depositContractAddress` bug introduced by ethereum/hive#1507:

- **#1524** wrapped the `//` alternative in parentheses. The unparenthesized form was a jq syntax error in object-value position, so the genesis mapper never compiled and the ethrex container failed to start (every test: `could not start client ... terminated unexpectedly`; the daily run dropped to 5/21776).
- **#1530** restored the mainnet deposit contract address as the fallback. With the parens fixed but the env unset, the default was the zero address, so the client watched `0x0` for deposit logs and derived no deposit requests; every eip6110 deposit / eip7685-with-deposit test failed as INVALID (59 in the Amsterdam consume jobs).

Both upstream fixes are merged, so pinning forward to `7c4c99eb` is the correct resolution. This replaces the earlier pre-#1507 backward pin and also gives the daily report a reproducible hive version instead of floating on the action's default.

A/B verified locally (same ethrex image, same `tests-bal@v7.2.0` fixtures, only the mapper default changed): mainnet default 74/74 pass, zero default 46 pass / 28 fail.
