### PR TITLE
ci(l1,l2): enrich daily snapsync Slack notifications and link run logs

### DIFF
--- a/.github/scripts/notify_snapsync_run.sh
+++ b/.github/scripts/notify_snapsync_run.sh
@@ -3,87 +3,113 @@ set -euo pipefail
 
 # Usage: notify_snapsync_run.sh
 # Expects the following env vars (provided by the caller workflow):
-#   SLACK_WEBHOOK_URL_SUCCESS, SLACK_WEBHOOK_URL_FAILURE, REPO, NAME, OUTCOME, HEAD_SHA, START_TIME
-
-if [[ -z "${SLACK_WEBHOOK_URL_SUCCESS}" ]]; then
-  echo "Slack webhook URL not provided; skipping notification." >&2
-  exit 0
-fi
-
-if [[ -z "${SLACK_WEBHOOK_URL_FAILURE}" ]]; then
-  echo "Slack webhook URL not provided; skipping notification." >&2
-  exit 0
-fi
+#   SLACK_WEBHOOK_URL_SUCCESS, SLACK_WEBHOOK_URL_FAILURE, REPO, NAME, OUTCOME,
+#   HEAD_SHA, START_TIME, RUN_ID, RUN_ATTEMPT
+# Optional:
+#   COMMIT_MESSAGE  (falls back to `git log` of HEAD_SHA when unset)
 
 REPO=${REPO:-}
 NAME=${NAME:-}
 OUTCOME=${OUTCOME:-}
 HEAD_SHA=${HEAD_SHA:-}
 START_TIME=${START_TIME:-}
+RUN_ID=${RUN_ID:-}
+RUN_ATTEMPT=${RUN_ATTEMPT:-1}
+COMMIT_MESSAGE=${COMMIT_MESSAGE:-}
 
-DURATION_SECS=$((EPOCHSECONDS - START_TIME))
-DURATION=$(date -d@"$DURATION_SECS" -u +%H:%M:%S)
+if ! [[ "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+  RUN_ATTEMPT=1
+fi
 
-SHORT_SHA="${HEAD_SHA:0:8}"
-COMMIT_URL="https://github.com/${REPO}/commit/${HEAD_SHA}"
+# Outcome decides both the destination channel and how the run is presented.
+# A cancellation (manual stop, runner death) is not a sync failure, so it gets
+# a distinct, lower-alarm headline while still going to the failure channel for
+# visibility.
+case "$OUTCOME" in
+  success)
+    WEBHOOK=${SLACK_WEBHOOK_URL_SUCCESS:-}
+    HEADLINE_EMOJI=":white_check_mark:"
+    HEADLINE_VERB="succeeded"
+    ;;
+  cancelled)
+    WEBHOOK=${SLACK_WEBHOOK_URL_FAILURE:-}
+    HEADLINE_EMOJI=":warning:"
+    HEADLINE_VERB="was cancelled"
+    ;;
+  *)
+    WEBHOOK=${SLACK_WEBHOOK_URL_FAILURE:-}
+    HEADLINE_EMOJI=":rotating_light:"
+    HEADLINE_VERB="failed"
+    ;;
+esac
+
+# A missing webhook (e.g. on forks, where secrets are unavailable) is not an
+# error; failing to deliver to a configured webhook is.
+if [[ -z "$WEBHOOK" ]]; then
+  echo "Slack webhook URL not provided for outcome '$OUTCOME'; skipping notification." >&2
+  exit 0
+fi
+
+# Escape the characters that are special in Slack mrkdwn text. Uses sed
+# because in bash >= 5.2 an unquoted `&` in a ${var//pat/repl} replacement
+# expands to the matched text instead of a literal ampersand.
+slack_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+DURATION="unknown"
+if [[ "$START_TIME" =~ ^[0-9]+$ ]]; then
+  DURATION_SECS=$((EPOCHSECONDS - START_TIME))
+  if (( DURATION_SECS >= 0 )); then
+    DURATION=$(date -d@"$DURATION_SECS" -u +%H:%M:%S)
+  fi
+fi
+
+RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+if (( RUN_ATTEMPT > 1 )); then
+  RUN_URL="${RUN_URL}/attempts/${RUN_ATTEMPT}"
+fi
+
+HEADLINE="Snapsync ${HEADLINE_VERB}: $(slack_escape "$NAME")"
+if (( RUN_ATTEMPT > 1 )); then
+  HEADLINE="${HEADLINE} (attempt ${RUN_ATTEMPT})"
+fi
+
+# Prefer an explicitly provided commit subject; otherwise read it from the
+# checkout the job already has.
+COMMIT_TITLE="$COMMIT_MESSAGE"
+if [[ -z "$COMMIT_TITLE" && -n "$HEAD_SHA" ]]; then
+  COMMIT_TITLE=$(git log -1 --format=%s "$HEAD_SHA" 2>/dev/null || true)
+fi
+COMMIT_TITLE=$(printf '%s' "$COMMIT_TITLE" | head -n 1)
+
+if [[ -n "$HEAD_SHA" ]]; then
+  SHORT_SHA="${HEAD_SHA:0:8}"
+  COMMIT_URL="https://github.com/${REPO}/commit/${HEAD_SHA}"
+  COMMIT_LINE="*Commit:* <${COMMIT_URL}|${SHORT_SHA}>"
+  if [[ -n "$COMMIT_TITLE" ]]; then
+    COMMIT_LINE="${COMMIT_LINE} $(slack_escape "$COMMIT_TITLE")"
+  fi
+else
+  COMMIT_LINE="*Commit:* unknown"
+fi
+
+DETAILS="${COMMIT_LINE}"$'\n'"*Duration:* ${DURATION}"
 
 # Construct the Slack payload using jq for safe JSON escaping
-if [[ "$OUTCOME" == "success" ]]; then
-  PAYLOAD=$(jq -n \
-  --arg name "$NAME" \
-  --arg sha "$SHORT_SHA" \
-  --arg commit_url "$COMMIT_URL" \
-  --arg duration "$DURATION" \
+PAYLOAD=$(jq -n \
+  --arg headline "${HEADLINE_EMOJI} *<${RUN_URL}|${HEADLINE}>*" \
+  --arg details "$DETAILS" \
   '{
     blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: ":white_check_mark: Node snapsynced successfully"
-        }
-      },
-      {
-        type: "section",
-        fields: [
-          { type: "mrkdwn", text: "*Job*\n\($name)" },
-          { type: "mrkdwn", text: "*Commit*\n<\($commit_url)|\($sha)>" },
-          { type: "mrkdwn", text: "*Duration*\n\($duration)" }
-        ]
-      }
+      { type: "section", text: { type: "mrkdwn", text: $headline } },
+      { type: "section", text: { type: "mrkdwn", text: $details } }
     ]
   }')
-  curl -sS --fail -X POST \
+
+# Let delivery failures fail the job so lost notifications are visible in the
+# Actions tab instead of being silently swallowed.
+curl -sS --fail --retry 3 -X POST \
   -H 'Content-type: application/json' \
   --data "$PAYLOAD" \
-  "$SLACK_WEBHOOK_URL_SUCCESS" || echo "Failed to send Slack notification" >&2
-else
-  PAYLOAD=$(jq -n \
-  --arg name "$NAME" \
-  --arg sha "$SHORT_SHA" \
-  --arg commit_url "$COMMIT_URL" \
-  --arg duration "$DURATION" \
-  '{
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: ":rotating_light: *Node failed to snapsync*"
-        }
-      },
-      {
-        type: "section",
-        fields: [
-          { type: "mrkdwn", text: "*Job*\n\($name)" },
-          { type: "mrkdwn", text: "*Commit*\n<\($commit_url)|\($sha)>" },
-          { type: "mrkdwn", text: "*Duration*\n\($duration)" }
-        ]
-      }
-    ]
-  }')
-  curl -sS --fail -X POST \
-  -H 'Content-type: application/json' \
-  --data "$PAYLOAD" \
-  "$SLACK_WEBHOOK_URL_FAILURE" || echo "Failed to send Slack notification" >&2
-fi
+  "$WEBHOOK"

--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -128,6 +128,8 @@ jobs:
           OUTCOME: ${{ steps.snapsync.outcome }}
           HEAD_SHA: ${{ github.sha }}
           START_TIME: ${{ steps.start.outputs.timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           bash .github/scripts/notify_snapsync_run.sh
 
@@ -178,5 +180,7 @@ jobs:
           OUTCOME: ${{ steps.snapsync.outcome }}
           HEAD_SHA: ${{ github.sha }}
           START_TIME: ${{ steps.start.outputs.timestamp }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           bash .github/scripts/notify_snapsync_run.sh


### PR DESCRIPTION
**Motivation**

The daily snapsync notifications carry only a bare commit SHA. When a sync fails there is no link to the workflow run, so getting to the logs means manually finding the run in the Actions tab. This mirrors the gaps recently fixed for the workflow-failure alerts in #6850.

**Description**

- Link the workflow run from the headline (`https://github.com/.../actions/runs/<id>`), so the success/failure message is one click from the logs.
- Show the commit title next to the SHA. The subject is read from the checkout the job already has (`git log`), which works for `schedule`/`workflow_dispatch` runs where the event payload has no `head_commit`, and avoids interpolating any untrusted input into the workflow.
- Distinguish a cancelled run (`:warning:` "was cancelled") from a real sync failure (`:rotating_light:` "failed"), so a manual stop or runner death does not read as a broken sync. Cancellations still go to the failure channel for visibility.
- Route by outcome to the existing channels unchanged (success → `ETHREX_NOTIFICATIONS_SLACK_WEBHOOK`, failure/cancelled → `ETHREX_INTERNO_SLACK_WEBHOOK`), and only require the webhook actually being used.
- Hygiene: Slack delivery failures now fail the notify step (with `--retry 3`) instead of being swallowed by `|| echo`; Slack mrkdwn special characters in the commit title are escaped; a re-run shows its attempt number and links the attempt.

**Examples**

Before — a failed sync:

```
🚨 Node failed to snapsync
Job              Commit       Duration
prysm-sepolia    abc12345     00:01:00
```

After — success, failure, and cancelled:

```
✅ Snapsync succeeded: lighthouse-hoodi
Commit: d66f17cb fix(l1): handle <edge> & cases (#9999)
Duration: 01:02:05

🚨 Snapsync failed: prysm-sepolia
Commit: abc12345 perf(l1): speed up trie
Duration: 00:01:01

⚠️ Snapsync was cancelled: lighthouse-hoodi
Commit: abc1234 chore: bump
Duration: 00:00:11
```

The headline links the run, the SHA links the commit, and the commit title gives the version context at a glance.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A (CI only)
