### PR TITLE
chore(l1,l2): bump version to 18.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-benches"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "criterion 0.5.1",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum 0.8.9",
  "ethrex-common",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-monitor"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-repl"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "clap",
  "colored 2.2.0",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "criterion 0.7.0",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-test"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 default-members = ["cmd/ethrex"]
 
 [workspace.package]
-version = "17.0.0"
+version = "18.0.0"
 edition = "2024"
 authors = ["LambdaClass"]
 documentation = "https://docs.ethrex.xyz"

--- a/crates/guest-program/bin/openvm/Cargo.lock
+++ b/crates/guest-program/bin/openvm/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-openvm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/openvm/Cargo.toml
+++ b/crates/guest-program/bin/openvm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "17.0.0"
+version = "18.0.0"
 name = "ethrex-guest-openvm"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/guest-program/bin/risc0/Cargo.lock
+++ b/crates/guest-program/bin/risc0/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-risc0"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "c-kzg",
  "ethrex-common",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/crates/guest-program/bin/risc0/Cargo.toml
+++ b/crates/guest-program/bin/risc0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-risc0"
-version = "17.0.0"
+version = "18.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/sp1/Cargo.lock
+++ b/crates/guest-program/bin/sp1/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-sp1"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ethrex-guest-program",
  "ethrex-vm",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/sp1/Cargo.toml
+++ b/crates/guest-program/bin/sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-sp1"
-version = "17.0.0"
+version = "18.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/zisk/Cargo.lock
+++ b/crates/guest-program/bin/zisk/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-zisk"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/zisk/Cargo.toml
+++ b/crates/guest-program/bin/zisk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "17.0.0"
+version = "18.0.0"
 name = "ethrex-guest-zisk"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "quote-gen"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "configfs-tsm",
  "ethrex-blockchain",

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote-gen"
-version = "17.0.0"
+version = "18.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/vm/levm/bench/revm_comparison/Cargo.lock
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -253,7 +253,7 @@ Block building options:
           Block extra data message.
           
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 17.0.0"]
+          [default: "ethrex 18.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
@@ -463,7 +463,7 @@ Block building options:
           Block extra data message.
 
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 17.0.0"]
+          [default: "ethrex 18.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -836,11 +836,11 @@ dependencies = [
  "clap 4.6.0",
  "clap_complete",
  "ethrex",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-rpc",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "eyre",
  "hex",
  "lazy_static",
@@ -2913,12 +2913,12 @@ dependencies = [
  "bytes",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-prover",
- "ethrex-rlp 17.0.0",
- "ethrex-storage 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-vm",
  "hex",
  "lazy_static",
@@ -2938,10 +2938,10 @@ dependencies = [
  "ctor",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-p2p",
  "ethrex-rpc",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "hex",
  "rayon",
  "regex",
@@ -2961,11 +2961,11 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 17.0.0",
- "ethrex-storage 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-vm",
  "hex",
  "itertools 0.13.0",
@@ -2990,12 +2990,12 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-l2-rpc",
  "ethrex-levm",
- "ethrex-rlp 17.0.0",
- "ethrex-storage 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-vm",
  "hex",
  "prettytable-rs",
@@ -3227,14 +3227,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "clap 4.6.0",
  "directories",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-config",
  "ethrex-crypto",
  "ethrex-dev",
@@ -3245,10 +3245,10 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-p2p",
  "ethrex-repl",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-storage-rollup",
  "ethrex-vm",
  "eyre",
@@ -3278,16 +3278,16 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
- "ethrex-rlp 17.0.0",
- "ethrex-storage 17.0.0",
- "ethrex-trie 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-storage 18.0.0",
+ "ethrex-trie 18.0.0",
  "ethrex-vm",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3326,14 +3326,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 17.0.0",
- "ethrex-trie 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-trie 18.0.0",
  "hex",
  "hex-literal",
  "hex-simd",
@@ -3359,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-p2p",
  "hex",
  "serde",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3414,14 +3414,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-vm",
  "hex",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3453,7 +3453,7 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
@@ -3461,12 +3461,12 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-monitor",
  "ethrex-p2p",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 17.0.0",
+ "ethrex-trie 18.0.0",
  "ethrex-vm",
  "futures",
  "hex",
@@ -3491,11 +3491,11 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambdaworks-crypto 0.13.0",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3517,14 +3517,14 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-guest-program",
  "ethrex-l2",
  "ethrex-l2-common",
  "ethrex-prover",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-sdk",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-vm",
  "hex",
  "rkyv",
@@ -3540,19 +3540,19 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum 0.8.8",
  "bytes",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-p2p",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-rpc",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-storage-rollup",
  "hex",
  "reqwest 0.12.28",
@@ -3570,13 +3570,13 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "malachite",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3587,10 +3587,10 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum 0.8.8",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -3607,13 +3607,13 @@ dependencies = [
  "bytes",
  "chrono",
  "crossterm 0.29.0",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-config",
  "ethrex-l2-common",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-storage-rollup",
  "futures",
  "hex",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3641,14 +3641,14 @@ dependencies = [
  "ctr",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-metrics",
- "ethrex-rlp 17.0.0",
- "ethrex-storage 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-storage 18.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 17.0.0",
+ "ethrex-trie 18.0.0",
  "futures",
  "hex",
  "hkdf",
@@ -3676,14 +3676,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bincode",
  "bytes",
  "clap 4.6.0",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-guest-program",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-vm",
  "rkyv",
  "serde",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -3748,13 +3748,13 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
  "ethrex-p2p",
- "ethrex-rlp 17.0.0",
- "ethrex-storage 17.0.0",
- "ethrex-trie 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-storage 18.0.0",
+ "ethrex-trie 18.0.0",
  "ethrex-vm",
  "hex",
  "hex-literal",
@@ -3779,14 +3779,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "ethrex-rpc",
  "ethrex-sdk-contract-utils",
  "hex",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -3834,14 +3834,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
- "ethrex-rlp 17.0.0",
- "ethrex-trie 17.0.0",
+ "ethrex-rlp 18.0.0",
+ "ethrex-trie 18.0.0",
  "fastbloom",
  "lru 0.16.3",
  "rayon",
@@ -3856,12 +3856,12 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "async-trait",
  "bincode",
  "ethereum-types",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-l2-common",
  "futures",
  "rkyv",
@@ -3892,14 +3892,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "lazy_static",
  "rayon",
  "rkyv",
@@ -3910,15 +3910,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "dyn-clone",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 17.0.0",
+ "ethrex-rlp 18.0.0",
  "rayon",
  "rustc-hash 2.1.2",
  "serde",
@@ -5603,7 +5603,7 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
  "ethrex-rpc",
@@ -5807,9 +5807,9 @@ dependencies = [
  "clap 4.6.0",
  "ethrex-blockchain",
  "ethrex-common 1.0.0",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-storage 1.0.0",
- "ethrex-storage 17.0.0",
+ "ethrex-storage 18.0.0",
  "libc",
  "rocksdb",
  "tokio",
@@ -7652,7 +7652,7 @@ version = "4.0.0"
 dependencies = [
  "ethrex",
  "ethrex-blockchain",
- "ethrex-common 17.0.0",
+ "ethrex-common 18.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",


### PR DESCRIPTION
**Motivation**

Bump version for the v18.0.0 release.

**Description**

- Bump workspace + guest-program/quote-gen `Cargo.toml` versions to 18.0.0
- Regenerate `Cargo.lock` files
- Update `--builder.extra-data` default in `docs/CLI.md`