### PR TITLE
ci(l1,l2): pass the promoted version to the apt publish

### DIFF
--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -113,11 +113,16 @@ jobs:
             "${REGISTRY}/${IMAGE_NAME}:${PREV_TAG}-l2"
 
   publish-apt:
-    needs: [retag_docker_images]
+    needs: [resolve, retag_docker_images]
     uses: lambdaclass/ethrex-apt/.github/workflows/publish-apt.yml@main
     permissions:
       contents: write
       actions: write
+    # Pass the exact version being promoted so the apt repo doesn't re-resolve
+    # it from GitHub's "latest release" lookup, which lags a just-promoted
+    # release and could publish the previous version.
+    with:
+      tag: ${{ needs.resolve.outputs.new_tag }}
     secrets:
       APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
       APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on lambdaclass/ethrex-apt#3 — **merge that first**. Until the apt reusable workflow on `@main` declares the `tag` input, the `with: tag:` here is rejected when the `publish-apt` job runs (only at release-promotion / manual dispatch time; this PR's own CI is unaffected since that job doesn't run on PRs).

**Motivation**

Follow-up to #6920. That PR moved the docker retag off GitHub's `/releases/latest` read and made the promotion fire on the release edit — but `publish-apt` still received no version, so the apt reusable workflow resolved it from `gh release view` (GitHub's latest published, non-pre-release release). That lookup lags a just-promoted release, and because the retag now fires during the promotion edit, the apt job runs inside that same propagation window — it can resolve the *previous* version and publish the wrong `.deb` (or skip via the pool check), with the run still green.

**Description**

- `publish-apt` now passes `tag: ${{ needs.resolve.outputs.new_tag }}` (the version being promoted) and gains `resolve` in its `needs`.
- The apt reusable workflow uses that explicit tag instead of `gh release view`, so apt version resolution no longer depends on GitHub's eventually-consistent "latest release" endpoint. The apt side normalizes both `18.0.0` and `v18.0.0` forms.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — N/A (CI-only change)
