### PR TITLE
feat(l1): implement debug_getBadBlocks with bad-block tracking

### DIFF
--- a/crates/networking/rpc/debug/bad_blocks.rs
+++ b/crates/networking/rpc/debug/bad_blocks.rs
@@ -1,0 +1,42 @@
+use ethrex_common::H256;
+use ethrex_rlp::encode::RLPEncode;
+use serde::Serialize;
+use serde_json::Value;
+use tracing::debug;
+
+use crate::{RpcApiContext, RpcErr, RpcHandler, types::block::RpcBlock};
+
+pub struct GetBadBlocksRequest;
+
+/// A single entry returned by `debug_getBadBlocks`, mirroring geth's `BadBlockArgs`.
+#[derive(Serialize)]
+struct BadBlock {
+    hash: H256,
+    block: RpcBlock,
+    rlp: String,
+}
+
+impl RpcHandler for GetBadBlocksRequest {
+    fn parse(_params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        Ok(GetBadBlocksRequest)
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        debug!("Requested bad blocks");
+
+        let bad_blocks = context.storage.get_bad_blocks().await?;
+        let mut results = Vec::with_capacity(bad_blocks.len());
+        for block in bad_blocks {
+            let hash = block.hash();
+            let rlp = format!("0x{}", hex::encode(block.encode_to_vec()));
+            let rpc_block = RpcBlock::build(block.header, block.body, hash, true)?;
+            results.push(BadBlock {
+                hash,
+                block: rpc_block,
+                rlp,
+            });
+        }
+
+        serde_json::to_value(results).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}

--- a/crates/networking/rpc/debug/mod.rs
+++ b/crates/networking/rpc/debug/mod.rs
@@ -1,3 +1,4 @@
+pub mod bad_blocks;
 pub mod chain_config;
 pub mod execution_witness;
 pub mod execution_witness_by_hash;

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -1239,6 +1239,11 @@ async fn try_execute_payload(
     // Execute and store the block
     debug!(%block_hash, %block_number, "Executing payload");
 
+    // Retain a copy so we can record it via `debug_getBadBlocks` if it turns out
+    // to be invalid. `add_block` consumes the block, so we must clone beforehand;
+    // this happens once per newPayload and is negligible next to block execution.
+    let bad_block_candidate = block.clone();
+
     match add_block(context, block, bal, make_witness).await {
         Err(ChainError::ParentNotFound) => {
             // Start sync
@@ -1260,6 +1265,7 @@ async fn try_execute_payload(
                 .storage
                 .set_latest_valid_ancestor(block_hash, latest_valid_hash)
                 .await?;
+            context.storage.add_bad_block(bad_block_candidate).await?;
             Ok(PayloadStatus::invalid_with(
                 latest_valid_hash,
                 error.to_string(),
@@ -1271,6 +1277,7 @@ async fn try_execute_payload(
                 .storage
                 .set_latest_valid_ancestor(block_hash, latest_valid_hash)
                 .await?;
+            context.storage.add_bad_block(bad_block_candidate).await?;
             Ok(PayloadStatus::invalid_with(
                 latest_valid_hash,
                 error.to_string(),

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1,4 +1,5 @@
 use crate::authentication::authenticate;
+use crate::debug::bad_blocks::GetBadBlocksRequest;
 use crate::debug::chain_config::ChainConfigRequest;
 use crate::debug::execution_witness::ExecutionWitnessRequest;
 use crate::debug::execution_witness_by_hash::ExecutionWitnessByBlockHashRequest;
@@ -1165,6 +1166,7 @@ pub async fn map_debug_requests(req: &RpcRequest, context: RpcApiContext) -> Res
             ExecutionWitnessByBlockHashRequest::call(req, context).await
         }
         "debug_chainConfig" => ChainConfigRequest::call(req, context).await,
+        "debug_getBadBlocks" => GetBadBlocksRequest::call(req, context).await,
         "debug_traceTransaction" => TraceTransactionRequest::call(req, context).await,
         "debug_traceBlockByNumber" => TraceBlockByNumberRequest::call(req, context).await,
         "debug_traceBlockByHash" => TraceBlockByHashRequest::call(req, context).await,

--- a/crates/storage/api/tables.rs
+++ b/crates/storage/api/tables.rs
@@ -113,7 +113,13 @@ pub const EXECUTION_WITNESSES: &str = "execution_witnesses";
 /// - [`Vec<u8>`] = RLP-encoded `BlockAccessList`
 pub const BLOCK_ACCESS_LISTS: &str = "block_access_lists";
 
-pub const TABLES: [&str; 20] = [
+/// Bad blocks column family: single-keyed list of the most recent bad blocks
+/// seen by the client, served by `debug_getBadBlocks`.
+/// - [`Vec<u8>`] = [`BAD_BLOCKS_KEY`]
+/// - [`Vec<u8>`] = RLP-encoded `Vec<Block>` (sorted by descending block number)
+pub const BAD_BLOCKS: &str = "bad_blocks";
+
+pub const TABLES: [&str; 21] = [
     CHAIN_DATA,
     ACCOUNT_CODES,
     ACCOUNT_CODE_METADATA,
@@ -134,4 +140,5 @@ pub const TABLES: [&str; 20] = [
     MISC_VALUES,
     EXECUTION_WITNESSES,
     BLOCK_ACCESS_LISTS,
+    BAD_BLOCKS,
 ];

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -6,10 +6,10 @@ use crate::{
         StorageBackend, StorageReadView, StorageWriteBatch,
         tables::{
             ACCOUNT_CODE_METADATA, ACCOUNT_CODES, ACCOUNT_FLATKEYVALUE, ACCOUNT_TRIE_NODES,
-            BLOCK_ACCESS_LISTS, BLOCK_NUMBERS, BODIES, CANONICAL_BLOCK_HASHES, CHAIN_DATA,
-            EXECUTION_WITNESSES, FULLSYNC_HEADERS, HEADERS, INVALID_CHAINS, MISC_VALUES,
-            PENDING_BLOCKS, RECEIPTS_V2, SNAP_STATE, STORAGE_FLATKEYVALUE, STORAGE_TRIE_NODES,
-            TRANSACTION_LOCATIONS,
+            BAD_BLOCKS, BLOCK_ACCESS_LISTS, BLOCK_NUMBERS, BODIES, CANONICAL_BLOCK_HASHES,
+            CHAIN_DATA, EXECUTION_WITNESSES, FULLSYNC_HEADERS, HEADERS, INVALID_CHAINS,
+            MISC_VALUES, PENDING_BLOCKS, RECEIPTS_V2, SNAP_STATE, STORAGE_FLATKEYVALUE,
+            STORAGE_TRIE_NODES, TRANSACTION_LOCATIONS,
         },
     },
     apply_prefix,
@@ -116,6 +116,12 @@ const CODE_CACHE_MAX_SIZE: u64 = 64 * 1024 * 1024;
 
 /// Key used to persist the `flushed_upto` block number in `MISC_VALUES`.
 const FLUSHED_UPTO_KEY: &[u8] = b"bodies_flushed_upto";
+
+/// Single key under which the bounded list of bad blocks is stored in `BAD_BLOCKS`.
+const BAD_BLOCKS_KEY: &[u8] = b"bad_blocks";
+
+/// Maximum number of bad blocks retained for `debug_getBadBlocks`.
+const MAX_BAD_BLOCKS: usize = 16;
 
 #[derive(Debug)]
 struct CodeCache {
@@ -1312,6 +1318,40 @@ impl Store {
             .map(|bytes| H256::decode(bytes.as_slice()))
             .transpose()
             .map_err(StoreError::from)
+    }
+
+    /// Records a block that failed validation so it can be served by
+    /// `debug_getBadBlocks`. The list is bounded to [`MAX_BAD_BLOCKS`] entries,
+    /// kept sorted by descending block number, with the oldest dropped once the
+    /// bound is exceeded. Duplicate `(number, hash)` entries are ignored.
+    pub async fn add_bad_block(&self, block: Block) -> Result<(), StoreError> {
+        let mut bad_blocks = self.get_bad_blocks().await?;
+        let block_number = block.header.number;
+        let block_hash = block.hash();
+        if bad_blocks
+            .iter()
+            .any(|b| b.header.number == block_number && b.hash() == block_hash)
+        {
+            return Ok(());
+        }
+        bad_blocks.push(block);
+        bad_blocks.sort_by(|a, b| b.header.number.cmp(&a.header.number));
+        bad_blocks.truncate(MAX_BAD_BLOCKS);
+        self.write_async(
+            BAD_BLOCKS,
+            BAD_BLOCKS_KEY.to_vec(),
+            bad_blocks.encode_to_vec(),
+        )
+        .await
+    }
+
+    /// Returns the recent bad blocks seen by the client, sorted by descending
+    /// block number. Used by `debug_getBadBlocks`.
+    pub async fn get_bad_blocks(&self) -> Result<Vec<Block>, StoreError> {
+        match self.read_async(BAD_BLOCKS, BAD_BLOCKS_KEY.to_vec()).await? {
+            Some(bytes) => Vec::<Block>::decode(&bytes).map_err(StoreError::from),
+            None => Ok(Vec::new()),
+        }
     }
 
     /// Obtain block number for a given hash

--- a/test/tests/storage/store_tests.rs
+++ b/test/tests/storage/store_tests.rs
@@ -4,8 +4,8 @@ use ethrex_common::{
     Address, Bloom, H160,
     constants::{EMPTY_KECCAK_HASH, EMPTY_TRIE_HASH},
     types::{
-        AccountState, BlockBody, BlockHeader, ChainConfig, Code, Genesis, Receipt, Transaction,
-        TxType,
+        AccountState, Block, BlockBody, BlockHeader, ChainConfig, Code, Genesis, Receipt,
+        Transaction, TxType,
     },
     utils::keccak,
 };
@@ -56,6 +56,7 @@ async fn test_store_suite(engine_type: EngineType) {
     run_test(test_genesis_block, engine_type).await;
     run_test(test_iter_accounts, engine_type).await;
     run_test(test_iter_storage, engine_type).await;
+    run_test(test_bad_blocks, engine_type).await;
 }
 
 async fn test_iter_accounts(store: Store) {
@@ -232,6 +233,46 @@ async fn test_store_block(store: Store) {
     let _ = block_header.hash();
     assert_eq!(stored_header, block_header);
     assert_eq!(stored_body, block_body);
+}
+
+async fn test_bad_blocks(store: Store) {
+    // Empty store returns no bad blocks.
+    assert!(store.get_bad_blocks().await.unwrap().is_empty());
+
+    let (_, body) = create_block_for_testing();
+    let make_block = |number: u64| {
+        let header = BlockHeader {
+            number,
+            ..Default::default()
+        };
+        Block::new(header, body.clone())
+    };
+
+    // Insert out of order; the list must come back sorted by descending number.
+    let block_a = make_block(5);
+    let block_b = make_block(9);
+    let block_c = make_block(2);
+    store.add_bad_block(block_a.clone()).await.unwrap();
+    store.add_bad_block(block_b.clone()).await.unwrap();
+    store.add_bad_block(block_c.clone()).await.unwrap();
+
+    let bad_blocks = store.get_bad_blocks().await.unwrap();
+    let numbers: Vec<u64> = bad_blocks.iter().map(|b| b.header.number).collect();
+    assert_eq!(numbers, vec![9, 5, 2]);
+
+    // Duplicate (number, hash) is ignored.
+    store.add_bad_block(block_b.clone()).await.unwrap();
+    assert_eq!(store.get_bad_blocks().await.unwrap().len(), 3);
+
+    // The list is bounded: inserting many more evicts the lowest-numbered blocks.
+    for number in 100..140u64 {
+        store.add_bad_block(make_block(number)).await.unwrap();
+    }
+    let bounded = store.get_bad_blocks().await.unwrap();
+    assert_eq!(bounded.len(), 16);
+    // Highest kept is the most recent insert; lowest kept is above the evicted range.
+    assert_eq!(bounded.first().unwrap().header.number, 139);
+    assert_eq!(bounded.last().unwrap().header.number, 124);
 }
 
 fn create_block_for_testing() -> (BlockHeader, BlockBody) {


### PR DESCRIPTION
Cherry-pick of #6948 onto `glamsterdam-devnet-6`.

Implements `debug_getBadBlocks` with real bad-block tracking: blocks rejected during `engine_newPayload` are persisted in a new `BAD_BLOCKS` storage table (deduped on `(number, hash)`, sorted descending, capped at 16) and returned as `[{ hash, block, rlp }]` matching geth's shape.

Cherry-picked cleanly (auto-merge on `rpc.rs`/`store.rs`); builds and the `test_bad_blocks` storage test passes on this branch.

See #6948 for full details.