### PR TITLE
chore(l1): bump snapsync CL images

### DIFF
--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -114,7 +114,7 @@ jobs:
           network: ${{ matrix.network }}
           timeout: ${{ matrix.timeout }}
           cl_type: lighthouse
-          cl_image: "sigp/lighthouse:v8.0.1"
+          cl_image: "sigp/lighthouse:v8.1.3"
           build_local: "true"
           build_profile: ${{ needs.prepare.outputs.build_profile }}
 
@@ -164,7 +164,7 @@ jobs:
           network: ${{ matrix.network }}
           timeout: ${{ matrix.timeout }}
           cl_type: prysm
-          cl_image: "gcr.io/offchainlabs/prysm/beacon-chain:v7.1.0"
+          cl_image: "gcr.io/offchainlabs/prysm/beacon-chain:v7.1.5"
           build_local: "true"
           build_profile: ${{ needs.prepare.outputs.build_profile }}
 


### PR DESCRIPTION
**Motivation**

In our snapsync job we are CL images that are several months old.

**Description**

This PR bumps them to the latest version.
