### PR TITLE
fix(l1): validate eth/71 BAL against header commitment and persist BALs during full-sync

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -934,7 +934,11 @@ pub async fn import_blocks(
                 block_batch.push(block);
                 if block_batch.len() >= IMPORT_BATCH_SIZE || index + MIN_FULL_BLOCKS + 1 == size {
                     blockchain
-                        .add_blocks_in_batch(mem::take(&mut block_batch), CancellationToken::new())
+                        .add_blocks_in_batch(
+                            mem::take(&mut block_batch),
+                            &[],
+                            CancellationToken::new(),
+                        )
                         .await
                         .map_err(|(err, _)| err)?;
                 }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2452,6 +2452,16 @@ impl Blockchain {
     ) -> Result<(), (ChainError, Option<BatchBlockProcessingFailure>)> {
         let mut last_valid_hash = H256::default();
 
+        // `bals` is either empty (no BALs available) or index-aligned with `blocks`.
+        // Guard the contract so a wrong-length slice can't silently drop/ignore BALs
+        // via the `zip` in the persistence step below.
+        debug_assert!(
+            bals.is_empty() || bals.len() == blocks.len(),
+            "bals must be empty or aligned with blocks (bals={}, blocks={})",
+            bals.len(),
+            blocks.len(),
+        );
+
         let Some(first_block_header) = blocks.first().map(|e| e.header.clone()) else {
             return Err((ChainError::Custom("First block not found".into()), None));
         };

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2440,6 +2440,10 @@ impl Blockchain {
     /// - [`BatchProcessingFailure`] (if the error was caused by block processing).
     ///
     /// Note: only the last block's state trie is stored in the db
+    /// `bals` holds the per-block Block Access Lists fetched during sync, aligned
+    /// by index with `blocks`. Pass an empty slice when no BALs are available
+    /// (e.g. block import from RLP); the persistence step then stores none. Only
+    /// BALs matching their block's header commitment are persisted.
     pub async fn add_blocks_in_batch(
         &self,
         blocks: Vec<Block>,

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2443,6 +2443,7 @@ impl Blockchain {
     pub async fn add_blocks_in_batch(
         &self,
         blocks: Vec<Block>,
+        bals: &[Option<BlockAccessList>],
         cancellation_token: CancellationToken,
     ) -> Result<(), (ChainError, Option<BatchBlockProcessingFailure>)> {
         let mut last_valid_hash = H256::default();
@@ -2570,6 +2571,22 @@ impl Blockchain {
         // Check state root matches the one in block header
         validate_state_root(&last_block.header, new_state_root).map_err(|e| (e, None))?;
 
+        // EIP-8159: persist the per-block BAL fetched during sync so peers can
+        // later request it over eth/71 without re-execution (the batch path
+        // doesn't record BALs, so without this they'd fall back to regenerating
+        // against possibly-pruned parent state). Only persist a BAL that matches
+        // its header commitment; a wrong/empty peer BAL is dropped here, and the
+        // serve path guards again. Captured before `blocks` is moved below.
+        let bals_to_store: Vec<(BlockHash, BlockAccessList)> = blocks
+            .iter()
+            .zip(bals.iter())
+            .filter_map(|(block, bal)| {
+                let bal = bal.as_ref()?;
+                bal.matches_commitment(block.header.block_access_list_hash)
+                    .then(|| (block.hash(), bal.clone()))
+            })
+            .collect();
+
         let update_batch = UpdateBatch {
             account_updates: state_updates,
             storage_updates: accounts_updates,
@@ -2582,6 +2599,14 @@ impl Blockchain {
         self.storage
             .store_block_updates(update_batch)
             .map_err(|e| (e.into(), None))?;
+
+        for (block_hash, bal) in &bals_to_store {
+            if let Err(err) = self.storage.store_block_access_list(*block_hash, bal) {
+                warn!(
+                    "Failed to persist block access list for {block_hash} during batch sync: {err}"
+                );
+            }
+        }
 
         let elapsed_seconds = interval.elapsed().as_secs_f64();
         let throughput = if elapsed_seconds > 0.0 && total_gas_used != 0 {

--- a/crates/common/types/block_access_list.rs
+++ b/crates/common/types/block_access_list.rs
@@ -543,6 +543,15 @@ impl BlockAccessList {
         Ok(())
     }
 
+    /// Returns true if this BAL matches the header's EIP-8159 commitment
+    /// (`block_access_list_hash`). Used to gate persisting/serving a BAL so a
+    /// stale or regenerated-against-wrong-state BAL is never handed to peers as
+    /// if it were authoritative; callers degrade to the `0x80` "unavailable"
+    /// sentinel on a `false` here.
+    pub fn matches_commitment(&self, commitment: Option<H256>) -> bool {
+        commitment == Some(self.compute_hash())
+    }
+
     /// Computes the hash of the block access list (sorts accounts by address per EIP-7928).
     /// Use this when hashing a BAL constructed locally from execution.
     pub fn compute_hash(&self) -> H256 {

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -1300,12 +1300,19 @@ async fn handle_incoming_message(
                 // than served as a wrong BAL, which receiving peers would reject.
                 let bal = match state.storage.get_block_access_list(*hash) {
                     Ok(Some(bal)) => {
-                        let commitment = state
-                            .storage
-                            .get_block_header_by_hash(*hash)
-                            .ok()
-                            .flatten()
-                            .and_then(|header| header.block_access_list_hash);
+                        let commitment = match state.storage.get_block_header_by_hash(*hash) {
+                            Ok(Some(header)) => header.block_access_list_hash,
+                            Ok(None) => None,
+                            Err(err) => {
+                                // Don't serve an unverified BAL: degrade to 0x80
+                                // (unavailable), but log so an operator can tell a
+                                // committed BAL was refused due to a DB error.
+                                warn!(
+                                    "Failed to read header for BAL commitment check (hash {hash:#x}): {err}; reporting BAL unavailable"
+                                );
+                                None
+                            }
+                        };
                         bal.matches_commitment(commitment).then_some(bal)
                     }
                     Ok(None) => None,

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -1293,13 +1293,28 @@ async fn handle_incoming_message(
             let mut block_access_lists =
                 Vec::with_capacity(block_hashes.len().min(BLOCK_ACCESS_LIST_LIMIT));
             for hash in &block_hashes {
-                match state.storage.get_block_access_list(*hash) {
-                    Ok(bal) => block_access_lists.push(bal),
+                // EIP-8159: only serve a BAL that matches the block header's
+                // commitment. A stored BAL that doesn't hash to the header's
+                // `block_access_list_hash` (e.g. a stale/empty entry from a prior
+                // regeneration) must be reported as unavailable (`0x80`) rather
+                // than served as a wrong BAL, which receiving peers would reject.
+                let bal = match state.storage.get_block_access_list(*hash) {
+                    Ok(Some(bal)) => {
+                        let commitment = state
+                            .storage
+                            .get_block_header_by_hash(*hash)
+                            .ok()
+                            .flatten()
+                            .and_then(|header| header.block_access_list_hash);
+                        bal.matches_commitment(commitment).then_some(bal)
+                    }
+                    Ok(None) => None,
                     Err(err) => {
                         error!("Error accessing DB while building BAL response for peer: {err}");
-                        block_access_lists.push(None);
+                        None
                     }
-                }
+                };
+                block_access_lists.push(bal);
                 if block_access_lists.len() >= BLOCK_ACCESS_LIST_LIMIT {
                     break;
                 }

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -376,14 +376,12 @@ async fn add_blocks_in_batch(
     let blocks_hashes = blocks.iter().map(|block| block.hash()).collect::<Vec<_>>();
     let chain_config = store.get_chain_config();
     let bals: Vec<Option<BlockAccessList>> = {
-        // Only the final batch goes through `run_blocks_pipeline`, which is the
-        // path that actually consumes BALs. Non-final batches use
-        // `blockchain.add_blocks_in_batch()` which doesn't accept BALs, so
-        // fetching them for those batches just wastes a network round-trip.
-        let any_amsterdam = final_batch
-            && blocks
-                .iter()
-                .any(|b| chain_config.is_amsterdam_activated(b.header.timestamp));
+        // Fetch BALs for every Amsterdam batch (not just the final one): both the
+        // batch path and `run_blocks_pipeline` now persist them, so peers can serve
+        // these blocks over eth/71 later without regenerating against pruned state.
+        let any_amsterdam = blocks
+            .iter()
+            .any(|b| chain_config.is_amsterdam_activated(b.header.timestamp));
         if any_amsterdam {
             match peers.request_block_access_lists(&blocks_hashes).await {
                 Ok(Some(bals)) if bals.len() == blocks.len() => bals,
@@ -474,7 +472,7 @@ async fn add_blocks(
     // them for the fallback. The clone cost is negligible (~1-5ms) vs batch
     // execution time (median ~29s on hoodi).
     match blockchain
-        .add_blocks_in_batch(blocks.clone(), cancel_token)
+        .add_blocks_in_batch(blocks.clone(), &bals, cancel_token)
         .await
     {
         Ok(()) => Ok(()),

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -783,23 +783,32 @@ fn bal_for_block(
     block: &Block,
 ) -> Result<Option<BlockAccessList>, RpcErr> {
     let block_hash = block.hash();
+    let commitment = block.header.block_access_list_hash;
     if let Some(bal) = context.storage.get_block_access_list(block_hash)? {
-        return Ok(Some(bal));
+        // EIP-8159: never serve a BAL that doesn't match the header commitment.
+        // A stale/empty entry (e.g. from a prior regeneration against state that
+        // was later pruned) must degrade to "unavailable" rather than a wrong BAL.
+        if bal.matches_commitment(commitment) {
+            return Ok(Some(bal));
+        }
+        warn!("Stored BAL for {block_hash} does not match header commitment; ignoring it");
     }
     let generated = context
         .blockchain
         .generate_bal_for_block(block)
         .map_err(|e| RpcErr::Internal(e.to_string()))?;
+    // Only persist/serve a regenerated BAL if it matches the header commitment.
+    // Regeneration re-executes against the parent state; if that state is gone
+    // or stale the result can be empty/wrong, so guard before writing it back.
+    let Some(bal) = generated.filter(|bal| bal.matches_commitment(commitment)) else {
+        return Ok(None);
+    };
     // Write back so subsequent requests for this block are served from the
-    // store instead of re-executing every time. Regeneration only succeeds
-    // while the parent state is still in the retained window; the block has
-    // long been accepted, so the regenerated BAL is authoritative for serving.
-    if let Some(bal) = &generated
-        && let Err(err) = context.storage.store_block_access_list(block_hash, bal)
-    {
+    // store instead of re-executing every time.
+    if let Err(err) = context.storage.store_block_access_list(block_hash, &bal) {
         warn!("Failed to persist regenerated block access list for {block_hash}: {err}");
     }
-    Ok(generated)
+    Ok(Some(bal))
 }
 
 // ==================== V2 Body Methods (EIP-7928) ====================

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -800,7 +800,14 @@ fn bal_for_block(
     // Only persist/serve a regenerated BAL if it matches the header commitment.
     // Regeneration re-executes against the parent state; if that state is gone
     // or stale the result can be empty/wrong, so guard before writing it back.
+    let regenerated = generated.is_some();
     let Some(bal) = generated.filter(|bal| bal.matches_commitment(commitment)) else {
+        // A successful regeneration whose hash doesn't match the commitment means
+        // the block was re-executed against wrong/incomplete state; don't serve or
+        // persist it. (Absent regeneration just means the state is unavailable.)
+        if regenerated {
+            warn!("Regenerated BAL for {block_hash} does not match header commitment; discarding");
+        }
         return Ok(None);
     };
     // Write back so subsequent requests for this block are served from the

--- a/crates/networking/rpc/eth/block_access_list.rs
+++ b/crates/networking/rpc/eth/block_access_list.rs
@@ -21,8 +21,14 @@ impl RpcHandler for BlockAccessListRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         // Per execution-apis, unknown blocks map to the `notFound` schema (null).
-        let block_hash = match &self.block {
-            BlockIdentifierOrHash::Hash(h) => *h,
+        let (block_hash, commitment) = match &self.block {
+            BlockIdentifierOrHash::Hash(h) => {
+                let commitment = context
+                    .storage
+                    .get_block_header_by_hash(*h)?
+                    .and_then(|header| header.block_access_list_hash);
+                (*h, commitment)
+            }
             BlockIdentifierOrHash::Identifier(id) => {
                 let Some(block_number) = id.resolve_block_number(&context.storage).await? else {
                     return Ok(Value::Null);
@@ -30,13 +36,17 @@ impl RpcHandler for BlockAccessListRequest {
                 let Some(header) = context.storage.get_block_header(block_number)? else {
                     return Ok(Value::Null);
                 };
-                header.hash()
+                (header.hash(), header.block_access_list_hash)
             }
         };
 
-        // Fast path: serve from the BAL store populated at block import.
-        // Avoids re-executing the block when it's already known.
-        if let Some(bal) = context.storage.get_block_access_list(block_hash)? {
+        // Fast path: serve from the BAL store populated at block import, but only
+        // when it matches the header commitment (EIP-8159). A stale/empty stored
+        // entry (e.g. from a prior regeneration against state later pruned) must
+        // not be served; fall through to regeneration instead.
+        if let Some(bal) = context.storage.get_block_access_list(block_hash)?
+            && bal.matches_commitment(commitment)
+        {
             return Ok(bal_to_json(&bal));
         }
 
@@ -50,7 +60,9 @@ impl RpcHandler for BlockAccessListRequest {
             .generate_bal_for_block(&block)
             .map_err(|e| RpcErr::Internal(format!("Failed to generate BAL: {e}")))?;
 
-        match bal {
+        // Only serve a regenerated BAL that matches the header commitment; a
+        // mismatch means it was re-executed against wrong/incomplete state.
+        match bal.filter(|bal| bal.matches_commitment(commitment)) {
             Some(bal) => Ok(bal_to_json(&bal)),
             None => Ok(Value::Null),
         }

--- a/test/tests/blockchain/batch_tests.rs
+++ b/test/tests/blockchain/batch_tests.rs
@@ -237,7 +237,7 @@ async fn batch_selfdestruct_created_account_no_spurious_state() {
     let blockchain_b = Blockchain::default_with_store(store_b);
 
     let result = blockchain_b
-        .add_blocks_in_batch(vec![block1, block2], CancellationToken::new())
+        .add_blocks_in_batch(vec![block1, block2], &[], CancellationToken::new())
         .await;
 
     assert!(
@@ -385,7 +385,7 @@ async fn batch_cross_batch_blockhash_regression() {
     let blockchain_b = Blockchain::default_with_store(store_b);
 
     let result1 = blockchain_b
-        .add_blocks_in_batch(vec![block1, block2], CancellationToken::new())
+        .add_blocks_in_batch(vec![block1, block2], &[], CancellationToken::new())
         .await;
     assert!(
         result1.is_ok(),
@@ -394,7 +394,7 @@ async fn batch_cross_batch_blockhash_regression() {
     );
 
     let result2 = blockchain_b
-        .add_blocks_in_batch(vec![block3], CancellationToken::new())
+        .add_blocks_in_batch(vec![block3], &[], CancellationToken::new())
         .await;
     assert!(
         result2.is_ok(),
@@ -441,7 +441,7 @@ async fn batch_single_block_selfdestruct() {
     let blockchain_b = Blockchain::default_with_store(store_b);
 
     let result = blockchain_b
-        .add_blocks_in_batch(vec![block1], CancellationToken::new())
+        .add_blocks_in_batch(vec![block1], &[], CancellationToken::new())
         .await;
 
     assert!(

--- a/test/tests/p2p/rlpx/block_access_lists_tests.rs
+++ b/test/tests/p2p/rlpx/block_access_lists_tests.rs
@@ -1,4 +1,5 @@
-use ethrex_common::types::block_access_list::BlockAccessList;
+use ethereum_types::Address;
+use ethrex_common::types::block_access_list::{AccountChanges, BalanceChange, BlockAccessList};
 use ethrex_p2p::rlpx::{
     eth::block_access_lists::{BlockAccessLists, OptionalBal},
     message::RLPxMessage,
@@ -60,4 +61,40 @@ fn optional_bal_none_encodes_as_0x80_sentinel() {
     let mut bytes = Vec::new();
     OptionalBal(None).encode(&mut bytes);
     assert_eq!(bytes, vec![0x80]);
+}
+
+/// EIP-8159 serve guard: a BAL is authoritative only if it matches the block
+/// header's `block_access_list_hash`. Regression for serving `0xc0` (empty)
+/// for a canonical block whose header commits to a non-empty BAL (block 8501
+/// on glamsterdam-devnet-5): an empty/stale BAL must NOT match a non-empty
+/// commitment, so the serve and persist paths degrade to `None` (→ `0x80`).
+#[test]
+fn matches_commitment_guards_stale_and_empty_bals() {
+    fn addr(b: u8) -> Address {
+        let mut a = Address::zero();
+        a.0[19] = b;
+        a
+    }
+
+    let real = BlockAccessList::from_accounts(vec![
+        AccountChanges::new(addr(1)).with_balance_changes(vec![BalanceChange::new(0, 100.into())]),
+    ]);
+    let commitment = real.compute_hash();
+
+    // The real BAL matches its own commitment.
+    assert!(real.matches_commitment(Some(commitment)));
+
+    // An empty BAL does NOT match a non-empty commitment (the 8501 bug).
+    let empty = BlockAccessList::from_accounts(vec![]);
+    assert!(!empty.matches_commitment(Some(commitment)));
+
+    // A different (stale) BAL does NOT match.
+    let stale = BlockAccessList::from_accounts(vec![AccountChanges::new(addr(2))]);
+    assert!(!stale.matches_commitment(Some(commitment)));
+
+    // A missing header commitment never matches.
+    assert!(!real.matches_commitment(None));
+
+    // An empty BAL matches the empty-BAL commitment (genuinely-empty block → 0xc0).
+    assert!(empty.matches_commitment(Some(empty.compute_hash())));
 }

--- a/test/tests/rpc/block_access_list_tests.rs
+++ b/test/tests/rpc/block_access_list_tests.rs
@@ -47,10 +47,6 @@ fn header_committing_to(bal: &BlockAccessList) -> BlockHeader {
 // longer wire-compatible.
 #[tokio::test]
 async fn eth_get_block_access_list_matches_spec_example() {
-    let block_hash =
-        H256::from_str("0x1111111111111111111111111111111111111111111111111111111111111111")
-            .unwrap();
-
     let address = Address::from_str("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b").unwrap();
     let slot = U256::zero();
     let slot_changes = vec![
@@ -68,6 +64,14 @@ async fn eth_get_block_access_list_matches_spec_example() {
     let bal = BlockAccessList::from_accounts(vec![account]);
 
     let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+    // The endpoint validates the stored BAL against the header commitment, so the
+    // block's header must commit to this BAL's hash.
+    let block = Block {
+        header: header_committing_to(&bal),
+        body: BlockBody::default(),
+    };
+    let block_hash = block.hash();
+    storage.add_block(block).await.expect("store block");
     storage
         .store_block_access_list(block_hash, &bal)
         .expect("store BAL");

--- a/test/tests/rpc/block_access_list_tests.rs
+++ b/test/tests/rpc/block_access_list_tests.rs
@@ -210,6 +210,48 @@ async fn payload_bodies_by_range_v2_serves_stored_bal() {
     assert_eq!(got, expected);
 }
 
+// Regression for glamsterdam-devnet-5 block 8501: a stored BAL whose hash does
+// not match the header commitment must NOT be served. Here the header commits
+// to `sample_bal()` but an empty BAL is stored under the block hash; the guard
+// must drop it (and regeneration short-circuits to None for this block), so the
+// body carries no BAL rather than a wrong one.
+#[tokio::test]
+async fn payload_bodies_by_hash_v2_drops_bal_not_matching_commitment() {
+    let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+
+    let bal = sample_bal();
+    let block = Block {
+        header: header_committing_to(&bal),
+        body: BlockBody::default(),
+    };
+    let block_hash = block.hash();
+    storage.add_block(block).await.expect("store block");
+
+    // Store a BAL that does NOT match the header commitment (the 8501 bug).
+    storage
+        .store_block_access_list(block_hash, &BlockAccessList::from_accounts(vec![]))
+        .expect("store BAL");
+
+    let context = default_context_with_storage(storage).await;
+    let request = GetPayloadBodiesByHashV2Request {
+        hashes: vec![block_hash],
+    };
+    let got = request.handle(context).await.expect("rpc ok");
+
+    let expected =
+        serde_json::json!([
+            serde_json::to_value(ExecutionPayloadBodyV2::from_body_with_bal(
+                BlockBody::default(),
+                None
+            ))
+            .unwrap()
+        ]);
+    assert_eq!(
+        got, expected,
+        "a stored BAL not matching the header commitment must not be served"
+    );
+}
+
 // Fallback path: when no BAL is stored, the handler must not re-execute a block
 // whose parent state is unavailable. For a pre-Amsterdam block, regeneration
 // short-circuits to None, so a None-carrying body proves the response was

--- a/test/tests/rpc/block_access_list_tests.rs
+++ b/test/tests/rpc/block_access_list_tests.rs
@@ -23,6 +23,24 @@ fn sample_bal() -> BlockAccessList {
     BlockAccessList::from_accounts(vec![account])
 }
 
+// A header (number 1) that commits to `bal` via `block_access_list_hash`.
+// All optional header fields preceding it are set so the header round-trips
+// through RLP — `encode_optional_field` is trailing-only, so a lone trailing
+// optional would otherwise be misdecoded into the first optional slot.
+fn header_committing_to(bal: &BlockAccessList) -> BlockHeader {
+    BlockHeader {
+        number: 1,
+        base_fee_per_gas: Some(0),
+        withdrawals_root: Some(H256::zero()),
+        blob_gas_used: Some(0),
+        excess_blob_gas: Some(0),
+        parent_beacon_block_root: Some(H256::zero()),
+        requests_hash: Some(H256::zero()),
+        block_access_list_hash: Some(bal.compute_hash()),
+        ..Default::default()
+    }
+}
+
 // Mirrors the `eth_getBlockAccessList` example in
 // execution-apis/src/eth/block.yaml (schema at
 // src/schemas/block-access-list.yaml). If this drifts, the endpoint is no
@@ -119,17 +137,16 @@ async fn eth_get_block_access_list_unknown_hash_returns_null() {
 async fn payload_bodies_by_hash_v2_serves_stored_bal() {
     let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
 
+    // The header must commit to the stored BAL's hash (EIP-8159); the serve
+    // path validates the stored BAL against this commitment before returning it.
+    let bal = sample_bal();
     let block = Block {
-        header: BlockHeader {
-            number: 1,
-            ..Default::default()
-        },
+        header: header_committing_to(&bal),
         body: BlockBody::default(),
     };
     let block_hash = block.hash();
     storage.add_block(block).await.expect("store block");
 
-    let bal = sample_bal();
     storage
         .store_block_access_list(block_hash, &bal)
         .expect("store BAL");
@@ -157,11 +174,11 @@ async fn payload_bodies_by_hash_v2_serves_stored_bal() {
 async fn payload_bodies_by_range_v2_serves_stored_bal() {
     let storage = Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
 
+    // The header must commit to the stored BAL's hash (EIP-8159); the serve
+    // path validates the stored BAL against this commitment before returning it.
+    let bal = sample_bal();
     let block = Block {
-        header: BlockHeader {
-            number: 1,
-            ..Default::default()
-        },
+        header: header_committing_to(&bal),
         body: BlockBody::default(),
     };
     let block_hash = block.hash();
@@ -172,7 +189,6 @@ async fn payload_bodies_by_range_v2_serves_stored_bal() {
         .await
         .expect("forkchoice update");
 
-    let bal = sample_bal();
     storage
         .store_block_access_list(block_hash, &bal)
         .expect("store BAL");


### PR DESCRIPTION
Two bugs found on glamsterdam-devnet-5 (block 8501): ethrex served `0xc0` (empty BAL) over eth/71 for a canonical, finalized block whose header commits to a non-empty `block_access_list_hash`. Erigon rejected it; `0x80` (unavailable) would have been acceptable.

**Root cause**: the full-sync batch path executed and stored blocks without fetching or persisting their BALs (only the final batch did). A later eth/71 or engine request fell back to regenerating the BAL by re-executing against the parent state; once that state is pruned, regeneration produces an empty/wrong BAL that was written back unvalidated and then served as `0xc0`.

**Fix 1 (serve guard, spec-mandated):** adds `BlockAccessList::matches_commitment` in `crates/common/types/block_access_list.rs`. The eth/71 serve handler (`crates/networking/p2p/rlpx/connection/server.rs`) and `bal_for_block` in `crates/networking/rpc/engine/payload.rs` now check the stored/regenerated BAL against `block_access_list_hash` before serving or persisting it; any mismatch, regeneration failure, or absence degrades to the `0x80` "unavailable" sentinel. This makes ethrex robust against already-corrupt stored entries regardless of how they got there.

**Fix 2 (retention, root cause):** `full.rs` now fetches BALs for every Amsterdam batch, not just the final one. `add_blocks_in_batch` in `crates/blockchain/blockchain.rs` accepts the per-block BAL slice and persists each entry whose hash matches the header commitment, so peers can serve them over eth/71 without regenerating against pruned state.

Regression test added in `test/tests/p2p/rlpx/block_access_lists_tests.rs` (`matches_commitment_guards_stale_and_empty_bals`); existing RPC/batch tests updated for the new `bals` parameter. BAL/batch/full_sync test suites and workspace build pass.

Refs EIP-8159 (eth/71 Block Access List Exchange).