### PR TITLE
perf(l1): download storage ranges concurrently with the account phase

### DIFF
--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -26,6 +26,7 @@ use crate::{
 use bytes::Bytes;
 use ethrex_common::{
     BigEndianHash, H256, U256,
+    constants::EMPTY_TRIE_HASH,
     types::{AccountState, BlockHeader},
 };
 use ethrex_crypto::NativeCrypto;
@@ -43,6 +44,14 @@ use tracing::{debug, error, trace, warn};
 
 // Re-export DumpError from error module
 pub use super::error::DumpError;
+
+/// Hooks letting the account-range download feed the concurrent storage
+/// downloader: discovered (account, storage_root) pairs, and pivot updates so
+/// stale storage waves can wait for a fresh header instead of re-pivoting.
+pub struct StorageDiscoveryHooks {
+    pub feed: tokio::sync::mpsc::UnboundedSender<Vec<(H256, H256)>>,
+    pub pivot_watch: tokio::sync::watch::Sender<BlockHeader>,
+}
 
 /// Metadata for requesting trie nodes
 #[derive(Debug, Clone)]
@@ -90,6 +99,7 @@ struct StorageTask {
 ///
 /// - There are no available peers (the node just started up or was rejected by all other nodes)
 /// - No peer returned a valid response in the given time and retry limits
+#[allow(clippy::too_many_arguments)]
 pub async fn request_account_range(
     peers: &mut PeerHandler,
     start: H256,
@@ -98,6 +108,7 @@ pub async fn request_account_range(
     pivot_header: &mut BlockHeader,
     block_sync_state: &mut SnapBlockSyncState,
     diagnostics: &std::sync::Arc<tokio::sync::RwLock<crate::sync::SyncDiagnostics>>,
+    storage_hooks: Option<&StorageDiscoveryHooks>,
 ) -> Result<(), SnapError> {
     METRICS
         .current_step
@@ -210,6 +221,18 @@ pub async fn request_account_range(
                 accounts.len(),
                 peer_id
             );
+            if let Some(hooks) = storage_hooks {
+                let discovered: Vec<(H256, H256)> = accounts
+                    .iter()
+                    .filter(|unit| unit.account.storage_root != *EMPTY_TRIE_HASH)
+                    .map(|unit| (unit.hash, unit.account.storage_root))
+                    .collect();
+                if !discovered.is_empty() {
+                    // Best-effort: a dead wave runner surfaces its error at
+                    // the join point; the post-build loop covers the misses.
+                    let _ = hooks.feed.send(discovered);
+                }
+            }
             all_account_hashes.extend(accounts.iter().map(|unit| unit.hash));
             all_accounts_state.extend(accounts.iter().map(|unit| unit.account));
         }
@@ -506,9 +529,6 @@ pub async fn request_storage_ranges(
     pivot_header: &mut BlockHeader,
     store: Store,
 ) -> Result<u64, SnapError> {
-    METRICS
-        .current_step
-        .set(CurrentStepValue::RequestingStorageRanges);
     debug!("Starting request_storage_ranges function");
     // 1) split the range in chunks of same length
     let mut accounts_by_root_hash: BTreeMap<_, Vec<_>> = BTreeMap::new();
@@ -776,10 +796,14 @@ pub async fn request_storage_ranges(
                                 task_count += 1;
                             }
                         } else {
-                            // TODO: DRY
+                            // Keep the group's root with the interval state:
+                            // the storage waves run before the state trie
+                            // exists, so a None root (resolved via a trie
+                            // lookup) must never be produced here.
+                            let group_root = accounts_by_root_hash[remaining_start].0;
                             account_storage_roots
                                 .accounts_with_storage_root
-                                .insert(first_acc_hash, (None, vec![]));
+                                .insert(first_acc_hash, (Some(group_root), vec![]));
                             let (_, intervals) = account_storage_roots
                                     .accounts_with_storage_root
                                     .get_mut(&first_acc_hash)

--- a/crates/networking/p2p/snap/mod.rs
+++ b/crates/networking/p2p/snap/mod.rs
@@ -31,8 +31,8 @@ pub use error::{DumpError, SnapError};
 
 // Re-export client types and functions
 pub use client::{
-    RequestMetadata, RequestStorageTrieNodesError, request_account_range, request_bytecodes,
-    request_state_trienodes, request_storage_ranges, request_storage_trienodes,
+    RequestMetadata, RequestStorageTrieNodesError, StorageDiscoveryHooks, request_account_range,
+    request_bytecodes, request_state_trienodes, request_storage_ranges, request_storage_trienodes,
 };
 
 // Helper to convert proof to RLP-encodable format

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -9,6 +9,7 @@ mod code_collector;
 mod full;
 mod healing;
 mod snap_sync;
+mod storage_feed;
 
 use crate::metrics::METRICS;
 use crate::peer_handler::{BlockRequestOrder, PeerHandler, PeerHandlerError};

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -519,6 +519,23 @@ pub async fn snap_sync(
         // account_state_snapshots_dir
 
         diagnostics.write().await.current_phase = "account_ranges".to_string();
+        // Storage ranges download concurrently with the account phase: every
+        // account leaf carries its storage root, so discovered accounts feed
+        // a background wave runner instead of waiting for the built and
+        // healed state trie. Wave leftovers rejoin the post-build loop.
+        let (storage_feed_tx, storage_feed_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (pivot_watch_tx, pivot_watch_rx) = tokio::sync::watch::channel(pivot_header.clone());
+        let storage_waves = tokio::spawn(super::storage_feed::run_storage_waves(
+            peers.clone(),
+            store.clone(),
+            account_storages_snapshots_dir.clone(),
+            storage_feed_rx,
+            pivot_watch_rx,
+        ));
+        let storage_hooks = crate::snap::StorageDiscoveryHooks {
+            feed: storage_feed_tx,
+            pivot_watch: pivot_watch_tx,
+        };
         request_account_range(
             peers,
             H256::zero(),
@@ -527,6 +544,7 @@ pub async fn snap_sync(
             &mut pivot_header,
             block_sync_state,
             diagnostics,
+            Some(&storage_hooks),
         )
         .await?;
         debug!("Finished downloading account ranges from peers");
@@ -569,9 +587,40 @@ pub async fn snap_sync(
 
         diagnostics.write().await.current_phase = "storage_ranges".to_string();
         *METRICS.storage_tries_download_start_time.lock().await = Some(SystemTime::now());
+        // The wave runner drains once the feed closes (request_account_range
+        // returning dropped the sender); give it a fresh pivot to finish with,
+        // then reconcile: wave-completed accounts must not be re-downloaded,
+        // wave leftovers replace their stale bookkeeping here.
+        while block_is_stale(&pivot_header) {
+            pivot_header = update_pivot(
+                pivot_header.number,
+                pivot_header.timestamp,
+                peers,
+                block_sync_state,
+                diagnostics,
+            )
+            .await?;
+        }
+        storage_hooks.pivot_watch.send_replace(pivot_header.clone());
+        drop(storage_hooks);
+        let wave_outcome = storage_waves.await??;
+        storage_accounts
+            .accounts_with_storage_root
+            .retain(|account, _| !wave_outcome.done.contains(account));
+        storage_accounts
+            .accounts_with_storage_root
+            .extend(wave_outcome.carry.accounts_with_storage_root);
+        storage_accounts
+            .healed_accounts
+            .extend(wave_outcome.carry.healed_accounts);
+        debug!(
+            wave_done = wave_outcome.done.len(),
+            remaining = storage_accounts.accounts_with_storage_root.len(),
+            "Reconciled storage waves with the post-build loop"
+        );
         // We start downloading the storage leafs. To do so, we need to be sure that the storage root
         // is correct. To do so, we always heal the state trie before requesting storage rates
-        let mut chunk_index = 0_u64;
+        let mut chunk_index = wave_outcome.chunk_index;
         let mut state_leafs_healed = 0_u64;
         let mut storage_range_request_attempts = 0;
         loop {
@@ -607,6 +656,9 @@ pub async fn snap_sync(
             );
             storage_range_request_attempts += 1;
             if storage_range_request_attempts < 5 {
+                METRICS
+                    .current_step
+                    .set(CurrentStepValue::RequestingStorageRanges);
                 chunk_index = request_storage_ranges(
                     peers,
                     &mut storage_accounts,

--- a/crates/networking/p2p/sync/storage_feed.rs
+++ b/crates/networking/p2p/sync/storage_feed.rs
@@ -1,0 +1,175 @@
+//! Streaming storage download.
+//!
+//! Storage ranges historically downloaded only after the full account phase
+//! (download, trie build, state heal), because the downloader resolved
+//! storage roots from the built trie. But every account leaf already carries
+//! its storage root, so storage can download as soon as account ranges
+//! deliver leaves. This module runs the existing storage downloader in
+//! "waves" over incrementally discovered accounts, concurrently with the
+//! account download and trie build; whatever a wave cannot finish (stale
+//! pivot, big-account remainders, repeated failures) is carried back to the
+//! post-build storage loop, which keeps today's heal-based reconciliation.
+
+use crate::peer_handler::PeerHandler;
+use crate::snap::request_storage_ranges;
+use crate::sync::{AccountStorageRoots, SyncError};
+use ethrex_common::H256;
+use ethrex_common::types::BlockHeader;
+use ethrex_storage::Store;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tracing::{debug, info, warn};
+
+use super::block_is_stale;
+
+/// Accounts that fail to complete within this many waves stop being retried
+/// here and are carried to the post-build loop (whose heal fallback covers
+/// them). Bounds the retry work for accounts whose root keeps moving.
+const MAX_WAVE_ATTEMPTS: u8 = 3;
+
+pub(crate) struct StorageWaveOutcome {
+    /// Next storage snapshot file index (continues the wave numbering).
+    pub chunk_index: u64,
+    /// Accounts fully downloaded by the waves; the post-build loop must not
+    /// re-download them.
+    pub done: HashSet<H256>,
+    /// Unfinished bookkeeping (interval state, repeated failures) plus the
+    /// healed-account marks accumulated by the waves.
+    pub carry: AccountStorageRoots,
+}
+
+/// Runs storage-range downloads over accounts as they are discovered by the
+/// account-range download. `feed_rx` delivers `(account_hash, storage_root)`
+/// batches; closing it signals that no more discoveries are coming, after
+/// which remaining work is attempted once more and the rest is carried out.
+/// `pivot_rx` provides the freshest known pivot; when the borrowed pivot goes
+/// stale the runner waits for a newer one instead of re-pivoting itself.
+pub(crate) async fn run_storage_waves(
+    mut peers: PeerHandler,
+    store: Store,
+    snapshots_dir: PathBuf,
+    mut feed_rx: UnboundedReceiver<Vec<(H256, H256)>>,
+    mut pivot_rx: tokio::sync::watch::Receiver<BlockHeader>,
+) -> Result<StorageWaveOutcome, SyncError> {
+    let mut chunk_index = 0u64;
+    let mut seen: HashSet<H256> = HashSet::new();
+    let mut attempts: HashMap<H256, u8> = HashMap::new();
+    let mut carry = AccountStorageRoots::default();
+    let mut pending = AccountStorageRoots::default();
+    let mut feed_open = true;
+
+    loop {
+        // Gather new discoveries: block for the first batch while the feed is
+        // open and there is nothing pending, then drain whatever is queued.
+        if feed_open {
+            if pending.accounts_with_storage_root.is_empty() {
+                match feed_rx.recv().await {
+                    Some(batch) => admit(batch, &mut seen, &mut pending),
+                    None => feed_open = false,
+                }
+            }
+            while let Ok(batch) = feed_rx.try_recv() {
+                admit(batch, &mut seen, &mut pending);
+            }
+        }
+        if pending.accounts_with_storage_root.is_empty() {
+            if feed_open {
+                continue;
+            }
+            break;
+        }
+
+        // A stale pivot would only produce empty responses; wait for the
+        // account phase (or the post-build loop preparing to join us) to
+        // publish a fresher one.
+        let mut pivot = pivot_rx.borrow().clone();
+        if block_is_stale(&pivot) {
+            debug!("Storage waves waiting for a fresh pivot");
+            if pivot_rx.changed().await.is_err() {
+                // Publisher dropped: leave remaining work to the carry.
+                break;
+            }
+            continue;
+        }
+
+        let wave_accounts: Vec<H256> = pending.accounts_with_storage_root.keys().copied().collect();
+        debug!(
+            accounts = wave_accounts.len(),
+            "Starting storage download wave"
+        );
+        chunk_index = request_storage_ranges(
+            &mut peers,
+            &mut pending,
+            &snapshots_dir,
+            chunk_index,
+            &mut pivot,
+            store.clone(),
+        )
+        .await?;
+
+        // Whatever was removed from the map completed; the rest retries in a
+        // later wave until its attempt budget runs out.
+        for account in wave_accounts {
+            if !pending.accounts_with_storage_root.contains_key(&account) {
+                done_insert(&mut attempts, account);
+            }
+        }
+        carry
+            .healed_accounts
+            .extend(pending.healed_accounts.drain());
+        let leftovers: Vec<H256> = pending.accounts_with_storage_root.keys().copied().collect();
+        for account in leftovers {
+            let tries = attempts.entry(account).or_insert(0);
+            *tries = tries.saturating_add(1);
+            if *tries >= MAX_WAVE_ATTEMPTS
+                && let Some(entry) = pending.accounts_with_storage_root.remove(&account)
+            {
+                carry.accounts_with_storage_root.insert(account, entry);
+            }
+        }
+    }
+
+    let done: HashSet<H256> = attempts
+        .iter()
+        .filter(|(_, tries)| **tries == DONE_SENTINEL)
+        .map(|(account, _)| *account)
+        .collect();
+    info!(
+        downloaded = done.len(),
+        carried = carry.accounts_with_storage_root.len(),
+        healed_marks = carry.healed_accounts.len(),
+        "Storage waves finished"
+    );
+    Ok(StorageWaveOutcome {
+        chunk_index,
+        done,
+        carry,
+    })
+}
+
+/// Attempt-counter value marking an account as fully downloaded.
+const DONE_SENTINEL: u8 = u8::MAX;
+
+fn done_insert(attempts: &mut HashMap<H256, u8>, account: H256) {
+    attempts.insert(account, DONE_SENTINEL);
+}
+
+fn admit(batch: Vec<(H256, H256)>, seen: &mut HashSet<H256>, pending: &mut AccountStorageRoots) {
+    let mut admitted = 0;
+    for (account, root) in batch {
+        if seen.insert(account) {
+            pending
+                .accounts_with_storage_root
+                .insert(account, (Some(root), Vec::new()));
+            admitted += 1;
+        }
+    }
+    if admitted > 0 {
+        debug!(admitted, "Storage waves admitted new accounts");
+    } else if !seen.is_empty() {
+        // Re-delivered chunks after a re-pivot are expected; their accounts
+        // keep the first-seen root and reconcile through healing if it moved.
+        warn!("Storage wave feed delivered only already-seen accounts");
+    }
+}


### PR DESCRIPTION
**Motivation**

Storage downloads waited for the full account phase (download, build, heal) because the downloader resolved storage roots from the built trie — but every account leaf already carries its storage root. This was the largest remaining serialization in snap sync.

**Description**

Account-range responses feed discovered (account, storage root) pairs to a background runner driving the existing storage downloader in waves, concurrently with account download and trie build. Roots travel with the work: the big-account split keeps its group root instead of degrading to a None entry (which required the built trie and exited the node on a miss). Wave leftovers carry into the post-build loop, which keeps heal-based reconciliation and the heal-everything fallback; wave-completed accounts are excluded. Stale waves wait for a fresher pivot published by the account dispatcher rather than re-pivoting. Design doc: storage-root ownership, pull-based handout, bounded dedup loss.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — not needed.