### PR TITLE
fix(l1): validate block_access_list_hash on the parallel import path

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -725,14 +725,26 @@ impl Blockchain {
                             &chain_config,
                             &execution_result.requests,
                         )?;
-                        // The parallel Amsterdam validation path uses the header BAL directly
-                        // to drive execution; it doesn't rebuild a BAL, so produced_bal is None.
-                        // BAL correctness on that path is enforced inside
-                        // execute_block_pipeline (header-BAL index/size/withdrawal-index
-                        // checks plus unread_storage_reads / unaccessed_pure_accounts).
-                        // The sequential Amsterdam path rebuilds a BAL and returns
-                        // Some(produced_bal), so the hash check below runs. Pre-Amsterdam
-                        // blocks never record a BAL, so produced_bal is None there too.
+                        // EIP-7928 block_access_list_hash commitment check.
+                        //
+                        // Sequential Amsterdam path: rebuilds a BAL and returns
+                        // Some(produced_bal), so the full hash+index+size check runs here.
+                        //
+                        // Parallel Amsterdam path: uses the header BAL directly to drive
+                        // execution and returns produced_bal = None. The header BAL's
+                        // index/size are already validated inside execute_block_pipeline,
+                        // and content-equivalence (unread_storage_reads /
+                        // unaccessed_pure_accounts) plus the state_root comparison prove the
+                        // header BAL is the canonical one. The one thing those checks do NOT
+                        // bind is the header commitment itself, so we must compare
+                        // keccak(rlp(header_bal)) against header.block_access_list_hash here;
+                        // otherwise a block with a content-valid BAL but a forged commitment
+                        // is accepted on this path while every spec-conformant client (and
+                        // our own sequential/batch paths) rejects it. This is a pure hash
+                        // compare on a BAL already in memory; the parallel exec optimization
+                        // (no BAL rebuild) is preserved.
+                        //
+                        // Pre-Amsterdam blocks never record a BAL, so both arms are skipped.
                         if let Some(bal) = &produced_bal {
                             validate_block_access_list_hash(
                                 &block.header,
@@ -740,6 +752,11 @@ impl Blockchain {
                                 bal,
                                 block.body.transactions.len(),
                             )?;
+                        } else if let Some(header_bal) = bal
+                            && chain_config.is_amsterdam_activated(block.header.timestamp)
+                            && !header_bal.matches_commitment(block.header.block_access_list_hash)
+                        {
+                            return Err(InvalidBlockError::BlockAccessListHashMismatch.into());
                         }
 
                         let exec_end_instant = Instant::now();
@@ -1057,10 +1074,12 @@ impl Blockchain {
 
     /// Validation path synthesizes `BalSynthesisItem`s from the input BAL pre-execution and
     /// merkleizes optimistically in parallel with EVM execution. Two gates guard the result:
-    /// (1) `validate_block_access_list_hash` against the produced BAL post-execution, and
-    /// (2) the downstream `state_root` comparison against the block header. A missing
-    /// `produced_bal` on this path is treated as a hard error so gate (1) is never silently
-    /// skipped. On any mismatch the optimistic merkle output is discarded via `?` on the
+    /// (1) the EIP-7928 `block_access_list_hash` commitment check, and
+    /// (2) the downstream `state_root` comparison against the block header. The parallel
+    /// path returns `produced_bal = None` (the header BAL drives execution rather than being
+    /// rebuilt), so gate (1) compares `keccak(rlp(header_bal))` against the header commitment
+    /// directly in the execution thread; the sequential path runs the same gate against the
+    /// rebuilt BAL. On any mismatch the optimistic merkle output is discarded via `?` on the
     /// execution thread's join result.
     #[instrument(
         level = "trace",

--- a/test/tests/blockchain/bal_hash_parallel_skip.rs
+++ b/test/tests/blockchain/bal_hash_parallel_skip.rs
@@ -1,0 +1,151 @@
+//! Regression test for the `bal-hash-parallel-skip` finding: the default
+//! parallel block-import path must reject a block whose header
+//! `block_access_list_hash` does not match `keccak(rlp(BAL))`, just like the
+//! sequential path and every spec-conformant client (EIP-7928 block validity).
+//!
+//! The parallel Amsterdam path uses the header BAL to drive execution and never
+//! rebuilds it, so before the fix the commitment check (gated on a rebuilt BAL)
+//! never fired: a block with a content-valid BAL but a forged commitment was
+//! accepted on the parallel path while the sequential path rejected it.
+//!
+//! The differential below builds a fully-valid Amsterdam block, forges only its
+//! header `block_access_list_hash`, and imports it down both paths with the
+//! canonical BAL supplied (what the P2P-sync caller hands to the pipeline).
+//! Only `bal_parallel_exec_enabled` is flipped between the two imports.
+
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain, BlockchainOptions,
+    error::{ChainError, InvalidBlockError},
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    H160, H256,
+    types::{
+        Block, DEFAULT_BUILDER_GAS_CEIL, ELASTICITY_MULTIPLIER, Genesis,
+        block_access_list::BlockAccessList,
+    },
+};
+use ethrex_storage::{EngineType, Store};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+async fn setup_store() -> Store {
+    let file = File::open(workspace_root().join("fixtures/genesis/l1-bal.json"))
+        .expect("open l1-bal genesis");
+    let genesis: Genesis =
+        serde_json::from_reader(BufReader::new(file)).expect("parse l1-bal genesis");
+    let mut store = Store::new("store.db", EngineType::InMemory).expect("build in-memory store");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("add genesis state");
+    store
+}
+
+/// Produce a fully-valid empty Amsterdam block on top of genesis and the
+/// canonical BAL the producer recorded for it.
+async fn build_valid_amsterdam_block(store: &Store) -> (Block, BlockAccessList) {
+    let bc = Blockchain::new(store.clone(), BlockchainOptions::default());
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let args = BuildPayloadArgs {
+        parent: genesis_header.hash(),
+        timestamp: genesis_header.timestamp + 12,
+        fee_recipient: H160::zero(),
+        random: H256::zero(),
+        withdrawals: Some(Vec::new()),
+        beacon_root: Some(H256::zero()),
+        slot_number: None,
+        version: 1,
+        elasticity_multiplier: ELASTICITY_MULTIPLIER,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    let payload = create_payload(&args, store, Bytes::new()).unwrap();
+    let result = bc.build_payload(payload).unwrap();
+    let bal = result
+        .block_access_list
+        .expect("amsterdam block must produce a BAL");
+    (result.payload, bal)
+}
+
+#[tokio::test]
+async fn parallel_path_rejects_invalid_block_access_list_hash() {
+    let build_store = setup_store().await;
+    let (mut block, bal) = build_valid_amsterdam_block(&build_store).await;
+
+    // The empty block still records a non-empty BAL via the EIP-4788 block-start
+    // system call, so the fork-activation guard is not vacuous.
+    assert!(
+        !bal.accounts().is_empty(),
+        "BAL should be non-empty (4788 system call)"
+    );
+
+    let canonical_hash = bal.compute_hash();
+    let forged = H256([0xde; 32]);
+    assert_ne!(canonical_hash, forged);
+
+    // Positive control: the UNFORGED block must still import on the parallel
+    // path. Guards against a fix that rejects everything.
+    let store_ok = setup_store().await;
+    let bc_ok = Blockchain::new(
+        store_ok,
+        BlockchainOptions {
+            bal_parallel_exec_enabled: true,
+            ..Default::default()
+        },
+    );
+    let valid = bc_ok.add_block_pipeline_bal(block.clone(), Some(&bal));
+    assert!(
+        valid.is_ok(),
+        "parallel path must accept a block with a correct commitment, got: {valid:?}"
+    );
+
+    // Forge ONLY the header commitment; keep the canonical BAL.
+    block.header.block_access_list_hash = Some(forged);
+
+    // PARALLEL (default): import with the canonical BAL supplied.
+    let store_par = setup_store().await;
+    let bc_par = Blockchain::new(
+        store_par,
+        BlockchainOptions {
+            bal_parallel_exec_enabled: true,
+            ..Default::default()
+        },
+    );
+    let par = bc_par.add_block_pipeline_bal(block.clone(), Some(&bal));
+
+    // SEQUENTIAL: same block, same BAL, only the parallel flag flipped.
+    let store_seq = setup_store().await;
+    let bc_seq = Blockchain::new(
+        store_seq,
+        BlockchainOptions {
+            bal_parallel_exec_enabled: false,
+            ..Default::default()
+        },
+    );
+    let seq = bc_seq.add_block_pipeline_bal(block.clone(), Some(&bal));
+
+    // Both paths must reject a forged commitment with the same error.
+    assert!(
+        matches!(
+            par,
+            Err(ChainError::InvalidBlock(
+                InvalidBlockError::BlockAccessListHashMismatch
+            ))
+        ),
+        "parallel path must reject forged block_access_list_hash, got: {par:?}"
+    );
+    assert!(
+        matches!(
+            seq,
+            Err(ChainError::InvalidBlock(
+                InvalidBlockError::BlockAccessListHashMismatch
+            ))
+        ),
+        "sequential path must reject forged block_access_list_hash, got: {seq:?}"
+    );
+}

--- a/test/tests/blockchain/mod.rs
+++ b/test/tests/blockchain/mod.rs
@@ -1,3 +1,4 @@
+mod bal_hash_parallel_skip;
 mod batch_tests;
 mod eip7702_revert_authority_tests;
 mod eip7702_zero_transfer_tests;


### PR DESCRIPTION
## Motivation

EIP-7928 makes `block_access_list_hash` a block-validity condition: reject the block unless `header.block_access_list_hash == keccak(rlp(canonical_BAL))`.

The default **parallel** import path never checked it. The check is gated on the rebuilt BAL (`produced_bal`), but the parallel Amsterdam path drives execution from the header BAL and returns `produced_bal = None`, so it never fired — a block with a content-valid BAL but a forged commitment was accepted on the parallel path while the sequential/batch paths rejected it. Reachable via P2P full-sync's final-batch import; `engine_newPayloadV5` was already sound.

## Description

When `produced_bal` is `None` but a header BAL drove an Amsterdam block, compare `keccak(rlp(header_bal))` against `header.block_access_list_hash` via `matches_commitment`. Pure hash compare on the BAL already in memory — the no-rebuild parallel optimization is preserved.

## Test

`bal_hash_parallel_skip.rs`: forge only the header commitment, import both paths with the canonical BAL. Post-fix both reject with `BlockAccessListHashMismatch`; positive control confirms a valid block still imports on the parallel path.