### PR TITLE
fix(l1): execute pending blocks without peer headers when they cover the sync gap

### DIFF
--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -78,6 +78,40 @@ pub async fn sync_cycle_full(
         pending_blocks.insert(0, block);
     }
 
+    // If the gap to the forkchoice head is entirely covered by pending blocks (delivered
+    // via engine_newPayload), the rewound sync_head is already on our canonical chain with
+    // its post-state on disk: no peer data is needed. Skip the header/body download and
+    // execute the pending blocks directly. Without this, a node that receives every block
+    // through newPayload stalls behind head whenever peers don't serve headers: the
+    // header-fetch abort below returns without executing `pending_blocks`, each retry runs
+    // against a head that has moved further ahead, and the node trails the chain
+    // indefinitely, never reporting synced and answering every newPayload with SYNCING.
+    if !pending_blocks.is_empty() && store.is_canonical_sync(sync_head)? {
+        let parent_has_state = match store.get_block_header_by_hash(sync_head)? {
+            Some(parent) => store.has_state_root(parent.state_root)?,
+            None => false,
+        };
+        if parent_has_state {
+            info!(
+                "Executing {} pending blocks for full sync (gap fully covered by blocks from the consensus client, no peer download needed). First block hash: {:#?} Last block hash: {:#?}",
+                pending_blocks.len(),
+                pending_blocks.first().ok_or(SyncError::NoBlocks)?.hash(),
+                pending_blocks.last().ok_or(SyncError::NoBlocks)?.hash()
+            );
+            add_blocks_in_batch(
+                blockchain.clone(),
+                cancel_token.clone(),
+                pending_blocks,
+                true,
+                store.clone(),
+                peers,
+            )
+            .await?;
+            store.clear_fullsync_headers().await?;
+            return Ok(());
+        }
+    }
+
     // The consensus-provided forkchoice head, captured before `sync_head` is rewound
     // over the pending blocks above. Used for sync-target diagnostics so we report the
     // actual head rather than the rewound ancestor we end up requesting headers from.


### PR DESCRIPTION
**Motivation**

On glamsterdam-devnet-5 (Kurtosis enclave joining the public devnet), an ethrex node driven by a consensus client gets stuck **permanently 2-3 blocks behind head**: `eth_syncing` never reports false, every `engine_newPayload` is answered with `SYNCING`, and the CL (Lodestar) stays in optimistic mode indefinitely.

The failure loop, observed on `ethpandaops/ethrex:glamsterdam-devnet-5` (commit `3fcae6650`, same logic on `main`):

```
INFO  Starting full sync cycle local_head=26588 eth_capable_peers=12 sync_head=0x3b3a…
WARN  Didn't receive block headers from peer, penalizing peer 0x2ae6…
WARN  Failed to fetch headers for sync head (attempt 1/10), retrying in 2s
      reason="peer(s) queried but did not serve headers"
...
INFO  Sync cycle finished successfully time_elapsed_s=16
```

In `sync_cycle_full`:

1. The pending-block rewind collects the blocks already delivered via `engine_newPayload` into `pending_blocks` and rewinds `sync_head` past them. In the steady state of a node following the chain head, this covers the **entire** gap, and the rewound `sync_head` is already canonical with its post-state on disk.
2. The cycle then **unconditionally** enters the peer header-fetch loop — requesting headers for a chain segment it already has.
3. If peers don't serve headers (10 attempts), the cycle aborts with `return Ok(())` — **without executing `pending_blocks`**, whose execution sits at the end of the function behind the peer pipeline.

When peers are unreliable (common for devnet topologies behind NAT), the only way forward is the rare cycle where a peer happens to answer — advancing ~1 block per ~16s cycle while the chain produces 2-3 in the same window. The node never catches up, even though every missing block is already sitting in its pending store.

**Description**

After the pending-block rewind, short-circuit: if `pending_blocks` is non-empty and the rewound `sync_head` is already canonical with its post-state present, skip the peer header/body pipeline entirely and execute the pending blocks directly. The node then self-heals from newPayload-fed gaps with zero peer cooperation, which is the normal situation for a CL-driven node.

If the rewound parent is canonical but its state is absent (e.g. pruned, or canonicalized ahead of execution), the short-circuit does not trigger and the existing peer-based path runs unchanged.

Verified with `cargo check -p ethrex-p2p` and `cargo clippy -p ethrex-p2p` (clean). Root cause was diagnosed from live devnet logs; fix drafted with AI assistance (Claude Code) and reviewed by me.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A, no schema changes.
