### PR TITLE
fix(l1): stop panicking when the account-range dispatcher fails to update a stale pivot

### DIFF
--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -17,7 +17,7 @@ use crate::{
         },
     },
     snap::{async_fs, constants::*, encodable_to_proof, error::SnapError},
-    sync::{AccountStorageRoots, SnapBlockSyncState, block_is_stale, update_pivot},
+    sync::{AccountStorageRoots, SnapBlockSyncState, block_is_stale, refresh_stale_pivot},
     utils::{
         AccountsWithStorage, dump_accounts_to_file, dump_storages_to_file,
         get_account_state_snapshot_file, get_account_storages_snapshot_file,
@@ -242,18 +242,7 @@ pub async fn request_account_range(
 
         let tx = task_sender.clone();
 
-        if block_is_stale(pivot_header) {
-            info!("request_account_range became stale, updating pivot");
-            *pivot_header = update_pivot(
-                pivot_header.number,
-                pivot_header.timestamp,
-                peers,
-                block_sync_state,
-                diagnostics,
-            )
-            .await
-            .expect("Should be able to update pivot")
-        }
+        refresh_stale_pivot(pivot_header, peers, block_sync_state, diagnostics).await?;
 
         tokio::spawn(request_account_range_worker(
             peer_id,

--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -17,7 +17,7 @@ use crate::{
         },
     },
     snap::{async_fs, constants::*, encodable_to_proof, error::SnapError},
-    sync::{AccountStorageRoots, SnapBlockSyncState, block_is_stale, refresh_stale_pivot},
+    sync::{AccountStorageRoots, SnapBlockSyncState, block_is_stale, update_pivot},
     utils::{
         AccountsWithStorage, dump_accounts_to_file, dump_storages_to_file,
         get_account_state_snapshot_file, get_account_storages_snapshot_file,
@@ -242,7 +242,24 @@ pub async fn request_account_range(
 
         let tx = task_sender.clone();
 
-        refresh_stale_pivot(pivot_header, peers, block_sync_state, diagnostics).await?;
+        if block_is_stale(pivot_header) {
+            info!("request_account_range became stale, updating pivot");
+            // A pivot we couldn't refresh is a transient peer condition: map
+            // it to the one snap error the sync cycle retries instead of
+            // treating as fatal (this used to be an .expect that panicked).
+            *pivot_header = update_pivot(
+                pivot_header.number,
+                pivot_header.timestamp,
+                peers,
+                block_sync_state,
+                diagnostics,
+            )
+            .await
+            .map_err(|e| {
+                error!("Failed to update stale pivot during account range download: {e}");
+                SnapError::PivotUpdateFailed
+            })?;
+        }
 
         tokio::spawn(request_account_range_worker(
             peer_id,

--- a/crates/networking/p2p/snap/error.rs
+++ b/crates/networking/p2p/snap/error.rs
@@ -90,6 +90,12 @@ pub enum SnapError {
     /// Hash mismatch in received data
     #[error("Hash mismatch in received data")]
     InvalidHash,
+
+    /// Could not refresh a stale pivot (peers exhausted or unavailable).
+    /// A transient peer condition: unlike other snap errors, the sync cycle
+    /// must retry it rather than treat it as fatal.
+    #[error("Failed to update stale pivot")]
+    PivotUpdateFailed,
 }
 
 impl SnapError {

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -33,8 +33,8 @@ use tracing::{debug, error, info, warn};
 
 // Re-export types used by submodules
 pub use snap_sync::{
-    SnapBlockSyncState, block_is_stale, calculate_staleness_timestamp, refresh_stale_pivot,
-    update_pivot, validate_bytecodes, validate_state_root, validate_storage_root,
+    SnapBlockSyncState, block_is_stale, calculate_staleness_timestamp, update_pivot,
+    validate_bytecodes, validate_state_root, validate_storage_root,
 };
 
 #[cfg(feature = "sync-test")]

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -33,8 +33,8 @@ use tracing::{debug, error, info, warn};
 
 // Re-export types used by submodules
 pub use snap_sync::{
-    SnapBlockSyncState, block_is_stale, calculate_staleness_timestamp, update_pivot,
-    validate_bytecodes, validate_state_root, validate_storage_root,
+    SnapBlockSyncState, block_is_stale, calculate_staleness_timestamp, refresh_stale_pivot,
+    update_pivot, validate_bytecodes, validate_state_root, validate_storage_root,
 };
 
 #[cfg(feature = "sync-test")]
@@ -418,8 +418,11 @@ impl SyncError {
             | SyncError::NoLatestCanonical
             | SyncError::PeerTableError(_)
             | SyncError::MissingFullsyncBatch
-            | SyncError::Snap(_)
             | SyncError::FileSystem(_) => false,
+            // A stale pivot we couldn't refresh is a transient peer
+            // condition; every other snap error stays fatal.
+            SyncError::Snap(crate::snap::SnapError::PivotUpdateFailed) => true,
+            SyncError::Snap(_) => false,
             SyncError::Chain(_)
             | SyncError::Store(_)
             | SyncError::Send(_)

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -691,6 +691,35 @@ pub async fn store_block_bodies(
     Ok(())
 }
 
+/// Refreshes the pivot in place if it became stale, for use inside download
+/// dispatchers. Failure is a transient peer condition and must propagate as
+/// a recoverable error so the sync cycle retries: the account-range
+/// dispatcher used to panic here, while the equivalent sync-cycle call
+/// sites retry.
+pub async fn refresh_stale_pivot(
+    pivot_header: &mut BlockHeader,
+    peers: &mut PeerHandler,
+    block_sync_state: &mut SnapBlockSyncState,
+    diagnostics: &Arc<tokio::sync::RwLock<super::SyncDiagnostics>>,
+) -> Result<(), crate::snap::SnapError> {
+    if block_is_stale(pivot_header) {
+        info!("Download pivot became stale, updating pivot");
+        *pivot_header = update_pivot(
+            pivot_header.number,
+            pivot_header.timestamp,
+            peers,
+            block_sync_state,
+            diagnostics,
+        )
+        .await
+        .map_err(|e| {
+            error!("Failed to update stale pivot: {e}");
+            crate::snap::SnapError::PivotUpdateFailed
+        })?;
+    }
+    Ok(())
+}
+
 pub async fn update_pivot(
     block_number: u64,
     block_timestamp: u64,
@@ -1393,6 +1422,33 @@ mod unbounded_wait_tests {
             Err(_) => panic!("update_pivot still waiting after a virtual hour with no peers"),
             Ok(Ok(_)) => panic!("update_pivot cannot succeed with no peers"),
             Ok(Err(e)) => assert!(e.is_recoverable(), "expected a recoverable error, got: {e}"),
+        }
+    }
+
+    // The download dispatchers refresh the pivot in-loop when it goes stale.
+    // A failed refresh must surface as a recoverable error so the sync cycle
+    // retries; the account-range dispatcher used to panic on it, and a naive
+    // error conversion would land in the fatal SyncError::Snap arm instead.
+    #[tokio::test(start_paused = true)]
+    async fn failed_pivot_refresh_is_recoverable() {
+        let store = Store::new("", EngineType::InMemory).expect("in-memory store");
+        let mut peers = PeerHandler::new_for_test(store.clone());
+        let mut state = SnapBlockSyncState::new(store.clone());
+        let diagnostics = Arc::new(tokio::sync::RwLock::new(SyncDiagnostics::default()));
+        // timestamp 0 makes the pivot stale by the clock-based check.
+        let mut pivot = BlockHeader::default();
+        let res = tokio::time::timeout(
+            Duration::from_secs(3600),
+            refresh_stale_pivot(&mut pivot, &mut peers, &mut state, &diagnostics),
+        )
+        .await;
+        match res {
+            Err(_) => panic!("refresh_stale_pivot still waiting after a virtual hour"),
+            Ok(Ok(())) => panic!("refresh cannot succeed with no peers"),
+            Ok(Err(e)) => {
+                let e = SyncError::from(e);
+                assert!(e.is_recoverable(), "expected a recoverable error, got: {e}");
+            }
         }
     }
 }

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -691,35 +691,6 @@ pub async fn store_block_bodies(
     Ok(())
 }
 
-/// Refreshes the pivot in place if it became stale, for use inside download
-/// dispatchers. Failure is a transient peer condition and must propagate as
-/// a recoverable error so the sync cycle retries: the account-range
-/// dispatcher used to panic here, while the equivalent sync-cycle call
-/// sites retry.
-pub async fn refresh_stale_pivot(
-    pivot_header: &mut BlockHeader,
-    peers: &mut PeerHandler,
-    block_sync_state: &mut SnapBlockSyncState,
-    diagnostics: &Arc<tokio::sync::RwLock<super::SyncDiagnostics>>,
-) -> Result<(), crate::snap::SnapError> {
-    if block_is_stale(pivot_header) {
-        info!("Download pivot became stale, updating pivot");
-        *pivot_header = update_pivot(
-            pivot_header.number,
-            pivot_header.timestamp,
-            peers,
-            block_sync_state,
-            diagnostics,
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to update stale pivot: {e}");
-            crate::snap::SnapError::PivotUpdateFailed
-        })?;
-    }
-    Ok(())
-}
-
 pub async fn update_pivot(
     block_number: u64,
     block_timestamp: u64,
@@ -1422,33 +1393,6 @@ mod unbounded_wait_tests {
             Err(_) => panic!("update_pivot still waiting after a virtual hour with no peers"),
             Ok(Ok(_)) => panic!("update_pivot cannot succeed with no peers"),
             Ok(Err(e)) => assert!(e.is_recoverable(), "expected a recoverable error, got: {e}"),
-        }
-    }
-
-    // The download dispatchers refresh the pivot in-loop when it goes stale.
-    // A failed refresh must surface as a recoverable error so the sync cycle
-    // retries; the account-range dispatcher used to panic on it, and a naive
-    // error conversion would land in the fatal SyncError::Snap arm instead.
-    #[tokio::test(start_paused = true)]
-    async fn failed_pivot_refresh_is_recoverable() {
-        let store = Store::new("", EngineType::InMemory).expect("in-memory store");
-        let mut peers = PeerHandler::new_for_test(store.clone());
-        let mut state = SnapBlockSyncState::new(store.clone());
-        let diagnostics = Arc::new(tokio::sync::RwLock::new(SyncDiagnostics::default()));
-        // timestamp 0 makes the pivot stale by the clock-based check.
-        let mut pivot = BlockHeader::default();
-        let res = tokio::time::timeout(
-            Duration::from_secs(3600),
-            refresh_stale_pivot(&mut pivot, &mut peers, &mut state, &diagnostics),
-        )
-        .await;
-        match res {
-            Err(_) => panic!("refresh_stale_pivot still waiting after a virtual hour"),
-            Ok(Ok(())) => panic!("refresh cannot succeed with no peers"),
-            Ok(Err(e)) => {
-                let e = SyncError::from(e);
-                assert!(e.is_recoverable(), "expected a recoverable error, got: {e}");
-            }
         }
     }
 }


### PR DESCRIPTION
**Motivation**

The account-range dispatcher refreshed a stale pivot with an `.expect` on `update_pivot`, panicking the sync task when peer rotations were exhausted — while the three sibling re-pivot call sites in the sync cycle propagate the same error and retry. The `.expect` existed because a plain error conversion is a trap: `request_account_range` returns `SnapError`, and `SyncError::Snap` is classified non-recoverable, so naively bubbling the failure would have replaced the panic with `exit(2)`.

**Description**

- Replace the `.expect` with error propagation: map the failure to a dedicated `SnapError::PivotUpdateFailed` at the dispatcher call site.
- Carve that variant out as **recoverable** in the sync error classification: a pivot that couldn't be refreshed is a transient peer condition, while every other snap error stays fatal.

The `update_pivot` failure path this propagates is exercised by the regression test in #6826.

> [!NOTE]
> Stacked on #6826 (`fix/snap-sync-unbounded-waits`), which bounds `update_pivot`'s no-peer wait so this error path is reachable — merge that first; this PR's base is set to its branch.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — not needed: no storage changes.