### PR TITLE
fix(l1): accept v1 blob sidecars pre-osaka and relax pooled-tx size check

### DIFF
--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -201,10 +201,22 @@ impl BlobsBundle {
             return Err(BlobsBundleError::BlobBundleEmptyError);
         }
 
-        // The wrapper version is fork-specific: 0 (blob proofs) before Osaka, 1 (cell
-        // proofs, EIP-7594) on Osaka+. Any other value is invalid.
-        let expected_version = if fork >= Fork::Osaka { 1 } else { 0 };
-        if self.version != expected_version {
+        // Blob sidecar wrapper version: 0 = EIP-4844 blob proofs, 1 = EIP-7594 cell proofs.
+        // The sidecar is a mempool/propagation-only artifact (never included in a block) and
+        // both formats are cryptographically verifiable at any fork.
+        //
+        // Acceptance criteria:
+        //   - pre-Osaka: accept BOTH v0 and v1. Peers are migrating to cell proofs at
+        //     different times (e.g. post go-ethereum#35191 geth sends v1 even pre-Osaka,
+        //     while older peers still send v0), so rejecting either would needlessly
+        //     disconnect otherwise-valid peers.
+        //   - Osaka+: only v1 (cell proofs) is valid.
+        let version_ok = if fork >= Fork::Osaka {
+            self.version == 1
+        } else {
+            self.version <= 1
+        };
+        if !version_ok {
             return Err(BlobsBundleError::InvalidBlobVersionForFork);
         }
 
@@ -397,9 +409,12 @@ mod tests {
         ));
     }
 
+    // v1 (cell-proof) sidecars are accepted pre-Osaka (network is mid-migration to cell
+    // proofs; some peers send v1 even before Osaka), but v0 (blob-proof) sidecars are
+    // rejected on Osaka+.
     #[test]
     #[cfg(feature = "c-kzg")]
-    fn transaction_with_invalid_fork_should_fail() {
+    fn v1_sidecar_is_accepted_pre_osaka() {
         let blobs = vec!["Hello, world!".as_bytes(), "Goodbye, world!".as_bytes()]
             .into_iter()
             .map(|data| {
@@ -427,8 +442,44 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(!matches!(
+        assert!(matches!(
             blobs_bundle.validate(&tx, crate::types::Fork::Prague),
+            Ok(())
+        ));
+    }
+
+    #[test]
+    #[cfg(feature = "c-kzg")]
+    fn v0_sidecar_is_rejected_on_osaka() {
+        let blobs = vec!["Hello, world!".as_bytes(), "Goodbye, world!".as_bytes()]
+            .into_iter()
+            .map(|data| {
+                crate::types::blobs_bundle::blob_from_bytes(data.into())
+                    .expect("Failed to create blob")
+            })
+            .collect();
+
+        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, Some(0))
+            .expect("Failed to create blobs bundle");
+
+        let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
+
+        let tx = crate::types::transaction::EIP4844Transaction {
+            nonce: 3,
+            max_priority_fee_per_gas: 0,
+            max_fee_per_gas: 0,
+            max_fee_per_blob_gas: 0.into(),
+            gas: 15_000_000,
+            to: crate::Address::from_low_u64_be(1), // Normal tx
+            value: crate::U256::zero(),             // Value zero
+            data: crate::Bytes::default(),          // No data
+            access_list: Default::default(),        // No access list
+            blob_versioned_hashes,
+            ..Default::default()
+        };
+
+        assert!(!matches!(
+            blobs_bundle.validate(&tx, crate::types::Fork::Osaka),
             Ok(())
         ));
     }

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -19,6 +19,13 @@ use ethrex_rlp::{
 use ethrex_storage::error::StoreError;
 use tracing::debug;
 
+/// Allowed skew between a peer's announced pooled-transaction size and the size we compute
+/// from the received transaction. The announced size is a soft hint that varies slightly
+/// between clients (e.g. geth's `Transaction.Size()` omits the v1 blob-sidecar wrapper
+/// version byte), so we tolerate a few bytes before treating it as a protocol violation.
+/// Matches go-ethereum's tx fetcher (`eth/fetcher/tx_fetcher.go`).
+const POOLED_TX_SIZE_TOLERANCE: usize = 8;
+
 // https://github.com/ethereum/devp2p/blob/master/caps/eth.md#transactions-0x02
 // Broadcast message
 #[derive(Debug, Clone)]
@@ -305,8 +312,14 @@ impl PooledTransactions {
             if tx.tx_type() as u8 != expected_type {
                 return Err(MempoolError::InvalidPooledTxType(expected_type));
             }
+            // The announced size is a soft hint, not an exact value. geth's
+            // `Transaction.Size()` under-counts a v1 (EIP-7594 cell-proof) blob sidecar by
+            // one byte — it omits the wrapper version byte — so a strict equality check
+            // would disconnect geth peers on every v1 blob-tx announcement. Match geth's tx
+            // fetcher, which tolerates up to 8 bytes of skew before treating it as a
+            // violation (go-ethereum eth/fetcher/tx_fetcher.go).
             let tx_size = tx.encode_canonical_to_vec().len();
-            if tx_size != expected_size {
+            if tx_size.abs_diff(expected_size) > POOLED_TX_SIZE_TOLERANCE {
                 return Err(MempoolError::InvalidPooledTxSize);
             }
         }

--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -238,6 +238,26 @@ mod tests {
         (bundle, hashes)
     }
 
+    fn sample_v0_bundle(count: usize) -> (BlobsBundle, Vec<H256>) {
+        let blobs = vec![[1u8; BYTES_PER_BLOB]; count];
+        let commitments: Vec<Commitment> = (0..count).map(|i| [i as u8; 48]).collect();
+        // v0 (EIP-4844): exactly one blob proof per blob.
+        let proofs: Vec<Proof> = vec![[2u8; 48]; count];
+
+        let hashes = commitments
+            .iter()
+            .map(kzg_commitment_to_versioned_hash)
+            .collect();
+
+        let bundle = BlobsBundle {
+            blobs,
+            commitments,
+            proofs,
+            version: 0,
+        };
+        (bundle, hashes)
+    }
+
     fn blob_and_proof(bundle: &BlobsBundle, index: usize) -> BlobAndProofV2 {
         let start = index * CELLS_PER_EXT_BLOB;
         let end = start + CELLS_PER_EXT_BLOB;
@@ -330,9 +350,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blobs_v1_returns_full_before_osaka() {
+    async fn blobs_v1_returns_v0_proof_before_osaka() {
         let context = context_with_chain_config(false).await;
-        let (bundle, hashes) = sample_bundle(1);
+        let (bundle, hashes) = sample_v0_bundle(1);
         context
             .blockchain
             .mempool
@@ -349,6 +369,28 @@ mod tests {
             proof: bundle.proofs[0],
         })])
         .unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn blobs_v1_returns_null_for_v1_sidecar_before_osaka() {
+        // A v1 (cell-proof) sidecar can reach a pre-Osaka mempool, but getBlobsV1 can only
+        // serve a single EIP-4844 blob proof, so it must report the blob as unavailable
+        // rather than returning a cell proof in the blob-proof field.
+        let context = context_with_chain_config(false).await;
+        let (bundle, hashes) = sample_bundle(1);
+        context
+            .blockchain
+            .mempool
+            .add_blobs_bundle(H256::from_low_u64_be(1), bundle)
+            .unwrap();
+
+        let request = BlobsV1Request {
+            blob_versioned_hashes: hashes,
+        };
+
+        let result = request.handle(context).await.unwrap();
+        let expected = serde_json::to_value(vec![None::<BlobAndProofV1>]).unwrap();
         assert_eq!(result, expected);
     }
 

--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -93,11 +93,17 @@ impl RpcHandler for BlobsV1Request {
         let res: Vec<Option<BlobAndProofV1>> = blob_tuples
             .into_iter()
             .map(|b| {
-                b.map(|(blob, _, proofs)| BlobAndProofV1 {
-                    blob: *blob,
-                    // If blob bundle version is 0 then the proofs vec will have only one proof.
-                    // Look at `get_blob_tuple_by_index` for reference.
-                    proof: proofs[0],
+                b.and_then(|(blob, _, proofs)| {
+                    // getBlobsV1 serves the single EIP-4844 blob proof. A v0 bundle yields
+                    // exactly one proof here (see `get_blob_tuple_by_index`); a v1 (EIP-7594)
+                    // sidecar yields 128 cell proofs per blob and can now reach a pre-Osaka
+                    // mempool. Cell proofs can't be represented as a single blob proof, so
+                    // report the blob as unavailable (the CL re-fetches it from gossip)
+                    // rather than returning a cell proof in the blob-proof field.
+                    (proofs.len() == 1).then(|| BlobAndProofV1 {
+                        blob: *blob,
+                        proof: proofs[0],
+                    })
                 })
             })
             .collect();


### PR DESCRIPTION
**Motivation**

The `devp2p` hive suite (`TestBlobTxWithoutSidecar`, `TestBlobTxWithMismatchedSidecar`) started failing main-wide with "unexpected disconnect". The trigger is go-ethereum [#35191](https://github.com/ethereum/go-ethereum/pull/35191) ("V0 Blob Sidecar Support Removal"), which makes geth always produce **v1 (EIP-7594 cell-proof)** blob sidecars — even pre-Osaka — instead of v0 (EIP-4844 blob proofs). The hive simulator builds its `devp2p` test peer from go-ethereum at image-build time, so once that picked up #35191 the peer began sending v1 sidecars, which ethrex rejected, disconnecting an otherwise-valid peer.

**Description**

Two independent issues surfaced, both on the mempool/propagation path (blob sidecars are never included in a block, so neither change affects consensus):

1. **Blob sidecar version acceptance** (`crates/common/types/blobs_bundle.rs`, `validate_cheap`): previously a fork-exact check (`v0` before Osaka, `v1` on Osaka+) rejected v1 sidecars pre-Osaka. The network is mid-migration to cell proofs and peers switch at different times, so pre-Osaka we now accept **both v0 and v1**; Osaka+ still requires v1. Updated the unit tests accordingly (`v1_sidecar_is_accepted_pre_osaka`, `v0_sidecar_is_rejected_on_osaka`).

2. **Pooled-transaction size check** (`crates/networking/p2p/rlpx/eth/transactions.rs`): `validate_requested` required the received transaction's encoded length to *exactly* equal the size announced in `NewPooledTransactionHashes`. geth's `Transaction.Size()` under-counts a v1 sidecar by exactly one byte — it omits the wrapper version byte — so the strict check disconnected geth on every v1 blob-tx announcement. The announced size is a soft hint; we now tolerate up to 8 bytes of skew, matching go-ethereum's tx fetcher (`eth/fetcher/tx_fetcher.go`). ethrex's own announcements already fall within geth's 8-byte tolerance, so the send side needs no change.

Validated by reproducing the exact CI configuration (hive simulator rebuilt with fresh geth incl. #35191): the `devp2p` `eth` suite goes from `failed=3` to **21/21 passing**, including both target tests. `blobs_bundle` unit tests (8/8 with `--features c-kzg`) and clippy on the touched crates are clean.

**Checklist**

- [x] Reproduced the failure against a fresh-geth hive simulator and confirmed the fix (`devp2p`/`eth` 21/21).
