### PR TITLE
fix(l1): include block hash and number in payload execution error logs

### DIFF
--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -1260,7 +1260,7 @@ async fn try_execute_payload(
             Ok(PayloadStatus::syncing())
         }
         Err(ChainError::InvalidBlock(error)) => {
-            warn!("Error executing block: {error}");
+            warn!(%block_hash, %block_number, "Error executing block: {error}");
             context
                 .storage
                 .set_latest_valid_ancestor(block_hash, latest_valid_hash)
@@ -1271,7 +1271,7 @@ async fn try_execute_payload(
             ))
         }
         Err(ChainError::EvmError(error)) => {
-            warn!("Error executing block: {error}");
+            warn!(%block_hash, %block_number, "Error executing block: {error}");
             context
                 .storage
                 .set_latest_valid_ancestor(block_hash, latest_valid_hash)
@@ -1282,7 +1282,7 @@ async fn try_execute_payload(
             ))
         }
         Err(ChainError::StoreError(error)) => {
-            warn!("Error storing block: {error}");
+            warn!(%block_hash, %block_number, "Error storing block: {error}");
             Err(RpcErr::Internal(error.to_string()))
         }
         Err(e) => {


### PR DESCRIPTION
## Motivation

When a payload fails execution, the log line only printed the error:

```
WARN Error executing block: BAL validation failed for tx 82: account 0x... balance mismatch ...
```

There was no way to tie this to a specific block. Rejected blocks never get a `[METRIC] BLOCK <n> <hash>` line (those only print for successfully executed blocks), so the failing block's hash/number had to be reconstructed by correlating timestamps against debug logs.

## Description

`block_hash` and `block_number` were already in scope (the surrounding `debug!` calls use them); they were just missing from the `warn!` lines. Added them to the `InvalidBlock`, `EvmError`, and `StoreError` arms in `handle_new_payload`'s `add_block` match.

Log line now carries the block identity:

```
WARN Error executing block: BAL validation failed for tx 82: ... block_hash=0x... block_number=51957
```
