### PR TITLE
fix(levm): match EELS system-call gas accounting under EIP-8037

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2681,9 +2681,17 @@ pub fn generic_system_contract_levm(
     let config = EVMConfig::new_from_chain_config(&chain_config, block_header);
     let env = Environment {
         origin: system_address,
-        // EIPs 2935, 4788, 7002 and 7251 dictate that the system calls have a gas limit of 30 million and they do not use intrinsic gas.
-        // So we add the base cost that will be taken in the execution.
-        gas_limit: SYS_CALL_GAS_LIMIT + TX_BASE_COST,
+        // EIPs 2935, 4788, 7002 and 7251 dictate that the system calls have a gas
+        // limit of 30 million and they do not use intrinsic gas. EELS
+        // (process_unchecked_system_transaction) builds the message with
+        // intrinsic_regular_gas=0 and gas=SYSTEM_TRANSACTION_GAS, so the contract
+        // gets the full SYS_CALL_GAS_LIMIT. We match that by NOT padding the limit
+        // here and by zeroing the intrinsic for system calls in the default hook.
+        // (A previous `+ TX_BASE_COST` buffer assumed the flat 21000 Prague
+        // intrinsic; EIP-2780 lowered Amsterdam's intrinsic to 15000, so the buffer
+        // over-funded the frame by 6000 and let an OOG-by-1 system contract avoid
+        // running out of gas.)
+        gas_limit: SYS_CALL_GAS_LIMIT,
         block_number: block_header.number,
         coinbase: block_header.coinbase,
         timestamp: block_header.timestamp,

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -43,7 +43,7 @@ use ethrex_levm::EVMConfig;
 use ethrex_levm::account::{AccountStatus, LevmAccount};
 use ethrex_levm::call_frame::Stack;
 use ethrex_levm::constants::{
-    POST_OSAKA_GAS_LIMIT_CAP, STACK_LIMIT, SYS_CALL_GAS_LIMIT, TX_BASE_COST,
+    POST_OSAKA_GAS_LIMIT_CAP, STACK_LIMIT, SYS_CALL_GAS_LIMIT,
     TX_MAX_GAS_LIMIT_AMSTERDAM,
 };
 use ethrex_levm::db::gen_db::GeneralizedDatabase;

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -32,7 +32,17 @@ impl Hook for DefaultHook {
         // EELS never reads the SYSTEM_ADDRESS account, so skip the whole
         // sender path to keep the read out of execution witnesses (EIP-8025).
         if vm.env.is_system_call {
-            let intrinsic = vm.get_intrinsic_gas()?;
+            // EELS `process_unchecked_system_transaction` builds the message with
+            // intrinsic_regular_gas=0 and intrinsic_state_gas=0: a system call gets
+            // the full SYS_CALL_GAS_LIMIT with no intrinsic deducted. We still call
+            // `add_intrinsic_gas` (with a zeroed intrinsic) so the Amsterdam state-gas
+            // reservoir is set up, but charge no intrinsic — otherwise the frame
+            // budget would fall below SYS_CALL_GAS_LIMIT and diverge from EELS (a
+            // system contract engineered to consume exactly SYS_CALL_GAS_LIMIT+1
+            // would then fail to run out of gas).
+            let mut intrinsic = vm.get_intrinsic_gas()?;
+            intrinsic.regular = 0;
+            intrinsic.state = 0;
             vm.add_intrinsic_gas(&intrinsic)?;
             transfer_value(vm)?;
             set_bytecode_and_code_address(vm)?;

--- a/tooling/ef_tests/engine/src/exception_mapper.rs
+++ b/tooling/ef_tests/engine/src/exception_mapper.rs
@@ -133,7 +133,7 @@ const PATTERNS: &[Entry] = &[
     Entry { canonical: "BlockException.INVALID_BAL_HASH", kind: Kind::Re,
         text: r"BAL validation failed" },
     Entry { canonical: "BlockException.INVALID_BLOCK_ACCESS_LIST", kind: Kind::Re,
-        text: r"Block access list contains index \d+ exceeding max valid index \d+|Failed to RLP decode BAL|Block access list .+ not in strictly ascending order.*|BAL validation failed for (tx \d+|system_tx|withdrawal): .*|BAL validation failed: .*|absent from BAL|Block access list slot .+ is in both storage_changes and storage_reads.*|Invalid block hash" },
+        text: r"Block access list contains index \d+ exceeding max valid index \d+|Failed to RLP decode BAL|Block access list .+ not in strictly ascending order.*|BAL validation failed for (tx \d+|system_tx|withdrawal): .*|BAL validation failed: .*|absent from BAL|Block access list slot .+ is in both storage_changes and storage_reads.*|Block access list .+ has an empty change set|Invalid block hash" },
     Entry { canonical: "BlockException.INCORRECT_BLOCK_FORMAT", kind: Kind::Re,
         text: r"Block access list hash does not match the one in the header after executing|Block access list contains index \d+ exceeding max valid index \d+|Failed to RLP decode BAL|Block access list accounts not in strictly ascending order.*" },
 ];


### PR DESCRIPTION
**Motivation**

Under Amsterdam, a system contract that runs out of gas is not rejected with `SYSTEM_CONTRACT_CALL_FAILED`. The system-call frame is funded with `SYS_CALL_GAS_LIMIT + TX_BASE_COST` and then charged intrinsic gas during execution. The fixed `+21000` buffer was sized to cancel Prague's flat 21000 intrinsic, but EIP-2780 lowers Amsterdam's intrinsic to 15000, over-funding the frame by 6000 — enough that a system contract engineered to consume exactly `SYS_CALL_GAS_LIMIT + 1` finishes instead of running out of gas, so the block is rejected with a BAL-validation error instead of `SYSTEM_CONTRACT_CALL_FAILED`.

**Description**

- `generic_system_contract_levm`: set the system-call frame gas to `SYS_CALL_GAS_LIMIT` (drop the `+ TX_BASE_COST` padding).
- `DefaultHook::prepare_execution`: charge zero intrinsic for system calls, matching EELS `process_unchecked_system_transaction` (`gas = SYSTEM_TRANSACTION_GAS`, `intrinsic_regular_gas = 0`), while still setting up the EIP-8037 state-gas reservoir.
- `exception_mapper`: map the EIP-7928 "empty change set" BAL error to `INVALID_BLOCK_ACCESS_LIST` so the in-process engine mapper matches the EELS mapper.

Verified against the full Amsterdam suite: EEST blockchain 2907/2907, engine 2908/2908 (including strict exception matching, 23596/23596), state 14673/14673; and hive `ethereum/eels/consume-engine` `fork_Amsterdam` 23596/23596, 0 failed. The `system_contract_out_of_gas` cases are now rejected with `SYSTEM_CONTRACT_CALL_FAILED` while the `reaches_gas_limit` boundary still succeeds.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
