### PR TITLE
fix(l1): fix the crates.io publish failure and make the workflow re-runnable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ run-name: Publish crates to crates.io${{ (github.event_name == 'workflow_dispatc
 # It does NOT fire on `vX.Y.Z-rc.W` pre-release creation, so release candidates
 # never publish to crates.io (crates.io versions are immutable).
 on:
+  # TEMP-DEBUG (revert before merge): validate the dry-run on x86_64 CI for this branch.
+  push:
+    branches: [fix-publish-verify-and-rerun]
   release:
     types: [released]
   workflow_dispatch:
@@ -40,7 +43,10 @@ jobs:
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          # TEMP-DEBUG (revert before merge): dry-run for everything except a real
+          # release, so the push trigger above can never publish. Restore
+          # `github.event_name == 'workflow_dispatch' && inputs.dry_run` before merge.
+          DRY_RUN: ${{ github.event_name != 'release' }}
         run: |
           set -euo pipefail
           # Topological order: each crate is published after all of its dependencies.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "List package contents only, do not publish"
+        description: "Verify each crate (package + compile) without publishing"
         type: boolean
         default: true
 
@@ -30,6 +30,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
         with:
           toolchain: stable
+          # This action defaults RUSTFLAGS to "-D warnings", which (a) makes the
+          # cargo-publish verify build fail on lints and (b) overrides the
+          # `[target.*].rustflags` target-features in .cargo/config.toml. Publishing
+          # already-reviewed, CI-linted code should not deny warnings -- lints are
+          # gated on PRs separately -- so disable it here.
+          rustflags: ""
 
       - name: Publish crates in dependency order
         env:
@@ -59,18 +65,21 @@ jobs:
           for c in "${CRATES[@]}"; do
             echo "::group::$c"
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              # Real publish dry-run: packaging + index resolution + verify build.
-              # On a dry-run nothing is actually published, so crates later in the
-              # order can't resolve their siblings yet -- tolerate ONLY that error.
-              OUTPUT=$(cargo publish -p "$c" --dry-run 2>&1) || {
-                echo "$OUTPUT"
-                echo "$OUTPUT" | grep -q "no matching package named" || exit 1
-                echo "$c: sibling not on crates.io yet (expected during a dry-run)"
-              }
+              # `cargo publish --dry-run` can't validate a whole unpublished
+              # workspace: each crate's siblings aren't on the index yet, so every
+              # dependent stops at dependency resolution before it ever compiles.
+              # Instead verify each crate against its workspace path deps, which
+              # needs nothing published: package (manifest + tarball file list) and
+              # compile with default features (the same build cargo's verify step
+              # runs from the tarball).
+              cargo package -p "$c" --no-verify --allow-dirty >/dev/null
+              cargo check -p "$c"
             else
               OUTPUT=$(cargo publish -p "$c" 2>&1) || {
                 echo "$OUTPUT"
-                if echo "$OUTPUT" | grep -q "already exists"; then
+                # Idempotent re-runs: skip versions already on crates.io. cargo emits
+                # "already uploaded" (modern) or "already exists" (older/other registries).
+                if echo "$OUTPUT" | grep -qiE "already (uploaded|exists)"; then
                   echo "$c already published, skipping"
                   echo "::endgroup::"
                   continue

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,14 +65,13 @@ jobs:
           for c in "${CRATES[@]}"; do
             echo "::group::$c"
             if [ "${DRY_RUN:-false}" = "true" ]; then
-              # `cargo publish --dry-run` can't validate a whole unpublished
-              # workspace: each crate's siblings aren't on the index yet, so every
-              # dependent stops at dependency resolution before it ever compiles.
-              # Instead verify each crate against its workspace path deps, which
-              # needs nothing published: package (manifest + tarball file list) and
-              # compile with default features (the same build cargo's verify step
-              # runs from the tarball).
-              cargo package -p "$c" --no-verify --allow-dirty >/dev/null
+              # `cargo publish --dry-run` (and `cargo package` without --list)
+              # resolve each crate's siblings against the crates.io index, which
+              # aren't published yet -- so dependents fail at resolution before they
+              # ever compile. Validate against workspace path deps instead, which
+              # needs nothing published: list the tarball file set (no index lookup)
+              # and compile with default features (what cargo's verify step builds).
+              cargo package -p "$c" --no-verify --list >/dev/null
               cargo check -p "$c"
             else
               OUTPUT=$(cargo publish -p "$c" 2>&1) || {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,6 @@ run-name: Publish crates to crates.io${{ (github.event_name == 'workflow_dispatc
 # It does NOT fire on `vX.Y.Z-rc.W` pre-release creation, so release candidates
 # never publish to crates.io (crates.io versions are immutable).
 on:
-  # TEMP-DEBUG (revert before merge): validate the dry-run on x86_64 CI for this branch.
-  push:
-    branches: [fix-publish-verify-and-rerun]
   release:
     types: [released]
   workflow_dispatch:
@@ -43,10 +40,7 @@ jobs:
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          # TEMP-DEBUG (revert before merge): dry-run for everything except a real
-          # release, so the push trigger above can never publish. Restore
-          # `github.event_name == 'workflow_dispatch' && inputs.dry_run` before merge.
-          DRY_RUN: ${{ github.event_name != 'release' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
         run: |
           set -euo pipefail
           # Topological order: each crate is published after all of its dependencies.

--- a/crates/common/trie/nibbles.rs
+++ b/crates/common/trie/nibbles.rs
@@ -195,8 +195,6 @@ unsafe fn pack_nibble_pairs(nibbles: &[u8], output: *mut u8) {
 #[allow(unsafe_code)]
 #[inline]
 unsafe fn pack_nibble_pairs_x86_64(nibbles: &[u8], output: *mut u8) {
-    use std::arch::x86_64::*;
-
     let n = nibbles.len(); // always even
     let mut i = 0usize; // index into nibbles (steps of 32)
     let mut o = 0usize; // index into output (steps of 16)
@@ -207,6 +205,7 @@ unsafe fn pack_nibble_pairs_x86_64(nibbles: &[u8], output: *mut u8) {
     #[cfg(target_feature = "ssse3")]
     // SAFETY: SSSE3 enabled at compile time; pointer arithmetic stays within bounds.
     unsafe {
+        use std::arch::x86_64::*;
         // Multiplier: weight = [16, 1] repeated → multiply even nibble by 16, odd by 1
         let weights = _mm_set1_epi16(0x0110_u16 as i16); // bytes: [16, 1, 16, 1, ...]
         while i + 32 <= n {


### PR DESCRIPTION
**Motivation**

The first real `Publish crates to crates.io` run published `ethrex-rlp`, `ethrex-crypto`, `ethrex-sdk-contract-utils`, then **failed on the 4th crate, `ethrex-trie`**:

```
error: unused import: `std::arch::x86_64::*`
   --> nibbles.rs:198:9
   = note: `-D unused-imports` implied by `-D warnings`
error: failed to verify package tarball
```

Three distinct problems surfaced:

1. **The crate failure.** `use std::arch::x86_64::*` is only used inside a `#[cfg(target_feature = "ssse3")]` block. The publish verify build runs under `-D warnings` (injected by `setup-rust-toolchain`), and that `RUSTFLAGS` *also overrides* the `+ssse3` target-feature set in `.cargo/config.toml` — so SSSE3 is off, the import is unused, and `-D warnings` turns it into a hard error.
2. **The dry-run was useless.** `cargo publish --dry-run` over an unpublished workspace makes every dependent fail dependency resolution (its siblings aren't on the index yet) *before it compiles*; the tolerant logic reported success while testing nothing. That's why the trie failure wasn't caught.
3. **Re-runs weren't idempotent.** The workflow matched `"already exists"`, but modern cargo emits `"already uploaded"` — so a re-run would fail on `ethrex-rlp` (already published) instead of skipping it.

**Description**

- **`crates/common/trie/nibbles.rs`**: move `use std::arch::x86_64::*` into the `#[cfg(target_feature = "ssse3")]` block so it is only present when its intrinsics are.
- **`publish.yml` — disable `-D warnings`** (`rustflags: ""` on `setup-rust-toolchain`). Publishing already-reviewed, separately-linted code should not deny warnings; this also stops `RUSTFLAGS` from clobbering the config.toml target-features during the verify build. Neutralizes the entire warning class for all crates.
- **`publish.yml` — idempotent re-runs**: match `already (uploaded|exists)` so re-running skips versions already on crates.io.
- **`publish.yml` — a dry-run that works**: replace `cargo publish --dry-run` with `cargo package --no-verify --list` (tarball file set, no index lookup) + `cargo check` (compile with default features). Both run against workspace path deps, so they validate every crate without anything being published.

**Validation**

- Reproduced the trie failure locally under the exact verify conditions (`--target x86_64-unknown-linux-gnu`, `RUSTFLAGS=-D warnings`); confirmed the fix compiles clean there and the import is still used when SSSE3 is on.
- Audited every `std::arch` / `target_feature` site in the publish set: only `ethrex-trie` (fixed) and `ethrex-crypto` (already published OK) have arch-gated code.
- Ran the new dry-run on a real x86_64 CI runner: all 16 crates pass (`cargo check` green for each).

**How to re-run the publish after merge**

1. **Actions → Publish crates to crates.io → Run workflow**, `dry_run` checked (default) → verifies all 16 without publishing.
2. Re-run with `dry_run` off → publishes; the 3 already-published crates are skipped, `ethrex-trie` onward publish.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A.