### PR TITLE
fix(l2): use full git SHA for nix-built TDX prover

### DIFF
--- a/crates/l2/tee/quote-gen/Makefile
+++ b/crates/l2/tee/quote-gen/Makefile
@@ -3,7 +3,7 @@
 
 IMAGE_NAME = ethrex-image_0.1.raw
 NIXPKGS_URL = https://github.com/NixOS/nixpkgs/archive/3fcbdcfc707e0aa42c541b7743e05820472bdaec.tar.gz
-GIT_REV := $(shell git rev-parse --short=7 HEAD)
+GIT_REV := $(shell git rev-parse HEAD)
 NIX_BUILD_ARGS = --no-out-link -I nixpkgs=$(NIXPKGS_URL) --argstr gitRev "$(GIT_REV)"
 
 image.raw:

--- a/crates/l2/tee/quote-gen/service.nix
+++ b/crates/l2/tee/quote-gen/service.nix
@@ -1,6 +1,6 @@
 { gitRev }:
-assert (builtins.stringLength gitRev == 7)
-  || throw "gitRev must be exactly 7 characters use (git rev-parse --short=7 HEAD)";
+assert (builtins.stringLength gitRev == 40)
+  || throw "gitRev must be exactly 40 characters use (git rev-parse HEAD)";
 
 let
   pkgs = import <nixpkgs> { };


### PR DESCRIPTION
**Motivation**

The TDX job has been failing since the change in #6725. In #6789 we fixed the general L2 case but TDX, which uses a different (nix) build system, wasn't addressed.

**Description**

We replicate the fix of passing the full SHA to the builder.
