### PR TITLE
fix(l1): don't log SNAP SYNC COMPLETE when no snap sync ran

### DIFF
--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -236,6 +236,10 @@ pub async fn periodically_show_peer_stats_during_syncing(
 
     loop {
         if blockchain.is_synced() {
+            if !sync_started_logged {
+                info!("Node already has state; following chain via full sync");
+                return;
+            }
             // Log sync complete summary
             let total_elapsed = format_duration(start.elapsed());
             let headers_downloaded = METRICS.downloaded_headers.get();


### PR DESCRIPTION
**Motivation**

Fixes a bad UX pattern where we print the snap sync complete when in reality we don't snap sync and just switch to full sync mode on a node restart

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

