### PR TITLE
fix(l1): make ethrex-rlp bench dev-deps path-only so the first crates.io publish succeeds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ name: Publish crates to crates.io
 # It does NOT fire on `vX.Y.Z-rc.W` pre-release creation, so release candidates
 # never publish to crates.io (crates.io versions are immutable).
 on:
+  # TEMP-DEBUG (revert before merge): run the publish workflow in dry-run on this
+  # PR branch to validate it in CI. Delete this `push:` block before merging.
+  push:
+    branches: [fix-publish-rlp-devdeps]
   release:
     types: [released]
   workflow_dispatch:
@@ -33,7 +37,10 @@ jobs:
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          # TEMP-DEBUG (revert before merge): dry-run for everything except a real
+          # release, so the `push:` trigger above never publishes for real. Restore
+          # `github.event_name == 'workflow_dispatch' && inputs.dry_run` before merging.
+          DRY_RUN: ${{ github.event_name != 'release' }}
         run: |
           set -euo pipefail
           # Topological order: each crate is published after all of its dependencies.
@@ -58,7 +65,20 @@ jobs:
           for c in "${CRATES[@]}"; do
             echo "::group::$c"
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              cargo package -p "$c" --no-verify --list
+              # TEMP-DEBUG (revert before merge): full publish dry-run (packaging +
+              # index resolution + verify build) instead of just `cargo package
+              # --list`. Dependents legitimately can't resolve siblings that aren't
+              # published yet, so tolerate ONLY that specific error; fail on anything
+              # else. Restore `cargo package -p "$c" --no-verify --list` before merge.
+              OUTPUT=$(cargo publish -p "$c" --dry-run 2>&1) || {
+                echo "$OUTPUT"
+                if echo "$OUTPUT" | grep -q "no matching package named"; then
+                  echo "$c: sibling dep not on crates.io yet (expected in dry-run), continuing"
+                  echo "::endgroup::"
+                  continue
+                fi
+                exit 1
+              }
             else
               OUTPUT=$(cargo publish -p "$c" 2>&1) || {
                 echo "$OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,54 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Guard against an unpublishable dependency cycle
+        run: |
+          python3 - <<'PY'
+          import json, subprocess, sys
+          meta = json.loads(subprocess.check_output(["cargo", "metadata", "--format-version", "1"]))
+          # Keep in sync with the CRATES list in the next step.
+          PUB = {
+              "ethrex-rlp", "ethrex-crypto", "ethrex-sdk-contract-utils", "ethrex-trie",
+              "ethrex-common", "ethrex-metrics", "ethrex-levm", "ethrex-l2-common",
+              "ethrex-storage", "ethrex-vm", "ethrex-storage-rollup", "ethrex-blockchain",
+              "ethrex-p2p", "ethrex-rpc", "ethrex-l2-rpc", "ethrex-sdk",
+          }
+          adj = {n: set() for n in PUB}
+          for p in meta["packages"]:
+              if p["name"] not in PUB:
+                  continue
+              for d in p["dependencies"]:
+                  if d["name"] not in PUB:
+                      continue
+                  # cargo publish keeps normal + build deps always, and dev-deps only
+                  # if they carry a version (path-only dev-deps are stripped on publish).
+                  kept = d.get("kind") in (None, "build") or (d.get("kind") == "dev" and d.get("req") != "*")
+                  if kept:
+                      adj[p["name"]].add(d["name"])
+          color = {n: 0 for n in PUB}
+          cyc = []
+          def dfs(u, st):
+              color[u] = 1
+              for v in sorted(adj[u]):
+                  if color[v] == 1:
+                      cyc.extend(st[st.index(v):] + [v])
+                      return True
+                  if color[v] == 0 and dfs(v, st + [v]):
+                      return True
+              color[u] = 2
+              return False
+          for n in sorted(PUB):
+              if color[n] == 0 and dfs(n, [n]):
+                  break
+          if cyc:
+              print("Unpublishable dependency cycle among published crates:")
+              print("  " + " -> ".join(cyc))
+              print("A versioned dev/build-dependency points at a crate published later;")
+              print("make such dev-deps path-only (no version) so they are stripped on publish.")
+              sys.exit(1)
+          print("OK: kept-edge dependency graph is acyclic (a valid publish order exists).")
+          PY
+
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
@@ -58,7 +106,15 @@ jobs:
           for c in "${CRATES[@]}"; do
             echo "::group::$c"
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              cargo package -p "$c" --no-verify --list
+              # Real publish dry-run: packaging + index resolution + verify build.
+              # On a dry-run nothing is actually published, so crates later in the
+              # order can't resolve their siblings yet -- tolerate ONLY that error
+              # (the cycle guard above catches genuinely unpublishable graphs).
+              OUTPUT=$(cargo publish -p "$c" --dry-run 2>&1) || {
+                echo "$OUTPUT"
+                echo "$OUTPUT" | grep -q "no matching package named" || exit 1
+                echo "$c: sibling not on crates.io yet (expected during a dry-run)"
+              }
             else
               OUTPUT=$(cargo publish -p "$c" 2>&1) || {
                 echo "$OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,6 @@ name: Publish crates to crates.io
 # It does NOT fire on `vX.Y.Z-rc.W` pre-release creation, so release candidates
 # never publish to crates.io (crates.io versions are immutable).
 on:
-  # TEMP-DEBUG (revert before merge): run the publish workflow in dry-run on this
-  # PR branch to validate it in CI. Delete this `push:` block before merging.
-  push:
-    branches: [fix-publish-rlp-devdeps]
   release:
     types: [released]
   workflow_dispatch:
@@ -37,10 +33,7 @@ jobs:
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          # TEMP-DEBUG (revert before merge): dry-run for everything except a real
-          # release, so the `push:` trigger above never publishes for real. Restore
-          # `github.event_name == 'workflow_dispatch' && inputs.dry_run` before merging.
-          DRY_RUN: ${{ github.event_name != 'release' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           set -euo pipefail
           # Topological order: each crate is published after all of its dependencies.
@@ -65,20 +58,7 @@ jobs:
           for c in "${CRATES[@]}"; do
             echo "::group::$c"
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              # TEMP-DEBUG (revert before merge): full publish dry-run (packaging +
-              # index resolution + verify build) instead of just `cargo package
-              # --list`. Dependents legitimately can't resolve siblings that aren't
-              # published yet, so tolerate ONLY that specific error; fail on anything
-              # else. Restore `cargo package -p "$c" --no-verify --list` before merge.
-              OUTPUT=$(cargo publish -p "$c" --dry-run 2>&1) || {
-                echo "$OUTPUT"
-                if echo "$OUTPUT" | grep -q "no matching package named"; then
-                  echo "$c: sibling dep not on crates.io yet (expected in dry-run), continuing"
-                  echo "::endgroup::"
-                  continue
-                fi
-                exit 1
-              }
+              cargo package -p "$c" --no-verify --list
             else
               OUTPUT=$(cargo publish -p "$c" 2>&1) || {
                 echo "$OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,54 +30,6 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Guard against an unpublishable dependency cycle
-        run: |
-          python3 - <<'PY'
-          import json, subprocess, sys
-          meta = json.loads(subprocess.check_output(["cargo", "metadata", "--format-version", "1"]))
-          # Keep in sync with the CRATES list in the next step.
-          PUB = {
-              "ethrex-rlp", "ethrex-crypto", "ethrex-sdk-contract-utils", "ethrex-trie",
-              "ethrex-common", "ethrex-metrics", "ethrex-levm", "ethrex-l2-common",
-              "ethrex-storage", "ethrex-vm", "ethrex-storage-rollup", "ethrex-blockchain",
-              "ethrex-p2p", "ethrex-rpc", "ethrex-l2-rpc", "ethrex-sdk",
-          }
-          adj = {n: set() for n in PUB}
-          for p in meta["packages"]:
-              if p["name"] not in PUB:
-                  continue
-              for d in p["dependencies"]:
-                  if d["name"] not in PUB:
-                      continue
-                  # cargo publish keeps normal + build deps always, and dev-deps only
-                  # if they carry a version (path-only dev-deps are stripped on publish).
-                  kept = d.get("kind") in (None, "build") or (d.get("kind") == "dev" and d.get("req") != "*")
-                  if kept:
-                      adj[p["name"]].add(d["name"])
-          color = {n: 0 for n in PUB}
-          cyc = []
-          def dfs(u, st):
-              color[u] = 1
-              for v in sorted(adj[u]):
-                  if color[v] == 1:
-                      cyc.extend(st[st.index(v):] + [v])
-                      return True
-                  if color[v] == 0 and dfs(v, st + [v]):
-                      return True
-              color[u] = 2
-              return False
-          for n in sorted(PUB):
-              if color[n] == 0 and dfs(n, [n]):
-                  break
-          if cyc:
-              print("Unpublishable dependency cycle among published crates:")
-              print("  " + " -> ".join(cyc))
-              print("A versioned dev/build-dependency points at a crate published later;")
-              print("make such dev-deps path-only (no version) so they are stripped on publish.")
-              sys.exit(1)
-          print("OK: kept-edge dependency graph is acyclic (a valid publish order exists).")
-          PY
-
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
@@ -108,8 +60,7 @@ jobs:
             if [ "${DRY_RUN:-false}" = "true" ]; then
               # Real publish dry-run: packaging + index resolution + verify build.
               # On a dry-run nothing is actually published, so crates later in the
-              # order can't resolve their siblings yet -- tolerate ONLY that error
-              # (the cycle guard above catches genuinely unpublishable graphs).
+              # order can't resolve their siblings yet -- tolerate ONLY that error.
               OUTPUT=$(cargo publish -p "$c" --dry-run 2>&1) || {
                 echo "$OUTPUT"
                 echo "$OUTPUT" | grep -q "no matching package named" || exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish crates to crates.io
+run-name: Publish crates to crates.io${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && ' (dry run)' || '' }}
 
 # `released` fires only when a release is promoted to a full (non-pre-release)
 # release — i.e. step 4 of the release process, after the RC has been tested.

--- a/crates/common/rlp/Cargo.toml
+++ b/crates/common/rlp/Cargo.toml
@@ -16,8 +16,12 @@ ethereum-types = { version = "0.15.1", default-features = false, features = ["et
 [dev-dependencies]
 hex-literal.workspace = true
 criterion = { version = "0.7.0", features = ["html_reports"] }
-ethrex-common.workspace = true
-ethrex-trie.workspace = true
+# Path-only (no version) on purpose: these are bench-only dev-deps on crates that
+# publish AFTER ethrex-rlp. A versioned dev-dep would make `cargo publish` require
+# them from crates.io before they exist (ethrex-rlp is the first crate published).
+# Path-only dev-deps are stripped from the published manifest.
+ethrex-common = { path = ".." }
+ethrex-trie = { path = "../trie" }
 rand = "0.9.2"
 once_cell = "1"
 


### PR DESCRIPTION
**Motivation**

The manual `Publish crates to crates.io` run failed on the very first crate:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `ethrex-common` found
  location searched: crates.io index
  required by package `ethrex-rlp v17.0.0`
```

`ethrex-rlp` is published first, but its **bench dev-dependencies** on `ethrex-common` and `ethrex-trie` became *versioned* when `version = "17.0.0"` was added to the `[workspace.dependencies]` entries (via `.workspace = true`). `cargo publish` keeps versioned dev-deps in the published manifest and resolves them against crates.io — but those crates aren't published yet (they come later in the order), so packaging `ethrex-rlp` fails.

**Description**

Declare `ethrex-rlp`'s bench dev-deps as **path-only** (no version):

```toml
ethrex-common = { path = ".." }
ethrex-trie = { path = "../trie" }
```

Path-only dev-deps are stripped from the published manifest (the pre-publishing behavior), so `cargo publish` no longer requires them from the index. Benches still build locally via the path.

This was the only affected crate: `ethrex-l2-rpc`'s dev-dep on `ethrex-rpc` and `ethrex-sdk`'s build-dep on `ethrex-sdk-contract-utils` are forward edges (the dep publishes before the consumer), so they resolve in order.

**Validation**

`cargo publish --dry-run` now succeeds for all three leaf crates — each reaches "Uploading … aborting upload due to dry run":
- `ethrex-rlp`, `ethrex-crypto`, `ethrex-sdk-contract-utils`

(The dependents can't be dry-run'd locally until their deps are on crates.io, but the topological order is unchanged and no other versioned sibling dev/build-deps point forward.)

**How to test**

After merge, re-run the **Publish crates to crates.io** workflow (dry-run first, then real). The first crate `ethrex-rlp` will package and upload instead of erroring.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A.