### PR TITLE
perf(l1): emit account FlatKeyValue rows during the snap-sync trie build

### DIFF
--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -1065,6 +1065,11 @@ async fn insert_accounts(
 ) -> Result<(H256, BTreeSet<H256>), SyncError> {
     use crate::utils::get_rocksdb_temp_accounts_dir;
     use ethrex_trie::trie_sorted::trie_from_sorted_accounts_wrap;
+    use ethrex_trie::{Nibbles, TrieDB, TrieError};
+
+    /// How many account leaves to accumulate before flushing a
+    /// FlatKeyValue batch through the trie backend.
+    const FKV_EMISSION_BATCH_SIZE: usize = 100_000;
 
     let trie = store.open_direct_state_trie(*EMPTY_TRIE_HASH)?;
     let mut db_options = rocksdb::Options::default();
@@ -1082,9 +1087,22 @@ async fn insert_accounts(
     // Single pass: the trie build consumes the sorted leaves while the same
     // decode feeds code-hash collection and the storage-root map, instead of
     // a dedicated full iteration of the temp DB for the code hashes.
+    //
+    // The same pass also mirrors each leaf into ACCOUNT_FLATKEYVALUE: the
+    // (nibble path, RLP value) pairs are byte-identical to the rows the
+    // post-sync FlatKeyValue generator would re-derive by walking the finished
+    // trie. The rows stay inert — the FKV read gate ("last_written") is
+    // untouched, and the coverage marker written below only records that they
+    // exist so a later phase can reconcile and promote them.
+    let trie_db = trie.db();
+    let mut fkv_buffer: Vec<(Nibbles, Vec<u8>)> = Vec::with_capacity(FKV_EMISSION_BATCH_SIZE);
+    // `inspect` can't propagate errors, so the first flush failure is parked
+    // here and returned once the trie build finishes.
+    let mut fkv_flush_error: Option<TrieError> = None;
+    let mut fkv_last_emitted: Option<H256> = None;
     let iter = db.full_iterator(rocksdb::IteratorMode::Start);
     let compute_state_root = trie_from_sorted_accounts_wrap(
-        trie.db(),
+        trie_db,
         &mut iter
             .map(|k| k.expect("We shouldn't have a rocksdb error here")) // TODO: remove unwrap
             .inspect(|(k, v)| {
@@ -1102,10 +1120,31 @@ async fn insert_accounts(
                         (Some(account_state.storage_root), Vec::new()),
                     );
                 }
+                if fkv_flush_error.is_none() {
+                    fkv_buffer.push((Nibbles::from_bytes(k), v.to_vec()));
+                    fkv_last_emitted = Some(H256::from_slice(k));
+                    if fkv_buffer.len() >= FKV_EMISSION_BATCH_SIZE
+                        && let Err(err) = trie_db.put_batch(std::mem::take(&mut fkv_buffer))
+                    {
+                        fkv_flush_error = Some(err);
+                    }
+                }
             })
             .map(|(k, v)| (H256::from_slice(&k), v.to_vec())),
     )
     .map_err(SyncError::TrieGenerationError)?;
+
+    if let Some(err) = fkv_flush_error {
+        return Err(err.into());
+    }
+    if !fkv_buffer.is_empty() {
+        trie_db.put_batch(fkv_buffer)?;
+    }
+    if let Some(account_hash) = fkv_last_emitted {
+        store.set_fkv_prebuilt_accounts_marker(
+            Nibbles::from_bytes(account_hash.as_bytes()).as_ref(),
+        )?;
+    }
 
     drop(db); // close db before removing directory
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -3154,6 +3154,29 @@ impl Store {
         Ok(last_computed_flatkeyvalue.clone())
     }
 
+    /// Records how far snap sync prebuilt ACCOUNT_FLATKEYVALUE rows during the
+    /// account trie build. `path` is the nibble path (64 nibbles + leaf flag)
+    /// of the last account leaf emitted.
+    ///
+    /// Rows `[0..=path]` in ACCOUNT_FLATKEYVALUE were written from
+    /// proof-verified snap range data during sync, before healing — they may be
+    /// stale wherever healing later changed leaves, and must not be trusted
+    /// (the FKV read gate, the "last_written" key, stays closed) until a later
+    /// reconciliation step promotes them.
+    pub fn set_fkv_prebuilt_accounts_marker(&self, path: &[u8]) -> Result<(), StoreError> {
+        self.write(
+            MISC_VALUES,
+            b"fkv_prebuilt_accounts".to_vec(),
+            path.to_vec(),
+        )
+    }
+
+    /// Returns the marker written by [`Self::set_fkv_prebuilt_accounts_marker`],
+    /// or `None` if snap sync never prebuilt account FlatKeyValue rows.
+    pub fn get_fkv_prebuilt_accounts_marker(&self) -> Result<Option<Vec<u8>>, StoreError> {
+        self.read(MISC_VALUES, b"fkv_prebuilt_accounts".to_vec())
+    }
+
     fn flatkeyvalue_computed_with_last_written(account: H256, last_written: &[u8]) -> bool {
         let account_nibbles = Nibbles::from_bytes(account.as_bytes());
         &last_written[0..64] > account_nibbles.as_ref()
@@ -3800,5 +3823,50 @@ mod merge_tests {
         let p3 = tx_locations_merge(None, vec![p2, op(3, h256(0x03), 0)]).unwrap();
         let out = tx_locations_merge(None, vec![p3]).unwrap();
         assert_eq!(decode(&out).len(), 3);
+    }
+}
+
+#[cfg(test)]
+mod fkv_prebuilt_marker_tests {
+    use super::*;
+
+    #[test]
+    fn marker_roundtrip() {
+        let store =
+            Store::new("test.db", EngineType::InMemory).expect("in-memory store should open");
+
+        // No marker until snap sync writes one.
+        assert_eq!(
+            store
+                .get_fkv_prebuilt_accounts_marker()
+                .expect("getter should not fail"),
+            None
+        );
+
+        // A 65-element account leaf path: 64 nibbles plus the leaf flag.
+        let path = Nibbles::from_bytes(&[0xab; 32]);
+        store
+            .set_fkv_prebuilt_accounts_marker(path.as_ref())
+            .expect("setter should not fail");
+        assert_eq!(
+            store
+                .get_fkv_prebuilt_accounts_marker()
+                .expect("getter should not fail")
+                .as_deref(),
+            Some(path.as_ref())
+        );
+
+        // Writing again overwrites the previous marker.
+        let path2 = Nibbles::from_bytes(&[0xcd; 32]);
+        store
+            .set_fkv_prebuilt_accounts_marker(path2.as_ref())
+            .expect("setter should not fail");
+        assert_eq!(
+            store
+                .get_fkv_prebuilt_accounts_marker()
+                .expect("getter should not fail")
+                .as_deref(),
+            Some(path2.as_ref())
+        );
     }
 }


### PR DESCRIPTION
**Motivation**

The post-sync FlatKeyValue generator re-derives account rows by walking the whole trie, hours of background I/O — while the snap-sync trie build streams the exact same sorted leaves with byte-identical values.

**Description**

The build's inspect closure also writes each account leaf into ACCOUNT_FLATKEYVALUE (routed by key length through the existing trie backend), under a construction marker (MISC_VALUES "fkv_prebuilt_accounts"). The read gate (last_written) stays closed and the generator is untouched: rows are inert until a later promotion phase reconciles them — this PR lands the emission mechanism only.

Stacked on the lane-table PR.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — not needed: new rows live in an existing CF, no schema change.