### PR TITLE
perf(l1): batch BAL storage-slot prefetch via sorted rocksdb multi_get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Perf
 
+### 2026-06-15
+
+- Batch BAL storage-slot prefetch via a single sorted rocksdb `multi_get_cf` on the storage flat key-value table
+
 ### 2026-06-03
 
 - Short-circuit the `KECCAK256` opcode on zero-length input by returning the precomputed `keccak256("")` constant, skipping the permutation [#6775](https://github.com/lambdaclass/ethrex/pull/6775)

--- a/crates/blockchain/vm.rs
+++ b/crates/blockchain/vm.rs
@@ -210,6 +210,59 @@ impl VmDatabase for StoreVmDatabase {
 
     #[instrument(
         level = "trace",
+        name = "Storage read batch",
+        skip_all,
+        fields(namespace = "block_execution", n = keys.len())
+    )]
+    fn get_storage_slots_batch(
+        &self,
+        keys: &[(Address, H256)],
+    ) -> Result<Vec<Option<U256>>, EvmError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Resolve the account state (hashed address + storage root) for each
+        // distinct address. This mirrors the per-slot `get_storage_slot` path,
+        // which opens the storage trie from the cached account entry. Slots for
+        // a non-existent account resolve to `None`, exactly as the single-get
+        // path returns `None` when the account entry is missing.
+        let mut entries: FxHashMap<Address, Option<AccountStateCacheEntry>> = FxHashMap::default();
+        for &(addr, _) in keys {
+            if let std::collections::hash_map::Entry::Vacant(slot) = entries.entry(addr) {
+                slot.insert(self.get_cached_account_state_entry(addr)?);
+            }
+        }
+
+        // Build the store-batch input for slots whose account exists, remembering
+        // the original index so results can be scattered back in input order.
+        let mut results: Vec<Option<U256>> = vec![None; keys.len()];
+        let mut batch_idx: Vec<usize> = Vec::with_capacity(keys.len());
+        let mut batch: Vec<(H256, H256, H256)> = Vec::with_capacity(keys.len());
+        for (i, &(addr, key)) in keys.iter().enumerate() {
+            if let Some(Some(entry)) = entries.get(&addr) {
+                batch_idx.push(i);
+                batch.push((entry.hashed_address, entry.state.storage_root, key));
+            }
+        }
+
+        if batch.is_empty() {
+            return Ok(results);
+        }
+
+        let fetched = self
+            .store
+            .get_storage_values_batch_by_root(self.state_root, &batch)
+            .map_err(|e| EvmError::DB(e.to_string()))?;
+        for (i, value) in batch_idx.into_iter().zip(fetched.into_iter()) {
+            results[i] = value;
+        }
+
+        Ok(results)
+    }
+
+    #[instrument(
+        level = "trace",
         name = "Block hash read",
         skip_all,
         fields(namespace = "block_execution")

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2771,6 +2771,131 @@ impl Store {
         Ok(results)
     }
 
+    /// Batch lookup of storage slot values against a given state root.
+    ///
+    /// Each input tuple is `(account_hash, storage_root, slot)` where
+    /// `account_hash` is the keccak hash of the account address and `slot` is
+    /// the raw (un-hashed) storage key, matching the inputs available to
+    /// [`Self::get_storage_at_root_with_known_storage_root`].
+    ///
+    /// Fast path: for slots whose prefixed FKV leaf path falls within the FKV
+    /// cursor (and which are not present in the in-memory diff-layer cache),
+    /// values are fetched in a single `multi_get` on `STORAGE_FLATKEYVALUE`.
+    /// The batch is sorted by the prefixed FKV key (hashed order) before the
+    /// `multi_get` so that adjacent slots share RocksDB data blocks, removing
+    /// the random-order read amplification of per-slot lookups. Slots not yet
+    /// swept by the FKV generator fall back to per-slot trie walks via
+    /// [`Self::get_storage_at_root_with_known_storage_root`], which preserves the
+    /// exact FKV / trie / diff-cache ordering of the single-slot path.
+    ///
+    /// Results are returned in the same order as the input slots. A missing slot
+    /// (deleted or never written) yields `None`, identical to the single-get path.
+    pub fn get_storage_values_batch_by_root(
+        &self,
+        state_root: H256,
+        slots: &[(H256, H256, H256)],
+    ) -> Result<Vec<Option<U256>>, StoreError> {
+        if slots.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let last_written = self.last_written()?;
+        let trie_cache = self
+            .trie_cache
+            .read()
+            .map_err(|_| StoreError::LockError)?
+            .clone();
+
+        let mut results: Vec<Option<U256>> = vec![None; slots.len()];
+        // Per-slot prefixed FKV leaf paths: account_hash nibbles + separator
+        // (17) + hashed-slot nibbles + leaf flag. Length 131. This is the exact
+        // key `BackendTrieDB::flatkeyvalue_computed` / `Trie::get` use for a
+        // storage leaf (see `apply_prefix`).
+        let leaf_paths: Vec<Vec<u8>> = slots
+            .iter()
+            .map(|(account_hash, _storage_root, slot)| {
+                let hashed_slot = hash_key_fixed(slot);
+                apply_prefix(Some(*account_hash), Nibbles::from_bytes(&hashed_slot)).into_vec()
+            })
+            .collect();
+
+        let mut fkv_indices: Vec<usize> = Vec::new();
+        let mut trie_indices: Vec<usize> = Vec::new();
+
+        // Same watermark check as the account batch and `BackendTrieDB`: a path
+        // is covered by FKV iff `last_written >= prefixed_path` compared as raw
+        // nibble bytes. `Nibbles` orders by its inner `data` vec, so the raw
+        // slice comparison is byte-identical to the `Nibbles >= Nibbles` check
+        // in `BackendTrieDB::flatkeyvalue_computed`.
+        let fkv_cursor: &[u8] = last_written.as_slice();
+        for (i, path) in leaf_paths.iter().enumerate() {
+            // Diff-layer cache holds the authoritative latest value for this
+            // key at this state root, overriding both FKV and trie. Mirror the
+            // cache-first semantics of `TrieWrapper::get` / the account batch:
+            // an empty cached value means the slot was deleted -> None.
+            if let Some(value) = trie_cache.get(state_root, path.as_slice()) {
+                if !value.is_empty() {
+                    results[i] = Some(U256::decode(&value).map_err(StoreError::RLPDecode)?);
+                }
+                continue;
+            }
+            if fkv_cursor >= path.as_slice() {
+                fkv_indices.push(i);
+            } else {
+                trie_indices.push(i);
+            }
+        }
+
+        if !fkv_indices.is_empty() {
+            // Sort the FKV batch by the prefixed (hashed-order) key so adjacent
+            // slots land in the same 4KB RocksDB data blocks. This is the whole
+            // point of the batch: it removes the random-order amplification of
+            // issuing one point lookup per slot in execution order.
+            fkv_indices.sort_unstable_by(|&a, &b| leaf_paths[a].cmp(&leaf_paths[b]));
+            let read_view = self.backend.begin_read()?;
+            let keys: Vec<&[u8]> = fkv_indices
+                .iter()
+                .map(|&i| leaf_paths[i].as_slice())
+                .collect();
+            let raw = read_view.multi_get(STORAGE_FLATKEYVALUE, &keys);
+            for (slot_idx, res) in fkv_indices.iter().zip(raw.into_iter()) {
+                let Some(encoded) = res? else { continue };
+                if encoded.is_empty() {
+                    continue;
+                }
+                results[*slot_idx] = Some(U256::decode(&encoded).map_err(StoreError::RLPDecode)?);
+            }
+        }
+
+        if !trie_indices.is_empty() {
+            // Fall back to the regular single-slot path for any slot whose path
+            // hasn't been swept by the FKV generator yet. Reusing
+            // `get_storage_at_root_with_known_storage_root` guarantees the
+            // trie-walk fallback is byte-identical to the unbatched read,
+            // including its own per-slot FKV / EMPTY_TRIE_HASH handling.
+            // Parallelized to recover the per-slot fan-out the pre-batch
+            // `par_iter` prefetch path had.
+            let fetched: Result<Vec<(usize, Option<U256>)>, StoreError> = trie_indices
+                .par_iter()
+                .map(|&i| {
+                    let (account_hash, storage_root, slot) = slots[i];
+                    self.get_storage_at_root_with_known_storage_root(
+                        state_root,
+                        account_hash,
+                        storage_root,
+                        slot,
+                    )
+                    .map(|v| (i, v))
+                })
+                .collect();
+            for (i, v) in fetched? {
+                results[i] = v;
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Constructs a merkle proof for the given account address against a given state.
     /// If storage_keys are provided, also constructs the storage proofs for those keys.
     ///

--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -117,6 +117,18 @@ impl LevmDatabase for DynVmDatabase {
         )
     }
 
+    fn get_storage_values_batch(
+        &self,
+        keys: &[(CoreAddress, CoreH256)],
+    ) -> Result<Vec<CoreU256>, DatabaseError> {
+        let values = <dyn VmDatabase>::get_storage_slots_batch(self.as_ref(), keys)
+            .map_err(|e| DatabaseError::Custom(e.to_string()))?;
+        Ok(values
+            .into_iter()
+            .map(|opt| opt.unwrap_or_default())
+            .collect())
+    }
+
     fn get_block_hash(&self, block_number: u64) -> Result<CoreH256, DatabaseError> {
         <dyn VmDatabase>::get_block_hash(self.as_ref(), block_number)
             .map_err(|e| DatabaseError::Custom(e.to_string()))

--- a/crates/vm/db.rs
+++ b/crates/vm/db.rs
@@ -25,6 +25,18 @@ pub trait VmDatabase: Send + Sync + DynClone {
             .map(|a| self.get_account_state(*a))
             .collect()
     }
+
+    /// Batch storage-slot lookup. Default impl loops `get_storage_slot`.
+    /// Backends that can amortize per-key cost (e.g. rocksdb `multi_get_cf` on
+    /// the flat key-value table) should override this.
+    fn get_storage_slots_batch(
+        &self,
+        keys: &[(Address, H256)],
+    ) -> Result<Vec<Option<U256>>, EvmError> {
+        keys.iter()
+            .map(|&(addr, key)| self.get_storage_slot(addr, key))
+            .collect()
+    }
 }
 
 dyn_clone::clone_trait_object!(VmDatabase);

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -3,8 +3,6 @@ use ethrex_common::{
     Address, H256, U256,
     types::{AccountState, ChainConfig, Code, CodeMetadata},
 };
-#[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 use std::sync::{Arc, OnceLock, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -36,6 +34,17 @@ pub trait Database: Send + Sync {
         addresses
             .iter()
             .map(|a| self.get_account_state(*a))
+            .collect()
+    }
+    /// Batch storage-slot lookup. Default: loop. Backends with a batched read
+    /// path (e.g. rocksdb `multi_get_cf` on the storage flat key-value table)
+    /// should override this and the caching layer above will dispatch to it.
+    fn get_storage_values_batch(
+        &self,
+        keys: &[(Address, H256)],
+    ) -> Result<Vec<U256>, DatabaseError> {
+        keys.iter()
+            .map(|&(addr, key)| self.get_storage_value(addr, key))
             .collect()
     }
     /// Prefetch a batch of accounts into the cache. Default: sequential fallback.
@@ -216,19 +225,24 @@ impl Database for CachingDatabase {
         Ok(())
     }
 
-    #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
     fn prefetch_storage(&self, keys: &[(Address, H256)]) -> Result<(), DatabaseError> {
-        // Fetch from inner in parallel (no lock contention), then single write-lock to populate cache.
-        let fetched: Vec<((Address, H256), U256)> = keys
-            .par_iter()
-            .map(|&(addr, key)| {
-                self.inner
-                    .get_storage_value(addr, key)
-                    .map(|v| ((addr, key), v))
-            })
-            .collect::<Result<_, _>>()?;
+        // Filter out already-cached slots before issuing the batch read.
+        let missing: Vec<(Address, H256)> = {
+            let cache = self.read_storage()?;
+            keys.iter()
+                .copied()
+                .filter(|k| !cache.contains_key(k))
+                .collect()
+        };
+        if missing.is_empty() {
+            return Ok(());
+        }
+        // Dispatch to inner's batch path. For the rocksdb-backed StoreVmDatabase
+        // this collapses into a single sorted multi_get on STORAGE_FLATKEYVALUE
+        // for the FKV-covered subset; default impl loops for other backends.
+        let values = self.inner.get_storage_values_batch(&missing)?;
         let mut cache = self.write_storage()?;
-        for (key, value) in fetched {
+        for (key, value) in missing.into_iter().zip(values.into_iter()) {
             cache.entry(key).or_insert(value);
         }
         Ok(())

--- a/test/tests/storage/mod.rs
+++ b/test/tests/storage/mod.rs
@@ -1,3 +1,4 @@
 mod fcu_race_tests;
+mod storage_batch_tests;
 mod store_tests;
 mod trie_db_tests;

--- a/test/tests/storage/storage_batch_tests.rs
+++ b/test/tests/storage/storage_batch_tests.rs
@@ -1,0 +1,187 @@
+//! Correctness parity between the batched storage-slot lookup
+//! (`Store::get_storage_values_batch_by_root`) used by the BAL prefetch and the
+//! per-slot single-get path (`Store::get_storage_at_root_with_known_storage_root`)
+//! the executor reads through.
+//!
+//! The prefetch warms a cache that execution trusts, so the batched path must
+//! return byte-identical key->value mappings (including "missing slot" -> None)
+//! as the single-slot path, across both the FKV-swept and FKV-unswept states.
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use ethrex_common::{
+    Address, H256, U256,
+    types::{Genesis, GenesisAccount},
+};
+use ethrex_storage::{EngineType, Store, hash_address};
+
+/// Number of populated storage slots on the seeded contract.
+const POPULATED_SLOTS: u64 = 256;
+
+fn account_hash(address: &Address) -> H256 {
+    H256::from_slice(&hash_address(address))
+}
+
+/// Slots to query: all populated slots, interleaved with absent slots so the
+/// parity check covers the `None` (never-written) case too.
+fn query_slots() -> Vec<H256> {
+    let mut slots = Vec::new();
+    for i in 0..POPULATED_SLOTS {
+        slots.push(H256::from_low_u64_be(i));
+        // An absent slot in the high range: never written at genesis.
+        slots.push(H256::from_low_u64_be(1_000_000 + i));
+    }
+    slots
+}
+
+/// Build a genesis with a single contract account holding `POPULATED_SLOTS`
+/// non-zero storage slots.
+fn seed_genesis(contract: Address) -> Genesis {
+    const GENESIS_EXECUTION_API: &str =
+        include_str!("../../../fixtures/genesis/execution-api.json");
+    let mut genesis: Genesis =
+        serde_json::from_str(GENESIS_EXECUTION_API).expect("deserialize execution-api genesis");
+
+    let mut storage: BTreeMap<U256, U256> = BTreeMap::new();
+    for i in 0..POPULATED_SLOTS {
+        // Non-zero value (genesis drops zero-valued slots). Use a value distinct
+        // from the slot index to catch any key/value swap.
+        storage.insert(U256::from(i), U256::from(i) + U256::from(7));
+    }
+
+    genesis.alloc.insert(
+        contract,
+        GenesisAccount {
+            balance: U256::zero(),
+            code: Bytes::from_static(&[0x60, 0x00]),
+            storage,
+            nonce: 1,
+        },
+    );
+    genesis
+}
+
+/// Assert the batched helper matches the per-slot single-get path exactly.
+fn assert_parity(store: &Store, state_root: H256, contract: Address) {
+    let acct = store
+        .get_account_state_by_root(state_root, contract)
+        .expect("account lookup")
+        .expect("contract account present");
+    let acct_hash = account_hash(&contract);
+    let storage_root = acct.storage_root;
+
+    let slots = query_slots();
+
+    // Reference: per-slot single-get path the executor actually reads through.
+    let single: Vec<Option<U256>> = slots
+        .iter()
+        .map(|slot| {
+            store
+                .get_storage_at_root_with_known_storage_root(
+                    state_root,
+                    acct_hash,
+                    storage_root,
+                    *slot,
+                )
+                .expect("single-get storage")
+        })
+        .collect();
+
+    // Batched path under test. Pass slots in a non-sorted order to exercise the
+    // internal sort.
+    let batch_input: Vec<(H256, H256, H256)> = slots
+        .iter()
+        .map(|slot| (acct_hash, storage_root, *slot))
+        .collect();
+    let batched = store
+        .get_storage_values_batch_by_root(state_root, &batch_input)
+        .expect("batched storage");
+
+    assert_eq!(
+        batched.len(),
+        single.len(),
+        "batched result length must match single-get length"
+    );
+    for (i, slot) in slots.iter().enumerate() {
+        assert_eq!(
+            batched[i], single[i],
+            "slot {slot:?} (index {i}) value mismatch: batched={:?} single={:?}",
+            batched[i], single[i]
+        );
+    }
+
+    // Sanity: at least one populated slot returned a value and at least one
+    // absent slot returned None, so we know both branches were exercised.
+    assert!(
+        batched.iter().any(|v| matches!(v, Some(v) if !v.is_zero())),
+        "expected at least one populated slot value"
+    );
+    assert!(
+        batched.iter().any(|v| v.is_none()),
+        "expected at least one absent slot to be None"
+    );
+}
+
+/// Drive FKV generation to completion and wait until the cursor covers every
+/// key (the generator writes `vec![0xff; 131]` on completion).
+fn wait_for_full_fkv(store: &Store) {
+    store
+        .generate_flatkeyvalue()
+        .expect("trigger FKV generation");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let last_written = store.last_written().expect("read FKV cursor");
+        // Completion marker: a 131-byte all-0xff cursor that is >= any real key.
+        if last_written.len() == 131 && last_written.iter().all(|b| *b == 0xff) {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("FKV generation did not finish within timeout (cursor={last_written:?})");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+async fn run_parity_test(engine_type: EngineType) {
+    let nonce: u64 = H256::random().to_low_u64_be();
+    let path = format!("storage-batch-test-db-{nonce}");
+    if !matches!(engine_type, EngineType::InMemory) && std::path::Path::new(&path).exists() {
+        std::fs::remove_dir_all(&path).expect("clean test db dir");
+    }
+
+    let contract = Address::from_low_u64_be(0xC0FFEE);
+    let mut store = Store::new(&path, engine_type).expect("create test store");
+    let genesis = seed_genesis(contract);
+    let state_root = genesis.get_block().header.state_root;
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("add genesis state");
+
+    // State A: FKV not yet generated -> the batched helper takes the per-slot
+    // trie-walk fallback for every slot. Must match single-get exactly.
+    assert_parity(&store, state_root, contract);
+
+    // State B: FKV fully swept -> the batched helper takes the sorted multi_get
+    // fast path for every slot. Must still match single-get exactly.
+    wait_for_full_fkv(&store);
+    assert_parity(&store, state_root, contract);
+
+    drop(store);
+    if !matches!(engine_type, EngineType::InMemory) && std::path::Path::new(&path).exists() {
+        std::fs::remove_dir_all(&path).expect("clean test db dir");
+    }
+}
+
+#[tokio::test]
+async fn storage_batch_parity_in_memory() {
+    run_parity_test(EngineType::InMemory).await;
+}
+
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn storage_batch_parity_rocksdb() {
+    run_parity_test(EngineType::RocksDB).await;
+}


### PR DESCRIPTION
Stacked on #6712. Merge after (or rebase to main once #6712 lands).

`CachingDatabase::prefetch_storage` issued one rocksdb point-get per BAL storage slot in raw (execution) order. The storage flat-KV CF is keyed by `keccak(slot)`, so raw order is random in the keyspace -- a bloated read-heavy block scatters ~N point-gets across N distinct 4KB blocks, plus per-get index/filter overhead. This is the storage-slot companion to #6712, which did the same for account-state; it leaves `prefetch_storage` as the last unbatched prefetch path.

`Store::get_storage_values_batch_by_root` mirrors `get_account_states_batch_by_root`: diff-layer cache is checked first per slot, FKV-covered slots are sorted by their prefixed hashed key and read via a single `multi_get` on `STORAGE_FLATKEYVALUE`, unswept slots fall back to per-slot trie walks via the existing `get_storage_at_root_with_known_storage_root`. `prefetch_storage` in `CachingDatabase` now dispatches to `inner.get_storage_values_batch`, which `StoreVmDatabase` overrides in `blockchain/vm.rs`. Trait plumbing added through `VmDatabase`, `StoreVmDatabase`, and `DynVmDatabase` following the same pattern as #6712.

Measured on a micro-bench (20K-slot bloated account, cold cache): raw-order point-gets did ~15,018 distinct 4KB block reads vs ~435 for sorted batch (~30x fewer); wall time ~384ms -> ~138ms.

`storage_batch_parity_{in_memory,rocksdb}` in `test/tests/storage/storage_batch_tests.rs` assert the batched path returns byte-identical results to the single-get path in both the pre-FKV (trie fallback) and post-FKV (sorted multi_get fast path) states. EF engine gate all-pass: blockchain `make test` 8726+2864 passed / 0 failed; state `make test-levm` 62979 passed / 0 failed.