### PR TITLE
fix(l1): fix flaky bal_hash_parallel_skip via merkleizer channel drain on BAL path

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -798,6 +798,17 @@ impl Blockchain {
                                     prepared,
                                     parent_header_ref,
                                 )?;
+                                // The merkleizer builds the trie from the BAL-synthesized
+                                // updates and ignores the streaming channel. But sequential
+                                // execution (`!bal_parallel_exec_enabled`) still streams per-tx
+                                // updates over `rx_for_merkle`; if we drop the receiver before
+                                // the executor's last send, that send fails with "sending on a
+                                // closed channel", racing the real validation error. Drain the
+                                // channel (the updates are redundant here — the BAL path is
+                                // authoritative) so the executor always completes cleanly.
+                                if let Some(rx) = rx_for_merkle {
+                                    for _ in rx {}
+                                }
                                 (list, None)
                             } else {
                                 self.handle_merkleization(


### PR DESCRIPTION
**Motivation**

`bal_hash_parallel_skip::parallel_path_rejects_invalid_block_access_list_hash` is flaky: it intermittently fails with

```
got: Err(EvmError(Custom("send failed: sending on a closed channel")))
```

instead of the expected `BlockAccessListHashMismatch`. This spuriously red-gates CI on unrelated PRs (~2/30 locally; higher across the 3 `Test` platforms).

**Description**

Root cause is a channel race in the **sequential-exec + BAL** path of `add_block_pipeline_bal`:

- When a BAL is present, the merkleizer builds the trie from BAL-synthesized "optimistic" updates (`handle_merkleization_bal_from_updates`) and never reads the streaming channel, so it drops `rx`.
- But sequential execution (`bal_parallel_exec_enabled: false`) still streams per-tx updates via `send_state_transitions_tx`.
- The channel is only skipped (`tx = None`) when optimistic **and** `bal_parallel_exec_enabled`, so the sequential+BAL combo leaves a channel the merkleizer never drains. If the merkleizer drops `rx` before the executor's last send, that send fails with "sending on a closed channel" — racing (and sometimes masking) the real validation error.

Fix: in the merkleizer's optimistic branch, drain the streaming channel before returning. The streamed updates are redundant there (the BAL path is authoritative), so draining them just lets the sequential executor always complete cleanly, eliminating the race.

The flaky test itself is the regression test; no new test is added.

**Verification**

- Before: 2/30 runs failed.
- After: 0/50 runs failed.
- `cargo clippy` / `cargo fmt` clean.

**Checklist**

- [x] Race reproduced (2/30) and fixed (0/50)
- [x] `cargo fmt` + `cargo clippy` clean
- [ ] No `Store` changes (no `STORE_SCHEMA_VERSION` bump needed)
