### PR TITLE
ci(l1,l2): enrich Slack failure alerts and drop aggregator job noise

### DIFF
--- a/.github/scripts/notify_workflow_failure.sh
+++ b/.github/scripts/notify_workflow_failure.sh
@@ -1,63 +1,90 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: notify_workflow_failure.sh <slack_webhook_url>
+# Usage: notify_workflow_failure.sh
 # Expects the following env vars (provided by the caller workflow):
-#   REPO, WORKFLOW_NAME, CONCLUSION, RUN_HTML_URL, RUN_ID, HEAD_SHA
+#   SLACK_WEBHOOK_URL, REPO, WORKFLOW_NAME, CONCLUSION, EVENT, RUN_HTML_URL,
+#   RUN_ID, RUN_ATTEMPT, HEAD_SHA, COMMIT_MESSAGE, FAILED_JOBS
 
-SLACK_WEBHOOK_URL=${1:-}
-if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+# A missing webhook (e.g. on forks, where secrets are unavailable) is not an
+# error; failing to deliver to a configured webhook is.
+if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
   echo "Slack webhook URL not provided; skipping notification." >&2
   exit 0
 fi
 
 REPO=${REPO:-}
 WORKFLOW_NAME=${WORKFLOW_NAME:-}
-CONCLUSION=${CONCLUSION:-}
+CONCLUSION=${CONCLUSION:-failure}
+EVENT=${EVENT:-push}
 RUN_HTML_URL=${RUN_HTML_URL:-}
 RUN_ID=${RUN_ID:-}
+RUN_ATTEMPT=${RUN_ATTEMPT:-1}
 HEAD_SHA=${HEAD_SHA:-}
+COMMIT_MESSAGE=${COMMIT_MESSAGE:-}
 FAILED_JOBS=${FAILED_JOBS:-Unknown job}
+
+if ! [[ "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+  RUN_ATTEMPT=1
+fi
+
+# Escape the characters that are special in Slack mrkdwn text. Uses sed
+# because in bash >= 5.2 an unquoted `&` in a ${var//pat/repl} replacement
+# expands to the matched text instead of a literal ampersand.
+slack_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
 
 RUN_URL="$RUN_HTML_URL"
 if [[ -z "$RUN_URL" ]]; then
   RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
 fi
 
-SHORT_SHA="${HEAD_SHA:0:8}"
-COMMIT_URL="https://github.com/${REPO}/commit/${HEAD_SHA}"
+case "$CONCLUSION" in
+  timed_out) VERB="timed out" ;;
+  startup_failure) VERB="failed to start" ;;
+  *) VERB="failed" ;;
+esac
+
+# Scheduled runs are not caused by the commit at the head of main, so don't
+# present them as a failure introduced "on main".
+if [[ "$EVENT" == "schedule" ]]; then
+  HEADLINE="Scheduled workflow $(slack_escape "$WORKFLOW_NAME") ${VERB}"
+else
+  HEADLINE="$(slack_escape "$WORKFLOW_NAME") ${VERB} on main"
+fi
+if (( RUN_ATTEMPT > 1 )); then
+  HEADLINE="${HEADLINE} (attempt ${RUN_ATTEMPT})"
+fi
+
+if [[ -n "$HEAD_SHA" ]]; then
+  SHORT_SHA="${HEAD_SHA:0:8}"
+  COMMIT_URL="https://github.com/${REPO}/commit/${HEAD_SHA}"
+  COMMIT_LINE="*Commit:* <${COMMIT_URL}|${SHORT_SHA}>"
+  COMMIT_TITLE=$(printf '%s' "$COMMIT_MESSAGE" | head -n 1)
+  if [[ -n "$COMMIT_TITLE" ]]; then
+    COMMIT_LINE="${COMMIT_LINE} $(slack_escape "$COMMIT_TITLE")"
+  fi
+else
+  COMMIT_LINE="*Commit:* unknown"
+fi
 
 # Construct the Slack payload using jq for safe JSON escaping
 PAYLOAD=$(jq -n \
-  --arg repo "$REPO" \
-  --arg workflow "$WORKFLOW_NAME" \
-  --arg conclusion "$CONCLUSION" \
-  --arg sha "$SHORT_SHA" \
-  --arg commit_url "$COMMIT_URL" \
-  --arg url "$RUN_URL" \
-  --arg failed_jobs "$FAILED_JOBS" \
+  --arg headline ":rotating_light: *<${RUN_URL}|${HEADLINE}>*" \
+  --arg commit "$COMMIT_LINE" \
+  --arg failed_jobs "*Failed job(s)*"$'\n'"$FAILED_JOBS" \
   '{
     blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: ":rotating_light: *Workflow failed on main*"
-        }
-      },
-      {
-        type: "section",
-        fields: [
-          { type: "mrkdwn", text: "*Workflow*\n\($workflow)" },
-          { type: "mrkdwn", text: "*Conclusion*\n\($conclusion)" },
-          { type: "mrkdwn", text: "*Commit*\n<\($commit_url)|\($sha)>" },
-          { type: "mrkdwn", text: "*Run*\n<\($url)|Open in GitHub>" },
-          { type: "mrkdwn", text: "*Failed job(s)*\n\($failed_jobs)" }
-        ]
-      }
+      { type: "section", text: { type: "mrkdwn", text: $headline } },
+      { type: "section", text: { type: "mrkdwn", text: $commit } },
+      { type: "section", text: { type: "mrkdwn", text: $failed_jobs } }
     ]
   }')
-curl -sS --fail -X POST \
+
+# Let delivery failures fail the job so lost alerts are visible in the
+# Actions tab instead of being silently swallowed.
+curl -sS --fail --retry 3 -X POST \
   -H 'Content-type: application/json' \
   --data "$PAYLOAD" \
-  "$SLACK_WEBHOOK_URL" || echo "Failed to send Slack notification" >&2
+  "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/common_failure_alerts.yaml
+++ b/.github/workflows/common_failure_alerts.yaml
@@ -28,20 +28,17 @@ jobs:
   notify-on-failure:
     name: Notify Slack on failure (main)
     runs-on: ubuntu-latest
+    # `cancelled` runs are deliberately not alerted: a manually cancelled run
+    # on main is not a CI failure.
     if: >-
-      ${{ github.event.workflow_run.conclusion != 'success' &&
+      ${{ contains(fromJSON('["failure", "timed_out", "startup_failure"]'), github.event.workflow_run.conclusion) &&
           (github.event.workflow_run.event == 'push' ||
            github.event.workflow_run.event == 'schedule') }}
     steps:
-      - name: Select Slack webhook
-        id: select_webhook
-        run: |
-          echo "webhook=${{ secrets.ETHREX_INTERNO_SLACK_WEBHOOK }}" >> "$GITHUB_OUTPUT"
-
       - name: Checkout sources
         uses: actions/checkout@v6
 
-      - name: Collect failed job names
+      - name: Collect failed jobs
         id: failed_jobs
         uses: actions/github-script@v8
         with:
@@ -52,12 +49,16 @@ jobs:
 
       - name: Post failure to Slack
         env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ETHREX_INTERNO_SLACK_WEBHOOK }}
           REPO: ${{ github.repository }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          EVENT: ${{ github.event.workflow_run.event }}
           RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          FAILED_JOBS: ${{ steps.failed_jobs.outputs.names }}
+          COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          FAILED_JOBS: ${{ steps.failed_jobs.outputs.summary }}
         run: |
-          bash .github/scripts/notify_workflow_failure.sh "${{ steps.select_webhook.outputs.webhook }}"
+          bash .github/scripts/notify_workflow_failure.sh

--- a/scripts/collect_failed_jobs.js
+++ b/scripts/collect_failed_jobs.js
@@ -1,7 +1,87 @@
 'use strict';
 
+// Aggregator jobs exist only to give branch protection a single required
+// check (e.g. "Integration Test L2"); they fail whenever any real job fails,
+// so listing them in the alert would only duplicate information. They are
+// recognized by their check step rather than by name so that every workflow's
+// aggregator is covered regardless of what the job itself is called.
+const AGGREGATOR_STEP_NAME = 'Check if any job failed';
+
+const FAILING_JOB_CONCLUSIONS = new Set([
+  'failure',
+  'timed_out',
+  'action_required',
+]);
+
+// A step killed by a timeout or a runner-side cancellation reports
+// `cancelled` while its job still reports `failure`, so `cancelled` steps
+// must be considered to locate where a failed job actually stopped.
+const FAILING_STEP_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled']);
+
+// Slack section blocks are limited to 3000 characters and each job line can
+// take ~200 with its link, so cap the list defensively.
+const MAX_LISTED_JOBS = 10;
+
+const CONCLUSION_VERBS = {
+  failure: 'failed',
+  timed_out: 'timed out',
+  cancelled: 'was cancelled',
+  action_required: 'needs action',
+};
+
+// Escape the characters that are special in Slack mrkdwn text.
+function escapeSlackText(text) {
+  return String(text)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function formatDuration(startedAt, completedAt) {
+  if (!startedAt || !completedAt) {
+    return null;
+  }
+  const ms = new Date(completedAt) - new Date(startedAt);
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return null;
+  }
+  const totalMinutes = Math.floor(ms / 60_000);
+  if (totalMinutes >= 60) {
+    return `${Math.floor(totalMinutes / 60)}h ${totalMinutes % 60}m`;
+  }
+  const seconds = Math.round((ms % 60_000) / 1000);
+  if (totalMinutes > 0) {
+    return `${totalMinutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function firstFailingStep(job) {
+  return (job.steps ?? []).find(
+    step => step?.conclusion && FAILING_STEP_CONCLUSIONS.has(step.conclusion)
+  );
+}
+
+function isAggregatorJob(job) {
+  return firstFailingStep(job)?.name === AGGREGATOR_STEP_NAME;
+}
+
+// Render one Slack mrkdwn bullet per job, e.g.:
+// - <https://github.com/...|State Reconstruction Tests> — step `Run tests` was cancelled after 18m 47s
+function describeJob(job) {
+  const name = escapeSlackText(job.name);
+  const link = job.html_url ? `<${job.html_url}|${name}>` : name;
+  const step = firstFailingStep(job);
+  const verb = CONCLUSION_VERBS[step?.conclusion ?? job.conclusion] ?? 'failed';
+  const where = step ? `step \`${escapeSlackText(step.name)}\` ` : '';
+  const duration = formatDuration(job.started_at, job.completed_at);
+  const after = duration ? ` after ${duration}` : '';
+  return `- ${link} — ${where}${verb}${after}`;
+}
+
 /**
- * Collects failed job names for the current workflow run and exposes them via step output.
+ * Collects the failed jobs of the triggering workflow run and exposes a
+ * Slack mrkdwn summary of them via the `summary` step output.
  * @param {{ github: import('@actions/github').GitHub, core: import('@actions/core'), context: any }} deps
  */
 module.exports = async function collectFailedJobs({ github, core, context }) {
@@ -9,9 +89,23 @@ module.exports = async function collectFailedJobs({ github, core, context }) {
   const attemptNumber = context.payload.workflow_run.run_attempt ?? 1;
   const { owner, repo } = context.repo;
 
-  const failingConclusions = new Set(['failure', 'timed_out', 'action_required']);
-  const ignoredJobs = new Set(['Integration Test']);
-  const relevantJobs = new Set();
+  // Deduplicate by name keeping the latest attempt, since the run-wide
+  // fallback listing includes jobs from every attempt.
+  const failedJobsByName = new Map();
+
+  function considerJob(job) {
+    if (
+      !job?.name ||
+      !job?.conclusion ||
+      !FAILING_JOB_CONCLUSIONS.has(job.conclusion)
+    ) {
+      return;
+    }
+    const seen = failedJobsByName.get(job.name);
+    if (!seen || (job.run_attempt ?? 1) > (seen.run_attempt ?? 1)) {
+      failedJobsByName.set(job.name, job);
+    }
+  }
 
   async function collectJobs(fetchPage) {
     let page = 1;
@@ -19,16 +113,7 @@ module.exports = async function collectFailedJobs({ github, core, context }) {
       const response = await fetchPage(page);
 
       const jobs = Array.isArray(response?.data?.jobs) ? response.data.jobs : [];
-      for (const job of jobs) {
-        if (
-          job?.conclusion &&
-          failingConclusions.has(job.conclusion) &&
-          job?.name &&
-          !ignoredJobs.has(job.name)
-        ) {
-          relevantJobs.add(job.name);
-        }
-      }
+      jobs.forEach(considerJob);
 
       if (jobs.length < 100) {
         break;
@@ -64,7 +149,18 @@ module.exports = async function collectFailedJobs({ github, core, context }) {
     );
   }
 
-  const jobList = Array.from(relevantJobs);
-  const names = jobList.length > 0 ? jobList.join('\n- ') : 'Unknown job';
-  core.setOutput('names', jobList.length > 0 ? `- ${names}` : names);
+  const failedJobs = Array.from(failedJobsByName.values());
+  // Fall back to the aggregators only when no real job failed, so the alert
+  // always names at least one job.
+  let listedJobs = failedJobs.filter(job => !isAggregatorJob(job));
+  if (listedJobs.length === 0) {
+    listedJobs = failedJobs;
+  }
+
+  const lines = listedJobs.slice(0, MAX_LISTED_JOBS).map(describeJob);
+  if (listedJobs.length > MAX_LISTED_JOBS) {
+    lines.push(`- …and ${listedJobs.length - MAX_LISTED_JOBS} more`);
+  }
+
+  core.setOutput('summary', lines.length > 0 ? lines.join('\n') : 'Unknown job');
 };


### PR DESCRIPTION
**Motivation**

Failure alerts on main carry little actionable information: a bare SHA, a redundant "failure" field, and a job list that includes branch-protection aggregator jobs while hiding which step failed and why. In a recent alert ([run 27363569281](https://github.com/lambdaclass/ethrex/actions/runs/27363569281)) both listed jobs traced back to one real failure whose test step had been cancelled ~19 minutes in — none of which was visible in Slack.

**Description**

- Filter aggregator jobs by their `Check if any job failed` step instead of a hardcoded name list, so every workflow's aggregator ("Integration Test", "Integration Test L2", "Test", "Lint") is excluded regardless of its name; fall back to listing them only when no real job failed.
- Enrich the message: the headline links to the run and distinguishes scheduled workflows, timeouts, startup failures, and re-run attempts; a commit line shows the commit title (which embeds the PR number); each failed job links to its job page and names the failing step, how it ended (failed / was cancelled / timed out), and its duration.
- Alert only on `failure`, `timed_out`, and `startup_failure` run conclusions, so manually cancelled runs no longer notify.
- Hygiene: the webhook and untrusted inputs (workflow name, commit message) are passed via `env:`; the job list is capped at 10 with attempt-level dedupe; Slack mrkdwn special characters are escaped; `curl` retries 3 times and propagates failure so lost alerts show up as red runs.

**Examples**

Before — the actual alert for run 27363569281:

```
🚨 Workflow failed on main
Workflow                Conclusion
L2 (without proving)    failure
Commit                  Run
d66f17cb                Open in GitHub
Failed job(s)
- State Reconstruction Tests
- Integration Test L2
```

After — the same run replayed through the new scripts:

```
🚨 L2 (without proving) failed on main
Commit: d66f17cb chore(l1): use rocksdb block cache of 4 GiB in multisync (#6836)
Failed job(s)
- State Reconstruction Tests — step `Run tests` was cancelled after 18m 47s
```

The headline links to the run, the SHA to the commit, and each job name to its job page. "Integration Test L2" is the aggregator job and is no longer listed.

Headline variants:

```
🚨 Scheduled workflow Daily Hive Report timed out
🚨 L1 failed on main (attempt 2)
🚨 L1 failed to start on main
```

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A (CI only)
