### PR TITLE
fix(l1): align with v6.1.0 of the spec

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,4 +1,4 @@
 # Amsterdam (BAL) hive test configuration
-# Pinned to tests-glamsterdam-devnet@v6.0.1 (execution-specs `devnets/glamsterdam/6`)
-fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.0.1/fixtures_glamsterdam-devnet.tar.gz
-eels_commit: 3d1a054b826d04109db349268c68c646ed3295d4
+# Pinned to tests-glamsterdam-devnet@v6.1.0 (execution-specs `devnets/glamsterdam/6`)
+fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.1.0/fixtures_glamsterdam-devnet.tar.gz
+eels_commit: 4bc0fc6a7b69639db396a301302352f8cd9fc5be

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -114,7 +114,7 @@ fn check_gas_limit(
 /// capped at `TX_MAX_GAS_LIMIT`); intrinsic underfunding is rejected separately
 /// in transaction validation, not here. Mirrors
 /// `src/ethereum/forks/amsterdam/fork.py` `check_transaction` at the
-/// `tests-glamsterdam-devnet@v6.0.1` spec.
+/// `tests-glamsterdam-devnet@v6.1.0` spec.
 ///
 /// Note: `block_gas_used_regular` here equals EELS's `block_output.block_gas_used`
 /// because our `report.gas_used` already reflects `max(raw_regular, calldata_floor)`

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -160,14 +160,15 @@ impl Hook for DefaultHook {
             // value transfer will materialize a new account: charge the
             // new-account state gas. (Skipped if a 7702 auth already materialized
             // the recipient this tx, since emptiness is evaluated post-auth.)
-            // EIP-2780: precompile recipients are exempt from the top-level
-            // new-account state charge (EELS interpreter.py: `recipient_is_precompile`).
+            // EIP-2780 (EELS PR #3048): no precompile carve-out. EIP-161/EIP-2780
+            // define emptiness structurally, so an empty (unfunded) precompile
+            // receiving value is created like any other account and pays
+            // NEW_ACCOUNT. A pre-funded precompile is non-empty, so
+            // `recipient_is_empty` is already false and it stays exempt.
             // The charge is deferred to `run_execution` (charged from the reservoir there)
             // so an OOG reverts the tx rather than invalidating the block; the emptiness
             // check must happen here, before the value transfer materializes the account.
-            let to_is_precompile =
-                crate::precompiles::is_precompile(&to, vm.env.config.fork, vm.vm_type);
-            if recipient_is_empty && !to_is_precompile && !vm.tx.value().is_zero() {
+            if recipient_is_empty && !vm.tx.value().is_zero() {
                 vm.pending_top_frame_state_gas = vm.state_gas_new_account;
             }
 

--- a/tooling/ef_tests/blockchain/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/blockchain/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.0.1/fixtures_glamsterdam-devnet.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.1.0/fixtures_glamsterdam-devnet.tar.gz

--- a/tooling/ef_tests/engine/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/engine/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.0.1/fixtures_glamsterdam-devnet.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.1.0/fixtures_glamsterdam-devnet.tar.gz

--- a/tooling/ef_tests/state/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/state/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.0.1/fixtures_glamsterdam-devnet.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.1.0/fixtures_glamsterdam-devnet.tar.gz


### PR DESCRIPTION
**Motivation**

The latest version of the spec removes special behavior when sending ETH (and thus creating in the state trie) to an account where a precompile exists.

**Description**

Bumps the fixtures and aligns with the change.
