### PR TITLE
fix(l1): box engine_newPayload dispatch arms to avoid stack overflow on first Engine API call

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1195,12 +1195,19 @@ pub async fn map_engine_requests(
         "engine_forkchoiceUpdatedV2" => ForkChoiceUpdatedV2::call(req, context).await,
         "engine_forkchoiceUpdatedV3" => ForkChoiceUpdatedV3::call(req, context).await,
         "engine_forkchoiceUpdatedV4" => ForkChoiceUpdatedV4::call(req, context).await,
+        // The newPayload handlers carry the largest futures of any engine arm
+        // (block execution + optional witness collection). Because this `match`
+        // awaits each arm inline, the future of `map_engine_requests` is sized to
+        // its largest arm and shared by every engine request. Box these arms so
+        // they live on the heap instead of inflating the stack frame that even a
+        // lightweight `forkchoiceUpdated` poll must reserve — otherwise a single
+        // poll overflows the 2 MB tokio worker stack in unoptimized debug builds.
         "engine_newPayloadWithWitnessV5" => {
-            NewPayloadWithWitnessV5Request::call(req, context).await
+            Box::pin(NewPayloadWithWitnessV5Request::call(req, context)).await
         }
-        "engine_newPayloadV5" => NewPayloadV5Request::call(req, context).await,
-        "engine_newPayloadV4" => NewPayloadV4Request::call(req, context).await,
-        "engine_newPayloadV3" => NewPayloadV3Request::call(req, context).await,
+        "engine_newPayloadV5" => Box::pin(NewPayloadV5Request::call(req, context)).await,
+        "engine_newPayloadV4" => Box::pin(NewPayloadV4Request::call(req, context)).await,
+        "engine_newPayloadV3" => Box::pin(NewPayloadV3Request::call(req, context)).await,
         "engine_newPayloadV2" => NewPayloadV2Request::call(req, context).await,
         "engine_newPayloadV1" => NewPayloadV1Request::call(req, context).await,
         "engine_exchangeTransitionConfigurationV1" => {


### PR DESCRIPTION
**Motivation**

The Reorg Tests CI job started failing after `engine_newPayloadWithWitnessV5` support (#6680) landed. The node aborts with a stack overflow on the very first Engine API call, so the test's RPC connection dies mid-response.

**Description**

`map_engine_requests` is a single `async fn` whose `match` awaits every handler inline. A Rust async fn's future is sized to its *largest* arm, so the future of `map_engine_requests` is sized to the heaviest engine handler and shared by *every* engine request.

The `newPayload` handlers carry the largest futures of any arm (block execution plus optional witness collection). After #6680 they grew enough — threading `make_witness` through `handle_new_payload_v1_v2 → v3 → v4 → v5`, returning `Result<Option<ExecutionWitness>, ChainError>` from `add_block`, and adding the `handle_with_witness` / `payload_status_for_existing_block` / `witness_for_existing_block` async fns — that a single poll of `map_engine_requests` now exceeds the 2 MB tokio worker stack in the unoptimized debug build CI uses (`cargo build --bin ethrex`). This overflows while handling the first `forkchoiceUpdatedV3`, aborting the node:

```
thread 'tokio-rt-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

This is why a change that never touched `fork_choice.rs` or the build path still broke the reorg suite, and only in the debug build: the cost is shared through the dispatch future.

This PR `Box::pin`s the `newPayload` arms so their futures live on the heap instead of inflating the stack frame that even a lightweight `forkchoiceUpdated` poll must reserve.

How tested: the full reorg suite (`cd tooling/reorgs && cargo run`) passes locally — all 7 tests, including `test_many_blocks_reorg`. Without the fix the suite aborts on the first test.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
