### PR TITLE
perf(l1): stream bytecode download concurrently with the remaining snap-sync phases

### DIFF
--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -312,9 +312,10 @@ pub async fn request_bytecodes(
     peers: &mut PeerHandler,
     all_bytecode_hashes: &[H256],
 ) -> Result<Option<Vec<Bytes>>, SnapError> {
-    METRICS
-        .current_step
-        .set(CurrentStepValue::RequestingBytecodes);
+    // Deliberately does not set METRICS.current_step: bytecode batches run
+    // concurrently with the other phases, and flipping the global step from
+    // here would report a phase change on every batch. The drain point in
+    // the sync cycle sets it once bytecodes are the critical path.
     if all_bytecode_hashes.is_empty() {
         return Ok(Some(Vec::new()));
     }

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -4,6 +4,7 @@
 //! between full sync mode (all blocks executed) and snap sync mode (state fetched
 //! via snap protocol).
 
+mod bytecode_fetcher;
 mod code_collector;
 mod full;
 mod healing;

--- a/crates/networking/p2p/sync/bytecode_fetcher.rs
+++ b/crates/networking/p2p/sync/bytecode_fetcher.rs
@@ -1,0 +1,92 @@
+//! Streaming bytecode downloader.
+//!
+//! Bytecodes are content-addressed (each response is keccak-verified against
+//! the requested hash) and carry no dependency on the pivot or on healing, so
+//! they can download concurrently with every other sync phase. This module
+//! consumes the code-hash snapshot files as the collector finishes writing
+//! them — during account insertion and healing — instead of waiting for a
+//! dedicated phase after healing completes. The files remain the hand-off
+//! medium so the on-disk format and restart behavior are unchanged.
+
+use crate::metrics::METRICS;
+use crate::peer_handler::PeerHandler;
+use crate::snap::{async_fs, constants::BYTECODE_CHUNK_SIZE, request_bytecodes};
+use crate::sync::SyncError;
+use ethrex_common::{H256, types::Code};
+use ethrex_rlp::decode::RLPDecode;
+use ethrex_storage::Store;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::SystemTime;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::task::JoinHandle;
+use tracing::debug;
+
+/// Spawns the background fetcher. Send each finished code-hash snapshot file
+/// over the channel; drop the sender (the collector's `finish`) to signal
+/// that no more files are coming, then await the handle to drain the final
+/// partial batch and surface any download/store error.
+pub(crate) fn spawn_bytecode_fetcher(
+    peers: PeerHandler,
+    store: Store,
+    file_rx: UnboundedReceiver<PathBuf>,
+) -> JoinHandle<Result<(), SyncError>> {
+    tokio::spawn(run(peers, store, file_rx))
+}
+
+async fn run(
+    mut peers: PeerHandler,
+    store: Store,
+    mut file_rx: UnboundedReceiver<PathBuf>,
+) -> Result<(), SyncError> {
+    let mut seen_code_hashes: HashSet<H256> = HashSet::new();
+    let mut to_download: Vec<H256> = Vec::new();
+    let mut started = false;
+
+    while let Some(file_path) = file_rx.recv().await {
+        if !started {
+            started = true;
+            *METRICS.bytecode_download_start_time.lock().await = Some(SystemTime::now());
+        }
+        let snapshot_contents = async_fs::read_file(&file_path).await?;
+        let code_hashes: Vec<H256> = RLPDecode::decode(&snapshot_contents)
+            .map_err(|_| SyncError::CodeHashesSnapshotDecodeError(file_path))?;
+
+        for hash in code_hashes {
+            if seen_code_hashes.insert(hash) {
+                to_download.push(hash);
+                if to_download.len() >= BYTECODE_CHUNK_SIZE {
+                    download_batch(&mut peers, &store, &mut to_download).await?;
+                }
+            }
+        }
+    }
+
+    // Channel closed: the collector finished and every file was processed.
+    if !to_download.is_empty() {
+        download_batch(&mut peers, &store, &mut to_download).await?;
+    }
+    Ok(())
+}
+
+async fn download_batch(
+    peers: &mut PeerHandler,
+    store: &Store,
+    to_download: &mut Vec<H256>,
+) -> Result<(), SyncError> {
+    debug!("Starting bytecode download of {} hashes", to_download.len());
+    let bytecodes = request_bytecodes(peers, to_download)
+        .await?
+        .ok_or(SyncError::BytecodesNotFound)?;
+    store
+        .write_account_code_batch(
+            to_download
+                .drain(..)
+                .zip(bytecodes)
+                // SAFETY: hash already checked by the download worker
+                .map(|(hash, code)| (hash, Code::from_bytecode_unchecked(code, hash)))
+                .collect(),
+        )
+        .await?;
+    Ok(())
+}

--- a/crates/networking/p2p/sync/code_collector.rs
+++ b/crates/networking/p2p/sync/code_collector.rs
@@ -6,6 +6,7 @@ use ethrex_common::H256;
 use ethrex_rlp::encode::RLPEncode;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinSet;
 use tracing::error;
 
@@ -19,16 +20,21 @@ pub struct CodeHashCollector {
     file_index: u64,
     // JoinSet to manage async disk writes
     disk_tasks: JoinSet<Result<(), DumpError>>,
+    // Notified with each snapshot file path once its write completes; the
+    // receiving end is the streaming bytecode fetcher. Dropped by `finish`,
+    // which closes the channel and lets the fetcher drain.
+    notify_tx: UnboundedSender<PathBuf>,
 }
 
 impl CodeHashCollector {
     /// Creates a new code collector
-    pub fn new(snapshots_dir: PathBuf) -> Self {
+    pub fn new(snapshots_dir: PathBuf, notify_tx: UnboundedSender<PathBuf>) -> Self {
         Self {
             buffer: HashSet::new(),
             snapshots_dir,
             file_index: 0,
             disk_tasks: JoinSet::new(),
+            notify_tx,
         }
     }
 
@@ -96,8 +102,14 @@ impl CodeHashCollector {
     fn flush_buffer(&mut self, buffer: HashSet<H256>) {
         let file_name = get_code_hashes_snapshot_file(&self.snapshots_dir, self.file_index);
         let encoded = buffer.into_iter().collect::<Vec<_>>().encode_to_vec();
-        self.disk_tasks
-            .spawn(async move { dump_to_file(&file_name, encoded) });
+        let notify_tx = self.notify_tx.clone();
+        self.disk_tasks.spawn(async move {
+            dump_to_file(&file_name, encoded)?;
+            // A failed send means the fetcher already exited; its error
+            // surfaces at the join point, the unread file is harmless.
+            let _ = notify_tx.send(file_name);
+            Ok(())
+        });
         self.file_index += 1;
     }
 

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -555,6 +555,9 @@ pub async fn snap_sync(
     code_hash_collector.finish().await?;
 
     diagnostics.write().await.current_phase = "bytecodes".to_string();
+    METRICS
+        .current_step
+        .set(CurrentStepValue::RequestingBytecodes);
     debug!("Waiting for streamed bytecode download to finish");
     bytecode_fetcher.await??;
 

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -3,7 +3,7 @@
 //! This module contains the logic for snap synchronization mode where state is
 //! fetched via snap p2p requests while blocks and receipts are fetched in parallel.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 #[cfg(feature = "rocksdb")]
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ use std::sync::atomic::Ordering;
 use std::time::{Duration, SystemTime};
 
 use ethrex_blockchain::Blockchain;
-use ethrex_common::types::{AccountState, BlockHeader, Code};
+use ethrex_common::types::{AccountState, BlockHeader};
 use ethrex_common::{
     H256,
     constants::{EMPTY_KECCAK_HASH, EMPTY_TRIE_HASH},
@@ -31,10 +31,10 @@ use crate::rlpx::p2p::SUPPORTED_ETH_CAPABILITIES;
 use crate::snap::{
     async_fs,
     constants::{
-        BYTECODE_CHUNK_SIZE, MAX_HEADER_FETCH_ATTEMPTS, MIN_FULL_BLOCKS, MISSING_SLOTS_PERCENTAGE,
-        SECONDS_PER_BLOCK, SNAP_LIMIT,
+        MAX_HEADER_FETCH_ATTEMPTS, MIN_FULL_BLOCKS, MISSING_SLOTS_PERCENTAGE, SECONDS_PER_BLOCK,
+        SNAP_LIMIT,
     },
-    request_account_range, request_bytecodes, request_storage_ranges,
+    request_account_range, request_storage_ranges,
 };
 use crate::sync::code_collector::CodeHashCollector;
 use crate::sync::healing::{heal_state_trie_wrap, heal_storage_trie};
@@ -325,9 +325,15 @@ pub async fn snap_sync(
     let code_hashes_snapshot_dir = get_code_hashes_snapshots_dir(datadir);
     async_fs::ensure_dir_exists(&code_hashes_snapshot_dir).await?;
 
-    // Create collector to store code hashes in files
+    // Create collector to store code hashes in files. Bytecodes are
+    // content-addressed and pivot-independent, so a background fetcher
+    // downloads them concurrently with the remaining phases, consuming each
+    // code-hash file as the collector finishes writing it.
+    let (code_file_tx, code_file_rx) = tokio::sync::mpsc::unbounded_channel();
     let mut code_hash_collector: CodeHashCollector =
-        CodeHashCollector::new(code_hashes_snapshot_dir.clone());
+        CodeHashCollector::new(code_hashes_snapshot_dir.clone(), code_file_tx);
+    let bytecode_fetcher =
+        super::bytecode_fetcher::spawn_bytecode_fetcher(peers.clone(), store.clone(), code_file_rx);
 
     let mut storage_accounts = AccountStorageRoots::default();
     if !std::env::var("SKIP_START_SNAP_SYNC").is_ok_and(|var| !var.is_empty()) {
@@ -544,71 +550,15 @@ pub async fn snap_sync(
 
     debug!("Finished healing");
 
-    // Finish code hash collection
+    // Finish code hash collection: flushes the final file and closes the
+    // file channel, letting the bytecode fetcher drain its last batch.
     code_hash_collector.finish().await?;
 
-    *METRICS.bytecode_download_start_time.lock().await = Some(SystemTime::now());
+    diagnostics.write().await.current_phase = "bytecodes".to_string();
+    debug!("Waiting for streamed bytecode download to finish");
+    bytecode_fetcher.await??;
 
     let code_hashes_dir = get_code_hashes_snapshots_dir(datadir);
-    let mut seen_code_hashes = HashSet::new();
-    let mut code_hashes_to_download = Vec::new();
-
-    diagnostics.write().await.current_phase = "bytecodes".to_string();
-    debug!("Starting download code hashes from peers");
-    let code_hash_files = async_fs::read_dir_paths(&code_hashes_dir).await?;
-    for file_path in code_hash_files {
-        let snapshot_contents = async_fs::read_file(&file_path).await?;
-        let code_hashes: Vec<H256> = RLPDecode::decode(&snapshot_contents)
-            .map_err(|_| SyncError::CodeHashesSnapshotDecodeError(file_path))?;
-
-        for hash in code_hashes {
-            // If we haven't seen the code hash yet, add it to the list of hashes to download
-            if seen_code_hashes.insert(hash) {
-                code_hashes_to_download.push(hash);
-
-                if code_hashes_to_download.len() >= BYTECODE_CHUNK_SIZE {
-                    debug!(
-                        "Starting bytecode download of {} hashes",
-                        code_hashes_to_download.len()
-                    );
-                    let bytecodes = request_bytecodes(peers, &code_hashes_to_download)
-                        .await?
-                        .ok_or(SyncError::BytecodesNotFound)?;
-
-                    store
-                        .write_account_code_batch(
-                            code_hashes_to_download
-                                .drain(..)
-                                .zip(bytecodes)
-                                // SAFETY: hash already checked by the download worker
-                                .map(|(hash, code)| {
-                                    (hash, Code::from_bytecode_unchecked(code, hash))
-                                })
-                                .collect(),
-                        )
-                        .await?;
-                }
-            }
-        }
-    }
-
-    // Download remaining bytecodes if any
-    if !code_hashes_to_download.is_empty() {
-        let bytecodes = request_bytecodes(peers, &code_hashes_to_download)
-            .await?
-            .ok_or(SyncError::BytecodesNotFound)?;
-        store
-            .write_account_code_batch(
-                code_hashes_to_download
-                    .drain(..)
-                    .zip(bytecodes)
-                    // SAFETY: hash already checked by the download worker
-                    .map(|(hash, code)| (hash, Code::from_bytecode_unchecked(code, hash)))
-                    .collect(),
-            )
-            .await?;
-    }
-
     async_fs::remove_dir_all(&code_hashes_dir).await?;
 
     *METRICS.bytecode_download_end_time.lock().await = Some(SystemTime::now());


### PR DESCRIPTION
**Motivation**

Bytecode download ran as a dedicated phase strictly after healing, despite bytecodes being content-addressed (keccak-verified per response) and independent of the pivot and of healing — a sequential barrier with no data dependency behind it.

**Description**

A background fetcher consumes each code-hash snapshot file as the collector finishes writing it, downloading bytecodes while account insertion, storage download, and healing run. Files remain the durable hand-off (format, dedup semantics, batch size, restart behavior unchanged). The old phase site reduces to finishing the collector and awaiting the fetcher, preserving error classification. Also keeps the global sync step on the critical path (the concurrent fetcher no longer flips it per batch).

Stacked on the single-pass insertion PR.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — not needed: no storage changes.