### PR TITLE
fix(l1): backport actor-timeout + FCU-wedge fixes to bal-devnet-7

### DIFF
--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -160,14 +160,15 @@ pub async fn apply_fork_choice(
         return Err(InvalidForkChoice::UnlinkedHead);
     };
 
-    // If the state can't be constructed from the DB, we ignore it and log a warning.
+    // If the state can't be constructed from the DB, the caller starts a sync
+    // toward the head instead of ignoring the FCU.
     // TODO(#5564): handle arbitrary reorgs
     if !store.has_state_root(link_header.state_root)? {
         warn!(
             link_block=%link_block_hash,
             link_number=%link_header.number,
             head_number=%head.number,
-            "FCU head state not reachable from DB state. Ignoring fork choice update. This is expected if the consensus client is currently syncing. Otherwise, if consensus is synced and this is a consistent message it can be fixed by removing the DB and re-syncing the execution client."
+            "FCU head state not reachable from DB state. Starting sync toward head. This is expected if the consensus client is currently syncing."
         );
         return Err(InvalidForkChoice::StateNotReachable);
     }

--- a/crates/networking/p2p/peer_handler.rs
+++ b/crates/networking/p2p/peer_handler.rs
@@ -728,8 +728,9 @@ pub enum PeerHandlerError {
 
 impl PeerHandlerError {
     /// Transient errors caused by individual peer interactions (bad/slow/absent
-    /// responses) that should trigger a retry. Actor/storage/snap failures
-    /// indicate a more fundamental problem and should be surfaced as fatal.
+    /// responses) or actor-request timeouts that should trigger a retry.
+    /// Storage/snap failures and stopped actors indicate a more fundamental
+    /// problem and should be surfaced as fatal.
     pub fn is_recoverable(&self) -> bool {
         match self {
             PeerHandlerError::SendMessageToPeer(_)
@@ -740,9 +741,13 @@ impl PeerHandlerError {
             | PeerHandlerError::ReceiveMessageFromPeerTimeout(_)
             | PeerHandlerError::InvalidHeaders
             | PeerHandlerError::NoResponseFromPeer => true,
-            PeerHandlerError::StorageFull
-            | PeerHandlerError::PeerTableError(_)
-            | PeerHandlerError::Snap(_) => false,
+            // A timed-out actor request is transient (mailbox pressure or a
+            // slow handler — requests use spawned-concurrency's 5s default
+            // timeout); a stopped actor means p2p is shutting down and must
+            // stay fatal.
+            PeerHandlerError::PeerTableError(ActorError::RequestTimeout) => true,
+            PeerHandlerError::PeerTableError(ActorError::ActorStopped) => false,
+            PeerHandlerError::StorageFull | PeerHandlerError::Snap(_) => false,
         }
     }
 }

--- a/crates/networking/p2p/sync.rs
+++ b/crates/networking/p2p/sync.rs
@@ -416,10 +416,15 @@ impl SyncError {
             | SyncError::RocksDBError(_)
             | SyncError::BytecodeFileError
             | SyncError::NoLatestCanonical
-            | SyncError::PeerTableError(_)
             | SyncError::MissingFullsyncBatch
             | SyncError::Snap(_)
             | SyncError::FileSystem(_) => false,
+            // A timed-out actor request is transient (mailbox pressure or a
+            // slow handler — requests use spawned-concurrency's 5s default
+            // timeout); a stopped actor means p2p is shutting down and must
+            // stay fatal.
+            SyncError::PeerTableError(ActorError::RequestTimeout) => true,
+            SyncError::PeerTableError(ActorError::ActorStopped) => false,
             SyncError::Chain(_)
             | SyncError::Store(_)
             | SyncError::Send(_)

--- a/crates/networking/rpc/engine/fork_choice.rs
+++ b/crates/networking/rpc/engine/fork_choice.rs
@@ -339,7 +339,15 @@ async fn handle_forkchoice(
                 }
                 // TODO(#5564): handle arbitrary reorgs
                 InvalidForkChoice::StateNotReachable => {
-                    // Ignore the FCU
+                    // We can't reach the head's state from our DB (the nearest
+                    // link block has pruned or not-yet-executed state). Kick off
+                    // a sync toward the head instead of reporting SYNCING while
+                    // sitting idle, which wedges the node: the CL keeps resending
+                    // FCUs we keep ignoring and we never make progress.
+                    // sync_to_head is idempotent (only starts a cycle if the
+                    // syncer is inactive) and mode-agnostic, so this is safe for
+                    // both full and snap clients.
+                    syncer.sync_to_head(fork_choice_state.head_block_hash);
                     ForkChoiceResponse::from(PayloadStatus::syncing())
                 }
                 InvalidForkChoice::Disconnected(_, _) | InvalidForkChoice::ElementNotFound(_) => {


### PR DESCRIPTION
## Motivation

Root-cause analysis of the major reorgs on bal-devnet-7 identified two interacting bugs that caused `lighthouse-ethrex-1` to produce reorgs of 1334–2330 slots over June 21–22. Both fixes already exist on `glamsterdam-devnet-6`; this PR backports them cleanly onto `bal-devnet-7`.

## Root cause

**Bug 1 — actor `RequestTimeout` kills the sync loop** (cherry-pick of #6823)

Every `PeerTable` actor call has a 5-second timeout hardwired by the `#[protocol]` macro. On `bal-devnet-7` both `SyncError::is_recoverable()` and `PeerHandlerError::is_recoverable()` treated _any_ `ActorError` — including `RequestTimeout` — as fatal, so a single timed-out `get_best_peer` under mailbox pressure called `exit(2)` mid-sync. Once the sync loop died, EthrEx's state fell behind Lighthouse's head, and the engine API went silent.

**Bug 2 — `StateNotReachable` FCU idles instead of restarting sync** (cherry-pick of #6851)

After the sync crash, when Lighthouse sent `engine_forkchoiceUpdatedV4` referencing a head whose state EthrEx couldn't reach from the DB (`StateNotReachable`), the handler returned `PayloadStatus::syncing()` but never called `syncer.sync_to_head()`. The node wedged permanently: the CL kept resending FCUs that EthrEx kept ignoring, and the block executor's `failed to notify caller` errors piled up as Lighthouse repeatedly timed out.

## Changes

Cherry-picks of two self-contained commits, touching 4 files only:

- `b6fce45f` — `fix(l1): classify actor request timeouts as recoverable in sync error handling` (#6823)
  - `crates/networking/p2p/sync.rs`: `ActorError::RequestTimeout` → recoverable, `ActorStopped` → fatal
  - `crates/networking/p2p/peer_handler.rs`: same split in `PeerHandlerError::is_recoverable`

- `f8b92bd2` — `fix(l1): start sync on unreachable-state FCU instead of idling` (#6851)
  - `crates/blockchain/fork_choice.rs`: comment + log message update
  - `crates/networking/rpc/engine/fork_choice.rs`: call `syncer.sync_to_head()` on `StateNotReachable` instead of silently returning SYNCING

No other `glamsterdam-devnet-6` changes are included.