### PR TITLE
fix(l1): record inbound connection direction for admin_peers

### DIFF
--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -396,6 +396,7 @@ pub trait PeerTableServerProtocol: Send + Sync {
         node: Node,
         connection: PeerConnection,
         capabilities: Vec<Capability>,
+        is_inbound: bool,
     ) -> Result<(), ActorError>;
     fn set_session_info(&self, node_id: H256, session: Session) -> Result<(), ActorError>;
     fn remove_peer(&self, node_id: H256) -> Result<(), ActorError>;
@@ -543,7 +544,8 @@ impl PeerTableServer {
         _ctx: &Context<Self>,
     ) {
         let new_peer_id = msg.node.node_id();
-        let new_peer = PeerData::new(msg.node, None, Some(msg.connection), msg.capabilities);
+        let mut new_peer = PeerData::new(msg.node, None, Some(msg.connection), msg.capabilities);
+        new_peer.is_connection_inbound = msg.is_inbound;
         self.peers.insert(new_peer_id, new_peer);
     }
 

--- a/crates/networking/p2p/rlpx/connection/handshake.rs
+++ b/crates/networking/p2p/rlpx/connection/handshake.rs
@@ -62,7 +62,7 @@ pub(crate) async fn perform(
     state: ConnectionState,
     eth_version: Arc<RwLock<EthCapVersion>>,
 ) -> Result<(Established, SplitStream<Framed<TcpStream, RLPxCodec>>), PeerConnectionError> {
-    let (context, node, framed) = match state {
+    let (context, node, framed, is_inbound) = match state {
         ConnectionState::Initiator(Initiator { context, node }) => {
             let addr = SocketAddr::new(node.ip, node.tcp_port);
             let mut stream = match tcp_stream(addr).await {
@@ -81,7 +81,7 @@ pub(crate) async fn perform(
                 keccak_hash([remote_state.nonce.0, local_state.nonce.0].concat());
             let codec = RLPxCodec::new(&local_state, &remote_state, hashed_nonces, eth_version)?;
             trace!(peer=%node, "Completed handshake as initiator");
-            (context, node, Framed::new(stream, codec))
+            (context, node, Framed::new(stream, codec), false)
         }
         ConnectionState::Receiver(Receiver {
             context,
@@ -107,7 +107,7 @@ pub(crate) async fn perform(
                 remote_state.public_key,
             );
             trace!(peer=%node, "Completed handshake as receiver");
-            (context, node, Framed::new(stream, codec))
+            (context, node, Framed::new(stream, codec), true)
         }
         ConnectionState::Established(_) => {
             return Err(PeerConnectionError::StateError(
@@ -128,6 +128,7 @@ pub(crate) async fn perform(
             signer: context.signer,
             sink,
             node,
+            is_inbound,
             storage: context.storage.clone(),
             blockchain: context.blockchain.clone(),
             capabilities: vec![],

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -225,6 +225,9 @@ pub struct Established {
     // The receiving part is owned by the stream listen loop task
     pub(crate) sink: SplitSink<Framed<TcpStream, RLPxCodec>, Message>,
     pub(crate) node: Node,
+    // Whether the remote peer initiated this connection (we acted as Receiver).
+    // `false` when we initiated it (we acted as Initiator).
+    pub(crate) is_inbound: bool,
     pub(crate) storage: Store,
     pub(crate) blockchain: Arc<Blockchain>,
     pub(crate) capabilities: Vec<Capability>,
@@ -743,6 +746,7 @@ where
         state.node.clone(),
         connection.clone(),
         state.capabilities.clone(),
+        state.is_inbound,
     )?;
 
     trace!(peer=%state.node, "Peer connection initialized.");


### PR DESCRIPTION
## Summary

`admin_peers` always reported `inbound: false`, so dashboards (e.g. dora) showed 0 inbound peers even though ethrex does accept inbound connections. It was a reporting bug: the connection direction was never recorded.

The handshake distinguishes `Receiver` (inbound) from `Initiator` (outbound), but that info was dropped at the handshake to established transition, and `PeerData::is_connection_inbound` always fell back to `false`.

## Changes

- Add `is_inbound` to `Established`, set `true` from the `Receiver` arm and `false` from the `Initiator` arm in the handshake.
- Add an `is_inbound` param to `new_connected_peer` and its handler, and set it on `PeerData` instead of using the hardcoded default.
- Pass `state.is_inbound` at the established call site.

Closes #6933
