### PR TITLE
fix(l1): bound eth_getLogs response size and cap the filter registry (configurable)

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -423,6 +423,33 @@ pub struct Options {
     )]
     pub gas_limit: u64,
     #[arg(
+        long = "rpc.max-log-block-range",
+        default_value_t = ethrex_rpc::MAX_BLOCK_RANGE,
+        value_name = "BLOCKS",
+        help = "Max block span for a single eth_getLogs/eth_getFilterChanges query (0 = unlimited).",
+        help_heading = "RPC options",
+        env = "ETHREX_RPC_MAX_LOG_BLOCK_RANGE"
+    )]
+    pub rpc_max_log_block_range: u64,
+    #[arg(
+        long = "rpc.max-logs-per-response",
+        default_value_t = ethrex_rpc::MAX_LOGS_PER_RESPONSE,
+        value_name = "COUNT",
+        help = "Max logs returned by a single eth_getLogs/eth_getFilterChanges query (0 = unlimited).",
+        help_heading = "RPC options",
+        env = "ETHREX_RPC_MAX_LOGS_PER_RESPONSE"
+    )]
+    pub rpc_max_logs_per_response: usize,
+    #[arg(
+        long = "rpc.max-active-filters",
+        default_value_t = ethrex_rpc::MAX_ACTIVE_FILTERS,
+        value_name = "COUNT",
+        help = "Max concurrently-installed eth_* filters across all callers (0 = unlimited).",
+        help_heading = "RPC options",
+        env = "ETHREX_RPC_MAX_ACTIVE_FILTERS"
+    )]
+    pub rpc_max_active_filters: usize,
+    #[arg(
         long = "builder.max-blobs",
         value_name = "MAX_BLOBS",
         help = "EIP-7872: Maximum blobs per block for local building. Minimum of 1. Defaults to protocol max.",
@@ -524,6 +551,9 @@ impl Default for Options {
             lookup_interval: Default::default(),
             extra_data: get_minimal_client_version(),
             gas_limit: DEFAULT_BUILDER_GAS_CEIL,
+            rpc_max_log_block_range: ethrex_rpc::MAX_BLOCK_RANGE,
+            rpc_max_logs_per_response: ethrex_rpc::MAX_LOGS_PER_RESPONSE,
+            rpc_max_active_filters: ethrex_rpc::MAX_ACTIVE_FILTERS,
             max_blobs_per_block: None,
             precompute_witnesses: false,
             no_migrate: false,

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -280,6 +280,11 @@ pub async fn init_rpc_api(
         get_client_version(),
         log_filter_handler,
         opts.gas_limit,
+        ethrex_rpc::EthRpcLimits {
+            max_log_block_range: opts.rpc_max_log_block_range,
+            max_logs_per_response: opts.rpc_max_logs_per_response,
+            max_active_filters: opts.rpc_max_active_filters,
+        },
         opts.extra_data.clone(),
         opts.http_api.iter().copied().collect(),
     );

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -76,6 +76,11 @@ fn init_rpc_api(
         log_filter_handler,
         l2_gas_limit,
         l2_opts.sponsored_gas_limit,
+        ethrex_rpc::EthRpcLimits {
+            max_log_block_range: opts.rpc_max_log_block_range,
+            max_logs_per_response: opts.rpc_max_logs_per_response,
+            max_active_filters: opts.rpc_max_active_filters,
+        },
         allowed_namespaces,
         ethrex_namespace_allowed,
     );

--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -94,6 +94,7 @@ pub async fn start_api(
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     l2_gas_limit: u64,
     sponsored_gas_limit: u64,
+    eth_limits: ethrex_rpc::EthRpcLimits,
     allowed_namespaces: HashSet<L1RpcNamespace>,
     ethrex_namespace_allowed: bool,
 ) -> Result<(), RpcErr> {
@@ -124,6 +125,7 @@ pub async fn start_api(
             gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
             log_filter_handler,
             gas_ceil: l2_gas_limit,
+            eth_limits,
             block_worker_channel,
             ws: ws.clone(),
             allowed_namespaces: Arc::new(allowed_namespaces),

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -76,6 +76,7 @@ impl NewFilterRequest {
         &self,
         storage: ethrex_storage::Store,
         filters: ActiveFilters,
+        max_active_filters: usize,
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
         let from = self
             .request_data
@@ -106,9 +107,9 @@ impl NewFilterRequest {
         // Cap the global filter registry. HTTP filters are not connection-scoped,
         // so this is the only bound on how many a client can accumulate (a polled
         // filter never hits the inactivity TTL).
-        if active_filters_guard.len() >= MAX_ACTIVE_FILTERS {
+        if max_active_filters != 0 && active_filters_guard.len() >= max_active_filters {
             return Err(RpcErr::Internal(format!(
-                "Active filter limit reached ({MAX_ACTIVE_FILTERS}); uninstall unused filters with eth_uninstallFilter before creating new ones"
+                "Active filter limit reached ({max_active_filters}); uninstall unused filters with eth_uninstallFilter before creating new ones"
             )));
         }
         active_filters_guard.insert(
@@ -129,9 +130,10 @@ impl NewFilterRequest {
         req: &RpcRequest,
         storage: Store,
         state: ActiveFilters,
+        max_active_filters: usize,
     ) -> Result<Value, RpcErr> {
         let request = Self::parse(&req.params)?;
-        request.handle(storage, state).await
+        request.handle(storage, state, max_active_filters).await
     }
 }
 
@@ -201,6 +203,8 @@ impl FilterChangesRequest {
         &self,
         storage: ethrex_storage::Store,
         filters: ActiveFilters,
+        max_block_range: u64,
+        max_logs_per_response: usize,
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
         let latest_block_num = storage.get_latest_block_number().await?;
         // Box needed to keep the future Sync
@@ -237,7 +241,13 @@ impl FilterChangesRequest {
                 // Drop the lock early to process this filter's query
                 // and not keep the lock more than we should.
                 drop(active_filters_guard);
-                let logs = fetch_logs_with_filter(&filter.filter_data, storage).await?;
+                let logs = fetch_logs_with_filter(
+                    &filter.filter_data,
+                    storage,
+                    max_block_range,
+                    max_logs_per_response,
+                )
+                .await?;
                 serde_json::to_value(logs).map_err(|error| {
                     tracing::error!("Log filtering request failed with: {error}");
                     RpcErr::Internal("Failed to filter logs".to_string())
@@ -258,9 +268,13 @@ impl FilterChangesRequest {
         req: &RpcRequest,
         storage: ethrex_storage::Store,
         filters: ActiveFilters,
+        max_block_range: u64,
+        max_logs_per_response: usize,
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
         let request = Self::parse(&req.params)?;
-        request.handle(storage, filters).await
+        request
+            .handle(storage, filters, max_block_range, max_logs_per_response)
+            .await
     }
 }
 
@@ -663,7 +677,7 @@ mod tests {
             },
         };
         let err = req
-            .handle(storage, filters.clone())
+            .handle(storage, filters.clone(), MAX_ACTIVE_FILTERS)
             .await
             .expect_err("filter creation must be refused at capacity");
         assert!(matches!(err, RpcErr::Internal(_)), "got {err:?}");

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -109,7 +109,7 @@ impl NewFilterRequest {
         // filter never hits the inactivity TTL).
         if max_active_filters != 0 && active_filters_guard.len() >= max_active_filters {
             return Err(RpcErr::Internal(format!(
-                "Active filter limit reached ({max_active_filters}); uninstall unused filters with eth_uninstallFilter before creating new ones"
+                "Active filter limit reached ({max_active_filters}); uninstall unused filters with eth_uninstallFilter, or raise/disable the limit with --rpc.max-active-filters (0 = unlimited)"
             )));
         }
         active_filters_guard.insert(

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -20,6 +20,14 @@ use serde_json::{Value, json};
 
 use super::logs::{LogsFilter, fetch_logs_with_filter};
 
+/// Maximum number of concurrently-installed `eth_*` filters across all callers.
+/// The filter registry is process-global and, unlike WebSocket subscriptions
+/// (capped at `MAX_TOTAL_SUBSCRIPTIONS`), HTTP filters are not tied to a
+/// connection — so without this bound a client can install unbounded filters
+/// and keep them alive past the inactivity TTL by polling. Mirrors the
+/// subscription total to keep the two surfaces symmetric.
+pub const MAX_ACTIVE_FILTERS: usize = 10_000;
+
 #[derive(Debug, Clone)]
 pub struct NewFilterRequest {
     pub request_data: LogsFilter,
@@ -95,6 +103,14 @@ impl NewFilterRequest {
             filters.clear_poison();
             poisoned_guard.into_inner()
         });
+        // Cap the global filter registry. HTTP filters are not connection-scoped,
+        // so this is the only bound on how many a client can accumulate (a polled
+        // filter never hits the inactivity TTL).
+        if active_filters_guard.len() >= MAX_ACTIVE_FILTERS {
+            return Err(RpcErr::Internal(format!(
+                "Active filter limit reached ({MAX_ACTIVE_FILTERS}); uninstall unused filters with eth_uninstallFilter before creating new ones"
+            )));
+        }
         active_filters_guard.insert(
             id,
             (
@@ -601,5 +617,57 @@ mod tests {
         );
 
         server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn new_filter_rejected_at_capacity() {
+        use super::{MAX_ACTIVE_FILTERS, NewFilterRequest};
+        use crate::utils::RpcErr;
+
+        let mut storage = Store::new("in-mem", EngineType::InMemory)
+            .expect("Fatal: could not create in memory test db");
+        let genesis: Genesis =
+            serde_json::from_str(TEST_GENESIS).expect("Fatal: non-valid genesis test config");
+        storage
+            .add_initial_state(genesis)
+            .await
+            .expect("Fatal: could not add test genesis");
+
+        // Pre-fill the registry to capacity.
+        let mut map = HashMap::new();
+        for i in 0..MAX_ACTIVE_FILTERS as u64 {
+            map.insert(
+                i,
+                (
+                    Instant::now(),
+                    PollableFilter {
+                        last_block_number: 0,
+                        filter_data: LogsFilter {
+                            from_block: BlockIdentifier::Number(0),
+                            to_block: BlockIdentifier::Number(0),
+                            address_filters: None,
+                            topics: vec![],
+                        },
+                    },
+                ),
+            );
+        }
+        let filters: ActiveFilters = Arc::new(Mutex::new(map));
+
+        let req = NewFilterRequest {
+            request_data: LogsFilter {
+                from_block: BlockIdentifier::Number(0),
+                to_block: BlockIdentifier::Number(0),
+                address_filters: None,
+                topics: vec![],
+            },
+        };
+        let err = req
+            .handle(storage, filters.clone())
+            .await
+            .expect_err("filter creation must be refused at capacity");
+        assert!(matches!(err, RpcErr::Internal(_)), "got {err:?}");
+        // The registry did not grow past the cap.
+        assert_eq!(filters.lock().unwrap().len(), MAX_ACTIVE_FILTERS);
     }
 }

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -117,7 +117,13 @@ impl RpcHandler for LogsFilter {
         }
     }
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        let filtered_logs = fetch_logs_with_filter(self, context.storage).await?;
+        let filtered_logs = fetch_logs_with_filter(
+            self,
+            context.storage,
+            context.eth_limits.max_log_block_range,
+            context.eth_limits.max_logs_per_response,
+        )
+        .await?;
         serde_json::to_value(filtered_logs).map_err(|error| {
             tracing::error!("Log filtering request failed with: {error}");
             RpcErr::Internal("Failed to filter logs".to_string())
@@ -137,6 +143,8 @@ impl RpcHandler for LogsFilter {
 pub(crate) async fn fetch_logs_with_filter(
     filter: &LogsFilter,
     storage: Store,
+    max_block_range: u64,
+    max_logs_per_response: usize,
 ) -> Result<Vec<RpcLog>, RpcErr> {
     let from = filter
         .from_block
@@ -153,9 +161,9 @@ pub(crate) async fn fetch_logs_with_filter(
     }
     // Bound the block span before touching the database so a single request
     // cannot force an unbounded `Vec<RpcLog>` over an attacker-chosen range.
-    if MAX_BLOCK_RANGE != 0 && to - from + 1 > MAX_BLOCK_RANGE {
+    if max_block_range != 0 && to - from + 1 > max_block_range {
         return Err(RpcErr::BadParams(format!(
-            "Block range too large: requested {} blocks ({from}..={to}), max is {MAX_BLOCK_RANGE}. Split the query into smaller ranges.",
+            "Block range too large: requested {} blocks ({from}..={to}), max is {max_block_range}. Split the query into smaller ranges.",
             to - from + 1
         )));
     }
@@ -219,9 +227,9 @@ pub(crate) async fn fetch_logs_with_filter(
         // Bound peak memory: stop accumulating once the (address-filtered)
         // result set exceeds the cap and return a paginatable error pointing
         // at the block reached, so the caller can split the query.
-        if MAX_LOGS_PER_RESPONSE != 0 && logs.len() > MAX_LOGS_PER_RESPONSE {
+        if max_logs_per_response != 0 && logs.len() > max_logs_per_response {
             return Err(RpcErr::BadParams(format!(
-                "Query exceeds the maximum of {MAX_LOGS_PER_RESPONSE} logs (range {from}..={block_num} already matched {}). Narrow the block range or add address/topic filters.",
+                "Query exceeds the maximum of {max_logs_per_response} logs (range {from}..={block_num} already matched {}). Narrow the block range or add address/topic filters.",
                 logs.len()
             )));
         }
@@ -325,7 +333,9 @@ mod tests {
             address_filters: None,
             topics: vec![],
         };
-        let err = fetch_logs_with_filter(&filter, storage).await.unwrap_err();
+        let err = fetch_logs_with_filter(&filter, storage, MAX_BLOCK_RANGE, MAX_LOGS_PER_RESPONSE)
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, RpcErr::BadParams(_)),
             "expected BadParams, got {err:?}"
@@ -344,7 +354,9 @@ mod tests {
             address_filters: None,
             topics: vec![],
         };
-        let err = fetch_logs_with_filter(&filter, storage).await.unwrap_err();
+        let err = fetch_logs_with_filter(&filter, storage, MAX_BLOCK_RANGE, MAX_LOGS_PER_RESPONSE)
+            .await
+            .unwrap_err();
         assert!(
             matches!(&err, RpcErr::Internal(msg) if msg.contains("body")),
             "expected to pass the range guard and fail on missing body, got {err:?}"

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -163,7 +163,7 @@ pub(crate) async fn fetch_logs_with_filter(
     // cannot force an unbounded `Vec<RpcLog>` over an attacker-chosen range.
     if max_block_range != 0 && to - from + 1 > max_block_range {
         return Err(RpcErr::BadParams(format!(
-            "Block range too large: requested {} blocks ({from}..={to}), max is {max_block_range}. Split the query into smaller ranges.",
+            "Block range too large: requested {} blocks ({from}..={to}), max is {max_block_range}. Split the query into smaller ranges, or raise/disable the limit with --rpc.max-log-block-range (0 = unlimited).",
             to - from + 1
         )));
     }
@@ -229,7 +229,7 @@ pub(crate) async fn fetch_logs_with_filter(
         // at the block reached, so the caller can split the query.
         if max_logs_per_response != 0 && logs.len() > max_logs_per_response {
             return Err(RpcErr::BadParams(format!(
-                "Query exceeds the maximum of {max_logs_per_response} logs (range {from}..={block_num} already matched {}). Narrow the block range or add address/topic filters.",
+                "Query exceeds the maximum of {max_logs_per_response} logs (range {from}..={block_num} already matched {}). Narrow the block range or add address/topic filters, or raise/disable the limit with --rpc.max-logs-per-response (0 = unlimited).",
                 logs.len()
             )));
         }

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -16,6 +16,21 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashSet;
 
+/// Maximum number of blocks a single `eth_getLogs` / `eth_getFilterChanges`
+/// query may span. Without it, one request resolves an attacker-chosen
+/// `fromBlock..=toBlock` and materializes a `Vec<RpcLog>` (plus a second
+/// `serde_json::Value` copy) over the whole range, with no upper bound on
+/// memory. Mirrors the range caps other clients ship (Besu 5_000, Erigon
+/// 1_000, reth 100_000) and the existing `MAX_BLOCK_COUNT` guard used by
+/// `eth_feeHistory`. `0` disables the cap.
+pub const MAX_BLOCK_RANGE: u64 = 5_000;
+
+/// Maximum number of logs a single query may accumulate before it is rejected
+/// with a paginatable error. Bounds peak memory independently of the block
+/// span and matches the de-facto default across reth, Nethermind and Erigon
+/// (20_000). `0` disables the cap.
+pub const MAX_LOGS_PER_RESPONSE: usize = 20_000;
+
 #[derive(Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum AddressFilter {
@@ -136,6 +151,14 @@ pub(crate) async fn fetch_logs_with_filter(
     if (from..=to).is_empty() {
         return Err(RpcErr::BadParams("Empty range".to_string()));
     }
+    // Bound the block span before touching the database so a single request
+    // cannot force an unbounded `Vec<RpcLog>` over an attacker-chosen range.
+    if MAX_BLOCK_RANGE != 0 && to - from + 1 > MAX_BLOCK_RANGE {
+        return Err(RpcErr::BadParams(format!(
+            "Block range too large: requested {} blocks ({from}..={to}), max is {MAX_BLOCK_RANGE}. Split the query into smaller ranges.",
+            to - from + 1
+        )));
+    }
     let address_filter: HashSet<_> = match &filter.address_filters {
         Some(AddressFilter::Single(address)) => std::iter::once(address).collect(),
         Some(AddressFilter::Many(addresses)) => addresses.iter().collect(),
@@ -192,6 +215,15 @@ pub(crate) async fn fetch_logs_with_filter(
                     block_log_index += 1;
                 }
             }
+        }
+        // Bound peak memory: stop accumulating once the (address-filtered)
+        // result set exceeds the cap and return a paginatable error pointing
+        // at the block reached, so the caller can split the query.
+        if MAX_LOGS_PER_RESPONSE != 0 && logs.len() > MAX_LOGS_PER_RESPONSE {
+            return Err(RpcErr::BadParams(format!(
+                "Query exceeds the maximum of {MAX_LOGS_PER_RESPONSE} logs (range {from}..={block_num} already matched {}). Narrow the block range or add address/topic filters.",
+                logs.len()
+            )));
         }
     }
     // Now that we have the logs filtered by address,
@@ -279,5 +311,43 @@ mod tests {
             "{request:?}"
         );
         assert_eq!(request.topics, vec![TopicFilter::Topic(Some(H256::zero()))]);
+    }
+
+    #[tokio::test]
+    async fn get_logs_rejects_oversized_block_range() {
+        use ethrex_storage::{EngineType, Store};
+        let storage = Store::new("in-mem", EngineType::InMemory).unwrap();
+        // `Number(_)` resolves without touching the DB, so the range cap is hit
+        // before any block access.
+        let filter = LogsFilter {
+            from_block: BlockIdentifier::Number(0),
+            to_block: BlockIdentifier::Number(MAX_BLOCK_RANGE + 5),
+            address_filters: None,
+            topics: vec![],
+        };
+        let err = fetch_logs_with_filter(&filter, storage).await.unwrap_err();
+        assert!(
+            matches!(err, RpcErr::BadParams(_)),
+            "expected BadParams, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_logs_allows_max_block_range() {
+        use ethrex_storage::{EngineType, Store};
+        let storage = Store::new("in-mem", EngineType::InMemory).unwrap();
+        // Exactly MAX_BLOCK_RANGE blocks (1..=MAX_BLOCK_RANGE) is allowed; it
+        // fails later on the missing body, not on the range guard.
+        let filter = LogsFilter {
+            from_block: BlockIdentifier::Number(1),
+            to_block: BlockIdentifier::Number(MAX_BLOCK_RANGE),
+            address_filters: None,
+            topics: vec![],
+        };
+        let err = fetch_logs_with_filter(&filter, storage).await.unwrap_err();
+        assert!(
+            matches!(&err, RpcErr::Internal(msg) if msg.contains("body")),
+            "expected to pass the range guard and fail on missing body, got {err:?}"
+        );
     }
 }

--- a/crates/networking/rpc/lib.rs
+++ b/crates/networking/rpc/lib.rs
@@ -82,15 +82,16 @@ pub mod test_utils;
 // TODO: These exports are needed by ethrex-l2-rpc, but we do not want to
 // export them in the public API of this crate.
 pub use eth::{
-    filter::{ActiveFilters, clean_outdated_filters},
+    filter::{ActiveFilters, MAX_ACTIVE_FILTERS, clean_outdated_filters},
     gas_price::GasPrice,
     gas_tip_estimator::GasTipEstimator,
+    logs::{MAX_BLOCK_RANGE, MAX_LOGS_PER_RESPONSE},
     transaction::EstimateGasRequest,
 };
 pub use rpc::{
-    ClientVersion, NodeData, RpcApiContext, RpcHandler, RpcRequestWrapper, WebSocketConfig,
-    handle_eth_subscribe, handle_eth_unsubscribe, handle_websocket, map_debug_requests,
-    map_eth_requests, map_http_requests, rpc_response, shutdown_signal,
+    ClientVersion, EthRpcLimits, NodeData, RpcApiContext, RpcHandler, RpcRequestWrapper,
+    WebSocketConfig, handle_eth_subscribe, handle_eth_unsubscribe, handle_websocket,
+    map_debug_requests, map_eth_requests, map_http_requests, rpc_response, shutdown_signal,
 };
 pub use subscription_manager::{SubscriptionManager, SubscriptionManagerProtocol};
 pub use utils::{RpcErr, RpcErrorMetadata, RpcNamespace};

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -193,6 +193,29 @@ type BlockWorkerMessage = (
 /// including storage access, blockchain state, P2P networking, and configuration.
 ///
 /// The context is cloned for each request, with most fields being cheap `Arc` references.
+/// RPC memory-safety limits for the log/filter endpoints, configurable via the
+/// `--rpc.*` CLI flags. A value of `0` disables the corresponding cap. Defaults
+/// (see [`Default`]) come from the canonical consts in `eth::logs`/`eth::filter`.
+#[derive(Debug, Clone, Copy)]
+pub struct EthRpcLimits {
+    /// Max block span for `eth_getLogs` / `eth_getFilterChanges` (`0` = unlimited).
+    pub max_log_block_range: u64,
+    /// Max logs a single query may accumulate before erroring (`0` = unlimited).
+    pub max_logs_per_response: usize,
+    /// Max concurrently-installed `eth_*` filters (`0` = unlimited).
+    pub max_active_filters: usize,
+}
+
+impl Default for EthRpcLimits {
+    fn default() -> Self {
+        Self {
+            max_log_block_range: crate::eth::logs::MAX_BLOCK_RANGE,
+            max_logs_per_response: crate::eth::logs::MAX_LOGS_PER_RESPONSE,
+            max_active_filters: crate::eth::filter::MAX_ACTIVE_FILTERS,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct RpcApiContext {
     /// Database storage for blocks, transactions, and state.
@@ -213,6 +236,8 @@ pub struct RpcApiContext {
     pub log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     /// Maximum gas limit for blocks (used in payload building).
     pub gas_ceil: u64,
+    /// Memory-safety limits for the log/filter endpoints (configurable via `--rpc.*`).
+    pub eth_limits: EthRpcLimits,
     /// Channel for sending blocks to the block executor worker thread.
     pub block_worker_channel: UnboundedSender<BlockWorkerMessage>,
     /// WebSocket configuration. `None` when the WS server is disabled.
@@ -525,6 +550,7 @@ pub async fn start_api(
     client_version: ClientVersion,
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
     gas_ceil: u64,
+    eth_limits: EthRpcLimits,
     extra_data: String,
     allowed_namespaces: HashSet<RpcNamespace>,
 ) -> Result<(), RpcErr> {
@@ -548,6 +574,7 @@ pub async fn start_api(
         gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
         log_filter_handler,
         gas_ceil,
+        eth_limits,
         block_worker_channel,
         ws: ws.clone(),
         allowed_namespaces: Arc::new(allowed_namespaces),
@@ -1131,13 +1158,29 @@ pub async fn map_eth_requests(req: &RpcRequest, context: RpcApiContext) -> Resul
         "eth_estimateGas" => EstimateGasRequest::call(req, context).await,
         "eth_getLogs" => LogsFilter::call(req, context).await,
         "eth_newFilter" => {
-            NewFilterRequest::stateful_call(req, context.storage, context.active_filters).await
+            let max_active_filters = context.eth_limits.max_active_filters;
+            NewFilterRequest::stateful_call(
+                req,
+                context.storage,
+                context.active_filters,
+                max_active_filters,
+            )
+            .await
         }
         "eth_uninstallFilter" => {
             DeleteFilterRequest::stateful_call(req, context.storage, context.active_filters)
         }
         "eth_getFilterChanges" => {
-            FilterChangesRequest::stateful_call(req, context.storage, context.active_filters).await
+            let max_block_range = context.eth_limits.max_log_block_range;
+            let max_logs_per_response = context.eth_limits.max_logs_per_response;
+            FilterChangesRequest::stateful_call(
+                req,
+                context.storage,
+                context.active_filters,
+                max_block_range,
+                max_logs_per_response,
+            )
+            .await
         }
         "eth_sendRawTransaction" => SendRawTransactionRequest::call(req, context).await,
         "eth_getProof" => GetProofRequest::call(req, context).await,

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -8,8 +8,8 @@
 use crate::{
     eth::gas_tip_estimator::GasTipEstimator,
     rpc::{
-        ClientVersion, NodeData, RpcApiContext, handle_authrpc_request, handle_http_request,
-        start_api, start_block_executor,
+        ClientVersion, EthRpcLimits, NodeData, RpcApiContext, handle_authrpc_request,
+        handle_http_request, start_api, start_block_executor,
     },
     utils::RpcNamespace,
 };
@@ -294,6 +294,7 @@ pub async fn start_test_api() -> tokio::task::JoinHandle<()> {
             ),
             None,
             DEFAULT_BUILDER_GAS_CEIL,
+            EthRpcLimits::default(),
             String::new(),
             all_namespaces_for_tests(),
         )
@@ -344,6 +345,7 @@ pub async fn default_context_with_storage(storage: Store) -> RpcApiContext {
         gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
         log_filter_handler: None,
         gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+        eth_limits: EthRpcLimits::default(),
         block_worker_channel,
         ws: None,
         allowed_namespaces: Arc::new(all_namespaces_for_tests()),

--- a/tooling/ef_tests/engine/src/engine_ctx.rs
+++ b/tooling/ef_tests/engine/src/engine_ctx.rs
@@ -13,7 +13,7 @@ use ethrex_blockchain::Blockchain;
 use ethrex_common::types::DEFAULT_BUILDER_GAS_CEIL;
 use ethrex_p2p::sync_manager::SyncManager;
 use ethrex_rpc::{
-    ClientVersion, GasTipEstimator, NodeData, RpcApiContext, start_block_executor,
+    ClientVersion, EthRpcLimits, GasTipEstimator, NodeData, RpcApiContext, start_block_executor,
     test_utils::{
         all_namespaces_for_tests, dummy_sync_manager, example_local_node_record, example_p2p_node,
     },
@@ -88,6 +88,7 @@ pub async fn engine_only_context(storage: Store) -> RpcApiContext {
         gas_tip_estimator: Arc::new(TokioMutex::new(GasTipEstimator::new())),
         log_filter_handler: None,
         gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+        eth_limits: EthRpcLimits::default(),
         block_worker_channel,
         ws: None,
         allowed_namespaces: Arc::new(all_namespaces_for_tests()),


### PR DESCRIPTION
## Motivation

Three `eth_*` JSON-RPC surfaces had no memory bound, all reachable **unauthenticated** on the default HTTP/WS port (`eth` is in `DEFAULT_HTTP_API`):

- `eth_getLogs` / `eth_getFilterChanges` resolved an attacker-chosen `fromBlock..=toBlock` and built the full `Vec<RpcLog>` (plus a second `serde_json::Value` copy) — no range or result cap.
- `eth_newFilter` inserted into a process-global map with no count cap.

Validated empirically on a mainnet node: a single ~300-byte request held the whole chain's logs in RAM, and 500,000 filters were accepted with zero refusals.

## Description

Adds a log-range cap, a log-count cap, and a filter-count cap, each **configurable via CLI** (defaults below; `0` disables). Defaults follow the cross-client consensus (reth/Nethermind/Erigon cap logs at 20,000; Besu/Erigon cap range; the filter-count cap mirrors the existing subscription total). The same limits are threaded into the L2 RPC server. When a cap is hit, the JSON-RPC error **names the flag** that raises or disables it.

### CLI configuration

| Flag | Default | Env var | `0` |
|------|---------|---------|-----|
| `--rpc.max-log-block-range` | 5000 | `ETHREX_RPC_MAX_LOG_BLOCK_RANGE` | unlimited |
| `--rpc.max-logs-per-response` | 20000 | `ETHREX_RPC_MAX_LOGS_PER_RESPONSE` | unlimited |
| `--rpc.max-active-filters` | 10000 | `ETHREX_RPC_MAX_ACTIVE_FILTERS` | unlimited |

## Validation (mainnet node, before → after)

| Exploit | Before | After (defaults) |
|---------|--------|------------------|
| `getLogs` span 6001 | builds full `Vec` | rejected: *"Block range too large… max is 5000"* (no DB access) |
| `getLogs` ~200k-log window | 167 MB / **+759 MB RSS** | rejected at 20,376 logs; **+11 MB RSS** |
| `getLogs` normal (4800 logs) | works | works (unchanged) |
| `getLogs` ×40 concurrent | **+4–6 GB/round** | **+312 MB** |
| filter flood | 500,000 / 0 refused | **10,000 then refused** |

CLI override confirmed live (e.g. `--rpc.max-active-filters 5` → 6th `eth_newFilter` refused), and each error message names its flag, e.g.:

> `Active filter limit reached (5); uninstall unused filters with eth_uninstallFilter, or raise/disable the limit with --rpc.max-active-filters (0 = unlimited)`

## How to test

- `cargo test -p ethrex-rpc` — 3 new unit tests (range rejection, range-boundary pass, filter-capacity refusal) plus the existing suite.
- Manual: start with `--rpc.max-active-filters 5` and create 6 filters via `eth_newFilter`; the 6th returns the limit error above. Likewise `--rpc.max-log-block-range`/`--rpc.max-logs-per-response` reject over-limit `eth_getLogs` queries and name the flag.

## Notes

- `eth_getFilterChanges` shares `fetch_logs_with_filter`, so it inherits the same range/result caps.
- Per-poll TTL refresh on filters is intentional/standard behavior across clients and is unchanged; the count cap is the DoS bound.
- Follow-up (separate): the public HTTP/WS router has no global concurrency limit / request timeout, which amplifies any per-request response builder — worth adding as a defense-in-depth layer.
