### PR TITLE
perf(levm): pad bytecode with 33 STOPs to remove hot-path bounds checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Perf
 
+### 2026-06-15
+
+- Pad `Code` bytecode with 33 trailing `STOP` bytes so the hot dispatch fetch and `pc` advance drop their bounds checks (~8% fewer instructions, ~13% fewer branches on dispatch). The logical length is tracked separately and `Code` is encapsulated so all consumers read the true length [#6866](https://github.com/lambdaclass/ethrex/pull/6866)
+
 ### 2026-06-03
 
 - Short-circuit the `KECCAK256` opcode on zero-length input by returning the precomputed `keccak256("")` constant, skipping the permutation [#6775](https://github.com/lambdaclass/ethrex/pull/6775)

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1555,7 +1555,7 @@ impl Blockchain {
                     .ok_or(ChainError::WitnessGeneration(
                         "Failed to get account code".to_string(),
                     ))?;
-                codes.push(code.bytecode.to_vec());
+                codes.push(code.code().to_vec());
             }
 
             // Apply account updates to the trie recording all the necessary nodes to do so
@@ -1817,7 +1817,7 @@ impl Blockchain {
                 .ok_or(ChainError::WitnessGeneration(
                     "Failed to get account code".to_string(),
                 ))?;
-            codes.push(code.bytecode.to_vec());
+            codes.push(code.code().to_vec());
         }
 
         // Apply account updates to the trie recording all the necessary nodes to do so

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -30,7 +30,7 @@ static EMPTY_JUMP_TARGETS: LazyLock<Arc<[u32]>> = LazyLock::new(|| Arc::from(Vec
 /// padding regardless of which opcode sits at the last real byte.
 pub const BYTECODE_PADDING: usize = 33;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Code {
     // hash is only used for bytecodes stored in the DB, either for reading it from the DB
     // or with the CODEHASH opcode, which needs an account address as argument and
@@ -154,6 +154,41 @@ impl Code {
     }
 }
 
+/// Serde shadow for [`Code`]. Stores the *logical* (unpadded) bytecode so the
+/// padding is never part of the serialized form. Deserialization re-pads through
+/// [`Code::from_parts_unchecked`], which keeps the dispatch-loop invariant (every
+/// `Code` is padded with [`BYTECODE_PADDING`] trailing STOPs) sound regardless of
+/// where the bytes came from. Deserializing the padded buffer directly would
+/// otherwise let unpadded input through and cause OOB reads during execution.
+#[derive(Serialize, Deserialize)]
+struct CodeSerde {
+    hash: H256,
+    code: Bytes,
+    jump_targets: Arc<[u32]>,
+}
+
+impl Serialize for Code {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        CodeSerde {
+            hash: self.hash,
+            code: self.code_bytes(),
+            jump_targets: self.jump_targets.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Code {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let CodeSerde {
+            hash,
+            code,
+            jump_targets,
+        } = CodeSerde::deserialize(deserializer)?;
+        Ok(Self::from_parts_unchecked(hash, &code, jump_targets))
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodeMetadata {
     pub length: u64,
@@ -215,7 +250,7 @@ impl Default for AccountState {
 impl Default for Code {
     fn default() -> Self {
         Self {
-            bytecode: Bytes::from_static(&[0u8; 33]),
+            bytecode: Bytes::from_static(&[0u8; BYTECODE_PADDING]),
             bytecode_len: 0,
             hash: *EMPTY_KECCAK_HASH,
             jump_targets: EMPTY_JUMP_TARGETS.clone(),

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -24,6 +24,12 @@ use crate::constants::{EMPTY_KECCAK_HASH, EMPTY_TRIE_HASH};
 /// placeholder and every EOA / empty-code load would otherwise each allocate.
 static EMPTY_JUMP_TARGETS: LazyLock<Arc<[u32]>> = LazyLock::new(|| Arc::from(Vec::new()));
 
+/// Trailing STOP bytes appended to every bytecode so the dispatch loop can read
+/// the next opcode without a bounds check. 33 is the widest single-opcode advance
+/// (PUSH32: 1 opcode byte + 32 immediate bytes), so `pc` can never step past the
+/// padding regardless of which opcode sits at the last real byte.
+pub const BYTECODE_PADDING: usize = 33;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Code {
     // hash is only used for bytecodes stored in the DB, either for reading it from the DB
@@ -51,20 +57,22 @@ impl Code {
     // or never be read (e.g. for initcode).
     pub fn from_bytecode_unchecked(code: Bytes, hash: H256) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
-        Self::from_parts(hash, &code, jump_targets)
+        Self::from_parts_unchecked(hash, &code, jump_targets)
     }
 
     pub fn from_bytecode(code: Bytes, crypto: &dyn Crypto) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
         let hash = H256(crypto.keccak256(code.as_ref()));
-        Self::from_parts(hash, &code, jump_targets)
+        Self::from_parts_unchecked(hash, &code, jump_targets)
     }
 
-    pub fn from_parts(hash: H256, code: &[u8], jump_targets: Arc<[u32]>) -> Self {
+    /// Builds a `Code` from precomputed parts. The caller must guarantee `hash`
+    /// and `jump_targets` correspond to `code`; neither is recomputed or validated.
+    pub fn from_parts_unchecked(hash: H256, code: &[u8], jump_targets: Arc<[u32]>) -> Self {
         let bytecode_len = code.len();
-        let mut padded_code = Vec::with_capacity(bytecode_len + 33);
+        let mut padded_code = Vec::with_capacity(bytecode_len + BYTECODE_PADDING);
         padded_code.extend_from_slice(code);
-        padded_code.extend_from_slice(&[0u8; 33]);
+        padded_code.extend_from_slice(&[0u8; BYTECODE_PADDING]);
         Self {
             hash,
             bytecode: Bytes::from_owner(padded_code),
@@ -122,6 +130,9 @@ impl Code {
         self.bytecode_len == 0
     }
 
+    /// Returns the padded bytecode buffer (real code + [`BYTECODE_PADDING`] trailing
+    /// STOPs) used by the opcode dispatch loop to read opcodes without bounds checks.
+    /// Use [`Code::code`] for the real, unpadded bytecode.
     #[inline]
     pub fn dispatch_buf(&self) -> &[u8] {
         &self.bytecode

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -32,7 +32,10 @@ pub struct Code {
     // We use a bogus H256::zero() value for initcodes as there is no way for the VM or
     // endpoints to access that hash, saving one expensive Keccak hash.
     pub hash: H256,
-    pub bytecode: Bytes,
+    /// bytecode padded with 33 zeroes (STOP opcodes, due to PUSH32) to avoid checks on the hot path.
+    bytecode: Bytes,
+    /// The real bytecode length, needed for some opcodes, `bytecode` is padded with 33 STOPs to avoid checked adds on hot loop.
+    bytecode_len: usize,
     // `Arc<[u32]>` so cloning `Code` (hot: every message-call resolves and clones
     // the callee's code) is a refcount bump instead of deep-copying the table.
     // Serializes via serde's `rc` feature (enabled workspace-wide).
@@ -48,18 +51,24 @@ impl Code {
     // or never be read (e.g. for initcode).
     pub fn from_bytecode_unchecked(code: Bytes, hash: H256) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
-        Self {
-            hash,
-            bytecode: code,
-            jump_targets,
-        }
+        Self::from_parts(hash, &code, jump_targets)
     }
 
     pub fn from_bytecode(code: Bytes, crypto: &dyn Crypto) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
+        let hash = H256(crypto.keccak256(code.as_ref()));
+        Self::from_parts(hash, &code, jump_targets)
+    }
+
+    pub fn from_parts(hash: H256, code: &[u8], jump_targets: Arc<[u32]>) -> Self {
+        let bytecode_len = code.len();
+        let mut padded_code = Vec::with_capacity(bytecode_len + 33);
+        padded_code.extend_from_slice(code);
+        padded_code.extend_from_slice(&[0u8; 33]);
         Self {
-            hash: H256(crypto.keccak256(code.as_ref())),
-            bytecode: code,
+            hash,
+            bytecode: Bytes::from_owner(padded_code),
+            bytecode_len,
             jump_targets,
         }
     }
@@ -93,6 +102,31 @@ impl Code {
         }
     }
 
+    #[inline]
+    pub fn code(&self) -> &[u8] {
+        self.bytecode.get(..self.bytecode_len).unwrap_or_default()
+    }
+
+    #[inline]
+    pub fn code_bytes(&self) -> Bytes {
+        self.bytecode.slice(..self.bytecode_len)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.bytecode_len
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytecode_len == 0
+    }
+
+    #[inline]
+    pub fn dispatch_buf(&self) -> &[u8] {
+        &self.bytecode
+    }
+
     /// Estimates the size of the Code struct in bytes
     /// (including stack size and heap allocation).
     ///
@@ -106,12 +140,6 @@ impl Code {
         let bytes_size = size_of::<Bytes>();
         let vec_size = size_of::<Arc<[u32]>>() + self.jump_targets.len() * size_of::<u32>();
         hash_size + bytes_size + vec_size
-    }
-}
-
-impl AsRef<Bytes> for Code {
-    fn as_ref(&self) -> &Bytes {
-        &self.bytecode
     }
 }
 
@@ -176,7 +204,8 @@ impl Default for AccountState {
 impl Default for Code {
     fn default() -> Self {
         Self {
-            bytecode: Bytes::new(),
+            bytecode: Bytes::from_static(&[0u8; 33]),
+            bytecode_len: 0,
             hash: *EMPTY_KECCAK_HASH,
             jump_targets: EMPTY_JUMP_TARGETS.clone(),
         }

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -55,11 +55,16 @@ impl Code {
     // SAFETY: hash will be stored as-is, so it either needs to match
     // the real code hash (i.e. it was precomputed and we're reusing)
     // or never be read (e.g. for initcode).
+    //
+    // `code` is the logical, unpadded bytecode; `BYTECODE_PADDING` STOP bytes are
+    // appended internally by `from_parts_unchecked`.
     pub fn from_bytecode_unchecked(code: Bytes, hash: H256) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
         Self::from_parts_unchecked(hash, &code, jump_targets)
     }
 
+    /// `code` is the logical, unpadded bytecode; `BYTECODE_PADDING` STOP bytes are
+    /// appended internally by `from_parts_unchecked`.
     pub fn from_bytecode(code: Bytes, crypto: &dyn Crypto) -> Self {
         let jump_targets = Self::compute_jump_targets(&code);
         let hash = H256(crypto.keccak256(code.as_ref()));
@@ -68,6 +73,11 @@ impl Code {
 
     /// Builds a `Code` from precomputed parts. The caller must guarantee `hash`
     /// and `jump_targets` correspond to `code`; neither is recomputed or validated.
+    ///
+    /// `code` is the logical, unpadded bytecode: this function appends
+    /// `BYTECODE_PADDING` STOP bytes and records the original length in
+    /// `bytecode_len`. Never pass a pre-padded buffer, or the logical length and
+    /// every `JUMPDEST`/`PUSH` offset derived from it would be wrong.
     pub fn from_parts_unchecked(hash: H256, code: &[u8], jump_targets: Arc<[u32]>) -> Self {
         let bytecode_len = code.len();
         let mut padded_code = Vec::with_capacity(bytecode_len + BYTECODE_PADDING);

--- a/crates/common/types/block_access_list.rs
+++ b/crates/common/types/block_access_list.rs
@@ -1864,7 +1864,7 @@ mod synthesize_tests {
         let expected_hash = keccak(&bytecode);
         assert_eq!(item.code_hash, Some(expected_hash));
         assert!(item.code.is_some());
-        assert_eq!(item.code.as_ref().unwrap().bytecode, bytecode);
+        assert_eq!(item.code.as_ref().unwrap().code(), &bytecode[..]);
         assert!(item.added_storage.is_empty());
     }
 
@@ -1905,7 +1905,7 @@ mod synthesize_tests {
         let item = result.get(&addr(8)).expect("expected entry");
         let expected_hash = keccak(&last);
         assert_eq!(item.code_hash, Some(expected_hash));
-        assert_eq!(item.code.as_ref().unwrap().bytecode, last);
+        assert_eq!(item.code.as_ref().unwrap().code(), &last[..]);
     }
 
     /// When a slot has multiple StorageChanges, the last post_value wins.
@@ -1983,7 +1983,7 @@ mod synthesize_tests {
         let expected_hash = keccak(&bytecode);
         assert_eq!(item.code_hash, Some(expected_hash));
         assert!(item.code.is_some());
-        assert_eq!(item.code.as_ref().unwrap().bytecode, bytecode);
+        assert_eq!(item.code.as_ref().unwrap().code(), &bytecode[..]);
         let key = H256::from_uint(&U256::zero());
         assert_eq!(item.added_storage.get(&key), Some(&U256::from(7)));
     }

--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -652,7 +652,7 @@ impl GuestProgramState {
         self.codes_hashed
             .get(&code_hash)
             .map(|code| CodeMetadata {
-                length: code.bytecode.len() as u64,
+                length: code.len() as u64,
             })
             .ok_or(GuestProgramStateError::MissingBytecode(code_hash))
     }

--- a/crates/l2/networking/rpc/l2/transaction.rs
+++ b/crates/l2/networking/rpc/l2/transaction.rs
@@ -99,14 +99,12 @@ impl RpcHandler for SponsoredTx {
                 .map_err(RpcErr::from)?
                 .unwrap_or_default();
 
-            if code.bytecode.len() != EIP7702_DELEGATED_CODE_LEN
-                || code.bytecode[..3] != DELGATION_PREFIX
-            {
+            if code.len() != EIP7702_DELEGATED_CODE_LEN || code.code()[..3] != DELGATION_PREFIX {
                 return Err(RpcErr::InvalidEthrexL2Message(
                     "Invalid tx trying to call non delegated account".to_string(),
                 ));
             }
-            let address = Address::from_slice(&code.bytecode[3..]);
+            let address = Address::from_slice(&code.code()[3..EIP7702_DELEGATED_CODE_LEN]);
             if address.is_zero() {
                 return Err(RpcErr::InvalidEthrexL2Message(
                     "Invalid tx trying to call non delegated account".to_string(),

--- a/crates/networking/p2p/snap/server.rs
+++ b/crates/networking/p2p/snap/server.rs
@@ -113,7 +113,7 @@ pub async fn process_byte_codes_request(
         let mut codes = vec![];
         let mut bytes_used = 0;
         for code_hash in request.hashes {
-            if let Some(code) = store.get_account_code(code_hash)?.map(|c| c.bytecode) {
+            if let Some(code) = store.get_account_code(code_hash)?.map(|c| c.code_bytes()) {
                 bytes_used += code.len() as u64;
                 codes.push(code);
             }

--- a/crates/networking/rpc/eth/account.rs
+++ b/crates/networking/rpc/eth/account.rs
@@ -99,7 +99,7 @@ impl RpcHandler for GetCodeRequest {
             .storage
             .get_code_by_account_address(block_number, self.address)
             .await?
-            .map(|c| c.bytecode)
+            .map(|c| c.code_bytes())
             .unwrap_or_default();
 
         serde_json::to_value(format!("0x{code:x}"))

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -21,7 +21,6 @@ use crate::{
     utils::{ChainDataIndex, SnapStateIndex},
 };
 
-use bytes::Bytes;
 use ethrex_common::{
     Address, H256, U256,
     types::{
@@ -844,15 +843,12 @@ impl Store {
         else {
             return Ok(None);
         };
-        let bytes = Bytes::from_owner(bytes);
         let (bytecode_slice, targets) = decode_bytes(&bytes)?;
-        let bytecode = bytes.slice_ref(bytecode_slice);
-
-        let code = Code {
-            hash: code_hash,
-            bytecode,
-            jump_targets: <Vec<u32>>::decode(targets)?.into(),
-        };
+        let code = Code::from_parts(
+            code_hash,
+            bytecode_slice,
+            <Vec<u32>>::decode(targets)?.into(),
+        );
 
         // insert into cache and evict if needed
         self.account_code_cache
@@ -926,7 +922,7 @@ impl Store {
                 return Ok(None);
             };
             let metadata = CodeMetadata {
-                length: code.bytecode.len() as u64,
+                length: code.len() as u64,
             };
 
             // Write metadata for future use (async, fire and forget)
@@ -961,7 +957,7 @@ impl Store {
     pub async fn add_account_code(&self, code: Code) -> Result<(), StoreError> {
         let hash_key = code.hash.0.to_vec();
         let buf = encode_code(&code);
-        let metadata_buf = (code.bytecode.len() as u64).to_be_bytes();
+        let metadata_buf = (code.len() as u64).to_be_bytes();
 
         // Write both code and metadata atomically
         let backend = self.backend.clone();
@@ -1385,7 +1381,7 @@ impl Store {
 
         for (code_hash, code) in account_codes {
             let buf = encode_code(&code);
-            let metadata_buf = (code.bytecode.len() as u64).to_be_bytes().to_vec();
+            let metadata_buf = (code.len() as u64).to_be_bytes().to_vec();
             code_batch_items.push((code_hash.as_bytes().to_vec(), buf));
             metadata_batch_items.push((code_hash.as_bytes().to_vec(), metadata_buf));
         }
@@ -1612,7 +1608,7 @@ impl Store {
 
         for (code_hash, code) in update_batch.code_updates {
             let buf = encode_code(&code);
-            let metadata_buf = (code.bytecode.len() as u64).to_be_bytes();
+            let metadata_buf = (code.len() as u64).to_be_bytes();
             tx.put(ACCOUNT_CODES, code_hash.as_ref(), &buf)?;
             tx.put(ACCOUNT_CODE_METADATA, code_hash.as_ref(), &metadata_buf)?;
         }
@@ -3527,10 +3523,9 @@ pub fn receipt_key(block_hash: &BlockHash, index: u64) -> Vec<u8> {
 }
 
 fn encode_code(code: &Code) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(
-        6 + code.bytecode.len() + std::mem::size_of_val::<[u32]>(&code.jump_targets),
-    );
-    code.bytecode.encode(&mut buf);
+    let mut buf =
+        Vec::with_capacity(6 + code.len() + std::mem::size_of_val::<[u32]>(&code.jump_targets));
+    code.code().encode(&mut buf);
     // `Arc<[u32]>` (the in-memory share) has no `RLPEncode` impl; encode through an
     // owned `Vec` on this cold DB-write path (code is persisted once per hash).
     code.jump_targets.to_vec().encode(&mut buf);

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -844,7 +844,7 @@ impl Store {
             return Ok(None);
         };
         let (bytecode_slice, targets) = decode_bytes(&bytes)?;
-        let code = Code::from_parts(
+        let code = Code::from_parts_unchecked(
             code_hash,
             bytecode_slice,
             <Vec<u32>>::decode(targets)?.into(),

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -1516,16 +1516,14 @@ impl LEVM {
                     match actual {
                         Some(a) => {
                             let actual_code = if let Some(c) = codes.get(&a.info.code_hash) {
-                                c.bytecode.clone()
+                                c.code_bytes()
                             } else {
-                                store
-                                    .get_account_code(a.info.code_hash)
-                                    .map_err(|e| {
-                                        BalValidationError::Database(format!(
-                                            "DB error reading account code for {addr:?}: {e}"
-                                        ))
-                                    })?
-                                    .bytecode
+                                let c = store.get_account_code(a.info.code_hash).map_err(|e| {
+                                    BalValidationError::Database(format!(
+                                        "DB error reading account code for {addr:?}: {e}"
+                                    ))
+                                })?;
+                                c.code_bytes()
                             };
                             if actual_code != *expected_code {
                                 return Err(BalValidationError::Mismatch(format!(
@@ -1550,17 +1548,15 @@ impl LEVM {
                                     })?
                             };
                             let pre_code = if let Some(c) = codes.get(&code_hash) {
-                                c.bytecode.clone()
+                                c.code_bytes()
                             } else {
-                                store
-                                    .get_account_code(code_hash)
-                                    .map_err(|e| {
-                                        BalValidationError::Database(format!(
-                                            "DB error reading account code for hash \
+                                let c = store.get_account_code(code_hash).map_err(|e| {
+                                    BalValidationError::Database(format!(
+                                        "DB error reading account code for hash \
                                              {code_hash:?}: {e}"
-                                        ))
-                                    })?
-                                    .bytecode
+                                    ))
+                                })?;
+                                c.code_bytes()
                             };
                             if *expected_code != pre_code {
                                 return Err(BalValidationError::Mismatch(format!(
@@ -2674,7 +2670,7 @@ pub fn generic_system_contract_levm(
     if PRAGUE_SYSTEM_CONTRACTS
         .iter()
         .any(|contract| contract.address == contract_address)
-        && db.get_account_code(contract_address)?.bytecode.is_empty()
+        && db.get_account_code(contract_address)?.is_empty()
     {
         return Err(EvmError::SystemContractCallFailed(format!(
             "System contract: {contract_address} has no code after deployment"
@@ -3204,7 +3200,7 @@ mod bal_tests {
         assert_eq!(updates.len(), 1);
         let u = &updates[0];
         assert_eq!(u.info.as_ref().unwrap().code_hash, expected_hash);
-        assert_eq!(u.code.as_ref().unwrap().bytecode, code);
+        assert_eq!(u.code.as_ref().unwrap().code(), &code[..]);
     }
 }
 
@@ -3262,7 +3258,7 @@ mod system_call_coinbase_tests {
         }
         fn get_code_metadata(&self, code_hash: H256) -> Result<CodeMetadata, DatabaseError> {
             let length = if code_hash == self.history_code.hash {
-                self.history_code.bytecode.len() as u64
+                self.history_code.len() as u64
             } else {
                 0
             };

--- a/crates/vm/backends/levm/tracing.rs
+++ b/crates/vm/backends/levm/tracing.rs
@@ -225,7 +225,7 @@ fn build_account_output(
 fn get_preloaded_code(db: &GeneralizedDatabase, hash: &H256) -> Result<bytes::Bytes, EvmError> {
     db.codes
         .get(hash)
-        .map(|c| c.bytecode.clone())
+        .map(|c| c.code_bytes())
         .ok_or_else(|| EvmError::Custom(format!("missing preloaded code for {hash:?}")))
 }
 

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -400,13 +400,9 @@ impl CallFrame {
 
     #[inline(always)]
     pub fn next_opcode(&self) -> u8 {
-        if self.pc < self.bytecode.bytecode.len() {
-            #[expect(unsafe_code, reason = "bounds checked above")]
-            unsafe {
-                *self.bytecode.bytecode.get_unchecked(self.pc)
-            }
-        } else {
-            0
+        #[expect(unsafe_code, reason = "bytecode padded with 33 STOPs at construction")]
+        unsafe {
+            *self.bytecode.dispatch_buf().get_unchecked(self.pc)
         }
     }
 
@@ -534,12 +530,11 @@ impl<'a> VM<'a> {
     }
 
     #[inline(always)]
-    pub fn advance_pc(&mut self, count: usize) -> Result<(), VMError> {
-        self.current_call_frame.pc = self
-            .current_call_frame
-            .pc
-            .checked_add(count)
-            .ok_or(InternalError::Overflow)?;
-        Ok(())
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "pc bounded by padded bytecode len"
+    )]
+    pub fn advance_pc(&mut self, count: usize) {
+        self.current_call_frame.pc += count;
     }
 }

--- a/crates/vm/levm/src/call_frame.rs
+++ b/crates/vm/levm/src/call_frame.rs
@@ -400,7 +400,11 @@ impl CallFrame {
 
     #[inline(always)]
     pub fn next_opcode(&self) -> u8 {
-        #[expect(unsafe_code, reason = "bytecode padded with 33 STOPs at construction")]
+        // SAFETY: pc reaches at most bytecode_len + 32 (a PUSH32 at the last real
+        // byte advances 33 total: +1 in the dispatch loop, +32 in the handler).
+        // dispatch_buf() is bytecode_len + BYTECODE_PADDING (33) long, so the read
+        // is always in bounds.
+        #[expect(unsafe_code, reason = "pc bounded by padded bytecode len")]
         unsafe {
             *self.bytecode.dispatch_buf().get_unchecked(self.pc)
         }
@@ -534,7 +538,7 @@ impl<'a> VM<'a> {
         clippy::arithmetic_side_effects,
         reason = "pc bounded by padded bytecode len"
     )]
-    pub fn advance_pc(&mut self, count: usize) {
-        self.current_call_frame.pc += count;
+    pub fn advance_pc(&mut self) {
+        self.current_call_frame.pc += 1;
     }
 }

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -506,7 +506,7 @@ impl GeneralizedDatabase {
                         }
                     };
 
-                    code.bytecode.len() as u64
+                    code.len() as u64
                 };
 
                 let metadata = CodeMetadata {
@@ -938,12 +938,12 @@ impl<'a> VM<'a> {
                 .current_accounts_state
                 .get(&address)
                 .and_then(|account| self.db.codes.get(&account.info.code_hash))
-                .map(|c| c.bytecode.clone())
+                .map(|c| c.code_bytes())
                 .unwrap_or_default();
             let has_code = !current_code_bytes.is_empty();
             recorder.capture_initial_code_presence(address, has_code);
             recorder.set_initial_code(address, current_code_bytes);
-            recorder.record_code_change(address, new_bytecode.bytecode.clone());
+            recorder.record_code_change(address, new_bytecode.code_bytes());
         }
 
         let acc = self.get_account_mut(address)?;

--- a/crates/vm/levm/src/gas_cost.rs
+++ b/crates/vm/levm/src/gas_cost.rs
@@ -5,7 +5,6 @@ use crate::{
     memory,
 };
 use ExceptionalHalt::OutOfGas;
-use bytes::Bytes;
 /// Contains the gas costs of the EVM instructions
 use ethrex_common::{U256, types::Fork, types::tx_fields::AccessList};
 use malachite::base::num::logic::traits::*;
@@ -615,7 +614,7 @@ pub fn selfdestruct(
         .ok_or(OutOfGas.into())
 }
 
-pub fn tx_calldata(calldata: &Bytes) -> Result<u64, VMError> {
+pub fn tx_calldata(calldata: &[u8]) -> Result<u64, VMError> {
     // This cost applies both for call and create
     // 4 gas for each zero byte in the transaction data, 16 gas for each non-zero byte.
     // Counting non-zero bytes in a single pass autovectorizes; the previous per-byte

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -8,7 +8,6 @@ use crate::{
     vm::VM,
 };
 
-use bytes::Bytes;
 use ethrex_common::{
     Address, H256, U256,
     types::{Code, Fork},
@@ -109,7 +108,7 @@ impl Hook for DefaultHook {
 
         // (9) SENDER_NOT_EOA
         let code = vm.db.get_code(sender_info.code_hash)?;
-        validate_sender(sender_address, &code.bytecode)?;
+        validate_sender(sender_address, code.code())?;
 
         // (10) GAS_ALLOWANCE_EXCEEDED
         validate_gas_allowance(vm)?;
@@ -603,7 +602,7 @@ pub fn validate_type_4_tx(vm: &mut VM<'_>) -> Result<(), VMError> {
     vm.eip7702_set_access_code()
 }
 
-pub fn validate_sender(sender_address: Address, code: &Bytes) -> Result<(), VMError> {
+pub fn validate_sender(sender_address: Address, code: &[u8]) -> Result<(), VMError> {
     if !code.is_empty() && !code_has_delegation(code)? {
         return Err(TxValidationError::SenderNotEOA(sender_address).into());
     }

--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -664,7 +664,7 @@ fn prepare_execution_fee_token(vm: &mut VM<'_>) -> Result<U256, crate::errors::V
 
     // (9) SENDER_NOT_EOA
     let code = vm.db.get_code(sender_info.code_hash)?;
-    default_hook::validate_sender(sender_address, &code.bytecode)?;
+    default_hook::validate_sender(sender_address, code.code())?;
 
     // (10) GAS_ALLOWANCE_EXCEEDED
     default_hook::validate_gas_allowance(vm)?;

--- a/crates/vm/levm/src/opcode_handlers/dup.rs
+++ b/crates/vm/levm/src/opcode_handlers/dup.rs
@@ -35,7 +35,7 @@ impl OpcodeHandler for OpDupNHandler {
         let relative_offset = vm
             .current_call_frame
             .bytecode
-            .bytecode
+            .dispatch_buf()
             .get(vm.current_call_frame.pc)
             .copied()
             .unwrap_or_default();

--- a/crates/vm/levm/src/opcode_handlers/environment.rs
+++ b/crates/vm/levm/src/opcode_handlers/environment.rs
@@ -236,7 +236,7 @@ impl OpcodeHandler for OpCodeSizeHandler {
 
         vm.current_call_frame
             .stack
-            .push(vm.current_call_frame.bytecode.bytecode.len().into())?;
+            .push(vm.current_call_frame.bytecode.len().into())?;
 
         Ok(OpcodeResult::Continue)
     }
@@ -262,7 +262,7 @@ impl OpcodeHandler for OpCodeCopyHandler {
             let data = vm
                 .current_call_frame
                 .bytecode
-                .bytecode
+                .dispatch_buf()
                 .get(src_offset..)
                 .unwrap_or_default();
             let data = data.get(..len).unwrap_or(data);
@@ -339,7 +339,7 @@ impl OpcodeHandler for OpExtCodeCopyHandler {
             let data = vm
                 .db
                 .get_account_code(address)?
-                .bytecode
+                .dispatch_buf()
                 .get(src_offset..)
                 .unwrap_or_default();
             let data = data.get(..len).unwrap_or(data);

--- a/crates/vm/levm/src/opcode_handlers/exchange.rs
+++ b/crates/vm/levm/src/opcode_handlers/exchange.rs
@@ -37,7 +37,7 @@ impl OpcodeHandler for OpSwapNHandler {
         let relative_offset = vm
             .current_call_frame
             .bytecode
-            .bytecode
+            .dispatch_buf()
             .get(vm.current_call_frame.pc)
             .copied()
             .unwrap_or_default();
@@ -94,7 +94,7 @@ impl OpcodeHandler for OpExchangeHandler {
         let relative_offset = vm
             .current_call_frame
             .bytecode
-            .bytecode
+            .dispatch_buf()
             .get(vm.current_call_frame.pc)
             .copied()
             .unwrap_or_default();

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -41,7 +41,7 @@ impl<const N: usize> OpcodeHandler for OpPushHandler<N> {
         vm.current_call_frame
             .increase_consumed_gas(gas_cost::PUSHN)?;
 
-        let bytecode = &vm.current_call_frame.bytecode.bytecode;
+        let bytecode = vm.current_call_frame.bytecode.dispatch_buf();
         let value = match bytecode.get(literal_offset..) {
             #[expect(clippy::indexing_slicing, reason = "length is checked in match guard")]
             Some(data) if data.len() >= N => {

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -32,9 +32,11 @@ impl<const N: usize> OpcodeHandler for OpPushHandler<N> {
     #[inline(always)]
     fn eval(vm: &mut VM<'_>) -> Result<OpcodeResult, VMError> {
         // PUSHn reads up to 32 immediate bytes without a bounds check, relying on
-        // the trailing zero padding appended to every bytecode. Keep the unchecked
-        // read below sound if the padding ever shrinks.
-        const { assert!(BYTECODE_PADDING >= 32) };
+        // the trailing zero padding appended to every bytecode. After the read the
+        // dispatch loop fetches the next opcode at `pc + N`, which needs one byte
+        // beyond the immediates, so the padding must exceed 32 (i.e. be >= 33).
+        // Keep the unchecked read below sound if the padding ever shrinks.
+        const { assert!(BYTECODE_PADDING > 32) };
 
         let literal_offset = vm.current_call_frame.pc;
         // Use a *checked* add for the pc advance, not unchecked `+= N`. Both

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -5,12 +5,9 @@
 //!   - `PUSH1` to `PUSH32`
 
 use crate::{
-    errors::{InternalError, OpcodeResult, VMError},
-    gas_cost,
-    opcode_handlers::OpcodeHandler,
-    vm::VM,
+    errors::OpcodeResult, errors::VMError, gas_cost, opcode_handlers::OpcodeHandler, vm::VM,
 };
-use ethrex_common::{U256, utils::u256_from_big_endian_const};
+use ethrex_common::{types::BYTECODE_PADDING, utils::u256_from_big_endian_const};
 
 /// Implementation for the `PUSH0` opcode.
 pub struct OpPush0Handler;
@@ -31,31 +28,35 @@ pub struct OpPushHandler<const N: usize>;
 impl<const N: usize> OpcodeHandler for OpPushHandler<N> {
     #[inline(always)]
     fn eval(vm: &mut VM<'_>) -> Result<OpcodeResult, VMError> {
+        // PUSHn reads up to 32 immediate bytes without a bounds check, relying on
+        // the trailing zero padding appended to every bytecode. Keep the unchecked
+        // read below sound if the padding ever shrinks.
+        const { assert!(BYTECODE_PADDING >= 32) };
+
         let literal_offset = vm.current_call_frame.pc;
-        vm.current_call_frame.pc = vm
-            .current_call_frame
-            .pc
-            .checked_add(N)
-            .ok_or(InternalError::Overflow)?;
+        #[expect(
+            clippy::arithmetic_side_effects,
+            reason = "pc bounded by padded bytecode len"
+        )]
+        {
+            vm.current_call_frame.pc += N;
+        }
+        // `pc` is now exactly `literal_offset + N`; reuse it as the immediate end.
+        let literal_end = vm.current_call_frame.pc;
 
         vm.current_call_frame
             .increase_consumed_gas(gas_cost::PUSHN)?;
 
         let bytecode = vm.current_call_frame.bytecode.dispatch_buf();
-        let value = match bytecode.get(literal_offset..) {
-            #[expect(clippy::indexing_slicing, reason = "length is checked in match guard")]
-            Some(data) if data.len() >= N => {
-                let mut buf = [0u8; N];
-                buf.copy_from_slice(&data[..N]);
-                u256_from_big_endian_const(buf)
-            }
-            Some(data) => {
-                let mut bytes = [0u8; N];
-                bytes[..data.len()].copy_from_slice(data);
-                u256_from_big_endian_const(bytes)
-            }
-            None => U256::zero(),
-        };
+        // SAFETY: PUSH only dispatches on a real opcode byte, so
+        // `literal_offset <= bytecode_len`; the buffer is padded with
+        // BYTECODE_PADDING (>= N) trailing zeros, so N bytes are always in bounds.
+        // Immediate bytes past the real code end read as zero, matching EVM
+        // PUSH-past-end semantics (the padding is zeroed).
+        let mut buf = [0u8; N];
+        #[expect(unsafe_code, reason = "read bounded by padded bytecode len")]
+        buf.copy_from_slice(unsafe { bytecode.get_unchecked(literal_offset..literal_end) });
+        let value = u256_from_big_endian_const(buf);
         vm.current_call_frame.stack.push(value)?;
 
         Ok(OpcodeResult::Continue)

--- a/crates/vm/levm/src/opcode_handlers/push.rs
+++ b/crates/vm/levm/src/opcode_handlers/push.rs
@@ -5,7 +5,10 @@
 //!   - `PUSH1` to `PUSH32`
 
 use crate::{
-    errors::OpcodeResult, errors::VMError, gas_cost, opcode_handlers::OpcodeHandler, vm::VM,
+    errors::{InternalError, OpcodeResult, VMError},
+    gas_cost,
+    opcode_handlers::OpcodeHandler,
+    vm::VM,
 };
 use ethrex_common::{types::BYTECODE_PADDING, utils::u256_from_big_endian_const};
 
@@ -34,13 +37,17 @@ impl<const N: usize> OpcodeHandler for OpPushHandler<N> {
         const { assert!(BYTECODE_PADDING >= 32) };
 
         let literal_offset = vm.current_call_frame.pc;
-        #[expect(
-            clippy::arithmetic_side_effects,
-            reason = "pc bounded by padded bytecode len"
-        )]
-        {
-            vm.current_call_frame.pc += N;
-        }
+        // Use a *checked* add for the pc advance, not unchecked `+= N`. Both
+        // compute the same value (pc never overflows in practice), but the
+        // checked form is required for good codegen here: with unchecked/wrapping
+        // arithmetic LLVM can no longer prove the immediate slice length is the
+        // constant `N`, so the `get_unchecked` read below degrades to a
+        // runtime-length memcpy and the PUSH hot loop runs ~2x slower (IPC
+        // collapses 3.4 -> 1.2). The overflow branch is free (perfectly
+        // predicted) and never taken.
+        vm.current_call_frame.pc = literal_offset
+            .checked_add(N)
+            .ok_or(InternalError::Overflow)?;
         // `pc` is now exactly `literal_offset + N`; reuse it as the immediate end.
         let literal_end = vm.current_call_frame.pc;
 

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -437,7 +437,7 @@ fn jump(vm: &mut VM<'_>, target: usize, parent_gas_cost: u64) -> Result<(), VMEr
     if vm
         .current_call_frame
         .bytecode
-        .bytecode
+        .dispatch_buf()
         .get(target)
         .is_some_and(|&value| {
             value == Opcode::JUMPDEST as u8

--- a/crates/vm/levm/src/opcode_tracer.rs
+++ b/crates/vm/levm/src/opcode_tracer.rs
@@ -98,7 +98,7 @@ impl LevmOpcodeTracer {
     /// Captures pre-step state, building and buffering an `OpcodeStep` entry.
     ///
     /// Called BEFORE the opcode executes.  `pc` must be the address of the
-    /// current opcode (before `advance_pc(1)`).
+    /// current opcode (before `advance_pc()`).
     ///
     /// `stack_view` must already be bottom-first (caller reverses LEVM's top-first
     /// layout) and empty when `cfg.disable_stack` is true.

--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -177,7 +177,7 @@ pub fn word_to_address(word: U256) -> Address {
 
 // ================== EIP-7702 related functions =====================
 
-pub fn code_has_delegation(code: &Bytes) -> Result<bool, VMError> {
+pub fn code_has_delegation(code: &[u8]) -> Result<bool, VMError> {
     if code.len() == EIP7702_DELEGATED_CODE_LEN {
         let first_3_bytes = &code.get(..3).ok_or(InternalError::Slicing)?;
         return Ok(*first_3_bytes == SET_CODE_DELEGATION_BYTES);
@@ -187,7 +187,7 @@ pub fn code_has_delegation(code: &Bytes) -> Result<bool, VMError> {
 
 /// Gets the address inside the bytecode if it has been
 /// delegated as the EIP7702 determines.
-pub fn get_authorized_address_from_code(code: &Bytes) -> Result<Address, VMError> {
+pub fn get_authorized_address_from_code(code: &[u8]) -> Result<Address, VMError> {
     if code_has_delegation(code)? {
         let address_bytes = &code
             .get(SET_CODE_DELEGATION_BYTES.len()..)
@@ -258,13 +258,13 @@ pub fn eip7702_get_code(
     // return false meaning that is not a delegation
     // return the same address given
     // return the bytecode of the given address
-    if !code_has_delegation(&bytecode.bytecode)? {
+    if !code_has_delegation(bytecode.code())? {
         return Ok((false, 0, address, bytecode.clone()));
     }
 
     // Here the address has a delegation code
     // The delegation code has the authorized address
-    let auth_address = get_authorized_address_from_code(&bytecode.bytecode)?;
+    let auth_address = get_authorized_address_from_code(bytecode.code())?;
 
     let access_cost = if accrued_substate.add_accessed_address(auth_address) {
         COLD_ADDRESS_ACCESS_COST
@@ -332,9 +332,9 @@ impl<'a> VM<'a> {
 
             // 5. Verify the code of authority is either empty or already delegated.
             // Check this BEFORE recording to BAL so we can release the borrow on authority_code.
-            let authority_code_is_empty = authority_code.bytecode.is_empty();
+            let authority_code_is_empty = authority_code.is_empty();
             let empty_or_delegated =
-                authority_code_is_empty || code_has_delegation(&authority_code.bytecode)?;
+                authority_code_is_empty || code_has_delegation(authority_code.code())?;
 
             // Record authority as touched for BAL per EIP-7928, even if validation fails later.
             // This ensures authority appears in BAL with empty change set when:
@@ -638,9 +638,9 @@ impl<'a> VM<'a> {
 
         // If the transaction is a CREATE transaction, the calldata is emptied and the bytecode is assigned.
         let calldata = if self.is_create()? {
-            &self.current_call_frame.bytecode.bytecode
+            self.current_call_frame.bytecode.code()
         } else {
-            &self.current_call_frame.calldata
+            self.current_call_frame.calldata.as_ref()
         };
 
         // EIP-7976 floor tokens: for the floor arm, all calldata bytes count unweighted.

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1012,10 +1012,10 @@ impl<'a> VM<'a> {
         let opcode_table = self.opcode_table;
 
         loop {
-            // Capture pc BEFORE advance_pc(1) — this is the address of the current opcode.
+            // Capture pc BEFORE advance_pc() — this is the address of the current opcode.
             let pc_of_current_op = self.current_call_frame.pc;
             let opcode = self.current_call_frame.next_opcode();
-            self.advance_pc(1);
+            self.advance_pc();
 
             // Hoist the active flag to avoid reading it twice per opcode.
             let tracer_active = self.opcode_tracer.active;

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -937,7 +937,7 @@ impl<'a> VM<'a> {
     #[inline(always)]
     fn is_simple_transfer_fast_path(&self) -> bool {
         !self.current_call_frame.is_create
-            && self.current_call_frame.bytecode.bytecode.is_empty()
+            && self.current_call_frame.bytecode.is_empty()
             // Privileged L2 txs can leave gas negative; let the slow path surface that as OOG.
             && self.current_call_frame.gas_remaining >= 0
             && self.tx.authorization_list().is_none()
@@ -1015,7 +1015,7 @@ impl<'a> VM<'a> {
             // Capture pc BEFORE advance_pc(1) — this is the address of the current opcode.
             let pc_of_current_op = self.current_call_frame.pc;
             let opcode = self.current_call_frame.next_opcode();
-            self.advance_pc(1)?;
+            self.advance_pc(1);
 
             // Hoist the active flag to avoid reading it twice per opcode.
             let tracer_active = self.opcode_tracer.active;

--- a/test/tests/common/code_serde_tests.rs
+++ b/test/tests/common/code_serde_tests.rs
@@ -1,0 +1,44 @@
+use ethrex_common::types::{BYTECODE_PADDING, Code};
+use ethrex_crypto::NativeCrypto;
+
+// A PUSH32 as the last opcode forces `pc` to step `BYTECODE_PADDING - 1` bytes
+// past the real code end, so the deserialized `Code` must be re-padded or the
+// dispatch-loop reads would be OOB.
+fn sample_code() -> Code {
+    let bytecode = vec![0x7f /* PUSH32 */; 8];
+    Code::from_bytecode(bytecode.into(), &NativeCrypto)
+}
+
+#[test]
+fn code_serde_roundtrip_preserves_logical_code_and_repads() {
+    let code = sample_code();
+
+    let bytes = serde_json::to_vec(&code).expect("serialize");
+    let restored: Code = serde_json::from_slice(&bytes).expect("deserialize");
+
+    assert_eq!(restored.code(), code.code());
+    assert_eq!(restored.len(), code.len());
+    assert_eq!(restored.hash, code.hash);
+    assert_eq!(restored.jump_targets, code.jump_targets);
+    // The dispatch buffer must carry the trailing padding after a round-trip.
+    assert_eq!(restored.dispatch_buf().len(), code.len() + BYTECODE_PADDING);
+    assert_eq!(restored, code);
+}
+
+#[test]
+fn code_serde_does_not_persist_padding() {
+    // The serialized form must encode the logical code, not the padded buffer:
+    // serializing the padding would both waste space and let unpadded input
+    // through on deserialize.
+    let code = sample_code();
+    let restored: Code = serde_json::from_slice(&serde_json::to_vec(&code).unwrap()).unwrap();
+    assert_eq!(restored.dispatch_buf().len(), code.dispatch_buf().len());
+    assert_eq!(restored.code(), &[0x7f; 8]);
+}
+
+#[test]
+fn default_code_is_padded() {
+    let code = Code::default();
+    assert!(code.is_empty());
+    assert_eq!(code.dispatch_buf().len(), BYTECODE_PADDING);
+}

--- a/test/tests/common/mod.rs
+++ b/test/tests/common/mod.rs
@@ -1,6 +1,7 @@
 mod base64_tests;
 #[cfg(feature = "c-kzg")]
 mod blobs_bundle_tests;
+mod code_serde_tests;
 mod eip7702_authorization_tests;
 mod logs_bloom_validation_tests;
 mod rkyv_utils_tests;

--- a/test/tests/levm/eip7708_tests.rs
+++ b/test/tests/levm/eip7708_tests.rs
@@ -89,7 +89,7 @@ impl Database for TestDatabase {
         for acc in self.accounts.values() {
             if acc.info.code_hash == code_hash {
                 return Ok(CodeMetadata {
-                    length: acc.code.bytecode.len() as u64,
+                    length: acc.code.len() as u64,
                 });
             }
         }

--- a/test/tests/levm/l2_fee_token_ratio_tests.rs
+++ b/test/tests/levm/l2_fee_token_ratio_tests.rs
@@ -104,7 +104,7 @@ impl Database for TestDatabase {
         for acc in self.accounts.values() {
             if acc.info.code_hash == code_hash {
                 return Ok(CodeMetadata {
-                    length: acc.code.bytecode.len() as u64,
+                    length: acc.code.len() as u64,
                 });
             }
         }

--- a/test/tests/levm/l2_fee_token_tests.rs
+++ b/test/tests/levm/l2_fee_token_tests.rs
@@ -84,7 +84,7 @@ impl Database for TestDatabase {
         for acc in self.accounts.values() {
             if acc.info.code_hash == code_hash {
                 return Ok(CodeMetadata {
-                    length: acc.code.bytecode.len() as u64,
+                    length: acc.code.len() as u64,
                 });
             }
         }

--- a/test/tests/levm/test_db.rs
+++ b/test/tests/levm/test_db.rs
@@ -65,7 +65,7 @@ impl Database for TestDatabase {
         for acc in self.accounts.values() {
             if acc.info.code_hash == code_hash {
                 return Ok(CodeMetadata {
-                    length: acc.code.bytecode.len() as u64,
+                    length: acc.code.len() as u64,
                 });
             }
         }

--- a/tooling/ef_tests/state/report.rs
+++ b/tooling/ef_tests/state/report.rs
@@ -709,18 +709,18 @@ impl fmt::Display for ComparisonReport {
                         writeln!(
                             f,
                             "\t\t\t\t\tCode: {} -> {}",
-                            if base_account.code.bytecode.is_empty() {
+                            if base_account.code.is_empty() {
                                 "empty".to_string()
                             } else {
-                                hex::encode(&base_account.code.bytecode)
+                                hex::encode(base_account.code.code())
                             },
                             account_update
                                 .code
                                 .as_ref()
-                                .map(|code| if code.bytecode.is_empty() {
+                                .map(|code| if code.is_empty() {
                                     "empty".to_string()
                                 } else {
-                                    hex::encode(&code.bytecode)
+                                    hex::encode(code.code())
                                 })
                                 .expect("If code hash changed then 'code' shouldn't be None.")
                         )?;

--- a/tooling/ef_tests/state/runner/revm_db.rs
+++ b/tooling/ef_tests/state/runner/revm_db.rs
@@ -74,7 +74,7 @@ impl revm::Database for RevmDynVmDatabase {
     fn code_by_hash(&mut self, code_hash: RevmB256) -> Result<RevmBytecode, Self::Error> {
         let code =
             <dyn VmDatabase>::get_account_code(self.0.as_ref(), H256::from(code_hash.as_ref()))?;
-        Ok(RevmBytecode::new_raw(RevmBytes(code.bytecode)))
+        Ok(RevmBytecode::new_raw(RevmBytes(code.code_bytes())))
     }
 
     fn storage(&mut self, address: RevmAddress, index: RevmU256) -> Result<RevmU256, Self::Error> {
@@ -117,7 +117,7 @@ impl revm::DatabaseRef for RevmDynVmDatabase {
     fn code_by_hash_ref(&self, code_hash: RevmB256) -> Result<RevmBytecode, Self::Error> {
         let code =
             <dyn VmDatabase>::get_account_code(self.0.as_ref(), H256::from(code_hash.as_ref()))?;
-        Ok(RevmBytecode::new_raw(RevmBytes(code.bytecode)))
+        Ok(RevmBytecode::new_raw(RevmBytes(code.code_bytes())))
     }
 
     fn storage_ref(&self, address: RevmAddress, index: RevmU256) -> Result<RevmU256, Self::Error> {


### PR DESCRIPTION
Pad `Code.bytecode` with 33 zero bytes (STOP opcodes) at construction time so `next_opcode` can do an unchecked index and `advance_pc` becomes a plain `pc += n` with no `Result`. The logical length is tracked in `bytecode_len`; `dispatch_buf()` exposes the padded buffer only for the dispatch loop.

Branch removal is real (~8% fewer instructions, ~13% fewer branches on the dispatch path) but perf-neutral on cycles/wall-time since those branches were ~100% predictable. The value is hot-path simplification: no `Result` return from `next_opcode`/`advance_pc`, no pattern-match overhead per opcode.

`Code::default()` is now `[0u8; 33]` so unchecked reads on empty inner CALLs are safe.

Because the physical `bytecode.len()` now differs from the logical length, `Code.bytecode` and `bytecode_len` were made private and accessors added (`code()`, `code_bytes()`, `len()`, `is_empty()`, `dispatch_buf()`). Roughly 12 call sites across consensus-relevant paths were switched to the logical length: EIP-7702 delegation detection, CREATE gas counting, `eth_getCode`, snap-server `GetByteCodes`, BAL code-change recording/validation, witness code collection, tracing, L2 sponsored-tx parsing, and empty-code checks.