### PR TITLE
refactor(l1): align p2p log levels and messages with operator-facing UX

### DIFF
--- a/crates/networking/p2p/discovery/discv4_handlers.rs
+++ b/crates/networking/p2p/discovery/discv4_handlers.rs
@@ -20,7 +20,7 @@ use ethrex_common::{H256, H512, types::ForkId};
 use rand::rngs::OsRng;
 use secp256k1::SecretKey;
 use std::time::Duration;
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 
 use super::server::{DiscoveryServer, DiscoveryServerError};
 
@@ -63,7 +63,7 @@ impl DiscoveryServer {
                 );
 
                 let _ = self.discv4_handle_ping(ping_message, hash, sender_public_key, node).await.inspect_err(|e| {
-                    error!(protocol = "discv4", sent = "Ping", to = %format!("{sender_public_key:#x}"), err = ?e, "Error handling message");
+                    debug!(protocol = "discv4", sent = "Ping", to = %format!("{sender_public_key:#x}"), err = ?e, "Error handling message");
                 });
             }
             Message::Pong(pong_message) => {
@@ -216,7 +216,7 @@ impl DiscoveryServer {
 
         for (idx, node_id, node, message) in queries {
             if let Err(e) = self.udp_socket.send_to(&message, &node.udp_addr()).await {
-                error!(protocol = "discv4", sending = "FindNode", addr = ?node.udp_addr(), err=?e, "Error sending message");
+                debug!(protocol = "discv4", sending = "FindNode", addr = ?node.udp_addr(), err=?e, "Error sending message");
                 self.peer_table.set_disposable(node_id)?;
                 METRICS.record_new_discarded_node();
                 if let Some(discv4) = &mut self.discv4
@@ -602,7 +602,7 @@ impl DiscoveryServer {
         let mut buf = BytesMut::new();
         message.encode_with_header(&mut buf, &self.signer);
         Ok(self.udp_socket.send_to(&buf, addr).await.inspect_err(
-            |e| error!(protocol = "discv4", sending = ?message, addr = ?addr, err=?e, "Error sending message"),
+            |e| debug!(protocol = "discv4", sending = ?message, addr = ?addr, err=?e, "Error sending message"),
         )?)
     }
 
@@ -622,7 +622,7 @@ impl DiscoveryServer {
             .try_into()
             .expect("first 32 bytes are the message hash");
         if let Err(e) = self.udp_socket.send_to(&buf, node.udp_addr()).await {
-            error!(protocol = "discv4", sending = ?message, addr = ?node.udp_addr(), to = ?node.node_id(), err=?e, "Error sending message");
+            debug!(protocol = "discv4", sending = ?message, addr = ?node.udp_addr(), to = ?node.node_id(), err=?e, "Error sending message");
             self.peer_table.set_disposable(node.node_id())?;
             METRICS.record_new_discarded_node();
             return Err(e.into());

--- a/crates/networking/p2p/discovery/discv5_handlers.rs
+++ b/crates/networking/p2p/discovery/discv5_handlers.rs
@@ -25,7 +25,7 @@ use std::{
     net::SocketAddr,
     time::{Duration, Instant},
 };
-use tracing::{error, trace, warn};
+use tracing::{debug, trace, warn};
 
 use super::server::{DiscoveryServer, DiscoveryServerError};
 
@@ -57,7 +57,7 @@ impl DiscoveryServer {
             0x01 => self.discv5_handle_who_are_you(packet, from).await,
             0x02 => self.discv5_handle_handshake(packet, from).await,
             f => {
-                tracing::info!(protocol = "discv5", "Unexpected flag {f}");
+                tracing::trace!(protocol = "discv5", "Unexpected flag {f}");
                 Err(crate::discv5::messages::PacketCodecError::MalformedData.into())
             }
         }
@@ -354,7 +354,7 @@ impl DiscoveryServer {
         for (idx, target, node_id, node) in queries {
             let find_node_msg = self.discv5_build_find_node_for_target(target, &node);
             if let Err(e) = self.discv5_send_ordinary(find_node_msg, &node).await {
-                error!(protocol = "discv5", sending = "FindNode", addr = ?node.udp_addr(), err=?e, "Error sending message");
+                debug!(protocol = "discv5", sending = "FindNode", addr = ?node.udp_addr(), err=?e, "Error sending message");
                 self.peer_table.set_disposable(node_id)?;
                 METRICS.record_new_discarded_node();
                 if let Some(discv5) = &mut self.discv5

--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -115,7 +115,7 @@ impl DiscoveryServer {
         bootnodes: Vec<Node>,
         config: DiscoveryConfig,
     ) -> Result<(), DiscoveryServerError> {
-        info!("Starting unified discovery server");
+        debug!("Starting discovery server");
 
         let mut local_node_record = NodeRecord::from_node(&local_node, INITIAL_ENR_SEQ, &signer)
             .expect("Failed to create local node record");

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -796,7 +796,7 @@ pub async fn periodically_show_peer_stats_after_sync(peer_table: &PeerTable) {
                         .any(|cap| peer.supported_capabilities.contains(cap))
             })
             .count();
-        info!("Snap Peers: {snap_active_peers} / Total Peers: {active_peers}");
+        info!("Peers: {active_peers} (snap-capable: {snap_active_peers})");
         interval.tick().await;
     }
 }

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -29,7 +29,7 @@ use std::{
     sync::atomic::Ordering,
     time::{Duration, SystemTime},
 };
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, trace};
 
 // Re-export constants from snap::constants for backward compatibility
 pub use crate::snap::constants::{
@@ -380,13 +380,15 @@ impl PeerHandler {
                     debug!("All downloaded headers are unique");
                 }
                 std::cmp::Ordering::Greater => {
-                    warn!(
+                    debug!(
                         "Downloaded headers contain duplicates, {} duplicates found",
                         downloaded_headers - unique_headers.len()
                     );
                 }
                 std::cmp::Ordering::Less => {
-                    warn!("Downloaded headers are less than unique headers, something went wrong");
+                    debug!(
+                        "Downloaded headers are less than unique headers, this should not happen"
+                    );
                 }
             }
         }
@@ -425,9 +427,7 @@ impl PeerHandler {
                 {
                     if block_headers.is_empty() {
                         // Empty response is valid per eth spec (peer may not have these blocks)
-                        debug!(
-                            "[SYNCING] Received empty headers from peer {peer_id}, trying another"
-                        );
+                        debug!("Received empty headers from peer {peer_id}, trying another");
                         let _ = self.peer_table.set_disposable(peer_id);
                         return Ok(None);
                     }
@@ -436,16 +436,14 @@ impl PeerHandler {
                         return Ok(Some(block_headers));
                     }
                     // Non-empty but unchained headers is a protocol violation
-                    warn!(
-                        "[SYNCING] Received invalid (unchained) headers from peer, penalizing peer {peer_id}"
+                    debug!(
+                        "Received invalid (unchained) headers from peer, penalizing peer {peer_id}"
                     );
                     self.peer_table.record_failure(peer_id)?;
                     return Ok(None);
                 }
                 // Timeout or invalid response - mark peer as disposable
-                warn!(
-                    "[SYNCING] Didn't receive block headers from peer, penalizing peer {peer_id}..."
-                );
+                debug!("Didn't receive block headers from peer, penalizing peer {peer_id}");
                 self.peer_table.record_failure(peer_id)?;
                 Ok(None)
             }
@@ -483,7 +481,7 @@ impl PeerHandler {
             if are_block_headers_chained(&block_headers, &BlockRequestOrder::OldToNew) {
                 Ok(block_headers)
             } else {
-                warn!("[SYNCING] Received invalid headers from peer: {peer_id}");
+                debug!("Received invalid headers from peer: {peer_id}");
                 Err(PeerHandlerError::InvalidHeaders)
             }
         } else {
@@ -523,9 +521,7 @@ impl PeerHandler {
                         return Ok(Some((block_bodies, peer_id)));
                     }
                 }
-                warn!(
-                    "[SYNCING] Didn't receive block bodies from peer, penalizing peer {peer_id}..."
-                );
+                debug!("Didn't receive block bodies from peer, penalizing peer {peer_id}");
                 self.peer_table.record_failure(peer_id)?;
                 let _ = self.peer_table.set_disposable(peer_id);
                 Ok(None)
@@ -554,9 +550,7 @@ impl PeerHandler {
             let mut validation_success = true;
             for (header, body) in block_headers[..block_bodies.len()].iter().zip(block_bodies) {
                 if let Err(e) = validate_block_body(header, &body, &NativeCrypto) {
-                    warn!(
-                        "Invalid block body error {e}, discarding peer {peer_id} and retrying..."
-                    );
+                    debug!("Invalid block body error {e}, discarding peer {peer_id} and retrying");
                     validation_success = false;
                     self.peer_table.record_critical_failure(peer_id)?;
                     break;
@@ -600,7 +594,7 @@ impl PeerHandler {
                         Ok(Some(block_access_lists))
                     }
                     _ => {
-                        warn!("[SYNCING] Didn't receive block access lists from peer {peer_id}");
+                        debug!("Didn't receive block access lists from peer {peer_id}");
                         self.peer_table.record_failure(peer_id)?;
                         Ok(None)
                     }
@@ -674,7 +668,7 @@ impl PeerHandler {
             // TODO: we need to check, this seems a scenario where the peer channel does teardown
             // after we sent the backend message
             Err(_) => {
-                warn!("The RLPxConnection closed the backend channel");
+                debug!("Peer connection closed while waiting for response");
             }
         }
 

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -280,14 +280,14 @@ impl Established {
                 .mempool
                 .clear_in_flight_txs(&requested_hashes)
             {
-                warn!(error = %e, "clear_in_flight_txs failed during teardown");
+                warn!(error = %e, "Failed to clear in-flight transaction tracking during peer teardown");
             }
             retry_on_alternates(&self.blockchain, &self.peer_table, &requested_hashes).await;
         }
         // Also clear hashes that were buffered but not yet sent.
         for (_announced, pending_hashes) in self.pending_tx_requests.drain(..) {
             if let Err(e) = self.blockchain.mempool.clear_in_flight_txs(&pending_hashes) {
-                warn!(error = %e, "clear_in_flight_txs failed during teardown");
+                warn!(error = %e, "Failed to clear in-flight transaction tracking during peer teardown");
             }
             retry_on_alternates(&self.blockchain, &self.peer_table, &pending_hashes).await;
         }
@@ -463,7 +463,7 @@ impl PeerConnectionServer {
                 "Received outgoing request",
             );
             let Some(sender) = Arc::<oneshot::Sender<Message>>::into_inner(msg.sender) else {
-                warn!("Could not obtain sender channel: Arc has multiple references");
+                debug!("Could not obtain sender channel: Arc has multiple references");
                 return;
             };
             let result = handle_outgoing_request(established_state, msg.message, sender).await;
@@ -545,7 +545,7 @@ impl PeerConnectionServer {
                     // Clear in-flight before retry so the alternate's reserve_unknown_hashes
                     // doesn't race against still-in-flight state and silently no-op.
                     if let Err(e) = state.blockchain.mempool.clear_in_flight_txs(&hashes) {
-                        warn!(error = %e, "clear_in_flight_txs failed while sweeping stale requests");
+                        warn!(error = %e, "Failed to clear in-flight transaction tracking while sweeping stale requests");
                     }
                     retry_on_alternates(&state.blockchain, &state.peer_table, &hashes).await;
                 }
@@ -680,7 +680,7 @@ impl PeerConnectionServer {
                         error!(
                             peer=%established_state.node,
                             error=%e,
-                            "Error handling cast message",
+                            "Inconsistent trie while serving peer request; local state may be corrupted",
                         );
                     } else {
                         // If we're not synced, we expect to have inconsistent trie errors
@@ -1078,11 +1078,11 @@ where
             if negotiated_eth_version == 0 {
                 return Err(PeerConnectionError::NoMatchingCapabilities);
             }
-            debug!("Negotatied eth version: eth/{}", negotiated_eth_version);
+            debug!("Negotiated eth version: eth/{}", negotiated_eth_version);
             state.negotiated_eth_capability = Some(Capability::eth(negotiated_eth_version));
 
             if negotiated_snap_version != 0 {
-                debug!("Negotatied snap version: snap/{}", negotiated_snap_version);
+                debug!("Negotiated snap version: snap/{}", negotiated_snap_version);
                 state.negotiated_snap_capability = Some(Capability::snap(negotiated_snap_version));
             }
 
@@ -1169,7 +1169,7 @@ async fn handle_incoming_message(
             | Message::GetTrieNodes(_)
     );
     if is_data_request && !check_serve_request_rate(state) {
-        warn!(
+        debug!(
             peer = %state.node,
             window_requests = state.serve_requests_in_window,
             "Disconnecting peer: exceeded incoming request rate limit",
@@ -1387,10 +1387,10 @@ async fn handle_incoming_message(
             );
             // We will only validate the incoming update, we may decide to store and use this information in the future
             if let Err(err) = update.validate() {
-                warn!(
+                debug!(
                     peer=%state.node,
                     reason=%err,
-                    "disconnected from peer",
+                    "Disconnecting peer: invalid block range update",
                 );
                 send_disconnect_message(state, Some(DisconnectReason::SubprotocolError)).await;
                 return Err(PeerConnectionError::DisconnectSent(
@@ -1419,7 +1419,7 @@ async fn handle_incoming_message(
             if state.txs_sent_to_peer + batch_size > LEECH_TX_SENT_THRESHOLD
                 && !state.received_txs_from_peer
             {
-                warn!(
+                debug!(
                     peer = %state.node,
                     txs_sent = state.txs_sent_to_peer,
                     "Disconnecting peer: leech detected (sent many txs but received none)",
@@ -1454,9 +1454,9 @@ async fn handle_incoming_message(
                             .validate_blob_commitment_hashes(&itx.tx.blob_versioned_hashes)
                             .is_err())
                 {
-                    warn!(
+                    debug!(
                         peer=%state.node,
-                        "disconnected from peer. Reason: Invalid/Missing Blobs",
+                        "Disconnecting peer: invalid or missing blobs",
                     );
                     if let Some((_announced, requested_hashes, _)) = &removed_request {
                         retry_on_alternates(&state.blockchain, &state.peer_table, requested_hashes)
@@ -1472,10 +1472,10 @@ async fn handle_incoming_message(
                 if let Some((announced, requested_hashes, _)) = &removed_request {
                     let fork = state.blockchain.current_fork().await?;
                     if let Err(error) = msg.validate_requested(announced, fork) {
-                        warn!(
+                        debug!(
                             peer=%state.node,
                             reason=%error,
-                            "disconnected from peer",
+                            "Disconnecting peer: invalid pooled transactions response",
                         );
                         retry_on_alternates(&state.blockchain, &state.peer_table, requested_hashes)
                             .await;
@@ -1496,10 +1496,10 @@ async fn handle_incoming_message(
                         error,
                         ethrex_blockchain::error::MempoolError::BlobsBundleError(_)
                     ) {
-                        warn!(
+                        debug!(
                             peer=%state.node,
                             reason=%error,
-                            "disconnected from peer",
+                            "Disconnecting peer: invalid pooled transactions response",
                         );
                         if let Some((_announced, requested_hashes, _)) = &removed_request {
                             retry_on_alternates(
@@ -1685,7 +1685,7 @@ async fn flush_pending_tx_requests(state: &mut Established) -> Result<(), PeerCo
             let unsent = &all_hashes[offset..];
             if !unsent.is_empty() {
                 if let Err(clear_err) = state.blockchain.mempool.clear_in_flight_txs(unsent) {
-                    warn!(error = %clear_err, "clear_in_flight_txs failed after send error");
+                    warn!(error = %clear_err, "Failed to clear in-flight transaction tracking after send error");
                 }
                 retry_on_alternates(&state.blockchain, &state.peer_table, unsent).await;
             }
@@ -1767,7 +1767,7 @@ async fn retry_on_alternates(
         let announcement =
             NewPooledTransactionHashes::from_raw(types.into(), sizes, hash_list.clone());
         if let Err(e) = conn.enqueue_tx_requests(announcement, hash_list) {
-            warn!(error = %e, "failed to enqueue tx requests on alternate peer");
+            debug!(error = %e, "Failed to enqueue tx requests on alternate peer");
         }
     }
 }

--- a/crates/networking/p2p/rlpx/initiator.rs
+++ b/crates/networking/p2p/rlpx/initiator.rs
@@ -11,7 +11,7 @@ use spawned_concurrency::{
     },
 };
 use std::time::Duration;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 #[derive(Debug, thiserror::Error)]
 pub enum RLPxInitiatorError {
@@ -49,7 +49,7 @@ impl RLPxInitiator {
         context: P2PContext,
         backend: Option<Backend>,
     ) -> ActorRef<RLPxInitiator> {
-        info!("Starting RLPx Initiator");
+        debug!("Starting RLPx initiator");
         let state = RLPxInitiator::new(context);
         let actor_ref = match backend {
             Some(b) => state.start_with_backend(b),

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -39,7 +39,7 @@ use std::{
     sync::atomic::Ordering,
     time::{Duration, SystemTime},
 };
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 // Re-export DumpError from error module
 pub use super::error::DumpError;
@@ -139,7 +139,7 @@ pub async fn request_account_range(
     let (task_sender, mut task_receiver) =
         tokio::sync::mpsc::channel::<(Vec<AccountRangeUnit>, H256, Option<(H256, H256)>)>(1000);
 
-    info!("Starting to download account ranges from peers");
+    debug!("Starting to download account ranges from peers");
 
     *METRICS.account_tries_download_start_time.lock().await = Some(SystemTime::now());
 
@@ -234,7 +234,7 @@ pub async fn request_account_range(
 
         let Some((chunk_start, chunk_end)) = tasks_queue_not_started.pop_front() else {
             if completed_tasks >= chunk_count {
-                info!("All account ranges downloaded successfully");
+                debug!("All account ranges downloaded successfully");
                 break;
             }
             continue;
@@ -243,7 +243,7 @@ pub async fn request_account_range(
         let tx = task_sender.clone();
 
         if block_is_stale(pivot_header) {
-            info!("request_account_range became stale, updating pivot");
+            debug!("Pivot became stale during account range download, updating pivot");
             *pivot_header = update_pivot(
                 pivot_header.number,
                 pivot_header.timestamp,
@@ -287,12 +287,7 @@ pub async fn request_account_range(
 
         let path = get_account_state_snapshot_file(account_state_snapshots_dir, chunk_file);
         dump_accounts_to_file(&path, account_state_chunk)
-            .inspect_err(|err| {
-                error!(
-                    "We had an error dumping the last accounts to disk {}",
-                    err.error
-                )
-            })
+            .inspect_err(|err| error!("Failed to dump remaining accounts to disk: {}", err.error))
             .map_err(|_| {
                 SnapError::SnapshotDir(format!(
                     "Failed to write state snapshot chunk {}",
@@ -358,7 +353,7 @@ pub async fn request_bytecodes(
     }
     let (task_sender, mut task_receiver) = tokio::sync::mpsc::channel::<TaskResult>(1000);
 
-    info!("Starting to download bytecodes from peers");
+    debug!("Starting to download bytecodes from peers");
 
     METRICS
         .bytecodes_to_download
@@ -421,7 +416,7 @@ pub async fn request_bytecodes(
 
         let Some((chunk_start, chunk_end)) = tasks_queue_not_started.pop_front() else {
             if completed_tasks >= chunk_count {
-                info!("All bytecodes downloaded successfully");
+                debug!("All bytecodes downloaded successfully");
                 break;
             }
             continue;
@@ -487,7 +482,7 @@ pub async fn request_bytecodes(
     METRICS
         .downloaded_bytecodes
         .fetch_add(downloaded_count, Ordering::Relaxed);
-    info!(
+    debug!(
         "Finished downloading bytecodes, total bytecodes: {}",
         all_bytecode_hashes.len()
     );
@@ -602,7 +597,7 @@ pub async fn request_storage_ranges(
                     .await
                     .expect("Shouldn't be empty")
                     .expect("Shouldn't have a join error")
-                    .inspect_err(|err| error!("We found this error while dumping to file {err:?}"))
+                    .inspect_err(|err| error!("Failed to dump storage snapshot to file: {err:?}"))
                     .map_err(SnapError::from)?;
             }
             disk_joinset.spawn(async move {
@@ -917,7 +912,7 @@ pub async fn request_storage_ranges(
         }
 
         if block_is_stale(pivot_header) {
-            info!("request_storage_ranges became stale, breaking");
+            debug!("Pivot became stale during storage range download, stopping this round");
             break;
         }
 
@@ -992,7 +987,7 @@ pub async fn request_storage_ranges(
         .await
         .into_iter()
         .map(|result| {
-            result.inspect_err(|err| error!("We found this error while dumping to file {err:?}"))
+            result.inspect_err(|err| error!("Failed to dump storage snapshot to file: {err:?}"))
         })
         .collect::<Result<Vec<()>, DumpError>>()
         .map_err(SnapError::from)?;
@@ -1059,7 +1054,7 @@ pub async fn request_state_trienodes(
 
     for (index, node) in nodes.iter().enumerate() {
         if node.compute_hash(&NativeCrypto).finalize(&NativeCrypto) != paths[index].hash {
-            error!(
+            debug!(
                 "A peer is sending wrong data for the state trie node {:?}",
                 paths[index].path
             );
@@ -1183,7 +1178,7 @@ async fn request_account_range_worker(
                     (filtered, chunk_left)
                 }
                 Err(_) => {
-                    tracing::error!("Received invalid account range");
+                    tracing::debug!("Received invalid account range");
                     retry()
                 }
             }
@@ -1272,7 +1267,7 @@ async fn request_storage_ranges_worker(
         let last_slot_index = slots.len() - 1;
         for (i, next_account_slots) in slots.into_iter().enumerate() {
             if next_account_slots.is_empty() {
-                error!("Received empty storage range, skipping");
+                debug!("Received empty storage range, skipping");
                 validation_failed = true;
                 break;
             }
@@ -1285,7 +1280,7 @@ async fn request_storage_ranges_worker(
             let storage_root = match storage_roots.next() {
                 Some(root) => root,
                 None => {
-                    error!("No storage root for account {i}");
+                    debug!("No storage root for account {i}");
                     break 'outcome retry_outcome();
                 }
             };

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -189,7 +189,7 @@ impl Syncer {
                     }
                     true => {
                         // We do nothing, as the error is recoverable
-                        error!(
+                        warn!(
                             time_elapsed_s = start_time.elapsed().as_secs(),
                             %sync_head,
                             %error, "Sync cycle failed, retrying",

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -65,7 +65,7 @@ pub async fn sync_cycle_full(
     mut sync_head: H256,
     store: Store,
 ) -> Result<(), SyncError> {
-    info!("Syncing to sync_head {:?}", sync_head);
+    debug!("Syncing to sync_head {:?}", sync_head);
 
     // Check if the sync_head is a pending block, if so, gather all pending blocks belonging to its chain
     let mut pending_blocks = vec![];
@@ -114,7 +114,7 @@ pub async fn sync_cycle_full(
                 return Ok(());
             }
             attempts += 1;
-            warn!(
+            debug!(
                 "Failed to fetch headers for sync head (attempt {attempts}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
             );
             tokio::time::sleep(Duration::from_secs(2)).await;
@@ -127,8 +127,8 @@ pub async fn sync_cycle_full(
         let first_header = block_headers.first().ok_or(SyncError::NoBlocks)?;
         let last_header = block_headers.last().ok_or(SyncError::NoBlocks)?;
 
-        info!(
-            "Received {} block headers| First Number: {} Last Number: {}",
+        debug!(
+            "Received {} block headers | First Number: {} Last Number: {}",
             block_headers.len(),
             first_header.number,
             last_header.number,
@@ -297,7 +297,7 @@ pub async fn sync_cycle_full(
     // Main loop: receive downloaded batches and execute them
     while let Some(result) = body_rx.recv().await {
         let (blocks, final_batch) = result?;
-        info!(
+        debug!(
             "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
             blocks.len(),
             blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
@@ -319,7 +319,7 @@ pub async fn sync_cycle_full(
 
     // Execute pending blocks
     if !pending_blocks.is_empty() {
-        info!(
+        debug!(
             "Executing {} blocks for full sync. First block hash: {:#?} Last block hash: {:#?}",
             pending_blocks.len(),
             pending_blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
@@ -388,7 +388,7 @@ async fn add_blocks_in_batch(
             match peers.request_block_access_lists(&blocks_hashes).await {
                 Ok(Some(bals)) if bals.len() == blocks.len() => bals,
                 _ => {
-                    debug!("[SYNCING] BAL fetch unavailable or failed, proceeding without BALs");
+                    debug!("BAL fetch unavailable or failed, proceeding without BALs");
                     vec![None; blocks.len()]
                 }
             }
@@ -437,17 +437,14 @@ async fn add_blocks_in_batch(
     let blocks_per_second = blocks_len as f64 / execution_time;
 
     info!(
-        "[SYNCING] Executed & stored {} blocks in {:.3} seconds.\n\
-        Started at block with hash {} (number {}).\n\
-        Finished at block with hash {} (number {}).\n\
-        Blocks per second: {:.3}",
+        "Executed and stored {} blocks in {:.3} seconds ({:.3} blocks/s). First block: {} ({}). Last block: {} ({}).",
         blocks_len,
         execution_time,
-        first_block_hash,
+        blocks_per_second,
         first_block_number,
-        last_block_hash,
+        first_block_hash,
         last_block_number,
-        blocks_per_second
+        last_block_hash
     );
     Ok(())
 }

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -126,7 +126,7 @@ pub async fn sync_cycle_snap(
         diag.current_phase = "headers".to_string();
         diag.sync_mode = "snap".to_string();
     }
-    info!(
+    debug!(
         "Syncing from current head {:?} to sync_head {:?}",
         current_head, sync_head
     );
@@ -154,7 +154,7 @@ pub async fn sync_cycle_snap(
                 return Ok(());
             }
             attempts += 1;
-            warn!(
+            debug!(
                 "Failed to fetch headers for sync head (attempt {attempts}/{MAX_HEADER_FETCH_ATTEMPTS}), retrying in 2s"
             );
             tokio::time::sleep(Duration::from_secs(2)).await;
@@ -336,7 +336,6 @@ pub async fn snap_sync(
         // account_state_snapshots_dir
 
         diagnostics.write().await.current_phase = "account_ranges".to_string();
-        info!("Starting to download account ranges from peers");
         request_account_range(
             peers,
             H256::zero(),
@@ -347,7 +346,7 @@ pub async fn snap_sync(
             diagnostics,
         )
         .await?;
-        info!("Finish downloading account ranges from peers");
+        debug!("Finished downloading account ranges from peers");
 
         {
             let mut diag = diagnostics.write().await;
@@ -376,14 +375,14 @@ pub async fn snap_sync(
             &mut code_hash_collector,
         )
         .await?;
-        info!(
+        debug!(
             "Finished inserting account ranges, total storage accounts: {}",
             storage_accounts.accounts_with_storage_root.len()
         );
         *METRICS.account_tries_insert_end_time.lock().await = Some(SystemTime::now());
 
-        info!("Original state root: {state_root:?}");
-        info!("Computed state root after request_account_rages: {computed_state_root:?}");
+        debug!("Original state root: {state_root:?}");
+        debug!("Computed state root after request_account_ranges: {computed_state_root:?}");
 
         diagnostics.write().await.current_phase = "storage_ranges".to_string();
         *METRICS.storage_tries_download_start_time.lock().await = Some(SystemTime::now());
@@ -419,7 +418,7 @@ pub async fn snap_sync(
                 continue;
             };
 
-            info!(
+            debug!(
                 "Started request_storage_ranges with {} accounts with storage root unchanged",
                 storage_accounts.accounts_with_storage_root.len()
             );
@@ -453,14 +452,13 @@ pub async fn snap_sync(
                 }
 
                 warn!(
-                    "Storage could not be downloaded after multiple attempts. Marking for healing.
-                    This could impact snap sync time (healing may take a while)."
+                    "Storage could not be downloaded after multiple attempts. Marking for healing. This could impact snap sync time (healing may take a while)."
                 );
 
                 storage_accounts.accounts_with_storage_root.clear();
             }
 
-            info!(
+            debug!(
                 "Ended request_storage_ranges with {} accounts with storage root unchanged and not downloaded yet and with {} big/healed accounts",
                 storage_accounts.accounts_with_storage_root.len(),
                 // These accounts are marked as heals if they're a big account. This is
@@ -470,9 +468,9 @@ pub async fn snap_sync(
             if !block_is_stale(&pivot_header) {
                 break;
             }
-            info!("We stopped because of staleness, restarting loop");
+            debug!("Pivot became stale during storage download, restarting loop");
         }
-        info!("Finished request_storage_ranges");
+        debug!("Finished request_storage_ranges");
         *METRICS.storage_tries_download_end_time.lock().await = Some(SystemTime::now());
 
         diagnostics.write().await.current_phase = "storage_insertion".to_string();
@@ -492,12 +490,12 @@ pub async fn snap_sync(
 
         *METRICS.storage_tries_insert_end_time.lock().await = Some(SystemTime::now());
 
-        info!("Finished storing storage tries");
+        debug!("Finished storing storage tries");
     }
 
     diagnostics.write().await.current_phase = "healing".to_string();
     *METRICS.heal_start_time.lock().await = Some(SystemTime::now());
-    info!("Starting Healing Process");
+    debug!("Starting healing process");
     let mut global_state_leafs_healed: u64 = 0;
     let mut global_storage_leafs_healed: u64 = 0;
     let mut healing_done = false;
@@ -544,7 +542,7 @@ pub async fn snap_sync(
     debug_assert!(validate_state_root(store.clone(), pivot_header.state_root).await);
     debug_assert!(validate_storage_root(store.clone(), pivot_header.state_root).await);
 
-    info!("Finished healing");
+    debug!("Finished healing");
 
     // Finish code hash collection
     code_hash_collector.finish().await?;
@@ -556,7 +554,7 @@ pub async fn snap_sync(
     let mut code_hashes_to_download = Vec::new();
 
     diagnostics.write().await.current_phase = "bytecodes".to_string();
-    info!("Starting download code hashes from peers");
+    debug!("Starting download code hashes from peers");
     let code_hash_files = async_fs::read_dir_paths(&code_hashes_dir).await?;
     for file_path in code_hash_files {
         let snapshot_contents = async_fs::read_file(&file_path).await?;
@@ -569,7 +567,7 @@ pub async fn snap_sync(
                 code_hashes_to_download.push(hash);
 
                 if code_hashes_to_download.len() >= BYTECODE_CHUNK_SIZE {
-                    info!(
+                    debug!(
                         "Starting bytecode download of {} hashes",
                         code_hashes_to_download.len()
                     );
@@ -781,7 +779,7 @@ pub async fn update_pivot(
             rotation = rotation_count,
             "update_pivot: attempting with peer"
         );
-        info!(
+        debug!(
             "Trying to update pivot to {new_pivot_block_number} with peer {peer_id} (score: {peer_score})"
         );
 
@@ -796,7 +794,7 @@ pub async fn update_pivot(
                 peers.peer_table.record_success(peer_id)?;
                 #[cfg(feature = "metrics")]
                 ethrex_metrics::sync::METRICS_SYNC.inc_pivot_update("success");
-                info!("Successfully updated pivot");
+                info!("Snap sync pivot updated to block {}", pivot.number);
 
                 {
                     let mut diag = diagnostics.write().await;
@@ -828,7 +826,7 @@ pub async fn update_pivot(
             Ok(None) => {
                 peers.peer_table.record_failure(peer_id)?;
                 let peer_score = peers.peer_table.get_score(peer_id).await?;
-                warn!(
+                debug!(
                     "update_pivot: peer {peer_id} returned None (score: {peer_score}), excluding for this rotation"
                 );
                 #[cfg(feature = "metrics")]
@@ -837,7 +835,7 @@ pub async fn update_pivot(
             }
             Err(e) if e.is_recoverable() => {
                 peers.peer_table.record_failure(peer_id)?;
-                warn!("update_pivot: peer {peer_id} failed with {e}, excluding for this rotation");
+                debug!("update_pivot: peer {peer_id} failed with {e}, excluding for this rotation");
                 #[cfg(feature = "metrics")]
                 ethrex_metrics::sync::METRICS_SYNC.inc_pivot_update("peer_error");
                 excluded_peers.push(peer_id);
@@ -885,7 +883,7 @@ pub async fn validate_state_root(store: Store, state_root: H256) -> bool {
     .expect("We should be able to create threads");
 
     if validated.is_ok() {
-        info!("Succesfully validated tree, {state_root} found");
+        info!("Successfully validated tree, {state_root} found");
     } else {
         error!("We have failed the validation of the state tree");
         std::process::exit(1);
@@ -995,7 +993,7 @@ async fn insert_accounts(
     let mut computed_state_root = *EMPTY_TRIE_HASH;
     let snapshot_files = async_fs::read_dir_paths(account_state_snapshots_dir).await?;
     for snapshot_path in snapshot_files {
-        info!("Reading account file from {snapshot_path:?}");
+        debug!("Reading account file from {snapshot_path:?}");
         let snapshot_contents = async_fs::read_file(&snapshot_path).await?;
         let account_states_snapshot: Vec<(H256, AccountState)> =
             RLPDecode::decode(&snapshot_contents)

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -14,7 +14,7 @@ use tokio::{
     time::{Duration, sleep},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     peer_handler::PeerHandler,
@@ -203,6 +203,7 @@ impl SyncManager {
             let Ok(mut syncer) = syncer.try_lock() else {
                 return;
             };
+            let mut waiting_for_fcu_logged = false;
             loop {
                 let sync_head = {
                     // Read latest fcu head without holding the lock for longer than needed
@@ -214,7 +215,16 @@ impl SyncManager {
                 };
                 // Edge case: If we are resuming a sync process after a node restart, wait until the next fcu to start
                 if sync_head.is_zero() {
-                    info!("Resuming sync after node restart, waiting for next FCU");
+                    if waiting_for_fcu_logged {
+                        debug!(
+                            "Still waiting for a forkchoice update from the consensus client to resume sync"
+                        );
+                    } else {
+                        info!(
+                            "Resuming sync after node restart, waiting for a forkchoice update from the consensus client"
+                        );
+                        waiting_for_fcu_logged = true;
+                    }
                     sleep(Duration::from_secs(5)).await;
                     continue;
                 }

--- a/crates/networking/p2p/tx_broadcaster.rs
+++ b/crates/networking/p2p/tx_broadcaster.rs
@@ -15,7 +15,7 @@ use spawned_concurrency::{
     protocol,
     tasks::{Actor, ActorRef, ActorStart as _, Context, Handler, send_interval},
 };
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, trace};
 
 use crate::{
     peer_table::{PeerTable, PeerTableServerProtocol as _},
@@ -130,7 +130,7 @@ pub async fn send_tx_hashes(
                 NewPooledTransactionHashes::new(txs_to_send, blockchain)?,
             );
             connection.outgoing_message(hashes_message.clone()).await.unwrap_or_else(|err| {
-                error!(peer_id = %format!("{:#x}", peer_id), err = ?err, "Failed to send transactions hashes");
+                debug!(peer_id = %format!("{:#x}", peer_id), err = ?err, "Failed to send transaction hashes");
             });
         }
     }
@@ -144,7 +144,7 @@ impl TxBroadcaster {
         blockchain: Arc<Blockchain>,
         tx_broadcasting_time_interval: u64,
     ) -> Result<ActorRef<TxBroadcaster>, TxBroadcasterError> {
-        info!("Starting Transaction Broadcaster");
+        debug!("Starting transaction broadcaster");
 
         let state = TxBroadcaster {
             peer_table: kademlia,
@@ -181,8 +181,8 @@ impl TxBroadcaster {
     ) {
         trace!(received = "BroadcastTxs");
 
-        let _ = self.do_broadcast_txs().await.inspect_err(|_| {
-            error!("Failed to broadcast transactions");
+        let _ = self.do_broadcast_txs().await.inspect_err(|err| {
+            error!(err = ?err, "Failed to broadcast transactions");
         });
     }
 
@@ -299,7 +299,7 @@ impl TxBroadcaster {
                 transactions: txs_to_send,
             });
             connection.outgoing_message(txs_message).await.unwrap_or_else(|err| {
-                error!(peer_id = %format!("{:#x}", peer_id), err = ?err, "Failed to send transactions");
+                debug!(peer_id = %format!("{:#x}", peer_id), err = ?err, "Failed to send transactions");
             });
             self.send_tx_hashes_internal(blob_txs.clone(), capabilities, &mut connection, peer_id)
                 .await?;

--- a/crates/networking/p2p/utils.rs
+++ b/crates/networking/p2p/utils.rs
@@ -160,7 +160,7 @@ pub fn dump_accounts_to_file(
 ) -> Result<(), DumpError> {
     #[cfg(feature = "rocksdb")]
     return dump_accounts_to_rocks_db(path, accounts)
-        .inspect_err(|err| error!("Rocksdb writing stt error {err:?}"))
+        .inspect_err(|err| error!("RocksDB SST write error: {err:?}"))
         .map_err(|_| DumpError {
             path: path.to_path_buf(),
             error: std::io::ErrorKind::Other,
@@ -202,7 +202,7 @@ pub fn dump_storages_to_file(
             .flatten()
             .collect::<Vec<_>>(),
     )
-    .inspect_err(|err| error!("Rocksdb writing stt error {err:?}"))
+    .inspect_err(|err| error!("RocksDB SST write error: {err:?}"))
     .map_err(|_| DumpError {
         path: path.to_path_buf(),
         error: std::io::ErrorKind::Other,


### PR DESCRIPTION
**Motivation**

The default log level is INFO, and at INFO the module target is not printed, so everything the p2p stack logs at INFO/WARN/ERROR is what a node operator reads. A review of all 453 log statements in `crates/networking/p2p` found three recurring problems:

1. **ERROR used for remote-peer behavior and network churn.** Discovery UDP send failures (e.g. unreachable/IPv6 endpoints), tx broadcasts to peers that are disconnecting, and invalid snap responses all log red ERROR lines while the code already self-heals (peer penalized/disposed, request retried). On a healthy mainnet node these recur in steady state.
2. **WARN spam from per-peer request failures during sync.** Every peer timeout or invalid header/body response logs a warn (`[SYNCING] Didn't receive ... penalizing peer ...`), continuously on flaky networks, while the operator-relevant signal already exists at the aggregate level (cycle-abort warn, peer counts in the snap-sync progress UI).
3. **INFO chatter competing with the progress UI.** Raw phase narration (`Started request_storage_ranges with ...`, `We stopped because of staleness, restarting loop`, one line even logged twice back-to-back) interleaves with the banner/progress-bar UI that already reports the same phases. On a *synced* node, the full-sync cycle runs every slot, so `Syncing to sync_head ...`, `Received N block headers| ...`, `Executing N blocks ...` and a 4-line `[SYNCING] Executed & stored ...` message repeat every ~12s.

**Description**

Level policy applied: ERROR = local faults needing operator attention (disk/DB/corruption/invariants), never remote-peer behavior · WARN = degraded-but-recovering, operator-relevant · INFO = lifecycle milestones + progress UI · DEBUG = per-peer/per-request events and internal phases · TRACE = wire traffic.

- **ERROR → DEBUG (11 sites):** discovery UDP send failures (`discv4_handlers`, `discv5_handlers`), incoming-ping handling errors, tx-broadcaster send failures to individual peers, invalid/empty snap responses (`snap/client.rs`). All are remote-caused and retried.
- **ERROR → WARN (1):** `Sync cycle failed, retrying` — by construction recoverable; the irrecoverable branch that exits the node stays ERROR.
- **WARN → DEBUG (~20):** per-peer sync request failures in `peer_handler.rs`, routine protective disconnects in the connection server (rate limit, leech detection, invalid responses), per-peer pivot-update failures, per-attempt header-fetch retries (the final-abort warn stays).
- **INFO → DEBUG (~28):** snap-sync phase chatter superseded by the progress UI, full-sync per-batch/per-slot lines, internal component startup messages (`Starting RLPx initiator`, `Starting transaction broadcaster`, discovery startup line that duplicated the "listening" line). `Unexpected flag` on malformed discv5 packets goes to TRACE, matching how the sibling unrecognized-packet path already logs. Removed the duplicated `Starting to download account ranges from peers` (was logged twice back-to-back from `snap_sync.rs` and `snap/client.rs`).
- **Kept at level, message fixed:**
  - Flattened the multi-line `Executed & stored` summary into one line and dropped the `[SYNCING]` prefix (used inconsistently by only a handful of messages).
  - Pivot update success now logs the new pivot block number instead of a bare `Successfully updated pivot` (the number previously only appeared on the *attempt* line).
  - `Resuming sync after node restart, waiting for next FCU` logged once instead of every 5s while the consensus client is down, and spells out "forkchoice update".
  - Replaced function names and first-person phrasing in user-visible messages (`clear_in_flight_txs failed ...`, `We had an error dumping ...`, `Error handling cast message` → operator language).
  - Post-sync peer stats line reordered: `Peers: N (snap-capable: M)`.
  - `Failed to broadcast transactions` now includes the underlying error (was discarded).
  - Typos: `request_account_rages`, `Succesfully`, `Negotatied`, `Rocksdb writing stt error`, `transactions hashes`, `Finish downloading`.

Deliberately **not** changed (borderline, can follow up): `healing/storage.rs` "more trie nodes than requested" warn, `pop_alternate`/`get_peer_connection` failure warns (actor/store faults), the L2 connection messages, and the per-slot storage-insert warn in `compute_storage_roots` (swallows the error today — worth its own correctness-focused PR).

No behavior changes beyond log levels/messages and the two log-once flags. `cargo clippy -p ethrex-p2p` clean with default, `rocksdb,metrics`, and `l2` feature sets; `cargo test -p ethrex-p2p --lib` passes (50/50); `cargo fmt` applied.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.