### PR TITLE
perf(l1): BAL-driven trie-node prefetch to warm merkle reads

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -607,6 +607,8 @@ impl Blockchain {
         // Gated by `--no-bal-prefetch`: when the operator disables BAL-driven
         // prefetching, skip the synchronous storage warm too. The warmer thread
         // below already honors the same toggle.
+        // Flat-KV warm for execution (SLOAD and SSTORE original values). Uses the
+        // full BAL access set, since execution genuinely reads every accessed slot.
         #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
         if self.options.bal_prefetch_enabled
             && let Some(bal) = bal
@@ -615,33 +617,38 @@ impl Blockchain {
             if !slots.is_empty() {
                 let _ = caching_store.prefetch_storage(&slots);
             }
+        }
 
-            // Warm the MPT internal nodes the merkleizer will walk, from the same
-            // BAL working set (different CFs than the flat-KV warm above, which
-            // only serves execution). The merkle phase is otherwise 100% cold on
-            // the trie-node CFs. Synchronous + up front: never races the
-            // merkleizer, and touches CFs execution doesn't, so no exec contention
-            // either.
-            //
-            // Gated so ordinary merkle-light blocks (few touched slots/accounts,
-            // usually cache-warm) don't pay the probe cost. The payoff is on
-            // high-gas-limit blocks that touch a large number of distinct storage
-            // slots and/or accounts, for example many SSTOREs and value-transferring
-            // CALLs over cold state, where the merkle phase has to walk a large set
-            // of scattered, cold trie nodes. Sizing: a cold slot/account access costs
-            // ~2100 gas, so a block reaches at most ~gas_limit/2100 distinct
-            // accesses; 16384 (~34M gas of cold accesses) sits well above any
-            // ordinary block yet below the large-state blocks this targets, so it
-            // stays inert on normal traffic and fires only once merkle goes
-            // cold-read-bound. Scale with the gas limit. Tunable.
-            //
-            // SLOAD-dominated blocks are handled by the flat-KV warm above (reads
-            // don't touch the trie); this is the complementary write/account-update
-            // side, so the two cover different workloads without overlapping.
+        // Warm the MPT internal nodes the merkleizer will walk (the trie-node CFs,
+        // which execution never reads). Derived from the MERKLE WRITE SET, not the
+        // access set: the merkleizer only walks accounts/slots that actually change,
+        // and `optimistic_updates` (synthesize_bal_updates) already drops read-only
+        // accesses and read-only slots. Warming trie nodes for read-only accesses is
+        // wasted cold reads that compete with execution for the same device; gating
+        // on the access set regressed read-heavy blocks (value-0 CALLs to existing
+        // accounts, bloated SLOADs) that have little or no merkle work.
+        //
+        // Gated so ordinary merkle-light blocks skip the probe cost; the payoff is on
+        // blocks that WRITE many distinct slots or modify many accounts, where merkle
+        // walks a large set of scattered, cold nodes. A cold node access costs on the
+        // order of ~2100+ gas, so 16384 sits above ordinary blocks and below the
+        // large-state blocks this targets. Tunable.
+        #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+        if self.options.bal_prefetch_enabled
+            && let Some(updates) = optimistic_updates.as_ref()
+        {
             const MERKLE_PREFETCH_THRESHOLD: usize = 16_384;
-            let accounts = LEVM::bal_accounts(bal);
-            if slots.len() + accounts.len() >= MERKLE_PREFETCH_THRESHOLD {
-                let _ = self.storage.prefetch_trie_nodes(&slots, &accounts);
+            let mut write_slots: Vec<(Address, H256)> = Vec::new();
+            for (addr, item) in updates {
+                for slot in item.added_storage.keys() {
+                    write_slots.push((*addr, *slot));
+                }
+            }
+            let write_accounts: Vec<Address> = updates.keys().copied().collect();
+            if write_slots.len() + write_accounts.len() >= MERKLE_PREFETCH_THRESHOLD {
+                let _ = self
+                    .storage
+                    .prefetch_trie_nodes(&write_slots, &write_accounts);
             }
         }
 

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -615,6 +615,34 @@ impl Blockchain {
             if !slots.is_empty() {
                 let _ = caching_store.prefetch_storage(&slots);
             }
+
+            // Warm the MPT internal nodes the merkleizer will walk, from the same
+            // BAL working set (different CFs than the flat-KV warm above, which
+            // only serves execution). The merkle phase is otherwise 100% cold on
+            // the trie-node CFs. Synchronous + up front: never races the
+            // merkleizer, and touches CFs execution doesn't, so no exec contention
+            // either.
+            //
+            // Gated so ordinary merkle-light blocks (few touched slots/accounts,
+            // usually cache-warm) don't pay the probe cost. The payoff is on
+            // high-gas-limit blocks that touch a large number of distinct storage
+            // slots and/or accounts, for example many SSTOREs and value-transferring
+            // CALLs over cold state, where the merkle phase has to walk a large set
+            // of scattered, cold trie nodes. Sizing: a cold slot/account access costs
+            // ~2100 gas, so a block reaches at most ~gas_limit/2100 distinct
+            // accesses; 16384 (~34M gas of cold accesses) sits well above any
+            // ordinary block yet below the large-state blocks this targets, so it
+            // stays inert on normal traffic and fires only once merkle goes
+            // cold-read-bound. Scale with the gas limit. Tunable.
+            //
+            // SLOAD-dominated blocks are handled by the flat-KV warm above (reads
+            // don't touch the trie); this is the complementary write/account-update
+            // side, so the two cover different workloads without overlapping.
+            const MERKLE_PREFETCH_THRESHOLD: usize = 16_384;
+            let accounts = LEVM::bal_accounts(bal);
+            if slots.len() + accounts.len() >= MERKLE_PREFETCH_THRESHOLD {
+                let _ = self.storage.prefetch_trie_nodes(&slots, &accounts);
+            }
         }
 
         let (execution_result, merkleization_result, warmer_duration) =

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2926,6 +2926,121 @@ impl Store {
         Ok(results)
     }
 
+    /// Best-effort warming of the MPT *internal* nodes the merkleizer will walk,
+    /// driven entirely by the BAL working set. The merkle phase reads trie nodes
+    /// from `STORAGE_TRIE_NODES` / `ACCOUNT_TRIE_NODES` (see `BackendTrieDB::get`)
+    /// by nibble path; the existing flat-KV prefetch warms only the leaf-value
+    /// CFs that *execution* reads, so every merkle-walk node read is otherwise
+    /// cold. This pulls those node blocks into the page/block cache up front so
+    /// the subsequent walk runs warm.
+    ///
+    /// The keys are not discovered by walking (a walk is QD1 and serial): the
+    /// internal nodes on the path to a leaf are all at *prefixes* of that leaf's
+    /// nibble path, so for every BAL leaf we speculatively probe every prefix up
+    /// to `MAX_PREFETCH_DEPTH`. Prefixes that are not real nodes are rejected by
+    /// the CF bloom filter in RAM (no disk read; measured ~free), and the shallow
+    /// prefixes collapse on dedup. This turns the cold merkle node reads into one
+    /// sorted, sharded, high-queue-depth `multi_get` per CF — the same lever that
+    /// fixed the flat-KV `sload` path, applied to the trie-node CFs.
+    ///
+    /// Results are discarded. Missing a node (e.g. one deeper than the probe
+    /// band) is harmless: the merkleizer just cold-reads it. Run this
+    /// synchronously up front (mirroring the flat-KV prefetch) so it never races
+    /// the merkleizer; it touches different CFs than execution, so it does not
+    /// contend with the executor either.
+    /// Returns the number of probed keys that hit a real stored node (warmed).
+    /// On the warm/no-op path this still reports coverage; a near-zero hit count
+    /// against a non-empty working set signals a key-encoding mismatch (the
+    /// effectiveness test asserts on this).
+    pub fn prefetch_trie_nodes(
+        &self,
+        storage_slots: &[(Address, H256)],
+        accounts: &[Address],
+    ) -> Result<usize, StoreError> {
+        // Probe band: nodes live at depth <= ~ceil(log16(trie_size)). 8 nibbles
+        // covers tries up to ~16^8 entries near-fully; any deeper node is simply
+        // cold-read by the walk, so under-covering only loses a little warming,
+        // never correctness. Tunable.
+        const MAX_PREFETCH_DEPTH: usize = 8;
+
+        // STORAGE_TRIE_NODES: prefixes of apply_prefix(hashed_addr, hashed_slot).
+        let mut storage_keys: Vec<Vec<u8>> = Vec::with_capacity(storage_slots.len() * 4);
+        for (address, slot) in storage_slots {
+            let hashed_address = hash_address_fixed(address);
+            let hashed_slot = hash_key_fixed(slot);
+            let slot_nibbles = Nibbles::from_bytes(&hashed_slot);
+            let max_d = MAX_PREFETCH_DEPTH.min(slot_nibbles.len());
+            for d in 0..=max_d {
+                let prefix = apply_prefix(Some(hashed_address), slot_nibbles.slice(0, d));
+                storage_keys.push(prefix.into_vec());
+            }
+        }
+
+        // ACCOUNT_TRIE_NODES: prefixes of the hashed address (no account prefix).
+        let mut account_keys: Vec<Vec<u8>> = Vec::with_capacity(accounts.len() * 4);
+        for address in accounts {
+            let hashed_address = hash_address_fixed(address);
+            let addr_nibbles = Nibbles::from_bytes(hashed_address.as_bytes());
+            let max_d = MAX_PREFETCH_DEPTH.min(addr_nibbles.len());
+            for d in 0..=max_d {
+                account_keys.push(addr_nibbles.slice(0, d).into_vec());
+            }
+        }
+
+        let hits = self.warm_trie_node_keys(STORAGE_TRIE_NODES, storage_keys)?
+            + self.warm_trie_node_keys(ACCOUNT_TRIE_NODES, account_keys)?;
+        Ok(hits)
+    }
+
+    /// Sorted, sharded, high-queue-depth `multi_get` over `keys` in `table`,
+    /// discarding results. Sorting makes adjacent keys share RocksDB data blocks;
+    /// sharding across blocking threads issues the reads at queue depth ~= shard
+    /// count (async_io is off, so a single multi_get runs at QD1). Mirrors the
+    /// storage flat-KV batch path. Dedups first so shared shallow prefixes are
+    /// read once.
+    fn warm_trie_node_keys(
+        &self,
+        table: &'static str,
+        mut keys: Vec<Vec<u8>>,
+    ) -> Result<usize, StoreError> {
+        if keys.is_empty() {
+            return Ok(0);
+        }
+        keys.sort_unstable();
+        keys.dedup();
+
+        const KEYS_PER_SHARD: usize = 256;
+        const MAX_SHARDS: usize = 64;
+        let shards = keys.len().div_ceil(KEYS_PER_SHARD).clamp(1, MAX_SHARDS);
+        let read_view = self.backend.begin_read()?;
+        let count_hits = |res: Vec<Result<Option<Vec<u8>>, StoreError>>| {
+            res.into_iter().filter(|r| matches!(r, Ok(Some(_)))).count()
+        };
+        if shards <= 1 {
+            let refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
+            return Ok(count_hits(read_view.multi_get(table, &refs)));
+        }
+        let chunk = keys.len().div_ceil(shards);
+        let rv = read_view.as_ref();
+        let hits = std::thread::scope(|scope| {
+            let handles: Vec<_> = keys
+                .chunks(chunk)
+                .map(|ck| {
+                    scope.spawn(move || {
+                        let refs: Vec<&[u8]> = ck.iter().map(|k| k.as_slice()).collect();
+                        // Warm-only: keep cache population, just tally the hits.
+                        count_hits(rv.multi_get(table, &refs))
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| h.join().expect("trie-node prefetch shard panicked"))
+                .sum::<usize>()
+        });
+        Ok(hits)
+    }
+
     /// Constructs a merkle proof for the given account address against a given state.
     /// If storage_keys are provided, also constructs the storage proofs for those keys.
     ///

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -3035,7 +3035,11 @@ impl Store {
                 .collect();
             handles
                 .into_iter()
-                .map(|h| h.join().expect("trie-node prefetch shard panicked"))
+                // Best-effort warming: a panicked shard contributes 0 hits rather
+                // than re-panicking. The caller treats this prefetch as best-effort
+                // (missing nodes are just cold-read by the walk), so a shard hiccup
+                // must not unwind block processing.
+                .map(|h| h.join().unwrap_or(0))
                 .sum::<usize>()
         });
         Ok(hits)

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2964,7 +2964,9 @@ impl Store {
         const MAX_PREFETCH_DEPTH: usize = 8;
 
         // STORAGE_TRIE_NODES: prefixes of apply_prefix(hashed_addr, hashed_slot).
-        let mut storage_keys: Vec<Vec<u8>> = Vec::with_capacity(storage_slots.len() * 4);
+        // Each input pushes MAX_PREFETCH_DEPTH+1 prefixes (depths 0..=max_d).
+        let mut storage_keys: Vec<Vec<u8>> =
+            Vec::with_capacity(storage_slots.len() * (MAX_PREFETCH_DEPTH + 1));
         for (address, slot) in storage_slots {
             let hashed_address = hash_address_fixed(address);
             let hashed_slot = hash_key_fixed(slot);
@@ -2977,7 +2979,8 @@ impl Store {
         }
 
         // ACCOUNT_TRIE_NODES: prefixes of the hashed address (no account prefix).
-        let mut account_keys: Vec<Vec<u8>> = Vec::with_capacity(accounts.len() * 4);
+        let mut account_keys: Vec<Vec<u8>> =
+            Vec::with_capacity(accounts.len() * (MAX_PREFETCH_DEPTH + 1));
         for address in accounts {
             let hashed_address = hash_address_fixed(address);
             let addr_nibbles = Nibbles::from_bytes(hashed_address.as_bytes());

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2137,6 +2137,14 @@ impl LEVM {
             .collect()
     }
 
+    /// Every account address touched in the BAL. Drives the account-trie
+    /// (state-trie) node prefetch — including balance/nonce-only accounts with
+    /// no storage slots (the CALL/BALANCE-family blocks), which
+    /// `bal_storage_slots` does not surface.
+    pub fn bal_accounts(bal: &BlockAccessList) -> Vec<Address> {
+        bal.accounts().iter().map(|ac| ac.address).collect()
+    }
+
     /// Concurrent block warmer for the BAL path: prefetches account states and
     /// contract code while execution runs.
     ///

--- a/test/tests/storage/storage_batch_tests.rs
+++ b/test/tests/storage/storage_batch_tests.rs
@@ -179,6 +179,65 @@ async fn run_parity_test(engine_type: EngineType) {
     }
 }
 
+/// Effectiveness of the BAL-driven trie-node prefetch (`prefetch_trie_nodes`):
+/// the speculative prefix probes must actually hit the real stored internal
+/// nodes. A key-encoding mismatch (wrong nibble order, stray leaf flag, wrong
+/// `apply_prefix` wrapping) would turn every probe into a bloom miss and warm
+/// nothing, so we assert it hits a substantial node set for a storage-heavy
+/// account plus its state-trie path. The slot keys used here match the genesis
+/// seeding (`H256::from_low_u64_be(i)` == `U256::from(i)` big-endian).
+async fn run_prefetch_effectiveness_test(engine_type: EngineType) {
+    let nonce: u64 = H256::random().to_low_u64_be();
+    let path = format!("trie-prefetch-test-db-{nonce}");
+    if !matches!(engine_type, EngineType::InMemory) && std::path::Path::new(&path).exists() {
+        std::fs::remove_dir_all(&path).expect("clean test db dir");
+    }
+
+    let contract = Address::from_low_u64_be(0xC0FFEE);
+    let mut store = Store::new(&path, engine_type).expect("create test store");
+    let genesis = seed_genesis(contract);
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("add genesis state");
+
+    let slots: Vec<(Address, H256)> = (0..POPULATED_SLOTS)
+        .map(|i| (contract, H256::from_low_u64_be(i)))
+        .collect();
+    let accounts = vec![contract];
+
+    let hits = store
+        .prefetch_trie_nodes(&slots, &accounts)
+        .expect("prefetch trie nodes");
+
+    // A correct encoding warms the storage trie's branch nodes (hundreds for
+    // 2048 random-hashed slots) plus the contract's state-trie path. A broken
+    // encoding hits at most the two root nodes (depth 0). 64 cleanly separates
+    // the two outcomes.
+    assert!(
+        hits >= 64,
+        "trie-node prefetch hit only {hits} real nodes for {POPULATED_SLOTS} slots; \
+         expected hundreds. A near-zero count means the probe key encoding does \
+         not match the stored node keys"
+    );
+
+    drop(store);
+    if !matches!(engine_type, EngineType::InMemory) && std::path::Path::new(&path).exists() {
+        std::fs::remove_dir_all(&path).expect("clean test db dir");
+    }
+}
+
+#[tokio::test]
+async fn trie_node_prefetch_effectiveness_in_memory() {
+    run_prefetch_effectiveness_test(EngineType::InMemory).await;
+}
+
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn trie_node_prefetch_effectiveness_rocksdb() {
+    run_prefetch_effectiveness_test(EngineType::RocksDB).await;
+}
+
 #[tokio::test]
 async fn storage_batch_parity_in_memory() {
     run_parity_test(EngineType::InMemory).await;


### PR DESCRIPTION
Stacked on #6872. Will retarget to main once that merges.

The existing flat-KV prefetch (from #6872) warms the leaf-value CFs that execution reads. The merkle phase reads from a completely separate set of column families, `STORAGE_TRIE_NODES` and `ACCOUNT_TRIE_NODES`, and every node read there is cold. This adds a complementary prefetch that warms those internal nodes up front from the same BAL working set, before the merkleizer starts.

The key insight is that internal nodes on the path to a leaf all live at prefixes of that leaf's nibble path, so for each BAL leaf we speculatively probe every prefix up to depth 8 (covers tries up to ~16^8 entries near-fully). Prefixes that don't correspond to real nodes are rejected by the CF bloom filter in RAM with no disk I/O. This turns the cold merkle node reads into one sorted, sharded, high-queue-depth `multi_get` per CF, mirroring the approach from #6872. Deduplication collapses shared shallow prefixes so roots and high-level branches are read once regardless of working-set size.

Covers both storage tries (BAL storage slots, via `apply_prefix(hashed_addr, slot_nibbles)`) and the state/account trie (BAL addresses including balance/nonce-only accounts that `bal_storage_slots` doesn't surface). The `bal_accounts` helper in `levm/mod.rs` extracts those. Runs synchronously next to the flat-KV prefetch in `blockchain.rs`: it touches different CFs than execution so it doesn't contend with the executor, and it completes before the merkleizer starts so it doesn't race it.

Gated on `slots.len() + accounts.len() >= 16_384` so ordinary blocks don't pay the probe cost. At ~2100 gas per cold access, 16384 corresponds to roughly 34M gas of cold accesses, well above normal traffic and below the large-state blocks this targets.

The prefetch is best-effort and read-only: missing a node (e.g. one deeper than depth 8) is harmless, the merkleizer cold-reads it. It cannot affect consensus output.

`Store::prefetch_trie_nodes` returns a hit count. Two new tests, `trie_node_prefetch_effectiveness_in_memory` and `trie_node_prefetch_effectiveness_rocksdb`, seed a contract with 2048 storage slots, run the prefetch, and assert the hit count is at least 64. A key-encoding mismatch (wrong nibble order, stray leaf flag, wrong `apply_prefix` wrapping) would turn every probe into a bloom miss and produce a near-zero hit count, so this guards against silent encoding regressions.