### PR TITLE
fix(l1): return SYNCING instead of INVALID when parent state is missing in engine_newPayload

### DIFF
--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -1147,6 +1147,23 @@ async fn try_execute_payload(
         return Ok(PayloadStatus::valid_with_hash(block_hash));
     }
 
+    // A payload whose parent *state* we don't have yet must be answered with
+    // SYNCING, never INVALID: without the parent state we cannot validate it,
+    // so we must not declare it invalid. This happens after a restart, when
+    // state regeneration hasn't caught up to the CL head, or when the CL sends a
+    // newPayload for a block beyond our current state. Without this guard,
+    // execution fails with `EvmError::DB("state root missing")` and gets mapped
+    // to INVALID below, wrongly poisoning the CL's view of a valid block (and
+    // persisting it via `set_latest_valid_ancestor`). The parent block being
+    // entirely absent is handled as `ParentNotFound` by `add_block` below.
+    if let Some(parent_header) = storage.get_block_header_by_hash(block.header.parent_hash)?
+        && !storage.has_state_root(parent_header.state_root)?
+    {
+        debug!(%block_hash, %block_number, "Parent state missing, returning SYNCING and triggering sync");
+        syncer.sync_to_head(block_hash);
+        return Ok(PayloadStatus::syncing());
+    }
+
     // Execute and store the block
     debug!(%block_hash, %block_number, "Executing payload");
 
@@ -1156,14 +1173,14 @@ async fn try_execute_payload(
             syncer.sync_to_head(block_hash);
             Ok(PayloadStatus::syncing())
         }
-        // Under the current implementation this is not possible: we always calculate the state
-        // transition of any new payload as long as the parent is present. If we received the
-        // parent payload but it was stashed, then new payload would stash this one too, with a
-        // ParentNotFoundError.
+        // Parent block is present but its state isn't available yet (e.g. state
+        // regeneration after a restart hasn't reached the CL head). This is a
+        // SYNCING condition, not an error and not INVALID: trigger a sync and
+        // report SYNCING so the CL keeps the (valid) block.
         Err(ChainError::ParentStateNotFound) => {
-            let e = "Failed to obtain parent state";
-            error!("{e} for block {block_hash}");
-            Err(RpcErr::Internal(e.to_string()))
+            debug!(%block_hash, "Parent state not found, returning SYNCING and triggering sync");
+            syncer.sync_to_head(block_hash);
+            Ok(PayloadStatus::syncing())
         }
         Err(ChainError::InvalidBlock(error)) => {
             warn!("Error executing block: {error}");


### PR DESCRIPTION
`engine_newPayload` was returning INVALID when a payload's parent state was absent from the DB. Without the parent state, execution fails with `EvmError::DB("state root missing")`, which was being mapped to INVALID and persisted via `set_latest_valid_ancestor`. This is wrong: per the Engine API spec (`execution-apis/src/engine/paris.md`), missing requisite state is a SYNCING condition, not INVALID. Returning INVALID for a valid block poisons the CL's view of the canonical chain.

This was observed live on glamsterdam-devnet-5: after an EL restart, ethrex regenerated state up to block 5354; Grandine sent `newPayload` for block 5356 (parent 5355) before the EL caught up, got INVALID back, and halted.

Fix in `try_execute_payload` (`crates/networking/rpc/engine/payload.rs`):

- Before executing, check `storage.has_state_root(parent_header.state_root)`. If the parent header exists but its state is absent, return `PayloadStatus::syncing()` and trigger `syncer.sync_to_head(...)`.
- Change the `ChainError::ParentStateNotFound` match arm from returning an internal RPC error to returning SYNCING and triggering sync. Remove the now-incorrect "this is not possible" comment.

The missing-parent-block case (`ParentNotFound`) is unchanged and still returns SYNCING as before. Normal steady-state operation is unaffected; the only added overhead is one `has_state_root` check per `newPayload` call.

Note: the repo has no integration-test harness for `engine_newPayload`, so no regression test is included. A follow-up test using a mocked `RpcApiContext`/syncer that asserts SYNCING when the parent state is absent would be a good addition.

Fixes https://github.com/lambdaclass/ethrex/issues/6794