### PR TITLE
perf(l1): collect code hashes in a single pass during the account trie build

### DIFF
--- a/crates/networking/p2p/sync/code_collector.rs
+++ b/crates/networking/p2p/sync/code_collector.rs
@@ -55,6 +55,19 @@ impl CodeHashCollector {
         Ok(())
     }
 
+    /// Sync variant of [`Self::flush_if_needed`], callable from iterator
+    /// closures (the sorted trie build). Skips awaiting the previous disk
+    /// write: the JoinSet accumulates the handful of in-flight dump tasks
+    /// instead, and their results — including write errors — are collected
+    /// by [`Self::finish`].
+    #[cfg(feature = "rocksdb")]
+    pub fn flush_if_needed_sync(&mut self) {
+        if self.buffer.len() >= CODE_HASH_WRITE_BUFFER_SIZE {
+            let buffer = std::mem::take(&mut self.buffer);
+            self.flush_buffer(buffer);
+        }
+    }
+
     /// Finishes the code collector and returns the final index of file
     pub async fn finish(mut self) -> Result<(), SyncError> {
         // Final flush if needed

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -1126,16 +1126,9 @@ async fn insert_accounts(
     ingest_opts.set_move_files(true);
     db.ingest_external_file_opts(&ingest_opts, file_paths)
         .map_err(|err| SyncError::RocksDBError(err.into_string()))?;
-    let iter = db.full_iterator(rocksdb::IteratorMode::Start);
-    for account in iter {
-        let account = account.map_err(|err| SyncError::RocksDBError(err.into_string()))?;
-        let account_state = AccountState::decode(&account.1).map_err(SyncError::Rlp)?;
-        if account_state.code_hash != *EMPTY_KECCAK_HASH {
-            code_hash_collector.add(account_state.code_hash);
-            code_hash_collector.flush_if_needed().await?;
-        }
-    }
-
+    // Single pass: the trie build consumes the sorted leaves while the same
+    // decode feeds code-hash collection and the storage-root map, instead of
+    // a dedicated full iteration of the temp DB for the code hashes.
     let iter = db.full_iterator(rocksdb::IteratorMode::Start);
     let compute_state_root = trie_from_sorted_accounts_wrap(
         trie.db(),
@@ -1146,6 +1139,10 @@ async fn insert_accounts(
                     .account_tries_inserted
                     .fetch_add(1, Ordering::Relaxed);
                 let account_state = AccountState::decode(v).expect("We should have accounts here");
+                if account_state.code_hash != *EMPTY_KECCAK_HASH {
+                    code_hash_collector.add(account_state.code_hash);
+                    code_hash_collector.flush_if_needed_sync();
+                }
                 if account_state.storage_root != *EMPTY_TRIE_HASH {
                     storage_accounts.accounts_with_storage_root.insert(
                         H256::from_slice(k),


### PR DESCRIPTION
**Motivation**

insert_accounts iterated the ingested temp DB twice: a dedicated full pass that only decoded each account to collect its code hash, then the build pass whose inspect closure already decodes the same accounts. On mainnet that is one redundant sequential scan plus RLP decode over the entire account set.

**Description**

Fold code-hash collection into the build pass's closure, via a sync flush variant on CodeHashCollector (skips awaiting the previous disk write; the JoinSet accumulates a handful of dump tasks whose results finish() already collects).

Part of the snap-sync pipelining stack; tested all-in-one on a fresh mainnet sync plus multisync trie-validation cycles.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — not needed: no storage changes.