### PR TITLE
fix(l1): clamp snap GetAccountRange/GetStorageRanges response_bytes to server limit

### DIFF
--- a/crates/networking/p2p/snap/server.rs
+++ b/crates/networking/p2p/snap/server.rs
@@ -118,6 +118,10 @@ pub async fn process_byte_codes_request(
     store: Store,
 ) -> Result<ByteCodes, SnapError> {
     tokio::task::spawn_blocking(move || {
+        // Clamp the peer-supplied budget: `hashes` can be a large (or snappy-inflated,
+        // repeated) list, so an unbounded `bytes` would let one request buffer many large
+        // bytecodes into memory.
+        let bytes = request.bytes.min(MAX_RESPONSE_BYTES);
         let mut codes = vec![];
         let mut bytes_used = 0;
         for code_hash in request.hashes {
@@ -125,7 +129,7 @@ pub async fn process_byte_codes_request(
                 bytes_used += code.len() as u64;
                 codes.push(code);
             }
-            if bytes_used >= request.bytes {
+            if bytes_used >= bytes {
                 break;
             }
         }
@@ -144,7 +148,9 @@ pub async fn process_trie_nodes_request(
 ) -> Result<TrieNodes, SnapError> {
     tokio::task::spawn_blocking(move || {
         let mut nodes = vec![];
-        let mut remaining_bytes = request.bytes;
+        // Clamp the peer-supplied budget so a single request cannot pull an unbounded
+        // number of trie nodes into memory.
+        let mut remaining_bytes = request.bytes.min(MAX_RESPONSE_BYTES);
         for paths in request.paths {
             if paths.is_empty() {
                 return Err(SnapError::BadRequest(

--- a/crates/networking/p2p/snap/server.rs
+++ b/crates/networking/p2p/snap/server.rs
@@ -22,14 +22,14 @@ pub async fn process_account_range_request(
         // `responseBytes` is a soft limit chosen by the requester; clamp it to our server
         // maximum so a peer cannot request an unbounded walk of the whole state trie
         // (a single such request buffers every account into memory before replying — OOM).
-        let response_bytes = request.response_bytes.min(MAX_RESPONSE_BYTES);
+        let byte_budget = request.response_bytes.min(MAX_RESPONSE_BYTES);
         let mut accounts = vec![];
         let mut bytes_used = 0;
         for (hash, account) in store.iter_accounts_from(request.root_hash, request.starting_hash)? {
             debug_assert!(hash >= request.starting_hash);
             bytes_used += 32 + AccountStateSlimCodec(account).length() as u64;
             accounts.push(AccountRangeUnit { hash, account });
-            if hash >= request.limit_hash || bytes_used >= response_bytes {
+            if hash >= request.limit_hash || bytes_used >= byte_budget {
                 break;
             }
         }
@@ -55,7 +55,7 @@ pub async fn process_storage_ranges_request(
     tokio::task::spawn_blocking(move || {
         // Same soft-limit clamp as the account-range handler: bound the attacker-supplied
         // budget so a peer cannot walk a contract's entire storage trie into memory.
-        let response_bytes = request.response_bytes.min(MAX_RESPONSE_BYTES);
+        let byte_budget = request.response_bytes.min(MAX_RESPONSE_BYTES);
         let mut slots = vec![];
         let mut proof = vec![];
         let mut bytes_used = 0;
@@ -71,8 +71,8 @@ pub async fn process_storage_ranges_request(
                     debug_assert!(hash >= request.starting_hash);
                     bytes_used += 64_u64; // slot size
                     account_slots.push(StorageSlot { hash, data });
-                    if hash >= request.limit_hash || bytes_used >= response_bytes {
-                        if bytes_used >= response_bytes {
+                    if hash >= request.limit_hash || bytes_used >= byte_budget {
+                        if bytes_used >= byte_budget {
                             res_capped = true;
                         }
                         break;
@@ -99,7 +99,7 @@ pub async fn process_storage_ranges_request(
                 slots.push(account_slots);
             }
 
-            if bytes_used >= response_bytes {
+            if bytes_used >= byte_budget {
                 break;
             }
         }
@@ -121,7 +121,7 @@ pub async fn process_byte_codes_request(
         // Clamp the peer-supplied budget: `hashes` can be a large (or snappy-inflated,
         // repeated) list, so an unbounded `bytes` would let one request buffer many large
         // bytecodes into memory.
-        let bytes = request.bytes.min(MAX_RESPONSE_BYTES);
+        let byte_budget = request.bytes.min(MAX_RESPONSE_BYTES);
         let mut codes = vec![];
         let mut bytes_used = 0;
         for code_hash in request.hashes {
@@ -129,7 +129,7 @@ pub async fn process_byte_codes_request(
                 bytes_used += code.len() as u64;
                 codes.push(code);
             }
-            if bytes_used >= bytes {
+            if bytes_used >= byte_budget {
                 break;
             }
         }
@@ -150,7 +150,7 @@ pub async fn process_trie_nodes_request(
         let mut nodes = vec![];
         // Clamp the peer-supplied budget so a single request cannot pull an unbounded
         // number of trie nodes into memory.
-        let mut remaining_bytes = request.bytes.min(MAX_RESPONSE_BYTES);
+        let mut byte_budget = request.bytes.min(MAX_RESPONSE_BYTES);
         for paths in request.paths {
             if paths.is_empty() {
                 return Err(SnapError::BadRequest(
@@ -160,12 +160,12 @@ pub async fn process_trie_nodes_request(
             let trie_nodes = store.get_trie_nodes(
                 request.root_hash,
                 paths.into_iter().map(|bytes| bytes.to_vec()).collect(),
-                remaining_bytes,
+                byte_budget,
             )?;
             nodes.extend(trie_nodes.iter().map(|nodes| Bytes::copy_from_slice(nodes)));
-            remaining_bytes = remaining_bytes
+            byte_budget = byte_budget
                 .saturating_sub(trie_nodes.iter().fold(0, |acc, nodes| acc + nodes.len()) as u64);
-            if remaining_bytes == 0 {
+            if byte_budget == 0 {
                 break;
             }
         }

--- a/crates/networking/p2p/snap/server.rs
+++ b/crates/networking/p2p/snap/server.rs
@@ -8,6 +8,7 @@ use crate::rlpx::snap::{
 };
 use ethrex_common::types::AccountStateSlimCodec;
 
+use super::constants::MAX_RESPONSE_BYTES;
 use super::error::SnapError;
 use super::proof_to_encodable;
 
@@ -18,13 +19,17 @@ pub async fn process_account_range_request(
     store: Store,
 ) -> Result<AccountRange, SnapError> {
     tokio::task::spawn_blocking(move || {
+        // `responseBytes` is a soft limit chosen by the requester; clamp it to our server
+        // maximum so a peer cannot request an unbounded walk of the whole state trie
+        // (a single such request buffers every account into memory before replying — OOM).
+        let response_bytes = request.response_bytes.min(MAX_RESPONSE_BYTES);
         let mut accounts = vec![];
         let mut bytes_used = 0;
         for (hash, account) in store.iter_accounts_from(request.root_hash, request.starting_hash)? {
             debug_assert!(hash >= request.starting_hash);
             bytes_used += 32 + AccountStateSlimCodec(account).length() as u64;
             accounts.push(AccountRangeUnit { hash, account });
-            if hash >= request.limit_hash || bytes_used >= request.response_bytes {
+            if hash >= request.limit_hash || bytes_used >= response_bytes {
                 break;
             }
         }
@@ -48,6 +53,9 @@ pub async fn process_storage_ranges_request(
     store: Store,
 ) -> Result<StorageRanges, SnapError> {
     tokio::task::spawn_blocking(move || {
+        // Same soft-limit clamp as the account-range handler: bound the attacker-supplied
+        // budget so a peer cannot walk a contract's entire storage trie into memory.
+        let response_bytes = request.response_bytes.min(MAX_RESPONSE_BYTES);
         let mut slots = vec![];
         let mut proof = vec![];
         let mut bytes_used = 0;
@@ -63,8 +71,8 @@ pub async fn process_storage_ranges_request(
                     debug_assert!(hash >= request.starting_hash);
                     bytes_used += 64_u64; // slot size
                     account_slots.push(StorageSlot { hash, data });
-                    if hash >= request.limit_hash || bytes_used >= request.response_bytes {
-                        if bytes_used >= request.response_bytes {
+                    if hash >= request.limit_hash || bytes_used >= response_bytes {
+                        if bytes_used >= response_bytes {
                             res_capped = true;
                         }
                         break;
@@ -91,7 +99,7 @@ pub async fn process_storage_ranges_request(
                 slots.push(account_slots);
             }
 
-            if bytes_used >= request.response_bytes {
+            if bytes_used >= response_bytes {
                 break;
             }
         }

--- a/test/tests/p2p/snap_server_tests.rs
+++ b/test/tests/p2p/snap_server_tests.rs
@@ -5,10 +5,16 @@
 
 use std::str::FromStr;
 
-use ethrex_common::{BigEndianHash, H256, types::AccountStateSlimCodec};
+use ethrex_common::{
+    BigEndianHash, H256, U256,
+    types::{AccountState, AccountStateSlimCodec},
+};
 use ethrex_crypto::NativeCrypto;
-use ethrex_p2p::rlpx::snap::GetAccountRange;
-use ethrex_p2p::snap::{SnapError, process_account_range_request};
+use ethrex_p2p::rlpx::snap::{GetAccountRange, GetStorageRanges};
+use ethrex_p2p::snap::constants::MAX_RESPONSE_BYTES;
+use ethrex_p2p::snap::{
+    SnapError, process_account_range_request, process_storage_ranges_request,
+};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_storage::{EngineType, Store};
 use ethrex_trie::EMPTY_TRIE_HASH;
@@ -822,4 +828,130 @@ fn setup_initial_state() -> Result<(Store, H256), SnapError> {
             .unwrap();
     }
     Ok((store, state_trie.hash(&NativeCrypto).unwrap()))
+}
+
+/// Builds a state with `n` accounts (one small account replicated under `n` distinct,
+/// spread-out keys) — enough total encoded size to exceed `MAX_RESPONSE_BYTES`, so an
+/// unclamped `GetAccountRange` walk would buffer far more than the server budget.
+fn setup_large_state(n: u32) -> Result<(Store, H256), SnapError> {
+    let account_bytes: Vec<u8> = vec![196, 128, 1, 128, 128];
+    let AccountStateSlimCodec(account) = RLPDecode::decode(&account_bytes).unwrap();
+    let store = Store::new("null", EngineType::InMemory).unwrap();
+    let mut state_trie = store.open_direct_state_trie(*EMPTY_TRIE_HASH)?;
+    for i in 1..=n {
+        // Put `i` in the high bytes so keys spread across the hash space (avoids a
+        // pathologically deep trie) while staying distinct and ascending.
+        let mut key = [0u8; 32];
+        key[..4].copy_from_slice(&i.to_be_bytes());
+        state_trie
+            .insert(H256(key).as_bytes().to_vec(), account.encode_to_vec())
+            .unwrap();
+    }
+    Ok((store, state_trie.hash(&NativeCrypto).unwrap()))
+}
+
+/// A peer setting `response_bytes = u64::MAX` and `limit_hash = HASH_MAX` must not make
+/// the server walk the entire state trie into memory: the budget is clamped to
+/// `MAX_RESPONSE_BYTES`, so the response is bounded regardless of the requested size.
+/// (Without the clamp, this returns all `N` accounts — the full-trie-walk OOM vector.)
+#[tokio::test]
+async fn account_range_clamps_response_bytes() -> Result<(), SnapError> {
+    const N: u32 = 20_000;
+    let (store, root) = setup_large_state(N)?;
+
+    let request = GetAccountRange {
+        id: 0,
+        root_hash: root,
+        starting_hash: *HASH_MIN,
+        limit_hash: *HASH_MAX,
+        response_bytes: u64::MAX,
+    };
+    let res = process_account_range_request(request, store).await.unwrap();
+
+    // Pre-fix this walked the whole trie and returned all N accounts.
+    assert!(
+        (res.accounts.len() as u32) < N,
+        "expected a bounded response, but got all {N} accounts (unclamped full-trie walk)"
+    );
+
+    // The returned set must fit the server budget. The loop pushes one account before
+    // checking the bound, so allow a single account of overshoot.
+    let bytes_used: u64 = res
+        .accounts
+        .iter()
+        .map(|unit| 32 + AccountStateSlimCodec(unit.account.clone()).length() as u64)
+        .sum();
+    let max_account_bytes =
+        32 + AccountStateSlimCodec(res.accounts[0].account.clone()).length() as u64;
+    assert!(
+        bytes_used <= MAX_RESPONSE_BYTES + max_account_bytes,
+        "response of {bytes_used} bytes exceeds the clamp of {MAX_RESPONSE_BYTES} (+overshoot)"
+    );
+    Ok(())
+}
+
+/// Builds a state with a single account whose storage trie holds `n` slots — enough to
+/// exceed `MAX_RESPONSE_BYTES` (the handler charges a fixed 64 bytes per slot), so an
+/// unclamped `GetStorageRanges` walk would buffer the whole storage trie.
+fn setup_large_storage_state(account_hash: H256, n: u32) -> Result<(Store, H256), SnapError> {
+    let store = Store::new("null", EngineType::InMemory).unwrap();
+
+    let mut storage_trie = store.open_direct_storage_trie(account_hash, *EMPTY_TRIE_HASH)?;
+    for i in 1..=n {
+        let mut slot_key = [0u8; 32];
+        slot_key[..4].copy_from_slice(&i.to_be_bytes());
+        storage_trie
+            .insert(slot_key.to_vec(), U256::from(i).encode_to_vec())
+            .unwrap();
+    }
+    let storage_root = storage_trie.hash(&NativeCrypto).unwrap();
+
+    let account = AccountState {
+        nonce: 0,
+        balance: U256::zero(),
+        storage_root,
+        code_hash: H256::zero(),
+    };
+    let mut state_trie = store.open_direct_state_trie(*EMPTY_TRIE_HASH)?;
+    state_trie
+        .insert(account_hash.as_bytes().to_vec(), account.encode_to_vec())
+        .unwrap();
+    Ok((store, state_trie.hash(&NativeCrypto).unwrap()))
+}
+
+/// Same clamp for the storage-range handler: `response_bytes = u64::MAX` over a large
+/// storage trie must return a bounded set of slots, not the whole trie.
+#[tokio::test]
+async fn storage_ranges_clamps_response_bytes() -> Result<(), SnapError> {
+    const N: u32 = 12_000; // 12_000 * 64 B > MAX_RESPONSE_BYTES (512 KiB)
+    let account_hash = H256::from_low_u64_be(0xabcd);
+    let (store, root) = setup_large_storage_state(account_hash, N)?;
+
+    let request = GetStorageRanges {
+        id: 0,
+        root_hash: root,
+        account_hashes: vec![account_hash],
+        starting_hash: *HASH_MIN,
+        limit_hash: *HASH_MAX,
+        response_bytes: u64::MAX,
+    };
+    let res = process_storage_ranges_request(request, store).await.unwrap();
+
+    let slots_returned: u32 = res.slots.iter().map(|s| s.len() as u32).sum();
+    // Guard against a broken fixture silently passing the upper-bound check.
+    assert!(
+        slots_returned > 1000,
+        "fixture produced too few slots ({slots_returned}); the clamp is not being exercised"
+    );
+    // Pre-fix this walked the whole storage trie and returned all N slots.
+    assert!(
+        slots_returned < N,
+        "expected a bounded storage response, but got all {N} slots (unclamped full-trie walk)"
+    );
+    // 64 bytes are charged per slot; allow one slot of overshoot past the clamp.
+    assert!(
+        u64::from(slots_returned) * 64 <= MAX_RESPONSE_BYTES + 64,
+        "storage response of {slots_returned} slots exceeds the clamp"
+    );
+    Ok(())
 }

--- a/test/tests/p2p/snap_server_tests.rs
+++ b/test/tests/p2p/snap_server_tests.rs
@@ -12,9 +12,7 @@ use ethrex_common::{
 use ethrex_crypto::NativeCrypto;
 use ethrex_p2p::rlpx::snap::{GetAccountRange, GetStorageRanges};
 use ethrex_p2p::snap::constants::MAX_RESPONSE_BYTES;
-use ethrex_p2p::snap::{
-    SnapError, process_account_range_request, process_storage_ranges_request,
-};
+use ethrex_p2p::snap::{SnapError, process_account_range_request, process_storage_ranges_request};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_storage::{EngineType, Store};
 use ethrex_trie::EMPTY_TRIE_HASH;
@@ -868,6 +866,12 @@ async fn account_range_clamps_response_bytes() -> Result<(), SnapError> {
     };
     let res = process_account_range_request(request, store).await.unwrap();
 
+    // Guard against a broken fixture silently passing the upper-bound check.
+    assert!(
+        res.accounts.len() > 1000,
+        "fixture produced too few accounts ({}); the clamp is not being exercised",
+        res.accounts.len()
+    );
     // Pre-fix this walked the whole trie and returned all N accounts.
     assert!(
         (res.accounts.len() as u32) < N,
@@ -881,8 +885,11 @@ async fn account_range_clamps_response_bytes() -> Result<(), SnapError> {
         .iter()
         .map(|unit| 32 + AccountStateSlimCodec(unit.account.clone()).length() as u64)
         .sum();
-    let max_account_bytes =
-        32 + AccountStateSlimCodec(res.accounts[0].account.clone()).length() as u64;
+    let max_account_bytes = res
+        .accounts
+        .first()
+        .map(|unit| 32 + AccountStateSlimCodec(unit.account.clone()).length() as u64)
+        .unwrap_or(0);
     assert!(
         bytes_used <= MAX_RESPONSE_BYTES + max_account_bytes,
         "response of {bytes_used} bytes exceeds the clamp of {MAX_RESPONSE_BYTES} (+overshoot)"
@@ -935,7 +942,9 @@ async fn storage_ranges_clamps_response_bytes() -> Result<(), SnapError> {
         limit_hash: *HASH_MAX,
         response_bytes: u64::MAX,
     };
-    let res = process_storage_ranges_request(request, store).await.unwrap();
+    let res = process_storage_ranges_request(request, store)
+        .await
+        .unwrap();
 
     let slots_returned: u32 = res.slots.iter().map(|s| s.len() as u32).sum();
     // Guard against a broken fixture silently passing the upper-bound check.

--- a/test/tests/p2p/snap_server_tests.rs
+++ b/test/tests/p2p/snap_server_tests.rs
@@ -887,12 +887,12 @@ async fn account_range_clamps_response_bytes() -> Result<(), SnapError> {
     let bytes_used: u64 = res
         .accounts
         .iter()
-        .map(|unit| 32 + AccountStateSlimCodec(unit.account.clone()).length() as u64)
+        .map(|unit| 32 + AccountStateSlimCodec(unit.account).length() as u64)
         .sum();
     let max_account_bytes = res
         .accounts
         .first()
-        .map(|unit| 32 + AccountStateSlimCodec(unit.account.clone()).length() as u64)
+        .map(|unit| 32 + AccountStateSlimCodec(unit.account).length() as u64)
         .unwrap_or(0);
     assert!(
         bytes_used <= MAX_RESPONSE_BYTES + max_account_bytes,

--- a/test/tests/p2p/snap_server_tests.rs
+++ b/test/tests/p2p/snap_server_tests.rs
@@ -5,14 +5,18 @@
 
 use std::str::FromStr;
 
+use bytes::Bytes;
 use ethrex_common::{
     BigEndianHash, H256, U256,
-    types::{AccountState, AccountStateSlimCodec},
+    types::{AccountState, AccountStateSlimCodec, Code},
 };
 use ethrex_crypto::NativeCrypto;
-use ethrex_p2p::rlpx::snap::{GetAccountRange, GetStorageRanges};
+use ethrex_p2p::rlpx::snap::{GetAccountRange, GetByteCodes, GetStorageRanges};
 use ethrex_p2p::snap::constants::MAX_RESPONSE_BYTES;
-use ethrex_p2p::snap::{SnapError, process_account_range_request, process_storage_ranges_request};
+use ethrex_p2p::snap::{
+    SnapError, process_account_range_request, process_byte_codes_request,
+    process_storage_ranges_request,
+};
 use ethrex_rlp::{decode::RLPDecode, encode::RLPEncode};
 use ethrex_storage::{EngineType, Store};
 use ethrex_trie::EMPTY_TRIE_HASH;
@@ -964,3 +968,50 @@ async fn storage_ranges_clamps_response_bytes() -> Result<(), SnapError> {
     );
     Ok(())
 }
+
+/// `GetByteCodes` with `bytes = u64::MAX` over many large bytecodes must return a bounded
+/// set, not every requested code. (`hashes` is peer-supplied and snappy-compresses well
+/// when repeated, so an unclamped budget lets a tiny request pull GBs of code.)
+#[tokio::test]
+async fn byte_codes_clamps_response_bytes() -> Result<(), SnapError> {
+    const M: usize = 30;
+    const CODE_LEN: usize = 40 * 1024; // 30 * 40 KiB = 1.2 MiB > MAX_RESPONSE_BYTES (512 KiB)
+    let store = Store::new("null", EngineType::InMemory).unwrap();
+    let mut hashes = Vec::with_capacity(M);
+    for i in 0..M {
+        let bytecode = Bytes::from(vec![i as u8; CODE_LEN]);
+        let code = Code::from_bytecode(bytecode, &NativeCrypto);
+        hashes.push(code.hash);
+        store.add_account_code(code).await.unwrap();
+    }
+
+    let request = GetByteCodes {
+        id: 0,
+        hashes,
+        bytes: u64::MAX,
+    };
+    let res = process_byte_codes_request(request, store).await.unwrap();
+
+    assert!(
+        res.codes.len() > 1,
+        "fixture produced too few codes ({}); the clamp is not being exercised",
+        res.codes.len()
+    );
+    // Pre-fix this returned all M codes (1.2 MiB).
+    assert!(
+        res.codes.len() < M,
+        "expected a bounded response, but got all {M} codes (unclamped)"
+    );
+    let bytes_used: u64 = res.codes.iter().map(|c| c.len() as u64).sum();
+    assert!(
+        bytes_used <= MAX_RESPONSE_BYTES + CODE_LEN as u64,
+        "response of {bytes_used} bytes exceeds the clamp of {MAX_RESPONSE_BYTES} (+overshoot)"
+    );
+    Ok(())
+}
+
+// NOTE: `process_trie_nodes_request` receives the same `request.bytes.min(MAX_RESPONSE_BYTES)`
+// clamp (see `snap/server.rs`), but is not given a dedicated regression test here: exercising
+// it requires a committed state trie readable through `get_trie_nodes`' `open_state_trie`
+// path, which the direct-write test fixtures don't populate. The clamp is mechanically
+// identical to the three handlers covered above.


### PR DESCRIPTION
**Motivation**

The snap/1 server handlers honor the requester's `responseBytes`/`bytes` budget verbatim, with no server-side cap. Per the [snap spec](https://github.com/ethereum/devp2p/blob/master/caps/snap.md#getaccountrange-0x00) this is a **soft limit** the server must bound to its own maximum (go-ethereum applies a 2 MiB `softResponseLimit` to **every** `Get*` handler). ethrex has the constant — `MAX_RESPONSE_BYTES = 512 KiB` — but applied it **only when issuing** requests (`snap/client.rs`), never when serving them.

So a single small, unauthenticated snap request can drive unbounded server-side allocation:
- **`GetAccountRange`** / **`GetStorageRanges`** with `limit_hash = 0xff…ff` and `response_bytes = u64::MAX` walk the **entire** state / storage trie into a `Vec` (then copy it for the proof) before encoding any reply — the loop's only termination is the two attacker-controlled maxima. Allocation scales with state size (~190 B/account; >10⁶× request→memory amplification), unbounded by request size. Each runs on its own `spawn_blocking` worker and completes even after the peer disconnects, so the per-peer serve-rate limiter doesn't help (K peers → K concurrent walks). **Demonstrated to OOM-kill** an 8 GiB node on a 4M-account state with 32 peers in ~10 s (reported by EF).
- **`GetByteCodes`** / **`GetTrieNodes`** take an explicit peer-supplied list (`hashes` / `paths`), but with `bytes = u64::MAX` the soft limit never fires, and the list snappy-compresses to almost nothing when entries repeat — so a tiny request naming one large bytecode (or node path) thousands of times expands to a multi-GB response.

**Description**

Clamp the requester-supplied budget to the server maximum at the top of **all four** `Get*` handlers (`crates/networking/p2p/snap/server.rs`), using the clamped local in the loop break conditions:
```rust
let response_bytes = request.response_bytes.min(MAX_RESPONSE_BYTES); // account / storage ranges
let bytes          = request.bytes.min(MAX_RESPONSE_BYTES);          // byte codes
let mut remaining_bytes = request.bytes.min(MAX_RESPONSE_BYTES);     // trie nodes
```
`limit_hash` is intentionally untouched — a full-range request is legitimate and is now bounded by the byte budget; returning fewer bytes than requested is valid for a soft limit, so there's no interop regression (and ethrex's own client already requests exactly `MAX_RESPONSE_BYTES`). This also bounds the related `low/snap-account-range-proof-amplification` finding (the proof is now built over a clamped set).

**Test**

`test/tests/p2p/snap_server_tests.rs`:
- `account_range_clamps_response_bytes` — 20,000-account state, `response_bytes = u64::MAX` → bounded (count < N, byte sum ≤ clamp + one account). Red before (all 20,000), green after.
- `storage_ranges_clamps_response_bytes` — 12,000-slot storage trie. Red before (all 12,000), green after. (Both have a `> 1000` lower-bound guard so a broken fixture can't false-pass.)
- `byte_codes_clamps_response_bytes` — 30 × 40 KiB codes, `bytes = u64::MAX` → bounded set. Red before, green after.
- `GetTrieNodes` gets the identical clamp but no dedicated test: exercising it needs a committed state trie readable through `get_trie_nodes`' `open_state_trie` path, which the direct-write test fixtures don't populate (noted in the test file). The clamp is mechanically identical to the three covered handlers.
- All 12 existing hive `AccountRange` tests are unchanged (their budgets are below the clamp → no behavior change).

**Checklist**

- [x] Regression tests added (red before, green after — account/storage/bytecodes)
- [x] `cargo fmt` + `cargo clippy` clean
- [x] All four snap `Get*` server handlers clamped; existing hive tests unaffected
