### PR TITLE
ci(l1): refresh Amsterdam hive fixtures, fix dead eels branch, add engine ef-test job

### DIFF
--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -147,7 +147,11 @@ jobs:
           fi
 
           if [[ -n "$SIM_LIMIT" ]]; then
-            FLAGS+=" --sim.limit \"$SIM_LIMIT\""
+            # Single-quote the limit so regex metacharacters (e.g. the `|` in
+            # multi-fork limits) survive the action's shell re-evaluation of
+            # extra_flags. Matches pr-main_l1.yaml's escaping.
+            escaped_limit=${SIM_LIMIT//\'/\'\\\'\'}
+            FLAGS+=" --sim.limit '$escaped_limit'"
           fi
           echo "flags=$FLAGS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -136,8 +136,8 @@ jobs:
             else
               # All other forks (Prague, Osaka, Cancun, Shanghai, Paris) use fixtures_develop
               # which includes comprehensive test coverage including static tests
-              FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_develop.tar.gz"
-              FLAGS+=" --sim.buildarg branch=forks/osaka"
+              FLAGS+=" --sim.buildarg fixtures=https://github.com/ethereum/execution-spec-tests/releases/download/v5.4.0/fixtures_develop.tar.gz"
+              FLAGS+=" --sim.buildarg branch=forks/amsterdam"
             fi
             FLAGS+=" --client.checktimelimit=180s"
           fi

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -463,7 +463,7 @@ jobs:
     # "Integration Test" is a required check, don't change the name
     name: Integration Test
     runs-on: ubuntu-latest
-    needs: [detect-changes, run-assertoor, run-hive, check-cargo-locks]
+    needs: [detect-changes, run-assertoor, run-hive, check-cargo-locks, engine-ef-tests]
     # Make sure this job runs even if the previous jobs failed or were skipped
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
     steps:
@@ -476,6 +476,12 @@ jobs:
 
           if [ "${{ needs.run-hive.result }}" != "success" ]; then
             echo "Job Hive failed"
+            exit 1
+          fi
+
+          # engine-ef-tests is skipped in the merge queue (merge_group), which is OK.
+          if [ "${{ needs.engine-ef-tests.result }}" != "success" ] && [ "${{ needs.engine-ef-tests.result }}" != "skipped" ]; then
+            echo "Job Engine EF tests failed"
             exit 1
           fi
 

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -138,6 +138,24 @@ jobs:
             cat docs/known_issues.md
           } >> "$GITHUB_STEP_SUMMARY"
 
+  engine-ef-tests:
+    name: Engine EF tests
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && github.event_name != 'merge_group' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk
+
+      - name: Setup Rust Environment
+        uses: ./.github/actions/setup-rust
+
+      - name: Run Engine EF tests
+        run: make -C tooling/ef_tests/engine test
+
   known-issues-comment:
     name: Post Known Issues sticky comment
     runs-on: ubuntu-latest

--- a/tooling/ef_tests/engine/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/engine/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-6%40v1.1.0/fixtures_snobal-devnet-6.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-bal%40v7.2.0/fixtures_bal.tar.gz


### PR DESCRIPTION
Three test-infra fixes surfaced from the daily hive report.

**`daily_hive_report.yaml`** — the non-Amsterdam consume jobs pinned execution-specs `forks/osaka`, deleted upstream (now `forks/amsterdam`), so the eels image build failed with exit 128 for the Prague/Rest jobs (visible only as annotations since the step isn't gated). Point at `forks/amsterdam` and bump develop fixtures `v5.3.0` → `v5.4.0`.

**`tooling/ef_tests/engine/.fixtures_url_amsterdam`** — the Amsterdam overlay pinned `snobal-devnet-6`, which predates the current BAL implementation, so `make -C tooling/ef_tests/engine test` failed ~8.5k fixtures. Point at `tests-bal@v7.2.0` (what the Amsterdam hive jobs use); the suite now passes 83143/83143.

**`pr-main_l1.yaml`** — add an `engine-ef-tests` job so the in-process engine runner gates per-PR alongside the existing blockchain ef-tests.
