### PR TITLE
ci(l1,l2): report a clean release version, not the RC git tag

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -92,21 +92,9 @@ runs:
         REF_NAME: ${{ github.ref_name }}
         HEAD_REF: ${{ github.head_ref }}
         SHA: ${{ github.sha }}
-      run: |
-        # Feeds the binary's client-version channel (VERGEN_GIT_BRANCH) and the
-        # image's org.opencontainers.image.version label. Promotion retags the
-        # tested RC image, so both are baked at RC-build time -- use a clean,
-        # release-appropriate identity instead of the RC git tag, which otherwise
-        # surfaces on the promoted :latest as e.g. ethrex/v18.0.0-v18.0.0-rc.1-<sha>.
-        if [ "$REF_TYPE" = "tag" ]; then
-          channel="stable"
-          version="${REF_NAME#v}"; version="${version%%-*}"
-        else
-          channel="${HEAD_REF:-$REF_NAME}"
-          version="dev-${SHA}"
-        fi
-        echo "channel=$channel" >> "$GITHUB_OUTPUT"
-        echo "version=$version" >> "$GITHUB_OUTPUT"
+      # Derives the channel + version (see image-meta.sh for the why);
+      # unit-tested across ref types in .github/workflows/pr_lint_gha.yaml.
+      run: bash "$GITHUB_ACTION_PATH/image-meta.sh"
 
     - name: Login to DockerHub (for rate limiting)
       if: inputs.dockerhub_username != '' && inputs.dockerhub_password != ''

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -85,6 +85,29 @@ runs:
         VARIANT="${{ inputs.variant }}"
         echo "Cache scope: $CACHE_SCOPE, variant: $VARIANT, platform: $PLATFORM_SAFE"
 
+    - id: imgmeta
+      shell: bash
+      env:
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
+        HEAD_REF: ${{ github.head_ref }}
+        SHA: ${{ github.sha }}
+      run: |
+        # Feeds the binary's client-version channel (VERGEN_GIT_BRANCH) and the
+        # image's org.opencontainers.image.version label. Promotion retags the
+        # tested RC image, so both are baked at RC-build time -- use a clean,
+        # release-appropriate identity instead of the RC git tag, which otherwise
+        # surfaces on the promoted :latest as e.g. ethrex/v18.0.0-v18.0.0-rc.1-<sha>.
+        if [ "$REF_TYPE" = "tag" ]; then
+          channel="stable"
+          version="${REF_NAME#v}"; version="${version%%-*}"
+        else
+          channel="${HEAD_REF:-$REF_NAME}"
+          version="dev-${SHA}"
+        fi
+        echo "channel=$channel" >> "$GITHUB_OUTPUT"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Login to DockerHub (for rate limiting)
       if: inputs.dockerhub_username != '' && inputs.dockerhub_password != ''
       uses: docker/login-action@v4
@@ -119,8 +142,8 @@ runs:
         build-args: |
           ${{ inputs.build_args }}
           GIT_SHA=${{ github.sha }}
-          GIT_BRANCH=${{ github.head_ref || github.ref_name }}
-          VERSION=${{ github.ref_type == 'tag' && github.ref_name || format('dev-{0}', github.sha) }}
+          GIT_BRANCH=${{ steps.imgmeta.outputs.channel }}
+          VERSION=${{ steps.imgmeta.outputs.version }}
         platforms: ${{ inputs.platforms }}
 
     # Since we're exporting the image as a tar, we need to load it manually as well

--- a/.github/actions/build-docker/image-meta.sh
+++ b/.github/actions/build-docker/image-meta.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Derives the client-version channel (baked into the binary as VERGEN_GIT_BRANCH)
+# and the image version (org.opencontainers.image.version label) from the build ref.
+#
+# Release (tag) builds use a clean, release-appropriate identity -- channel
+# "stable" and the bare semver -- instead of the git tag. Promotion retags the
+# tested RC image to :X.Y.Z / :latest, so whatever a tag build bakes in is what
+# the stable image reports; echoing the RC tag here surfaced on :latest as e.g.
+# "ethrex/v18.0.0-v18.0.0-rc.1-<sha>". Branch/PR builds keep the branch name and
+# a dev-<sha> version.
+#
+# Inputs (env): REF_TYPE, REF_NAME, HEAD_REF, SHA.
+# Output: channel=… / version=… appended to $GITHUB_OUTPUT (stdout if unset).
+# Unit-tested by .github/workflows/pr_lint_gha.yaml.
+set -euo pipefail
+
+if [ "${REF_TYPE:-}" = "tag" ]; then
+  channel="stable"
+  version="${REF_NAME#v}"   # strip a leading v
+  version="${version%%-*}"  # strip any pre-release suffix (-rc.N, -alpha, …)
+else
+  channel="${HEAD_REF:-${REF_NAME:-}}"
+  version="dev-${SHA:-unknown}"
+fi
+
+{
+  echo "channel=$channel"
+  echo "version=$version"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/actions/build-docker/image-meta.sh
+++ b/.github/actions/build-docker/image-meta.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# Derives the client-version channel (baked into the binary as VERGEN_GIT_BRANCH)
-# and the image version (org.opencontainers.image.version label) from the build ref.
+# Derives the build-time client-version channel (baked as VERGEN_GIT_BRANCH) and
+# the image version (org.opencontainers.image.version label) from the build ref.
 #
-# Release (tag) builds use a clean, release-appropriate identity -- channel
-# "stable" and the bare semver -- instead of the git tag. Promotion retags the
-# tested RC image to :X.Y.Z / :latest, so whatever a tag build bakes in is what
-# the stable image reports; echoing the RC tag here surfaced on :latest as e.g.
-# "ethrex/v18.0.0-v18.0.0-rc.1-<sha>". Branch/PR builds keep the branch name and
-# a dev-<sha> version.
+# The channel baked here is only the DEFAULT. The stability of a release is not
+# known at build time -- an RC may be discarded and re-cut -- so a release-tag
+# build bakes its RC suffix (e.g. "rc.1"), not "stable". When an RC is promoted,
+# tag_latest.yaml stamps ETHREX_CHANNEL=stable onto the image config (the binary
+# reads that at runtime, see cmd/ethrex/utils.rs::get_channel), so:
+#   :18.0.0-rc.1  -> ethrex/v18.0.0-rc.1-<sha>     (candidate, honest)
+#   :latest       -> ethrex/v18.0.0-stable-<sha>   (promoted, honest)
+# Branch/PR builds keep the branch name and a dev-<sha> version.
 #
 # Inputs (env): REF_TYPE, REF_NAME, HEAD_REF, SHA.
 # Output: channel=… / version=… appended to $GITHUB_OUTPUT (stdout if unset).
@@ -15,9 +17,13 @@
 set -euo pipefail
 
 if [ "${REF_TYPE:-}" = "tag" ]; then
-  channel="stable"
-  version="${REF_NAME#v}"   # strip a leading v
-  version="${version%%-*}"  # strip any pre-release suffix (-rc.N, -alpha, …)
+  ref="${REF_NAME#v}"     # strip a leading v -> 18.0.0-rc.1
+  version="${ref%%-*}"    # bare semver -> 18.0.0
+  if [ "$ref" != "$version" ]; then
+    channel="${ref#*-}"   # the pre-release suffix, e.g. rc.1 (build-time default)
+  else
+    channel="release"     # a final vX.Y.Z tag with no suffix
+  fi
 else
   channel="${HEAD_REF:-${REF_NAME:-}}"
   version="dev-${SHA:-unknown}"

--- a/.github/workflows/pr_lint_gha.yaml
+++ b/.github/workflows/pr_lint_gha.yaml
@@ -58,8 +58,9 @@ jobs:
             fi
             echo "ok  $1 -> $got"
           }
-          check "rc tag"        tag    v18.0.0-rc.1 ""     "stable|18.0.0"
-          check "final tag"     tag    v18.0.0      ""     "stable|18.0.0"
-          check "alpha pre-tag" tag    v0.0.2-alpha ""     "stable|0.0.2"
+          check "rc.1 tag"      tag    v18.0.0-rc.1 ""     "rc.1|18.0.0"
+          check "rc.2 tag"      tag    v18.0.0-rc.2 ""     "rc.2|18.0.0"
+          check "alpha pre-tag" tag    v0.0.2-alpha ""     "alpha|0.0.2"
+          check "final tag"     tag    v18.0.0      ""     "release|18.0.0"
           check "main push"     branch main         ""     "main|dev-deadbeef"
           check "PR build"      branch main         feat/x "feat/x|dev-deadbeef"

--- a/.github/workflows/pr_lint_gha.yaml
+++ b/.github/workflows/pr_lint_gha.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/**.yaml"
       - ".github/*.yml"
+      - ".github/actions/**"
 
 permissions:
   contents: read
@@ -27,3 +28,38 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -ignore SC2086 -ignore SC2006 -ignore SC2046
+
+  image-meta:
+    name: build-docker image-meta
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Assert image-meta derivation across ref types
+        env:
+          SCRIPT: .github/actions/build-docker/image-meta.sh
+        run: |
+          set -euo pipefail
+          # Exercises the REAL script the build-docker action runs, so a future
+          # edit that breaks the release version string fails here, not in a release.
+          derive() { # derive <ref_type> <ref_name> <head_ref> -> "channel|version"
+            local out
+            out="$(mktemp)"
+            REF_TYPE="$1" REF_NAME="$2" HEAD_REF="$3" SHA="deadbeef" GITHUB_OUTPUT="$out" bash "$SCRIPT"
+            printf '%s|%s' "$(sed -n 's/^channel=//p' "$out")" "$(sed -n 's/^version=//p' "$out")"
+          }
+          check() { # check <desc> <ref_type> <ref_name> <head_ref> <expected>
+            local got
+            got="$(derive "$2" "$3" "$4")"
+            if [ "$got" != "$5" ]; then
+              echo "::error::$1: got '$got', expected '$5'"
+              exit 1
+            fi
+            echo "ok  $1 -> $got"
+          }
+          check "rc tag"        tag    v18.0.0-rc.1 ""     "stable|18.0.0"
+          check "final tag"     tag    v18.0.0      ""     "stable|18.0.0"
+          check "alpha pre-tag" tag    v0.0.2-alpha ""     "stable|0.0.2"
+          check "main push"     branch main         ""     "main|dev-deadbeef"
+          check "PR build"      branch main         feat/x "feat/x|dev-deadbeef"

--- a/.github/workflows/pr_release_promotion_smoke.yaml
+++ b/.github/workflows/pr_release_promotion_smoke.yaml
@@ -1,0 +1,76 @@
+name: Release promotion smoke test
+
+# Validates the release version-string promotion (the channel is decided at
+# promotion, not at build) end-to-end, without cutting a release and without
+# touching any production tag:
+#   1. build a throwaway RC image (as a vX.Y.Z-rc.W build would: GIT_BRANCH=rc.smoke)
+#   2. run the SAME `FROM <rc> / ENV ETHREX_CHANNEL=stable` promote as tag_latest.yaml
+#   3. assert `ethrex --version` flips from the baked `-rc.smoke-` channel to
+#      `-stable-` on the otherwise-identical binary.
+# Nothing is pushed; the images live only in the runner's docker daemon.
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "Dockerfile"
+      - ".github/actions/build-docker/**"
+      - ".github/workflows/tag_latest.yaml"
+      - ".github/workflows/pr_release_promotion_smoke.yaml"
+      - "cmd/ethrex/utils.rs"
+      - "cmd/ethrex/initializers.rs"
+      - "cmd/ethrex/l2/initializers.rs"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  promote-smoke:
+    name: Promote smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: ./.github/actions/free-disk
+
+      - name: Build a throwaway RC image (simulates a vX.Y.Z-rc.W build)
+        run: |
+          set -euo pipefail
+          docker build -f Dockerfile \
+            --build-arg GIT_BRANCH=rc.smoke \
+            --build-arg VERSION=0.0.0 \
+            --build-arg GIT_SHA="$(git rev-parse HEAD)" \
+            -t ethrex:smoke-rc .
+
+      - name: Promote it (identical FROM/ENV step to tag_latest.yaml)
+        run: |
+          set -euo pipefail
+          printf 'FROM ethrex:smoke-rc\nENV ETHREX_CHANNEL=stable\n' > Dockerfile.promote
+          docker build -f Dockerfile.promote -t ethrex:smoke-stable .
+
+      - name: Assert the channel flips at promotion (same binary)
+        run: |
+          set -euo pipefail
+          rc="$(docker run --rm ethrex:smoke-rc --version)"
+          st="$(docker run --rm ethrex:smoke-stable --version)"
+          echo "RC image       : $rc"
+          echo "promoted image : $st"
+          if ! echo "$rc" | grep -q -- '-rc.smoke-'; then
+            echo "::error::RC image must report the baked '-rc.smoke-' channel"
+            exit 1
+          fi
+          if ! echo "$st" | grep -q -- '-stable-'; then
+            echo "::error::promoted image must report '-stable-'"
+            exit 1
+          fi
+          if echo "$st" | grep -q -- '-rc.smoke-'; then
+            echo "::error::promoted image still reports the RC channel"
+            exit 1
+          fi
+          echo "OK: channel flips rc.smoke -> stable on the same binary."

--- a/.github/workflows/tag_latest.yaml
+++ b/.github/workflows/tag_latest.yaml
@@ -98,19 +98,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag Docker images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Promote RC images to release tags
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
-            -t "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}" \
-            -t "${REGISTRY}/${IMAGE_NAME}:latest" \
-            -t "${REGISTRY}/${IMAGE_NAME}:performance" \
-            "${REGISTRY}/${IMAGE_NAME}:${PREV_TAG}"
-          docker buildx imagetools create \
-            -t "${REGISTRY}/${IMAGE_NAME}:${NEW_TAG}-l2" \
-            -t "${REGISTRY}/${IMAGE_NAME}:l2" \
-            -t "${REGISTRY}/${IMAGE_NAME}:performance-l2" \
-            "${REGISTRY}/${IMAGE_NAME}:${PREV_TAG}-l2"
+          # Promote by re-stamping the tested RC image with the stable channel. A
+          # one-instruction `FROM <rc> / ENV ETHREX_CHANNEL=stable` build keeps the
+          # compiled binary layers straight from the RC image (no recompile), so the
+          # tested executable is byte-identical; only the image config gains
+          # ETHREX_CHANNEL, which the binary reads at runtime to report `…-stable-…`.
+          # RC images carry no such env and report their baked `…-rc.N-…`. The
+          # org.opencontainers.image.version label is inherited from the RC image.
+          promote() { # promote <src-tag> <version-tag> <floating-1> <floating-2>
+            printf 'FROM %s\nENV ETHREX_CHANNEL=stable\n' "${REGISTRY}/${IMAGE_NAME}:$1" > Dockerfile.promote
+            docker buildx build -f Dockerfile.promote \
+              --platform linux/amd64,linux/arm64 \
+              -t "${REGISTRY}/${IMAGE_NAME}:$2" \
+              -t "${REGISTRY}/${IMAGE_NAME}:$3" \
+              -t "${REGISTRY}/${IMAGE_NAME}:$4" \
+              --push .
+          }
+          promote "${PREV_TAG}"    "${NEW_TAG}"    "latest" "performance"
+          promote "${PREV_TAG}-l2" "${NEW_TAG}-l2" "l2"     "performance-l2"
 
   publish-apt:
     needs: [retag_docker_images]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1,8 +1,9 @@
 use crate::{
     cli::{LogColor, Options},
     utils::{
-        display_chain_initialization, get_client_version, get_client_version_string, init_datadir,
-        is_memory_datadir, parse_socket_addr, read_jwtsecret_file, read_node_config_file,
+        display_chain_initialization, get_channel, get_client_version, get_client_version_string,
+        init_datadir, is_memory_datadir, parse_socket_addr, read_jwtsecret_file,
+        read_node_config_file,
     },
 };
 use ethrex_blockchain::{Blockchain, BlockchainOptions, BlockchainType};
@@ -84,7 +85,7 @@ pub fn init_tracing(
             std::fs::create_dir_all(log_dir).expect("Failed to create log directory");
         }
 
-        let branch = env!("VERGEN_GIT_BRANCH").replace('/', "-");
+        let branch = get_channel().replace('/', "-");
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -123,7 +124,7 @@ pub fn init_metrics(opts: &Options, network: &Network, tracker: TaskTracker) {
     ethrex_metrics::node::MetricsNode::init(
         env!("CARGO_PKG_VERSION"),
         env!("VERGEN_GIT_SHA"),
-        env!("VERGEN_GIT_BRANCH"),
+        &get_channel(),
         env!("VERGEN_RUSTC_SEMVER"),
         env!("VERGEN_RUSTC_HOST_TRIPLE"),
         &network.to_string(),

--- a/cmd/ethrex/l2/initializers.rs
+++ b/cmd/ethrex/l2/initializers.rs
@@ -6,7 +6,7 @@ use crate::initializers::{
 };
 use crate::l2::{L2Options, SequencerOptions};
 use crate::utils::{
-    NodeConfigFile, get_client_version, get_client_version_string, init_datadir,
+    NodeConfigFile, get_channel, get_client_version, get_client_version_string, init_datadir,
     read_jwtsecret_file, store_node_config_file,
 };
 use ethrex_blockchain::{Blockchain, BlockchainType, L2Config};
@@ -120,7 +120,7 @@ fn init_metrics(opts: &L1Options, network: &str, tracker: TaskTracker) {
     ethrex_metrics::node::MetricsNode::init(
         env!("CARGO_PKG_VERSION"),
         env!("VERGEN_GIT_SHA"),
-        env!("VERGEN_GIT_BRANCH"),
+        &get_channel(),
         env!("VERGEN_RUSTC_SEMVER"),
         env!("VERGEN_RUSTC_HOST_TRIPLE"),
         network,

--- a/cmd/ethrex/utils.rs
+++ b/cmd/ethrex/utils.rs
@@ -175,12 +175,24 @@ pub fn parse_hex(s: &str) -> eyre::Result<Bytes, FromHexError> {
     }
 }
 
+/// The release channel reported in the client version. The published release
+/// image sets `ETHREX_CHANNEL=stable` on its config at promotion time; otherwise
+/// this falls back to the value baked at build time — the git branch, or the RC
+/// suffix (e.g. `rc.1`) for release-tag builds. Promotion only stamps the env on
+/// the image config, so the tested binary itself is byte-for-byte unchanged.
+pub fn get_channel() -> String {
+    std::env::var("ETHREX_CHANNEL")
+        .ok()
+        .filter(|channel| !channel.is_empty())
+        .unwrap_or_else(|| env!("VERGEN_GIT_BRANCH").to_string())
+}
+
 /// Returns a detailed client version struct with git info.
 pub fn get_client_version() -> ethrex_rpc::ClientVersion {
     ethrex_rpc::ClientVersion::new(
         env!("CARGO_PKG_NAME").to_string(),
         env!("CARGO_PKG_VERSION").to_string(),
-        env!("VERGEN_GIT_BRANCH").to_string(),
+        get_channel(),
         env!("VERGEN_GIT_SHA").to_string(),
         env!("VERGEN_RUSTC_HOST_TRIPLE").to_string(),
         env!("VERGEN_RUSTC_SEMVER").to_string(),


### PR DESCRIPTION
**Motivation**

A release image reports its client version (`web3_clientVersion`, the devp2p node id, `ethd version`) as `ethrex/v18.0.0-v18.0.0-rc.1-<sha>/…`. The middle field is the git ref the image was built from, and because the release process promotes a tested RC by **retagging** the `:X.Y.Z-rc.W` image to `:X.Y.Z` / `:latest`, the bits built from the RC tag carry that ref forever — so the stable `:latest` looks like it serves a release candidate, and operators reasonably avoid it.

Naively baking `stable` at build time would be wrong too: an RC can be discarded as unstable and re-cut (`rc.1` → `rc.2` → …), so a build cannot know it will become the stable release. Stability is established at **promotion** — that is where the channel must be decided.

**Description**

Decide the channel at promotion, without rebuilding (the tested artifact is preserved):

- The binary reads its channel from `ETHREX_CHANNEL` at runtime, falling back to the value baked at build time (`cmd/ethrex/utils.rs::get_channel`; also routed through the node-version metrics and the log filename so they stay consistent). Release-tag builds bake their RC suffix (`rc.1`, `rc.2`, …) as the default; branch/PR builds keep the branch name. The `org.opencontainers.image.version` label is the bare semver.
- Promotion (`tag_latest.yaml`) re-stamps the tested RC image with `ETHREX_CHANNEL=stable` via a one-instruction `FROM <rc> / ENV` build — the compiled binary layers come straight from the RC image (byte-identical, no recompile); only the image config gains the env.

Result — honest in every state:

| build | image | `--version` reports |
|---|---|---|
| rc.1 (discarded as unstable) | `:18.0.0-rc.1` | `ethrex/v18.0.0-rc.1-<sha1>` — candidate |
| rc.2 (passes) | `:18.0.0-rc.2` | `ethrex/v18.0.0-rc.2-<sha2>` — candidate |
| promoted | `:18.0.0` / `:latest` | `ethrex/v18.0.0-stable-<sha2>` — **stable** |

The rc-vs-final distinction lives in the git/docker tag; the channel reflects actual stability; the sha disambiguates builds.

**Scope (build-time vs promotion)**

The baked default applies from the next RC build; the `stable` stamp applies at the next promotion. Already-published v18 images are immutable and keep their current string.

**Testing**

- The build-time derivation (`image-meta.sh`) is unit-tested in the `Github Actions` workflow across ref types (`rc.1`/`rc.2`/`alpha`/final/`main`/PR), so a regression in the version string fails on the PR rather than in a release.
- To verify the binary: build with a baked channel and run `ethrex --version`. With no `ETHREX_CHANNEL` it reports the baked default (e.g. `ethrex/v18.0.0-rc.1-<sha>`); with `ETHREX_CHANNEL=stable` it reports `ethrex/v18.0.0-stable-<sha>` — same binary, channel chosen at runtime.
- A **promotion smoke test** (`pr_release_promotion_smoke.yaml` — `workflow_dispatch` and PRs touching the version/promote machinery) builds a throwaway RC image, runs the same `FROM <rc> / ENV ETHREX_CHANNEL=stable` promote as `tag_latest.yaml`, and asserts `ethrex --version` flips from `-rc.smoke-` to `-stable-` on the otherwise-identical binary — exercising the real promote path without cutting a release or touching any production tag.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — N/A (CI / version-string change)
