### PR TITLE
feat(l1): enforce movePrecompileToAddress in eth_simulateV1

### DIFF
--- a/crates/blockchain/simulate.rs
+++ b/crates/blockchain/simulate.rs
@@ -15,18 +15,18 @@ use ethrex_common::{
     Address, U256,
     constants::{DEFAULT_OMMERS_HASH, DEFAULT_REQUESTS_HASH, GAS_PER_BLOB},
     types::{
-        AccountInfo, AccountUpdate, Block, BlockBody, BlockHeader, ChainConfig,
-        EIP1559Transaction, EIP4844Transaction, EIP7702Transaction, ELASTICITY_MULTIPLIER, Fork,
-        GenericTransaction, LegacyTransaction, Log, Receipt, Transaction, TxKind, Withdrawal,
-        bloom_from_logs, calc_excess_blob_gas, calculate_base_fee_per_gas, compute_receipts_root,
+        AccountInfo, AccountUpdate, Block, BlockBody, BlockHeader, ChainConfig, EIP1559Transaction,
+        EIP4844Transaction, EIP7702Transaction, ELASTICITY_MULTIPLIER, Fork, GenericTransaction,
+        LegacyTransaction, Log, Receipt, Transaction, TxKind, Withdrawal, bloom_from_logs,
+        calc_excess_blob_gas, calculate_base_fee_per_gas, compute_receipts_root,
         compute_transactions_root, compute_withdrawals_root, requests::compute_requests_hash,
         tx_fields::AuthorizationTuple,
     },
 };
 use ethrex_crypto::NativeCrypto;
 use ethrex_vm::{
-    SimTxConfig, SimulationTxError, TRACE_TRANSFER_ADDRESS, TxResult, TxValidationError,
-    backends::levm::get_max_allowed_gas_limit,
+    PrecompileOverrides, SimTxConfig, SimulationTxError, TRACE_TRANSFER_ADDRESS, TxResult,
+    TxValidationError, VMType, backends::levm::get_max_allowed_gas_limit, is_precompile,
 };
 use thiserror::Error;
 
@@ -129,6 +129,10 @@ pub enum SimulationError {
     InvalidTx(TxValidationError),
     #[error("{0}")]
     InvalidParams(String),
+    /// Invalid `movePrecompileToAddress` usage (non-precompile source,
+    /// overridden destination, ...). Reported with code -32000, like geth.
+    #[error("{0}")]
+    PrecompileOverride(String),
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -444,6 +448,50 @@ fn build_sim_transaction(
     Ok((tx, sender, gas_capped))
 }
 
+/// Validate and collect the block's `movePrecompileToAddress` overrides,
+/// mirroring geth's `StateOverride.Apply` precompile handling: sources must be
+/// active precompiles, destinations must not themselves be overridden, a later
+/// override may not touch an address a precompile was moved to, and any
+/// override on a precompile address removes its precompile behavior. The map
+/// iterates in address order, so error precedence is deterministic and matches
+/// geth (which sorts explicitly).
+fn build_precompile_overrides(
+    state_overrides: &BTreeMap<Address, StateOverride>,
+    fork: Fork,
+    vm_type: VMType,
+) -> Result<Option<Arc<PrecompileOverrides>>, SimulationError> {
+    let mut overrides = PrecompileOverrides::default();
+    let mut moved_destinations: std::collections::BTreeSet<Address> = Default::default();
+    for (address, override_) in state_overrides {
+        if moved_destinations.contains(address) {
+            return Err(SimulationError::PrecompileOverride(format!(
+                "account {address:#x} has already been overridden by a precompile"
+            )));
+        }
+        let source_is_precompile = is_precompile(address, fork, vm_type);
+        if let Some(destination) = override_.move_precompile_to {
+            if !source_is_precompile {
+                return Err(SimulationError::PrecompileOverride(format!(
+                    "account {address:#x} is not a precompile"
+                )));
+            }
+            if state_overrides.contains_key(&destination) {
+                return Err(SimulationError::PrecompileOverride(format!(
+                    "account {destination:#x} is already overridden"
+                )));
+            }
+            // A second move to the same destination overwrites the first,
+            // like geth's map insert.
+            overrides.moved.insert(destination, *address);
+            moved_destinations.insert(destination);
+        }
+        if source_is_precompile {
+            overrides.removed.insert(*address);
+        }
+    }
+    Ok((!overrides.removed.is_empty() || !overrides.moved.is_empty()).then(|| Arc::new(overrides)))
+}
+
 impl Blockchain {
     /// Execute an `eth_simulateV1` request: simulate a chain of blocks on top
     /// of `request.base`, chaining state across blocks, without committing
@@ -456,9 +504,12 @@ impl Blockchain {
         let base_hash = base.hash();
         let chain_config = self.storage.get_chain_config();
         let is_l1 = matches!(self.options.r#type, BlockchainType::L1);
-        let sim_config = SimTxConfig {
-            validate: request.validation,
-            trace_transfers: request.trace_transfers,
+        // Only the VM flavor matters for the precompile set; the L2 fee
+        // config plays no role in `is_precompile`.
+        let vm_type = if is_l1 {
+            VMType::L1
+        } else {
+            VMType::L2(Default::default())
         };
 
         let blocks = sanitize_blocks(&base, request.blocks)?;
@@ -470,16 +521,32 @@ impl Blockchain {
         let mut results = Vec::with_capacity(blocks.len());
 
         for sanitized in blocks {
-            let mut header = make_sim_header(&parent, &sanitized, &chain_config, request.validation);
+            let mut header =
+                make_sim_header(&parent, &sanitized, &chain_config, request.validation);
             let fork = chain_config.fork(header.timestamp);
+
+            // Precompile moves are per-block scoped and validated before any
+            // state is touched.
+            let precompile_overrides =
+                build_precompile_overrides(&sanitized.spec.state_overrides, fork, vm_type)?;
+            let sim_config = SimTxConfig {
+                validate: request.validation,
+                trace_transfers: request.trace_transfers,
+                precompile_overrides,
+            };
 
             // State overrides are applied prior to execution of the block and
             // become part of the overlay (and thus the state root).
             if !sanitized.spec.state_overrides.is_empty() {
-                let pre_db =
-                    SimulationVmDatabase::new(store_db.clone(), Arc::new(overlay.clone()));
+                let pre_db = SimulationVmDatabase::new(store_db.clone(), Arc::new(overlay.clone()));
                 for (address, override_) in sanitized.spec.state_overrides.clone() {
-                    if override_.is_noop() {
+                    // Move-only overrides carry no account state: materializing
+                    // them would create empty accounts in the state root.
+                    let has_state_change = override_.balance.is_some()
+                        || override_.nonce.is_some()
+                        || override_.code.is_some()
+                        || !matches!(override_.storage_mode, StorageMode::None);
+                    if !has_state_change {
                         continue;
                     }
                     overlay.merge_update(state_override_to_update(address, override_, &pre_db)?);
@@ -534,8 +601,7 @@ impl Blockchain {
 
                 gas_used += report.gas_used;
                 budget_remaining = budget_remaining.saturating_sub(report.gas_used);
-                blob_gas_used +=
-                    (tx.blob_versioned_hashes().len() * GAS_PER_BLOB as usize) as u64;
+                blob_gas_used += (tx.blob_versioned_hashes().len() * GAS_PER_BLOB as usize) as u64;
 
                 // Trace-transfer logs go to the per-call results but must stay
                 // out of receipts, the logs bloom and request extraction.
@@ -617,9 +683,7 @@ impl Blockchain {
 
             // EIP-7685 request system calls (withdrawal/consolidation queues).
             if is_l1 && chain_config.is_prague_activated(header.timestamp) {
-                let requests = evm
-                    .extract_requests(&receipts, &header)
-                    .map_err(internal)?;
+                let requests = evm.extract_requests(&receipts, &header).map_err(internal)?;
                 let encoded: Vec<_> = requests.iter().map(|request| request.encode()).collect();
                 header.requests_hash = Some(compute_requests_hash(&encoded));
             }
@@ -694,10 +758,13 @@ mod tests {
     #[test]
     fn sanitize_defaults_number_and_timestamp() {
         let base = base_header(100, 1000);
-        let blocks = sanitize_blocks(&base, vec![spec_with(None, None), spec_with(None, None)])
-            .unwrap();
+        let blocks =
+            sanitize_blocks(&base, vec![spec_with(None, None), spec_with(None, None)]).unwrap();
         assert_eq!(
-            blocks.iter().map(|b| (b.number, b.timestamp)).collect::<Vec<_>>(),
+            blocks
+                .iter()
+                .map(|b| (b.number, b.timestamp))
+                .collect::<Vec<_>>(),
             vec![(101, 1012), (102, 1024)]
         );
     }
@@ -707,7 +774,10 @@ mod tests {
         let base = base_header(100, 1000);
         let blocks = sanitize_blocks(&base, vec![spec_with(Some(104), None)]).unwrap();
         assert_eq!(
-            blocks.iter().map(|b| (b.number, b.timestamp)).collect::<Vec<_>>(),
+            blocks
+                .iter()
+                .map(|b| (b.number, b.timestamp))
+                .collect::<Vec<_>>(),
             vec![(101, 1012), (102, 1024), (103, 1036), (104, 1048)]
         );
         assert!(blocks[0].spec.calls.is_empty());
@@ -722,7 +792,13 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            matches!(err, SimulationError::BlockNumberNotAscending { given: 105, prev: 110 }),
+            matches!(
+                err,
+                SimulationError::BlockNumberNotAscending {
+                    given: 105,
+                    prev: 110
+                }
+            ),
             "unexpected error: {err:?}"
         );
         // Equal numbers are rejected too (this is how "more blocks than fit
@@ -738,7 +814,10 @@ mod tests {
         .unwrap_err();
         assert!(matches!(
             err,
-            SimulationError::BlockNumberNotAscending { given: 102, prev: 102 }
+            SimulationError::BlockNumberNotAscending {
+                given: 102,
+                prev: 102
+            }
         ));
     }
 
@@ -752,7 +831,10 @@ mod tests {
         .unwrap_err();
         assert!(matches!(
             err,
-            SimulationError::TimestampNotAscending { given: 1100, prev: 1100 }
+            SimulationError::TimestampNotAscending {
+                given: 1100,
+                prev: 1100
+            }
         ));
     }
 
@@ -772,7 +854,10 @@ mod tests {
         let err = sanitize_blocks(&base, vec![spec_with(Some(103), Some(1020))]).unwrap_err();
         assert!(matches!(
             err,
-            SimulationError::TimestampNotAscending { given: 1020, prev: 1024 }
+            SimulationError::TimestampNotAscending {
+                given: 1020,
+                prev: 1024
+            }
         ));
     }
 

--- a/crates/networking/rpc/eth/simulate.rs
+++ b/crates/networking/rpc/eth/simulate.rs
@@ -364,6 +364,9 @@ fn simulation_error_to_rpc(error: SimulationError) -> RpcErr {
         SimulationError::BlockGasLimitReached { .. } => -38015,
         SimulationError::InvalidTx(validation_error) => validation_error_code(validation_error),
         SimulationError::InvalidParams(_) => -32602,
+        // geth reports invalid movePrecompileToAddress usage as a plain
+        // server error.
+        SimulationError::PrecompileOverride(_) => -32000,
         SimulationError::Internal(_) => -32603,
     };
     RpcErr::EthSimulate {
@@ -954,5 +957,115 @@ mod integration_tests {
             json!("0x000000000000000000000000000000000000beef")
         );
         assert_eq!(block["baseFeePerGas"], json!("0x7"));
+    }
+
+    /// Identity precompile (0x04).
+    const IDENTITY: &str = "0x0000000000000000000000000000000000000004";
+    const MOVE_DEST: &str = "0xc900000000000000000000000000000000000000";
+
+    #[tokio::test]
+    async fn move_precompile_executes_at_destination_only() {
+        // `ethSimulate-move-ecrecover-and-call-old-and-new.io` (adapted to the
+        // identity precompile): after the move, the destination echoes input
+        // and the source behaves like an empty account.
+        let result = simulate(json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {IDENTITY: {"movePrecompileToAddress": MOVE_DEST}},
+                "calls": [
+                    {"from": RICH, "to": MOVE_DEST, "input": "0xdeadbeef"},
+                    {"from": RICH, "to": IDENTITY, "input": "0xdeadbeef"},
+                ],
+            }],
+        }, "latest"]))
+        .await
+        .unwrap();
+        let calls = &result[0]["calls"];
+        assert_eq!(calls[0]["status"], json!("0x1"));
+        assert_eq!(calls[0]["returnData"], json!("0xdeadbeef"));
+        assert_eq!(calls[1]["status"], json!("0x1"));
+        assert_eq!(calls[1]["returnData"], json!("0x"));
+    }
+
+    #[tokio::test]
+    async fn move_is_scoped_to_its_block() {
+        // The move applies to block 1 only; block 2 sees the canonical
+        // precompile layout again.
+        let result = simulate(json!([{
+            "blockStateCalls": [
+                {"stateOverrides": {IDENTITY: {"movePrecompileToAddress": MOVE_DEST}},
+                 "calls": [{"from": RICH, "to": MOVE_DEST, "input": "0x01"}]},
+                {"calls": [
+                    {"from": RICH, "to": MOVE_DEST, "input": "0x02"},
+                    {"from": RICH, "to": IDENTITY, "input": "0x03"},
+                ]},
+            ],
+        }, "latest"]))
+        .await
+        .unwrap();
+        assert_eq!(result[0]["calls"][0]["returnData"], json!("0x01"));
+        // Block 2: destination is a plain account again, source echoes again.
+        assert_eq!(result[1]["calls"][0]["returnData"], json!("0x"));
+        assert_eq!(result[1]["calls"][1]["returnData"], json!("0x03"));
+    }
+
+    #[tokio::test]
+    async fn overriding_code_at_a_precompile_disables_it() {
+        // geth removes precompile behavior for any overridden precompile
+        // address: the deployed bytecode executes instead (PUSH1 1 MSTORE
+        // MSTORE8-free simple return of one word).
+        let result = simulate(json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {IDENTITY: {"code": "0x600160005260206000f3"}},
+                "calls": [{"from": RICH, "to": IDENTITY, "input": "0xdeadbeef"}],
+            }],
+        }, "latest"]))
+        .await
+        .unwrap();
+        let call = &result[0]["calls"][0];
+        assert_eq!(call["status"], json!("0x1"));
+        assert_eq!(
+            call["returnData"],
+            json!("0x0000000000000000000000000000000000000000000000000000000000000001")
+        );
+    }
+
+    #[tokio::test]
+    async fn moving_a_non_precompile_fails() {
+        // `ethSimulate-try-to-move-non-precompile.io`.
+        let err = simulate(json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {FRESH_A: {"movePrecompileToAddress": MOVE_DEST}},
+            }],
+        }, "latest"]))
+        .await
+        .unwrap_err();
+        let metadata = RpcErrorMetadata::from(err);
+        assert_eq!(metadata.code, -32000);
+        assert!(
+            metadata.message.contains("is not a precompile"),
+            "unexpected message: {}",
+            metadata.message
+        );
+    }
+
+    #[tokio::test]
+    async fn moving_to_an_overridden_address_fails() {
+        let err = simulate(json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    IDENTITY: {"movePrecompileToAddress": FRESH_A},
+                    FRESH_A: {"balance": "0x1"},
+                },
+            }],
+        }, "latest"]))
+        .await
+        .unwrap_err();
+        let metadata = RpcErrorMetadata::from(err);
+        assert_eq!(metadata.code, -32000);
+        assert!(
+            metadata.message.contains("is already overridden"),
+            "unexpected message: {}",
+            metadata.message
+        );
     }
 }

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2354,6 +2354,7 @@ impl LEVM {
             disable_nonce_check: false,
             disable_eoa_check: false,
             trace_eth_transfers: false,
+            precompile_overrides: None,
             is_system_call: false,
         };
 
@@ -2380,8 +2381,7 @@ impl LEVM {
     /// Like [`LEVM::execute_tx`] but for `eth_simulateV1`: validation failures
     /// come back as structured [`SimulationTxError::Validation`] (the caller
     /// maps each variant to its spec error code and aborts the request), and
-    /// the simulation relaxations are applied to the environment.
-    #[allow(clippy::too_many_arguments)]
+    /// the simulation relaxations from `config` are applied to the environment.
     pub fn execute_tx_for_simulation(
         tx: &Transaction,
         tx_sender: Address,
@@ -2389,18 +2389,18 @@ impl LEVM {
         db: &mut GeneralizedDatabase,
         vm_type: VMType,
         crypto: &dyn Crypto,
-        validate: bool,
-        trace_eth_transfers: bool,
+        config: &super::SimTxConfig,
     ) -> Result<ExecutionReport, SimulationTxError> {
         let mut env = Self::setup_env(tx, tx_sender, block_header, db, vm_type)?;
         // The sender-is-EOA check is always skipped in eth_simulateV1; nonce
         // enforcement only applies with `validation: true`.
         env.disable_eoa_check = true;
-        env.disable_nonce_check = !validate;
-        env.trace_eth_transfers = trace_eth_transfers;
+        env.disable_nonce_check = !config.validate;
+        env.trace_eth_transfers = config.trace_transfers;
+        env.precompile_overrides = config.precompile_overrides.clone();
         // With `validation: false` blob fees are zeroed unless the call prices
         // them explicitly (mirrors `adjust_disabled_base_fee`'s blob branch).
-        if !validate && tx.max_fee_per_blob_gas().unwrap_or_default().is_zero() {
+        if !config.validate && tx.max_fee_per_blob_gas().unwrap_or_default().is_zero() {
             env.base_blob_fee_per_gas = U256::zero();
             env.block_excess_blob_gas = None;
         }
@@ -3047,6 +3047,7 @@ pub(crate) fn env_from_generic(
         disable_nonce_check: false,
         disable_eoa_check: false,
         trace_eth_transfers: false,
+        precompile_overrides: None,
         is_system_call: false,
     })
 }

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -16,6 +16,7 @@ pub use ethrex_levm::call_frame::CallFrameBackup;
 use ethrex_levm::db::gen_db::GeneralizedDatabase;
 pub use ethrex_levm::db::{CachingDatabase, Database as LevmDatabase};
 use ethrex_levm::errors::{ExecutionReport, TxResult};
+use ethrex_levm::precompiles::PrecompileOverrides;
 use ethrex_levm::vm::VMType;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -31,13 +32,16 @@ pub struct Evm {
 
 /// Per-transaction knobs for `eth_simulateV1` execution
 /// (see [`Evm::execute_tx_simulate`]).
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SimTxConfig {
     /// `validation` payload flag: when false the tx runs with `eth_call`-like
     /// relaxed checks (no nonce enforcement, zeroed unpriced blob fees).
     pub validate: bool,
     /// `traceTransfers` payload flag: emit informational ETH-transfer logs.
     pub trace_transfers: bool,
+    /// Per-block `movePrecompileToAddress` relocations, shared by every tx of
+    /// the simulated block.
+    pub precompile_overrides: Option<Arc<PrecompileOverrides>>,
 }
 
 impl core::fmt::Debug for Evm {
@@ -189,8 +193,7 @@ impl Evm {
             &mut self.db,
             self.vm_type,
             self.crypto.as_ref(),
-            config.validate,
-            config.trace_transfers,
+            config,
         )?;
 
         *cumulative_gas_spent += execution_report.gas_spent;

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -55,6 +55,9 @@ pub struct Environment {
     /// `TRACE_TRANSFER_ADDRESS` sentinel (`eth_simulateV1` traceTransfers).
     /// On Amsterdam+ forks the consensus EIP-7708 logs take precedence.
     pub trace_eth_transfers: bool,
+    /// `eth_simulateV1` movePrecompileToAddress relocations for this block,
+    /// if any (see [`crate::precompiles::PrecompileOverrides`]).
+    pub precompile_overrides: Option<std::sync::Arc<crate::precompiles::PrecompileOverrides>>,
     /// When true, the tx is a pre-execution system contract call (EIP-2935, EIP-4788,
     /// EIP-7002, EIP-7251 etc.). Skips the block-level gas-allowance check since system
     /// calls are allowed to exceed `block_gas_limit` (their 30M cap is a separate rule).

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -18,7 +18,6 @@ use crate::{
     gas_cost,
     memory::{self, calculate_memory_size},
     opcode_handlers::OpcodeHandler,
-    precompiles,
     utils::{address_to_word, create_eth_transfer_log, word_to_address, *},
     vm::VM,
 };
@@ -1152,7 +1151,7 @@ impl<'a> VM<'a> {
             return Ok(OpcodeResult::Continue);
         }
 
-        if precompiles::is_precompile(&code_address, self.env.config.fork, self.vm_type)
+        if let Some(precompile_address) = self.active_precompile_at(&code_address)
             && !is_delegation_7702
         {
             // Record precompile address touch for BAL per EIP-7928
@@ -1162,7 +1161,7 @@ impl<'a> VM<'a> {
 
             let mut gas_remaining = gas_limit;
             let ctx_result = Self::execute_precompile(
-                code_address,
+                precompile_address,
                 &calldata,
                 gas_limit,
                 &mut gas_remaining,

--- a/crates/vm/levm/src/precompiles.rs
+++ b/crates/vm/levm/src/precompiles.rs
@@ -259,6 +259,21 @@ pub fn is_precompile(address: &Address, fork: Fork, vm_type: VMType) -> bool {
         || precompiles_for_fork(fork).any(|precompile| precompile.address == *address)
 }
 
+/// `eth_simulateV1` per-block precompile relocations (`movePrecompileToAddress`).
+///
+/// A moved precompile executes at its destination address, its source address
+/// stops behaving as a precompile — as does any precompile whose account was
+/// touched by other state overrides. Resolved through
+/// [`crate::vm::VM::active_precompile_at`].
+#[derive(Debug, Clone, Default)]
+pub struct PrecompileOverrides {
+    /// Precompile addresses whose behavior was removed for the block (moved
+    /// away or overridden).
+    pub removed: std::collections::BTreeSet<Address>,
+    /// Execution address -> source precompile whose function runs there.
+    pub moved: std::collections::BTreeMap<Address, Address>,
+}
+
 /// Per-block cache for precompile results shared between warmer and executor.
 pub struct PrecompileCache {
     cache: RwLock<FxHashMap<(Address, Bytes), (Bytes, u64)>>,

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1054,11 +1054,9 @@ impl<'a> VM<'a> {
             && self.current_call_frame.gas_remaining >= 0
             && self.tx.authorization_list().is_none()
             // Precompiles dispatch via run_execution even with empty bytecode.
-            && !precompiles::is_precompile(
-                &self.current_call_frame.to,
-                self.env.config.fork,
-                self.vm_type,
-            )
+            && self
+                .active_precompile_at(&self.current_call_frame.to)
+                .is_none()
     }
 
     /// Main execution loop.
@@ -1106,11 +1104,7 @@ impl<'a> VM<'a> {
         }
 
         #[expect(clippy::as_conversions, reason = "remaining gas conversion")]
-        if precompiles::is_precompile(
-            &self.current_call_frame.to,
-            self.env.config.fork,
-            self.vm_type,
-        ) {
+        if let Some(precompile_address) = self.active_precompile_at(&self.current_call_frame.to) {
             // `execute_precompile` itself never touches state gas (it only mutates
             // `gas_remaining`; it has no access to `state_gas_used` / `state_gas_reservoir` /
             // `state_gas_spill`) — the assert below guards that. The EIP-2780 top-frame
@@ -1119,11 +1113,10 @@ impl<'a> VM<'a> {
             // by field rather than via `&mut self.current_call_frame` so the refund call,
             // which needs `&mut self`, can run after `execute_precompile`.
             let state_gas_used_before_precompile = self.state_gas_used;
-            let code_address = self.current_call_frame.code_address;
             let precompile_gas_limit = self.current_call_frame.gas_limit;
             let mut gas_remaining = self.current_call_frame.gas_remaining as u64;
             let result = Self::execute_precompile(
-                code_address,
+                precompile_address,
                 &self.current_call_frame.calldata,
                 precompile_gas_limit,
                 &mut gas_remaining,
@@ -1341,6 +1334,23 @@ impl<'a> VM<'a> {
     /// True if external transaction is a contract creation
     pub fn is_create(&self) -> Result<bool, InternalError> {
         Ok(self.current_call_frame.is_create)
+    }
+
+    /// The precompile that executes at `address`, if any, honoring
+    /// `eth_simulateV1` movePrecompileToAddress overrides: a moved precompile
+    /// executes at its destination address, and its source — like any
+    /// precompile whose account was overridden — stops being one.
+    #[inline]
+    pub fn active_precompile_at(&self, address: &Address) -> Option<Address> {
+        if let Some(overrides) = &self.env.precompile_overrides {
+            if let Some(source) = overrides.moved.get(address) {
+                return Some(*source);
+            }
+            if overrides.removed.contains(address) {
+                return None;
+            }
+        }
+        precompiles::is_precompile(address, self.env.config.fork, self.vm_type).then_some(*address)
     }
 
     /// The address an ETH-transfer log for `value` moving `from` → `to` should

--- a/crates/vm/lib.rs
+++ b/crates/vm/lib.rs
@@ -23,13 +23,18 @@ pub use ethrex_levm::errors::TxValidationError;
 /// Per-tx execution outcome types, re-exported for `eth_simulateV1` call
 /// result classification.
 pub use ethrex_levm::errors::{ExecutionReport, TxResult};
-pub use ethrex_levm::precompiles::{PrecompileCache, precompiles_for_fork};
+pub use ethrex_levm::precompiles::{
+    PrecompileCache, PrecompileOverrides, is_precompile, precompiles_for_fork,
+};
 /// EIP-8037 intrinsic gas split `(regular, state)` for a transaction.
 /// Re-exported for mempool / payload-builder use.
 pub use ethrex_levm::utils::intrinsic_gas_dimensions;
 /// EIP-7623/7976/7981 floor gas for a transaction. Re-exported so the mempool
 /// can match the VM's `validate_min_gas_limit` check at admission time.
 pub use ethrex_levm::utils::intrinsic_gas_floor;
+/// Re-exported so the `eth_simulateV1` engine can pass the VM flavor to
+/// `is_precompile` when validating movePrecompileToAddress overrides.
+pub use ethrex_levm::vm::VMType;
 pub use execution_result::ExecutionResult;
 pub use witness_db::GuestProgramStateWrapper;
 pub mod system_contracts;

--- a/docs/roadmaps/forks-roadmap.md
+++ b/docs/roadmaps/forks-roadmap.md
@@ -126,8 +126,7 @@ overrides, `validation`, `traceTransfers` and `returnFullTransactions`, spec
 error codes (-38010..-38026). Engine in `crates/blockchain/simulate.rs`,
 handler in `crates/networking/rpc/eth/simulate.rs`. Known gaps, documented in
 the engine: Amsterdam EIP-8037 2D gas / EIP-7928 BAL headers are not modeled,
-`maxUsedGas` reports pre-refund gas rather than geth's in-flight peak, and
-`movePrecompileToAddress` is parsed but not yet enforced. The hive
+`maxUsedGas` reports pre-refund gas rather than geth's in-flight peak. The hive
 `rpc-compat` pin predates the `eth_simulateV1` test corpus, so CI does not
 exercise it yet; conformance is covered by ported `.io` scenarios in the RPC
 crate's tests.


### PR DESCRIPTION
**Motivation**

The State Override Set (#6660) parses `movePrecompileToAddress` but nothing consumes it, and `eth_simulateV1` (#6951) documented it as a known gap. This closes the gap; stacked on #6951.

**Description**

- LEVM gains `PrecompileOverrides` (per-block removed set + moved destination→source map) on the `Environment`, resolved through `VM::active_precompile_at` at the three precompile decision points (simple-transfer fast path, top-level dispatch, `generic_call`): a moved precompile executes at its destination address while its source — like any precompile whose account is touched by state overrides — stops behaving as one. Consensus execution is unchanged: without overrides the helper falls through to the static per-fork check.
- The simulate engine validates each block's overrides exactly like geth's `StateOverride.Apply` (address order): moving a non-precompile, moving to an overridden address, or overriding a move destination abort the request with code `-32000` and geth's message shapes; a second move to the same destination silently wins, matching current geth (the historical -38022/-38023 codes are gone from the reference corpus). Moves are scoped to their block.
- Move-only overrides no longer materialize account state (that would have created empty accounts in the simulated state roots).

Known divergence (accepted): the pre-warmed address set stays the canonical per-fork precompile list, so access-warmth of moved precompiles can differ from geth in gas-exact scenarios; revisit with the hive pin bump.

**How to Test**

```
cargo test -p ethrex-rpc --lib simulate
```

New integration tests move/override the identity precompile: the destination echoes input while the source becomes a plain account, per-block scoping restores the canonical layout in the next block, code overrides at a precompile address execute the bytecode, and both error paths return -32000 with the expected messages.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A, no Store schema changes.