### PR TITLE
fix: repoint canonical index on BSC reorg

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -1941,8 +1941,25 @@ impl Blockchain {
         if number <= latest {
             return Ok(());
         }
+        // Repoint the canonical number→hash index for every reorged height, not
+        // just the new head. When a heavier chain replaces blocks at heights
+        // <= the previous head before extending past it, those heights must be
+        // re-canonicalized; otherwise BLOCKHASH / get_block_hash return the
+        // reorged-out fork's hashes, diverging EVM execution (see
+        // smoke_tests::advance_canonical_head_repoints_reorged_heights). Mirror
+        // `apply_fork_choice`: walk back to the common canonical ancestor and
+        // hand the whole branch to `forkchoice_update`. The `number > latest`
+        // guard above is kept so a concurrently-advanced head is never rewound.
+        let new_canonical_blocks = match self.storage.get_block_header_by_hash(hash)? {
+            Some(header) => {
+                crate::fork_choice::find_link_with_canonical_chain(&self.storage, &header)
+                    .await?
+                    .unwrap_or_default()
+            }
+            None => Vec::new(),
+        };
         self.storage
-            .forkchoice_update(vec![(number, hash)], number, hash, None, None)
+            .forkchoice_update(new_canonical_blocks, number, hash, None, None)
             .await
             .map_err(Into::into)
     }

--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -219,7 +219,7 @@ fn check_order(
 // - Ok(Some([])): the block is already canonical.
 // - Ok(Some(branch)): the "branch" is a sequence of blocks that connects the ancestor and the
 //   descendant.
-async fn find_link_with_canonical_chain(
+pub(crate) async fn find_link_with_canonical_chain(
     store: &Store,
     block_header: &BlockHeader,
 ) -> Result<Option<Vec<(BlockNumber, BlockHash)>>, StoreError> {

--- a/test/tests/blockchain/smoke_tests.rs
+++ b/test/tests/blockchain/smoke_tests.rs
@@ -345,6 +345,74 @@ async fn unfinalized_reorg_deeper_than_32_is_allowed() {
     }
 }
 
+#[tokio::test]
+async fn advance_canonical_head_repoints_reorged_heights() {
+    // Regression for the BSC stale canonical-index bug. The BSC sync + NewBlock
+    // import paths canonicalize each block via `advance_canonical_head`. When a
+    // heavier chain reorgs heights at or below the current head and then extends
+    // past it, every reorged height must be repointed to the new chain's hash —
+    // not just the new head. Otherwise the number→hash index keeps pointing at
+    // the reorged-out fork, and BLOCKHASH/get_block_hash return stale hashes,
+    // diverging EVM execution (this is what wedged bnb-mainnet at block
+    // 105536921: a betting contract read BLOCKHASH of a reorged height).
+    let store = test_store().await;
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let blockchain = Blockchain::default_with_store(store.clone());
+
+    // Chain A: genesis → A1 → A2 → A3, canonicalized per-block via
+    // advance_canonical_head (mirroring the BSC import path).
+    let mut parent = genesis_header.clone();
+    let mut chain_a = Vec::new();
+    for _ in 0..3 {
+        let block = new_block(&store, &parent).await;
+        parent = block.header.clone();
+        chain_a.push((block.header.number, block.hash()));
+        blockchain.add_block(block).unwrap();
+    }
+    for (number, hash) in &chain_a {
+        blockchain
+            .advance_canonical_head(*number, *hash)
+            .await
+            .unwrap();
+    }
+    let (_, head_a) = *chain_a.last().unwrap();
+    assert!(is_canonical(&store, 3, head_a).await.unwrap());
+
+    // Chain B: genesis → B1 → B2 → B3 → B4. Reorgs heights 1-3 (<= head) and
+    // extends to height 4. `new_block` randomizes fields so B hashes differ.
+    let mut parent = genesis_header.clone();
+    let mut chain_b = Vec::new();
+    for _ in 0..4 {
+        let block = new_block(&store, &parent).await;
+        parent = block.header.clone();
+        chain_b.push((block.header.number, block.hash()));
+        blockchain.add_block(block).unwrap();
+    }
+    // Import chain B per-block via advance_canonical_head, exactly as BSC does.
+    for (number, hash) in &chain_b {
+        blockchain
+            .advance_canonical_head(*number, *hash)
+            .await
+            .unwrap();
+    }
+
+    // Every chain-B height must now be canonical — including the reorged 1-3.
+    for (number, hash) in &chain_b {
+        assert!(
+            is_canonical(&store, *number, *hash).await.unwrap(),
+            "chain B block at height {number} should be canonical after reorg"
+        );
+    }
+    // And the by-number index must not still return chain A's stale hashes.
+    for (number, hash) in &chain_a {
+        assert_ne!(
+            store.get_canonical_block_hash(*number).await.unwrap(),
+            Some(*hash),
+            "stale chain A hash still indexed at height {number} (BLOCKHASH bug)"
+        );
+    }
+}
+
 async fn new_block(store: &Store, parent: &BlockHeader) -> Block {
     let args = BuildPayloadArgs {
         parent: parent.hash(),


### PR DESCRIPTION
## Problem

The BSC block-import paths (`p2p/rlpx/connection/server.rs` NewBlock import and `p2p/sync/full.rs` forward sync) canonicalize each block via `Blockchain::advance_canonical_head`, which:

- early-returns when `number <= latest`, and
- passed only `vec![(number, hash)]` (the single new head) to `forkchoice_update`.

`forkchoice_update_inner` writes only the pairs it's handed and deletes entries above the head — it never rewrites heights between the common ancestor and the head. So when a heavier chain reorgs blocks at heights `<= the current head` and then extends past it, the reorged heights are stored (by hash) but their `block_number -> canonical_hash` index entries are never repointed: they keep pointing at the reorged-out fork.

`BLOCKHASH` / `get_block_hash` read that by-number index, so they return stale hashes for the reorged heights. Any contract reading `BLOCKHASH` of such a height (e.g. blockhash-based randomness) then diverges from canonical execution.

This wedged a BSC mainnet node at block 105536921: blocks 105536905–105536909 had a stale canonical index after a 5-block reorg; tx 205 (`settle(betId)`) read `BLOCKHASH` of a reorged height, computed the wrong outcome, skipped its payout, and produced a block gas total 49,559 short of the header — rejected on every retry.

The L1 engine-API and L2 paths are unaffected: they canonicalize through `apply_fork_choice` -> `find_link_with_canonical_chain`, which already rewrites the whole branch.

## Fix

`advance_canonical_head` now mirrors `apply_fork_choice`: when the new head extends the chain (`number > latest`), it walks back to the common canonical ancestor via `find_link_with_canonical_chain` and hands the **whole branch** to `forkchoice_update`, so every reorged height is repointed — not just the head. The `number <= latest` guard (which avoids rewinding a concurrently-advanced head) is preserved, and it falls back to head-only if the header/link can't be found. `find_link_with_canonical_chain` is now `pub(crate)`.

Linear-extension overhead: one extra header lookup + one `is_canonical` check.

## Test

`advance_canonical_head_repoints_reorged_heights` (test/tests/blockchain/smoke_tests.rs): canonicalizes chain A via `advance_canonical_head`, then imports a heavier chain B that reorgs heights 1–3 and extends to 4, and asserts every chain-B height (including the reorged ones) is canonical. Fails before the fix ("height 1 should be canonical after reorg"), passes after. All 7 smoke tests pass; clippy + fmt clean.