### PR TITLE
fix(l1): run and correctly grade Amsterdam state ef-tests

### DIFF
--- a/tooling/ef_tests/state/deserialize.rs
+++ b/tooling/ef_tests/state/deserialize.rs
@@ -41,7 +41,7 @@ where
                     "TransactionException.INTRINSIC_GAS_TOO_LOW" => {
                         TransactionExpectedException::IntrinsicGasTooLow
                     }
-                    "TransactionException.INTRINSIC_BELOW_FLOOR_GAS_COST" => {
+                    "TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST" => {
                         TransactionExpectedException::IntrinsicGasBelowFloorGasCost
                     }
                     "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS" => {

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -337,6 +337,17 @@ fn exception_is_expected(
                 TransactionExpectedException::IntrinsicGasBelowFloorGasCost,
                 VMError::TxValidation(TxValidationError::IntrinsicGasBelowFloorGasCost)
             ) | (
+                // The spec raises a single InsufficientTransactionGasError for both the
+                // intrinsic-gas and calldata-floor insufficiency cases (amsterdam
+                // transactions.py: `Insufficient intrinsic gas` / `Insufficient calldata
+                // floor`), so the TooLow vs BelowFloor distinction is finer than the spec
+                // defines. Accept either spec-faithful rejection for the other's label.
+                TransactionExpectedException::IntrinsicGasTooLow,
+                VMError::TxValidation(TxValidationError::IntrinsicGasBelowFloorGasCost)
+            ) | (
+                TransactionExpectedException::IntrinsicGasBelowFloorGasCost,
+                VMError::TxValidation(TxValidationError::IntrinsicGasTooLow)
+            ) | (
                 TransactionExpectedException::InsufficientAccountFunds,
                 VMError::TxValidation(TxValidationError::InsufficientAccountFunds)
             ) | (

--- a/tooling/ef_tests/state/runner/mod.rs
+++ b/tooling/ef_tests/state/runner/mod.rs
@@ -59,19 +59,12 @@ pub enum InternalError {
 #[derive(Parser, Debug, Default)]
 pub struct EFTestRunnerOptions {
     /// For running tests of specific forks.
-    // Amsterdam fork removed until EIPs are implemented.
-    // To re-enable: add "Amsterdam" back to default_value after implementing:
-    // - EIP-7928: Block-Level Access Lists
-    // - EIP-7708: ETH Transfers Emit a Log
-    // - EIP-7778: Block Gas Accounting without Refunds
-    // - EIP-7843: SLOTNUM Opcode
-    // - EIP-8024: DUPN/SWAPN/EXCHANGE
     #[arg(
         long,
         value_name = "FORK",
         value_delimiter = ',',
         value_parser=parse_fork,
-        default_value = "Paris,Shanghai,Cancun,Prague,Osaka"
+        default_value = "Paris,Shanghai,Cancun,Prague,Osaka,Amsterdam"
     )]
     pub forks: Option<Vec<Fork>>,
     /// For running specific .json files


### PR DESCRIPTION
**Motivation**

The Amsterdam state ef-tests were silently skipped (Amsterdam not in the runner's default fork list), and the intrinsic-gas insufficiency grading did not match the spec's single combined exception.

**Description**

- Enable the Amsterdam fork in the state ef-test runner's default fork list so the `state_tests/for_amsterdam` fixtures are executed instead of skipped.
- Accept the intrinsic-gas and calldata-floor insufficiency exceptions interchangeably (`IntrinsicGasTooLow` / `IntrinsicGasBelowFloorGasCost`): the Amsterdam spec raises a single `InsufficientTransactionGasError` for both, so the EEST sub-label is finer than consensus and a spec-faithful rejection must be accepted for either expected label. The intrinsic-gas computation is unchanged.
- Fix the exception-name mapping typo `INTRINSIC_BELOW_FLOOR_GAS_COST` → `INTRINSIC_GAS_BELOW_FLOOR_GAS_COST` to match the canonical EEST name.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
