### PR TITLE
Shard the account-state batch prefetch read

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2734,12 +2734,40 @@ impl Store {
         }
 
         if !fkv_indices.is_empty() {
+            // Sort by the prefixed (hashed-order) key so adjacent accounts land
+            // in the same RocksDB data blocks, then read the sorted keys in
+            // contiguous shards concurrently. A single `multi_get` runs the whole
+            // batch at queue depth 1 (async_io is off), which on a cold account-
+            // heavy block serializes thousands of random reads (coldbench: ~13x
+            // slower than this sharded path). Mirrors the storage FKV batch.
+            fkv_indices.sort_unstable_by(|&a, &b| leaf_paths[a].cmp(&leaf_paths[b]));
             let read_view = self.backend.begin_read()?;
             let keys: Vec<&[u8]> = fkv_indices
                 .iter()
                 .map(|&i| leaf_paths[i].as_slice())
                 .collect();
-            let raw = read_view.multi_get(ACCOUNT_FLATKEYVALUE, &keys);
+            // Accounts are scattered (no shared prefix) and the batch is smaller
+            // than a bloated account's storage, so 64 shards is the sweet spot
+            // (128 over-fragments; coldbench).
+            const KEYS_PER_SHARD: usize = 256;
+            const MAX_SHARDS: usize = 64;
+            let shards = keys.len().div_ceil(KEYS_PER_SHARD).clamp(1, MAX_SHARDS);
+            let raw: Vec<Result<Option<Vec<u8>>, StoreError>> = if shards <= 1 {
+                read_view.multi_get(ACCOUNT_FLATKEYVALUE, &keys)
+            } else {
+                let chunk = keys.len().div_ceil(shards);
+                let rv = read_view.as_ref();
+                std::thread::scope(|scope| {
+                    let handles: Vec<_> = keys
+                        .chunks(chunk)
+                        .map(|ck| scope.spawn(move || rv.multi_get(ACCOUNT_FLATKEYVALUE, ck)))
+                        .collect();
+                    handles
+                        .into_iter()
+                        .flat_map(|h| h.join().expect("account prefetch shard panicked"))
+                        .collect()
+                })
+            };
             for (slot, res) in fkv_indices.iter().zip(raw.into_iter()) {
                 let Some(encoded) = res? else { continue };
                 if encoded.is_empty() {

--- a/crates/vm/levm/src/db/mod.rs
+++ b/crates/vm/levm/src/db/mod.rs
@@ -148,6 +148,32 @@ impl CachingDatabase {
             .map(|&(addr, key)| self.inner.get_storage_value(addr, key))
             .collect()
     }
+
+    /// Per-account parallel point-gets, in `missing` order. Warm-optimal fan-out
+    /// for normal-sized prefetch batches; large batches use the sorted sharded
+    /// multi_get instead (see `prefetch_accounts`).
+    #[cfg(all(feature = "rayon", not(feature = "eip-8025")))]
+    fn point_get_accounts_many(
+        &self,
+        missing: &[Address],
+    ) -> Result<Vec<AccountState>, DatabaseError> {
+        use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+        missing
+            .par_iter()
+            .map(|&addr| self.inner.get_account_state(addr))
+            .collect()
+    }
+
+    #[cfg(not(all(feature = "rayon", not(feature = "eip-8025"))))]
+    fn point_get_accounts_many(
+        &self,
+        missing: &[Address],
+    ) -> Result<Vec<AccountState>, DatabaseError> {
+        missing
+            .iter()
+            .map(|&addr| self.inner.get_account_state(addr))
+            .collect()
+    }
 }
 
 fn poison_error_to_db_error<T>(err: PoisonError<T>) -> DatabaseError {
@@ -240,10 +266,21 @@ impl Database for CachingDatabase {
         if missing.is_empty() {
             return Ok(());
         }
-        // Dispatch to inner's batch path. For the rocksdb-backed StoreVmDatabase
-        // this collapses into a single multi_get on ACCOUNT_FLATKEYVALUE for the
-        // FKV-covered subset; default impl loops for other backends.
-        let states = self.inner.get_account_states_batch(&missing)?;
+        // Same gate as `prefetch_storage`: a large set of distinct COLD accounts is
+        // queue-depth bound. The inner batch path on the rocksdb-backed
+        // StoreVmDatabase used a single multi_get (queue depth 1, async_io off),
+        // which collapses on cold account-heavy blocks (coldbench: ~13x slower than
+        // the sharded batch). Route large/cold sets to the (now sharded) batch and
+        // small/warm sets to parallel point-gets. The gate counts MISSING (cold)
+        // accounts, so warm blocks stay on the point-get path however many accounts
+        // they touch. Tunable.
+        const BLOATED_BATCH_THRESHOLD: usize = 16_384;
+
+        let states = if missing.len() >= BLOATED_BATCH_THRESHOLD {
+            self.inner.get_account_states_batch(&missing)?
+        } else {
+            self.point_get_accounts_many(&missing)?
+        };
         let mut cache = self.write_accounts()?;
         for (addr, state) in missing.into_iter().zip(states.into_iter()) {
             cache.entry(addr).or_insert(state);

--- a/test/tests/storage/storage_batch_tests.rs
+++ b/test/tests/storage/storage_batch_tests.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use ethrex_common::{
     Address, H256, U256,
-    types::{Genesis, GenesisAccount},
+    types::{AccountState, Genesis, GenesisAccount},
 };
 use ethrex_storage::{EngineType, Store, hash_address};
 
@@ -188,4 +188,126 @@ async fn storage_batch_parity_in_memory() {
 #[tokio::test]
 async fn storage_batch_parity_rocksdb() {
     run_parity_test(EngineType::RocksDB).await;
+}
+
+// ---- account-batch parity ----
+//
+// `Store::get_account_states_batch_by_root` (the sharded account prefetch read)
+// must return byte-identical results to the per-account single-get path
+// (`get_account_state_by_root`) the executor reads through, across both the
+// FKV-swept (sharded multi_get) and FKV-unswept (trie fallback) states.
+
+/// Enough seeded accounts that the FKV batch spans several 256-key shards
+/// (interleaved with absent addresses doubles the query set), exercising the
+/// parallel-shard path rather than only the single-shard fallback.
+const POPULATED_ACCOUNTS: u64 = 2048;
+
+/// Genesis with `POPULATED_ACCOUNTS` non-empty EOAs at distinct addresses, each
+/// with a distinct nonzero balance and nonce so a key/value swap is caught.
+fn seed_genesis_accounts() -> (Genesis, Vec<Address>) {
+    const GENESIS_EXECUTION_API: &str =
+        include_str!("../../../fixtures/genesis/execution-api.json");
+    let mut genesis: Genesis =
+        serde_json::from_str(GENESIS_EXECUTION_API).expect("deserialize execution-api genesis");
+
+    let mut addrs = Vec::with_capacity(POPULATED_ACCOUNTS as usize);
+    for i in 0..POPULATED_ACCOUNTS {
+        let addr = Address::from_low_u64_be(0x0010_0000 + i);
+        genesis.alloc.insert(
+            addr,
+            GenesisAccount {
+                balance: U256::from(i) + U256::from(1),
+                code: Bytes::new(),
+                storage: BTreeMap::new(),
+                nonce: i + 1,
+            },
+        );
+        addrs.push(addr);
+    }
+    (genesis, addrs)
+}
+
+/// Assert the batched account helper matches the per-account single-get path
+/// exactly, including the absent-account (`None`) case.
+fn assert_account_parity(store: &Store, state_root: H256, populated: &[Address]) {
+    // Interleave each populated address with an absent one so the parity check
+    // covers both the present and the never-written branches.
+    let mut query: Vec<Address> = Vec::with_capacity(populated.len() * 2);
+    for (i, a) in populated.iter().enumerate() {
+        query.push(*a);
+        query.push(Address::from_low_u64_be(0x9000_0000 + i as u64));
+    }
+
+    let single: Vec<Option<AccountState>> = query
+        .iter()
+        .map(|a| {
+            store
+                .get_account_state_by_root(state_root, *a)
+                .expect("single-get account")
+        })
+        .collect();
+
+    let batched = store
+        .get_account_states_batch_by_root(state_root, &query)
+        .expect("batched accounts");
+
+    assert_eq!(
+        batched.len(),
+        single.len(),
+        "batched result length must match single-get length"
+    );
+    for (i, a) in query.iter().enumerate() {
+        assert_eq!(
+            batched[i], single[i],
+            "account {a:?} (index {i}) mismatch: batched={:?} single={:?}",
+            batched[i], single[i]
+        );
+    }
+
+    assert!(
+        batched.iter().any(|v| v.is_some()),
+        "expected at least one present account"
+    );
+    assert!(
+        batched.iter().any(|v| v.is_none()),
+        "expected at least one absent account to be None"
+    );
+}
+
+async fn run_account_parity_test(engine_type: EngineType) {
+    let nonce: u64 = H256::random().to_low_u64_be();
+    let path = format!("account-batch-test-db-{nonce}");
+    if !matches!(engine_type, EngineType::InMemory) && std::path::Path::new(&path).exists() {
+        std::fs::remove_dir_all(&path).expect("clean test db dir");
+    }
+
+    let mut store = Store::new(&path, engine_type).expect("create test store");
+    let (genesis, addrs) = seed_genesis_accounts();
+    let state_root = genesis.get_block().header.state_root;
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("add genesis state");
+
+    // State A: FKV not yet generated -> trie fallback for every account.
+    assert_account_parity(&store, state_root, &addrs);
+    // State B: FKV fully swept -> sorted, sharded multi_get for every account.
+    wait_for_full_fkv(&store);
+    assert_account_parity(&store, state_root, &addrs);
+
+    drop(store);
+    if !matches!(engine_type, EngineType::InMemory) && std::path::Path::new(&path).exists() {
+        std::fs::remove_dir_all(&path).expect("clean test db dir");
+    }
+}
+
+#[tokio::test]
+async fn account_batch_parity_in_memory() {
+    run_account_parity_test(EngineType::InMemory).await;
+}
+
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn account_batch_parity_rocksdb() {
+    run_account_parity_test(EngineType::RocksDB).await;
 }


### PR DESCRIPTION
Stacked on #6872. Retargets to main when that merges.

`get_account_states_batch_by_root` read its FKV-covered keys with a single `multi_get` over `ACCOUNT_FLATKEYVALUE`. With async_io off, that runs at queue depth 1, which on cold account-heavy blocks serializes thousands of random reads. The storage FKV batch already used sorted, parallel shards; the account path never got the same treatment.

Fix: sort the FKV keys before reading (adjacent accounts share RocksDB data blocks) then split them into contiguous shards read concurrently via `std::thread::scope`. MAX_SHARDS is 64, accounts are scattered and the batch is smaller than a bloated account's storage, so 64 is the sweet spot; 128 over-fragments.

`prefetch_accounts` in `CachingDatabase` now gates the same way `prefetch_storage` does: cold batches above a threshold go to the sharded batch, small or warm batches go to parallel point-gets. The gate counts missing (uncached) accounts, so warm blocks stay on the point-get path regardless of total account count.

Prefetch is best-effort cache warming and cannot change execution output. Tests in `test/tests/storage/storage_batch_tests.rs` assert the sharded batch is byte-identical to the per-account single-get path in both FKV-unswept (trie fallback) and FKV-swept (sharded multi_get) states, for both in-memory and RocksDB engines.