### PR TITLE
chore(l1,l2): bump version to 17.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-benches"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "criterion 0.5.1",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum 0.8.9",
  "ethrex-common",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-monitor"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-repl"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "clap",
  "colored 2.2.0",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "criterion 0.7.0",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-test"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 default-members = ["cmd/ethrex"]
 
 [workspace.package]
-version = "16.0.0"
+version = "17.0.0"
 edition = "2024"
 authors = ["LambdaClass"]
 documentation = "https://docs.ethrex.xyz"

--- a/crates/guest-program/bin/openvm/Cargo.lock
+++ b/crates/guest-program/bin/openvm/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-openvm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/openvm/Cargo.toml
+++ b/crates/guest-program/bin/openvm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "16.0.0"
+version = "17.0.0"
 name = "ethrex-guest-openvm"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/guest-program/bin/risc0/Cargo.lock
+++ b/crates/guest-program/bin/risc0/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-risc0"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "c-kzg",
  "ethrex-common",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/crates/guest-program/bin/risc0/Cargo.toml
+++ b/crates/guest-program/bin/risc0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-risc0"
-version = "16.0.0"
+version = "17.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/sp1/Cargo.lock
+++ b/crates/guest-program/bin/sp1/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-sp1"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ethrex-guest-program",
  "ethrex-vm",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/sp1/Cargo.toml
+++ b/crates/guest-program/bin/sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-sp1"
-version = "16.0.0"
+version = "17.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/zisk/Cargo.lock
+++ b/crates/guest-program/bin/zisk/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-zisk"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/zisk/Cargo.toml
+++ b/crates/guest-program/bin/zisk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "16.0.0"
+version = "17.0.0"
 name = "ethrex-guest-zisk"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "quote-gen"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "configfs-tsm",
  "ethrex-blockchain",

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote-gen"
-version = "16.0.0"
+version = "17.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/vm/levm/bench/revm_comparison/Cargo.lock
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -253,7 +253,7 @@ Block building options:
           Block extra data message.
           
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 16.0.0"]
+          [default: "ethrex 17.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
@@ -463,7 +463,7 @@ Block building options:
           Block extra data message.
 
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 16.0.0"]
+          [default: "ethrex 17.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -836,11 +836,11 @@ dependencies = [
  "clap 4.6.0",
  "clap_complete",
  "ethrex",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-rpc",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "eyre",
  "hex",
  "lazy_static",
@@ -2913,12 +2913,12 @@ dependencies = [
  "bytes",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-prover",
- "ethrex-rlp 16.0.0",
- "ethrex-storage 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-vm",
  "hex",
  "lazy_static",
@@ -2938,10 +2938,10 @@ dependencies = [
  "ctor",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-p2p",
  "ethrex-rpc",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "hex",
  "rayon",
  "regex",
@@ -2961,11 +2961,11 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 16.0.0",
- "ethrex-storage 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-vm",
  "hex",
  "itertools 0.13.0",
@@ -2990,12 +2990,12 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-l2-rpc",
  "ethrex-levm",
- "ethrex-rlp 16.0.0",
- "ethrex-storage 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-vm",
  "hex",
  "prettytable-rs",
@@ -3227,14 +3227,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "clap 4.6.0",
  "directories",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-config",
  "ethrex-crypto",
  "ethrex-dev",
@@ -3245,10 +3245,10 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-p2p",
  "ethrex-repl",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-storage-rollup",
  "ethrex-vm",
  "eyre",
@@ -3278,16 +3278,16 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
- "ethrex-rlp 16.0.0",
- "ethrex-storage 16.0.0",
- "ethrex-trie 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-storage 17.0.0",
+ "ethrex-trie 17.0.0",
  "ethrex-vm",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3326,14 +3326,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 16.0.0",
- "ethrex-trie 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-trie 17.0.0",
  "hex",
  "hex-literal",
  "hex-simd",
@@ -3359,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-p2p",
  "hex",
  "serde",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3413,14 +3413,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-vm",
  "hex",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3452,7 +3452,7 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
@@ -3460,12 +3460,12 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-monitor",
  "ethrex-p2p",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 16.0.0",
+ "ethrex-trie 17.0.0",
  "ethrex-vm",
  "futures",
  "hex",
@@ -3490,11 +3490,11 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambdaworks-crypto 0.13.0",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3516,14 +3516,14 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-guest-program",
  "ethrex-l2",
  "ethrex-l2-common",
  "ethrex-prover",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-sdk",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-vm",
  "hex",
  "rkyv",
@@ -3539,19 +3539,19 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum 0.8.8",
  "bytes",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-p2p",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-rpc",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-storage-rollup",
  "hex",
  "reqwest 0.12.28",
@@ -3569,13 +3569,13 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "malachite",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3586,10 +3586,10 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum 0.8.8",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -3606,13 +3606,13 @@ dependencies = [
  "bytes",
  "chrono",
  "crossterm 0.29.0",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-config",
  "ethrex-l2-common",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-storage-rollup",
  "futures",
  "hex",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3640,14 +3640,14 @@ dependencies = [
  "ctr",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-metrics",
- "ethrex-rlp 16.0.0",
- "ethrex-storage 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-storage 17.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 16.0.0",
+ "ethrex-trie 17.0.0",
  "futures",
  "hex",
  "hkdf",
@@ -3675,14 +3675,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bincode",
  "bytes",
  "clap 4.6.0",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-guest-program",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-vm",
  "rkyv",
  "serde",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -3747,13 +3747,13 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
  "ethrex-p2p",
- "ethrex-rlp 16.0.0",
- "ethrex-storage 16.0.0",
- "ethrex-trie 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-storage 17.0.0",
+ "ethrex-trie 17.0.0",
  "ethrex-vm",
  "hex",
  "hex-literal",
@@ -3778,14 +3778,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "ethrex-rpc",
  "ethrex-sdk-contract-utils",
  "hex",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -3833,14 +3833,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
- "ethrex-rlp 16.0.0",
- "ethrex-trie 16.0.0",
+ "ethrex-rlp 17.0.0",
+ "ethrex-trie 17.0.0",
  "fastbloom",
  "lru 0.16.3",
  "rayon",
@@ -3855,12 +3855,12 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "async-trait",
  "bincode",
  "ethereum-types",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-l2-common",
  "futures",
  "rkyv",
@@ -3891,14 +3891,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "lazy_static",
  "rayon",
  "rkyv",
@@ -3909,15 +3909,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "dyn-clone",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 16.0.0",
+ "ethrex-rlp 17.0.0",
  "rayon",
  "rustc-hash 2.1.2",
  "serde",
@@ -5602,7 +5602,7 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
  "ethrex-rpc",
@@ -5806,9 +5806,9 @@ dependencies = [
  "clap 4.6.0",
  "ethrex-blockchain",
  "ethrex-common 1.0.0",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-storage 1.0.0",
- "ethrex-storage 16.0.0",
+ "ethrex-storage 17.0.0",
  "libc",
  "rocksdb",
  "tokio",
@@ -7651,7 +7651,7 @@ version = "4.0.0"
 dependencies = [
  "ethrex",
  "ethrex-blockchain",
- "ethrex-common 16.0.0",
+ "ethrex-common 17.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",


### PR DESCRIPTION
**Motivation**

Prepare the v17.0.0 release by bumping the workspace version to 16.0.0 and merging the release branch back to main.

**Description**

- Bump the workspace package version from 16.0.0 to 17.0.0 in the root Cargo.toml, the guest-program Cargo.toml files (sp1, risc0, openvm, zisk) and crates/l2/tee/quote-gen/Cargo.toml; refresh all Cargo.lock files via make update-cargo-lock.
- Update the --builder.extra-data default in docs/CLI.md to ethrex 17.0.0 for both the ethrex and ethrex L2 sections.
