### PR TITLE
perf(l1): emit FlatKeyValue rows for leaves healed during snap sync

### DIFF
--- a/crates/networking/p2p/sync/healing/state.rs
+++ b/crates/networking/p2p/sync/healing/state.rs
@@ -353,6 +353,20 @@ async fn heal_state_trie(
                     for i in 0..path.len() {
                         encoded_to_write.insert(path.slice(0, i), vec![]);
                     }
+                    // Mirror healed leaves into the account FlatKeyValue table in
+                    // the same batch: prebuilt FKV rows emitted from pre-healing
+                    // range data go stale wherever healing changes a leaf, so the
+                    // healed value must overwrite them. The full leaf path is 65
+                    // elements (64 nibbles + leaf flag), which `put_batch` routes
+                    // to ACCOUNT_FLATKEYVALUE automatically.
+                    //
+                    // Limitation: healing only observes nodes it downloads, so
+                    // leaves *removed* from the trie are not visible here. Stale
+                    // FKV rows for deleted accounts are left in place for a later
+                    // reconciliation phase to detect and remove.
+                    if let Node::Leaf(leaf) = &node {
+                        encoded_to_write.insert(path.concat(&leaf.partial), leaf.value.clone());
+                    }
                     encoded_to_write.insert(path, node.encode_to_vec());
                 }
                 let trie_db = store.open_direct_state_trie(*EMPTY_TRIE_HASH)?;

--- a/crates/networking/p2p/sync/healing/storage.rs
+++ b/crates/networking/p2p/sync/healing/storage.rs
@@ -263,19 +263,48 @@ pub async fn heal_storage_trie(
             }
             db_joinset.spawn_blocking(move || {
                 let mut encoded_to_write = vec![];
+                let mut fkv_to_write = vec![];
                 for (hashed_account, nodes) in to_write {
                     let mut account_nodes = vec![];
+                    let mut account_leaves = vec![];
                     for (path, node) in nodes {
                         for i in 0..path.len() {
                             account_nodes.push((path.slice(0, i), vec![]));
                         }
+                        // Mirror healed leaves into the storage FlatKeyValue
+                        // table: prebuilt FKV rows derived from pre-healing
+                        // range data go stale wherever healing changes a leaf,
+                        // so the healed value must overwrite them. The node
+                        // batch below goes through
+                        // `write_storage_trie_nodes_batch`, which targets
+                        // STORAGE_TRIE_NODES unconditionally, so leaves take a
+                        // dedicated FKV write issued by this same single
+                        // background task to preserve write ordering.
+                        //
+                        // Limitation: healing only observes nodes it downloads,
+                        // so leaves *removed* from the trie are not visible
+                        // here. Stale FKV rows for deleted slots are left in
+                        // place for a later reconciliation phase to detect and
+                        // remove.
+                        if let Node::Leaf(leaf) = &node {
+                            account_leaves.push((path.concat(&leaf.partial), leaf.value.clone()));
+                        }
                         account_nodes.push((path, node.encode_to_vec()));
                     }
                     encoded_to_write.push((hashed_account, account_nodes));
+                    if !account_leaves.is_empty() {
+                        fkv_to_write.push((hashed_account, account_leaves));
+                    }
                 }
                 // PERF: use put_batch_no_alloc? (it needs to remove parent nodes too)
                 spawned_rt::tasks::block_on(store.write_storage_trie_nodes_batch(encoded_to_write))
                     .expect("db write failed");
+                if !fkv_to_write.is_empty() {
+                    spawned_rt::tasks::block_on(
+                        store.write_storage_flatkeyvalue_batch(fkv_to_write),
+                    )
+                    .expect("db write failed");
+                }
             });
         }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1375,6 +1375,30 @@ impl Store {
     }
 
     /// CAUTION: This method writes directly to the underlying database, bypassing any caching layer.
+    /// Writes storage-trie leaf rows into the storage FlatKeyValue table. Each leaf
+    /// path (64 slot nibbles + leaf flag) is prefixed with its account hash via
+    /// [`apply_prefix`], producing the 131-element keys STORAGE_FLATKEYVALUE expects.
+    /// Unlike [`Self::write_storage_trie_nodes_batch`], which targets STORAGE_TRIE_NODES
+    /// unconditionally, this lands rows in the flat table.
+    pub async fn write_storage_flatkeyvalue_batch(
+        &self,
+        storage_leaves: StorageUpdates,
+    ) -> Result<(), StoreError> {
+        let mut txn = self.backend.begin_write()?;
+        tokio::task::spawn_blocking(move || {
+            for (address_hash, leaves) in storage_leaves {
+                for (leaf_path, value) in leaves {
+                    let key = apply_prefix(Some(address_hash), leaf_path);
+                    txn.put(STORAGE_FLATKEYVALUE, key.as_ref(), &value)?;
+                }
+            }
+            txn.commit()
+        })
+        .await
+        .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?
+    }
+
+    /// CAUTION: This method writes directly to the underlying database, bypassing any caching layer.
     /// For updating the state after block execution, use [`Self::store_block_updates`].
     pub async fn write_account_code_batch(
         &self,


### PR DESCRIPTION
**Motivation**

Prebuilt FKV rows from pre-healing range data go stale wherever healing later changes leaves; emitting at heal time keeps the prebuilt set reconcilable for the promotion phase.

**Description**

State healing inserts each healed leaf's full-path row into the same batched write transaction as its node batch; storage healing collects per-account leaf rows and writes them via a new narrow Store::write_storage_flatkeyvalue_batch from the same single background writer task (ordering preserved). Leaf deletions are not observable in healing — documented at the emission sites; the verifier phase reconciles. Read gate and generator untouched; rows stay inert.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — not needed.