### PR TITLE
fix(l1): flush db on graceful shutdown

### DIFF
--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -5,11 +5,12 @@ use ethrex::{
     utils::{NodeConfigFile, get_client_version, is_memory_datadir, store_node_config_file},
 };
 use ethrex_p2p::{peer_table::PeerTable, types::NodeRecord};
+use ethrex_storage::Store;
 use serde::Deserialize;
 use std::{path::Path, time::Duration};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 
 const LATEST_VERSION_URL: &str = "https://api.github.com/repos/lambdaclass/ethrex/releases/latest";
 
@@ -50,9 +51,19 @@ async fn server_shutdown(
     cancel_token: &CancellationToken,
     peer_table: PeerTable,
     local_node_record: NodeRecord,
+    store: &Store,
 ) {
     info!("Server shut down started...");
+    // Stop feeding new blocks before draining, so the persist queue can't grow.
     cancel_token.cancel();
+    // Drain the persist worker, commit all in-memory trie diff-layers and the
+    // block-data buffer, and fsync the DB. Without this an abrupt exit (e.g.
+    // `docker restart -t 0`) loses up to ~128 blocks of in-memory state and
+    // leaves the DB needing WAL recovery on next start.
+    info!("Flushing database to disk...");
+    if let Err(err) = store.shutdown().await {
+        error!("Failed to flush database on shutdown: {err}");
+    }
     if !is_memory_datadir(datadir) {
         let node_config_path = datadir.join("node_config.json");
         info!("Storing config at {:?}...", node_config_path);
@@ -179,7 +190,7 @@ async fn main() -> eyre::Result<()> {
     info!("ethrex version: {}", get_client_version());
     tokio::spawn(periodically_check_version_update());
 
-    let (datadir, cancel_token, peer_table, local_node_record) =
+    let (datadir, cancel_token, peer_table, local_node_record, store) =
         init_l1(opts, Some(log_filter_handler)).await?;
 
     let mut signal_terminate = signal(SignalKind::terminate())?;
@@ -188,10 +199,10 @@ async fn main() -> eyre::Result<()> {
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-            server_shutdown(&datadir, &cancel_token, peer_table, local_node_record).await;
+            server_shutdown(&datadir, &cancel_token, peer_table, local_node_record, &store).await;
         }
         _ = signal_terminate.recv() => {
-            server_shutdown(&datadir, &cancel_token, peer_table, local_node_record).await;
+            server_shutdown(&datadir, &cancel_token, peer_table, local_node_record, &store).await;
         }
     }
 

--- a/cmd/ethrex/ethrex.rs
+++ b/cmd/ethrex/ethrex.rs
@@ -56,10 +56,11 @@ async fn server_shutdown(
     info!("Server shut down started...");
     // Stop feeding new blocks before draining, so the persist queue can't grow.
     cancel_token.cancel();
-    // Drain the persist worker, commit all in-memory trie diff-layers and the
-    // block-data buffer, and fsync the DB. Without this an abrupt exit (e.g.
-    // `docker restart -t 0`) loses up to ~128 blocks of in-memory state and
-    // leaves the DB needing WAL recovery on next start.
+    // Drain the persist worker, force-flush the block-data buffer, and fsync the
+    // DB. Without this an abrupt exit (e.g. `docker restart -t 0`) loses the
+    // buffered block-data tail and leaves the DB needing WAL recovery on next
+    // start. In-memory trie diff-layers are intentionally left uncommitted and
+    // re-executed on the next start (see `Store::shutdown`).
     info!("Flushing database to disk...");
     if let Err(err) = store.shutdown().await {
         error!("Failed to flush database on shutdown: {err}");

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -574,7 +574,7 @@ async fn set_sync_block(store: &Store) {
 pub async fn init_l1(
     opts: Options,
     log_filter_handler: Option<reload::Handle<EnvFilter, Registry>>,
-) -> eyre::Result<(PathBuf, CancellationToken, PeerTable, NodeRecord)> {
+) -> eyre::Result<(PathBuf, CancellationToken, PeerTable, NodeRecord, Store)> {
     let network = get_network(&opts);
     let datadir = crate::cli::compute_effective_datadir(&opts.datadir, &network, opts.dev);
 
@@ -714,6 +714,7 @@ pub async fn init_l1(
         cancel_token,
         peer_handler.peer_table,
         local_node_record,
+        store,
     ))
 }
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -251,7 +251,7 @@ pub async fn init_rpc_api(
     let syncer = SyncManager::new(
         peer_handler.clone(),
         syncmode,
-        cancel_token,
+        cancel_token.clone(),
         blockchain.clone(),
         store.clone(),
         datadir.to_path_buf(),
@@ -283,6 +283,7 @@ pub async fn init_rpc_api(
         opts.gas_limit,
         opts.extra_data.clone(),
         opts.http_api.iter().copied().collect(),
+        cancel_token,
     );
 
     tracker.spawn(rpc_api);

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -90,6 +90,7 @@ use tokio::sync::{
     oneshot,
 };
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use tower_http::cors::CorsLayer;
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload};
@@ -527,6 +528,7 @@ pub async fn start_api(
     gas_ceil: u64,
     extra_data: String,
     allowed_namespaces: HashSet<RpcNamespace>,
+    cancel_token: CancellationToken,
 ) -> Result<(), RpcErr> {
     // TODO: Refactor how filters are handled,
     // filters are used by the filters endpoints (eth_newFilter, eth_getFilterChanges, ...etc)
@@ -584,7 +586,7 @@ pub async fn start_api(
         .await
         .map_err(|error| RpcErr::Internal(error.to_string()))?;
     let http_server = axum::serve(http_listener, http_router)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(rpc_shutdown_signal(cancel_token.clone()))
         .into_future();
     info!("Starting HTTP server at {http_addr}");
 
@@ -615,7 +617,7 @@ pub async fn start_api(
         .await
         .map_err(|error| RpcErr::Internal(error.to_string()))?;
     let authrpc_server = axum::serve(authrpc_listener, authrpc_router)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(rpc_shutdown_signal(cancel_token.clone()))
         .into_future();
     info!("Starting Auth-RPC server at {authrpc_addr}");
 
@@ -637,7 +639,7 @@ pub async fn start_api(
             .await
             .map_err(|error| RpcErr::Internal(error.to_string()))?;
         let ws_server = axum::serve(ws_listener, ws_router)
-            .with_graceful_shutdown(shutdown_signal())
+            .with_graceful_shutdown(rpc_shutdown_signal(cancel_token.clone()))
             .into_future();
         info!("Starting WS server at {}", ws_config.addr);
 
@@ -658,6 +660,19 @@ pub async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("failed to install Ctrl+C handler");
+}
+
+/// Graceful-shutdown future for the node's RPC servers: completes on Ctrl+C or
+/// when `cancel_token` is cancelled.
+///
+/// `server_shutdown` cancels the token on both SIGINT and SIGTERM, so keying on
+/// it (not just Ctrl+C) is what makes the engine API stop accepting requests on
+/// SIGTERM, e.g. `docker stop`, before the store is flushed.
+async fn rpc_shutdown_signal(cancel_token: CancellationToken) {
+    tokio::select! {
+        _ = cancel_token.cancelled() => {}
+        _ = shutdown_signal() => {}
+    }
 }
 
 /// Maximum number of requests accepted in a single JSON-RPC batch on either

--- a/crates/networking/rpc/test_utils.rs
+++ b/crates/networking/rpc/test_utils.rs
@@ -296,6 +296,7 @@ pub async fn start_test_api() -> tokio::task::JoinHandle<()> {
             DEFAULT_BUILDER_GAS_CEIL,
             String::new(),
             all_namespaces_for_tests(),
+            tokio_util::sync::CancellationToken::new(),
         )
         .await
         .unwrap()

--- a/crates/storage/api/mod.rs
+++ b/crates/storage/api/mod.rs
@@ -52,10 +52,9 @@ pub trait StorageBackend: Debug + Send + Sync {
     /// Creates a checkpoint of the current database state at the specified path.
     fn create_checkpoint(&self, path: &Path) -> Result<(), StoreError>;
 
-    /// Durably persists all buffered writes: flushes in-memory memtables to disk
-    /// and syncs the write-ahead log. Called on graceful shutdown so a subsequent
-    /// process start needs no WAL recovery. Defaults to a no-op for backends that
-    /// are already durable or purely in-memory.
+    /// Durably persists all buffered writes to disk, so a subsequent process
+    /// start needs no crash recovery. Called on graceful shutdown. Defaults to a
+    /// no-op for backends that are already durable or purely in-memory.
     fn flush(&self) -> Result<(), StoreError> {
         Ok(())
     }

--- a/crates/storage/api/mod.rs
+++ b/crates/storage/api/mod.rs
@@ -51,6 +51,14 @@ pub trait StorageBackend: Debug + Send + Sync {
     // TODO: remove this and provide historic data via diff-layers
     /// Creates a checkpoint of the current database state at the specified path.
     fn create_checkpoint(&self, path: &Path) -> Result<(), StoreError>;
+
+    /// Durably persists all buffered writes: flushes in-memory memtables to disk
+    /// and syncs the write-ahead log. Called on graceful shutdown so a subsequent
+    /// process start needs no WAL recovery. Defaults to a no-op for backends that
+    /// are already durable or purely in-memory.
+    fn flush(&self) -> Result<(), StoreError> {
+        Ok(())
+    }
 }
 
 /// Read-only transaction interface.

--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -351,6 +351,23 @@ impl StorageBackend for RocksDBBackend {
 
         Ok(())
     }
+
+    fn flush(&self) -> Result<(), StoreError> {
+        // Flush every column family's memtable to an SST file, then sync the WAL.
+        // Together these make the next open a clean start: the memtables are
+        // durable as SST and the WAL tail (anything still in the log) is fsynced,
+        // so RocksDB does not have to replay the WAL on recovery.
+        for table in TABLES {
+            if let Some(cf) = self.db.cf_handle(table) {
+                self.db.flush_cf(&cf).map_err(|e| {
+                    StoreError::Custom(format!("RocksDB flush_cf({table}) failed: {e}"))
+                })?;
+            }
+        }
+        self.db
+            .flush_wal(true)
+            .map_err(|e| StoreError::Custom(format!("RocksDB flush_wal failed: {e}")))
+    }
 }
 
 /// Read-only view for RocksDB

--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -128,6 +128,18 @@ impl TrieLayerCache {
         None
     }
 
+    /// State root of the most recently inserted layer (the one with the highest
+    /// id, i.e. the current head), or `None` if the cache is empty.
+    ///
+    /// Used by the shutdown flush to commit every remaining layer: committing
+    /// from the newest root removes it and all its ancestors in one pass.
+    pub fn newest_root(&self) -> Option<H256> {
+        self.layers
+            .iter()
+            .max_by_key(|(_, layer)| layer.id)
+            .map(|(root, _)| *root)
+    }
+
     /// Returns the state root from which to start a disk commit, using the cache's
     /// default `commit_threshold`.
     ///

--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -128,18 +128,6 @@ impl TrieLayerCache {
         None
     }
 
-    /// State root of the most recently inserted layer (the one with the highest
-    /// id, i.e. the current head), or `None` if the cache is empty.
-    ///
-    /// Used by the shutdown flush to commit every remaining layer: committing
-    /// from the newest root removes it and all its ancestors in one pass.
-    pub fn newest_root(&self) -> Option<H256> {
-        self.layers
-            .iter()
-            .max_by_key(|(_, layer)| layer.id)
-            .map(|(root, _)| *root)
-    }
-
     /// Returns the state root from which to start a disk commit, using the cache's
     /// default `commit_threshold`.
     ///

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -4368,3 +4368,107 @@ mod datadir_tests {
         assert!(!dir_contains_legacy_db(dir.path()).unwrap());
     }
 }
+
+#[cfg(test)]
+mod shutdown_flush_tests {
+    use super::*;
+    use std::sync::mpsc::sync_channel;
+
+    // A short account-trie-node key: length != 65/131 (not a leaf) and <= 65
+    // (account trie), so `commit_trie_layers` routes it to ACCOUNT_TRIE_NODES.
+    fn node_key(tag: u8) -> Vec<u8> {
+        vec![tag, 0, 1, 2]
+    }
+
+    fn dropped_fkv_ctl() -> SyncSender<FKVGeneratorControlMessage> {
+        // Receiver dropped: the commit path's `let _ = fkv_ctl.send(..)` sends
+        // fail fast and are ignored, so no consumer thread is needed.
+        let (tx, rx) = sync_channel(0);
+        drop(rx);
+        tx
+    }
+
+    /// Regression for the shutdown flush anchoring: it must commit the canonical
+    /// head's layer chain, not the newest-inserted layer. A sidechain sibling
+    /// imported after the head (higher layer id) must NOT become the durable
+    /// state root.
+    #[test]
+    fn shutdown_commits_canonical_head_not_later_sidechain() {
+        // On-disk root0 -> A -> B (B = canonical head). B' is a sibling of B
+        // (also a child of A) inserted LAST, so it holds the highest layer id.
+        let root0 = H256::from_low_u64_be(0);
+        let root_a = H256::from_low_u64_be(0xAA);
+        let root_b = H256::from_low_u64_be(0xBB);
+        let root_b_prime = H256::from_low_u64_be(0xCC);
+
+        let key_a = node_key(0xA0);
+        let key_b = node_key(0xB0);
+        let key_b_prime = node_key(0xC0);
+
+        let mut cache = TrieLayerCache::new(128);
+        cache.put_batch(
+            root0,
+            root_a,
+            vec![(Nibbles::from_hex(key_a.clone()), vec![1])],
+        );
+        cache.put_batch(
+            root_a,
+            root_b,
+            vec![(Nibbles::from_hex(key_b.clone()), vec![2])],
+        );
+        cache.put_batch(
+            root_a,
+            root_b_prime,
+            vec![(Nibbles::from_hex(key_b_prime.clone()), vec![3])],
+        );
+
+        let trie_cache = Arc::new(RwLock::new(Arc::new(cache)));
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
+        let fkv_tx = dropped_fkv_ctl();
+
+        commit_all_trie_layers(backend.as_ref(), &trie_cache, &fkv_tx, root_b).unwrap();
+
+        let read = backend.begin_read().unwrap();
+        // Canonical head chain (A + B) is durable...
+        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &key_a).unwrap(), Some(vec![1]));
+        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &key_b).unwrap(), Some(vec![2]));
+        // ...but the later-inserted sidechain layer must not be persisted.
+        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &key_b_prime).unwrap(), None);
+
+        // Committed layers are evicted; the sidechain layer stays in memory
+        // (and is discarded on process exit).
+        let cache_after = trie_cache.read().unwrap().clone();
+        assert!(
+            cache_after
+                .get_commitable_with_threshold(root_b, 1)
+                .is_none(),
+            "committed head layer must be evicted"
+        );
+        assert!(
+            cache_after
+                .get_commitable_with_threshold(root_b_prime, 1)
+                .is_some(),
+            "uncommitted sidechain layer must remain in memory"
+        );
+    }
+
+    /// When the head root is already on disk (no live layer), the shutdown flush
+    /// is a no-op rather than an error.
+    #[test]
+    fn shutdown_commit_is_noop_when_head_already_on_disk() {
+        let trie_cache = Arc::new(RwLock::new(Arc::new(TrieLayerCache::new(128))));
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
+        let fkv_tx = dropped_fkv_ctl();
+
+        commit_all_trie_layers(
+            backend.as_ref(),
+            &trie_cache,
+            &fkv_tx,
+            H256::from_low_u64_be(0x99),
+        )
+        .unwrap();
+
+        let read = backend.begin_read().unwrap();
+        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &node_key(0xA0)).unwrap(), None);
+    }
+}

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -406,10 +406,16 @@ impl Store {
     pub async fn shutdown(&self) -> Result<(), StoreError> {
         let tx = self.persist_tx.clone();
         let backend = self.backend.clone();
+        // Anchor the flush to the confirmed canonical head so we never durably
+        // persist a non-canonical sidechain root.
+        let head_state_root = self.latest_block_header.get().state_root;
         tokio::task::spawn_blocking(move || {
             let (ack_tx, ack_rx) = sync_channel::<Result<(), StoreError>>(1);
-            tx.send(PersistMessage::Shutdown(ack_tx))
-                .map_err(|e| StoreError::Custom(format!("shutdown send: {e}")))?;
+            tx.send(PersistMessage::Shutdown {
+                head_state_root,
+                ack: ack_tx,
+            })
+            .map_err(|e| StoreError::Custom(format!("shutdown send: {e}")))?;
             ack_rx
                 .recv()
                 .map_err(|e| StoreError::Custom(format!("shutdown ack: {e}")))??;
@@ -1922,17 +1928,23 @@ impl Store {
                         // result so a live-path failure is not silently dropped.
                         let _ = ack.send(std::mem::replace(&mut last_flush_result, Ok(())));
                     }
-                    Ok(PersistMessage::Shutdown(ack)) => {
+                    Ok(PersistMessage::Shutdown {
+                        head_state_root,
+                        ack,
+                    }) => {
                         // Graceful shutdown: drain (already guaranteed by FIFO) and
                         // force-persist the not-yet-flushed tail. Flush the block
-                        // buffer, then commit every remaining trie diff-layer so a
-                        // restart needs no block re-execution.
+                        // buffer, then commit the canonical head's trie diff-layer
+                        // chain so a restart needs no block re-execution. Committing
+                        // from the confirmed head (not the newest-inserted layer)
+                        // avoids durably persisting a non-canonical sidechain root.
                         let result = flush_block_data(persist_backend.as_ref(), &persist_buffer)
                             .and_then(|_| {
                                 commit_all_trie_layers(
                                     persist_backend.as_ref(),
                                     &persist_trie_cache,
                                     &persist_fkv_ctl,
+                                    head_state_root,
                                 )
                             });
                         let prior = std::mem::replace(&mut last_flush_result, Ok(()));
@@ -3469,9 +3481,12 @@ enum PersistMessage {
     Ping(std::sync::mpsc::SyncSender<Result<(), StoreError>>),
     /// Graceful-shutdown handshake. Handled only after every earlier `Block`
     /// (FIFO), so it both drains in-flight work and force-persists the tail:
-    /// flushes the block-data buffer and commits *all* remaining trie
-    /// diff-layers to disk. The worker acks and then exits.
-    Shutdown(std::sync::mpsc::SyncSender<Result<(), StoreError>>),
+    /// flushes the block-data buffer and commits the canonical head's trie
+    /// diff-layer chain (`head_state_root`) to disk. The worker acks and exits.
+    Shutdown {
+        head_state_root: H256,
+        ack: std::sync::mpsc::SyncSender<Result<(), StoreError>>,
+    },
 }
 
 /// Write one block's header, body, number, and tx locations into an open batch.
@@ -3671,25 +3686,32 @@ fn commit_trie_if_due(
     commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, root)
 }
 
-/// Commits *every* remaining trie diff-layer to disk (graceful-shutdown path).
+/// Commits the canonical head's trie diff-layer chain to disk (graceful-shutdown
+/// path). `head_state_root` is the confirmed canonical head root, so committing
+/// from it persists exactly the canonical state and its ancestors; any
+/// later-inserted, not-yet-confirmed sidechain layers stay in memory and are
+/// discarded on exit rather than being durably written.
 ///
-/// Committing from the newest layer removes it and all its ancestors in one
-/// pass, draining the cache. Any orphaned reorg-sibling layers off the head
-/// chain are dropped without writing (only canonical state must be durable).
+/// No-ops if the head root is not in the cache (already flushed to disk).
 fn commit_all_trie_layers(
     backend: &dyn StorageBackend,
     trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
     fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
+    head_state_root: H256,
 ) -> Result<(), StoreError> {
     let trie = trie_cache
         .read()
         .map_err(|_| StoreError::LockError)?
         .clone();
-    let Some(root) = trie.newest_root() else {
-        // Cache empty — nothing buffered in memory.
+    // Threshold 1 returns the root itself iff it is a live layer; `None` means the
+    // head is already on disk, so there is nothing buffered to commit.
+    if trie
+        .get_commitable_with_threshold(head_state_root, 1)
+        .is_none()
+    {
         return Ok(());
-    };
-    commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, root)
+    }
+    commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, head_state_root)
 }
 
 /// Writes the layer at `root` and all of its ancestors to disk in one tx, then

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -3327,6 +3327,23 @@ impl Store {
         flush_block_data(self.backend.as_ref(), &self.block_data_buffer)
     }
 
+    /// Read a raw trie node straight from the on-disk account/storage trie-node
+    /// table by its committed key. For testing only — lets a reopen assert which
+    /// trie diff-layers a shutdown flush committed to disk.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn get_trie_node_for_test(
+        &self,
+        is_account: bool,
+        key: &[u8],
+    ) -> Result<Option<Vec<u8>>, StoreError> {
+        let table = if is_account {
+            ACCOUNT_TRIE_NODES
+        } else {
+            STORAGE_TRIE_NODES
+        };
+        self.backend.begin_read()?.get(table, key)
+    }
+
     /// Insert a block plus associated codes into the in-memory buffer without
     /// writing to disk.  For testing only — proves the buffer overlay resolves
     /// code that has not been persisted yet.
@@ -4366,109 +4383,5 @@ mod datadir_tests {
         fs::create_dir(dir.path().join("CURRENT")).unwrap();
         fs::create_dir(dir.path().join("MANIFEST-000001")).unwrap();
         assert!(!dir_contains_legacy_db(dir.path()).unwrap());
-    }
-}
-
-#[cfg(test)]
-mod shutdown_flush_tests {
-    use super::*;
-    use std::sync::mpsc::sync_channel;
-
-    // A short account-trie-node key: length != 65/131 (not a leaf) and <= 65
-    // (account trie), so `commit_trie_layers` routes it to ACCOUNT_TRIE_NODES.
-    fn node_key(tag: u8) -> Vec<u8> {
-        vec![tag, 0, 1, 2]
-    }
-
-    fn dropped_fkv_ctl() -> SyncSender<FKVGeneratorControlMessage> {
-        // Receiver dropped: the commit path's `let _ = fkv_ctl.send(..)` sends
-        // fail fast and are ignored, so no consumer thread is needed.
-        let (tx, rx) = sync_channel(0);
-        drop(rx);
-        tx
-    }
-
-    /// Regression for the shutdown flush anchoring: it must commit the canonical
-    /// head's layer chain, not the newest-inserted layer. A sidechain sibling
-    /// imported after the head (higher layer id) must NOT become the durable
-    /// state root.
-    #[test]
-    fn shutdown_commits_canonical_head_not_later_sidechain() {
-        // On-disk root0 -> A -> B (B = canonical head). B' is a sibling of B
-        // (also a child of A) inserted LAST, so it holds the highest layer id.
-        let root0 = H256::from_low_u64_be(0);
-        let root_a = H256::from_low_u64_be(0xAA);
-        let root_b = H256::from_low_u64_be(0xBB);
-        let root_b_prime = H256::from_low_u64_be(0xCC);
-
-        let key_a = node_key(0xA0);
-        let key_b = node_key(0xB0);
-        let key_b_prime = node_key(0xC0);
-
-        let mut cache = TrieLayerCache::new(128);
-        cache.put_batch(
-            root0,
-            root_a,
-            vec![(Nibbles::from_hex(key_a.clone()), vec![1])],
-        );
-        cache.put_batch(
-            root_a,
-            root_b,
-            vec![(Nibbles::from_hex(key_b.clone()), vec![2])],
-        );
-        cache.put_batch(
-            root_a,
-            root_b_prime,
-            vec![(Nibbles::from_hex(key_b_prime.clone()), vec![3])],
-        );
-
-        let trie_cache = Arc::new(RwLock::new(Arc::new(cache)));
-        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
-        let fkv_tx = dropped_fkv_ctl();
-
-        commit_all_trie_layers(backend.as_ref(), &trie_cache, &fkv_tx, root_b).unwrap();
-
-        let read = backend.begin_read().unwrap();
-        // Canonical head chain (A + B) is durable...
-        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &key_a).unwrap(), Some(vec![1]));
-        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &key_b).unwrap(), Some(vec![2]));
-        // ...but the later-inserted sidechain layer must not be persisted.
-        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &key_b_prime).unwrap(), None);
-
-        // Committed layers are evicted; the sidechain layer stays in memory
-        // (and is discarded on process exit).
-        let cache_after = trie_cache.read().unwrap().clone();
-        assert!(
-            cache_after
-                .get_commitable_with_threshold(root_b, 1)
-                .is_none(),
-            "committed head layer must be evicted"
-        );
-        assert!(
-            cache_after
-                .get_commitable_with_threshold(root_b_prime, 1)
-                .is_some(),
-            "uncommitted sidechain layer must remain in memory"
-        );
-    }
-
-    /// When the head root is already on disk (no live layer), the shutdown flush
-    /// is a no-op rather than an error.
-    #[test]
-    fn shutdown_commit_is_noop_when_head_already_on_disk() {
-        let trie_cache = Arc::new(RwLock::new(Arc::new(TrieLayerCache::new(128))));
-        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
-        let fkv_tx = dropped_fkv_ctl();
-
-        commit_all_trie_layers(
-            backend.as_ref(),
-            &trie_cache,
-            &fkv_tx,
-            H256::from_low_u64_be(0x99),
-        )
-        .unwrap();
-
-        let read = backend.begin_read().unwrap();
-        assert_eq!(read.get(ACCOUNT_TRIE_NODES, &node_key(0xA0)).unwrap(), None);
     }
 }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -396,9 +396,16 @@ impl Store {
     ///
     /// Sends a `Shutdown` handshake to the persist worker, which (being FIFO)
     /// first drains every queued `Block`, then force-flushes the block-data
-    /// buffer and commits *all* remaining trie diff-layers to disk. Once the
-    /// worker acks, this syncs the backend (memtables + WAL) so the next process
-    /// start needs neither block re-execution nor WAL recovery.
+    /// buffer to disk. Once the worker acks, this syncs the backend (memtables +
+    /// WAL) so the next process start needs no WAL recovery.
+    ///
+    /// The in-memory trie diff-layers are intentionally *not* force-committed.
+    /// The on-disk trie is a single-version, path-based store, so folding the
+    /// non-finalized tail into it would leave a post-restart reorg unable to
+    /// reconstruct the overwritten ancestor state (the node would wedge). The
+    /// recent (< `DB_COMMIT_THRESHOLD`) layers are dropped and re-executed on the
+    /// next start from the deep, reorg-safe on-disk base — exactly as after any
+    /// restart today.
     ///
     /// After this returns the persist worker has exited; the store must not be
     /// used for further writes. Idempotent only in the sense that a second call
@@ -406,21 +413,14 @@ impl Store {
     pub async fn shutdown(&self) -> Result<(), StoreError> {
         let tx = self.persist_tx.clone();
         let backend = self.backend.clone();
-        // Anchor the flush to the latest canonical head so we never durably
-        // persist a non-canonical sidechain root. (Latest-canonical, not
-        // finalized: the tail past the last finalized block may still reorg.)
-        let head_state_root = self.latest_block_header.get().state_root;
         tokio::task::spawn_blocking(move || {
             let (ack_tx, ack_rx) = sync_channel::<Result<(), StoreError>>(1);
-            tx.send(PersistMessage::Shutdown {
-                head_state_root,
-                ack: ack_tx,
-            })
-            .map_err(|e| StoreError::Custom(format!("shutdown send: {e}")))?;
+            tx.send(PersistMessage::Shutdown { ack: ack_tx })
+                .map_err(|e| StoreError::Custom(format!("shutdown send: {e}")))?;
             ack_rx
                 .recv()
                 .map_err(|e| StoreError::Custom(format!("shutdown ack: {e}")))??;
-            // Worker has persisted everything to the WAL/memtables; make it durable
+            // Worker has flushed block data to the WAL/memtables; make it durable
             // and recovery-free.
             backend.flush()
         })
@@ -1929,25 +1929,14 @@ impl Store {
                         // result so a live-path failure is not silently dropped.
                         let _ = ack.send(std::mem::replace(&mut last_flush_result, Ok(())));
                     }
-                    Ok(PersistMessage::Shutdown {
-                        head_state_root,
-                        ack,
-                    }) => {
+                    Ok(PersistMessage::Shutdown { ack }) => {
                         // Graceful shutdown: drain (already guaranteed by FIFO) and
-                        // force-persist the not-yet-flushed tail. Flush the block
-                        // buffer, then commit the canonical head's trie diff-layer
-                        // chain so a restart needs no block re-execution. Committing
-                        // from the latest canonical head (not the newest-inserted layer)
-                        // avoids durably persisting a non-canonical sidechain root.
-                        let result = flush_block_data(persist_backend.as_ref(), &persist_buffer)
-                            .and_then(|_| {
-                                commit_all_trie_layers(
-                                    persist_backend.as_ref(),
-                                    &persist_trie_cache,
-                                    &persist_fkv_ctl,
-                                    head_state_root,
-                                )
-                            });
+                        // force-flush the not-yet-flushed block-data tail. The trie
+                        // diff-layers stay in memory and are dropped on exit: the
+                        // on-disk trie is a single-version path store, so committing
+                        // the non-finalized tail would make a post-restart reorg
+                        // unrecoverable. Those layers re-execute on the next start.
+                        let result = flush_block_data(persist_backend.as_ref(), &persist_buffer);
                         let prior = std::mem::replace(&mut last_flush_result, Ok(()));
                         let _ = ack.send(prior.and(result));
                         // No more work will follow a shutdown request.
@@ -3330,7 +3319,7 @@ impl Store {
 
     /// Read a raw trie node straight from the on-disk account/storage trie-node
     /// table by its committed key. For testing only — lets a reopen assert which
-    /// trie diff-layers a shutdown flush committed to disk.
+    /// trie diff-layers a shutdown flush did (or did not) commit to disk.
     #[cfg(any(test, feature = "testing"))]
     pub fn get_trie_node_for_test(
         &self,
@@ -3498,11 +3487,10 @@ enum PersistMessage {
     Block(BlockPersist),
     Ping(std::sync::mpsc::SyncSender<Result<(), StoreError>>),
     /// Graceful-shutdown handshake. Handled only after every earlier `Block`
-    /// (FIFO), so it both drains in-flight work and force-persists the tail:
-    /// flushes the block-data buffer and commits the canonical head's trie
-    /// diff-layer chain (`head_state_root`) to disk. The worker acks and exits.
+    /// (FIFO), so it both drains in-flight work and force-flushes the block-data
+    /// buffer to disk. The trie diff-layers are deliberately left in memory (see
+    /// [`Store::shutdown`]). The worker acks and exits.
     Shutdown {
-        head_state_root: H256,
         ack: std::sync::mpsc::SyncSender<Result<(), StoreError>>,
     },
 }
@@ -3704,39 +3692,10 @@ fn commit_trie_if_due(
     commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, root)
 }
 
-/// Commits the canonical head's trie diff-layer chain to disk (graceful-shutdown
-/// path). `head_state_root` is the latest canonical head root (not necessarily
-/// finalized), so committing from it persists exactly the canonical state and
-/// its ancestors; any later-inserted sidechain layers stay in memory and are
-/// discarded on exit rather than being durably written.
-///
-/// No-ops if the head root is not in the cache (already flushed to disk).
-fn commit_all_trie_layers(
-    backend: &dyn StorageBackend,
-    trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
-    fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
-    head_state_root: H256,
-) -> Result<(), StoreError> {
-    let trie = trie_cache
-        .read()
-        .map_err(|_| StoreError::LockError)?
-        .clone();
-    // Threshold 1 returns the root itself iff it is a live layer; `None` means the
-    // head is already on disk, so there is nothing buffered to commit.
-    if trie
-        .get_commitable_with_threshold(head_state_root, 1)
-        .is_none()
-    {
-        return Ok(());
-    }
-    commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, head_state_root)
-}
-
 /// Writes the layer at `root` and all of its ancestors to disk in one tx, then
-/// RCU-evicts them from the cache. Shared by the per-block "commit when due"
-/// path ([`commit_trie_if_due`]) and the "commit everything"
-/// shutdown path ([`commit_all_trie_layers`]). `trie` is the caller's snapshot
-/// of the cache; `root` must be one of its layer keys.
+/// RCU-evicts them from the cache. Used by the per-block "commit when due" path
+/// ([`commit_trie_if_due`]). `trie` is the caller's snapshot of the cache;
+/// `root` must be one of its layer keys.
 fn commit_trie_layers(
     backend: &dyn StorageBackend,
     trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -392,6 +392,35 @@ impl Store {
         .map_err(|e| StoreError::Custom(format!("wait_for_persistence_idle join: {e}")))?
     }
 
+    /// Flushes all in-memory state to disk for a clean shutdown.
+    ///
+    /// Sends a `Shutdown` handshake to the persist worker, which (being FIFO)
+    /// first drains every queued `Block`, then force-flushes the block-data
+    /// buffer and commits *all* remaining trie diff-layers to disk. Once the
+    /// worker acks, this syncs the backend (memtables + WAL) so the next process
+    /// start needs neither block re-execution nor WAL recovery.
+    ///
+    /// After this returns the persist worker has exited; the store must not be
+    /// used for further writes. Idempotent only in the sense that a second call
+    /// errors on the closed channel — call it exactly once, on shutdown.
+    pub async fn shutdown(&self) -> Result<(), StoreError> {
+        let tx = self.persist_tx.clone();
+        let backend = self.backend.clone();
+        tokio::task::spawn_blocking(move || {
+            let (ack_tx, ack_rx) = sync_channel::<Result<(), StoreError>>(1);
+            tx.send(PersistMessage::Shutdown(ack_tx))
+                .map_err(|e| StoreError::Custom(format!("shutdown send: {e}")))?;
+            ack_rx
+                .recv()
+                .map_err(|e| StoreError::Custom(format!("shutdown ack: {e}")))??;
+            // Worker has persisted everything to the WAL/memtables; make it durable
+            // and recovery-free.
+            backend.flush()
+        })
+        .await
+        .map_err(|e| StoreError::Custom(format!("shutdown join: {e}")))?
+    }
+
     /// Add a block in a single transaction.
     /// This will store -> BlockHeader, BlockBody, BlockTransactions, BlockNumber.
     pub async fn add_block(&self, block: Block) -> Result<(), StoreError> {
@@ -1892,6 +1921,24 @@ impl Store {
                         // messages are fully processed. Carry the pending flush
                         // result so a live-path failure is not silently dropped.
                         let _ = ack.send(std::mem::replace(&mut last_flush_result, Ok(())));
+                    }
+                    Ok(PersistMessage::Shutdown(ack)) => {
+                        // Graceful shutdown: drain (already guaranteed by FIFO) and
+                        // force-persist the not-yet-flushed tail. Flush the block
+                        // buffer, then commit every remaining trie diff-layer so a
+                        // restart needs no block re-execution.
+                        let result = flush_block_data(persist_backend.as_ref(), &persist_buffer)
+                            .and_then(|_| {
+                                commit_all_trie_layers(
+                                    persist_backend.as_ref(),
+                                    &persist_trie_cache,
+                                    &persist_fkv_ctl,
+                                )
+                            });
+                        let prior = std::mem::replace(&mut last_flush_result, Ok(()));
+                        let _ = ack.send(prior.and(result));
+                        // No more work will follow a shutdown request.
+                        return;
                     }
                     Err(_) => return,
                 }
@@ -3420,6 +3467,11 @@ struct BlockPersist {
 enum PersistMessage {
     Block(BlockPersist),
     Ping(std::sync::mpsc::SyncSender<Result<(), StoreError>>),
+    /// Graceful-shutdown handshake. Handled only after every earlier `Block`
+    /// (FIFO), so it both drains in-flight work and force-persists the tail:
+    /// flushes the block-data buffer and commits *all* remaining trie
+    /// diff-layers to disk. The worker acks and then exits.
+    Shutdown(std::sync::mpsc::SyncSender<Result<(), StoreError>>),
 }
 
 /// Write one block's header, body, number, and tx locations into an open batch.
@@ -3616,12 +3668,48 @@ fn commit_trie_if_due(
         // Nothing to commit to disk, move on.
         return Ok(());
     };
+    commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, root)
+}
+
+/// Commits *every* remaining trie diff-layer to disk (graceful-shutdown path).
+///
+/// Committing from the newest layer removes it and all its ancestors in one
+/// pass, draining the cache. Any orphaned reorg-sibling layers off the head
+/// chain are dropped without writing (only canonical state must be durable).
+fn commit_all_trie_layers(
+    backend: &dyn StorageBackend,
+    trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
+    fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
+) -> Result<(), StoreError> {
+    let trie = trie_cache
+        .read()
+        .map_err(|_| StoreError::LockError)?
+        .clone();
+    let Some(root) = trie.newest_root() else {
+        // Cache empty — nothing buffered in memory.
+        return Ok(());
+    };
+    commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, root)
+}
+
+/// Writes the layer at `root` and all of its ancestors to disk in one tx, then
+/// RCU-evicts them from the cache. Shared by the per-block "commit when due"
+/// path ([`commit_trie_if_due`]) and the "commit everything"
+/// shutdown path ([`commit_all_trie_layers`]). `trie` is the caller's snapshot
+/// of the cache; `root` must be one of its layer keys.
+fn commit_trie_layers(
+    backend: &dyn StorageBackend,
+    trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
+    fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
+    trie: &Arc<TrieLayerCache>,
+    root: H256,
+) -> Result<(), StoreError> {
     // Stop the flat-key-value generator thread, as the underlying trie is about to change.
     // Ignore the error, if the channel is closed it means there is no worker to notify.
     let _ = fkv_ctl.send(FKVGeneratorControlMessage::Stop);
 
     // RCU to remove the bottom layer: update step needs to happen after disk layer is updated.
-    let mut trie_mut = (*trie).clone();
+    let mut trie_mut = (**trie).clone();
 
     let last_written = backend
         .begin_read()?

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -406,8 +406,9 @@ impl Store {
     pub async fn shutdown(&self) -> Result<(), StoreError> {
         let tx = self.persist_tx.clone();
         let backend = self.backend.clone();
-        // Anchor the flush to the confirmed canonical head so we never durably
-        // persist a non-canonical sidechain root.
+        // Anchor the flush to the latest canonical head so we never durably
+        // persist a non-canonical sidechain root. (Latest-canonical, not
+        // finalized: the tail past the last finalized block may still reorg.)
         let head_state_root = self.latest_block_header.get().state_root;
         tokio::task::spawn_blocking(move || {
             let (ack_tx, ack_rx) = sync_channel::<Result<(), StoreError>>(1);
@@ -1936,7 +1937,7 @@ impl Store {
                         // force-persist the not-yet-flushed tail. Flush the block
                         // buffer, then commit the canonical head's trie diff-layer
                         // chain so a restart needs no block re-execution. Committing
-                        // from the confirmed head (not the newest-inserted layer)
+                        // from the latest canonical head (not the newest-inserted layer)
                         // avoids durably persisting a non-canonical sidechain root.
                         let result = flush_block_data(persist_backend.as_ref(), &persist_buffer)
                             .and_then(|_| {
@@ -3704,9 +3705,9 @@ fn commit_trie_if_due(
 }
 
 /// Commits the canonical head's trie diff-layer chain to disk (graceful-shutdown
-/// path). `head_state_root` is the confirmed canonical head root, so committing
-/// from it persists exactly the canonical state and its ancestors; any
-/// later-inserted, not-yet-confirmed sidechain layers stay in memory and are
+/// path). `head_state_root` is the latest canonical head root (not necessarily
+/// finalized), so committing from it persists exactly the canonical state and
+/// its ancestors; any later-inserted sidechain layers stay in memory and are
 /// discarded on exit rather than being durably written.
 ///
 /// No-ops if the head root is not in the cache (already flushed to disk).

--- a/test/tests/storage/deferred_persistence_tests.rs
+++ b/test/tests/storage/deferred_persistence_tests.rs
@@ -941,14 +941,6 @@ async fn boot_walks_past_reorged_unflushed_head() {
     );
 }
 
-/// A short key that `commit_trie_layers` classifies as an account trie node:
-/// length is neither 65 nor 131 (so not a leaf) and is <= 65 (so account, not
-/// storage), routing it to ACCOUNT_TRIE_NODES.
-#[cfg(feature = "rocksdb")]
-fn account_trie_node_key(tag: u8) -> Vec<u8> {
-    vec![tag, 0, 1, 2]
-}
-
 /// A graceful `shutdown()` must flush block data that only lives in the buffer,
 /// so a block a crash would lose survives a restart.
 ///
@@ -1018,16 +1010,19 @@ async fn shutdown_flushes_buffered_block_a_crash_would_lose() {
     );
 }
 
-/// The shutdown trie flush must anchor to the confirmed canonical head, not the
-/// newest-inserted layer. A sidechain sibling imported after the head (higher
-/// layer id) must NOT become the durable state; the canonical chain must.
+/// A graceful `shutdown()` must NOT force-commit the in-memory trie diff-layers.
+/// The on-disk trie is a single-version, path-based store: folding the
+/// non-finalized tail into it would make a post-restart reorg unrecoverable, so
+/// the recent layers are deliberately left in memory and dropped on exit. They
+/// re-execute on the next start from the deep on-disk base, exactly as after any
+/// other restart.
 ///
-/// On-disk genesis -> A -> B (canonical head). B' is a sibling of B (also a child
-/// of A) stored LAST, so it holds the highest layer id. Committing from the head
-/// persists A + B and leaves B' unwritten.
+/// Genesis -> A (head). A's trie diff never reaches `DB_COMMIT_THRESHOLD` depth,
+/// so it lives only in the layer cache; after a clean shutdown + reopen its trie
+/// node must NOT be on disk.
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
-async fn shutdown_commits_canonical_head_trie_not_sidechain() {
+async fn shutdown_does_not_force_commit_trie_layers() {
     use ethrex_common::types::Genesis;
     use ethrex_trie::Nibbles;
 
@@ -1037,32 +1032,8 @@ async fn shutdown_commits_canonical_head_trie_not_sidechain() {
     let genesis_hash = genesis.get_block().hash();
 
     let root_a = H256::from_low_u64_be(0xA1);
-    let root_b = H256::from_low_u64_be(0xB2);
-    let root_b_prime = H256::from_low_u64_be(0xC3);
-
-    let key_a = account_trie_node_key(0xA0);
-    let key_b = account_trie_node_key(0xB0);
-    let key_b_prime = account_trie_node_key(0xC0);
-
-    // Build a single-block UpdateBatch with one account trie-node diff.
-    let make_batch = |number: BlockNumber, parent: H256, state_root: H256, key: Vec<u8>| {
-        let header = BlockHeader {
-            number,
-            parent_hash: parent,
-            state_root,
-            ..Default::default()
-        };
-        let block = Block::new(header, BlockBody::default());
-        let batch = UpdateBatch {
-            account_updates: vec![(Nibbles::from_hex(key), vec![0x42])],
-            storage_updates: vec![],
-            receipts: vec![(block.hash(), vec![])],
-            blocks: vec![block.clone()],
-            code_updates: vec![],
-            batch_mode: false,
-        };
-        (block, batch)
-    };
+    // A short key routed to ACCOUNT_TRIE_NODES (len neither 65 nor 131, and <= 65).
+    let key_a: Vec<u8> = vec![0xA0, 0, 1, 2];
 
     let dir = tempfile::tempdir().expect("tmp");
     let path = dir.path().to_str().unwrap();
@@ -1074,47 +1045,38 @@ async fn shutdown_commits_canonical_head_trie_not_sidechain() {
             .await
             .expect("genesis");
 
-        let (block_a, batch_a) = make_batch(1, genesis_hash, root_a, key_a.clone());
-        store.store_block_updates(batch_a).expect("store A");
+        let header = BlockHeader {
+            number: 1,
+            parent_hash: genesis_hash,
+            state_root: root_a,
+            ..Default::default()
+        };
+        let block_a = Block::new(header, BlockBody::default());
         let hash_a = block_a.hash();
+        let batch_a = UpdateBatch {
+            account_updates: vec![(Nibbles::from_hex(key_a.clone()), vec![0x42])],
+            storage_updates: vec![],
+            receipts: vec![(hash_a, vec![])],
+            blocks: vec![block_a],
+            code_updates: vec![],
+            batch_mode: false,
+        };
+        store.store_block_updates(batch_a).expect("store A");
 
-        let (block_b, batch_b) = make_batch(2, hash_a, root_b, key_b.clone());
-        store.store_block_updates(batch_b).expect("store B");
-        let hash_b = block_b.hash();
-
-        // Sidechain sibling of B, stored LAST so it holds the highest layer id.
-        let (_block_b_prime, batch_b_prime) =
-            make_batch(2, hash_a, root_b_prime, key_b_prime.clone());
-        store.store_block_updates(batch_b_prime).expect("store B'");
-
-        // Make the A -> B chain canonical (head = B).
         store
-            .forkchoice_update(vec![(1, hash_a), (2, hash_b)], 2, hash_b, None, None)
+            .forkchoice_update(vec![(1, hash_a)], 1, hash_a, None, None)
             .await
-            .expect("fcu to B");
+            .expect("fcu to A");
 
         store.shutdown().await.expect("shutdown flush");
     }
 
     let store = Store::new(path, EngineType::RocksDB).expect("reopen");
 
-    // Canonical head chain (A + B) is durable...
+    // The shallow trie layer must have stayed in memory: nothing was force-committed.
     assert_eq!(
         store.get_trie_node_for_test(true, &key_a).expect("read A"),
-        Some(vec![0x42]),
-        "canonical ancestor A must be committed on shutdown"
-    );
-    assert_eq!(
-        store.get_trie_node_for_test(true, &key_b).expect("read B"),
-        Some(vec![0x42]),
-        "canonical head B must be committed on shutdown"
-    );
-    // ...but the later-inserted sidechain layer must not be persisted.
-    assert_eq!(
-        store
-            .get_trie_node_for_test(true, &key_b_prime)
-            .expect("read B'"),
         None,
-        "non-canonical sidechain layer must not be durably committed"
+        "shutdown must not force-commit the in-memory trie diff-layer"
     );
 }

--- a/test/tests/storage/deferred_persistence_tests.rs
+++ b/test/tests/storage/deferred_persistence_tests.rs
@@ -940,3 +940,181 @@ async fn boot_walks_past_reorged_unflushed_head() {
         "marker must be lowered to the resolved durable head"
     );
 }
+
+/// A short key that `commit_trie_layers` classifies as an account trie node:
+/// length is neither 65 nor 131 (so not a leaf) and is <= 65 (so account, not
+/// storage), routing it to ACCOUNT_TRIE_NODES.
+#[cfg(feature = "rocksdb")]
+fn account_trie_node_key(tag: u8) -> Vec<u8> {
+    vec![tag, 0, 1, 2]
+}
+
+/// A graceful `shutdown()` must flush block data that only lives in the buffer,
+/// so a block a crash would lose survives a restart.
+///
+/// Mirror of `boot_clamps_head_to_flushed_upto` (where a drop loses the buffered
+/// block): here `shutdown()` is called instead of dropping, and the block must
+/// be durable on reopen.
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn shutdown_flushes_buffered_block_a_crash_would_lose() {
+    use ethrex_common::types::Genesis;
+
+    const GENESIS_KURTOSIS: &str = include_str!("../../../fixtures/genesis/kurtosis.json");
+    let genesis: Genesis =
+        serde_json::from_str(GENESIS_KURTOSIS).expect("deserialize kurtosis.json");
+    let genesis_hash = genesis.get_block().hash();
+
+    let dir = tempfile::tempdir().expect("tmp");
+    let path = dir.path().to_str().unwrap();
+
+    {
+        let mut store = Store::new(path, EngineType::RocksDB).expect("store");
+        store
+            .add_initial_state(genesis.clone())
+            .await
+            .expect("genesis");
+
+        // Block 10 is only buffered, never flushed via the per-block path.
+        let b10 = Block::new(
+            BlockHeader {
+                number: 10,
+                parent_hash: genesis_hash,
+                ..Default::default()
+            },
+            BlockBody::default(),
+        );
+        let hash10 = b10.hash();
+        store.buffer_block_for_test(&b10);
+        store
+            .forkchoice_update(vec![(10, hash10)], 10, hash10, None, None)
+            .await
+            .expect("fcu 10");
+        assert_eq!(
+            store.read_flushed_upto().expect("marker"),
+            0,
+            "precondition: block 10 is buffered, not yet flushed"
+        );
+
+        // Graceful shutdown must persist the buffered block (a crash would lose it).
+        store.shutdown().await.expect("shutdown flush");
+    }
+
+    let mut store = Store::new(path, EngineType::RocksDB).expect("reopen");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("boot after clean shutdown");
+
+    assert_eq!(
+        store.read_flushed_upto().expect("marker"),
+        10,
+        "shutdown must have flushed the buffered block to disk"
+    );
+    assert_eq!(
+        store.get_latest_block_number().await.expect("head"),
+        10,
+        "head must stay at the durable block after a clean shutdown"
+    );
+}
+
+/// The shutdown trie flush must anchor to the confirmed canonical head, not the
+/// newest-inserted layer. A sidechain sibling imported after the head (higher
+/// layer id) must NOT become the durable state; the canonical chain must.
+///
+/// On-disk genesis -> A -> B (canonical head). B' is a sibling of B (also a child
+/// of A) stored LAST, so it holds the highest layer id. Committing from the head
+/// persists A + B and leaves B' unwritten.
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn shutdown_commits_canonical_head_trie_not_sidechain() {
+    use ethrex_common::types::Genesis;
+    use ethrex_trie::Nibbles;
+
+    const GENESIS_KURTOSIS: &str = include_str!("../../../fixtures/genesis/kurtosis.json");
+    let genesis: Genesis =
+        serde_json::from_str(GENESIS_KURTOSIS).expect("deserialize kurtosis.json");
+    let genesis_hash = genesis.get_block().hash();
+
+    let root_a = H256::from_low_u64_be(0xA1);
+    let root_b = H256::from_low_u64_be(0xB2);
+    let root_b_prime = H256::from_low_u64_be(0xC3);
+
+    let key_a = account_trie_node_key(0xA0);
+    let key_b = account_trie_node_key(0xB0);
+    let key_b_prime = account_trie_node_key(0xC0);
+
+    // Build a single-block UpdateBatch with one account trie-node diff.
+    let make_batch = |number: BlockNumber, parent: H256, state_root: H256, key: Vec<u8>| {
+        let header = BlockHeader {
+            number,
+            parent_hash: parent,
+            state_root,
+            ..Default::default()
+        };
+        let block = Block::new(header, BlockBody::default());
+        let batch = UpdateBatch {
+            account_updates: vec![(Nibbles::from_hex(key), vec![0x42])],
+            storage_updates: vec![],
+            receipts: vec![(block.hash(), vec![])],
+            blocks: vec![block.clone()],
+            code_updates: vec![],
+            batch_mode: false,
+        };
+        (block, batch)
+    };
+
+    let dir = tempfile::tempdir().expect("tmp");
+    let path = dir.path().to_str().unwrap();
+
+    {
+        let mut store = Store::new(path, EngineType::RocksDB).expect("store");
+        store
+            .add_initial_state(genesis.clone())
+            .await
+            .expect("genesis");
+
+        let (block_a, batch_a) = make_batch(1, genesis_hash, root_a, key_a.clone());
+        store.store_block_updates(batch_a).expect("store A");
+        let hash_a = block_a.hash();
+
+        let (block_b, batch_b) = make_batch(2, hash_a, root_b, key_b.clone());
+        store.store_block_updates(batch_b).expect("store B");
+        let hash_b = block_b.hash();
+
+        // Sidechain sibling of B, stored LAST so it holds the highest layer id.
+        let (_block_b_prime, batch_b_prime) =
+            make_batch(2, hash_a, root_b_prime, key_b_prime.clone());
+        store.store_block_updates(batch_b_prime).expect("store B'");
+
+        // Make the A -> B chain canonical (head = B).
+        store
+            .forkchoice_update(vec![(1, hash_a), (2, hash_b)], 2, hash_b, None, None)
+            .await
+            .expect("fcu to B");
+
+        store.shutdown().await.expect("shutdown flush");
+    }
+
+    let store = Store::new(path, EngineType::RocksDB).expect("reopen");
+
+    // Canonical head chain (A + B) is durable...
+    assert_eq!(
+        store.get_trie_node_for_test(true, &key_a).expect("read A"),
+        Some(vec![0x42]),
+        "canonical ancestor A must be committed on shutdown"
+    );
+    assert_eq!(
+        store.get_trie_node_for_test(true, &key_b).expect("read B"),
+        Some(vec![0x42]),
+        "canonical head B must be committed on shutdown"
+    );
+    // ...but the later-inserted sidechain layer must not be persisted.
+    assert_eq!(
+        store
+            .get_trie_node_for_test(true, &key_b_prime)
+            .expect("read B'"),
+        None,
+        "non-canonical sidechain layer must not be durably committed"
+    );
+}


### PR DESCRIPTION
## Problem

`docker restart -t 0` (and any abrupt exit) leaves the db in an unclean state. The SIGTERM/SIGINT handler only cancelled the token, wrote `node_config.json`, and slept 1s. It never drained the persist worker, never force-flushed the tail of the block-data buffer, and never fsynced RocksDB.

Two problems on exit:
- The tail of the in-memory block-data buffer (blocks queued but below the flush threshold) was dropped, so a block a crash would lose was also lost on a *graceful* stop.
- RocksDB memtables were never flushed, so the next open did WAL recovery.

Result: slow, unclean restarts (WAL replay + re-execution). Users worked around it by waiting ~2 min before killing.

## Fix

Add `Store::shutdown()` and call it from `server_shutdown` after cancelling the token:

1. Sends a `Shutdown` handshake to the persist worker. Being FIFO, it drains every queued block first.
2. Worker force-flushes the block-data buffer (not just the "when due" tail).
3. After the worker acks, `backend.flush()` flushes every CF memtable to SST and syncs the WAL, so the next open needs no recovery.

The in-memory trie diff-layers are **intentionally not** force-committed. The on-disk trie is a single-version, path-based store, so folding the non-finalized tail into it would leave a post-restart reorg unable to reconstruct the overwritten ancestor state (the node would wedge). Those recent (< `DB_COMMIT_THRESHOLD`) layers are simply dropped and re-executed on the next start from the deep, reorg-safe on-disk base, exactly as after any restart today.

Supporting changes:
- `StorageBackend::flush()` trait method (default no-op; RocksDB impl flushes CFs + syncs WAL).
- New `PersistMessage::Shutdown` handshake handled by the persist worker.
- RPC/engine servers now key their graceful-shutdown future on the `cancel_token` (`rpc_shutdown_signal`), not just Ctrl+C. This makes the engine API stop accepting requests on **SIGTERM** (`docker stop`) before the store is flushed.
- `init_l1` returns the `Store` so the shutdown handler can reach it.

## Note

`-t 0` sends SIGKILL with no grace period, which no handler can intercept. Pair this with a real `stop_grace_period` / `docker stop -t N` so the handler runs.
