### PR TITLE
fix(l1): correct off-by-one and constant in engine getBlobs/getPayloadBodies size limits

### DIFF
--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -79,7 +79,7 @@ impl RpcHandler for BlobsV1Request {
             ));
         }
 
-        if self.blob_versioned_hashes.len() >= GET_BLOBS_V1_REQUEST_MAX_SIZE {
+        if self.blob_versioned_hashes.len() > GET_BLOBS_V1_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
 
@@ -155,7 +155,7 @@ async fn get_blobs_and_proof(
     context: RpcApiContext,
     version: u64,
 ) -> Result<Vec<Option<BlobAndProofV2>>, RpcErr> {
-    if blob_versioned_hashes.len() >= GET_BLOBS_V1_REQUEST_MAX_SIZE {
+    if blob_versioned_hashes.len() > GET_BLOBS_V1_REQUEST_MAX_SIZE {
         return Err(RpcErr::TooLargeRequest);
     }
 
@@ -373,5 +373,26 @@ mod tests {
 
         let err = request.handle(context).await.unwrap_err();
         assert!(matches!(err, RpcErr::TooLargeRequest));
+    }
+
+    #[tokio::test]
+    async fn blobs_v3_accepts_exactly_max_size() {
+        // Spec: clients MUST support at least MAX hashes, so exactly MAX must not be rejected.
+        let context = context_with_chain_config(true).await;
+        let request = BlobsV3Request {
+            blob_versioned_hashes: vec![H256::zero(); GET_BLOBS_V1_REQUEST_MAX_SIZE],
+        };
+        let result = request.handle(context).await;
+        assert!(!matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn blobs_v1_accepts_exactly_max_size_before_osaka() {
+        let context = context_with_chain_config(false).await;
+        let request = BlobsV1Request {
+            blob_versioned_hashes: vec![H256::zero(); GET_BLOBS_V1_REQUEST_MAX_SIZE],
+        };
+        let result = request.handle(context).await;
+        assert!(!matches!(result, Err(RpcErr::TooLargeRequest)));
     }
 }

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -21,8 +21,9 @@ use crate::types::payload::{
 use crate::utils::RpcErr;
 use crate::utils::{RpcRequest, parse_json_hex};
 
-// Engine API (Shanghai): clients MUST support request sizes of at least 1024 block hashes.
-// -> https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification-3
+// The Engine API (Shanghai) only mandates supporting request sizes of at least 32 blocks.
+// Cap at MAX_REQUEST_BLOCKS = 1024, the largest request a conforming consensus client makes.
+// -> https://github.com/ethereum/consensus-specs/blob/a84880a47a88700d8dfa451c2a7cd4b3f309bd0d/specs/phase0/p2p-interface.md#configuration
 const GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE: u64 = 1024;
 
 // NewPayload V1-V2-V3 implementations

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -21,10 +21,9 @@ use crate::types::payload::{
 use crate::utils::RpcErr;
 use crate::utils::{RpcRequest, parse_json_hex};
 
-// Must support rquest sizes of at least 32 blocks
-// Chosen an arbitrary x4 value
+// Engine API (Shanghai): clients MUST support request sizes of at least 1024 block hashes.
 // -> https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification-3
-const GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE: u64 = 128;
+const GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE: u64 = 1024;
 
 // NewPayload V1-V2-V3 implementations
 pub struct NewPayloadV1Request {
@@ -716,7 +715,7 @@ impl RpcHandler for GetPayloadBodiesByHashV1Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        if self.hashes.len() as u64 >= GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
+        if self.hashes.len() as u64 > GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
         let mut bodies = Vec::new();
@@ -752,7 +751,7 @@ impl RpcHandler for GetPayloadBodiesByRangeV1Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        if self.count >= GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
+        if self.count > GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
         let latest_block_number = context.storage.get_latest_block_number().await?;
@@ -839,7 +838,7 @@ impl RpcHandler for GetPayloadBodiesByHashV2Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        if self.hashes.len() as u64 >= GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
+        if self.hashes.len() as u64 > GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
 
@@ -885,7 +884,7 @@ impl RpcHandler for GetPayloadBodiesByRangeV2Request {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        if self.count >= GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
+        if self.count > GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
         let latest_block_number = context.storage.get_latest_block_number().await?;
@@ -1464,8 +1463,10 @@ async fn get_payload(payload_id: u64, context: &RpcApiContext) -> Result<Payload
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::default_context_with_storage;
     use ethrex_common::types::ChainConfig;
     use ethrex_rlp::encode::RLPEncode;
+    use ethrex_storage::{EngineType, Store};
 
     fn header(number: u64) -> BlockHeader {
         BlockHeader {
@@ -1593,5 +1594,89 @@ mod tests {
         )
             .encode_to_vec();
         assert_eq!(encoded.as_ref(), expected.as_slice());
+    }
+
+    async fn test_context() -> RpcApiContext {
+        let storage = Store::new("test-payload-bodies", EngineType::InMemory)
+            .expect("Failed to create test store");
+        default_context_with_storage(storage).await
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_hash_v1_accepts_exactly_max_size() {
+        // Spec: clients MUST support request sizes of at least the max constant, so
+        // exactly MAX must be served, not rejected.
+        let request = GetPayloadBodiesByHashV1Request {
+            hashes: vec![BlockHash::default(); GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE as usize],
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(!matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_hash_v1_rejects_above_max_size() {
+        let request = GetPayloadBodiesByHashV1Request {
+            hashes: vec![BlockHash::default(); GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE as usize + 1],
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_range_v1_accepts_exactly_max_size() {
+        let request = GetPayloadBodiesByRangeV1Request {
+            start: 1,
+            count: GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE,
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(!matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_range_v1_rejects_above_max_size() {
+        let request = GetPayloadBodiesByRangeV1Request {
+            start: 1,
+            count: GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE + 1,
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_hash_v2_accepts_exactly_max_size() {
+        let request = GetPayloadBodiesByHashV2Request {
+            hashes: vec![BlockHash::default(); (GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE) as usize],
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(!matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_hash_v2_rejects_above_max_size() {
+        let request = GetPayloadBodiesByHashV2Request {
+            hashes: vec![BlockHash::default(); (GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE + 1) as usize],
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_range_v2_accepts_exactly_max_size() {
+        let request = GetPayloadBodiesByRangeV2Request {
+            start: 1,
+            count: GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE,
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(!matches!(result, Err(RpcErr::TooLargeRequest)));
+    }
+
+    #[tokio::test]
+    async fn get_payload_bodies_by_range_v2_rejects_above_max_size() {
+        let request = GetPayloadBodiesByRangeV2Request {
+            start: 1,
+            count: GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE + 1,
+        };
+        let result = request.handle(test_context().await).await;
+        assert!(matches!(result, Err(RpcErr::TooLargeRequest)));
     }
 }


### PR DESCRIPTION
> Credit: the diagnosis, the cross-client audit, the spec citations and the exact proposed diff are
> all @stefa2k's work in #6674. This PR implements that fix and adds boundary tests.

## Motivation

Two engine-API request-size validation bugs (#6674):

1. **Off-by-one.** The size checks use `>= MAX` where the spec requires `> MAX`. The spec text
   "Client software MUST support request sizes of at least N" requires N itself to be served; only
   N + 1 and above should be rejected.
2. **Wrong constant.** `GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE` was `128`. The engine spec only
   mandates supporting request sizes of at least 32 here; the cap is raised to `1024` to match
   [`MAX_REQUEST_BLOCKS`](https://github.com/ethereum/consensus-specs/blob/a84880a47a88700d8dfa451c2a7cd4b3f309bd0d/specs/phase0/p2p-interface.md#configuration),
   the largest batch a conforming CL requests.

A spec-compliant CL requesting payload bodies during sync at typical batch sizes (256 / 512 / 1024)
received `TooLargeRequest`, forcing smaller retries and lowering throughput when peering with
ethrex. The other mainnet ELs (geth, reth, besu, erigon, nethermind) all use a strict `>` against
the spec constants.

## Changes

- `crates/networking/rpc/engine/blobs.rs`: `>=` -> `>` on the two `getBlobs` size checks.
- `crates/networking/rpc/engine/payload.rs`: `GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE` `128` -> `1024`,
  and `>=` -> `>` on the four `getPayloadBodies` handlers.

This only loosens validation: previously-rejected requests at the spec-required minimum now succeed;
no previously-accepted request becomes rejected.

## Tests

Added boundary tests asserting that requests at exactly `MAX_SIZE` are not rejected (they were
before this change), alongside the existing `MAX_SIZE + 1` rejection checks:

- `blobs.rs`: `blobs_v3_accepts_exactly_max_size`, `blobs_v1_accepts_exactly_max_size_before_osaka`.
- `payload.rs`: accept-at-`MAX` and reject-above-`MAX` boundary tests for all four handlers
  (`GetPayloadBodiesByHashV1`, `ByRangeV1`, `ByHashV2`, `ByRangeV2`).

Closes #6674.
