### PR TITLE
perf(l1): add bloombits log index for eth_getLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Perf
 
+### 2026-06-10
+
+- Add a geth-style bloombits log index so `eth_getLogs` queries only candidate blocks instead of scanning the whole range; built from header blooms by a background indexer (full historical coverage on snap-synced nodes), with a scan fallback [#6835](https://github.com/lambdaclass/ethrex/pull/6835)
+
 ### 2026-06-09
 
 - Skip non-matching blocks in `eth_getLogs` using the per-block header bloom, avoiding body/receipt loads for blocks that provably cannot match [#6813](https://github.com/lambdaclass/ethrex/pull/6813)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Perf
 
+### 2026-06-09
+
+- Skip non-matching blocks in `eth_getLogs` using the per-block header bloom, avoiding body/receipt loads for blocks that provably cannot match [#6813](https://github.com/lambdaclass/ethrex/pull/6813)
+
 ### 2026-06-03
 
 - Short-circuit the `KECCAK256` opcode on zero-length input by returning the precomputed `keccak256("")` constant, skipping the permutation [#6775](https://github.com/lambdaclass/ethrex/pull/6775)

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -38,7 +38,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 #[cfg(not(feature = "l2"))]
@@ -685,6 +685,8 @@ pub async fn init_l1(
     )
     .await;
 
+    tracker.spawn(run_bloombits_indexer(store.clone(), cancel_token.clone()));
+
     if opts.metrics_enabled {
         init_metrics(&opts, &network, tracker.clone());
     }
@@ -713,6 +715,45 @@ pub async fn init_l1(
         peer_handler.peer_table,
         local_node_record,
     ))
+}
+
+/// Background service that keeps the bloombits log index (used by
+/// `eth_getLogs`) up to date. It periodically transposes the header blooms of
+/// any newly-buried block sections into the index.
+///
+/// On first run after upgrading it walks the whole chain (backfill); in steady
+/// state it indexes one section at a time as the head advances. Only sections
+/// buried beyond the reorg window are indexed, so its writes are append-only and
+/// never need invalidation. The actual indexing runs on a blocking thread to
+/// avoid stalling the async runtime.
+async fn run_bloombits_indexer(store: Store, cancel_token: CancellationToken) {
+    // Poll cadence; indexing only does work once a fresh section is buried.
+    const POLL_INTERVAL: Duration = Duration::from_secs(12);
+    // Stay well clear of the 128-block reorg depth limit so indexed sections are
+    // immutable.
+    const CONFIRMATION_DEPTH: u64 = 256;
+
+    let mut interval = tokio::time::interval(POLL_INTERVAL);
+    loop {
+        tokio::select! {
+            _ = cancel_token.cancelled() => break,
+            _ = interval.tick() => {
+                let store = store.clone();
+                match tokio::task::spawn_blocking(move || {
+                    store.index_pending_bloombits_sections(CONFIRMATION_DEPTH)
+                })
+                .await
+                {
+                    Ok(Ok(indexed)) if indexed > 0 => {
+                        info!("bloombits: indexed {indexed} new log-index section(s)");
+                    }
+                    Ok(Ok(_)) => {}
+                    Ok(Err(err)) => warn!("bloombits indexer error: {err}"),
+                    Err(err) => warn!("bloombits indexer task failed: {err}"),
+                }
+            }
+        }
+    }
 }
 
 /// Migrates data from a pre-suffix datadir layout to the new network-specific

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -143,12 +143,29 @@ pub(crate) async fn fetch_logs_with_filter(
         None => HashSet::new(),
     };
 
+    // Ask the bloombits log index which blocks in the range might match. When it
+    // can help we only visit those candidates (plus the still-unindexed recent
+    // tail, returned in full); otherwise we fall back to scanning the whole range
+    // and rely on the per-block header-bloom prefilter below. Either way every
+    // visited block is exact-filtered, so false positives are harmless.
+    let addresses: Vec<H160> = filter
+        .address_filters
+        .as_ref()
+        .map(|filters| filters.as_ref().to_vec())
+        .unwrap_or_default();
+    let topic_positions = index_topic_positions(&filter.topics);
+    let block_numbers: Box<dyn Iterator<Item = u64> + Send> =
+        match storage.get_candidate_blocks(&addresses, &topic_positions, from, to)? {
+            Some(candidates) => Box::new(candidates.into_iter()),
+            None => Box::new(from..=to),
+        };
+
     let mut logs: Vec<RpcLog> = Vec::new();
     // The idea here is to fetch every log and filter by address, if given.
     // For that, we'll need each block in range, and its transactions,
     // and for each transaction, we'll need its receipts, which
     // contain the actual logs we want.
-    for block_num in from..=to {
+    for block_num in block_numbers {
         // The block header carries a bloom filter over every (address, topic)
         // pair logged in the block. If it can't possibly contain a log matching
         // this filter, skip the block without loading its body or receipts.
@@ -236,6 +253,27 @@ pub(crate) async fn fetch_logs_with_filter(
     };
 
     Ok(filtered_logs)
+}
+
+/// Reduces a filter's topic positions to the concrete topics the bloombits index
+/// should constrain on, mirroring [`block_bloom_matches`]: a wildcard position
+/// (`null`, an empty alternatives list, or a list containing any `null`) yields
+/// an empty set, which the index treats as "no constraint" for that position.
+fn index_topic_positions(topics: &[TopicFilter]) -> Vec<Vec<H256>> {
+    topics
+        .iter()
+        .map(|topic_filter| match topic_filter {
+            TopicFilter::Topic(Some(topic)) => vec![*topic],
+            TopicFilter::Topic(None) => Vec::new(),
+            TopicFilter::Topics(sub_topics) => {
+                if sub_topics.iter().any(Option::is_none) {
+                    Vec::new()
+                } else {
+                    sub_topics.iter().flatten().copied().collect()
+                }
+            }
+        })
+        .collect()
 }
 
 /// Necessary-condition check: returns `true` if the block's header bloom could
@@ -474,5 +512,89 @@ mod tests {
             &addr_set(&[addr(1)]),
             &[TopicFilter::Topic(Some(topic(2)))]
         ));
+    }
+
+    /// End-to-end: with the bloombits index populated, `fetch_logs_with_filter`
+    /// must return exactly the matching logs — proving the candidate-block path
+    /// agrees with a full scan (no dropped logs, false positives filtered out).
+    #[tokio::test]
+    async fn fetch_logs_via_index_returns_matching_logs() {
+        use ethrex_common::types::{
+            Block, BlockBody, BlockHeader, LegacyTransaction, Log, Receipt, Transaction, TxType,
+        };
+        use ethrex_storage::{EngineType, Store, bloombits};
+
+        let storage = Store::new("", EngineType::InMemory).unwrap();
+        let target = H160::from_low_u64_be(0xABCD);
+        let other = H160::from_low_u64_be(0x1111);
+        let topic_a = H256::from_low_u64_be(0xAA);
+
+        let tx = Transaction::LegacyTransaction(LegacyTransaction::default());
+        let mut canonical = Vec::new();
+        let mut section_blooms = vec![Bloom::zero(); bloombits::SECTION_SIZE as usize];
+
+        // Blocks 0..=6; only blocks 3 and 5 log `target`.
+        for number in 0..=6u64 {
+            let address = if number == 3 || number == 5 {
+                target
+            } else {
+                other
+            };
+            let log = Log {
+                address,
+                topics: vec![topic_a],
+                data: Default::default(),
+            };
+            let mut bloom = Bloom::zero();
+            bloom.accrue(BloomInput::Raw(address.as_bytes()));
+            bloom.accrue(BloomInput::Raw(topic_a.as_bytes()));
+
+            let header = BlockHeader {
+                number,
+                logs_bloom: bloom,
+                ..Default::default()
+            };
+            let body = BlockBody {
+                transactions: vec![tx.clone()],
+                ..Default::default()
+            };
+            let block = Block { header, body };
+            let hash = block.hash();
+            section_blooms[number as usize] = block.header.logs_bloom;
+            canonical.push((number, hash));
+            storage.add_block(block).await.unwrap();
+            storage
+                .add_receipts(
+                    hash,
+                    vec![Receipt {
+                        tx_type: TxType::Legacy,
+                        succeeded: true,
+                        cumulative_gas_used: 0,
+                        logs: vec![log],
+                    }],
+                )
+                .await
+                .unwrap();
+        }
+        let head_hash = canonical[6].1;
+        storage
+            .forkchoice_update(canonical, 6, head_hash, None, None)
+            .await
+            .unwrap();
+
+        // Populate the index for section 0 so the query takes the indexed path.
+        let rows = bloombits::transpose_section(&section_blooms);
+        storage.store_bloombits_section(0, &rows).unwrap();
+        assert_eq!(storage.get_indexed_bloombits_sections().unwrap(), 1);
+
+        let filter = LogsFilter {
+            from_block: BlockIdentifier::Number(0),
+            to_block: BlockIdentifier::Number(6),
+            address_filters: Some(AddressFilter::Single(target)),
+            topics: vec![TopicFilter::Topic(Some(topic_a))],
+        };
+        let logs = fetch_logs_with_filter(&filter, storage).await.unwrap();
+        let matched_blocks: Vec<u64> = logs.iter().map(|log| log.block_number).collect();
+        assert_eq!(matched_blocks, vec![3, 5]);
     }
 }

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -265,7 +265,16 @@ fn block_bloom_matches(
     topics.iter().all(|topic_filter| {
         let allowed: Vec<&H256> = match topic_filter {
             TopicFilter::Topic(topic) => topic.iter().collect(),
-            TopicFilter::Topics(sub_topics) => sub_topics.iter().flatten().collect(),
+            TopicFilter::Topics(sub_topics) => {
+                // A `None` alternative means "any topic" at this position, making
+                // the whole position a wildcard: it must not constrain the bloom.
+                // Without this, `topics: [[null, T]]` would skip blocks that match
+                // via the wildcard, dropping valid logs.
+                if sub_topics.iter().any(|t| t.is_none()) {
+                    return true;
+                }
+                sub_topics.iter().flatten().collect()
+            }
         };
         // An empty set of allowed topics is a wildcard for this position.
         allowed.is_empty()
@@ -406,6 +415,20 @@ mod tests {
             &Bloom::zero(),
             &HashSet::new(),
             &[TopicFilter::Topics(vec![])]
+        ));
+    }
+
+    #[test]
+    fn bloom_match_topics_with_none_element_is_wildcard() {
+        // A `None` inside a `Topics([...])` alternatives list means "any topic"
+        // at this position, so the position is a wildcard and must not be skipped
+        // even when the sibling topic is absent from the bloom. Regression test for
+        // a false-negative that dropped valid logs for `topics: [[null, T]]` queries.
+        let bloom = bloom_with(&[], &[]); // contains neither topic
+        assert!(block_bloom_matches(
+            &bloom,
+            &HashSet::new(),
+            &[TopicFilter::Topics(vec![Some(topic(2)), None])]
         ));
     }
 

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     utils::RpcErr,
 };
+use ethereum_types::{Bloom, BloomInput};
 use ethrex_common::{H160, H256};
 use ethrex_storage::Store;
 use serde::Deserialize;
@@ -148,18 +149,24 @@ pub(crate) async fn fetch_logs_with_filter(
     // and for each transaction, we'll need its receipts, which
     // contain the actual logs we want.
     for block_num in from..=to {
-        // Take the header of the block, we
+        // The block header carries a bloom filter over every (address, topic)
+        // pair logged in the block. If it can't possibly contain a log matching
+        // this filter, skip the block without loading its body or receipts.
+        let block_header = storage
+            .get_block_header(block_num)?
+            .ok_or(RpcErr::Internal(format!(
+                "Could not get header for block {block_num}"
+            )))?;
+        if !block_bloom_matches(&block_header.logs_bloom, &address_filter, &filter.topics) {
+            continue;
+        }
+        // Take the body of the block, we
         // will use it to access the transactions.
         let block_body = storage
             .get_block_body(block_num)
             .await?
             .ok_or(RpcErr::Internal(format!(
                 "Could not get body for block {block_num}"
-            )))?;
-        let block_header = storage
-            .get_block_header(block_num)?
-            .ok_or(RpcErr::Internal(format!(
-                "Could not get header for block {block_num}"
             )))?;
         let block_hash = block_header.hash();
 
@@ -231,6 +238,43 @@ pub(crate) async fn fetch_logs_with_filter(
     Ok(filtered_logs)
 }
 
+/// Necessary-condition check: returns `true` if the block's header bloom could
+/// contain a log matching the filter, `false` only when it provably cannot.
+///
+/// A log matches when its address is one of the requested addresses (or none
+/// were requested) AND, for every constrained topic position, the log's topic
+/// equals one of the allowed values. Since the header bloom records every
+/// logged address and topic (position-agnostic), a matching log implies its
+/// address and each constrained topic are present in the bloom. We therefore
+/// require: at least one requested address present (if any), and at least one
+/// allowed topic present for each constrained position. Bloom false positives
+/// are fine — exact filtering still runs on the blocks we don't skip.
+fn block_bloom_matches(
+    bloom: &Bloom,
+    address_filter: &HashSet<&H160>,
+    topics: &[TopicFilter],
+) -> bool {
+    if !address_filter.is_empty()
+        && !address_filter
+            .iter()
+            .any(|address| bloom.contains_input(BloomInput::Raw(address.as_bytes())))
+    {
+        return false;
+    }
+
+    topics.iter().all(|topic_filter| {
+        let allowed: Vec<&H256> = match topic_filter {
+            TopicFilter::Topic(topic) => topic.iter().collect(),
+            TopicFilter::Topics(sub_topics) => sub_topics.iter().flatten().collect(),
+        };
+        // An empty set of allowed topics is a wildcard for this position.
+        allowed.is_empty()
+            || allowed
+                .iter()
+                .any(|topic| bloom.contains_input(BloomInput::Raw(topic.as_bytes())))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -279,5 +323,133 @@ mod tests {
             "{request:?}"
         );
         assert_eq!(request.topics, vec![TopicFilter::Topic(Some(H256::zero()))]);
+    }
+
+    fn addr(n: u64) -> H160 {
+        H160::from_low_u64_be(n)
+    }
+
+    fn topic(n: u64) -> H256 {
+        H256::from_low_u64_be(n)
+    }
+
+    /// Builds a header bloom the same way the block producer does: by accruing
+    /// every address and topic of every log (see `bloom_from_logs`).
+    fn bloom_with(addresses: &[H160], topics: &[H256]) -> Bloom {
+        let mut bloom = Bloom::zero();
+        for address in addresses {
+            bloom.accrue(BloomInput::Raw(address.as_bytes()));
+        }
+        for topic in topics {
+            bloom.accrue(BloomInput::Raw(topic.as_bytes()));
+        }
+        bloom
+    }
+
+    fn addr_set(addresses: &[H160]) -> HashSet<&H160> {
+        addresses.iter().collect()
+    }
+
+    #[test]
+    fn bloom_match_empty_filter_always_matches() {
+        // No address and no topic constraints: never skip a block.
+        assert!(block_bloom_matches(&Bloom::zero(), &HashSet::new(), &[]));
+    }
+
+    #[test]
+    fn bloom_match_address_present_and_absent() {
+        let bloom = bloom_with(&[addr(1)], &[]);
+        assert!(block_bloom_matches(&bloom, &addr_set(&[addr(1)]), &[]));
+        assert!(!block_bloom_matches(&bloom, &addr_set(&[addr(2)]), &[]));
+    }
+
+    #[test]
+    fn bloom_match_multiple_addresses_is_or() {
+        let bloom = bloom_with(&[addr(1)], &[]);
+        // Only one of the requested addresses needs to be present.
+        assert!(block_bloom_matches(
+            &bloom,
+            &addr_set(&[addr(1), addr(2)]),
+            &[]
+        ));
+        assert!(!block_bloom_matches(
+            &bloom,
+            &addr_set(&[addr(2), addr(3)]),
+            &[]
+        ));
+    }
+
+    #[test]
+    fn bloom_match_topic_present_and_absent() {
+        let bloom = bloom_with(&[], &[topic(1)]);
+        assert!(block_bloom_matches(
+            &bloom,
+            &HashSet::new(),
+            &[TopicFilter::Topic(Some(topic(1)))]
+        ));
+        assert!(!block_bloom_matches(
+            &bloom,
+            &HashSet::new(),
+            &[TopicFilter::Topic(Some(topic(2)))]
+        ));
+    }
+
+    #[test]
+    fn bloom_match_wildcard_topic_ignored() {
+        // A `None` (wildcard) topic position imposes no constraint.
+        assert!(block_bloom_matches(
+            &Bloom::zero(),
+            &HashSet::new(),
+            &[TopicFilter::Topic(None)]
+        ));
+        assert!(block_bloom_matches(
+            &Bloom::zero(),
+            &HashSet::new(),
+            &[TopicFilter::Topics(vec![])]
+        ));
+    }
+
+    #[test]
+    fn bloom_match_topic_position_is_or_across_positions_is_and() {
+        let bloom = bloom_with(&[], &[topic(1), topic(2)]);
+        // OR within a position: any allowed value present is enough.
+        assert!(block_bloom_matches(
+            &bloom,
+            &HashSet::new(),
+            &[TopicFilter::Topics(vec![Some(topic(2)), Some(topic(9))])]
+        ));
+        // AND across positions: every constrained position must be satisfied.
+        assert!(block_bloom_matches(
+            &bloom,
+            &HashSet::new(),
+            &[
+                TopicFilter::Topic(Some(topic(1))),
+                TopicFilter::Topic(Some(topic(2))),
+            ]
+        ));
+        assert!(!block_bloom_matches(
+            &bloom,
+            &HashSet::new(),
+            &[
+                TopicFilter::Topic(Some(topic(1))),
+                TopicFilter::Topic(Some(topic(9))),
+            ]
+        ));
+    }
+
+    #[test]
+    fn bloom_match_requires_both_address_and_topic() {
+        let bloom = bloom_with(&[addr(1)], &[topic(1)]);
+        assert!(block_bloom_matches(
+            &bloom,
+            &addr_set(&[addr(1)]),
+            &[TopicFilter::Topic(Some(topic(1)))]
+        ));
+        // Address matches but topic does not.
+        assert!(!block_bloom_matches(
+            &bloom,
+            &addr_set(&[addr(1)]),
+            &[TopicFilter::Topic(Some(topic(2)))]
+        ));
     }
 }

--- a/crates/storage/api/tables.rs
+++ b/crates/storage/api/tables.rs
@@ -113,7 +113,15 @@ pub const EXECUTION_WITNESSES: &str = "execution_witnesses";
 /// - [`Vec<u8>`] = RLP-encoded `BlockAccessList`
 pub const BLOCK_ACCESS_LISTS: &str = "block_access_lists";
 
-pub const TABLES: [&str; 20] = [
+/// Bloombits log index column family: [`Vec<u8>`] => [`Vec<u8>`]
+/// - [`Vec<u8>`] = Composite key `section (u64 BE) || bloom_bit (u16 BE)`
+///   (section-major so a section's rows are contiguous and prunable by prefix)
+/// - [`Vec<u8>`] = transposed bit-vector for that `(section, bloom_bit)`:
+///   bit `j` set ⇔ the j-th block of the section has that bloom bit set.
+///   All-zero rows are not stored (absence reads back as zero).
+pub const LOG_BLOOM_BITS: &str = "log_bloom_bits";
+
+pub const TABLES: [&str; 21] = [
     CHAIN_DATA,
     ACCOUNT_CODES,
     ACCOUNT_CODE_METADATA,
@@ -134,4 +142,5 @@ pub const TABLES: [&str; 20] = [
     MISC_VALUES,
     EXECUTION_WITNESSES,
     BLOCK_ACCESS_LISTS,
+    LOG_BLOOM_BITS,
 ];

--- a/crates/storage/bloombits.rs
+++ b/crates/storage/bloombits.rs
@@ -1,0 +1,383 @@
+//! Bloombits log index (geth-style).
+//!
+//! `eth_getLogs` is expensive because it scans every block in the requested
+//! range. Every block header already carries a 2048-bit `logs_bloom` over the
+//! `(address, topic)` pairs logged in that block, so we can answer "which
+//! blocks *might* match this filter?" without touching bodies or receipts.
+//!
+//! A linear walk over those header blooms is still O(range) (see #6813). The
+//! bloombits index removes that ceiling by *transposing* the blooms: blocks are
+//! grouped into fixed-size sections of [`SECTION_SIZE`] blocks, and for each of
+//! the 2048 bloom bit positions we store one bit-vector across the section
+//! (bit `j` set ⇔ the j-th block of the section has that bloom bit set).
+//!
+//! To find candidate blocks for an item (address or topic) we look at the three
+//! bloom bits it maps to and AND the corresponding bit-vectors: a block is a
+//! candidate only where all three bits are set. Items are combined the same way
+//! the log filter combines them — OR within an address set or a topic position,
+//! AND across positions. The result is a candidate bitmap that lets the query
+//! skip straight to the handful of blocks worth reading receipts for.
+//!
+//! Bloom false positives are harmless: the exact filter still runs on every
+//! candidate, so the index never drops a matching log, it only occasionally
+//! nominates a block that turns out not to match.
+
+use ethrex_common::Bloom;
+use ethrex_common::utils::keccak;
+
+/// Number of blocks grouped into a single bloombits section. Matches geth's
+/// value; a section's transposed bit-vectors are this many bits wide.
+pub const SECTION_SIZE: u64 = 4096;
+
+/// Length of an Ethereum bloom filter in bits.
+const BLOOM_BIT_LENGTH: usize = 2048;
+
+/// Number of bloom bits each logged item (address/topic) sets.
+const BITS_PER_ITEM: usize = 3;
+
+/// Bytes needed to hold one section's worth of per-block bits.
+pub const SECTION_BYTES: usize = SECTION_SIZE as usize / 8;
+
+/// The three bloom bit positions a single item (address or topic) maps to.
+///
+/// Mirrors `ethbloom`'s `accrue`: the item is keccak256-hashed, then three
+/// big-endian `u16`s are taken from the first six bytes of the hash, each masked
+/// into the 2048-bit space. This is exactly how a block's `logs_bloom` is built,
+/// so an item is present in a bloom iff all three of these bits are set.
+pub fn bloom_bit_indices(item: &[u8]) -> [usize; BITS_PER_ITEM] {
+    let hash = keccak(item);
+    let bytes = hash.as_bytes();
+    let mut indices = [0usize; BITS_PER_ITEM];
+    for (i, index) in indices.iter_mut().enumerate() {
+        let hi = bytes[2 * i] as usize;
+        let lo = bytes[2 * i + 1] as usize;
+        *index = ((hi << 8) | lo) & (BLOOM_BIT_LENGTH - 1);
+    }
+    indices
+}
+
+/// Returns the byte position within the transposed row where the bit for the
+/// `block_offset`-th block of a section lives, plus the in-byte mask.
+#[inline]
+fn block_bit(block_offset: usize) -> (usize, u8) {
+    (block_offset / 8, 1 << (block_offset % 8))
+}
+
+/// Transposes a section's block blooms into [`BLOOM_BIT_LENGTH`] bit-rows.
+///
+/// `blooms[j]` must be the `logs_bloom` of the j-th block of the section, in
+/// ascending block order. The returned `rows[b]` is a [`SECTION_BYTES`]-long
+/// bit-vector whose bit `j` is set iff `blooms[j]` has bloom bit `b` set.
+///
+/// Rows are allocated for every bit position; callers may drop all-zero rows
+/// when persisting (their absence is read back as zero).
+pub fn transpose_section(blooms: &[Bloom]) -> Vec<Vec<u8>> {
+    debug_assert!(blooms.len() <= SECTION_SIZE as usize);
+    let mut rows = vec![vec![0u8; SECTION_BYTES]; BLOOM_BIT_LENGTH];
+    for (offset, bloom) in blooms.iter().enumerate() {
+        let (byte, mask) = block_bit(offset);
+        // Walk only the set bits of this bloom rather than all 2048 positions.
+        for (bloom_byte_pos, &bloom_byte) in bloom.as_bytes().iter().enumerate() {
+            if bloom_byte == 0 {
+                continue;
+            }
+            for bit_in_byte in 0..8 {
+                if (bloom_byte >> bit_in_byte) & 1 == 1 {
+                    // Inverse of ethbloom's storage layout: bit `b` lives at byte
+                    // `255 - b/8`, bit `b % 8`.
+                    let bit = (255 - bloom_byte_pos) * 8 + bit_in_byte;
+                    rows[bit][byte] |= mask;
+                }
+            }
+        }
+    }
+    rows
+}
+
+/// A filter reduced to bloom-bit terms, ready to query a section.
+///
+/// Each term is the OR-set of one constrained filter position: the address set,
+/// or one topic position. Within a term any item may match (OR); across terms
+/// every term must match (AND) — exactly the log-filter semantics. Wildcard
+/// positions contribute no term. A query with no terms constrains nothing.
+#[derive(Debug, Clone, Default)]
+pub struct BloomQuery {
+    terms: Vec<Vec<[usize; BITS_PER_ITEM]>>,
+}
+
+impl BloomQuery {
+    /// Builds a query from the filter's addresses and per-position topic sets.
+    ///
+    /// `addresses` is the address filter (empty ⇒ no address constraint).
+    /// `topics` holds one entry per topic position; an empty entry is a wildcard
+    /// for that position and contributes no constraint.
+    pub fn new<'a>(
+        addresses: impl IntoIterator<Item = &'a [u8]>,
+        topics: impl IntoIterator<Item = &'a [&'a [u8]]>,
+    ) -> Self {
+        let mut terms = Vec::new();
+        let address_term: Vec<_> = addresses.into_iter().map(bloom_bit_indices).collect();
+        if !address_term.is_empty() {
+            terms.push(address_term);
+        }
+        for position in topics {
+            if position.is_empty() {
+                continue;
+            }
+            terms.push(position.iter().copied().map(bloom_bit_indices).collect());
+        }
+        Self { terms }
+    }
+
+    /// Whether this query has any constraint at all. An unconstrained query
+    /// can't narrow the candidate set, so callers should just scan the range.
+    pub fn is_unconstrained(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// Every distinct bloom bit position this query needs to read.
+    pub fn required_bits(&self) -> impl Iterator<Item = usize> + '_ {
+        self.terms
+            .iter()
+            .flatten()
+            .flat_map(|item| item.iter().copied())
+    }
+
+    /// Runs the query against a single section, returning the candidate bitmap.
+    ///
+    /// `section_len` is the number of blocks actually present in the section
+    /// (≤ [`SECTION_SIZE`]; the final section may be short). `row(bit)` returns
+    /// the transposed bit-vector for a bloom bit position, as persisted by
+    /// [`transpose_section`]; an all-zero row may be returned as an empty slice.
+    ///
+    /// The returned bitmap has bit `j` set iff the j-th block of the section is
+    /// a candidate. Bits at or beyond `section_len` are always zero.
+    pub fn run_section<F>(&self, section_len: usize, mut row: F) -> Vec<u8>
+    where
+        F: FnMut(usize) -> Vec<u8>,
+    {
+        // No constraints ⇒ every present block is a candidate.
+        if self.terms.is_empty() {
+            return full_bitmap(section_len);
+        }
+
+        let mut candidates = full_bitmap(section_len);
+        for term in &self.terms {
+            let mut term_bitmap = vec![0u8; SECTION_BYTES];
+            for item in term {
+                // A block has the item iff all three of its bloom bits are set:
+                // AND the three rows together.
+                let mut item_bitmap: Option<Vec<u8>> = None;
+                for &bit in item {
+                    let r = row(bit);
+                    match &mut item_bitmap {
+                        None => item_bitmap = Some(normalize_row(r)),
+                        Some(acc) => and_into(acc, &r),
+                    }
+                }
+                if let Some(item_bitmap) = item_bitmap {
+                    or_into(&mut term_bitmap, &item_bitmap);
+                }
+            }
+            and_into(&mut candidates, &term_bitmap);
+        }
+        candidates
+    }
+}
+
+/// A bitmap with the low `len` bits set (the blocks present in a section).
+fn full_bitmap(len: usize) -> Vec<u8> {
+    let mut bitmap = vec![0u8; SECTION_BYTES];
+    for offset in 0..len {
+        let (byte, mask) = block_bit(offset);
+        bitmap[byte] |= mask;
+    }
+    bitmap
+}
+
+/// Pads a persisted row (which may be empty or short for an all-zero tail) to
+/// [`SECTION_BYTES`].
+fn normalize_row(mut row: Vec<u8>) -> Vec<u8> {
+    row.resize(SECTION_BYTES, 0);
+    row
+}
+
+/// `acc &= other`, treating a short/empty `other` as zero-padded.
+fn and_into(acc: &mut [u8], other: &[u8]) {
+    for (i, byte) in acc.iter_mut().enumerate() {
+        *byte &= other.get(i).copied().unwrap_or(0);
+    }
+}
+
+/// `acc |= other`, treating a short/empty `other` as zero-padded.
+fn or_into(acc: &mut [u8], other: &[u8]) {
+    for (i, byte) in other.iter().enumerate() {
+        if i < acc.len() {
+            acc[i] |= byte;
+        }
+    }
+}
+
+/// Iterates the in-section block offsets whose bit is set in `bitmap`.
+pub fn set_offsets(bitmap: &[u8]) -> impl Iterator<Item = usize> + '_ {
+    bitmap.iter().enumerate().flat_map(|(byte_pos, &byte)| {
+        (0..8usize).filter_map(move |bit| ((byte >> bit) & 1 == 1).then_some(byte_pos * 8 + bit))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethrex_common::{H160, H256};
+
+    /// Builds a bloom the way a block producer does: by accruing each item's
+    /// keccak hash. Equivalent to setting the bits from `bloom_bit_indices`.
+    fn bloom_with(items: &[&[u8]]) -> Bloom {
+        use ethrex_common::BloomInput;
+        let mut bloom = Bloom::zero();
+        for item in items {
+            bloom.accrue(BloomInput::Raw(item));
+        }
+        bloom
+    }
+
+    fn addr(n: u64) -> H160 {
+        H160::from_low_u64_be(n)
+    }
+
+    fn topic(n: u64) -> H256 {
+        H256::from_low_u64_be(n)
+    }
+
+    #[test]
+    fn bit_indices_match_bloom_layout() {
+        // The three bits an item maps to must be exactly the bits set in a bloom
+        // built from that item alone.
+        let item = addr(42);
+        let bloom = bloom_with(&[item.as_bytes()]);
+        for bit in bloom_bit_indices(item.as_bytes()) {
+            let byte = bloom.as_bytes()[255 - bit / 8];
+            assert!((byte >> (bit % 8)) & 1 == 1, "bit {bit} should be set");
+        }
+    }
+
+    #[test]
+    fn transpose_roundtrips_membership() {
+        // Block 0 logs addr(1); block 1 logs addr(2); block 2 logs nothing.
+        let blooms = vec![
+            bloom_with(&[addr(1).as_bytes()]),
+            bloom_with(&[addr(2).as_bytes()]),
+            bloom_with(&[]),
+        ];
+        let rows = transpose_section(&blooms);
+
+        // addr(1) present only in block 0.
+        for bit in bloom_bit_indices(addr(1).as_bytes()) {
+            let (byte, mask) = block_bit(0);
+            assert!(rows[bit][byte] & mask != 0);
+            let (byte1, mask1) = block_bit(1);
+            assert!(rows[bit][byte1] & mask1 == 0);
+        }
+    }
+
+    /// Convenience: query a set of blooms directly (transpose then run).
+    fn run(blooms: &[Bloom], query: &BloomQuery) -> Vec<usize> {
+        let rows = transpose_section(blooms);
+        let bitmap = query.run_section(blooms.len(), |bit| rows[bit].clone());
+        set_offsets(&bitmap).collect()
+    }
+
+    #[test]
+    fn query_single_address() {
+        let blooms = vec![
+            bloom_with(&[addr(1).as_bytes()]),
+            bloom_with(&[addr(2).as_bytes()]),
+            bloom_with(&[addr(1).as_bytes(), addr(3).as_bytes()]),
+        ];
+        let query = BloomQuery::new([addr(1).as_bytes()], []);
+        assert_eq!(run(&blooms, &query), vec![0, 2]);
+    }
+
+    #[test]
+    fn query_multiple_addresses_is_or() {
+        let blooms = vec![
+            bloom_with(&[addr(1).as_bytes()]),
+            bloom_with(&[addr(2).as_bytes()]),
+            bloom_with(&[addr(9).as_bytes()]),
+        ];
+        let query = BloomQuery::new([addr(1).as_bytes(), addr(2).as_bytes()], []);
+        assert_eq!(run(&blooms, &query), vec![0, 1]);
+    }
+
+    #[test]
+    fn query_topic_positions_and_across_or_within() {
+        // Block 0: t1 & t2. Block 1: t1 only. Block 2: t2 & t9.
+        let blooms = vec![
+            bloom_with(&[topic(1).as_bytes(), topic(2).as_bytes()]),
+            bloom_with(&[topic(1).as_bytes()]),
+            bloom_with(&[topic(2).as_bytes(), topic(9).as_bytes()]),
+        ];
+        // position0 = {t1}, position1 = {t2, t9}  → AND across, OR within.
+        let (t1, t2, t9) = (topic(1), topic(2), topic(9));
+        let pos0: Vec<&[u8]> = vec![t1.as_bytes()];
+        let pos1: Vec<&[u8]> = vec![t2.as_bytes(), t9.as_bytes()];
+        let query = BloomQuery::new([], [pos0.as_slice(), pos1.as_slice()]);
+        // Block 0 has t1 and t2 ✓. Block 1 has t1 but neither t2 nor t9 ✗.
+        // Block 2 has t2/t9 but not t1 ✗.
+        assert_eq!(run(&blooms, &query), vec![0]);
+    }
+
+    #[test]
+    fn query_address_and_topic_combined() {
+        let blooms = vec![
+            bloom_with(&[addr(1).as_bytes(), topic(1).as_bytes()]),
+            bloom_with(&[addr(1).as_bytes()]),
+            bloom_with(&[topic(1).as_bytes()]),
+        ];
+        let t1 = topic(1);
+        let pos0: Vec<&[u8]> = vec![t1.as_bytes()];
+        let query = BloomQuery::new([addr(1).as_bytes()], [pos0.as_slice()]);
+        assert_eq!(run(&blooms, &query), vec![0]);
+    }
+
+    #[test]
+    fn unconstrained_query_matches_all_present_blocks() {
+        let blooms = vec![bloom_with(&[addr(1).as_bytes()]), bloom_with(&[])];
+        let query = BloomQuery::new([], []);
+        assert!(query.is_unconstrained());
+        assert_eq!(run(&blooms, &query), vec![0, 1]);
+    }
+
+    #[test]
+    fn empty_topic_position_is_wildcard() {
+        let blooms = vec![
+            bloom_with(&[addr(1).as_bytes()]),
+            bloom_with(&[addr(2).as_bytes()]),
+        ];
+        // A wildcard topic position (empty set) imposes no constraint.
+        let empty: Vec<&[u8]> = vec![];
+        let query = BloomQuery::new([addr(1).as_bytes()], [empty.as_slice()]);
+        assert_eq!(run(&blooms, &query), vec![0]);
+    }
+
+    #[test]
+    fn no_false_negatives_against_brute_force() {
+        // Cross-check the index against the bloom's own membership test over a
+        // mixed section: every block the index nominates a *miss* for must
+        // genuinely lack the item (no false negatives).
+        let blooms: Vec<Bloom> = (0..50u64)
+            .map(|i| bloom_with(&[addr(i % 7).as_bytes(), topic(i % 5).as_bytes()]))
+            .collect();
+        let query = BloomQuery::new([addr(3).as_bytes()], []);
+        let rows = transpose_section(&blooms);
+        let bitmap = query.run_section(blooms.len(), |bit| rows[bit].clone());
+        let candidates: std::collections::HashSet<usize> = set_offsets(&bitmap).collect();
+        for (j, bloom) in blooms.iter().enumerate() {
+            use ethrex_common::BloomInput;
+            let really_present = bloom.contains_input(BloomInput::Raw(addr(3).as_bytes()));
+            if really_present {
+                assert!(candidates.contains(&j), "block {j} wrongly skipped");
+            }
+        }
+    }
+}

--- a/crates/storage/bloombits.rs
+++ b/crates/storage/bloombits.rs
@@ -218,6 +218,26 @@ fn or_into(acc: &mut [u8], other: &[u8]) {
     }
 }
 
+/// Composite `LOG_BLOOM_BITS` key for one transposed row:
+/// `section (u64 BE) || bloom_bit (u16 BE)`. Section-major so a whole section's
+/// rows sort contiguously and can be range-scanned by [`section_prefix`].
+pub fn row_key(section: u64, bit: u16) -> Vec<u8> {
+    let mut key = Vec::with_capacity(10);
+    key.extend_from_slice(&section.to_be_bytes());
+    key.extend_from_slice(&bit.to_be_bytes());
+    key
+}
+
+/// Key prefix matching every row of `section`.
+pub fn section_prefix(section: u64) -> [u8; 8] {
+    section.to_be_bytes()
+}
+
+/// The section a block number falls in.
+pub fn section_of(block_number: u64) -> u64 {
+    block_number / SECTION_SIZE
+}
+
 /// Iterates the in-section block offsets whose bit is set in `bitmap`.
 pub fn set_offsets(bitmap: &[u8]) -> impl Iterator<Item = usize> + '_ {
     bitmap.iter().enumerate().flat_map(|(byte_pos, &byte)| {

--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -66,6 +66,7 @@
 
 pub mod api;
 pub mod backend;
+pub mod bloombits;
 pub mod error;
 mod layering;
 pub mod migrations;

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1494,6 +1494,47 @@ impl Store {
         txn.commit()
     }
 
+    /// Indexes every section that is complete and buried at least
+    /// `confirmation_depth` blocks behind the latest block, transposing each
+    /// section's header blooms into the bloombits index. Returns how many new
+    /// sections were indexed.
+    ///
+    /// Only sections deeper than the reorg depth limit are eligible, so a stored
+    /// section is immutable — this is why the index never needs reorg
+    /// invalidation. Runs blocking reads; callers should invoke it off the async
+    /// runtime (e.g. via `spawn_blocking`). On first run after upgrade it walks
+    /// the whole chain (backfill); in steady state it indexes one section at a
+    /// time as the head advances.
+    pub fn index_pending_bloombits_sections(
+        &self,
+        confirmation_depth: u64,
+    ) -> Result<u64, StoreError> {
+        let latest = self.latest_block_header.get().number;
+        let mut section = self.get_indexed_bloombits_sections()?;
+        let mut newly_indexed = 0;
+        loop {
+            let last_block = (section + 1) * SECTION_SIZE - 1;
+            // Stop before any section that a reorg could still rewrite.
+            if last_block + confirmation_depth > latest {
+                break;
+            }
+            let mut blooms = Vec::with_capacity(SECTION_SIZE as usize);
+            for block_number in section * SECTION_SIZE..=last_block {
+                let header = self.get_block_header(block_number)?.ok_or_else(|| {
+                    StoreError::Custom(format!(
+                        "bloombits: missing canonical header for block {block_number}"
+                    ))
+                })?;
+                blooms.push(header.logs_bloom);
+            }
+            let rows = bloombits::transpose_section(&blooms);
+            self.store_bloombits_section(section, &rows)?;
+            section += 1;
+            newly_indexed += 1;
+        }
+        Ok(newly_indexed)
+    }
+
     /// Number of contiguous bloombits sections (from section 0) that are fully
     /// indexed. Blocks below `count * SECTION_SIZE` can be served from the index;
     /// everything above must be scanned directly.
@@ -3899,6 +3940,39 @@ mod bloombits_store_tests {
         assert_eq!(store.get_indexed_bloombits_sections().unwrap(), 0);
         index_section(&store, 0, |_| bloom_for(&[addr(1).as_bytes()]));
         assert_eq!(store.get_indexed_bloombits_sections().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn catch_up_respects_confirmation_depth() {
+        let store = store();
+        // Two full sections of headers plus a short, recent tail.
+        let head = 2 * SECTION_SIZE + 10;
+        let mut headers = Vec::new();
+        let mut canonical = Vec::new();
+        for block_number in 0..=head {
+            let mut header = BlockHeader::default();
+            header.number = block_number;
+            header.logs_bloom = bloom_for(&[addr(1).as_bytes()]);
+            canonical.push((block_number, header.hash()));
+            headers.push(header);
+        }
+        let head_hash = canonical[head as usize].1;
+        store.add_block_headers(headers).await.unwrap();
+        // Mark the chain canonical so `get_block_header`/latest resolve.
+        store
+            .forkchoice_update(canonical, head, head_hash, None, None)
+            .await
+            .unwrap();
+
+        // With a 128-block confirmation depth, section 0 (ends at 4095, buried
+        // by ~4106) is eligible; section 1 (ends at 8191) is only ~10 deep, so
+        // it stays unindexed.
+        let indexed = store.index_pending_bloombits_sections(128).unwrap();
+        assert_eq!(indexed, 1);
+        assert_eq!(store.get_indexed_bloombits_sections().unwrap(), 1);
+
+        // Idempotent: nothing new to index on a second pass.
+        assert_eq!(store.index_pending_bloombits_sections(128).unwrap(), 0);
     }
 }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -7,13 +7,14 @@ use crate::{
         tables::{
             ACCOUNT_CODE_METADATA, ACCOUNT_CODES, ACCOUNT_FLATKEYVALUE, ACCOUNT_TRIE_NODES,
             BLOCK_ACCESS_LISTS, BLOCK_NUMBERS, BODIES, CANONICAL_BLOCK_HASHES, CHAIN_DATA,
-            EXECUTION_WITNESSES, FULLSYNC_HEADERS, HEADERS, INVALID_CHAINS, MISC_VALUES,
-            PENDING_BLOCKS, RECEIPTS_V2, SNAP_STATE, STORAGE_FLATKEYVALUE, STORAGE_TRIE_NODES,
-            TRANSACTION_LOCATIONS,
+            EXECUTION_WITNESSES, FULLSYNC_HEADERS, HEADERS, INVALID_CHAINS, LOG_BLOOM_BITS,
+            MISC_VALUES, PENDING_BLOCKS, RECEIPTS_V2, SNAP_STATE, STORAGE_FLATKEYVALUE,
+            STORAGE_TRIE_NODES, TRANSACTION_LOCATIONS,
         },
     },
     apply_prefix,
     backend::in_memory::InMemoryBackend,
+    bloombits::{self, BloomQuery, SECTION_SIZE},
     error::StoreError,
     layering::{TrieLayerCache, TrieWrapper},
     rlp::{BlockBodyRLP, BlockHeaderRLP, BlockRLP},
@@ -117,6 +118,10 @@ enum FKVGeneratorControlMessage {
 
 // 64mb
 const CODE_CACHE_MAX_SIZE: u64 = 64 * 1024 * 1024;
+
+/// `MISC_VALUES` key holding the count of contiguous fully-indexed bloombits
+/// sections (`u64` LE).
+const BLOOMBITS_SECTIONS_KEY: &[u8] = b"bloombits_sections";
 
 #[derive(Debug)]
 struct CodeCache {
@@ -1487,6 +1492,112 @@ impl Store {
         let mut txn = backend.begin_write()?;
         txn.put_batch(table, batch_ops)?;
         txn.commit()
+    }
+
+    /// Number of contiguous bloombits sections (from section 0) that are fully
+    /// indexed. Blocks below `count * SECTION_SIZE` can be served from the index;
+    /// everything above must be scanned directly.
+    pub fn get_indexed_bloombits_sections(&self) -> Result<u64, StoreError> {
+        Ok(self
+            .read(MISC_VALUES, BLOOMBITS_SECTIONS_KEY.to_vec())?
+            .and_then(|bytes| bytes.try_into().ok().map(u64::from_le_bytes))
+            .unwrap_or(0))
+    }
+
+    fn set_indexed_bloombits_sections(&self, count: u64) -> Result<(), StoreError> {
+        self.write(
+            MISC_VALUES,
+            BLOOMBITS_SECTIONS_KEY.to_vec(),
+            count.to_le_bytes().to_vec(),
+        )
+    }
+
+    /// Persists the transposed rows of a finalized section and advances the
+    /// indexed-section count. `rows` must be ordered by bloom bit (index `b` is
+    /// the row for bloom bit `b`); all-zero rows are skipped. The caller must
+    /// only finalize sections that are buried beyond the reorg depth limit, so a
+    /// stored section is immutable.
+    pub fn store_bloombits_section(
+        &self,
+        section: u64,
+        rows: &[Vec<u8>],
+    ) -> Result<(), StoreError> {
+        let batch: Vec<(Vec<u8>, Vec<u8>)> = rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| row.iter().any(|&b| b != 0))
+            .map(|(bit, row)| (bloombits::row_key(section, bit as u16), row.clone()))
+            .collect();
+        self.write_batch(LOG_BLOOM_BITS, batch)?;
+        if section + 1 > self.get_indexed_bloombits_sections()? {
+            self.set_indexed_bloombits_sections(section + 1)?;
+        }
+        Ok(())
+    }
+
+    fn get_bloombits_row(&self, section: u64, bit: u16) -> Result<Vec<u8>, StoreError> {
+        Ok(self
+            .read(LOG_BLOOM_BITS, bloombits::row_key(section, bit))?
+            .unwrap_or_default())
+    }
+
+    /// Returns the candidate block numbers in `[from, to]` that may contain a log
+    /// matching the filter, or `None` if the index can't help (no constraints, or
+    /// the range starts beyond what's indexed) and the caller should scan.
+    ///
+    /// The indexed portion is narrowed via the bloombits index; any tail of the
+    /// range not yet indexed (the recent, reorg-reachable blocks) is returned in
+    /// full so the caller still scans it. False positives are fine — the caller
+    /// exact-filters every returned block.
+    pub fn get_candidate_blocks(
+        &self,
+        addresses: &[Address],
+        topics: &[Vec<H256>],
+        from: BlockNumber,
+        to: BlockNumber,
+    ) -> Result<Option<Vec<BlockNumber>>, StoreError> {
+        let address_items: Vec<&[u8]> = addresses.iter().map(|a| a.as_bytes()).collect();
+        let topic_items: Vec<Vec<&[u8]>> = topics
+            .iter()
+            .map(|position| position.iter().map(|t| t.as_bytes()).collect())
+            .collect();
+        let topic_refs: Vec<&[&[u8]]> = topic_items.iter().map(Vec::as_slice).collect();
+        let query = BloomQuery::new(address_items.iter().copied(), topic_refs.iter().copied());
+
+        let indexed_sections = self.get_indexed_bloombits_sections()?;
+        let indexed_until = indexed_sections.saturating_mul(SECTION_SIZE);
+        // Index can't narrow an unconstrained query, and gives nothing if the
+        // range lies entirely in the unindexed tail.
+        if query.is_unconstrained() || from >= indexed_until {
+            return Ok(None);
+        }
+
+        let mut candidates = Vec::new();
+        let indexed_to = to.min(indexed_until - 1);
+        for section in bloombits::section_of(from)..=bloombits::section_of(indexed_to) {
+            // Finalized sections are always full.
+            let section_start = section * SECTION_SIZE;
+            let mut rows: HashMap<u16, Vec<u8>> = HashMap::new();
+            for bit in query.required_bits() {
+                if let Entry::Vacant(entry) = rows.entry(bit as u16) {
+                    entry.insert(self.get_bloombits_row(section, bit as u16)?);
+                }
+            }
+            let bitmap = query.run_section(SECTION_SIZE as usize, |bit| {
+                rows.get(&(bit as u16)).cloned().unwrap_or_default()
+            });
+            for offset in bloombits::set_offsets(&bitmap) {
+                let block_number = section_start + offset as u64;
+                if (from..=indexed_to).contains(&block_number) {
+                    candidates.push(block_number);
+                }
+            }
+        }
+        // Unindexed tail of the range: include every block so it gets scanned.
+        if to >= indexed_until {
+            candidates.extend(from.max(indexed_until)..=to);
+        }
+        Ok(Some(candidates))
     }
 
     pub async fn add_fullsync_batch(&self, headers: Vec<BlockHeader>) -> Result<(), StoreError> {
@@ -3679,6 +3790,115 @@ pub fn read_chain_id_from_db(path: &Path) -> Option<u64> {
     {
         let _ = path;
         None
+    }
+}
+
+#[cfg(test)]
+mod bloombits_store_tests {
+    use super::*;
+    use crate::EngineType;
+    use ethrex_common::{Address, Bloom, BloomInput};
+
+    fn store() -> Store {
+        Store::new("", EngineType::InMemory).expect("in-memory store")
+    }
+
+    fn bloom_for(items: &[&[u8]]) -> Bloom {
+        let mut bloom = Bloom::zero();
+        for item in items {
+            bloom.accrue(BloomInput::Raw(item));
+        }
+        bloom
+    }
+
+    fn addr(n: u64) -> Address {
+        Address::from_low_u64_be(n)
+    }
+
+    // Builds and stores a section of `SECTION_SIZE` blocks, each block's bloom
+    // produced by `bloom_at(block_offset)`.
+    fn index_section(store: &Store, section: u64, bloom_at: impl Fn(usize) -> Bloom) {
+        let blooms: Vec<Bloom> = (0..SECTION_SIZE as usize).map(&bloom_at).collect();
+        let rows = bloombits::transpose_section(&blooms);
+        store.store_bloombits_section(section, &rows).unwrap();
+    }
+
+    #[test]
+    fn candidate_blocks_narrows_to_matching_blocks() {
+        let store = store();
+        // Section 0: only blocks 5 and 9 log addr(7); the rest log addr(1).
+        index_section(&store, 0, |offset| {
+            if offset == 5 || offset == 9 {
+                bloom_for(&[addr(7).as_bytes()])
+            } else {
+                bloom_for(&[addr(1).as_bytes()])
+            }
+        });
+
+        let candidates = store
+            .get_candidate_blocks(&[addr(7)], &[], 0, SECTION_SIZE - 1)
+            .unwrap()
+            .expect("range is indexed");
+        assert_eq!(candidates, vec![5, 9]);
+    }
+
+    #[test]
+    fn unconstrained_query_returns_none() {
+        let store = store();
+        index_section(&store, 0, |_| bloom_for(&[addr(1).as_bytes()]));
+        assert!(
+            store
+                .get_candidate_blocks(&[], &[], 0, 10)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn range_beyond_index_returns_none() {
+        let store = store();
+        index_section(&store, 0, |_| bloom_for(&[addr(1).as_bytes()]));
+        // from is past the single indexed section → fall back to scan.
+        let from = SECTION_SIZE;
+        assert!(
+            store
+                .get_candidate_blocks(&[addr(1)], &[], from, from + 10)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn unindexed_tail_is_returned_in_full() {
+        let store = store();
+        // Index section 0 only; block 5 matches addr(7).
+        index_section(&store, 0, |offset| {
+            if offset == 5 {
+                bloom_for(&[addr(7).as_bytes()])
+            } else {
+                bloom_for(&[addr(1).as_bytes()])
+            }
+        });
+
+        // Query spans the indexed section and 3 blocks into the unindexed tail.
+        let to = SECTION_SIZE + 2;
+        let candidates = store
+            .get_candidate_blocks(&[addr(7)], &[], 0, to)
+            .unwrap()
+            .expect("partially indexed");
+        // Block 5 from the index, plus the whole unindexed tail scanned.
+        assert_eq!(
+            candidates,
+            vec![5, SECTION_SIZE, SECTION_SIZE + 1, SECTION_SIZE + 2]
+        );
+    }
+
+    #[test]
+    fn indexed_section_count_advances() {
+        let store = store();
+        assert_eq!(store.get_indexed_bloombits_sections().unwrap(), 0);
+        index_section(&store, 0, |_| bloom_for(&[addr(1).as_bytes()]));
+        assert_eq!(store.get_indexed_bloombits_sections().unwrap(), 1);
     }
 }
 


### PR DESCRIPTION
> Stacked on #6813 (base branch `perf/getlogs-index`). Review/merge that first; this will be retargeted to `main` once it lands.

**Motivation**

#6813 made `eth_getLogs` skip non-matching blocks via the per-block header bloom, but the query still walks every header in the range — O(blocks-in-range). The benchmark on that PR confirmed the ceiling: ~1.2 ms/block of header reads, so 1,000+ block ranges still saturate under load and stay far from indexed clients (geth/reth/nethermind).

This closes that gap with a real log index.

**Description**

Adds a geth-style **bloombits** log index. Blocks are grouped into sections of 4096; for each of the 2048 bloom bit positions we store one transposed bit-vector across the section. A query ANDs the three bit-vectors an address/topic maps to (OR within an address set / topic position, AND across positions) to get a candidate-block bitmap, turning `eth_getLogs` from O(blocks-in-range) into ~O(matching blocks).

Why bloombits over an inverted index: a snap-synced node retains **all historical headers** (hence all `logs_bloom`) but **not historical receipts** (`snap_sync.rs` skips pre-pivot bodies/receipts). An inverted index built from receipt logs could only ever cover post-pivot history; bloombits is built purely from header blooms, so it indexes the full chain on the nodes people actually run.

Implementation (one commit per stage):
1. **Core module** (`crates/storage/bloombits.rs`) — bit-index derivation (mirrors `ethbloom`), section transpose, and the candidate-bitmap query. Pure logic, no storage.
2. **Storage** — `LOG_BLOOM_BITS` column family (section-major key `section || bit`; all-zero rows omitted) plus `store_bloombits_section` / `get_candidate_blocks`. Coverage tracked in `MISC_VALUES`.
3. **Background indexer** (`cmd/ethrex`) — finalizes sections only once they're buried ≥256 blocks (well past the 128 reorg-depth limit), so stored sections are immutable and **no reorg invalidation is needed**. First run backfills the whole chain; steady state indexes forward. Runs on a blocking thread, off the import hot path → no `store_ms` impact.
4. **Query wiring** — `fetch_logs_with_filter` visits index candidates instead of the full range; the still-unindexed recent tail is returned in full and scanned. Falls back to the #6813 header-bloom scan when the index can't help (unconstrained query, or range above what's indexed). Every visited block is still exact-filtered, so false positives are harmless and results are identical to a full scan.

No new schema version: the column family auto-creates on open, and an unindexed DB simply uses the scan fallback until the background indexer catches up.

Tested: bloombits transpose/query incl. a no-false-negatives brute-force check; storage candidate-narrowing, unindexed-tail, and confirmation-depth/backfill gating; and an end-to-end `eth_getLogs` test that populates the index and asserts the candidate path returns exactly the matching logs.

Benchmarking against #6813 and geth with the #6749 harness is the remaining step before marking ready.

Part of #6785.

**Checklist**

- [x] New `LOG_BLOOM_BITS` column family auto-creates on DB open; no migration and no `STORE_SCHEMA_VERSION` bump required (index is append-only, absence = scan fallback).
