### PR TITLE
fix(l1): fix full sync wedge on body fetch failures and canonical-but-stateless state gaps

### DIFF
--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -47,7 +47,10 @@ impl StoreVmDatabase {
             .has_state_root(block_header.state_root)
             .map_err(|e| EvmError::DB(e.to_string()))?
         {
-            return Err(EvmError::DB("state root missing".to_string()));
+            return Err(EvmError::DB(format!(
+                "state root missing for block {} (state_root {:#x})",
+                block_header.number, block_header.state_root
+            )));
         }
         Ok(StoreVmDatabase {
             store,
@@ -68,7 +71,10 @@ impl StoreVmDatabase {
             .has_state_root(block_header.state_root)
             .map_err(|e| EvmError::DB(e.to_string()))?
         {
-            return Err(EvmError::DB("state root missing".to_string()));
+            return Err(EvmError::DB(format!(
+                "state root missing for block {} (state_root {:#x})",
+                block_header.number, block_header.state_root
+            )));
         }
         Ok(StoreVmDatabase {
             store,

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -71,8 +71,10 @@ impl HeaderFetchOutcome {
     pub fn failure_reason(&self) -> &'static str {
         match self {
             HeaderFetchOutcome::Headers(_) => "headers received",
-            HeaderFetchOutcome::NoPeerAvailable => "no eth peer available to ask",
-            HeaderFetchOutcome::PeerFailed => "peer(s) asked but did not serve headers",
+            HeaderFetchOutcome::NoPeerAvailable => {
+                "no eth-capable peer with a live connection to query (peers may be connecting or recently dropped)"
+            }
+            HeaderFetchOutcome::PeerFailed => "peer(s) queried but did not serve headers",
         }
     }
 }
@@ -148,11 +150,12 @@ impl PeerHandler {
             .await?)
     }
 
-    /// Number of connected peers that advertise the eth capabilities used for sync.
-    /// Sync diagnostics use this to tell "no peers to ask" (discovery/connectivity
-    /// problem) apart from "peers present but not serving" (the chain data is gone).
-    /// Returns 0 on any peer-table error since this is only used for logging.
-    pub async fn eth_peer_count(&self) -> usize {
+    /// Number of peers known to the table that advertise the eth capabilities used for sync.
+    /// NOTE: this counts eth-capable peers regardless of whether they currently have a live
+    /// connection, so it can be greater than the number actually queryable via
+    /// `get_random_peer` (which requires a live connection). Used only for diagnostics; logged
+    /// as `eth_capable_peers`. Returns 0 on any peer-table error.
+    pub async fn eth_capable_peer_count(&self) -> usize {
         self.peer_table
             .peer_count_by_capabilities(SUPPORTED_ETH_CAPABILITIES.to_vec())
             .await

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -462,11 +462,16 @@ impl PeerHandler {
                 })) = response
                 {
                     if block_headers.is_empty() {
-                        // Empty response is valid per eth spec (peer may not have these blocks)
+                        // Empty response is valid per eth spec (peer may not have these blocks),
+                        // so apply only a soft score penalty (`record_failure`) rather than
+                        // ejecting the peer (`set_disposable`): a spec-conformant peer that simply
+                        // lacks a fork's blocks shouldn't be permanently dropped from rotation.
+                        // Genuine misbehavior below (unchained / wrong-chain-start) uses the same
+                        // soft tier, so the distinction stays consistent.
                         debug!(
                             "[SYNCING] Received empty headers from peer {peer_id}, trying another"
                         );
-                        let _ = self.peer_table.set_disposable(peer_id);
+                        self.peer_table.record_failure(peer_id)?;
                         return Ok(HeaderFetchOutcome::PeerFailed);
                     }
                     if are_block_headers_chained(&block_headers, &order) {

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -470,6 +470,23 @@ impl PeerHandler {
                         return Ok(HeaderFetchOutcome::PeerFailed);
                     }
                     if are_block_headers_chained(&block_headers, &order) {
+                        // Pin the response to the requested `start` hash. `are_block_headers_chained`
+                        // only verifies internal parent-hash linkage, not that the sequence actually
+                        // begins at `start`. A peer on a fork/minority chain can return an internally
+                        // consistent run of headers from its own chain that does NOT start at `start`;
+                        // accepting it derails the sync walk onto the wrong chain — it never reconciles
+                        // to our canonical head and walks all the way to genesis. Reject the mismatch and
+                        // penalize the peer so the caller re-rolls `get_random_peer` and keeps trying until
+                        // it lands a peer actually serving `start`'s chain (whose ancestry is hash-linked
+                        // and therefore bridges down to our canonical head). General hardening, not
+                        // devnet-specific.
+                        if block_headers[0].hash() != start {
+                            warn!(
+                                "[SYNCING] Peer {peer_id} returned headers not starting at the requested hash {start:#x}, penalizing peer"
+                            );
+                            self.peer_table.record_failure(peer_id)?;
+                            return Ok(HeaderFetchOutcome::PeerFailed);
+                        }
                         self.peer_table.record_success(peer_id)?;
                         return Ok(HeaderFetchOutcome::Headers(block_headers));
                     }

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -124,6 +124,17 @@ impl PeerHandler {
             .await?)
     }
 
+    /// Number of connected peers that advertise the eth capabilities used for sync.
+    /// Sync diagnostics use this to tell "no peers to ask" (discovery/connectivity
+    /// problem) apart from "peers present but not serving" (the chain data is gone).
+    /// Returns 0 on any peer-table error since this is only used for logging.
+    pub async fn eth_peer_count(&self) -> usize {
+        self.peer_table
+            .peer_count_by_capabilities(SUPPORTED_ETH_CAPABILITIES.to_vec())
+            .await
+            .unwrap_or(0)
+    }
+
     /// Requests block headers from any suitable peer, starting from the `start` block hash towards either older or newer blocks depending on the order
     /// Returns the block headers or None if:
     /// - There are no available peers (the node just started up or was rejected by all other nodes)

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -53,6 +53,30 @@ pub enum BlockRequestOrder {
     NewToOld,
 }
 
+/// Result of a block-header request, distinguishing why no headers came back so sync
+/// diagnostics can tell a connectivity problem from peers withholding data.
+#[derive(Debug)]
+pub enum HeaderFetchOutcome {
+    /// Headers were obtained from a peer.
+    Headers(Vec<BlockHeader>),
+    /// No suitable peer was available to send the request to (e.g. no eth-capable peer
+    /// connected, or all are busy / penalized).
+    NoPeerAvailable,
+    /// A peer was queried but returned no usable response (timeout, empty, or unchained).
+    PeerFailed,
+}
+
+impl HeaderFetchOutcome {
+    /// A short, log-friendly reason for a non-`Headers` outcome.
+    pub fn failure_reason(&self) -> &'static str {
+        match self {
+            HeaderFetchOutcome::Headers(_) => "headers received",
+            HeaderFetchOutcome::NoPeerAvailable => "no eth peer available to ask",
+            HeaderFetchOutcome::PeerFailed => "peer(s) asked but did not serve headers",
+        }
+    }
+}
+
 /// Asks a single already-selected peer for the block number at `sync_head`.
 /// Consumes a `RequestPermit`; the permit drops on return, releasing the slot.
 async fn ask_peer_head_number(
@@ -413,7 +437,7 @@ impl PeerHandler {
         &mut self,
         start: H256,
         order: BlockRequestOrder,
-    ) -> Result<Option<Vec<BlockHeader>>, PeerHandlerError> {
+    ) -> Result<HeaderFetchOutcome, PeerHandlerError> {
         let request_id = rand::random();
         let request = RLPxMessage::GetBlockHeaders(GetBlockHeaders {
             id: request_id,
@@ -423,7 +447,7 @@ impl PeerHandler {
             reverse: matches!(order, BlockRequestOrder::NewToOld),
         });
         match self.get_random_peer(&SUPPORTED_ETH_CAPABILITIES).await? {
-            None => Ok(None),
+            None => Ok(HeaderFetchOutcome::NoPeerAvailable),
             Some((peer_id, mut connection, permit)) => {
                 let response = connection
                     .outgoing_request(request, PEER_REPLY_TIMEOUT)
@@ -440,25 +464,25 @@ impl PeerHandler {
                             "[SYNCING] Received empty headers from peer {peer_id}, trying another"
                         );
                         let _ = self.peer_table.set_disposable(peer_id);
-                        return Ok(None);
+                        return Ok(HeaderFetchOutcome::PeerFailed);
                     }
                     if are_block_headers_chained(&block_headers, &order) {
                         self.peer_table.record_success(peer_id)?;
-                        return Ok(Some(block_headers));
+                        return Ok(HeaderFetchOutcome::Headers(block_headers));
                     }
                     // Non-empty but unchained headers is a protocol violation
                     warn!(
                         "[SYNCING] Received invalid (unchained) headers from peer, penalizing peer {peer_id}"
                     );
                     self.peer_table.record_failure(peer_id)?;
-                    return Ok(None);
+                    return Ok(HeaderFetchOutcome::PeerFailed);
                 }
                 // Timeout or invalid response - mark peer as disposable
                 warn!(
                     "[SYNCING] Didn't receive block headers from peer, penalizing peer {peer_id}..."
                 );
                 self.peer_table.record_failure(peer_id)?;
-                Ok(None)
+                Ok(HeaderFetchOutcome::PeerFailed)
             }
         }
     }

--- a/crates/networking/p2p/snap/constants.rs
+++ b/crates/networking/p2p/snap/constants.rs
@@ -122,6 +122,10 @@ pub const MAX_BLOCK_BODIES_TO_REQUEST: usize = 128;
 /// when no peer can serve headers at all.
 pub const MAX_HEADER_FETCH_ATTEMPTS: u64 = 10;
 
+/// Maximum attempts before giving up on a block-body download during full sync.
+/// Mirrors the header-fetch policy; split out so the two can diverge if needed.
+pub const MAX_BODY_FETCH_ATTEMPTS: u64 = MAX_HEADER_FETCH_ATTEMPTS;
+
 // =============================================================================
 // SNAP SYNC THRESHOLDS
 // =============================================================================

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -9,6 +9,11 @@ mod full;
 mod healing;
 mod snap_sync;
 
+/// Test-only re-export of the full-sync resume-point predicate so integration tests can
+/// assert that canonical-but-stateless blocks are not treated as already-executed.
+#[cfg(feature = "test-utils")]
+pub use full::is_resume_point;
+
 use crate::metrics::METRICS;
 use crate::peer_handler::{BlockRequestOrder, PeerHandler, PeerHandlerError};
 use crate::snap::constants::{EXECUTE_BATCH_SIZE_DEFAULT, MIN_FULL_BLOCKS};

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -12,7 +12,7 @@ mod snap_sync;
 /// Test-only re-export of the full-sync resume-point predicate so integration tests can
 /// assert that canonical-but-stateless blocks are not treated as already-executed.
 #[cfg(feature = "test-utils")]
-pub use full::is_resume_point;
+pub use full::{first_resume_point_in_batch, is_resume_point};
 
 use crate::metrics::METRICS;
 use crate::peer_handler::{BlockRequestOrder, HeaderFetchOutcome, PeerHandler, PeerHandlerError};

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -63,6 +63,12 @@ pub enum SyncMode {
 pub struct SyncDiagnostics {
     pub sync_mode: String,
     pub current_phase: String,
+    /// Highest block whose post-state is actually on disk (the executed/state head).
+    /// Updated by the full-sync cycle. May trail the canonical head when an FCU
+    /// canonicalized blocks before their state was computed; `eth_syncing` reports
+    /// this rather than the canonical pointer so the node isn't shown as near-synced
+    /// while it has no state up to the tip.
+    pub executed_head: u64,
     pub pivot_block_number: Option<u64>,
     pub pivot_timestamp: Option<u64>,
     pub pivot_age_seconds: Option<u64>,
@@ -238,6 +244,7 @@ impl Syncer {
                     self.cancel_token.clone(),
                     sync_head,
                     store,
+                    &self.diagnostics,
                 )
                 .await;
             }
@@ -264,6 +271,7 @@ impl Syncer {
                 self.cancel_token.clone(),
                 sync_head,
                 store,
+                &self.diagnostics,
             )
             .await
         }

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -351,8 +351,6 @@ pub enum SyncError {
     JoinHandle(#[from] tokio::task::JoinError),
     #[error("Missing data from DB")]
     CorruptDB,
-    #[error("No bodies were found for the given headers")]
-    BodiesNotFound,
     #[error("Failed to fetch latest canonical block, unable to sync")]
     NoLatestCanonical,
     #[error("Range received is invalid")]
@@ -441,7 +439,6 @@ impl SyncError {
             | SyncError::Rlp(_)
             | SyncError::JoinHandle(_)
             | SyncError::CorruptDB
-            | SyncError::BodiesNotFound
             | SyncError::InvalidRangeReceived
             | SyncError::BlockNumber(_)
             | SyncError::NoBlocks

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -15,7 +15,7 @@ mod snap_sync;
 pub use full::is_resume_point;
 
 use crate::metrics::METRICS;
-use crate::peer_handler::{BlockRequestOrder, PeerHandler, PeerHandlerError};
+use crate::peer_handler::{BlockRequestOrder, HeaderFetchOutcome, PeerHandler, PeerHandlerError};
 use crate::snap::constants::{EXECUTE_BATCH_SIZE_DEFAULT, MIN_FULL_BLOCKS};
 use crate::utils::delete_leaves_folder;
 use ethrex_blockchain::{Blockchain, error::ChainError};
@@ -292,15 +292,16 @@ async fn probe_sync_head_number(peers: &mut PeerHandler, sync_head: H256) -> Opt
             .request_block_headers_from_hash(sync_head, BlockRequestOrder::NewToOld)
             .await
         {
-            Ok(Some(headers)) => {
+            Ok(HeaderFetchOutcome::Headers(headers)) => {
                 if let Some(header) = headers.iter().find(|h| h.hash() == sync_head) {
                     return Some(header.number);
                 }
                 debug!("Sync head probe: response did not contain target header");
             }
-            Ok(None) => {
+            Ok(outcome) => {
                 debug!(
-                    "Sync head probe attempt {attempt}/{PROBE_SYNC_HEAD_ATTEMPTS}: no peer response"
+                    reason = outcome.failure_reason(),
+                    "Sync head probe attempt {attempt}/{PROBE_SYNC_HEAD_ATTEMPTS}: no headers"
                 );
             }
             Err(e) => {

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -79,9 +79,9 @@ async fn request_bodies_with_retry(
         }
         let from = headers.first().map(|h| h.number).unwrap_or_default();
         let to = headers.last().map(|h| h.number).unwrap_or_default();
-        let eth_peers = peers.eth_peer_count().await;
+        let eth_capable_peers = peers.eth_capable_peer_count().await;
         warn!(
-            eth_peers,
+            eth_capable_peers,
             from,
             to,
             "Failed to fetch block bodies (attempt {attempt}/{MAX_BODY_FETCH_ATTEMPTS}), retrying in 2s"
@@ -113,10 +113,10 @@ pub async fn sync_cycle_full(
     store: Store,
 ) -> Result<(), SyncError> {
     let local_head = store.get_latest_block_number().await?;
-    let eth_peers = peers.eth_peer_count().await;
+    let eth_capable_peers = peers.eth_capable_peer_count().await;
     info!(
         local_head,
-        eth_peers,
+        eth_capable_peers,
         ?sync_head,
         "Starting full sync cycle"
     );
@@ -168,10 +168,10 @@ pub async fn sync_cycle_full(
             // peers withholding data.
             other => {
                 let reason = other.failure_reason();
-                let eth_peers = peers.eth_peer_count().await;
+                let eth_capable_peers = peers.eth_capable_peer_count().await;
                 if attempts >= MAX_HEADER_FETCH_ATTEMPTS {
                     warn!(
-                        eth_peers,
+                        eth_capable_peers,
                         reason,
                         ?sync_head,
                         "Sync failed to find target block header after {attempts} attempts, aborting to wait for a newer sync head"
@@ -180,7 +180,7 @@ pub async fn sync_cycle_full(
                 }
                 attempts += 1;
                 warn!(
-                    eth_peers,
+                    eth_capable_peers,
                     reason,
                     "Failed to fetch headers for sync head (attempt {attempts}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
                 );
@@ -327,9 +327,9 @@ pub async fn sync_cycle_full(
                         // Bodies unavailable after retries: stop gracefully (drop the sender)
                         // so the executor finishes what it has and the cycle ends without an
                         // error. The next forkchoice head will trigger a fresh attempt.
-                        let eth_peers = download_peers.eth_peer_count().await;
+                        let eth_capable_peers = download_peers.eth_capable_peer_count().await;
                         warn!(
-                            eth_peers,
+                            eth_capable_peers,
                             "Block bodies unavailable from peers after retries; pausing full sync until a new forkchoice head arrives"
                         );
                         return;
@@ -390,9 +390,9 @@ pub async fn sync_cycle_full(
                         // Bodies unavailable after retries: stop gracefully (drop the sender)
                         // so the executor finishes what it has and the cycle ends without an
                         // error. The next forkchoice head will trigger a fresh attempt.
-                        let eth_peers = download_peers.eth_peer_count().await;
+                        let eth_capable_peers = download_peers.eth_capable_peer_count().await;
                         warn!(
-                            eth_peers,
+                            eth_capable_peers,
                             "Block bodies unavailable from peers after retries; pausing full sync until a new forkchoice head arrives"
                         );
                         return;

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -232,6 +232,19 @@ pub async fn sync_cycle_full(
                 // newer, already-stored batches that start one above this batch's newest.
                 None => start_block_number = batch_newest_number + 1,
             }
+            // If we are resuming at or below the canonical head, the canonical chain extends
+            // past the executed-state head: an FCU canonicalized blocks before their state
+            // was computed. Surface it explicitly; these canonical-but-stateless blocks are
+            // re-executed below, and the warning flags the underlying gap for investigation.
+            let canonical_head = store.get_latest_block_number().await?;
+            if start_block_number <= canonical_head {
+                warn!(
+                    state_head = start_block_number.saturating_sub(1),
+                    canonical_head,
+                    gap = canonical_head + 1 - start_block_number,
+                    "Full sync resuming below canonical head: re-executing canonical-but-stateless blocks (FCU canonicalized past executed state)"
+                );
+            }
             // If the fullsync consists of a single batch of headers we can just keep them in memory instead of writing them to Store
             if single_batch {
                 headers = block_headers.into_iter().rev().collect();

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -249,19 +249,31 @@ pub async fn sync_cycle_full(
             Some(parent) => is_resume_point(&store, &parent)?,
             None => false,
         };
-        if parent_is_resume_point || sync_head.is_zero() {
-            // Incoming chain merged with our executed state.
-            // Drop only the already-executed (canonical + stateful) prefix; keep any
-            // canonical-but-stateless blocks so they get re-executed. Because both
-            // canonical-ness and state presence are contiguous from genesis, the first
-            // canonical+stateful header scanning newest->oldest is exactly the state head.
-            let mut first_skippable = block_headers.len();
+        // Scan THIS batch for the first resume point (newest->oldest). The batch may itself
+        // straddle our executed/state head: the walk has reached down into the region we
+        // already have state for. Checking only `parent_is_resume_point` (the parent of the
+        // batch's OLDEST header) misses this — when our stateful head sits in the MIDDLE of a
+        // batch the parent check is false, so the walk blew past our own local head and kept
+        // descending all the way to genesis (the issue #9 overshoot). Only scan once the batch
+        // can actually contain our head (its oldest block is at/below `local_head`); higher
+        // batches are entirely unexecuted and cannot hold a resume point, so skip the scan for
+        // them to keep the deep-sync walk cheap.
+        let mut first_skippable = block_headers.len();
+        if last_header.number <= local_head {
             for (index, header) in block_headers.iter().enumerate() {
                 if is_resume_point(&store, header)? {
                     first_skippable = index;
                     break;
                 }
             }
+        }
+        let batch_contains_resume_point = first_skippable < block_headers.len();
+        if parent_is_resume_point || batch_contains_resume_point || sync_head.is_zero() {
+            // Incoming chain merged with our executed state.
+            // Drop only the already-executed (canonical + stateful) prefix (computed as
+            // `first_skippable` above); keep any canonical-but-stateless blocks so they get
+            // re-executed. Because both canonical-ness and state presence are contiguous from
+            // genesis, the first canonical+stateful header newest->oldest is exactly the state head.
             block_headers.drain(first_skippable..block_headers.len());
             match block_headers.last() {
                 Some(last_header) => start_block_number = last_header.number,

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -269,6 +269,39 @@ pub async fn sync_cycle_full(
                 // newer, already-stored batches that start one above this batch's newest.
                 None => start_block_number = batch_newest_number.saturating_add(1),
             }
+            // Guard against resuming onto a base whose post-state is gone. Execution begins at
+            // `start_block_number`, whose parent (`start_block_number - 1`) must have its post-state
+            // on disk. That holds when we broke on a stateful resume point (the normal catch-up and
+            // the FCU-ahead backfill cases, where the parent is the executed/state head). It does NOT
+            // hold when the walk bottomed out at genesis (`sync_head.is_zero()`) after reconciling the
+            // consensus sync head only to a canonical block whose state was already pruned: the layered
+            // store keeps state for a recent window and drops genesis-era layers as the head advances
+            // (see `TrieLayerCache`), so a fork/deep-reorg head that diverges below that window has no
+            // stateful resume point and the walk descends to block 0. Re-executing from such a pruned
+            // base fails forever with `state root missing for block {parent}`. Detect it and pause the
+            // cycle gracefully (Ok) — mirroring the body-fetch exhaustion path — until a forkchoice head
+            // reconciles to a block whose state we still retain. (Pre-#6803 the walk anchored on the
+            // pruned canonical block and failed at block N; the stateful-resume-point gate now walks
+            // past it to genesis, so this guard is required to avoid a doomed re-exec from block 0.)
+            let resume_parent_number = start_block_number.saturating_sub(1);
+            let resume_parent_has_state = match store.get_block_header(resume_parent_number)? {
+                Some(parent) => store.has_state_root(parent.state_root)?,
+                None => false,
+            };
+            if !resume_parent_has_state {
+                let local_head = store.get_latest_block_number().await?;
+                warn!(
+                    resume_parent_number,
+                    local_head,
+                    "Full sync cannot resume: post-state for block {resume_parent_number} is absent \
+                     (pruned from the layered store, or never executed). The consensus sync head does \
+                     not reconcile to a block whose state we retain; pausing until a reconcilable \
+                     forkchoice head arrives. If this persists with no state above genesis, the datadir \
+                     needs a fresh resync (ethrex removedb)."
+                );
+                store.clear_fullsync_headers().await?;
+                return Ok(());
+            }
             // If we are resuming at or below the canonical head, the canonical chain extends
             // past the executed-state head: an FCU canonicalized blocks before their state
             // was computed. Surface it explicitly; these canonical-but-stateless blocks are

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -21,7 +21,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::peer_handler::{BlockRequestOrder, PeerHandler};
-use crate::snap::constants::{MAX_BLOCK_BODIES_TO_REQUEST, MAX_HEADER_FETCH_ATTEMPTS};
+use crate::snap::constants::{
+    MAX_BLOCK_BODIES_TO_REQUEST, MAX_BODY_FETCH_ATTEMPTS, MAX_HEADER_FETCH_ATTEMPTS,
+};
 
 use super::{EXECUTE_BATCH_SIZE, SyncError};
 
@@ -65,9 +67,15 @@ async fn request_bodies_with_retry(
     peers: &mut PeerHandler,
     headers: &[BlockHeader],
 ) -> Result<Option<Vec<BlockBody>>, SyncError> {
-    for attempt in 1..=MAX_HEADER_FETCH_ATTEMPTS {
+    for attempt in 1..=MAX_BODY_FETCH_ATTEMPTS {
         if let Some(bodies) = peers.request_block_bodies(headers).await? {
             return Ok(Some(bodies));
+        }
+        // On the final attempt don't log "retrying" or sleep: the loop is about to give up.
+        // The caller emits the "bodies unavailable after retries" message. Mirrors the
+        // header-fetch loop, which checks the limit before sleeping.
+        if attempt == MAX_BODY_FETCH_ATTEMPTS {
+            break;
         }
         let from = headers.first().map(|h| h.number).unwrap_or_default();
         let to = headers.last().map(|h| h.number).unwrap_or_default();
@@ -76,7 +84,7 @@ async fn request_bodies_with_retry(
             eth_peers,
             from,
             to,
-            "Failed to fetch block bodies (attempt {attempt}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
+            "Failed to fetch block bodies (attempt {attempt}/{MAX_BODY_FETCH_ATTEMPTS}), retrying in 2s"
         );
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
@@ -248,7 +256,7 @@ pub async fn sync_cycle_full(
                 Some(last_header) => start_block_number = last_header.number,
                 // Whole batch was already executed; the blocks we keep (if any) live in
                 // newer, already-stored batches that start one above this batch's newest.
-                None => start_block_number = batch_newest_number + 1,
+                None => start_block_number = batch_newest_number.saturating_add(1),
             }
             // If we are resuming at or below the canonical head, the canonical chain extends
             // past the executed-state head: an FCU canonicalized blocks before their state
@@ -259,7 +267,9 @@ pub async fn sync_cycle_full(
                 warn!(
                     state_head = start_block_number.saturating_sub(1),
                     canonical_head,
-                    gap = canonical_head + 1 - start_block_number,
+                    gap = canonical_head
+                        .saturating_add(1)
+                        .saturating_sub(start_block_number),
                     "Full sync resuming below canonical head: re-executing canonical-but-stateless blocks (FCU canonicalized past executed state)"
                 );
             }
@@ -391,7 +401,11 @@ pub async fn sync_cycle_full(
         }
     });
 
-    // Main loop: receive downloaded batches and execute them
+    // Main loop: receive downloaded batches and execute them. `reached_target` records
+    // whether we executed the final batch; if body downloads gave up early (the task
+    // returns without sending the final batch), it stays false so we don't falsely report
+    // catching up to the consensus head below.
+    let mut reached_target = false;
     while let Some(result) = body_rx.recv().await {
         let (blocks, final_batch) = result?;
         info!(
@@ -409,6 +423,9 @@ pub async fn sync_cycle_full(
             peers,
         )
         .await?;
+        if final_batch {
+            reached_target = true;
+        }
     }
 
     // Ensure the download task completes and propagate any panics
@@ -431,15 +448,24 @@ pub async fn sync_cycle_full(
             peers,
         )
         .await?;
+        reached_target = true;
     }
 
-    // If this cycle started behind, announce that we've caught up to the head the
-    // consensus client gave us, so the operator can tell idle-waiting from a hang.
+    // If this cycle started behind, report the outcome so the operator can tell idle-waiting
+    // from a hang. Only claim we caught up if we actually executed through to the target;
+    // if body downloads gave up early we say so instead of falsely reporting success.
     if started_behind {
         let local_head = store.get_latest_block_number().await?;
-        info!(
-            "Reached consensus-provided head at block {local_head}. Waiting for the next forkchoice update from the consensus client."
-        );
+        if reached_target {
+            info!(
+                "Reached consensus-provided head at block {local_head}. Waiting for the next forkchoice update from the consensus client."
+            );
+        } else {
+            warn!(
+                local_head,
+                "Full sync paused before reaching the consensus-provided head (data unavailable from peers); will resume on the next forkchoice update"
+            );
+        }
     }
 
     store.clear_fullsync_headers().await?;

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -20,7 +20,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use crate::peer_handler::{BlockRequestOrder, PeerHandler};
+use crate::peer_handler::{BlockRequestOrder, HeaderFetchOutcome, PeerHandler};
 use crate::snap::constants::{
     MAX_BLOCK_BODIES_TO_REQUEST, MAX_BODY_FETCH_ATTEMPTS, MAX_HEADER_FETCH_ATTEMPTS,
 };
@@ -157,27 +157,36 @@ pub async fn sync_cycle_full(
 
     // Request and store all block headers from the advertised sync head
     loop {
-        let Some(mut block_headers) = peers
+        let outcome = peers
             .request_block_headers_from_hash(sync_head, BlockRequestOrder::NewToOld)
-            .await?
-        else {
-            let eth_peers = peers.eth_peer_count().await;
-            if attempts >= MAX_HEADER_FETCH_ATTEMPTS {
+            .await?;
+        let mut block_headers = match outcome {
+            HeaderFetchOutcome::Headers(headers) => headers,
+            // No headers this round: `reason` says whether we couldn't find a peer to ask
+            // ("no eth peer available") or peers were asked and didn't serve ("peer(s) asked
+            // but did not serve headers"), so operators can tell connectivity apart from
+            // peers withholding data.
+            other => {
+                let reason = other.failure_reason();
+                let eth_peers = peers.eth_peer_count().await;
+                if attempts >= MAX_HEADER_FETCH_ATTEMPTS {
+                    warn!(
+                        eth_peers,
+                        reason,
+                        ?sync_head,
+                        "Sync failed to find target block header after {attempts} attempts, aborting to wait for a newer sync head"
+                    );
+                    return Ok(());
+                }
+                attempts += 1;
                 warn!(
                     eth_peers,
-                    ?sync_head,
-                    "Sync failed to find target block header after {attempts} attempts, aborting to wait for a newer sync head. \
-                     eth_peers=0 means no peers to ask (discovery/connectivity); >0 means peers are not serving the headers"
+                    reason,
+                    "Failed to fetch headers for sync head (attempt {attempts}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
                 );
-                return Ok(());
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
             }
-            attempts += 1;
-            warn!(
-                eth_peers,
-                "Failed to fetch headers for sync head (attempt {attempts}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
-            );
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            continue;
         };
         debug!("Sync Log 9: Received {} block headers", block_headers.len());
         // Reset failure counter on success so it tracks consecutive failures

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -103,8 +103,10 @@ pub fn is_resume_point(store: &Store, header: &BlockHeader) -> Result<bool, Sync
 
 /// Index of the first resume point in a single newest->oldest header batch, or `None` if the
 /// batch contains none. The headers before that index are the missing blocks to execute; the
-/// header at that index is our executed/state head (state presence is contiguous from genesis,
-/// so the first canonical+stateful header scanning newest->oldest is exactly that head).
+/// header at that index is our executed/state head. State is retained only for a recent window
+/// down from the executed head (the layered store prunes older layers), so scanning newest->oldest
+/// the first canonical+stateful header is exactly that head — the stateless prefix above it is the
+/// not-yet-executed blocks, and everything below it within the retained window is also stateful.
 ///
 /// Scanning the batch *interior* — rather than only checking the parent of the batch's oldest
 /// header — is what stops the walk-back overshooting its own stateful head down to genesis when
@@ -202,10 +204,9 @@ pub async fn sync_cycle_full(
             .await?;
         let mut block_headers = match outcome {
             HeaderFetchOutcome::Headers(headers) => headers,
-            // No headers this round: `reason` says whether we couldn't find a peer to ask
-            // ("no eth peer available") or peers were asked and didn't serve ("peer(s) asked
-            // but did not serve headers"), so operators can tell connectivity apart from
-            // peers withholding data.
+            // No headers this round: `reason` (from `HeaderFetchOutcome::failure_reason`) says
+            // whether we couldn't find a peer to query or a peer was queried but didn't serve, so
+            // operators can tell connectivity apart from peers withholding data.
             other => {
                 let reason = other.failure_reason();
                 let eth_capable_peers = peers.eth_capable_peer_count().await;
@@ -296,9 +297,9 @@ pub async fn sync_cycle_full(
         if parent_is_resume_point || batch_resume_index.is_some() || sync_head.is_zero() {
             // Incoming chain merged with our executed state.
             // Drop only the already-executed (canonical + stateful) prefix; keep any
-            // canonical-but-stateless blocks so they get re-executed. Because both
-            // canonical-ness and state presence are contiguous from genesis, the first
-            // canonical+stateful header newest->oldest is exactly the state head.
+            // canonical-but-stateless blocks so they get re-executed. State is retained for a
+            // recent window down from the executed head, so the first canonical+stateful header
+            // scanning newest->oldest is exactly that state head.
             let first_skippable = batch_resume_index.unwrap_or(block_headers.len());
             block_headers.drain(first_skippable..block_headers.len());
             match block_headers.last() {
@@ -519,24 +520,43 @@ pub async fn sync_cycle_full(
     // Ensure the download task completes and propagate any panics
     download_task.await?;
 
-    // Execute pending blocks
-    if !pending_blocks.is_empty() {
-        info!(
-            "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
-            pending_blocks.len(),
-            pending_blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
-            pending_blocks.last().ok_or(SyncError::NoBlocks)?.hash()
-        );
-        add_blocks_in_batch(
-            blockchain.clone(),
-            cancel_token.clone(),
-            pending_blocks,
-            true,
-            store.clone(),
-            peers,
-        )
-        .await?;
-        reached_target = true;
+    // Execute pending blocks, but only if the downloaded chain they build on was fully
+    // executed first. The oldest pending block's parent is the rewound `sync_head`, i.e. the
+    // newest downloaded header; if body downloads gave up early its post-state is absent and
+    // executing the pending blocks would fail with `state root missing`. Gate on actual state
+    // presence rather than `reached_target`: the common follow-head case has no gap to download
+    // (nothing is sent, so `reached_target` stays false) yet the parent state is already on disk.
+    if let Some(oldest_pending) = pending_blocks.first() {
+        let parent_has_state =
+            match store.get_block_header_by_hash(oldest_pending.header.parent_hash)? {
+                Some(parent) => store.has_state_root(parent.state_root)?,
+                None => false,
+            };
+        if !parent_has_state {
+            let local_head = store.get_latest_block_number().await?;
+            warn!(
+                local_head,
+                "Skipping {} pending block(s): the downloaded chain they build on was not fully executed (parent state absent); will retry on the next forkchoice update",
+                pending_blocks.len()
+            );
+        } else {
+            info!(
+                "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
+                pending_blocks.len(),
+                pending_blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
+                pending_blocks.last().ok_or(SyncError::NoBlocks)?.hash()
+            );
+            add_blocks_in_batch(
+                blockchain.clone(),
+                cancel_token.clone(),
+                pending_blocks,
+                true,
+                store.clone(),
+                peers,
+            )
+            .await?;
+            reached_target = true;
+        }
     }
 
     // If this cycle started behind, report the outcome so the operator can tell idle-waiting

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -114,6 +114,12 @@ pub fn is_resume_point(store: &Store, header: &BlockHeader) -> Result<bool, Sync
 /// Gated to batches whose oldest block is at/below `local_head`: a batch entirely above our head
 /// is all unexecuted and cannot contain a resume point, so the per-header state lookups are
 /// skipped for it, keeping the deep-sync walk cheap.
+///
+/// Cost: up to O(N) `has_state_root` probes for a batch of length N (256-1024 in production), but
+/// typically 2-5 — the scan terminates at the state head, which sits at or just below the
+/// not-yet-executed prefix. The pathological full-batch walk only happens when the state head is
+/// far below the batch's newest header (a long canonical-but-stateless gap from an FCU-ahead-of-
+/// execution window); each probe is a single MPT root lookup.
 pub fn first_resume_point_in_batch(
     store: &Store,
     block_headers: &[BlockHeader],

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -16,6 +16,7 @@ use ethrex_common::{
     types::{Block, BlockBody, BlockHeader, block_access_list::BlockAccessList},
 };
 use ethrex_storage::Store;
+use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -25,7 +26,7 @@ use crate::snap::constants::{
     MAX_BLOCK_BODIES_TO_REQUEST, MAX_BODY_FETCH_ATTEMPTS, MAX_HEADER_FETCH_ATTEMPTS,
 };
 
-use super::{EXECUTE_BATCH_SIZE, SyncError};
+use super::{EXECUTE_BATCH_SIZE, SyncDiagnostics, SyncError};
 
 /// Forkchoice heads older than this (in seconds) trigger a "consensus is behind"
 /// warning during sync. A synced consensus client always advertises a head only
@@ -111,6 +112,7 @@ pub async fn sync_cycle_full(
     cancel_token: CancellationToken,
     mut sync_head: H256,
     store: Store,
+    diagnostics: &Arc<RwLock<SyncDiagnostics>>,
 ) -> Result<(), SyncError> {
     let local_head = store.get_latest_block_number().await?;
     let eth_capable_peers = peers.eth_capable_peer_count().await;
@@ -272,9 +274,15 @@ pub async fn sync_cycle_full(
             // was computed. Surface it explicitly; these canonical-but-stateless blocks are
             // re-executed below, and the warning flags the underlying gap for investigation.
             let canonical_head = store.get_latest_block_number().await?;
+            // `start_block_number - 1` is the highest block whose post-state is on
+            // disk (the executed/state head). Record it so `eth_syncing` reports real
+            // progress instead of the canonical pointer, which an FCU may have advanced
+            // past the executed state.
+            let state_head = start_block_number.saturating_sub(1);
+            diagnostics.write().await.executed_head = state_head;
             if start_block_number <= canonical_head {
                 warn!(
-                    state_head = start_block_number.saturating_sub(1),
+                    state_head,
                     canonical_head,
                     gap = canonical_head
                         .saturating_add(1)

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -13,7 +13,7 @@ use ethrex_blockchain::{
 };
 use ethrex_common::{
     H256,
-    types::{Block, block_access_list::BlockAccessList},
+    types::{Block, BlockBody, BlockHeader, block_access_list::BlockAccessList},
 };
 use ethrex_storage::Store;
 use tokio::time::Instant;
@@ -51,6 +51,39 @@ fn humanize_secs(secs: u64) -> String {
     } else {
         format!("{mins}m")
     }
+}
+
+/// Request block bodies for `headers`, retrying with backoff when peers don't serve them.
+///
+/// Mirrors the header-fetch resilience loop: peers transiently failing to return bodies
+/// (a `None` from `request_block_bodies`) is not a fatal condition, especially on a
+/// degraded network. Returns `Ok(None)` only after all attempts are exhausted, signalling
+/// the caller to stop the cycle gracefully and wait for a fresh sync head rather than
+/// aborting the whole cycle with an error (which would discard the downloaded headers and
+/// re-walk them from scratch on every retry).
+async fn request_bodies_with_retry(
+    peers: &mut PeerHandler,
+    headers: &[BlockHeader],
+) -> Result<Option<Vec<BlockBody>>, SyncError> {
+    for attempt in 1..=MAX_HEADER_FETCH_ATTEMPTS {
+        if let Some(bodies) = peers.request_block_bodies(headers).await? {
+            return Ok(Some(bodies));
+        }
+        warn!(
+            "Failed to fetch block bodies (attempt {attempt}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
+        );
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    Ok(None)
+}
+
+/// A block is a valid full-sync resume point only if it is canonical AND its post-state is
+/// present on disk. Canonical-but-stateless blocks (e.g. a head canonicalized by an FCU
+/// before its state was computed; see `apply_fork_choice`) are NOT resume points: building
+/// on them fails forever with `state root missing`, so full sync must keep and re-execute
+/// them rather than skip them as "already canonical".
+pub fn is_resume_point(store: &Store, header: &BlockHeader) -> Result<bool, SyncError> {
+    Ok(store.is_canonical_sync(header.hash())? && store.has_state_root(header.state_root)?)
 }
 
 /// Performs full sync cycle - fetches and executes all blocks between current head and sync head
@@ -100,11 +133,6 @@ pub async fn sync_cycle_full(
     // a synced node. Set on the first batch of headers we fetch.
     let mut started_behind = false;
     let mut sync_target_logged = false;
-
-    // Latest canonical block. The backward walk below also stops here: our head
-    // (e.g. a snap-sync pivot) may be a lone canonical block sitting mid-batch,
-    // which the lowest-parent check would skip, running the walk down to genesis.
-    let local_latest_number = store.get_latest_block_number().await?;
 
     // Request and store all block headers from the advertised sync head
     loop {
@@ -168,39 +196,49 @@ pub async fn sync_cycle_full(
         }
 
         end_block_number = end_block_number.max(first_header.number);
-        start_block_number = last_header.number;
+        // This batch's newest block number, captured before `block_headers` is drained.
+        // `start_block_number` is finalized in the break branch below.
+        let batch_newest_number = first_header.number;
 
         sync_head = last_header.parent_hash;
-        let parent_is_canonical = store.is_canonical_sync(sync_head)? || sync_head.is_zero();
-        // The batch has descended to our head: scan it for the canonical ancestor
-        // the lowest-parent check above can miss (e.g. a lone snap-sync pivot).
-        let reached_local_head = last_header.number <= local_latest_number;
-        if parent_is_canonical || reached_local_head {
-            // Incoming chain merged with current chain
-            // Filter out already canonical blocks from batch
-            let mut first_canon_block = block_headers.len();
+        // We can only resume execution from a block whose post-state is actually on disk.
+        // `is_canonical_sync` alone is insufficient: an FCU can canonicalize a head before
+        // its state is computed (`apply_fork_choice` gates only on the branch link block),
+        // so the canonical chain can extend past the executed-state head. Anchoring on such
+        // a canonical-but-stateless block makes execution fail forever with `state root
+        // missing`. A block is a valid resume point only if it is canonical AND stateful;
+        // canonical-but-stateless blocks are kept and re-executed to backfill their state.
+        let parent_is_resume_point = match store.get_block_header_by_hash(sync_head)? {
+            Some(parent) => is_resume_point(&store, &parent)?,
+            None => false,
+        };
+        if parent_is_resume_point || sync_head.is_zero() {
+            // Incoming chain merged with our executed state.
+            // Drop only the already-executed (canonical + stateful) prefix; keep any
+            // canonical-but-stateless blocks so they get re-executed. Because both
+            // canonical-ness and state presence are contiguous from genesis, the first
+            // canonical+stateful header scanning newest->oldest is exactly the state head.
+            let mut first_skippable = block_headers.len();
             for (index, header) in block_headers.iter().enumerate() {
-                if store.is_canonical_sync(header.hash())? {
-                    first_canon_block = index;
+                if is_resume_point(&store, header)? {
+                    first_skippable = index;
                     break;
                 }
             }
-            // Only merge if we actually connected: parent canonical, or a
-            // canonical ancestor found in the batch. Otherwise keep walking
-            // (e.g. a reorg where our head isn't on the incoming chain).
-            if parent_is_canonical || first_canon_block < block_headers.len() {
-                block_headers.drain(first_canon_block..block_headers.len());
-                if let Some(last_header) = block_headers.last() {
-                    start_block_number = last_header.number;
-                }
-                // If the fullsync consists of a single batch of headers we can just keep them in memory instead of writing them to Store
-                if single_batch {
-                    headers = block_headers.into_iter().rev().collect();
-                } else {
-                    store.add_fullsync_batch(block_headers).await?;
-                }
-                break;
+            block_headers.drain(first_skippable..block_headers.len());
+            match block_headers.last() {
+                Some(last_header) => start_block_number = last_header.number,
+                // Whole batch was already executed; the blocks we keep (if any) live in
+                // newer, already-stored batches that start one above this batch's newest.
+                None => start_block_number = batch_newest_number + 1,
             }
+            // If the fullsync consists of a single batch of headers we can just keep them in memory instead of writing them to Store
+            if single_batch {
+                headers = block_headers.into_iter().rev().collect();
+            } else {
+                store.add_fullsync_batch(block_headers).await?;
+            }
+            break;
         }
         store.add_fullsync_batch(block_headers).await?;
         single_batch = false;
@@ -226,7 +264,7 @@ pub async fn sync_cycle_full(
             while !batch_headers.is_empty() {
                 let end = min(MAX_BLOCK_BODIES_TO_REQUEST, batch_headers.len());
                 let header_batch = &batch_headers[..end];
-                match download_peers.request_block_bodies(header_batch).await {
+                match request_bodies_with_retry(&mut download_peers, header_batch).await {
                     Ok(Some(bodies)) => {
                         debug!("Obtained: {} block bodies", bodies.len());
                         let block_batch = batch_headers
@@ -236,11 +274,16 @@ pub async fn sync_cycle_full(
                         blocks.extend(block_batch);
                     }
                     Ok(None) => {
-                        let _ = body_tx.send(Err(SyncError::BodiesNotFound)).await;
+                        // Bodies unavailable after retries: stop gracefully (drop the sender)
+                        // so the executor finishes what it has and the cycle ends without an
+                        // error. The next forkchoice head will trigger a fresh attempt.
+                        warn!(
+                            "Block bodies unavailable from peers after retries; pausing full sync until a new forkchoice head arrives"
+                        );
                         return;
                     }
                     Err(e) => {
-                        let _ = body_tx.send(Err(e.into())).await;
+                        let _ = body_tx.send(Err(e)).await;
                         return;
                     }
                 }
@@ -282,7 +325,7 @@ pub async fn sync_cycle_full(
             while !batch_headers.is_empty() {
                 let end = min(MAX_BLOCK_BODIES_TO_REQUEST, batch_headers.len());
                 let header_batch = &batch_headers[..end];
-                match download_peers.request_block_bodies(header_batch).await {
+                match request_bodies_with_retry(&mut download_peers, header_batch).await {
                     Ok(Some(bodies)) => {
                         debug!("Obtained: {} block bodies", bodies.len());
                         let block_batch = batch_headers
@@ -292,11 +335,16 @@ pub async fn sync_cycle_full(
                         blocks.extend(block_batch);
                     }
                     Ok(None) => {
-                        let _ = body_tx.send(Err(SyncError::BodiesNotFound)).await;
+                        // Bodies unavailable after retries: stop gracefully (drop the sender)
+                        // so the executor finishes what it has and the cycle ends without an
+                        // error. The next forkchoice head will trigger a fresh attempt.
+                        warn!(
+                            "Block bodies unavailable from peers after retries; pausing full sync until a new forkchoice head arrives"
+                        );
                         return;
                     }
                     Err(e) => {
-                        let _ = body_tx.send(Err(e.into())).await;
+                        let _ = body_tx.send(Err(e)).await;
                         return;
                     }
                 }

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -69,7 +69,13 @@ async fn request_bodies_with_retry(
         if let Some(bodies) = peers.request_block_bodies(headers).await? {
             return Ok(Some(bodies));
         }
+        let from = headers.first().map(|h| h.number).unwrap_or_default();
+        let to = headers.last().map(|h| h.number).unwrap_or_default();
+        let eth_peers = peers.eth_peer_count().await;
         warn!(
+            eth_peers,
+            from,
+            to,
             "Failed to fetch block bodies (attempt {attempt}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
         );
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -98,7 +104,14 @@ pub async fn sync_cycle_full(
     mut sync_head: H256,
     store: Store,
 ) -> Result<(), SyncError> {
-    info!("Syncing to sync_head {:?}", sync_head);
+    let local_head = store.get_latest_block_number().await?;
+    let eth_peers = peers.eth_peer_count().await;
+    info!(
+        local_head,
+        eth_peers,
+        ?sync_head,
+        "Starting full sync cycle"
+    );
 
     // Check if the sync_head is a pending block, if so, gather all pending blocks belonging to its chain
     let mut pending_blocks = vec![];
@@ -140,14 +153,19 @@ pub async fn sync_cycle_full(
             .request_block_headers_from_hash(sync_head, BlockRequestOrder::NewToOld)
             .await?
         else {
+            let eth_peers = peers.eth_peer_count().await;
             if attempts >= MAX_HEADER_FETCH_ATTEMPTS {
                 warn!(
-                    "Sync failed to find target block header after {attempts} attempts, aborting to wait for a newer sync head"
+                    eth_peers,
+                    ?sync_head,
+                    "Sync failed to find target block header after {attempts} attempts, aborting to wait for a newer sync head. \
+                     eth_peers=0 means no peers to ask (discovery/connectivity); >0 means peers are not serving the headers"
                 );
                 return Ok(());
             }
             attempts += 1;
             warn!(
+                eth_peers,
                 "Failed to fetch headers for sync head (attempt {attempts}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
             );
             tokio::time::sleep(Duration::from_secs(2)).await;
@@ -290,7 +308,9 @@ pub async fn sync_cycle_full(
                         // Bodies unavailable after retries: stop gracefully (drop the sender)
                         // so the executor finishes what it has and the cycle ends without an
                         // error. The next forkchoice head will trigger a fresh attempt.
+                        let eth_peers = download_peers.eth_peer_count().await;
                         warn!(
+                            eth_peers,
                             "Block bodies unavailable from peers after retries; pausing full sync until a new forkchoice head arrives"
                         );
                         return;
@@ -351,7 +371,9 @@ pub async fn sync_cycle_full(
                         // Bodies unavailable after retries: stop gracefully (drop the sender)
                         // so the executor finishes what it has and the cycle ends without an
                         // error. The next forkchoice head will trigger a fresh attempt.
+                        let eth_peers = download_peers.eth_peer_count().await;
                         warn!(
+                            eth_peers,
                             "Block bodies unavailable from peers after retries; pausing full sync until a new forkchoice head arrives"
                         );
                         return;

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -101,6 +101,38 @@ pub fn is_resume_point(store: &Store, header: &BlockHeader) -> Result<bool, Sync
     Ok(store.is_canonical_sync(header.hash())? && store.has_state_root(header.state_root)?)
 }
 
+/// Index of the first resume point in a single newest->oldest header batch, or `None` if the
+/// batch contains none. The headers before that index are the missing blocks to execute; the
+/// header at that index is our executed/state head (state presence is contiguous from genesis,
+/// so the first canonical+stateful header scanning newest->oldest is exactly that head).
+///
+/// Scanning the batch *interior* — rather than only checking the parent of the batch's oldest
+/// header — is what stops the walk-back overshooting its own stateful head down to genesis when
+/// that head sits in the middle of a batch (the batch's oldest block can be a canonical-but-
+/// pruned block below the retained-state window, which is not a resume point).
+///
+/// Gated to batches whose oldest block is at/below `local_head`: a batch entirely above our head
+/// is all unexecuted and cannot contain a resume point, so the per-header state lookups are
+/// skipped for it, keeping the deep-sync walk cheap.
+pub fn first_resume_point_in_batch(
+    store: &Store,
+    block_headers: &[BlockHeader],
+    local_head: u64,
+) -> Result<Option<usize>, SyncError> {
+    let Some(oldest) = block_headers.last() else {
+        return Ok(None);
+    };
+    if oldest.number > local_head {
+        return Ok(None);
+    }
+    for (index, header) in block_headers.iter().enumerate() {
+        if is_resume_point(store, header)? {
+            return Ok(Some(index));
+        }
+    }
+    Ok(None)
+}
+
 /// Performs full sync cycle - fetches and executes all blocks between current head and sync head
 ///
 /// # Returns
@@ -249,31 +281,19 @@ pub async fn sync_cycle_full(
             Some(parent) => is_resume_point(&store, &parent)?,
             None => false,
         };
-        // Scan THIS batch for the first resume point (newest->oldest). The batch may itself
-        // straddle our executed/state head: the walk has reached down into the region we
-        // already have state for. Checking only `parent_is_resume_point` (the parent of the
-        // batch's OLDEST header) misses this — when our stateful head sits in the MIDDLE of a
-        // batch the parent check is false, so the walk blew past our own local head and kept
-        // descending all the way to genesis (the issue #9 overshoot). Only scan once the batch
-        // can actually contain our head (its oldest block is at/below `local_head`); higher
-        // batches are entirely unexecuted and cannot hold a resume point, so skip the scan for
-        // them to keep the deep-sync walk cheap.
-        let mut first_skippable = block_headers.len();
-        if last_header.number <= local_head {
-            for (index, header) in block_headers.iter().enumerate() {
-                if is_resume_point(&store, header)? {
-                    first_skippable = index;
-                    break;
-                }
-            }
-        }
-        let batch_contains_resume_point = first_skippable < block_headers.len();
-        if parent_is_resume_point || batch_contains_resume_point || sync_head.is_zero() {
+        // The batch may itself straddle our executed/state head — the walk has reached down
+        // into the region we have state for. Checking only `parent_is_resume_point` (the parent
+        // of the batch's OLDEST header) misses this: when our stateful head sits in the MIDDLE of
+        // a batch the parent check is false, so the walk blew past our own local head and kept
+        // descending all the way to genesis (the issue #9 overshoot). Scan the batch interior too.
+        let batch_resume_index = first_resume_point_in_batch(&store, &block_headers, local_head)?;
+        if parent_is_resume_point || batch_resume_index.is_some() || sync_head.is_zero() {
             // Incoming chain merged with our executed state.
-            // Drop only the already-executed (canonical + stateful) prefix (computed as
-            // `first_skippable` above); keep any canonical-but-stateless blocks so they get
-            // re-executed. Because both canonical-ness and state presence are contiguous from
-            // genesis, the first canonical+stateful header newest->oldest is exactly the state head.
+            // Drop only the already-executed (canonical + stateful) prefix; keep any
+            // canonical-but-stateless blocks so they get re-executed. Because both
+            // canonical-ness and state presence are contiguous from genesis, the first
+            // canonical+stateful header newest->oldest is exactly the state head.
+            let first_skippable = batch_resume_index.unwrap_or(block_headers.len());
             block_headers.drain(first_skippable..block_headers.len());
             match block_headers.last() {
                 Some(last_header) => start_block_number = last_header.number,

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -236,6 +236,7 @@ pub async fn sync_cycle_snap(
                 tokio_util::sync::CancellationToken::new(),
                 sync_head,
                 store.clone(),
+                diagnostics,
             )
             .await;
         }

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -32,6 +32,13 @@ impl RpcHandler for ChainId {
 
 pub struct Syncing;
 
+/// How many blocks the executed head may trail the forkchoice target while still
+/// being reported as synced. A node following head sits within a block or two of the
+/// forkchoice head, so this absorbs normal per-slot lag and brief batch imports
+/// without flapping, while a genuine fall-behind (hundreds of blocks) is reported as
+/// syncing even though the `is_synced()` latch is still set.
+const SYNCED_HEAD_TOLERANCE: u64 = 8;
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SyncingStatusRpc {
@@ -55,51 +62,60 @@ impl RpcHandler for Syncing {
                 "Syncing status requested but syncer is not initialized".to_string(),
             ));
         };
-        if context.blockchain.is_synced() {
-            Ok(Value::Bool(!context.blockchain.is_synced()))
-        } else {
-            // `current_block` must reflect the executed/state head, not the canonical
-            // pointer. An FCU can canonicalize blocks before their state is computed
-            // (full-sync wedge), and snap may not have healed up to the head, so the
-            // canonical head can be stateless. Reporting it would make the node look
-            // near-synced while it has no state up to the tip. Use the canonical head
-            // only when its post-state is on disk; otherwise report the executed head
-            // recorded by the sync cycle.
-            let canonical_head = context.storage.get_latest_block_number().await?;
-            let current_block = match context.storage.get_block_header(canonical_head)? {
-                Some(header) if context.storage.has_state_root(header.state_root)? => {
-                    canonical_head
-                }
-                _ => syncer
-                    .diagnostics()
-                    .read()
-                    .await
-                    .executed_head
-                    .min(canonical_head),
-            };
-            // `get_last_fcu_head` returns the head *hash* from the last forkchoiceUpdated.
-            // Resolve it to a block number. If the header isn't canonical yet it may still
-            // be a pending block whose number we can read; only when neither is available
-            // (e.g. mid snap-sync, target not downloaded) fall back to the canonical head
-            // instead of reporting garbage.
-            let head_hash = syncer
-                .get_last_fcu_head()
-                .map_err(|error| RpcErr::Internal(error.to_string()))?;
-            let highest_block = match context.storage.get_block_number(head_hash).await? {
-                Some(number) => number,
-                None => match context.storage.get_pending_block(head_hash).await? {
-                    Some(block) => block.header.number,
-                    None => canonical_head,
-                },
-            };
-            let syncing_status = SyncingStatusRpc {
-                starting_block: context.storage.get_earliest_block_number().await?,
-                current_block,
-                highest_block,
-            };
-            serde_json::to_value(syncing_status)
-                .map_err(|error| RpcErr::Internal(error.to_string()))
+
+        // `current_block` must reflect the executed/state head, not the canonical
+        // pointer. An FCU can canonicalize blocks before their state is computed
+        // (full-sync wedge), and snap may not have healed up to the head, so the
+        // canonical head can be stateless. Reporting it would make the node look
+        // near-synced while it has no state up to the tip. Use the canonical head
+        // only when its post-state is on disk; otherwise report the executed head
+        // recorded by the sync cycle.
+        let canonical_head = context.storage.get_latest_block_number().await?;
+        let current_block = match context.storage.get_block_header(canonical_head)? {
+            Some(header) if context.storage.has_state_root(header.state_root)? => canonical_head,
+            _ => syncer
+                .diagnostics()
+                .read()
+                .await
+                .executed_head
+                .min(canonical_head),
+        };
+
+        // `get_last_fcu_head` returns the head *hash* from the last forkchoiceUpdated.
+        // Resolve it to a block number (the consensus-provided sync target). If the
+        // header isn't canonical yet it may still be a pending block whose number we
+        // can read; only when neither is available (e.g. mid snap-sync, target not
+        // downloaded) fall back to the canonical head instead of reporting garbage.
+        let head_hash = syncer
+            .get_last_fcu_head()
+            .map_err(|error| RpcErr::Internal(error.to_string()))?;
+        let highest_block = match context.storage.get_block_number(head_hash).await? {
+            Some(number) => number,
+            None => match context.storage.get_pending_block(head_hash).await? {
+                Some(block) => block.header.number,
+                None => canonical_head,
+            },
+        };
+
+        // `is_synced()` is a latch: it flips true on the first successful FCU and is
+        // never reset on L1 (`set_not_synced` has no L1 caller), so it does not reflect
+        // a node that synced once and later fell behind its consensus client. Trusting
+        // it alone makes `eth_syncing` report `false` for a wedged/lagging node. Treat
+        // the node as synced only if the latch is set AND the executed head has reached
+        // (within a small following tolerance) the forkchoice target.
+        let synced = context.blockchain.is_synced()
+            && current_block + SYNCED_HEAD_TOLERANCE >= highest_block;
+
+        if synced {
+            return Ok(Value::Bool(false));
         }
+
+        let syncing_status = SyncingStatusRpc {
+            starting_block: context.storage.get_earliest_block_number().await?,
+            current_block,
+            highest_block,
+        };
+        serde_json::to_value(syncing_status).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -58,11 +58,29 @@ impl RpcHandler for Syncing {
         if context.blockchain.is_synced() {
             Ok(Value::Bool(!context.blockchain.is_synced()))
         } else {
-            let current_block = context.storage.get_latest_block_number().await?;
+            // `current_block` must reflect the executed/state head, not the canonical
+            // pointer. An FCU can canonicalize blocks before their state is computed
+            // (full-sync wedge), and snap may not have healed up to the head, so the
+            // canonical head can be stateless. Reporting it would make the node look
+            // near-synced while it has no state up to the tip. Use the canonical head
+            // only when its post-state is on disk; otherwise report the executed head
+            // recorded by the sync cycle.
+            let canonical_head = context.storage.get_latest_block_number().await?;
+            let current_block = match context.storage.get_block_header(canonical_head)? {
+                Some(header) if context.storage.has_state_root(header.state_root)? => {
+                    canonical_head
+                }
+                _ => syncer
+                    .diagnostics()
+                    .read()
+                    .await
+                    .executed_head
+                    .min(canonical_head),
+            };
             // `get_last_fcu_head` returns the head *hash* from the last forkchoiceUpdated.
             // Resolve it to a block number. If the header isn't canonical yet it may still
             // be a pending block whose number we can read; only when neither is available
-            // (e.g. mid snap-sync, target not downloaded) fall back to the current block
+            // (e.g. mid snap-sync, target not downloaded) fall back to the canonical head
             // instead of reporting garbage.
             let head_hash = syncer
                 .get_last_fcu_head()
@@ -71,7 +89,7 @@ impl RpcHandler for Syncing {
                 Some(number) => number,
                 None => match context.storage.get_pending_block(head_hash).await? {
                     Some(block) => block.header.number,
-                    None => current_block,
+                    None => canonical_head,
                 },
             };
             let syncing_status = SyncingStatusRpc {

--- a/test/tests/p2p/full_sync_tests.rs
+++ b/test/tests/p2p/full_sync_tests.rs
@@ -47,7 +47,7 @@ async fn seed_store(headers: &[BlockHeader], canonical: &[&BlockHeader]) -> Stor
 #[tokio::test]
 async fn canonical_and_stateful_is_resume_point() {
     let h = header(1, *EMPTY_TRIE_HASH, H256::zero());
-    let store = seed_store(&[h.clone()], &[&h]).await;
+    let store = seed_store(std::slice::from_ref(&h), &[&h]).await;
     assert!(
         is_resume_point(&store, &h).unwrap(),
         "canonical block with present state must be a resume point"
@@ -58,7 +58,7 @@ async fn canonical_and_stateful_is_resume_point() {
 async fn canonical_but_stateless_is_not_resume_point() {
     // Canonical, but post-state absent: the gap the fix must re-execute, not skip.
     let h = header(1, H256::from_low_u64_be(0xdead), H256::zero());
-    let store = seed_store(&[h.clone()], &[&h]).await;
+    let store = seed_store(std::slice::from_ref(&h), &[&h]).await;
     assert!(
         !is_resume_point(&store, &h).unwrap(),
         "canonical-but-stateless block must NOT be a resume point (else full sync wedges)"
@@ -69,7 +69,7 @@ async fn canonical_but_stateless_is_not_resume_point() {
 async fn non_canonical_is_not_resume_point() {
     // Present state but never canonicalized -> not a resume point.
     let h = header(1, *EMPTY_TRIE_HASH, H256::zero());
-    let store = seed_store(&[h.clone()], &[]).await;
+    let store = seed_store(std::slice::from_ref(&h), &[]).await;
     assert!(!is_resume_point(&store, &h).unwrap());
 }
 
@@ -183,5 +183,8 @@ async fn batch_with_no_retained_state_returns_none() {
     // Canonical 1..=8 but NO state anywhere (fully pruned). local_head = 8.
     let (store, chain) = seed_chain(8, &[]).await;
     let batch: Vec<BlockHeader> = chain[4..8].iter().rev().cloned().collect(); // 8,7,6,5
-    assert_eq!(first_resume_point_in_batch(&store, &batch, 8).unwrap(), None);
+    assert_eq!(
+        first_resume_point_in_batch(&store, &batch, 8).unwrap(),
+        None
+    );
 }

--- a/test/tests/p2p/full_sync_tests.rs
+++ b/test/tests/p2p/full_sync_tests.rs
@@ -11,7 +11,7 @@
 //! canonical AND its post-state is present on disk.
 
 use ethrex_common::{H256, types::BlockHeader};
-use ethrex_p2p::sync::is_resume_point;
+use ethrex_p2p::sync::{first_resume_point_in_batch, is_resume_point};
 use ethrex_storage::{EngineType, Store};
 use ethrex_trie::EMPTY_TRIE_HASH;
 
@@ -104,4 +104,84 @@ async fn walk_back_anchors_on_state_head_not_canonical_head() {
     // have skipped the gap, wedging execution on block 3's missing parent state.
     assert_eq!(first_resumable, Some(5));
     assert_eq!(newest_to_oldest[5].number, 2);
+}
+
+/// Builds blocks 1..=`tip`, all canonical, with present state only on `stateful` block numbers.
+/// Returns (store, full chain). Mirrors a pruned layered store: the executed/state head plus a
+/// recent window have state; older canonical blocks do not.
+async fn seed_chain(tip: u64, stateful: &[u64]) -> (Store, Vec<BlockHeader>) {
+    let mut chain = Vec::new();
+    let mut parent = H256::zero();
+    for number in 1..=tip {
+        let state_root = if stateful.contains(&number) {
+            *EMPTY_TRIE_HASH
+        } else {
+            H256::from_low_u64_be(0xc0de_0000 + number)
+        };
+        let h = header(number, state_root, parent);
+        parent = h.hash();
+        chain.push(h);
+    }
+    let canonical: Vec<&BlockHeader> = chain.iter().collect();
+    let store = seed_store(&chain, &canonical).await;
+    (store, chain)
+}
+
+/// Regression for the issue #9 overshoot (introduced by tightening the walk-back merge from
+/// `is_canonical_sync` to `is_resume_point`). The node's stateful head sits in the MIDDLE of a
+/// batch whose oldest block is canonical-but-pruned. The walk must merge at the in-batch resume
+/// point, not blow past it because the batch's bottom edge isn't a resume point.
+#[tokio::test]
+async fn walk_back_merges_at_resume_point_inside_batch() {
+    // Canonical 1..=8, head = 8 = state head (only block 8 has state; 1..=7 are pruned).
+    // New blocks 9,10 are not yet canonical. local_head = 8.
+    let (store, chain) = seed_chain(8, &[8]).await;
+    let local_head = 8;
+    let new_blocks = [
+        header(10, H256::from_low_u64_be(0xaaaa), chain[7].hash()), // 10 (parent 9 placeholder)
+        header(9, H256::from_low_u64_be(0xbbbb), chain[7].hash()),  // 9
+    ];
+
+    // Batch newest->oldest spanning the new blocks down past the state head: [10, 9, 8, 7, 6, 5].
+    let batch: Vec<BlockHeader> = new_blocks
+        .iter()
+        .cloned()
+        .chain(chain[4..8].iter().rev().cloned()) // 8,7,6,5
+        .collect();
+
+    // The in-batch scan finds block 8 (canonical+stateful) at index 2, so the walk merges there
+    // and executes 10,9 — instead of descending to genesis.
+    let idx = first_resume_point_in_batch(&store, &batch, local_head)
+        .unwrap()
+        .expect("must find the in-batch resume point");
+    assert_eq!(batch[idx].number, 8);
+
+    // The pre-fix break checked only the parent of the batch's OLDEST header (block 4), which is
+    // canonical-but-pruned -> not a resume point -> old logic overshot. Document that.
+    assert!(!is_resume_point(&store, &chain[3]).unwrap());
+}
+
+/// A batch entirely above `local_head` cannot contain a resume point; the scan is skipped
+/// (returns None) so the walk keeps descending without per-header state lookups.
+#[tokio::test]
+async fn batch_entirely_above_local_head_is_skipped() {
+    let (store, chain) = seed_chain(8, &[8]).await;
+    let new_blocks = vec![
+        header(10, H256::from_low_u64_be(0xaaaa), chain[7].hash()),
+        header(9, H256::from_low_u64_be(0xbbbb), chain[7].hash()),
+    ];
+    assert_eq!(
+        first_resume_point_in_batch(&store, &new_blocks, 8).unwrap(),
+        None
+    );
+}
+
+/// A batch below the head but entirely pruned (no state) yields no resume point; the walk must
+/// continue (and ultimately hit the pruned-base guard), not falsely merge.
+#[tokio::test]
+async fn batch_with_no_retained_state_returns_none() {
+    // Canonical 1..=8 but NO state anywhere (fully pruned). local_head = 8.
+    let (store, chain) = seed_chain(8, &[]).await;
+    let batch: Vec<BlockHeader> = chain[4..8].iter().rev().cloned().collect(); // 8,7,6,5
+    assert_eq!(first_resume_point_in_batch(&store, &batch, 8).unwrap(), None);
 }

--- a/test/tests/p2p/full_sync_tests.rs
+++ b/test/tests/p2p/full_sync_tests.rs
@@ -1,0 +1,107 @@
+//! Full-sync resume-point tests.
+//!
+//! Regression coverage for the full-sync state-gap wedge (glamsterdam-devnet-5 issue #6):
+//! an FCU can canonicalize a head before its state is computed (`apply_fork_choice` gates
+//! only on the branch link block), leaving canonical-but-stateless blocks. Full sync must
+//! re-execute those rather than treat them as already-synced; skipping them anchored
+//! execution on a parent with no state and wedged the node forever on `state root missing`.
+//!
+//! These tests exercise `is_resume_point`, the predicate the full-sync walk-back uses to
+//! decide where to resume execution. A block is a valid resume point only if it is
+//! canonical AND its post-state is present on disk.
+
+use ethrex_common::{H256, types::BlockHeader};
+use ethrex_p2p::sync::is_resume_point;
+use ethrex_storage::{EngineType, Store};
+use ethrex_trie::EMPTY_TRIE_HASH;
+
+/// Header at `number` with `state_root`, chained off `parent`.
+fn header(number: u64, state_root: H256, parent: H256) -> BlockHeader {
+    BlockHeader {
+        number,
+        state_root,
+        parent_hash: parent,
+        ..Default::default()
+    }
+}
+
+/// In-memory store seeded with `headers`, marking the `canonical` ones canonical via FCU.
+/// No EVM state is written: `has_state_root` returns true for `EMPTY_TRIE_HASH` and false
+/// for any other (absent) root, which is exactly the present/absent distinction we need.
+async fn seed_store(headers: &[BlockHeader], canonical: &[&BlockHeader]) -> Store {
+    let store = Store::new("", EngineType::InMemory).expect("in-memory store");
+    store
+        .add_block_headers(headers.to_vec())
+        .await
+        .expect("add headers");
+    if let Some(head) = canonical.last() {
+        let list: Vec<(u64, H256)> = canonical.iter().map(|h| (h.number, h.hash())).collect();
+        store
+            .forkchoice_update(list, head.number, head.hash(), None, None)
+            .await
+            .expect("forkchoice update");
+    }
+    store
+}
+
+#[tokio::test]
+async fn canonical_and_stateful_is_resume_point() {
+    let h = header(1, *EMPTY_TRIE_HASH, H256::zero());
+    let store = seed_store(&[h.clone()], &[&h]).await;
+    assert!(
+        is_resume_point(&store, &h).unwrap(),
+        "canonical block with present state must be a resume point"
+    );
+}
+
+#[tokio::test]
+async fn canonical_but_stateless_is_not_resume_point() {
+    // Canonical, but post-state absent: the gap the fix must re-execute, not skip.
+    let h = header(1, H256::from_low_u64_be(0xdead), H256::zero());
+    let store = seed_store(&[h.clone()], &[&h]).await;
+    assert!(
+        !is_resume_point(&store, &h).unwrap(),
+        "canonical-but-stateless block must NOT be a resume point (else full sync wedges)"
+    );
+}
+
+#[tokio::test]
+async fn non_canonical_is_not_resume_point() {
+    // Present state but never canonicalized -> not a resume point.
+    let h = header(1, *EMPTY_TRIE_HASH, H256::zero());
+    let store = seed_store(&[h.clone()], &[]).await;
+    assert!(!is_resume_point(&store, &h).unwrap());
+}
+
+#[tokio::test]
+async fn walk_back_anchors_on_state_head_not_canonical_head() {
+    // Blocks 1..=5 canonical; state present only up to block 2 (the state head). Blocks
+    // 3..=5 are canonical-but-stateless (the gap); 6..=7 are the non-canonical new blocks.
+    let mut chain = Vec::new();
+    let mut parent = H256::zero();
+    for number in 1..=7u64 {
+        let state_root = if number <= 2 {
+            *EMPTY_TRIE_HASH
+        } else {
+            H256::from_low_u64_be(0xc0de_0000 + number)
+        };
+        let h = header(number, state_root, parent);
+        parent = h.hash();
+        chain.push(h);
+    }
+    let canonical: Vec<&BlockHeader> = chain[0..5].iter().collect(); // 1..=5
+    let store = seed_store(&chain, &canonical).await;
+
+    // Full sync scans headers newest -> oldest looking for the first resume point.
+    let newest_to_oldest: Vec<BlockHeader> = chain.iter().rev().cloned().collect();
+    let first_resumable = newest_to_oldest
+        .iter()
+        .position(|h| is_resume_point(&store, h).unwrap());
+
+    // First resume point is block 2 (the state head), at index 5 (after 7,6,5,4,3). So
+    // blocks 7,6 (new) and 5,4,3 (the canonical-but-stateless gap) are all kept and
+    // re-executed. The pre-fix logic stopped at the first *canonical* block (5) and would
+    // have skipped the gap, wedging execution on block 3's missing parent state.
+    assert_eq!(first_resumable, Some(5));
+    assert_eq!(newest_to_oldest[5].number, 2);
+}

--- a/test/tests/p2p/mod.rs
+++ b/test/tests/p2p/mod.rs
@@ -1,5 +1,6 @@
 mod backend_tests;
 mod discovery;
+mod full_sync_tests;
 mod rlpx;
 mod snap_server_tests;
 mod types_tests;


### PR DESCRIPTION
Full sync on degraded networks (e.g. glamsterdam-devnet-5) could wedge in a loop alternating between `No bodies were found` and `state root missing`, freezing the head. This makes the walk-back resilient.

**Body-fetch resilience** (`sync/full.rs`): a single peer failing to return bodies aborted the whole cycle and re-walked all headers from scratch on the next retry. `request_bodies_with_retry` adds backoff retries (mirroring the header-fetch loop); on exhaustion it ends the cycle gracefully and waits for the next forkchoice head instead of propagating a fatal error.

**Resume-point anchoring** (`sync/full.rs`, `is_resume_point` / `first_resume_point_in_batch`): execution may only resume from a block that is canonical AND has its post-state on disk. `apply_fork_choice` can canonicalize a head before its state is computed, so the canonical chain can extend past the executed-state head; anchoring on such a canonical-but-stateless block fails forever with `state root missing`. The walk scans each header batch (newest->oldest, gated to batches reaching down to `local_head`) for the first canonical+stateful block — the true state head, wherever it falls in the batch — resumes there, and keeps the canonical-but-stateless blocks above it for re-execution to backfill the gap. If no resume point exists down to genesis (a fork/deep-reorg head reconciling only to a block whose state was pruned), the cycle pauses gracefully and waits for a reconcilable head rather than re-executing from a missing base.

**Header start-hash validation** (`peer_handler.rs`): `request_block_headers_from_hash` validated only internal parent-hash linkage, so a peer could return an internally-consistent run of headers from its own (fork/minority) chain that does not begin at the requested `start`. Reject responses where `block_headers[0].hash() != start`, penalize the peer, and let the retry re-roll to a peer serving the requested chain.

**Diagnostics**: `state root missing` names the block number and state root; a `WARN` fires when full sync resumes below the canonical head; `eth_peer_count` is logged at cycle start and on fetch failures so `eth_peers=0` (no peers) is distinguishable from `eth_peers>0` (peers not serving).

**Tests** (`test/tests/p2p/full_sync_tests.rs`): `is_resume_point` for canonical+stateful / canonical+stateless / non-canonical; the walk anchoring on the state head; and `first_resume_point_in_batch` merging at a resume point inside the batch, skipping a batch entirely above `local_head`, and returning none for a fully-pruned batch.

Validated on glamsterdam-devnet-5 (lodestar-ethrex-1).