### PR TITLE
ci(l1): publish each crate as a separate job via a reusable workflow

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,66 @@
+name: Publish a single crate
+
+# Reusable workflow: publishes (or, in dry-run, verifies) exactly one crate.
+# All the shared setup and logic lives here once; the caller (publish.yml) invokes
+# it per crate with `needs:` enforcing dependency order.
+on:
+  workflow_call:
+    inputs:
+      crate:
+        description: "Crate package name (e.g. ethrex-rlp)"
+        required: true
+        type: string
+      dry_run:
+        description: "Verify only (package + compile), do not publish"
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates-release-prod
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+        with:
+          toolchain: stable
+          # This action defaults RUSTFLAGS to "-D warnings", which (a) makes the
+          # cargo-publish verify build fail on lints and (b) overrides the
+          # `[target.*].rustflags` target-features in .cargo/config.toml. Publishing
+          # already-reviewed, CI-linted code should not deny warnings -- lints are
+          # gated on PRs separately -- so disable it here.
+          rustflags: ""
+
+      - name: ${{ inputs.dry_run && 'Verify' || 'Publish' }} ${{ inputs.crate }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CRATE: ${{ inputs.crate }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then
+            # `cargo publish --dry-run` (and `cargo package` without --list) resolve
+            # the crate's siblings against the crates.io index, which aren't published
+            # yet -- so dependents fail at resolution before they ever compile. Validate
+            # against workspace path deps instead, which needs nothing published: list the
+            # tarball file set (no index lookup) and compile with default features.
+            cargo package -p "$CRATE" --no-verify --list >/dev/null
+            cargo check -p "$CRATE"
+          else
+            OUTPUT=$(cargo publish -p "$CRATE" 2>&1) || {
+              echo "$OUTPUT"
+              # Idempotent re-runs: skip versions already on crates.io. cargo emits
+              # "already uploaded" (modern) or "already exists" (older/other registries).
+              if echo "$OUTPUT" | grep -qiE "already (uploaded|exists)"; then
+                echo "$CRATE already published, skipping"
+                exit 0
+              fi
+              exit 1
+            }
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,76 +18,144 @@ on:
 permissions:
   contents: read
 
+# Each crate is its own job calling the reusable publish-crate workflow. `needs`
+# encodes the crate dependency graph, so a crate is only published after all of
+# its dependencies, while independent crates publish in parallel. The shared
+# setup and publish/verify logic lives once in .github/workflows/publish-crate.yml.
 jobs:
-  publish:
+  # Compute the dry-run flag once: real releases publish; manual dispatch honors
+  # the dry_run input (default true). Every crate job reads this output.
+  config:
     runs-on: ubuntu-latest
-    environment: crates-release-prod
+    outputs:
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: 'echo "dry_run=${{ github.event_name == ''workflow_dispatch'' && inputs.dry_run }}"'
 
-      - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
-        with:
-          toolchain: stable
-          # This action defaults RUSTFLAGS to "-D warnings", which (a) makes the
-          # cargo-publish verify build fail on lints and (b) overrides the
-          # `[target.*].rustflags` target-features in .cargo/config.toml. Publishing
-          # already-reviewed, CI-linted code should not deny warnings -- lints are
-          # gated on PRs separately -- so disable it here.
-          rustflags: ""
+  ethrex-rlp:
+    needs: config
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-rlp
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
 
-      - name: Publish crates in dependency order
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
-        run: |
-          set -euo pipefail
-          # Topological order: each crate is published after all of its dependencies.
-          CRATES=(
-            ethrex-rlp
-            ethrex-crypto
-            ethrex-sdk-contract-utils
-            ethrex-trie
-            ethrex-common
-            ethrex-metrics
-            ethrex-levm
-            ethrex-l2-common
-            ethrex-storage
-            ethrex-vm
-            ethrex-storage-rollup
-            ethrex-blockchain
-            ethrex-p2p
-            ethrex-rpc
-            ethrex-l2-rpc
-            ethrex-sdk
-          )
-          for c in "${CRATES[@]}"; do
-            echo "::group::$c"
-            if [ "${DRY_RUN:-false}" = "true" ]; then
-              # `cargo publish --dry-run` (and `cargo package` without --list)
-              # resolve each crate's siblings against the crates.io index, which
-              # aren't published yet -- so dependents fail at resolution before they
-              # ever compile. Validate against workspace path deps instead, which
-              # needs nothing published: list the tarball file set (no index lookup)
-              # and compile with default features (what cargo's verify step builds).
-              cargo package -p "$c" --no-verify --list >/dev/null
-              cargo check -p "$c"
-            else
-              OUTPUT=$(cargo publish -p "$c" 2>&1) || {
-                echo "$OUTPUT"
-                # Idempotent re-runs: skip versions already on crates.io. cargo emits
-                # "already uploaded" (modern) or "already exists" (older/other registries).
-                if echo "$OUTPUT" | grep -qiE "already (uploaded|exists)"; then
-                  echo "$c already published, skipping"
-                  echo "::endgroup::"
-                  continue
-                fi
-                exit 1
-              }
-              # cargo >=1.66 blocks until the version is in the index;
-              # a short settle covers any registry propagation lag.
-              sleep 20
-            fi
-            echo "::endgroup::"
-          done
+  ethrex-crypto:
+    needs: config
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-crypto
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-sdk-contract-utils:
+    needs: config
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-sdk-contract-utils
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-trie:
+    needs: [config, ethrex-crypto, ethrex-rlp]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-trie
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-common:
+    needs: [config, ethrex-crypto, ethrex-rlp, ethrex-trie]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-common
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-metrics:
+    needs: [config, ethrex-common]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-metrics
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-levm:
+    needs: [config, ethrex-common, ethrex-crypto, ethrex-rlp]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-levm
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-l2-common:
+    needs: [config, ethrex-common, ethrex-crypto]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-l2-common
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-storage:
+    needs: [config, ethrex-common, ethrex-crypto, ethrex-rlp, ethrex-trie]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-storage
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-vm:
+    needs: [config, ethrex-common, ethrex-crypto, ethrex-levm, ethrex-rlp]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-vm
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-storage-rollup:
+    needs: [config, ethrex-common, ethrex-l2-common]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-storage-rollup
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-blockchain:
+    needs: [config, ethrex-common, ethrex-crypto, ethrex-metrics, ethrex-rlp, ethrex-storage, ethrex-trie, ethrex-vm]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-blockchain
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-p2p:
+    needs: [config, ethrex-blockchain, ethrex-common, ethrex-crypto, ethrex-l2-common, ethrex-metrics, ethrex-rlp, ethrex-storage, ethrex-storage-rollup, ethrex-trie]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-p2p
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-rpc:
+    needs: [config, ethrex-blockchain, ethrex-common, ethrex-crypto, ethrex-l2-common, ethrex-metrics, ethrex-p2p, ethrex-rlp, ethrex-storage, ethrex-storage-rollup, ethrex-trie, ethrex-vm]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-rpc
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-l2-rpc:
+    needs: [config, ethrex-blockchain, ethrex-common, ethrex-crypto, ethrex-l2-common, ethrex-p2p, ethrex-rlp, ethrex-rpc, ethrex-storage, ethrex-storage-rollup]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-l2-rpc
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}
+
+  ethrex-sdk:
+    needs: [config, ethrex-common, ethrex-l2-common, ethrex-l2-rpc, ethrex-rlp, ethrex-rpc, ethrex-sdk-contract-utils]
+    uses: ./.github/workflows/publish-crate.yml
+    secrets: inherit
+    with:
+      crate: ethrex-sdk
+      dry_run: ${{ needs.config.outputs.dry_run == 'true' }}


### PR DESCRIPTION
**Motivation**

The publish workflow ran all 16 crates inside one job looping over them, so the run showed a single "Publish crates in dependency order" step — no per-crate visibility, and a failure or re-run couldn't target an individual crate. This refactors publishing so each crate is its own job, without duplicating the setup/publish logic.

**Description**

- **`.github/workflows/publish-crate.yml`** (new, reusable via `workflow_call`): holds the checkout, Rust toolchain, and publish/verify logic **once**, acting on a single crate (inputs: `crate`, `dry_run`).
- **`.github/workflows/publish.yml`** (caller): one job per crate, each calling the reusable workflow. `needs` encodes the crate dependency graph (derived from `cargo metadata`), so a crate publishes only after its dependencies while independent crates (rlp, crypto, sdk-contract-utils) run in parallel. A small `config` job computes the dry-run flag once for all crate jobs.

Behaviour is unchanged from the current single-job version:
- `rustflags: ""` (don't deny warnings during the verify build),
- idempotent re-runs (skip crates already on crates.io: `already (uploaded|exists)`),
- dry-run = `cargo package --no-verify --list` + `cargo check` (validates every crate against workspace path deps, needs nothing published),
- run name shows `(dry run)` for a `workflow_dispatch` dry run.

The per-job `sleep` between publishes is gone: a dependent's job only starts after its dependency's job completes (and `cargo publish` already blocks until the version is in the index), so `needs` handles propagation.

**Trade-off**

Separate jobs each re-checkout and recompile their dependency subtree (no shared build dir across jobs), so total runner time is higher than the single-job loop. The DAG keeps wall-clock down via parallelism; the payoff is per-crate visibility and re-runnability.

**Validation**

Ran the refactored workflow on CI in dry-run mode (temporary push trigger, reverted): the `config` job and all 16 crate jobs passed, confirming the reusable-workflow wiring, `secrets: inherit`, DAG ordering, and dry-run logic. Verified the run name renders `… (dry run)` for a dry run. `actionlint` clean on both files.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A.