### PR TITLE
perf(l1): ingest account snapshot files while the range download is still running

### DIFF
--- a/crates/networking/p2p/snap/client.rs
+++ b/crates/networking/p2p/snap/client.rs
@@ -36,7 +36,7 @@ use ethrex_trie::Nibbles;
 use ethrex_trie::{Node, verify_range};
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
-    path::Path,
+    path::{Path, PathBuf},
     sync::atomic::Ordering,
     time::{Duration, SystemTime},
 };
@@ -93,6 +93,12 @@ struct StorageTask {
 /// Will also return a boolean indicating if there is more state to be fetched towards the right of the trie
 /// (Note that the boolean will be true even if the remaining state is ouside the boundary set by the limit hash)
 ///
+/// With `account_ingest_tx` set, each finished snapshot file is announced as
+/// `(chunk_index, path)` to the background ingest task so it can be ingested
+/// into the temp DB while the download is still running. Sends are
+/// best-effort: if the ingest task is gone the file stays in the snapshot
+/// dir and is picked up at build time.
+///
 /// # Returns
 ///
 /// The account range or `None` if:
@@ -109,6 +115,7 @@ pub async fn request_account_range(
     block_sync_state: &mut SnapBlockSyncState,
     diagnostics: &std::sync::Arc<tokio::sync::RwLock<crate::sync::SyncDiagnostics>>,
     storage_hooks: Option<&StorageDiscoveryHooks>,
+    account_ingest_tx: Option<tokio::sync::mpsc::UnboundedSender<(u64, PathBuf)>>,
 ) -> Result<(), SnapError> {
     METRICS
         .current_step
@@ -174,13 +181,26 @@ pub async fn request_account_range(
             async_fs::ensure_dir_exists(account_state_snapshots_dir).await?;
 
             let account_state_snapshots_dir_cloned = account_state_snapshots_dir.to_path_buf();
+            let ingest_tx = account_ingest_tx.clone();
             write_set.spawn(async move {
                 let path = get_account_state_snapshot_file(
                     &account_state_snapshots_dir_cloned,
                     chunk_file,
                 );
                 // TODO: check the error type and handle it properly
-                dump_accounts_to_file(&path, account_state_chunk)
+                dump_accounts_to_file(&path, account_state_chunk)?;
+                // Best-effort: if the ingest task died, leave the file in
+                // the snapshot dir; the build step ingests whatever is
+                // still there, so the chunk is not lost.
+                if let Some(tx) = ingest_tx
+                    && tx.send((chunk_file, path)).is_err()
+                {
+                    warn!(
+                        chunk_file,
+                        "Account snapshot ingestor is gone; leaving the chunk on disk for build-time ingestion"
+                    );
+                }
+                Ok(())
             });
 
             chunk_file += 1;
@@ -317,6 +337,16 @@ pub async fn request_account_range(
                     chunk_file
                 ))
             })?;
+        // All dump tasks were joined above, so this is the last and
+        // highest-numbered chunk; sending it closes out the ingest sequence.
+        if let Some(tx) = account_ingest_tx
+            && tx.send((chunk_file, path)).is_err()
+        {
+            warn!(
+                chunk_file,
+                "Account snapshot ingestor is gone; leaving the chunk on disk for build-time ingestion"
+            );
+        }
     }
 
     METRICS

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -4,6 +4,8 @@
 //! between full sync mode (all blocks executed) and snap sync mode (state fetched
 //! via snap protocol).
 
+#[cfg(feature = "rocksdb")]
+mod account_ingestor;
 mod bytecode_fetcher;
 mod code_collector;
 mod full;

--- a/crates/networking/p2p/sync/account_ingestor.rs
+++ b/crates/networking/p2p/sync/account_ingestor.rs
@@ -1,0 +1,133 @@
+//! Streaming SST ingestor for account snapshot files.
+//!
+//! During the account-range download the dispatcher dumps each completed
+//! chunk of accounts to an SST file. Previously every file was ingested into
+//! the temporary RocksDB only after the whole download finished; this module
+//! ingests each file as soon as it is written, overlapping the ingest I/O
+//! with the rest of the download. The sorted trie build still runs once, in
+//! `insert_accounts`, after both the download and this task complete.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+use crate::snap::async_fs;
+use crate::sync::SyncError;
+use crate::utils::get_rocksdb_temp_accounts_dir;
+
+/// Handle to the background ingest task; joining it yields the temp DB with
+/// every file received over the channel already ingested.
+pub(super) type AccountIngestHandle = JoinHandle<Result<rocksdb::DB, SyncError>>;
+
+/// Opens (or creates) the temporary RocksDB the account snapshot files are
+/// ingested into.
+pub(super) fn open_temp_accounts_db(datadir: &Path) -> Result<rocksdb::DB, SyncError> {
+    let mut db_options = rocksdb::Options::default();
+    db_options.create_if_missing(true);
+    rocksdb::DB::open(&db_options, get_rocksdb_temp_accounts_dir(datadir))
+        .map_err(|e| SyncError::AccountTempDBDirNotFound(e.to_string()))
+}
+
+/// Ingests a single account snapshot file into the temp DB, moving it out of
+/// the snapshot dir (so the files remaining there are exactly the ones not
+/// yet ingested).
+pub(super) fn ingest_snapshot_file(db: &rocksdb::DB, path: &Path) -> Result<(), SyncError> {
+    // An empty chunk produces no file at all (`dump_accounts_to_rocks_db`
+    // skips empty contents because RocksDB rejects empty SSTs); skip it
+    // while keeping the chunk sequence contiguous.
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut ingest_opts = rocksdb::IngestExternalFileOptions::default();
+    ingest_opts.set_move_files(true);
+    db.ingest_external_file_opts(&ingest_opts, vec![path.to_path_buf()])
+        .map_err(|err| SyncError::RocksDBError(err.into_string()))
+}
+
+/// Ingests any snapshot files still sitting in the snapshot dir, in
+/// ascending chunk order. Ingested files were moved out of the dir, so what
+/// remains is exactly the set the ingest task never consumed: chunks whose
+/// send failed because the task had already died, or leftovers from a
+/// previous run.
+pub(super) async fn ingest_remaining_snapshot_files(
+    db: &rocksdb::DB,
+    account_state_snapshots_dir: &Path,
+) -> Result<(), SyncError> {
+    let mut leftover_files = async_fs::read_dir_paths(account_state_snapshots_dir).await?;
+    if leftover_files.is_empty() {
+        return Ok(());
+    }
+    // Ascending chunk order preserves last-write-wins for accounts that were
+    // re-delivered with a newer value after a pivot update. The chunk index
+    // is the trailing `.{index}` of the file name; `read_dir_paths` sorts
+    // lexicographically, which misorders multi-digit indices.
+    leftover_files.sort_by_key(|path| chunk_index_of(path));
+    warn!(
+        count = leftover_files.len(),
+        "Ingesting account snapshot files left in the snapshot dir"
+    );
+    for path in leftover_files {
+        ingest_snapshot_file(db, &path)?;
+    }
+    Ok(())
+}
+
+fn chunk_index_of(path: &Path) -> u64 {
+    path.extension()
+        .and_then(|index| index.to_str())
+        .and_then(|index| index.parse().ok())
+        // Files without a parseable index sort last and keep their relative
+        // lexicographic order (the sort is stable).
+        .unwrap_or(u64::MAX)
+}
+
+/// Spawns the background ingest task that owns the temporary accounts
+/// RocksDB. Send each finished account snapshot file over the returned
+/// channel as `(chunk_index, path)`; drop the sender once the download is
+/// done, then await the handle to obtain the temp DB with every received
+/// file ingested.
+pub(super) fn spawn_account_snapshot_ingestor(
+    datadir: &Path,
+) -> (UnboundedSender<(u64, PathBuf)>, AccountIngestHandle) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let datadir = datadir.to_path_buf();
+    // `ingest_external_file` blocks on disk I/O, so the whole loop runs on a
+    // blocking thread instead of a tokio worker.
+    let handle = tokio::task::spawn_blocking(move || run(&datadir, rx));
+    (tx, handle)
+}
+
+fn run(
+    datadir: &Path,
+    mut file_rx: UnboundedReceiver<(u64, PathBuf)>,
+) -> Result<rocksdb::DB, SyncError> {
+    let db = open_temp_accounts_db(datadir)?;
+
+    // The same account hash can appear in more than one file with different
+    // values: a chunk re-downloaded after a pivot update delivers the newer
+    // value in a later file. RocksDB resolves duplicate keys across ingested
+    // files by ingestion recency, so files must be ingested in ascending
+    // chunk order. Dump tasks run concurrently and can finish (and send) out
+    // of order, so buffer arrivals and only ingest the contiguous prefix.
+    let mut pending: BTreeMap<u64, PathBuf> = BTreeMap::new();
+    let mut next_chunk: u64 = 0;
+    while let Some((chunk_index, path)) = file_rx.blocking_recv() {
+        pending.insert(chunk_index, path);
+        while let Some(path) = pending.remove(&next_chunk) {
+            ingest_snapshot_file(&db, &path)?;
+            next_chunk += 1;
+        }
+    }
+
+    // Channel closed: ingest whatever is still buffered, in ascending chunk
+    // order. A gap before a buffered chunk can only come from a dump task
+    // that failed, in which case the missing file was never written and the
+    // download itself errors out.
+    for (_, path) in pending {
+        ingest_snapshot_file(&db, &path)?;
+    }
+    Ok(db)
+}

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -536,6 +536,18 @@ pub async fn snap_sync(
             feed: storage_feed_tx,
             pivot_watch: pivot_watch_tx,
         };
+        // Ingest each finished snapshot file into the temporary RocksDB
+        // while the range download is still running, instead of ingesting
+        // the whole batch only after the download completes. The sorted trie
+        // build still runs once, in `insert_accounts`, after the download
+        // and the ingest task both finish.
+        #[cfg(feature = "rocksdb")]
+        let (account_ingest_tx, account_ingest_handle) = {
+            let (tx, handle) = super::account_ingestor::spawn_account_snapshot_ingestor(datadir);
+            (Some(tx), handle)
+        };
+        #[cfg(not(feature = "rocksdb"))]
+        let account_ingest_tx = None;
         request_account_range(
             peers,
             H256::zero(),
@@ -545,6 +557,7 @@ pub async fn snap_sync(
             block_sync_state,
             diagnostics,
             Some(&storage_hooks),
+            account_ingest_tx,
         )
         .await?;
         debug!("Finished downloading account ranges from peers");
@@ -566,7 +579,18 @@ pub async fn snap_sync(
         // We read the account leafs from the files in account_state_snapshots_dir, write it into
         // the trie to compute the nodes and stores the accounts with storages for later use
 
+        #[cfg(feature = "rocksdb")]
+        let (computed_state_root, accounts_with_storage) = insert_accounts(
+            store.clone(),
+            &mut storage_accounts,
+            &account_state_snapshots_dir,
+            datadir,
+            &mut code_hash_collector,
+            account_ingest_handle,
+        )
+        .await?;
         // Variable `accounts_with_storage` unused if not in rocksdb
+        #[cfg(not(feature = "rocksdb"))]
         #[allow(unused_variables)]
         let (computed_state_root, accounts_with_storage) = insert_accounts(
             store.clone(),
@@ -1310,7 +1334,9 @@ async fn insert_accounts(
     account_state_snapshots_dir: &Path,
     datadir: &Path,
     code_hash_collector: &mut CodeHashCollector,
+    ingest_handle: super::account_ingestor::AccountIngestHandle,
 ) -> Result<(H256, BTreeSet<H256>), SyncError> {
+    use crate::sync::account_ingestor;
     use crate::utils::get_rocksdb_temp_accounts_dir;
     use ethrex_trie::trie_sorted::trie_from_sorted_accounts_wrap;
     use ethrex_trie::{Nibbles, TrieDB, TrieError};
@@ -1320,18 +1346,25 @@ async fn insert_accounts(
     const FKV_EMISSION_BATCH_SIZE: usize = 100_000;
 
     let trie = store.open_direct_state_trie(*EMPTY_TRIE_HASH)?;
-    let mut db_options = rocksdb::Options::default();
-    db_options.create_if_missing(true);
-    let db = rocksdb::DB::open(&db_options, get_rocksdb_temp_accounts_dir(datadir))
-        .map_err(|e| SyncError::AccountTempDBDirNotFound(e.to_string()))?;
-    let file_paths: Vec<PathBuf> = async_fs::read_dir_paths(account_state_snapshots_dir).await?;
-    // Move SST files into the temp DB instead of copying them. The snapshot dir
-    // and the temp DB live under the same datadir, so rename succeeds and we
-    // avoid keeping two on-disk copies of the leaf data during ingest.
-    let mut ingest_opts = rocksdb::IngestExternalFileOptions::default();
-    ingest_opts.set_move_files(true);
-    db.ingest_external_file_opts(&ingest_opts, file_paths)
-        .map_err(|err| SyncError::RocksDBError(err.into_string()))?;
+    // The ingest task has been moving snapshot files into the temp DB since
+    // the download started; the download's return closed the channel, so the
+    // join yields the DB with every received file already ingested. If the
+    // task died early, reopen the DB: every chunk it never ingested is still
+    // in the snapshot dir (sends are best-effort and `move_files` only
+    // removes ingested files), so the sweep below retries them and a
+    // persistent ingest error resurfaces from there.
+    let db = match ingest_handle.await? {
+        Ok(db) => db,
+        Err(err) => {
+            warn!(
+                "Account snapshot ingest task failed ({err}); re-ingesting the remaining snapshot files"
+            );
+            account_ingestor::open_temp_accounts_db(datadir)?
+        }
+    };
+    // Ingest whatever is left in the snapshot dir: chunks whose send failed
+    // because the ingest task had died, or leftovers from a previous run.
+    account_ingestor::ingest_remaining_snapshot_files(&db, account_state_snapshots_dir).await?;
     // Single pass: the trie build consumes the sorted leaves while the same
     // decode feeds code-hash collection and the storage-root map, instead of
     // a dedicated full iteration of the temp DB for the code hashes.


### PR DESCRIPTION
**Motivation**

Account snapshot SSTs ingested into the temp DB only after the whole download completed — a serialization with no dependency behind it beyond per-file completion.

**Description**

Each finished dump file is sent (with its chunk index) to a background ingestor owning the temp RocksDB, which ingests the contiguous index prefix in order (re-pivoted re-downloads make ordering load-bearing: later files must win). At build time the ingestor is joined and an in-dir sweep ingests any remainder — move_files semantics make 'files still in the dir' exactly the un-ingested set, covering ingestor failure and restarts without double-ingest. The single trie build after the join is untouched.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` — not needed.