### PR TITLE
ci(l1): run no_std check against zkVM standard target

### DIFF
--- a/.github/targets/README.md
+++ b/.github/targets/README.md
@@ -1,0 +1,44 @@
+# zkVM RISC-V target spec (for no_std CI)
+
+`riscv64im_zicclsm-unknown-none-elf.json` is the [eth-act zkVM standards][std]
+target that Ethereum zkVMs are converging on: RV64IM + Zicclsm, soft-float LP64,
+single-hart, no syscalls, `panic = abort`. The no_std CI job
+(`../workflows/pr_nostd.yaml`) builds the guest crates against it to catch any
+`use std::` regression.
+
+Content is the authoritative spec from [`eth-act/ere`][ere]. Reproduce with:
+
+```sh
+rustc +nightly -Z unstable-options --print target-spec-json \
+  --target riscv64im-unknown-none-elf | jq '.["atomic-cas"] = true'
+```
+
+## Two things that look wrong but aren't
+
+**The ISA has no `A` (atomics) extension, yet the spec sets `atomic-cas: true`.**
+Two different layers:
+- *ISA / circuit* (what the standard defines): no `A` — the emitted guest binary
+  has zero atomic instructions. On a single hart they'd be pointless circuit cost.
+- *rustc target spec* (`atomic-cas: true` + `+forced-atomics`): a frontend
+  setting that only lets the atomic **API** (`core::sync::atomic`, `Arc`,
+  `bytes`, …) type-check. Codegen then lowers those ops to plain load/store
+  (`-Cpasses=lower-atomic`), sound because single-hart.
+
+So `atomic-cas: true` isn't a contradiction of "no atomics in the circuit" — it's
+how you get there for code that uses `Arc`/`bytes`. A target with
+`atomic-cas: false` (stock `riscv64im-unknown-none-elf`) refuses the API at the
+language level, so `bytes` fails to compile and `lower-atomic` can't help (it runs
+after rustc already rejected the call).
+
+**The name says `zicclsm` but `features` doesn't list it.** Zicclsm (misaligned
+load/store) is a runtime/VM property checked by the eth-act compliance monitor,
+not a rustc feature — it can't appear in `features`.
+
+## Why CI uses nightly + build-std
+
+This is a JSON spec, not a built-in rustc target, so there's no prebuilt
+`core`/`alloc`: the job uses nightly with `-Z build-std=core,alloc` and
+`-Z json-target-spec`.
+
+[std]: https://github.com/eth-act/zkvm-standards/blob/main/standards/riscv-target/target.md
+[ere]: https://github.com/eth-act/ere/blob/master/crates/compiler/sp1/src/rust_rv64ima/riscv64ima-unknown-none-elf.json

--- a/.github/targets/riscv64im_zicclsm-unknown-none-elf.json
+++ b/.github/targets/riscv64im_zicclsm-unknown-none-elf.json
@@ -1,0 +1,25 @@
+{
+  "arch": "riscv64",
+  "atomic-cas": true,
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "features": "+m,+forced-atomics",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "eth-act zkVM standard target: RV64IM + Zicclsm, soft-float LP64, single-hart (atomics lowered)",
+    "host_tools": false,
+    "std": false,
+    "tier": 3
+  },
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "target-pointer-width": 64
+}

--- a/.github/workflows/pr_nostd.yaml
+++ b/.github/workflows/pr_nostd.yaml
@@ -33,15 +33,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Pinned for reproducibility (build-std + json-target-spec are nightly-only);
+      # bump the date deliberately. dtolnay has no per-date ref, so pass it as input.
       - name: Install Rust nightly + rust-src
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-06-29
           components: rust-src
 
       - name: Check no_std crates against the zkVM standard target
         run: |
           TARGET=.github/targets/riscv64im_zicclsm-unknown-none-elf.json
-          cargo +nightly -Z json-target-spec -Z build-std=core,alloc check \
+          cargo +nightly-2026-06-29 -Z json-target-spec -Z build-std=core,alloc check \
             -p ethrex-rlp -p ethrex-crypto --no-default-features --target "$TARGET"
-          cargo +nightly -Z json-target-spec -Z build-std=core,alloc check \
+          cargo +nightly-2026-06-29 -Z json-target-spec -Z build-std=core,alloc check \
             -p ethrex-crypto --no-default-features --features kzg-rs --target "$TARGET"

--- a/.github/workflows/pr_nostd.yaml
+++ b/.github/workflows/pr_nostd.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "crates/common/**"
       - "crates/vm/**"
+      - ".github/targets/**"
       - ".github/workflows/pr_nostd.yaml"
 
 permissions:
@@ -24,17 +25,23 @@ env:
 
 jobs:
   no-std-check:
-    name: no_std build check (riscv64imac)
+    # Builds the guest crates against the eth-act zkVM standard target to catch
+    # `use std::` regressions. Needs nightly (JSON target spec + build-std);
+    # see .github/targets/README.md.
+    name: no_std build check (riscv64im_zicclsm)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.91.0
+      - name: Install Rust nightly + rust-src
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          targets: riscv64imac-unknown-none-elf
+          components: rust-src
 
-      - name: Check no_std crates
+      - name: Check no_std crates against the zkVM standard target
         run: |
-          cargo check -p ethrex-rlp -p ethrex-crypto --no-default-features --target riscv64imac-unknown-none-elf
-          cargo check -p ethrex-crypto --no-default-features --features kzg-rs --target riscv64imac-unknown-none-elf
+          TARGET=.github/targets/riscv64im_zicclsm-unknown-none-elf.json
+          cargo +nightly -Z json-target-spec -Z build-std=core,alloc check \
+            -p ethrex-rlp -p ethrex-crypto --no-default-features --target "$TARGET"
+          cargo +nightly -Z json-target-spec -Z build-std=core,alloc check \
+            -p ethrex-crypto --no-default-features --features kzg-rs --target "$TARGET"


### PR DESCRIPTION
**Motivation**

Previously we used the `riscv64imac` target, but the [standard](https://github.com/eth-act/zkvm-standards/blob/main/standards/riscv-target/target.md) is `riscv64im_zicclsm`.

**Description**

Sets the target to `riscv64im_zicclsm`. It's nonstandard, so it has to be built from a a target json.

Importantly, while the target does not support atomics we can enable lowering (turning atomic into non-atomic operations) because zkVMs run in single-core (hart in RISC-V terms).