### PR TITLE
fix(l1): stop unbounded P2P connection memory growth (bounded mailbox, lifecycle timeouts, admission cap, map pruning)

### DIFF
--- a/crates/networking/p2p/discovery/discv5_handlers.rs
+++ b/crates/networking/p2p/discovery/discv5_handlers.rs
@@ -81,7 +81,7 @@ impl DiscoveryServer {
         let ordinary = match decrypt_key {
             Some(key) => match Ordinary::decode(&packet, &key) {
                 Ok(ordinary) => {
-                    if let Some(session_ip) = discv5.session_ips.get(&src_id)
+                    if let Some((session_ip, _)) = discv5.session_ips.get(&src_id)
                         && addr.ip() != *session_ip
                     {
                         trace!(
@@ -253,7 +253,9 @@ impl DiscoveryServer {
 
         self.peer_table.set_session_info(src_id, session.clone())?;
         let discv5 = self.discv5.as_mut().expect("discv5 state must exist");
-        discv5.session_ips.insert(src_id, addr.ip());
+        discv5
+            .session_ips
+            .insert(src_id, (addr.ip(), std::time::Instant::now()));
 
         let mut encrypted = packet.encrypted_message.clone();
         decrypt_message(&session.inbound_key, &packet, &mut encrypted)?;

--- a/crates/networking/p2p/discovery/discv5_handlers.rs
+++ b/crates/networking/p2p/discovery/discv5_handlers.rs
@@ -6,7 +6,7 @@ use crate::{
             NodesMessage, Ordinary, Packet, PacketTrait as _, PingMessage, PongMessage,
             TalkResMessage, WhoAreYou, decrypt_message,
         },
-        server::{Discv5Message, Discv5State, update_local_ip},
+        server::{Discv5Message, Discv5State, SessionSource, update_local_ip},
         session::{
             build_challenge_data, create_id_signature, derive_session_keys, verify_id_signature,
         },
@@ -81,7 +81,8 @@ impl DiscoveryServer {
         let ordinary = match decrypt_key {
             Some(key) => match Ordinary::decode(&packet, &key) {
                 Ok(ordinary) => {
-                    if let Some((session_ip, _)) = discv5.session_ips.get(&src_id)
+                    if let Some(SessionSource { ip: session_ip, .. }) =
+                        discv5.session_ips.get(&src_id)
                         && addr.ip() != *session_ip
                     {
                         trace!(
@@ -253,9 +254,13 @@ impl DiscoveryServer {
 
         self.peer_table.set_session_info(src_id, session.clone())?;
         let discv5 = self.discv5.as_mut().expect("discv5 state must exist");
-        discv5
-            .session_ips
-            .insert(src_id, (addr.ip(), std::time::Instant::now()));
+        discv5.session_ips.insert(
+            src_id,
+            SessionSource {
+                ip: addr.ip(),
+                established_at: std::time::Instant::now(),
+            },
+        );
 
         let mut encrypted = packet.encrypted_message.clone();
         decrypt_message(&session.inbound_key, &packet, &mut encrypted)?;

--- a/crates/networking/p2p/discv5/server.rs
+++ b/crates/networking/p2p/discv5/server.rs
@@ -27,6 +27,14 @@ const MESSAGE_CACHE_TIMEOUT: Duration = Duration::from_secs(2);
 /// per discv5 handshake and (absent this) was never removed for nodes we don't keep as peers.
 const SESSION_TTL: Duration = Duration::from_secs(3600);
 
+/// Source IP a discv5 session was established from, paired with when it was recorded so stale
+/// entries can be evicted (see `SESSION_TTL`).
+#[derive(Debug, Clone)]
+pub struct SessionSource {
+    pub ip: IpAddr,
+    pub established_at: Instant,
+}
+
 /// Discv5-specific state held within the unified DiscoveryServer.
 #[derive(Debug)]
 pub struct Discv5State {
@@ -45,7 +53,7 @@ pub struct Discv5State {
     pub whoareyou_global_window_start: Instant,
     /// Tracks the source IP that each session was established from, with the insertion time
     /// so stale entries can be evicted (see `SESSION_TTL`).
-    pub session_ips: FxHashMap<H256, (IpAddr, Instant)>,
+    pub session_ips: FxHashMap<H256, SessionSource>,
     /// Collects recipient_addr IPs from PONGs for external IP detection via majority voting.
     pub ip_votes: FxHashMap<IpAddr, FxHashSet<H256>>,
     /// When the current IP voting period started. None if no votes received yet.
@@ -112,7 +120,7 @@ impl Discv5State {
 
         let before_sessions = self.session_ips.len();
         self.session_ips
-            .retain(|_node_id, (_ip, inserted_at)| now.duration_since(*inserted_at) < SESSION_TTL);
+            .retain(|_node_id, source| now.duration_since(source.established_at) < SESSION_TTL);
         let removed_sessions = before_sessions - self.session_ips.len();
 
         let total_removed = removed_messages + removed_challenges + removed_sessions;

--- a/crates/networking/p2p/discv5/server.rs
+++ b/crates/networking/p2p/discv5/server.rs
@@ -23,6 +23,9 @@ const IP_VOTE_WINDOW: Duration = Duration::from_secs(300);
 const IP_VOTE_THRESHOLD: usize = 3;
 /// Timeout for pending messages awaiting WhoAreYou response.
 const MESSAGE_CACHE_TIMEOUT: Duration = Duration::from_secs(2);
+/// Max age of a `session_ips` entry before it is evicted. Bounds the map: it is inserted
+/// per discv5 handshake and (absent this) was never removed for nodes we don't keep as peers.
+const SESSION_TTL: Duration = Duration::from_secs(3600);
 
 /// Discv5-specific state held within the unified DiscoveryServer.
 #[derive(Debug)]
@@ -40,8 +43,9 @@ pub struct Discv5State {
     pub whoareyou_global_count: u32,
     /// Start of the current global rate limit window.
     pub whoareyou_global_window_start: Instant,
-    /// Tracks the source IP that each session was established from.
-    pub session_ips: FxHashMap<H256, IpAddr>,
+    /// Tracks the source IP that each session was established from, with the insertion time
+    /// so stale entries can be evicted (see `SESSION_TTL`).
+    pub session_ips: FxHashMap<H256, (IpAddr, Instant)>,
     /// Collects recipient_addr IPs from PONGs for external IP detection via majority voting.
     pub ip_votes: FxHashMap<IpAddr, FxHashSet<H256>>,
     /// When the current IP voting period started. None if no votes received yet.
@@ -106,7 +110,12 @@ impl Discv5State {
             });
         let removed_challenges = before_challenges - self.pending_challenges.len();
 
-        let total_removed = removed_messages + removed_challenges;
+        let before_sessions = self.session_ips.len();
+        self.session_ips
+            .retain(|_node_id, (_ip, inserted_at)| now.duration_since(*inserted_at) < SESSION_TTL);
+        let removed_sessions = before_sessions - self.session_ips.len();
+
+        let total_removed = removed_messages + removed_challenges + removed_sessions;
         if total_removed > 0 {
             trace!(
                 protocol = "discv5",

--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -381,6 +381,12 @@ impl Metrics {
                     .and_modify(|e| *e += 1)
                     .or_insert(1);
             }
+            PeerConnectionError::OutboundQueueFull => {
+                failures_grouped_by_reason
+                    .entry("OutboundQueueFull".to_owned())
+                    .and_modify(|e| *e += 1)
+                    .or_insert(1);
+            }
             PeerConnectionError::Disconnected => {
                 failures_grouped_by_reason
                     .entry("Disconnected".to_owned())

--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -375,6 +375,12 @@ impl Metrics {
                     .and_modify(|e| *e += 1)
                     .or_insert(1);
             }
+            PeerConnectionError::OutboundSendTimeout => {
+                failures_grouped_by_reason
+                    .entry("OutboundSendTimeout".to_owned())
+                    .and_modify(|e| *e += 1)
+                    .or_insert(1);
+            }
             PeerConnectionError::Disconnected => {
                 failures_grouped_by_reason
                     .entry("Disconnected".to_owned())

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -48,7 +48,15 @@ pub struct P2PContext {
     pub based_context: Option<P2PBasedContext>,
     pub tx_broadcaster: ActorRef<TxBroadcaster>,
     pub initial_lookup_interval: f64,
+    /// Caps concurrent INBOUND connections (including pre-handshake) so a flood of inbound
+    /// dials can't accumulate connection actors/sockets without bound. Each inbound connection
+    /// actor holds a permit for its lifetime; the permit is released when the actor is dropped.
+    pub(crate) inbound_admission: Arc<tokio::sync::Semaphore>,
 }
+
+/// Max concurrent inbound connections (peer_table TARGET_PEERS = 100, plus headroom for
+/// pre-handshake churn and short-lived overlap).
+const MAX_INBOUND_CONNECTIONS: usize = 150;
 
 impl P2PContext {
     #[allow(clippy::too_many_arguments)]
@@ -96,6 +104,7 @@ impl P2PContext {
             based_context,
             tx_broadcaster,
             initial_lookup_interval: lookup_interval,
+            inbound_admission: Arc::new(tokio::sync::Semaphore::new(MAX_INBOUND_CONNECTIONS)),
         })
     }
 }
@@ -167,7 +176,18 @@ pub(crate) async fn serve_p2p_requests(context: P2PContext) {
             continue;
         }
 
-        let _ = PeerConnection::spawn_as_receiver(context.clone(), peer_addr, stream);
+        // Bound concurrent inbound connections: if we're at capacity, drop this one instead
+        // of letting connection actors/sockets accumulate. The permit is moved into the
+        // connection actor and released when the actor is dropped.
+        let permit = match context.inbound_admission.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                tracing::debug!(peer = %peer_addr, "Inbound connection cap reached, dropping connection");
+                continue;
+            }
+        };
+
+        let _ = PeerConnection::spawn_as_receiver(context.clone(), peer_addr, stream, permit);
     }
 }
 

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -568,6 +568,9 @@ impl PeerTableServer {
         _ctx: &Context<Self>,
     ) {
         self.peers.swap_remove(&msg.node_id);
+        // Also drop the standalone discv5 session so it isn't retained after the peer leaves
+        // (the sessions map was previously insert-only and grew per handshake).
+        self.sessions.remove(&msg.node_id);
     }
 
     #[send_handler]

--- a/crates/networking/p2p/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p/rlpx/connection/handshake.rs
@@ -123,10 +123,13 @@ pub(crate) async fn perform(
         }
     };
     let (sink, stream) = framed.split();
+    // Move the socket sink into a dedicated writer task; the actor keeps only a bounded
+    // sender, so it never blocks on a slow peer's network write (see `spawn_outbound_writer`).
+    let outbound_tx = crate::rlpx::connection::server::spawn_outbound_writer(sink);
     Ok((
         Established {
             signer: context.signer,
-            sink,
+            outbound_tx,
             node,
             storage: context.storage.clone(),
             blockchain: context.blockchain.clone(),

--- a/crates/networking/p2p/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p/rlpx/connection/handshake.rs
@@ -125,11 +125,13 @@ pub(crate) async fn perform(
     let (sink, stream) = framed.split();
     // Move the socket sink into a dedicated writer task; the actor keeps only a bounded
     // sender, so it never blocks on a slow peer's network write (see `spawn_outbound_writer`).
-    let outbound_tx = crate::rlpx::connection::server::spawn_outbound_writer(sink);
+    let (outbound_tx, outbound_writer_timed_out) =
+        crate::rlpx::connection::server::spawn_outbound_writer(sink);
     Ok((
         Established {
             signer: context.signer,
             outbound_tx,
+            outbound_writer_timed_out,
             node,
             storage: context.storage.clone(),
             blockchain: context.blockchain.clone(),

--- a/crates/networking/p2p/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p/rlpx/connection/handshake.rs
@@ -151,6 +151,7 @@ pub(crate) async fn perform(
             serve_requests_in_window: 0,
             txs_sent_to_peer: 0,
             received_txs_from_peer: false,
+            missed_pongs: 0,
         },
         stream,
     ))

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -77,6 +77,13 @@ const PING_INTERVAL: Duration = Duration::from_secs(10);
 const BLOCK_RANGE_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
 const INFLIGHT_TX_SWEEP_INTERVAL: Duration = Duration::from_secs(15);
 const INFLIGHT_TX_TIMEOUT: Duration = Duration::from_secs(30);
+/// Max time a single outbound frame may take to flush to a peer's socket before we
+/// consider the peer wedged and drop it. Without this bound, a slow/half-dead peer
+/// (TCP send window full, never draining) blocks the connection actor's serial drain
+/// indefinitely while its unbounded mailbox keeps growing — the timer/broadcast
+/// producers below enqueue regardless of drain progress — leaking memory that is
+/// never reclaimed (the actor cannot be stopped while a handler is wedged in `.await`).
+const OUTBOUND_SEND_TIMEOUT: Duration = Duration::from_secs(30);
 /// How often to flush buffered transaction hash requests into a single
 /// batched GetPooledTransactions message.
 const TX_REQUEST_BATCH_INTERVAL: Duration = Duration::from_millis(50);
@@ -659,7 +666,8 @@ impl PeerConnectionServer {
                 | PeerConnectionError::InvalidPeerId
                 | PeerConnectionError::InvalidMessageLength
                 | PeerConnectionError::StateError(_)
-                | PeerConnectionError::InvalidRecoveryId => {
+                | PeerConnectionError::InvalidRecoveryId
+                | PeerConnectionError::OutboundSendTimeout => {
                     trace!(peer=%established_state.node, error=e.to_string(), "Peer connection error");
                     ctx.stop();
                 }
@@ -1111,7 +1119,13 @@ pub(crate) async fn send(
         use ethrex_metrics::p2p::METRICS_P2P;
         METRICS_P2P.inc_outgoing_message(message.metric_label());
     }
-    state.sink.send(message).await
+    // Bound the flush so a wedged peer cannot block the actor's serial drain forever.
+    // On timeout we return an error; `process_cast_error` then stops the actor, which
+    // drops its (unbounded) mailbox and reclaims the accumulated memory.
+    match tokio::time::timeout(OUTBOUND_SEND_TIMEOUT, state.sink.send(message)).await {
+        Ok(result) => result,
+        Err(_elapsed) => Err(PeerConnectionError::OutboundSendTimeout),
+    }
 }
 
 /// Reads from the frame until a frame is available.

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -93,6 +93,10 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 /// If a peer fails to answer this many consecutive pings, consider it dead and drop it.
 /// Catches application-dead-but-TCP-alive peers that would otherwise never be removed.
 const MAX_MISSED_PONGS: u8 = 3;
+/// Capacity of the per-connection bounded outbound queue. The writer task drains this into
+/// the socket; if a peer can't keep up the queue fills and the peer is dropped, so outbound
+/// buffering per connection is bounded to this many messages instead of growing unbounded.
+const OUTBOUND_QUEUE_CAP: usize = 1024;
 /// How often to flush buffered transaction hash requests into a single
 /// batched GetPooledTransactions message.
 const TX_REQUEST_BATCH_INTERVAL: Duration = Duration::from_millis(50);
@@ -236,9 +240,11 @@ pub struct Receiver {
 #[derive(Debug)]
 pub struct Established {
     pub(crate) signer: SecretKey,
-    // Sending part of the TcpStream to connect with the remote peer
-    // The receiving part is owned by the stream listen loop task
-    pub(crate) sink: SplitSink<Framed<TcpStream, RLPxCodec>, Message>,
+    // Bounded outbound queue to the per-connection writer task (which owns the socket sink).
+    // A bounded queue + dropping the peer on overflow keeps per-connection outbound buffering
+    // bounded instead of letting the actor mailbox grow when a peer can't keep up. The receiving
+    // part of the TcpStream is owned by the stream listen loop task. See `spawn_outbound_writer`.
+    pub(crate) outbound_tx: tokio::sync::mpsc::Sender<Message>,
     pub(crate) node: Node,
     pub(crate) storage: Store,
     pub(crate) blockchain: Arc<Blockchain>,
@@ -311,13 +317,8 @@ impl Established {
             }
             retry_on_alternates(&self.blockchain, &self.peer_table, &pending_hashes).await;
         }
-        // Closing the sink. It may fail if it is already closed (eg. the other side already closed it)
-        // Just logging a debug line if that's the case.
-        let _ = self
-            .sink
-            .close()
-            .await
-            .inspect_err(|err| debug!("Could not close the socket: {err}"));
+        // The socket sink is owned by the per-connection writer task (`spawn_outbound_writer`),
+        // which closes it when this `Established` is dropped (its `outbound_tx` is the only sender).
     }
 }
 
@@ -705,7 +706,8 @@ impl PeerConnectionServer {
                 | PeerConnectionError::InvalidMessageLength
                 | PeerConnectionError::StateError(_)
                 | PeerConnectionError::InvalidRecoveryId
-                | PeerConnectionError::OutboundSendTimeout => {
+                | PeerConnectionError::OutboundSendTimeout
+                | PeerConnectionError::OutboundQueueFull => {
                     trace!(peer=%established_state.node, error=e.to_string(), "Peer connection error");
                     ctx.stop();
                 }
@@ -1157,13 +1159,41 @@ pub(crate) async fn send(
         use ethrex_metrics::p2p::METRICS_P2P;
         METRICS_P2P.inc_outgoing_message(message.metric_label());
     }
-    // Bound the flush so a wedged peer cannot block the actor's serial drain forever.
-    // On timeout we return an error; `process_cast_error` then stops the actor, which
-    // drops its (unbounded) mailbox and reclaims the accumulated memory.
-    match tokio::time::timeout(OUTBOUND_SEND_TIMEOUT, state.sink.send(message)).await {
-        Ok(result) => result,
-        Err(_elapsed) => Err(PeerConnectionError::OutboundSendTimeout),
-    }
+    // Hand off to the per-connection writer task via a BOUNDED queue (non-blocking). This
+    // decouples the actor's serial drain from the network write, so a slow/wedged peer can
+    // never back up the (unbounded) actor mailbox. If the bounded queue is full the peer
+    // can't keep up: surface OutboundQueueFull so `process_cast_error` drops it.
+    state
+        .outbound_tx
+        .try_send(message)
+        .map_err(|err| match err {
+            tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                PeerConnectionError::OutboundQueueFull
+            }
+            tokio::sync::mpsc::error::TrySendError::Closed(_) => PeerConnectionError::Disconnected,
+        })
+}
+
+/// Spawns the per-connection writer task that owns the `sink` and drains a bounded outbound
+/// queue into it. Keeping the network write off the actor thread means the actor's mailbox is
+/// never gated on a slow peer; the only outbound buffer is this bounded channel (capacity
+/// `OUTBOUND_QUEUE_CAP`). The task exits — closing the socket — when the connection is dropped
+/// (all senders gone), when a send errors, or when a single send exceeds `OUTBOUND_SEND_TIMEOUT`
+/// (a wedged peer). Once it exits, further `send()`s observe a closed queue and the peer is dropped.
+pub(crate) fn spawn_outbound_writer(
+    mut sink: SplitSink<Framed<TcpStream, RLPxCodec>, Message>,
+) -> tokio::sync::mpsc::Sender<Message> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Message>(OUTBOUND_QUEUE_CAP);
+    tokio::spawn(async move {
+        while let Some(message) = rx.recv().await {
+            match tokio::time::timeout(OUTBOUND_SEND_TIMEOUT, sink.send(message)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        let _ = sink.close().await;
+    });
+    tx
 }
 
 /// Reads from the frame until a frame is available.

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -152,13 +152,17 @@ impl PeerConnection {
         context: P2PContext,
         peer_addr: SocketAddr,
         stream: TcpStream,
+        admission_permit: tokio::sync::OwnedSemaphorePermit,
     ) -> PeerConnection {
         let state = ConnectionState::Receiver(Receiver {
             context,
             peer_addr,
             stream: Arc::new(stream),
         });
-        let connection = PeerConnectionServer { state };
+        let connection = PeerConnectionServer {
+            state,
+            _admission_permit: Some(admission_permit),
+        };
         Self {
             handle: connection.start(),
         }
@@ -169,7 +173,11 @@ impl PeerConnection {
             context,
             node: node.clone(),
         });
-        let connection = PeerConnectionServer { state };
+        // Outbound dials are not admission-capped (we initiate them); inbound is the attack surface.
+        let connection = PeerConnectionServer {
+            state,
+            _admission_permit: None,
+        };
         Self {
             handle: connection.start(),
         }
@@ -333,6 +341,10 @@ pub enum ConnectionState {
 #[derive(Debug)]
 pub struct PeerConnectionServer {
     state: ConnectionState,
+    /// Inbound-admission permit (Some for inbound connections, None for outbound dials we
+    /// initiate). Held for the actor's lifetime and released when the actor is dropped, so the
+    /// inbound connection count stays bounded. See `P2PContext::inbound_admission`.
+    _admission_permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 #[actor(protocol = PeerConnectionServerProtocol)]

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -254,6 +254,9 @@ pub struct Established {
     // bounded instead of letting the actor mailbox grow when a peer can't keep up. The receiving
     // part of the TcpStream is owned by the stream listen loop task. See `spawn_outbound_writer`.
     pub(crate) outbound_tx: tokio::sync::mpsc::Sender<Message>,
+    /// Set by the writer task when it exits because a single send exceeded `OUTBOUND_SEND_TIMEOUT`
+    /// (a wedged peer), so `send` can surface `OutboundSendTimeout` once the bounded queue closes.
+    pub(crate) outbound_writer_timed_out: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub(crate) node: Node,
     pub(crate) storage: Store,
     pub(crate) blockchain: Arc<Blockchain>,
@@ -564,6 +567,9 @@ impl PeerConnectionServer {
             // as dead and drop it instead of pinging a corpse (and keeping its actor) forever.
             if established_state.missed_pongs >= MAX_MISSED_PONGS {
                 debug!(peer=%established_state.node, missed=MAX_MISSED_PONGS, "Peer missed max pongs, dropping");
+                // Attribute the drop as `PingTimeout` so an unresponsive-peer drop is
+                // distinguishable from a generic `NetworkError` in `ethrex_p2p_disconnections`.
+                established_state.disconnect_reason = Some(DisconnectReason::PingTimeout);
                 ctx.stop();
                 return;
             }
@@ -1184,15 +1190,34 @@ pub(crate) async fn send(
     // decouples the actor's serial drain from the network write, so a slow/wedged peer can
     // never back up the (unbounded) actor mailbox. If the bounded queue is full the peer
     // can't keep up: surface OutboundQueueFull so `process_cast_error` drops it.
-    state
-        .outbound_tx
-        .try_send(message)
-        .map_err(|err| match err {
-            tokio::sync::mpsc::error::TrySendError::Full(_) => {
-                PeerConnectionError::OutboundQueueFull
+    match state.outbound_tx.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+            // The peer can't drain our outbound fast enough. Attribute the drop as `UselessPeer`
+            // so it is distinguishable from a generic `NetworkError` in `ethrex_p2p_disconnections`
+            // (a spike here flags slow peers or our own over-sending, rather than hiding it).
+            state
+                .disconnect_reason
+                .get_or_insert(DisconnectReason::UselessPeer);
+            Err(PeerConnectionError::OutboundQueueFull)
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            // The writer task is gone. If it exited because a single send exceeded
+            // `OUTBOUND_SEND_TIMEOUT`, the peer was wedged: surface `OutboundSendTimeout` and
+            // attribute it likewise; otherwise the socket simply closed (`Disconnected`).
+            if state
+                .outbound_writer_timed_out
+                .load(std::sync::atomic::Ordering::Acquire)
+            {
+                state
+                    .disconnect_reason
+                    .get_or_insert(DisconnectReason::UselessPeer);
+                Err(PeerConnectionError::OutboundSendTimeout)
+            } else {
+                Err(PeerConnectionError::Disconnected)
             }
-            tokio::sync::mpsc::error::TrySendError::Closed(_) => PeerConnectionError::Disconnected,
-        })
+        }
+    }
 }
 
 /// Spawns the per-connection writer task that owns the `sink` and drains a bounded outbound
@@ -1203,18 +1228,32 @@ pub(crate) async fn send(
 /// (a wedged peer). Once it exits, further `send()`s observe a closed queue and the peer is dropped.
 pub(crate) fn spawn_outbound_writer(
     mut sink: SplitSink<Framed<TcpStream, RLPxCodec>, Message>,
-) -> tokio::sync::mpsc::Sender<Message> {
+) -> (
+    tokio::sync::mpsc::Sender<Message>,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Message>(OUTBOUND_QUEUE_CAP);
+    // Set when the writer exits because a single send exceeded `OUTBOUND_SEND_TIMEOUT` (a wedged
+    // peer), so `send` can surface `OutboundSendTimeout` instead of a generic `Disconnected` once
+    // the bounded queue closes.
+    let timed_out = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let writer_timed_out = timed_out.clone();
     tokio::spawn(async move {
         while let Some(message) = rx.recv().await {
             match tokio::time::timeout(OUTBOUND_SEND_TIMEOUT, sink.send(message)).await {
                 Ok(Ok(())) => {}
-                Ok(Err(_)) | Err(_) => break,
+                // Send error: the socket is gone; let the closed queue surface as `Disconnected`.
+                Ok(Err(_)) => break,
+                // The send itself timed out: the peer is wedged. Flag it so the drop is attributed.
+                Err(_) => {
+                    writer_timed_out.store(true, std::sync::atomic::Ordering::Release);
+                    break;
+                }
             }
         }
         let _ = sink.close().await;
     });
-    tx
+    (tx, timed_out)
 }
 
 /// Reads from the frame until a frame is available.

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -442,6 +442,14 @@ impl PeerConnectionServer {
                 {
                     debug!("Failed to remove peer from table: {e}");
                 }
+                // Free the peer's tx-broadcaster index (and clear its bit across known txs) so
+                // the broadcaster's per-peer index map / PeerMask widths stay bounded to live peers.
+                if let Err(e) = established_state
+                    .tx_broadcaster
+                    .remove_peer(established_state.node.node_id())
+                {
+                    debug!("Failed to remove peer from tx broadcaster: {e}");
+                }
                 established_state.teardown().await;
             }
             _ => {

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -84,6 +84,15 @@ const INFLIGHT_TX_TIMEOUT: Duration = Duration::from_secs(30);
 /// producers below enqueue regardless of drain progress — leaking memory that is
 /// never reclaimed (the actor cannot be stopped while a handler is wedged in `.await`).
 const OUTBOUND_SEND_TIMEOUT: Duration = Duration::from_secs(30);
+/// Max time the RLPx handshake may take before we abandon the connection. Without
+/// this, an inbound peer that opens TCP and then stalls before/at the auth read
+/// parks a connection actor + socket indefinitely (the handshake runs inside
+/// `started()` with no timeout), so established sockets accumulate far beyond the
+/// peer target.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+/// If a peer fails to answer this many consecutive pings, consider it dead and drop it.
+/// Catches application-dead-but-TCP-alive peers that would otherwise never be removed.
+const MAX_MISSED_PONGS: u8 = 3;
 /// How often to flush buffered transaction hash requests into a single
 /// batched GetPooledTransactions message.
 const TX_REQUEST_BATCH_INTERVAL: Duration = Duration::from_millis(50);
@@ -272,6 +281,10 @@ pub struct Established {
     pub(crate) txs_sent_to_peer: u64,
     // Leech detection: whether we have received any transactions from this peer
     pub(crate) received_txs_from_peer: bool,
+    // Liveness: consecutive pings sent without a matching pong. Reset to 0 on every Pong,
+    // incremented on each Ping we send; at MAX_MISSED_PONGS the peer is considered dead
+    // and dropped (catches application-dead-but-TCP-alive peers that otherwise linger).
+    pub(crate) missed_pongs: u8,
 }
 
 impl Established {
@@ -330,7 +343,24 @@ impl PeerConnectionServer {
         let eth_version = Arc::new(RwLock::new(EthCapVersion::default()));
         // Take ownership of the state, replacing with HandshakeFailed as placeholder
         let state = std::mem::replace(&mut self.state, ConnectionState::HandshakeFailed);
-        match handshake::perform(state, eth_version.clone()).await {
+        // Bound the handshake: a peer that opens TCP and then stalls must not park this
+        // actor + socket forever (otherwise established sockets accumulate above the peer
+        // target). On timeout the handshake future is dropped, closing the socket.
+        let handshake_result = match tokio::time::timeout(
+            HANDSHAKE_TIMEOUT,
+            handshake::perform(state, eth_version.clone()),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                debug!("Handshake timed out on RLPx connection");
+                self.state = ConnectionState::HandshakeFailed;
+                ctx.stop();
+                return;
+            }
+        };
+        match handshake_result {
             Ok((mut established_state, stream)) => {
                 trace!(peer=%established_state.node, "Starting RLPx connection");
                 if let Err(reason) =
@@ -508,6 +538,14 @@ impl PeerConnectionServer {
         ctx: &Context<Self>,
     ) {
         if let ConnectionState::Established(ref mut established_state) = self.state {
+            // Liveness: if the peer hasn't answered the last MAX_MISSED_PONGS pings, treat it
+            // as dead and drop it instead of pinging a corpse (and keeping its actor) forever.
+            if established_state.missed_pongs >= MAX_MISSED_PONGS {
+                debug!(peer=%established_state.node, missed=MAX_MISSED_PONGS, "Peer missed max pongs, dropping");
+                ctx.stop();
+                return;
+            }
+            established_state.missed_pongs = established_state.missed_pongs.saturating_add(1);
             let result = send(established_state, Message::Ping(PingMessage {})).await;
             Self::process_cast_error(&self.state, result, ctx);
         } else {
@@ -1216,7 +1254,8 @@ async fn handle_incoming_message(
             send(state, Message::Pong(PongMessage {})).await?;
         }
         Message::Pong(_) => {
-            // We ignore received Pong messages
+            // Liveness: the peer answered our ping; reset the missed-pong counter.
+            state.missed_pongs = 0;
         }
         Message::Status68(msg_data) => {
             if let Some(eth) = &state.negotiated_eth_capability {

--- a/crates/networking/p2p/rlpx/error.rs
+++ b/crates/networking/p2p/rlpx/error.rs
@@ -30,6 +30,8 @@ pub enum PeerConnectionError {
     NoMatchingCapabilities,
     #[error("Too many peers")]
     TooManyPeers,
+    #[error("Outbound send to peer timed out")]
+    OutboundSendTimeout,
     #[error("Peer disconnected")]
     Disconnected,
     #[error("Disconnect requested: {0}")]

--- a/crates/networking/p2p/rlpx/error.rs
+++ b/crates/networking/p2p/rlpx/error.rs
@@ -32,6 +32,8 @@ pub enum PeerConnectionError {
     TooManyPeers,
     #[error("Outbound send to peer timed out")]
     OutboundSendTimeout,
+    #[error("Outbound queue full (peer not keeping up)")]
+    OutboundQueueFull,
     #[error("Peer disconnected")]
     Disconnected,
     #[error("Disconnect requested: {0}")]

--- a/crates/networking/p2p/tx_broadcaster.rs
+++ b/crates/networking/p2p/tx_broadcaster.rs
@@ -44,6 +44,7 @@ pub trait TxBroadcasterProtocol: Send + Sync {
     fn broadcast_txs(&self) -> Result<(), ActorError>;
     fn add_txs(&self, tx_hashes: Vec<H256>, peer_id: H256) -> Result<(), ActorError>;
     fn prune_txs(&self) -> Result<(), ActorError>;
+    fn remove_peer(&self, peer_id: H256) -> Result<(), ActorError>;
 }
 
 #[derive(Debug, Clone, Default)]
@@ -79,6 +80,17 @@ impl PeerMask {
         let bit = (idx as usize) % 64;
         self.bits[word] |= 1u64 << bit;
     }
+
+    #[inline]
+    // Clear bit `idx`. Used when a peer's index is freed so a future peer that reuses the
+    // index does not inherit a stale "already-sent" bit (which would suppress a real broadcast).
+    fn clear(&mut self, idx: u32) {
+        let word = (idx as usize) / 64;
+        if word < self.bits.len() {
+            let bit = (idx as usize) % 64;
+            self.bits[word] &= !(1u64 << bit);
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +118,9 @@ pub struct TxBroadcaster {
     peer_indexer: HashMap<H256, u32>,
     // Next index to assign to a new peer
     next_peer_idx: u32,
+    // Indices freed by disconnected peers, reused before allocating new ones. Without this,
+    // next_peer_idx (and therefore every PeerMask's width) grows unbounded with peer churn.
+    free_indices: Vec<u32>,
     tx_broadcasting_time_interval: u64,
 }
 
@@ -152,6 +167,7 @@ impl TxBroadcaster {
             known_txs: HashMap::new(),
             peer_indexer: HashMap::new(),
             next_peer_idx: 0,
+            free_indices: Vec::new(),
             tx_broadcasting_time_interval,
         };
 
@@ -215,6 +231,27 @@ impl TxBroadcaster {
         let _ = self.blockchain.mempool.prune_alternates(prune_window);
     }
 
+    #[send_handler]
+    async fn handle_remove_peer(
+        &mut self,
+        msg: tx_broadcaster_protocol::RemovePeer,
+        _ctx: &Context<Self>,
+    ) {
+        self.do_remove_peer(msg.peer_id);
+    }
+
+    // Remove a disconnected peer: drop its index mapping, clear its bit from every known_txs
+    // record (so a future peer reusing the index isn't treated as already-notified), and return
+    // the index to the free-list — bounding peer_indexer and every PeerMask's width to live peers.
+    fn do_remove_peer(&mut self, peer_id: H256) {
+        if let Some(idx) = self.peer_indexer.remove(&peer_id) {
+            for record in self.known_txs.values_mut() {
+                record.peers.clear(idx);
+            }
+            self.free_indices.push(idx);
+        }
+    }
+
     // Get or assign a unique index to the peer_id
     #[inline]
     fn peer_index(&mut self, peer_id: H256) -> u32 {
@@ -224,9 +261,13 @@ impl TxBroadcaster {
             // We are assigning indexes sequentially, so next_peer_idx is always the next available one.
             // self.peer_indexer.len() could be used instead of next_peer_idx but avoided here if we ever
             // remove entries from peer_indexer in the future.
-            let idx = self.next_peer_idx;
-            // In practice we won't exceed u32::MAX (~4.29 Billion) peers.
-            self.next_peer_idx += 1;
+            // Reuse a freed index if available, otherwise allocate the next one.
+            let idx = self.free_indices.pop().unwrap_or_else(|| {
+                let idx = self.next_peer_idx;
+                // In practice we won't exceed u32::MAX (~4.29 Billion) peers.
+                self.next_peer_idx += 1;
+                idx
+            });
             self.peer_indexer.insert(peer_id, idx);
             idx
         }


### PR DESCRIPTION
> Closes #6340 

**Motivation**

A long-running node's RSS grows monotonically over time and never frees, even under light, steady traffic. Heap profiling (jemalloc `inuse_space` diff over many hours) localizes the growth to the **P2P layer** — per-connection actors (`spawned_concurrency` `MessageEnvelope` / `spawn_listener`), `rlpx` decode, and `tx_broadcaster` — not RPC or the state trie. It is per-time (transaction gossip + connection churn), not per-request. Confirmed by an idle-drop: with RPC fully off for ~20 h, in-use heap still climbed ~1.5 GB/day and established connections drifted 347 → 432.

The leak is several reinforcing issues in the P2P connection layer: each connection is a `PeerConnectionServer` actor with an **unbounded mailbox**; the actor drains serially by awaiting `state.sink.send(message)`, so a slow/half-dead peer blocks it while fixed-rate producers keep enqueuing; the handshake had no timeout and pongs were ignored, so stalled/dead peers parked actors + sockets; inbound connections were accepted with no cap; and per-peer index/session maps were never pruned. The net effect is monotonic, never-freed growth that scales with peer churn.

**Description (L1 connection-leak fixes)**

- **Bounded outbound queue + writer task** — the socket sink moves into a per-connection writer task; the actor keeps only a **bounded** `mpsc::Sender` and `send()` is a non-blocking `try_send`, so the actor never blocks on the network and its mailbox can't grow on a slow peer. On a full queue the peer is dropped (`OutboundQueueFull`).
- **Handshake timeout** (`HANDSHAKE_TIMEOUT`, 10 s) — drops stalled-handshake ghost connections.
- **Pong-deadline** (`MAX_MISSED_PONGS`, 3) — drops application-dead-but-TCP-alive peers.
- **Inbound admission cap** (`MAX_INBOUND_CONNECTIONS`, 150) — a bounded semaphore permit, held by each inbound connection actor and released on drop, hard-bounds concurrent inbound connections (the attack surface). Outbound dials are not capped.
- **tx-broadcaster index prune** — a free-list reuses peer indices and removes them on disconnect (clearing the freed bit across `known_txs`), bounding `peer_indexer` and every `PeerMask` width to live peers.
- **discv5 / peer-table session pruning** — `session_ips` gets a TTL (`SESSION_TTL`, 1 h) evicted in the existing cleanup sweep, and the peer-table `sessions` entry is removed on peer drop (both were insert-only).

Together these drop the three ways a peer lingers (wedged / stalled / dead), bound the inbound connection count, and stop the per-peer/per-handshake maps from growing.

**Deliberately out of scope here**
- **Eviction to `TARGET_PEERS`:** `initialize_connection` already gates new connections on `target_peers_reached()`, and the admission cap above hard-bounds inbound connections — so the table/connection count is already bounded and eviction would only trim small race-overshoot. A correct version also needs best-effort actor shutdown of the victim; left as a focused follow-up.
- **L2 `ProofCoordinator`** replicates this same unbounded-mailbox-per-connection pattern — fixed in a separate L2 PR.

**Validation**

- `cargo check` + `clippy -D warnings` + `fmt` clean on `ethrex-p2p` (default and `l2` features).
- Standalone reproduction on the same actor framework + version shows the unbounded-mailbox / awaited-sink pattern leaks without bound; bounded-and-stop stays flat.
- **Live soak (mainnet, jemalloc `inuse_space` heap-diff):**
  - **Phase 1 — ~2 days under sustained load** (full tx-gossip, ~3.4k `NewPooledTransactionHashes`/s, plus replayed RPC): steady-state in-use ~+0.2 GB/day (vs unfixed ~1.5), with the per-connection actor / mailbox sites net-negative; established connections pinned at target (vs unfixed 347 → 432).
  - **Phase 2 — ~4 days idle with RPC fully off** (the decisive condition — the unfixed binary leaked under exactly this): in-use flat (mailbox slope −0.005 GB/day, total flat-to-down), connections stable. Leak rate cut >99%.
- Judge on the per-connection actor/mailbox sites in the diff, not total RSS: on a profiling build jemalloc's own `prof_backtrace_impl` bookkeeping grows several GB over days (absent in non-profiling builds).

**Related**

Upstream framework hardening that would prevent this class of bug at the source: lambdaclass/spawned#170 (opt-in bounded mailbox) and lambdaclass/spawned#171 (cancellation can't interrupt a wedged handler).

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) — N/A (no storage changes).

