### PR TITLE
docs(l1): fix broken EEST doc links

### DIFF
--- a/docs/developers/l1/testing/ef-tests.md
+++ b/docs/developers/l1/testing/ef-tests.md
@@ -5,7 +5,7 @@ These are the official execution spec tests. There are two kinds: `state tests` 
 ### State tests
 
 The state tests are individual transactions not related one to each other that test particular behavior of the EVM. Tests are usually run for multiple forks and the result of execution may vary between forks.
-See [docs](https://eest.ethereum.org/v4.1.0/consuming_tests/state_test/).
+See [docs](https://steel.ethereum.foundation/docs/execution-specs/mainnet/running_tests/test_formats/state_test/).
 
 To run the test first:
 
@@ -29,7 +29,7 @@ make run-evm-ef-tests
 
 
 The blockchain tests test block validation and the consensus rules of the Ethereum blockchain. Tests are usually run for multiple forks.
-See [docs](https://eest.ethereum.org/v4.1.0/consuming_tests/blockchain_test).
+See [docs](https://steel.ethereum.foundation/docs/execution-specs/mainnet/running_tests/test_formats/blockchain_test/).
 
 To run the tests first:
 

--- a/tooling/ef_tests/state_v2/README.md
+++ b/tooling/ef_tests/state_v2/README.md
@@ -9,7 +9,7 @@ This module includes a runner for the EF state tests. The main steps it performs
 ## What are EF State Tests?
 The Ethereum Foundation State Tests are individual transactions not related to one another that test particular behavior of the EVM. Tests are usually run for multiple forks and the result of execution may vary between forks.
 
-For more information on these tests check [the docs](https://eest.ethereum.org/main/running_tests/test_formats/state_test/#fixtureconfig).
+For more information on these tests check [the docs](https://steel.ethereum.foundation/docs/execution-specs/mainnet/running_tests/test_formats/state_test/#fixtureconfig).
 
 ## How to run the tests?
 


### PR DESCRIPTION
**Motivation**

The eest documentation moved from being under eest.ethereum.org to steel.ethereum.foundation. This has caused the CI to [fail](https://github.com/lambdaclass/ethrex/actions/runs/27697340977/job/81924997699).

**Description**

Updates all eest.ethereum.org links, even those that (due to a redirect being in place) still work.