### PR TITLE
perf(l1): run BAL trie-node prefetch concurrently with execution

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -619,38 +619,38 @@ impl Blockchain {
             }
         }
 
-        // Warm the MPT internal nodes the merkleizer will walk (the trie-node CFs,
-        // which execution never reads). Derived from the MERKLE WRITE SET, not the
-        // access set: the merkleizer only walks accounts/slots that actually change,
-        // and `optimistic_updates` (synthesize_bal_updates) already drops read-only
-        // accesses and read-only slots. Warming trie nodes for read-only accesses is
-        // wasted cold reads that compete with execution for the same device; gating
-        // on the access set regressed read-heavy blocks (value-0 CALLs to existing
-        // accounts, bloated SLOADs) that have little or no merkle work.
-        //
-        // Gated so ordinary merkle-light blocks skip the probe cost; the payoff is on
-        // blocks that WRITE many distinct slots or modify many accounts, where merkle
-        // walks a large set of scattered, cold nodes. A cold node access costs on the
-        // order of ~2100+ gas, so 16384 sits above ordinary blocks and below the
-        // large-state blocks this targets. Tunable.
+        // Prepare the trie-node prefetch input: the MERKLE WRITE SET (changed
+        // accounts + written slots), which is exactly what the merkleizer walks.
+        // `optimistic_updates` (synthesize_bal_updates) already drops read-only
+        // accesses and read-only slots, so warming is scoped to nodes the merkleizer
+        // will actually read; using the access set instead regressed read-heavy
+        // blocks (value-0 CALLs to existing accounts, bloated SLOADs). The prefetch
+        // runs on its own thread inside the scope below (`trie_prefetch_handle`),
+        // overlapping execution rather than preceding it. Gated so ordinary
+        // merkle-light blocks skip the probe cost; the payoff is on blocks that WRITE
+        // many distinct slots or modify many accounts, where merkle walks a large set
+        // of scattered, cold nodes. Tunable.
         #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
-        if self.options.bal_prefetch_enabled
-            && let Some(updates) = optimistic_updates.as_ref()
-        {
-            const MERKLE_PREFETCH_THRESHOLD: usize = 16_384;
-            let mut write_slots: Vec<(Address, H256)> = Vec::new();
-            for (addr, item) in updates {
-                for slot in item.added_storage.keys() {
-                    write_slots.push((*addr, *slot));
+        let trie_prefetch_input: Option<(Vec<(Address, H256)>, Vec<Address>)> =
+            if self.options.bal_prefetch_enabled
+                && let Some(updates) = optimistic_updates.as_ref()
+            {
+                const MERKLE_PREFETCH_THRESHOLD: usize = 16_384;
+                let mut write_slots: Vec<(Address, H256)> = Vec::new();
+                for (addr, item) in updates {
+                    for slot in item.added_storage.keys() {
+                        write_slots.push((*addr, *slot));
+                    }
                 }
-            }
-            let write_accounts: Vec<Address> = updates.keys().copied().collect();
-            if write_slots.len() + write_accounts.len() >= MERKLE_PREFETCH_THRESHOLD {
-                let _ = self
-                    .storage
-                    .prefetch_trie_nodes(&write_slots, &write_accounts);
-            }
-        }
+                let write_accounts: Vec<Address> = updates.keys().copied().collect();
+                if write_slots.len() + write_accounts.len() >= MERKLE_PREFETCH_THRESHOLD {
+                    Some((write_slots, write_accounts))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
 
         let (execution_result, merkleization_result, warmer_duration) =
             std::thread::scope(|s| -> Result<_, ChainError> {
@@ -707,6 +707,30 @@ impl Blockchain {
                     .map_err(|e| {
                         ChainError::Custom(format!("Failed to spawn warmer thread: {e}"))
                     })?;
+
+                // Warm the merkleizer's trie-node reads concurrently with execution
+                // instead of up front. Touches different CFs than execution, so no
+                // exec contention; as a high-queue-depth batch it races ahead of the
+                // merkleizer's per-account walk so those reads land warm. Best-effort:
+                // any node it misses is just cold-read by the walk. The scope joins it
+                // before the block returns, but it shares the trie-node cold reads with
+                // the merkleizer at higher aggregate queue depth, so it completes
+                // within the exec/merkle window rather than extending it.
+                #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+                let trie_prefetch_handle = match trie_prefetch_input {
+                    Some((slots, accounts)) => {
+                        let storage = &self.storage;
+                        std::thread::Builder::new()
+                            .name("block_executor_trie_prefetch".to_string())
+                            .spawn_scoped(s, move || {
+                                let _ = storage.prefetch_trie_nodes(&slots, &accounts);
+                            })
+                            .inspect_err(|e| debug!("trie-node prefetch spawn failed: {e}"))
+                            .ok()
+                    }
+                    None => None,
+                };
+
                 let max_queue_length_ref = &mut max_queue_length;
                 // Channel is needed whenever the merkleizer takes the streaming
                 // branch OR LEVM falls into the sequential path:
@@ -841,6 +865,15 @@ impl Blockchain {
                     .unwrap_or(Duration::ZERO);
                 #[cfg(any(not(feature = "rayon"), feature = "eip-8025"))]
                 let warmer_duration = Duration::ZERO;
+                // Best-effort prefetch: join so the scope's borrows end cleanly.
+                // The warming result is discarded, but surface a panic so a failing
+                // prefetch (e.g. a RocksDB error) is observable rather than silent.
+                #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+                if let Some(h) = trie_prefetch_handle
+                    && let Err(e) = h.join()
+                {
+                    warn!("trie-node prefetch thread panicked (best-effort, ignored): {e:?}");
+                }
                 Ok((execution_result, merkleization_result, warmer_duration))
             })?;
         let (account_updates_list, streaming_witness, merkle_start_instant, merkle_end_instant) =


### PR DESCRIPTION
Stacked on #6873. Retargets to that branch once it merges.

#6873 added a BAL-driven prefetch that warms the MPT internal nodes the merkleizer walks. It ran synchronously before execution, so its entire cost sat on the critical path.

This moves the trie-node prefetch onto its own thread inside the `std::thread::scope` that already holds the executor and merkleizer, so it overlaps execution instead of preceding it.

**Why it is safe to overlap with execution:** the trie-node prefetch reads the trie-node column families, which execution never touches (execution reads only the flat-KV CFs via SLOAD/SSTORE). No contention with the executor. Against the merkleizer, which reads those same trie-node CFs, the prefetch acts as a high-queue-depth batch running in parallel, raising aggregate I/O queue depth so the scattered cold reads land warm before the merkleizer's per-account walk reaches them.

The flat-KV warm (introduced in earlier PRs) stays synchronous before execution, since it serves the executor and must be ready before it starts.

**Safety properties:**

- Best-effort and read-only. A spawn failure is logged via `debug!` and silently skipped (`inspect_err(...).ok()`). Any node the thread misses is simply cold-read by the merkle walk, with no effect on block execution output.
- The scope joins the handle before returning, so all borrows end cleanly. A thread panic is caught via `h.join()`, surfaced with `warn!`, and otherwise ignored.
- No deadlock path: the thread holds a shared ref to `self.storage`, does a single batch read, and returns. It acquires no locks the executor or merkleizer hold.

Gated to `feature = "rayon"` and `not(feature = "eip-8025")`, same as the rest of the BAL prefetch machinery. The 16,384-slot/account threshold that gates the trie prefetch is unchanged, so ordinary blocks see no effect.

EF blockchain LEVM suite: 8758 passed, 0 failed.