### PR TITLE
ci(l1): match perf-ci genesis chain id to l2-1k-erc20 fixture transactions

### DIFF
--- a/fixtures/genesis/perf-ci.json
+++ b/fixtures/genesis/perf-ci.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": 65536999,
+    "chainId": 1729,
     "homesteadBlock": 0,
     "daoForkSupport": false,
     "eip150Block": 0,


### PR DESCRIPTION
**Motivation**

The "Benchmark Block execution" job (`pr_perf_blocks_exec.yaml`) fails on any PR carrying the `performance` label (first seen on #6852) since #6817 added per-transaction chain-id validation to `validate_block_pre_execution`:

```
Error: Invalid Block: Transaction has invalid chain id: have 1729, want 65536999
```

The job imports `fixtures/blockchain/l2-1k-erc20.rlp`, whose transactions were signed for chain id **1729** — the L2 default at the time the fixture was generated. #3337 (June 2025) later changed the L2 default chain id to 65536999 across all genesis files, including `fixtures/genesis/perf-ci.json`, leaving the genesis config and the fixture's signed transactions disagreeing. The mismatch sat dormant because nothing validated transaction chain ids at block import; #6817 made it fatal. It surfaces only now because the benchmark job is label-gated, so it never ran on #6817 itself.

**Description**

Sets `chainId` back to 1729 in `fixtures/genesis/perf-ci.json`, matching the fixture's transactions. Unlike the `logs_bloom` case (#6821), no fixture regeneration is needed: the chain id lives in the chain *config*, not in any header field, so the genesis block hash is unchanged (`0x49be…ffc1`) and the fixture chain still links. `perf-ci.json` is referenced only by this benchmark workflow, and EIP-155 sender recovery uses the transaction's own chain id, so nothing else observes the config value.

Verified with a binary built from current main:

- original genesis → `Error: Invalid Block: Transaction has invalid chain id: have 1729, want 65536999` (reproduces CI)
- patched genesis → `Import completed blocks=1110`, genesis hash unchanged

This PR carries the `performance` label so the previously-failing benchmark job runs here as an end-to-end check.

**Checklist**

- [x] Reproduced the failure and verified the fix locally with a full fixture import
