### PR TITLE
ci(l1,l2): make latest-release Docker tag promotion race-free

### DIFF
--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -1,52 +1,96 @@
 name: Ethrex Latest Release
 
+# Promotes a tested release candidate to the user-facing Docker tags
+# (latest / l2 / performance / X.Y.Z) and triggers the apt publish.
+#
+# The promotion decision is made purely from the triggering event payload
+# (or the manual inputs) -- it never reads GitHub's /releases/latest endpoint,
+# which excludes prereleases, sorts by created_at, and lags a just-saved edit.
+# That race previously made the retag job skip silently while the run stayed
+# green (e.g. v18.0.0 left :latest pointing at v17.0.0).
+#
+# Paths:
+#   - release: edited   -> a single edit that renames the RC tag to vX.Y.Z and
+#                          unchecks "pre-release" promotes automatically.
+#   - workflow_dispatch -> deterministic manual recovery: supply rc_tag + version.
+#   - release: released -> tripwire that asserts :latest actually moved to the
+#                          released version, failing loudly if it did not.
 on:
   workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: "Source RC image tag to promote, e.g. v18.0.0-rc.1 (the tested release candidate)"
+        required: true
+        type: string
+      version:
+        description: "Final version tag to publish, e.g. v18.0.0"
+        required: true
+        type: string
   release:
     types:
       - edited
+      - released
 
 permissions:
   contents: read
-  packages: write
+  packages: read
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  get_latest_release:
-    name: "Get latest release tag"
+  resolve:
+    name: "Resolve promotion tags"
     runs-on: ubuntu-latest
+    # Run on a manual dispatch, or on an edit that promotes an RC to a full
+    # release (the tag was renamed AND the release is no longer a pre-release).
+    # A notes-only edit, or an edit while still a pre-release, is skipped.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'edited' && github.event.changes.tag_name.from != '' && github.event.release.prerelease == false) }}
     outputs:
-      latest_tag: ${{ steps.get_latest_release.outputs.latest_tag }}
-
+      prev_tag: ${{ steps.tags.outputs.prev_tag }}
+      new_tag: ${{ steps.tags.outputs.new_tag }}
     steps:
-      - name: Get latest release tag from GH API
-        id: get_latest_release
+      - name: Determine source (RC) and target (version) tags
+        id: tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RC_TAG: ${{ inputs.rc_tag }}
+          INPUT_VERSION: ${{ inputs.version }}
+          EDIT_FROM: ${{ github.event.changes.tag_name.from }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          tag=$(curl -s https://api.github.com/repos/${{ env.IMAGE_NAME }}/releases/latest | jq -r .tag_name)
-          echo "Latest release tag: $tag"
-          echo "latest_tag=$tag" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PREV="$INPUT_RC_TAG"
+            NEW="$INPUT_VERSION"
+          else
+            PREV="$EDIT_FROM"
+            NEW="$RELEASE_TAG"
+          fi
+          # Strip a single leading 'v' (v18.0.0-rc.1 -> 18.0.0-rc.1).
+          PREV="${PREV#v}"
+          NEW="${NEW#v}"
+          if [ -z "$PREV" ] || [ -z "$NEW" ]; then
+            echo "::error::Could not determine promotion tags (prev='$PREV' new='$NEW')."
+            exit 1
+          fi
+          echo "prev_tag=$PREV" >> "$GITHUB_OUTPUT"
+          echo "new_tag=$NEW" >> "$GITHUB_OUTPUT"
+          echo "Promoting $PREV -> $NEW (+ latest / l2 / performance)"
 
   retag_docker_images:
     name: "Tag latest Docker images"
     runs-on: ubuntu-latest
-    needs: [get_latest_release]
-    if: ${{ needs.get_latest_release.outputs.latest_tag == github.event.release.tag_name && github.event.changes.tag_name.from }}
-
-    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    needs: [resolve]
     permissions:
       contents: read
       packages: write
       id-token: write
-
+    env:
+      PREV_TAG: ${{ needs.resolve.outputs.prev_tag }}
+      NEW_TAG: ${{ needs.resolve.outputs.new_tag }}
     steps:
-      - name: Set tags
-        run: |
-          echo "PREV_TAG=$(echo ${{ github.event.changes.tag_name.from }} | tr -d v)" >> $GITHUB_ENV
-          echo "NEW_TAG=$(echo ${{ github.event.release.tag_name }} | tr -d v)" >> $GITHUB_ENV
-
       - name: Login to Docker registry
         uses: docker/login-action@v4
         with:
@@ -56,16 +100,17 @@ jobs:
 
       - name: Retag Docker images
         run: |
+          set -euo pipefail
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEW_TAG }} \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:performance \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREV_TAG }}
+            -t "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}" \
+            -t "${REGISTRY}/${IMAGE_NAME}:latest" \
+            -t "${REGISTRY}/${IMAGE_NAME}:performance" \
+            "${REGISTRY}/${IMAGE_NAME}:${PREV_TAG}"
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.NEW_TAG }}-l2 \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:l2 \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:performance-l2 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREV_TAG }}-l2
+            -t "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}-l2" \
+            -t "${REGISTRY}/${IMAGE_NAME}:l2" \
+            -t "${REGISTRY}/${IMAGE_NAME}:performance-l2" \
+            "${REGISTRY}/${IMAGE_NAME}:${PREV_TAG}-l2"
 
   publish-apt:
     needs: [retag_docker_images]
@@ -77,3 +122,87 @@ jobs:
       APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
       APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
       APT_SSH_COMMIT_KEY: ${{ secrets.APT_SSH_COMMIT_KEY }}
+
+  verify-latest:
+    name: "Verify latest tag promotion"
+    runs-on: ubuntu-latest
+    needs: [resolve, retag_docker_images]
+    permissions:
+      contents: read
+      packages: read
+    env:
+      NEW_TAG: ${{ needs.resolve.outputs.new_tag }}
+    steps:
+      - name: Login to Docker registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert floating tags resolve to the promoted version
+        run: |
+          set -euo pipefail
+          # Index (manifest-list) digest of a tag. Falls back to the text output's
+          # "Digest:" line on older buildx that lacks the .Manifest.Digest template.
+          digest() {
+            docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}' 2>/dev/null \
+              || docker buildx imagetools inspect "$1" 2>/dev/null | awk '/^Digest:/{print $2; exit}'
+          }
+          status=0
+          for pair in "latest:${NEW_TAG}" "l2:${NEW_TAG}-l2"; do
+            float="${pair%%:*}"
+            pinned="${pair#*:}"
+            fd="$(digest "${REGISTRY}/${IMAGE_NAME}:${float}")"
+            pd="$(digest "${REGISTRY}/${IMAGE_NAME}:${pinned}")"
+            echo "${float}=${fd:-<none>}  ${pinned}=${pd:-<none>}"
+            if [ -z "$pd" ] || [ "$fd" != "$pd" ]; then
+              echo "::error::':${float}' (${fd:-<none>}) does not match ':${pinned}' (${pd:-<none>})"
+              status=1
+            fi
+          done
+          [ "$status" -eq 0 ] && echo "Verified :latest -> :${NEW_TAG} and :l2 -> :${NEW_TAG}-l2"
+          exit "$status"
+
+  assert-latest-promoted:
+    name: "Assert release was promoted to latest"
+    runs-on: ubuntu-latest
+    # Tripwire: a release promoted to a full release MUST end up on :latest. The
+    # 'edited' run (or a manual dispatch) does the retag concurrently, so poll
+    # until :latest catches up. A persistent mismatch means the automatic retag
+    # never fired (e.g. a multi-step promotion) -- fail loudly with the fix.
+    if: ${{ github.event_name == 'release' && github.event.action == 'released' }}
+    permissions:
+      contents: read
+      packages: read
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Login to Docker registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for :latest to match the released version
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          digest() {
+            docker buildx imagetools inspect "$1" --format '{{.Manifest.Digest}}' 2>/dev/null \
+              || docker buildx imagetools inspect "$1" 2>/dev/null | awk '/^Digest:/{print $2; exit}' \
+              || true
+          }
+          for i in $(seq 1 10); do
+            target="$(digest "${REGISTRY}/${IMAGE_NAME}:${VERSION}")"
+            current="$(digest "${REGISTRY}/${IMAGE_NAME}:latest")"
+            echo "attempt ${i}: latest=${current:-<none>}  ${VERSION}=${target:-<none>}"
+            if [ -n "$target" ] && [ "$current" = "$target" ]; then
+              echo "Confirmed :latest -> :${VERSION}"
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "::error::':latest' did not move to ':${VERSION}' after promotion. This usually means the release was promoted in multiple edits, so the automatic retag never fired. Re-run 'Ethrex Latest Release' via 'Run workflow' with rc_tag (the tested RC, e.g. v${VERSION}-rc.1) and version (v${VERSION})."
+          exit 1

--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -150,7 +150,7 @@ jobs:
               || docker buildx imagetools inspect "$1" 2>/dev/null | awk '/^Digest:/{print $2; exit}'
           }
           status=0
-          for pair in "latest:${NEW_TAG}" "l2:${NEW_TAG}-l2"; do
+          for pair in "latest:${NEW_TAG}" "l2:${NEW_TAG}-l2" "performance:${NEW_TAG}" "performance-l2:${NEW_TAG}-l2"; do
             float="${pair%%:*}"
             pinned="${pair#*:}"
             fd="$(digest "${REGISTRY}/${IMAGE_NAME}:${float}")"
@@ -161,7 +161,7 @@ jobs:
               status=1
             fi
           done
-          [ "$status" -eq 0 ] && echo "Verified :latest -> :${NEW_TAG} and :l2 -> :${NEW_TAG}-l2"
+          [ "$status" -eq 0 ] && echo "Verified floating tags (latest, l2, performance) resolve to :${NEW_TAG}"
           exit "$status"
 
   assert-latest-promoted:

--- a/docs/developers/release-process.md
+++ b/docs/developers/release-process.md
@@ -132,7 +132,10 @@ Once the pre-release is created and you want to publish the release, go to the [
 
     ![set latest release](../img/publish_release_step_4.png)
 
-Once done, the CI will publish new tags for the already compiled docker images:
+> [!IMPORTANT]
+> Do the tag rename (`vX.Y.Z-rc.W` → `vX.Y.Z`) **and** unchecking *pre-release* in a **single** `Update release` edit. The automatic promotion fires on that one edit because it both renames the tag and clears the pre-release flag; splitting it across two saves means neither edit carries both signals and the `latest` tag is not moved. If that happens, use the manual recovery in [Troubleshooting](#failure-on-latest-release-workflow).
+
+Once done, the `Ethrex Latest Release` workflow (triggered by that edit) will publish new tags for the already compiled docker images:
 
 - `ghcr.io/lambdaclass/ethrex:X.Y.Z`, `ghcr.io/lambdaclass/ethrex:latest`
 - `ghcr.io/lambdaclass/ethrex:X.Y.Z-l2`, `ghcr.io/lambdaclass/ethrex:l2`
@@ -212,7 +215,13 @@ If hotfixes are needed before the final release, commit them to `release/vX.Y.Z`
 
 ### Failure on "latest release" workflow
 
-If the CI fails when setting a release as latest (step 5), Docker tags `latest` and `l2` may not be updated. To manually push those changes, follow these steps:
+If the `latest` / `l2` Docker tags don't get updated after step 5 (the `Ethrex Latest Release` run skipped the retag, or its `assert-latest-promoted` job failed), recover with the workflow's manual path — no local Docker or PAT needed:
+
+- Go to **Actions → Ethrex Latest Release → Run workflow**.
+- Set `rc_tag` to the tested release candidate (e.g. `v18.0.0-rc.1`) and `version` to the final version (e.g. `v18.0.0`).
+- Run it. The run retags `latest` / `l2` / `performance` / `X.Y.Z` from the RC image, publishes the apt package, and the `verify-latest` job confirms `:latest` resolves to `:X.Y.Z` (the run goes red if it doesn't).
+
+If the registry itself is the problem and you need to push tags by hand, fall back to a local retag:
 
 - Create a new Github Personal Access Token (PAT) from the [settings](https://github.com/settings/tokens/new).
 - Check `write:packages` permission (this will auto-check `repo` permissions too), give a name and a short expiration time.

--- a/docs/developers/release-process.md
+++ b/docs/developers/release-process.md
@@ -221,36 +221,26 @@ If the `latest` / `l2` Docker tags don't get updated after step 5 (the `Ethrex L
 - Set `rc_tag` to the tested release candidate (e.g. `v18.0.0-rc.1`) and `version` to the final version (e.g. `v18.0.0`).
 - Run it. The run retags `latest` / `l2` / `performance` / `X.Y.Z` from the RC image, publishes the apt package, and the `verify-latest` job confirms `:latest` resolves to `:X.Y.Z` (the run goes red if it doesn't).
 
-If the registry itself is the problem and you need to push tags by hand, fall back to a local retag:
+If the registry itself is unreachable through Actions and you must promote by hand, do it **server-side** so the multi-arch image index is preserved. (A `docker pull --platform linux/amd64 … && docker tag && docker push` collapses `:latest` to a single architecture, silently dropping arm64.)
 
 - Create a new Github Personal Access Token (PAT) from the [settings](https://github.com/settings/tokens/new).
 - Check `write:packages` permission (this will auto-check `repo` permissions too), give a name and a short expiration time.
 - Save the token securely.
 - Click on `Configure SSO` button and authorize LambdaClass organization.
 - Log in to Github Container Registry: `docker login ghcr.io`. Put your Github's username and use the token as your password.
-- Pull RC images:
+- Retag the RC images to the release tags (server-side, multi-arch index preserved — same operation the workflow performs):
 
 ```bash
-docker pull --platform linux/amd64 ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W
-docker pull --platform linux/amd64 ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W-l2
-```
-
-- Retag them:
-
-```bash
-docker tag ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W ghcr.io/lambdaclass/ethrex:X.Y.Z
-docker tag ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W-l2 ghcr.io/lambdaclass/ethrex:X.Y.Z-l2
-docker tag ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W ghcr.io/lambdaclass/ethrex:latest
-docker tag ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W-l2 ghcr.io/lambdaclass/ethrex:l2
-```
-
-- Push them:
-
-```bash
-docker push ghcr.io/lambdaclass/ethrex:X.Y.Z
-docker push ghcr.io/lambdaclass/ethrex:X.Y.Z-l2
-docker push ghcr.io/lambdaclass/ethrex:latest
-docker push ghcr.io/lambdaclass/ethrex:l2
+docker buildx imagetools create \
+  -t ghcr.io/lambdaclass/ethrex:X.Y.Z \
+  -t ghcr.io/lambdaclass/ethrex:latest \
+  -t ghcr.io/lambdaclass/ethrex:performance \
+  ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W
+docker buildx imagetools create \
+  -t ghcr.io/lambdaclass/ethrex:X.Y.Z-l2 \
+  -t ghcr.io/lambdaclass/ethrex:l2 \
+  -t ghcr.io/lambdaclass/ethrex:performance-l2 \
+  ghcr.io/lambdaclass/ethrex:X.Y.Z-rc.W-l2
 ```
 
 - Delete the PAT for security ([here](https://github.com/settings/tokens))


### PR DESCRIPTION
**Motivation**

When v18.0.0 was released, `ghcr.io/lambdaclass/ethrex:latest` never moved off v17.0.0 — and `:18.0.0` was never created at all (HTTP 404). Users on `:latest` kept getting v17; the only newer image was the rolling `:main` tag. The v18 apt package also never published.

The "Ethrex Latest Release" run for v18 reported success, but its `retag_docker_images` and `publish-apt` jobs were **skipped**. The retag job was gated on a live read of GitHub's `/releases/latest`, which excludes prereleases, sorts by `created_at`, and lags a just-saved edit. During the promotion edit that read still returned `v17.0.0`, so `latest_tag == release.tag_name` was false and the job skipped — and a skipped job leaves the whole run green, so nothing flagged it. `publish-apt` skipped in the cascade (`needs: retag`). The v17 release needed three edit events before the gate happened to align; v18 never got that lucky.

**Description**

Decide the promotion from the event payload / manual inputs instead of the API, and make a non-promotion loud:

- **Race-free gate** — remove the `get_latest_release` job and its `/releases/latest` read. A new `resolve` job derives the source RC tag and target version from the edit payload (tag was renamed **and** the release is no longer a pre-release) or from `workflow_dispatch` inputs. No external state, so the race is gone.
- **Manual recovery** — `workflow_dispatch` gains `rc_tag` and `version` inputs that perform the identical promotion deterministically (a one-click replacement for the manual PAT + `docker tag`/`push` procedure).
- **Loud verification** — `verify-latest` fails the run unless the floating tags (`:latest`, `:l2`, `:performance`, `:performance-l2`) resolve to the same digest as `:X.Y.Z` / `:X.Y.Z-l2`. A skipped or partial promotion can no longer pass as a green run.
- **Promotion tripwire** — on `release: released`, `assert-latest-promoted` polls until `:latest` matches the released version, failing loudly when a multi-step promotion means the automatic retag never fired. It polls (not check-once) because a single-edit promotion emits both `edited` and `released` as two concurrent runs with no guaranteed order.
- **Docs** — `release-process.md`: promote in a single edit; use the `workflow_dispatch` recovery as the first-line fix.

The RC image remains the promotion source (reusing the tested build); the final `vX.Y.Z` tag does not build its own image.

**How to roll out (also fixes the live v18 breakage)**

After merge: **Actions → Ethrex Latest Release → Run workflow** with `rc_tag=v18.0.0-rc.1`, `version=v18.0.0`. The RC images are confirmed present in ghcr; this promotes `:latest`/`:l2`/`:performance`/`:18.0.0` from them, publishes the v18 apt package, and `verify-latest` confirms `:latest == :18.0.0`.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — N/A (CI-only change)

Closes #6918
