### PR TITLE
feat(l1): serialize execution witness with ssz instead of rkyv

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1626,7 +1626,7 @@ impl Blockchain {
             })
             .collect();
         let state_trie_root = if let NodeRef::Node(state_trie_root, _) =
-            Trie::get_embedded_root(&nodes, initial_state_root)?
+            Trie::get_embedded_root(&nodes, initial_state_root, &NativeCrypto)?
         {
             Some((*state_trie_root).clone())
         } else {
@@ -1653,7 +1653,7 @@ impl Blockchain {
             if !nodes.contains_key(&storage_root_hash) {
                 continue; // storage trie isn't relevant to this execution
             }
-            let node = Trie::get_embedded_root(&nodes, storage_root_hash)?;
+            let node = Trie::get_embedded_root(&nodes, storage_root_hash, &NativeCrypto)?;
             let NodeRef::Node(node, _) = node else {
                 return Err(ChainError::Custom(
                     "execution witness does not contain non-empty storage trie".to_string(),
@@ -1860,7 +1860,7 @@ impl Blockchain {
             })
             .collect();
         let state_trie_root = if let NodeRef::Node(state_trie_root, _) =
-            Trie::get_embedded_root(&nodes, initial_state_root)?
+            Trie::get_embedded_root(&nodes, initial_state_root, &NativeCrypto)?
         {
             Some((*state_trie_root).clone())
         } else {
@@ -1887,7 +1887,7 @@ impl Blockchain {
             if !nodes.contains_key(&storage_root_hash) {
                 continue; // storage trie isn't relevant to this execution
             }
-            let node = Trie::get_embedded_root(&nodes, storage_root_hash)?;
+            let node = Trie::get_embedded_root(&nodes, storage_root_hash, &NativeCrypto)?;
             let NodeRef::Node(node, _) = node else {
                 return Err(ChainError::Custom(
                     "execution witness does not contain non-empty storage trie".to_string(),

--- a/crates/common/trie/db.rs
+++ b/crates/common/trie/db.rs
@@ -71,7 +71,8 @@ impl InMemoryTrieDB {
         root_hash: H256,
         state_nodes: &BTreeMap<H256, Node>,
     ) -> Result<Self, TrieError> {
-        let mut embedded_root = Trie::get_embedded_root(state_nodes, root_hash)?;
+        let mut embedded_root =
+            Trie::get_embedded_root(state_nodes, root_hash, &ethrex_crypto::NativeCrypto)?;
         let mut hashed_nodes = vec![];
         embedded_root.commit(
             Nibbles::default(),

--- a/crates/common/trie/trie.rs
+++ b/crates/common/trie/trie.rs
@@ -319,6 +319,7 @@ impl Trie {
     pub fn get_embedded_root(
         all_nodes: &BTreeMap<H256, Node>,
         root_hash: H256,
+        crypto: &dyn Crypto,
     ) -> Result<NodeRef, TrieError> {
         // If the root hash is of the empty trie then we can get away by setting the NodeRef to default
         if root_hash == *EMPTY_TRIE_HASH {
@@ -332,6 +333,7 @@ impl Trie {
         fn get_embedded_node(
             all_nodes: &BTreeMap<H256, Node>,
             cur_node: &Node,
+            crypto: &dyn Crypto,
         ) -> Result<Node, TrieError> {
             Ok(match cur_node.clone() {
                 Node::Branch(mut node) => {
@@ -341,8 +343,8 @@ impl Trie {
                         };
 
                         if hash.is_valid() {
-                            *choice = match all_nodes.get(&hash.finalize(&NativeCrypto)) {
-                                Some(node) => get_embedded_node(all_nodes, node)?.into(),
+                            *choice = match all_nodes.get(&hash.finalize(crypto)) {
+                                Some(node) => get_embedded_node(all_nodes, node, crypto)?.into(),
                                 None => hash.into(),
                             };
                         }
@@ -355,8 +357,8 @@ impl Trie {
                         return Ok(node.into());
                     };
 
-                    node.child = match all_nodes.get(&hash.finalize(&NativeCrypto)) {
-                        Some(node) => get_embedded_node(all_nodes, node)?.into(),
+                    node.child = match all_nodes.get(&hash.finalize(crypto)) {
+                        Some(node) => get_embedded_node(all_nodes, node, crypto)?.into(),
                         None => hash.into(),
                     };
 
@@ -366,7 +368,7 @@ impl Trie {
             })
         }
 
-        let root = get_embedded_node(all_nodes, root_rlp)?;
+        let root = get_embedded_node(all_nodes, root_rlp, crypto)?;
         Ok(root.into())
     }
 
@@ -380,9 +382,10 @@ impl Trie {
     pub fn from_nodes(
         root_hash: H256,
         state_nodes: &BTreeMap<H256, Node>,
+        crypto: &dyn Crypto,
     ) -> Result<Self, TrieError> {
         let mut trie = Trie::new(Box::new(InMemoryTrieDB::default()));
-        let root = Self::get_embedded_root(state_nodes, root_hash)?;
+        let root = Self::get_embedded_root(state_nodes, root_hash, crypto)?;
         trie.root = root;
 
         Ok(trie)

--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -8,13 +8,15 @@ use crate::types::{Block, Code, CodeMetadata};
 use crate::{
     constants::EMPTY_KECCACK_HASH,
     types::{AccountState, AccountUpdate, BlockHeader, ChainConfig},
-    utils::keccak,
 };
 use ethereum_types::{Address, H256, U256};
-use ethrex_crypto::{Crypto, NativeCrypto};
+use ethrex_crypto::Crypto;
 use ethrex_rlp::error::RLPDecodeError;
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
-use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, Node, NodeRef, Trie, TrieError};
+use ethrex_trie::{
+    EMPTY_TRIE_HASH, Nibbles, Node, NodeRef, Trie, TrieError,
+    node::{BranchNode, ExtensionNode},
+};
 use rkyv::with::{Identity, MapKV};
 use serde::{Deserialize, Serialize};
 
@@ -83,6 +85,195 @@ pub struct ExecutionWitness {
     pub storage_trie_roots: BTreeMap<H256, Node>,
 }
 
+#[cfg(feature = "eip-8025")]
+mod ssz_witness {
+    use super::*;
+    use libssz::{SszDecode, SszEncode};
+    use libssz_derive::{SszDecode as DeriveSszDecode, SszEncode as DeriveSszEncode};
+    use libssz_types::SszList;
+
+    // Constants set based on the Ethereum spec
+    // https://github.com/ethereum/execution-specs/blob/projects/zkevm/src/ethereum/forks/amsterdam/stateless_ssz.py
+    pub const MAX_WITNESS_NODES: usize = 1 << 22;
+    pub const MAX_WITNESS_CODES: usize = 1 << 18;
+    pub const MAX_WITNESS_HEADERS: usize = 256;
+    pub const MAX_BYTES_PER_WITNESS_NODE: usize = 1 << 10;
+    pub const MAX_BYTES_PER_CODE: usize = 1 << 16;
+    pub const MAX_BYTES_PER_HEADER: usize = 1 << 10;
+    pub const MAX_PUBLIC_KEYS: usize = 1 << 15;
+
+    pub const MAX_BYTES_PER_PUBLIC_KEY: usize = 65;
+    pub const MAX_CHAIN_CONFIG_BYTES: usize = 1 << 10;
+
+    #[derive(Debug, DeriveSszEncode, DeriveSszDecode)]
+    struct SszExecutionWitness {
+        codes: SszList<SszList<u8, MAX_BYTES_PER_CODE>, MAX_WITNESS_CODES>,
+        block_headers_bytes: SszList<SszList<u8, MAX_BYTES_PER_HEADER>, MAX_WITNESS_HEADERS>,
+        first_block_number: u64,
+        chain_config_bytes: SszList<u8, MAX_CHAIN_CONFIG_BYTES>,
+        state_nodes: SszList<SszList<u8, MAX_BYTES_PER_WITNESS_NODE>, MAX_WITNESS_NODES>,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum ExecutionWitnessSszError {
+        #[error("invalid SSZ list bounds: {0}")]
+        InvalidSszType(String),
+        #[error("SSZ decode error: {0}")]
+        SszDecode(#[from] libssz::DecodeError),
+        #[error("RLP decode error: {0}")]
+        RlpDecode(#[from] RLPDecodeError),
+        #[error("chain config error: {0}")]
+        ChainConfig(String),
+        #[error("trie error: {0}")]
+        Trie(#[from] TrieError),
+    }
+
+    fn to_ssz_list<const MAX: usize>(
+        bytes: Vec<u8>,
+    ) -> Result<SszList<u8, MAX>, ExecutionWitnessSszError> {
+        SszList::try_from(bytes)
+            .map_err(|e| ExecutionWitnessSszError::InvalidSszType(e.to_string()))
+    }
+
+    fn to_ssz_vec_vec<const MAX_ITEMS: usize, const MAX_ITEM_BYTES: usize>(
+        items: Vec<Vec<u8>>,
+    ) -> Result<SszList<SszList<u8, MAX_ITEM_BYTES>, MAX_ITEMS>, ExecutionWitnessSszError> {
+        let mut out = Vec::with_capacity(items.len());
+        for item in items {
+            out.push(
+                SszList::try_from(item)
+                    .map_err(|e| ExecutionWitnessSszError::InvalidSszType(e.to_string()))?,
+            );
+        }
+        SszList::try_from(out).map_err(|e| ExecutionWitnessSszError::InvalidSszType(e.to_string()))
+    }
+
+    impl ExecutionWitness {
+        pub fn to_ssz_bytes(&self) -> Result<Vec<u8>, ExecutionWitnessSszError> {
+            // Flatten all embedded tries to RLP-encoded nodes
+            let mut rlp_nodes: Vec<Vec<u8>> = Vec::new();
+            if let Some(root) = &self.state_trie_root {
+                root.encode_subtrie(&mut rlp_nodes)?;
+            }
+            for node in self.storage_trie_roots.values() {
+                node.encode_subtrie(&mut rlp_nodes)?;
+            }
+
+            let ssz = SszExecutionWitness {
+                codes: to_ssz_vec_vec::<MAX_WITNESS_CODES, MAX_BYTES_PER_CODE>(self.codes.clone())?,
+                block_headers_bytes: to_ssz_vec_vec::<MAX_WITNESS_HEADERS, MAX_BYTES_PER_HEADER>(
+                    self.block_headers_bytes.clone(),
+                )?,
+                first_block_number: self.first_block_number,
+                chain_config_bytes: to_ssz_list::<MAX_CHAIN_CONFIG_BYTES>(
+                    self.chain_config.encode_bytes(),
+                )?,
+                state_nodes: to_ssz_vec_vec::<MAX_WITNESS_NODES, MAX_BYTES_PER_WITNESS_NODE>(
+                    rlp_nodes,
+                )?,
+            };
+            Ok(ssz.to_ssz())
+        }
+
+        pub fn from_ssz_bytes(
+            bytes: &[u8],
+            crypto: &dyn Crypto,
+        ) -> Result<Self, ExecutionWitnessSszError> {
+            let ssz_witness = SszExecutionWitness::from_ssz_bytes(bytes)?;
+            let chain_config = ChainConfig::decode_bytes(&ssz_witness.chain_config_bytes)
+                .map_err(ExecutionWitnessSszError::ChainConfig)?;
+
+            let mut node_map = BTreeMap::new();
+            let mut buf = Vec::new();
+            for rlp_list in ssz_witness.state_nodes.into_iter() {
+                let rlp = rlp_list.into_inner();
+                let node = Node::decode(&rlp)?;
+                let hash = node
+                    .compute_hash_no_alloc(&mut buf, crypto)
+                    .finalize(crypto);
+                node_map.insert(hash, node);
+            }
+
+            // Parse parent header to get state root
+            let parent_header_bytes =
+                ssz_witness
+                    .block_headers_bytes
+                    .iter()
+                    .last()
+                    .ok_or_else(|| {
+                        ExecutionWitnessSszError::InvalidSszType(
+                            "no block headers in witness".to_string(),
+                        )
+                    })?;
+            let parent_header = BlockHeader::decode(&mut parent_header_bytes.as_ref())
+                .map_err(ExecutionWitnessSszError::RlpDecode)?;
+            let initial_state_root = parent_header.state_root;
+
+            // Embed state trie and collect account storage roots in one pass
+            let (state_trie_root, storage_trie_roots) = if initial_state_root == *EMPTY_TRIE_HASH {
+                (None, BTreeMap::new())
+            } else if let Some(root_node) = node_map.get(&initial_state_root) {
+                let mut accounts = Vec::new();
+                let embedded = embed_and_collect_accounts(
+                    root_node,
+                    Nibbles::from_raw(&[], false),
+                    &mut accounts,
+                    &node_map,
+                    crypto,
+                );
+
+                // Embed each storage trie
+                let mut storage_trie_roots = BTreeMap::new();
+                for (hashed_address, storage_root_hash) in accounts {
+                    if storage_root_hash == *EMPTY_TRIE_HASH {
+                        continue;
+                    }
+                    if !node_map.contains_key(&storage_root_hash) {
+                        continue;
+                    }
+                    let node_ref = Trie::get_embedded_root(&node_map, storage_root_hash, crypto)?;
+                    let ethrex_trie::NodeRef::Node(node, _) = node_ref else {
+                        continue;
+                    };
+                    storage_trie_roots.insert(hashed_address, (*node).clone());
+                }
+
+                (Some(embedded), storage_trie_roots)
+            } else {
+                return Err(ExecutionWitnessSszError::Trie(TrieError::InconsistentTree(
+                    Box::new(ethrex_trie::InconsistentTreeError::RootNotFound(
+                        initial_state_root,
+                    )),
+                )));
+            };
+
+            Ok(Self {
+                codes: ssz_witness
+                    .codes
+                    .into_iter()
+                    .map(|l| l.into_inner())
+                    .collect(),
+                block_headers_bytes: ssz_witness
+                    .block_headers_bytes
+                    .into_iter()
+                    .map(|l| l.into_inner())
+                    .collect(),
+                first_block_number: ssz_witness.first_block_number,
+                chain_config,
+                state_trie_root,
+                storage_trie_roots,
+            })
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+pub use ssz_witness::{
+    ExecutionWitnessSszError, MAX_BYTES_PER_CODE, MAX_BYTES_PER_HEADER, MAX_BYTES_PER_PUBLIC_KEY,
+    MAX_BYTES_PER_WITNESS_NODE, MAX_PUBLIC_KEYS, MAX_WITNESS_CODES, MAX_WITNESS_HEADERS,
+    MAX_WITNESS_NODES,
+};
+
 /// RPC-friendly representation of an execution witness.
 ///
 /// This is the format returned by the `debug_executionWitness` RPC method.
@@ -144,6 +335,7 @@ impl RpcExecutionWitness {
         self,
         chain_config: ChainConfig,
         first_block_number: u64,
+        crypto: &dyn Crypto,
     ) -> Result<ExecutionWitness, GuestProgramStateError> {
         if first_block_number == 0 {
             return Err(GuestProgramStateError::Custom(
@@ -177,32 +369,25 @@ impl RpcExecutionWitness {
                     // which would fail to decode in ours
                     return None;
                 }
-                let hash = keccak(&b);
+                let hash = H256(crypto.keccak256(&b));
                 Some(Node::decode(&b).map(|node| (hash, node)))
             })
             .collect::<Result<_, RLPDecodeError>>()?;
 
-        // get state trie root and embed the rest of the trie into it
-        let state_trie_root = if let NodeRef::Node(state_trie_root, _) =
-            Trie::get_embedded_root(&nodes, initial_state_root)?
-        {
-            Some((*state_trie_root).clone())
-        } else {
-            None
-        };
-
-        // Walk the state trie to discover accounts and their storage roots,
-        // instead of relying on the keys field which is being removed from the RPC spec.
-        let mut storage_trie_roots = BTreeMap::new();
-        if let Some(state_trie_root) = &state_trie_root {
+        // Embed state trie and collect account storage roots in one pass
+        let (state_trie_root, storage_trie_roots) = if initial_state_root == *EMPTY_TRIE_HASH {
+            (None, BTreeMap::new())
+        } else if let Some(root_node) = nodes.get(&initial_state_root) {
             let mut accounts = Vec::new();
-            collect_accounts_from_trie(
-                state_trie_root,
+            let embedded = embed_and_collect_accounts(
+                root_node,
                 Nibbles::from_raw(&[], false),
                 &mut accounts,
                 &nodes,
+                crypto,
             );
 
+            let mut storage_trie_roots = BTreeMap::new();
             for (hashed_address, storage_root_hash) in accounts {
                 if storage_root_hash == *EMPTY_TRIE_HASH {
                     continue;
@@ -210,7 +395,7 @@ impl RpcExecutionWitness {
                 if !nodes.contains_key(&storage_root_hash) {
                     continue;
                 }
-                let node = Trie::get_embedded_root(&nodes, storage_root_hash)?;
+                let node = Trie::get_embedded_root(&nodes, storage_root_hash, crypto)?;
                 let NodeRef::Node(node, _) = node else {
                     return Err(GuestProgramStateError::Custom(
                         "execution witness does not contain non-empty storage trie".to_string(),
@@ -218,7 +403,13 @@ impl RpcExecutionWitness {
                 };
                 storage_trie_roots.insert(hashed_address, (*node).clone());
             }
-        }
+
+            (Some(embedded), storage_trie_roots)
+        } else {
+            return Err(GuestProgramStateError::Custom(format!(
+                "state root {initial_state_root:?} not found in witness nodes"
+            )));
+        };
 
         Ok(ExecutionWitness {
             codes: self.codes.into_iter().map(|b| b.to_vec()).collect(),
@@ -231,67 +422,69 @@ impl RpcExecutionWitness {
     }
 }
 
-/// Recursively walks an embedded state trie node and collects
+/// Returns the embedded node and populates `accounts` with
 /// `(hashed_address, storage_root)` pairs from leaf nodes.
-fn collect_accounts_from_trie(
+fn embed_and_collect_accounts(
     node: &Node,
     path: Nibbles,
     accounts: &mut Vec<(H256, H256)>,
     nodes: &BTreeMap<H256, Node>,
-) {
+    crypto: &dyn Crypto,
+) -> Node {
     match node {
         Node::Branch(branch) => {
+            let mut new_choices = BranchNode::EMPTY_CHOICES;
             for (i, child) in branch.choices.iter().enumerate() {
                 let child_node: Option<&Node> = match child {
                     NodeRef::Node(n, _) => Some(n),
-                    NodeRef::Hash(hash) if hash.is_valid() => {
-                        nodes.get(&hash.finalize(&NativeCrypto))
-                    }
+                    NodeRef::Hash(hash) if hash.is_valid() => nodes.get(&hash.finalize(crypto)),
                     _ => None,
                 };
-                if let Some(child_node) = child_node {
-                    collect_accounts_from_trie(
+                new_choices[i] = if let Some(child_node) = child_node {
+                    embed_and_collect_accounts(
                         child_node,
                         path.append_new(i as u8),
                         accounts,
                         nodes,
-                    );
-                }
+                        crypto,
+                    )
+                    .into()
+                } else {
+                    child.clone()
+                };
             }
+            BranchNode::new_with_value(new_choices, branch.value.clone()).into()
         }
         Node::Extension(ext) => {
             let child_node: Option<&Node> = match &ext.child {
                 NodeRef::Node(n, _) => Some(n),
-                NodeRef::Hash(hash) if hash.is_valid() => nodes.get(&hash.finalize(&NativeCrypto)),
+                NodeRef::Hash(hash) if hash.is_valid() => nodes.get(&hash.finalize(crypto)),
                 _ => None,
             };
-            if let Some(child_node) = child_node {
-                collect_accounts_from_trie(child_node, path.concat(&ext.prefix), accounts, nodes);
-            }
+            let child = if let Some(child_node) = child_node {
+                embed_and_collect_accounts(
+                    child_node,
+                    path.concat(&ext.prefix),
+                    accounts,
+                    nodes,
+                    crypto,
+                )
+                .into()
+            } else {
+                ext.child.clone()
+            };
+            ExtensionNode::new(ext.prefix.clone(), child).into()
         }
         Node::Leaf(leaf) => {
             let full_path = path.concat(&leaf.partial);
             let path_bytes = full_path.to_bytes();
             if path_bytes.len() == 32 {
                 let hashed_address = H256::from_slice(&path_bytes);
-                match AccountState::decode(&leaf.value) {
-                    Ok(account_state) => {
-                        accounts.push((hashed_address, account_state.storage_root));
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            ?hashed_address,
-                            error = %e,
-                            "Skipping leaf with un-decodable account state"
-                        );
-                    }
+                if let Ok(account_state) = AccountState::decode(&leaf.value) {
+                    accounts.push((hashed_address, account_state.storage_root));
                 }
-            } else {
-                tracing::debug!(
-                    path_len = path_bytes.len(),
-                    "Skipping leaf with unexpected path length (expected 32)"
-                );
             }
+            node.clone()
         }
     }
 }

--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -126,6 +126,8 @@ mod ssz_witness {
         ChainConfig(String),
         #[error("trie error: {0}")]
         Trie(#[from] TrieError),
+        #[error("witness contains no block headers; cannot derive state root")]
+        MissingHeaders,
     }
 
     fn to_ssz_list<const MAX: usize>(
@@ -195,19 +197,29 @@ mod ssz_witness {
             }
 
             // Parse parent header to get state root
-            let parent_header_bytes =
-                ssz_witness
-                    .block_headers_bytes
-                    .iter()
-                    .last()
-                    .ok_or_else(|| {
-                        ExecutionWitnessSszError::InvalidSszType(
-                            "no block headers in witness".to_string(),
-                        )
-                    })?;
-            let parent_header = BlockHeader::decode(&mut parent_header_bytes.as_ref())
-                .map_err(ExecutionWitnessSszError::RlpDecode)?;
-            let initial_state_root = parent_header.state_root;
+            if ssz_witness.block_headers_bytes.is_empty() {
+                return Err(ExecutionWitnessSszError::MissingHeaders);
+            }
+            if ssz_witness.first_block_number == 0 {
+                return Err(ExecutionWitnessSszError::InvalidSszType(
+                    "first_block_number must be > 0 (need parent header)".to_string(),
+                ));
+            }
+            let parent_number = ssz_witness.first_block_number - 1;
+            let mut initial_state_root = None;
+            for hb in &ssz_witness.block_headers_bytes {
+                let header = BlockHeader::decode(&mut hb.as_ref())
+                    .map_err(ExecutionWitnessSszError::RlpDecode)?;
+                if header.number == parent_number {
+                    initial_state_root = Some(header.state_root);
+                    break;
+                }
+            }
+            let initial_state_root = initial_state_root.ok_or_else(|| {
+                ExecutionWitnessSszError::InvalidSszType(format!(
+                    "header for block {parent_number} not found in witness"
+                ))
+            })?;
 
             // Embed state trie and collect account storage roots in one pass
             let (state_trie_root, storage_trie_roots) = if initial_state_root == *EMPTY_TRIE_HASH {

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -663,6 +663,20 @@ impl ChainConfig {
 
         (block_number_based_forks, timestamp_based_forks)
     }
+
+    #[cfg(feature = "eip-8025")]
+    pub fn encode_bytes(&self) -> Vec<u8> {
+        use libssz::SszEncode;
+        SszChainConfig::from(self).to_ssz()
+    }
+
+    #[cfg(feature = "eip-8025")]
+    pub fn decode_bytes(data: &[u8]) -> Result<Self, String> {
+        use libssz::SszDecode;
+        SszChainConfig::from_ssz_bytes(data)
+            .map(|s| ChainConfig::from(&s))
+            .map_err(|e| format!("failed to decode chain config bytes: {e}"))
+    }
 }
 
 #[allow(unused)]
@@ -773,6 +787,277 @@ impl Genesis {
         Trie::compute_hash_from_unsorted_iter(iter, &NativeCrypto)
     }
 }
+
+#[cfg(feature = "eip-8025")]
+#[derive(Clone, Default, libssz_derive::SszEncode, libssz_derive::SszDecode)]
+#[ssz(enum_behaviour = "union")]
+pub enum SszOptionU64 {
+    #[default]
+    None,
+    Some(u64),
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<Option<u64>> for SszOptionU64 {
+    fn from(v: Option<u64>) -> Self {
+        match v {
+            None => Self::None,
+            Some(v) => Self::Some(v),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<&SszOptionU64> for Option<u64> {
+    fn from(v: &SszOptionU64) -> Self {
+        match v {
+            SszOptionU64::None => None,
+            SszOptionU64::Some(v) => Some(*v),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Clone, Default, libssz_derive::SszEncode, libssz_derive::SszDecode)]
+#[ssz(enum_behaviour = "union")]
+pub enum SszOptionU128 {
+    #[default]
+    None,
+    Some(u128),
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<Option<u128>> for SszOptionU128 {
+    fn from(v: Option<u128>) -> Self {
+        match v {
+            None => Self::None,
+            Some(v) => Self::Some(v),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<&SszOptionU128> for Option<u128> {
+    fn from(v: &SszOptionU128) -> Self {
+        match v {
+            SszOptionU128::None => None,
+            SszOptionU128::Some(v) => Some(*v),
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Clone, Default, libssz_derive::SszEncode, libssz_derive::SszDecode)]
+#[ssz(enum_behaviour = "union")]
+pub enum SszOptionBlobSchedule {
+    #[default]
+    None,
+    Some(SszForkBlobSchedule),
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Default, Clone, libssz_derive::SszEncode, libssz_derive::SszDecode)]
+pub struct SszChainConfig {
+    pub chain_id: u64,
+    pub homestead_block: SszOptionU64,
+    pub dao_fork_block: SszOptionU64,
+    pub dao_fork_support: bool,
+
+    pub eip150_block: SszOptionU64,
+    pub eip155_block: SszOptionU64,
+    pub eip158_block: SszOptionU64,
+
+    pub byzantium_block: SszOptionU64,
+    pub constantinople_block: SszOptionU64,
+    pub petersburg_block: SszOptionU64,
+    pub istanbul_block: SszOptionU64,
+    pub muir_glacier_block: SszOptionU64,
+    pub berlin_block: SszOptionU64,
+    pub london_block: SszOptionU64,
+    pub arrow_glacier_block: SszOptionU64,
+    pub gray_glacier_block: SszOptionU64,
+    pub merge_netsplit_block: SszOptionU64,
+
+    pub shanghai_time: SszOptionU64,
+    pub cancun_time: SszOptionU64,
+    pub prague_time: SszOptionU64,
+    pub verkle_time: SszOptionU64,
+    pub osaka_time: SszOptionU64,
+
+    pub bpo1_time: SszOptionU64,
+    pub bpo2_time: SszOptionU64,
+    pub bpo3_time: SszOptionU64,
+    pub bpo4_time: SszOptionU64,
+    pub bpo5_time: SszOptionU64,
+    pub amsterdam_time: SszOptionU64,
+
+    pub terminal_total_difficulty: SszOptionU128,
+    pub terminal_total_difficulty_passed: bool,
+
+    pub blob_schedule_cancun: SszForkBlobSchedule,
+    pub blob_schedule_prague: SszForkBlobSchedule,
+    pub blob_schedule_osaka: SszForkBlobSchedule,
+    pub blob_schedule_bpo1: SszForkBlobSchedule,
+    pub blob_schedule_bpo2: SszForkBlobSchedule,
+    pub blob_schedule_bpo3: SszOptionBlobSchedule,
+    pub blob_schedule_bpo4: SszOptionBlobSchedule,
+    pub blob_schedule_bpo5: SszOptionBlobSchedule,
+    pub blob_schedule_amsterdam: SszOptionBlobSchedule,
+
+    pub deposit_contract_address: [u8; 20],
+    pub enable_verkle_at_genesis: bool,
+}
+
+#[cfg(feature = "eip-8025")]
+#[derive(Default, Clone, libssz_derive::SszEncode, libssz_derive::SszDecode)]
+pub struct SszForkBlobSchedule {
+    pub target: u32,
+    pub max: u32,
+    pub base_fee_update_fraction: u64,
+}
+
+#[cfg(feature = "eip-8025")]
+fn fork_blob_schedule_to_ssz(s: &ForkBlobSchedule) -> SszForkBlobSchedule {
+    SszForkBlobSchedule {
+        target: s.target,
+        max: s.max,
+        base_fee_update_fraction: s.base_fee_update_fraction,
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+fn ssz_to_fork_blob_schedule(s: &SszForkBlobSchedule) -> ForkBlobSchedule {
+    ForkBlobSchedule {
+        target: s.target,
+        max: s.max,
+        base_fee_update_fraction: s.base_fee_update_fraction,
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<&ChainConfig> for SszChainConfig {
+    fn from(c: &ChainConfig) -> Self {
+        SszChainConfig {
+            chain_id: c.chain_id,
+            homestead_block: c.homestead_block.into(),
+            dao_fork_block: c.dao_fork_block.into(),
+            dao_fork_support: c.dao_fork_support,
+            eip150_block: c.eip150_block.into(),
+            eip155_block: c.eip155_block.into(),
+            eip158_block: c.eip158_block.into(),
+            byzantium_block: c.byzantium_block.into(),
+            constantinople_block: c.constantinople_block.into(),
+            petersburg_block: c.petersburg_block.into(),
+            istanbul_block: c.istanbul_block.into(),
+            muir_glacier_block: c.muir_glacier_block.into(),
+            berlin_block: c.berlin_block.into(),
+            london_block: c.london_block.into(),
+            arrow_glacier_block: c.arrow_glacier_block.into(),
+            gray_glacier_block: c.gray_glacier_block.into(),
+            merge_netsplit_block: c.merge_netsplit_block.into(),
+            shanghai_time: c.shanghai_time.into(),
+            cancun_time: c.cancun_time.into(),
+            prague_time: c.prague_time.into(),
+            verkle_time: c.verkle_time.into(),
+            osaka_time: c.osaka_time.into(),
+            bpo1_time: c.bpo1_time.into(),
+            bpo2_time: c.bpo2_time.into(),
+            bpo3_time: c.bpo3_time.into(),
+            bpo4_time: c.bpo4_time.into(),
+            bpo5_time: c.bpo5_time.into(),
+            amsterdam_time: c.amsterdam_time.into(),
+            terminal_total_difficulty: c.terminal_total_difficulty.into(),
+            terminal_total_difficulty_passed: c.terminal_total_difficulty_passed,
+            blob_schedule_cancun: fork_blob_schedule_to_ssz(&c.blob_schedule.cancun),
+            blob_schedule_prague: fork_blob_schedule_to_ssz(&c.blob_schedule.prague),
+            blob_schedule_osaka: fork_blob_schedule_to_ssz(&c.blob_schedule.osaka),
+            blob_schedule_bpo1: fork_blob_schedule_to_ssz(&c.blob_schedule.bpo1),
+            blob_schedule_bpo2: fork_blob_schedule_to_ssz(&c.blob_schedule.bpo2),
+            blob_schedule_bpo3: match &c.blob_schedule.bpo3 {
+                Some(s) => SszOptionBlobSchedule::Some(fork_blob_schedule_to_ssz(s)),
+                None => SszOptionBlobSchedule::None,
+            },
+            blob_schedule_bpo4: match &c.blob_schedule.bpo4 {
+                Some(s) => SszOptionBlobSchedule::Some(fork_blob_schedule_to_ssz(s)),
+                None => SszOptionBlobSchedule::None,
+            },
+            blob_schedule_bpo5: match &c.blob_schedule.bpo5 {
+                Some(s) => SszOptionBlobSchedule::Some(fork_blob_schedule_to_ssz(s)),
+                None => SszOptionBlobSchedule::None,
+            },
+            blob_schedule_amsterdam: match &c.blob_schedule.amsterdam {
+                Some(s) => SszOptionBlobSchedule::Some(fork_blob_schedule_to_ssz(s)),
+                None => SszOptionBlobSchedule::None,
+            },
+            deposit_contract_address: c.deposit_contract_address.0,
+            enable_verkle_at_genesis: c.enable_verkle_at_genesis,
+        }
+    }
+}
+
+#[cfg(feature = "eip-8025")]
+impl From<&SszChainConfig> for ChainConfig {
+    fn from(s: &SszChainConfig) -> Self {
+        ChainConfig {
+            chain_id: s.chain_id,
+            homestead_block: (&s.homestead_block).into(),
+            dao_fork_block: (&s.dao_fork_block).into(),
+            dao_fork_support: s.dao_fork_support,
+            eip150_block: (&s.eip150_block).into(),
+            eip155_block: (&s.eip155_block).into(),
+            eip158_block: (&s.eip158_block).into(),
+            byzantium_block: (&s.byzantium_block).into(),
+            constantinople_block: (&s.constantinople_block).into(),
+            petersburg_block: (&s.petersburg_block).into(),
+            istanbul_block: (&s.istanbul_block).into(),
+            muir_glacier_block: (&s.muir_glacier_block).into(),
+            berlin_block: (&s.berlin_block).into(),
+            london_block: (&s.london_block).into(),
+            arrow_glacier_block: (&s.arrow_glacier_block).into(),
+            gray_glacier_block: (&s.gray_glacier_block).into(),
+            merge_netsplit_block: (&s.merge_netsplit_block).into(),
+            shanghai_time: (&s.shanghai_time).into(),
+            cancun_time: (&s.cancun_time).into(),
+            prague_time: (&s.prague_time).into(),
+            verkle_time: (&s.verkle_time).into(),
+            osaka_time: (&s.osaka_time).into(),
+            bpo1_time: (&s.bpo1_time).into(),
+            bpo2_time: (&s.bpo2_time).into(),
+            bpo3_time: (&s.bpo3_time).into(),
+            bpo4_time: (&s.bpo4_time).into(),
+            bpo5_time: (&s.bpo5_time).into(),
+            amsterdam_time: (&s.amsterdam_time).into(),
+            terminal_total_difficulty: (&s.terminal_total_difficulty).into(),
+            terminal_total_difficulty_passed: s.terminal_total_difficulty_passed,
+            blob_schedule: BlobSchedule {
+                cancun: ssz_to_fork_blob_schedule(&s.blob_schedule_cancun),
+                prague: ssz_to_fork_blob_schedule(&s.blob_schedule_prague),
+                osaka: ssz_to_fork_blob_schedule(&s.blob_schedule_osaka),
+                bpo1: ssz_to_fork_blob_schedule(&s.blob_schedule_bpo1),
+                bpo2: ssz_to_fork_blob_schedule(&s.blob_schedule_bpo2),
+                bpo3: match &s.blob_schedule_bpo3 {
+                    SszOptionBlobSchedule::None => None,
+                    SszOptionBlobSchedule::Some(s) => Some(ssz_to_fork_blob_schedule(s)),
+                },
+                bpo4: match &s.blob_schedule_bpo4 {
+                    SszOptionBlobSchedule::None => None,
+                    SszOptionBlobSchedule::Some(s) => Some(ssz_to_fork_blob_schedule(s)),
+                },
+                bpo5: match &s.blob_schedule_bpo5 {
+                    SszOptionBlobSchedule::None => None,
+                    SszOptionBlobSchedule::Some(s) => Some(ssz_to_fork_blob_schedule(s)),
+                },
+                amsterdam: match &s.blob_schedule_amsterdam {
+                    SszOptionBlobSchedule::None => None,
+                    SszOptionBlobSchedule::Some(s) => Some(ssz_to_fork_blob_schedule(s)),
+                },
+            },
+            deposit_contract_address: Address::from(s.deposit_contract_address),
+            enable_verkle_at_genesis: s.enable_verkle_at_genesis,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/crates/guest-program/src/l1/input.rs
+++ b/crates/guest-program/src/l1/input.rs
@@ -1,16 +1,14 @@
 use ethrex_common::types::Block;
 use ethrex_common::types::block_execution_witness::ExecutionWitness;
 
+#[cfg(feature = "eip-8025")]
+use ethrex_common::types::block_execution_witness::{
+    MAX_BYTES_PER_CODE, MAX_BYTES_PER_HEADER, MAX_BYTES_PER_PUBLIC_KEY, MAX_BYTES_PER_WITNESS_NODE,
+    MAX_PUBLIC_KEYS, MAX_WITNESS_CODES, MAX_WITNESS_HEADERS, MAX_WITNESS_NODES,
+};
+
 /// Input for the L1 stateless validation program.
-#[derive(
-    Clone,
-    Default,
-    serde::Serialize,
-    serde::Deserialize,
-    rkyv::Deserialize,
-    rkyv::Serialize,
-    rkyv::Archive,
-)]
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ProgramInput {
     /// Blocks to execute.
     pub blocks: Vec<Block>,
@@ -36,12 +34,12 @@ pub const EIP8025_VERSION_LEGACY: u8 = 0x00;
 #[cfg(feature = "eip-8025")]
 pub const EIP8025_VERSION_CANONICAL: u8 = 0x01;
 
-/// Encode a `NewPayloadRequest` (SSZ) and `ExecutionWitness` (rkyv) into the
+/// Encode a `NewPayloadRequest` (SSZ) and `ExecutionWitness` (SSZ) into the
 /// legacy EIP-8025 length-prefixed wire format:
 ///
-///   `[version=0x00] [ssz_len: u32 LE] [ssz_bytes] [rkyv_bytes]`
+///   `[version=0x00] [ssz_len: u32 LE] [ssz_bytes] [witness_ssz_bytes]`
 ///
-/// Returns an error if rkyv serialization of the execution witness fails.
+/// Returns an error if SSZ serialization of the execution witness fails.
 #[cfg(feature = "eip-8025")]
 pub fn encode_eip8025(
     new_payload_request: &ethrex_common::types::eip8025_ssz::NewPayloadRequest,
@@ -51,35 +49,17 @@ pub fn encode_eip8025(
 
     let ssz_bytes = new_payload_request.to_ssz();
     let ssz_len = ssz_bytes.len() as u32;
-    let rkyv_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(execution_witness)
-        .map_err(|e| ProgramInputEncodeError::Rkyv(e.to_string()))?;
+    let witness_ssz_bytes = execution_witness
+        .to_ssz_bytes()
+        .map_err(ProgramInputEncodeError::WitnessSsz)?;
 
-    let mut out = Vec::with_capacity(1 + 4 + ssz_bytes.len() + rkyv_bytes.len());
+    let mut out = Vec::with_capacity(1 + 4 + ssz_bytes.len() + witness_ssz_bytes.len());
     out.push(EIP8025_VERSION_LEGACY);
     out.extend_from_slice(&ssz_len.to_le_bytes());
     out.extend_from_slice(&ssz_bytes);
-    out.extend_from_slice(&rkyv_bytes);
+    out.extend_from_slice(&witness_ssz_bytes);
     Ok(out)
 }
-
-// ── canonical SSZ schema ───────────────────────────────────────────
-
-#[cfg(feature = "eip-8025")]
-const MAX_WITNESS_NODES: usize = 1 << 20;
-#[cfg(feature = "eip-8025")]
-const MAX_WITNESS_CODES: usize = 1 << 16;
-#[cfg(feature = "eip-8025")]
-const MAX_WITNESS_HEADERS: usize = 256;
-#[cfg(feature = "eip-8025")]
-const MAX_BYTES_PER_WITNESS_NODE: usize = 1 << 20;
-#[cfg(feature = "eip-8025")]
-const MAX_BYTES_PER_CODE: usize = 1 << 24;
-#[cfg(feature = "eip-8025")]
-const MAX_BYTES_PER_HEADER: usize = 1 << 10;
-#[cfg(feature = "eip-8025")]
-const MAX_PUBLIC_KEYS: usize = 1 << 20;
-#[cfg(feature = "eip-8025")]
-const MAX_BYTES_PER_PUBLIC_KEY: usize = 65;
 
 /// Mirrors `SszChainConfig` from the Amsterdam stateless-validation spec.
 #[cfg(feature = "eip-8025")]
@@ -144,19 +124,22 @@ impl core::fmt::Debug for DecodedEip8025 {
 ///
 /// The first byte is a version discriminator:
 /// - `0x00` → legacy framing
-///   (`[ssz_len: u32 LE] [ssz_bytes] [rkyv ExecutionWitness]`).
+///   (`[ssz_len: u32 LE] [ssz_bytes] [ssz_witness_bytes]`).
 /// - `0x01` → canonical-input framing
-///   (`[ssz_len: u32 LE] [ssz_bytes] [cfg_len: u32 LE] [rkyv ChainConfig]`).
+///   (`[ssz_len: u32 LE] [ssz_bytes] [cfg_len: u32 LE] [ssz ChainConfig]`).
 ///
 /// Anything else surfaces as [`ProgramInputDecodeError::UnknownVersion`].
 #[cfg(feature = "eip-8025")]
-pub fn decode_eip8025(bytes: &[u8]) -> Result<DecodedEip8025, ProgramInputDecodeError> {
+pub fn decode_eip8025(
+    bytes: &[u8],
+    crypto: &dyn ethrex_crypto::Crypto,
+) -> Result<DecodedEip8025, ProgramInputDecodeError> {
     let (version, rest) = bytes
         .split_first()
         .ok_or(ProgramInputDecodeError::TooShort)?;
     match *version {
         EIP8025_VERSION_LEGACY => {
-            let (new_payload_request, execution_witness) = decode_eip8025_legacy(rest)?;
+            let (new_payload_request, execution_witness) = decode_eip8025_legacy(rest, crypto)?;
             Ok(DecodedEip8025::Legacy {
                 new_payload_request,
                 execution_witness,
@@ -176,6 +159,7 @@ pub fn decode_eip8025(bytes: &[u8]) -> Result<DecodedEip8025, ProgramInputDecode
 #[cfg(feature = "eip-8025")]
 fn decode_eip8025_legacy(
     bytes: &[u8],
+    crypto: &dyn ethrex_crypto::Crypto,
 ) -> Result<
     (
         ethrex_common::types::eip8025_ssz::NewPayloadRequest,
@@ -194,13 +178,13 @@ fn decode_eip8025_legacy(
         return Err(ProgramInputDecodeError::TooShort);
     }
     let ssz_bytes = &bytes[4..4 + ssz_len];
-    let rkyv_bytes = &bytes[4 + ssz_len..];
+    let witness_ssz_bytes = &bytes[4 + ssz_len..];
 
     let new_payload_request =
         ethrex_common::types::eip8025_ssz::NewPayloadRequest::from_ssz_bytes(ssz_bytes)
             .map_err(ProgramInputDecodeError::Ssz)?;
-    let execution_witness = rkyv::from_bytes::<ExecutionWitness, rkyv::rancor::Error>(rkyv_bytes)
-        .map_err(|e| ProgramInputDecodeError::Rkyv(e.to_string()))?;
+    let execution_witness = ExecutionWitness::from_ssz_bytes(witness_ssz_bytes, crypto)
+        .map_err(ProgramInputDecodeError::WitnessSsz)?;
 
     Ok((new_payload_request, execution_witness))
 }
@@ -240,9 +224,8 @@ fn decode_eip8025_canonical(
 
     let stateless_input =
         CanonicalStatelessInput::from_ssz_bytes(ssz_bytes).map_err(ProgramInputDecodeError::Ssz)?;
-    let chain_config =
-        rkyv::from_bytes::<ethrex_common::types::ChainConfig, rkyv::rancor::Error>(cfg_bytes)
-            .map_err(|e| ProgramInputDecodeError::Rkyv(e.to_string()))?;
+    let chain_config = ethrex_common::types::ChainConfig::decode_bytes(cfg_bytes)
+        .map_err(ProgramInputDecodeError::ChainConfigSsz)?;
 
     Ok((stateless_input, chain_config))
 }
@@ -250,14 +233,14 @@ fn decode_eip8025_canonical(
 #[cfg(feature = "eip-8025")]
 #[derive(Debug)]
 pub enum ProgramInputEncodeError {
-    Rkyv(String),
+    WitnessSsz(ethrex_common::types::block_execution_witness::ExecutionWitnessSszError),
 }
 
 #[cfg(feature = "eip-8025")]
 impl core::fmt::Display for ProgramInputEncodeError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Rkyv(e) => write!(f, "rkyv encode error: {e}"),
+            Self::WitnessSsz(e) => write!(f, "execution witness SSZ encode error: {e}"),
         }
     }
 }
@@ -267,7 +250,8 @@ impl core::fmt::Display for ProgramInputEncodeError {
 pub enum ProgramInputDecodeError {
     TooShort,
     Ssz(libssz::DecodeError),
-    Rkyv(String),
+    WitnessSsz(ethrex_common::types::block_execution_witness::ExecutionWitnessSszError),
+    ChainConfigSsz(String),
     UnknownVersion(u8),
 }
 
@@ -277,7 +261,8 @@ impl core::fmt::Display for ProgramInputDecodeError {
         match self {
             Self::TooShort => write!(f, "input too short"),
             Self::Ssz(e) => write!(f, "SSZ decode error: {e}"),
-            Self::Rkyv(e) => write!(f, "rkyv decode error: {e}"),
+            Self::WitnessSsz(e) => write!(f, "execution witness SSZ decode error: {e}"),
+            Self::ChainConfigSsz(e) => write!(f, "chain config SSZ decode error: {e}"),
             Self::UnknownVersion(v) => write!(f, "unknown EIP-8025 wire version: {v:#04x}"),
         }
     }

--- a/crates/guest-program/src/l1/program.rs
+++ b/crates/guest-program/src/l1/program.rs
@@ -86,7 +86,7 @@ pub fn execution_program(
 ) -> Result<ProgramOutput, ExecutionError> {
     use libssz_merkle::HashTreeRoot;
 
-    let decoded = super::decode_eip8025(bytes).map_err(|err| {
+    let decoded = super::decode_eip8025(bytes, crypto.as_ref()).map_err(|err| {
         ExecutionError::Internal(format!("failed to decode EIP-8025 input: {err}"))
     })?;
 
@@ -357,27 +357,29 @@ fn validate_versioned_hashes<'a>(
 }
 
 #[cfg(feature = "eip-8025")]
+fn unwrap_ssz_list<const INNER: usize, const OUTER: usize>(
+    list: libssz_types::SszList<libssz_types::SszList<u8, INNER>, OUTER>,
+) -> Vec<bytes::Bytes> {
+    list.into_inner()
+        .into_iter()
+        .map(|inner| bytes::Bytes::from(inner.into_inner()))
+        .collect()
+}
+
+#[cfg(feature = "eip-8025")]
 fn canonical_execution_witness_to_rpc(
     witness: CanonicalExecutionWitness,
 ) -> ethrex_common::types::block_execution_witness::RpcExecutionWitness {
-    use bytes::Bytes;
-
-    fn copy_ssz_bytes<const MAX_BYTES: usize>(
-        bytes: &libssz_types::SszList<u8, MAX_BYTES>,
-    ) -> Bytes {
-        Bytes::from(bytes.iter().copied().collect::<Vec<u8>>())
-    }
-
     ethrex_common::types::block_execution_witness::RpcExecutionWitness {
-        state: witness.state.iter().map(copy_ssz_bytes).collect(),
+        state: unwrap_ssz_list(witness.state),
         // The specs do not have a `keys` field in the witness. This field
         // is inherited from a legacy debug_executionWitness design.
         // A `keys` field is not currently planned to be included in
         // the specs. It might if there is rough consensus it is valuable
         // for execution witness validation performance.
         keys: Vec::new(),
-        codes: witness.codes.iter().map(copy_ssz_bytes).collect(),
-        headers: witness.headers.iter().map(copy_ssz_bytes).collect(),
+        codes: unwrap_ssz_list(witness.codes),
+        headers: unwrap_ssz_list(witness.headers),
     }
 }
 
@@ -399,7 +401,8 @@ fn validate_eip8025_canonical_execution(
         .execution_payload
         .block_number;
     let rpc_witness = canonical_execution_witness_to_rpc(stateless_input.witness);
-    let execution_witness = rpc_witness.into_execution_witness(chain_config, block_number)?;
+    let execution_witness =
+        rpc_witness.into_execution_witness(chain_config, block_number, crypto.as_ref())?;
 
     validate_eip8025_amsterdam_execution(
         &stateless_input.new_payload_request,

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -27,6 +27,7 @@ fn merkle_pool() -> Arc<rayon::ThreadPool> {
 }
 #[cfg(feature = "stateless")]
 use ethrex_common::types::block_execution_witness::RpcExecutionWitness;
+use ethrex_crypto::NativeCrypto;
 use ethrex_common::{
     constants::EMPTY_KECCACK_HASH,
     types::{
@@ -590,7 +591,7 @@ async fn run_stateless_from_fixture(
                 format!("executionWitness parse failed for {test_key} block {block_number}: {e}")
             })?;
         let execution_witness = rpc_witness
-            .into_execution_witness(*chain_config, block_number)
+            .into_execution_witness(*chain_config, block_number, &NativeCrypto)
             .map_err(|e| {
                 format!("witness conversion failed for {test_key} block {block_number}: {e}")
             })?;


### PR DESCRIPTION
**Motivation**
Replace `rkyv` encoding of `ExecutionWitness` and `ChainConfig` with SSZ. This aligns with the encoding in the [stateless specification](https://github.com/ethereum/execution-specs/blob/projects/zkevm/src/ethereum/forks/amsterdam/stateless.py).

The earlier effort in PR #6524 was left behind because of a major change in PR #6550. This PR builds on top of it. 

**Description**
The major change is the new `SszExecutionWitness`, which stores RPL-nodes and wraps them in an SSZ container. The difference is that everything is flat bytes as opposed to the previous recursive representation as `Node`. Decoding in the guest reconstructs the embedded trie.

The new `SszChainConfig` implements SSZ encoding for `ChainConfig`. Since `libssz` does not have support for `Option`, we introduce `SszOptionU64`, `SszOptionU128`, and `SszOptionBlobSchedule` types with `#[ssz(enum_behaviour = "union")]`.

This PR intentionally keeps `RpcExecutionWitness` to keep the changes atomic. Currently, we cast from canonical witness to rpc witness and finally to execution witness. We could convert directly to execution witness and get rid of `RpcExecutionWitness`. I would like to open a discussion if it is necessary to maintain `RpcExecutionWitness`.

**Setting ChainConfig Size**
Fixed-size fields: `chain_id` 8B, `dao_fork_support` 1B, `terminal_total_difficulty_passed`1B, `deposit_contract_address` 20B, `enable_verkle_at_genesis` 1B, 5x `SszForkBlobSchedule` 16B
Total: 111B
        
Variable size have each [1B selector](https://github.com/lambdaclass/libssz/blob/main/crates/ssz-derive/src/lib.rs#L289) and value (assume worst case): 26x `SszOptionU64` each 9B, `SszOptionU128` 17B, 4x `SszOptionBlobSchedule`each 17B
Total: 319B

Offsets for variable size types are [4B each](https://github.com/lambdaclass/libssz/blob/main/crates/ssz/src/lib.rs), so 31x 4B =  124B. Total space required is 554B, so 1024 is enough, and we keep some buffer. 

**Profiling**
Profiling in ZisK v0.16.1 on mainnet blocks 24949787 - 24949811:
- Average cost (main `37669b7c3`): 45.17852B
- Average cost (this change): 57.15699B

This is ~20% regression. The flat SSZ encoding requires the guest to rebuild the tree as opposed to `rkyv,` which serialized the tree structure directly. To my understanding, this is inherent in the encoding choice of the specification. This PR is meant to be a transition towards the specification, and further optimizations should be introduced.