### PR TITLE
fix(l1): return error instead of panic in TrieWrapper::put_batch

### DIFF
--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -329,7 +329,10 @@ impl TrieDB for TrieWrapper {
     }
 
     fn put_batch(&self, _key_values: Vec<(Nibbles, Vec<u8>)>) -> Result<(), TrieError> {
-        // TODO: Get rid of this.
-        unimplemented!("This function should not be called");
+        // TrieWrapper is a read-only view over the trie layer cache;
+        // writes should go through the underlying storage directly.
+        Err(TrieError::DbError(anyhow::anyhow!(
+            "TrieWrapper is read-only; put_batch should not be called"
+        )))
     }
 }


### PR DESCRIPTION
**Motivation**

TrieWrapper::put_batch currently calls unimplemented!(), which panics at runtime if ever invoked. Since TrieWrapper is a read-only view over the trie layer cache, this method should never be called — but a panic is still an unnecessarily harsh failure mode. Returning a recoverable error is more defensive and consistent with other read-only TrieDB implementations in the codebase.



**Description**

 Replace unimplemented!("This function should not be called") with Err(TrieError::DbError(anyhow::anyhow!("TrieWrapper is read-only; put_batch should not be called"))), following the same pattern used by BackendTrieDBLocked::put_batch in crates/storage/trie.rs.

This is a one-line behavioral change with no impact on the happy path — the function was never meant to succeed.


**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

