### PR TITLE
fix(l1): use block gas limit for the Amsterdam eth_estimateGas ceiling

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2975,7 +2975,14 @@ fn vm_from_generic<'a>(
 }
 
 pub fn get_max_allowed_gas_limit(block_gas_limit: u64, fork: Fork) -> u64 {
-    if fork >= Fork::Osaka {
+    // EIP-7825 imposes a flat per-tx gas cap (POST_OSAKA_GAS_LIMIT_CAP) from
+    // Osaka through the BPO forks. Amsterdam supersedes it with the EIP-8037 2D
+    // gas model: tx.gas may exceed the flat cap (the excess funds the state-gas
+    // reservoir) and is instead bounded by block_gas_limit on the state
+    // dimension, so capping the estimateGas ceiling at the flat value would
+    // prevent convergence for state-heavy creations. Mirror the Osaka-only
+    // gating used at the other cap sites (block validation, default_hook).
+    if fork >= Fork::Osaka && fork < Fork::Amsterdam {
         POST_OSAKA_GAS_LIMIT_CAP
     } else {
         block_gas_limit


### PR DESCRIPTION
**Motivation**

`get_max_allowed_gas_limit` returned `POST_OSAKA_GAS_LIMIT_CAP` (16,777,216) for every fork ≥ Osaka, including Amsterdam. Under EIP-8037 a transaction's gas limit may exceed that flat cap (the excess funds the state-gas reservoir; only the regular dimension is bound by `TX_MAX_GAS_LIMIT`), so capping the `eth_estimateGas` binary-search ceiling at 16.7M prevents convergence for state-heavy creations.

**Description**

Gate the flat EIP-7825 cap to `Osaka..Amsterdam` (mirroring the Osaka-only gating at the other cap sites); Amsterdam+ uses `block_gas_limit`. RPC-only: consensus tx-gas-limit validation is already Amsterdam-exempt.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
