### PR TITLE
chore(l1): use rocksdb block cache of 4 GiB in multisync

### DIFF
--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -30,6 +30,8 @@ x-ethrex-common: &ethrex-common
   pull_policy: "${ETHREX_PULL_POLICY:-always}"
   environment:
     RUST_LOG: "${RUST_LOG:-info,ethrex_p2p::sync=debug}"
+    # Bound RocksDB resident memory (default 12 GiB) so 3 parallel snapsyncs fit in host RAM.
+    ETHREX_ROCKSDB_BLOCK_CACHE_SIZE: "${ETHREX_ROCKSDB_BLOCK_CACHE_SIZE:-4294967296}"  # 4 GiB
   ulimits:
     nofile: 1000000
   restart: unless-stopped


### PR DESCRIPTION
**Motivation**

The multisync script brings up three instances of ethrex and three of lighthouse, which implies very high memory usages.

**Description**

Lowers the cache size from 12gb to 4gb to significantly reduce RAM usage during multisync. This doesn't measurably affect sync times.