### PR TITLE
fix(l1): relax the nonce check for eth_call-family simulation RPCs

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -642,3 +642,78 @@ fn get_transaction_data(rpc_req_params: &Option<Vec<Value>>) -> Result<Vec<u8>, 
         .ok_or(RpcErr::BadParams("Params are note 0x prefixed".to_owned()))?;
     hex::decode(str_data).map_err(|error| RpcErr::BadParams(error.to_string()))
 }
+
+#[cfg(test)]
+mod call_nonce_tests {
+    use std::str::FromStr;
+
+    use crate::rpc::map_http_requests;
+    use crate::test_utils::default_context_with_storage;
+    use crate::utils::RpcRequest;
+    use ethrex_common::Address;
+    use ethrex_common::types::Genesis;
+    use ethrex_storage::{EngineType, Store};
+    use serde_json::{Value, json};
+
+    /// Funded EOA from fixtures/genesis/l1.json.
+    const SENDER: &str = "0x00000a8d3f37af8def18832962ee008d8dca4f7b";
+
+    /// In-memory store from the l1 test genesis with `SENDER`'s account nonce
+    /// bumped, so call objects can be exercised against a sender whose
+    /// on-chain nonce is nonzero.
+    async fn setup_store_with_sender_nonce(nonce: u64) -> Store {
+        let genesis: &str = include_str!("../../../../fixtures/genesis/l1.json");
+        let mut genesis: Genesis =
+            serde_json::from_str(genesis).expect("Fatal: test config is invalid");
+        genesis
+            .alloc
+            .get_mut(&Address::from_str(SENDER).unwrap())
+            .expect("test sender missing from genesis")
+            .nonce = nonce;
+        let mut store =
+            Store::new("test-store", EngineType::InMemory).expect("Fail to create in-memory db");
+        store.add_initial_state(genesis).await.unwrap();
+        store
+    }
+
+    async fn run_eth_call(call_object: Value) -> Value {
+        let storage = setup_store_with_sender_nonce(5).await;
+        let context = default_context_with_storage(storage).await;
+        let request: RpcRequest = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_call",
+            "params": [call_object, "latest"],
+        }))
+        .unwrap();
+        map_http_requests(&request, context).await.unwrap()
+    }
+
+    /// A call object without `nonce` must not be rejected for senders whose
+    /// account nonce is nonzero: the env defaults the tx nonce to 0, which the
+    /// hook used to enforce against the state nonce.
+    #[tokio::test]
+    async fn eth_call_ignores_missing_nonce() {
+        let result = run_eth_call(json!({
+            "from": SENDER,
+            "to": "0xc100000000000000000000000000000000000000",
+            "value": "0x1",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x".to_string()));
+    }
+
+    /// An explicit stale nonce is ignored too: no client validates the sender
+    /// nonce on eth_call, even when the call object supplies one.
+    #[tokio::test]
+    async fn eth_call_ignores_explicit_stale_nonce() {
+        let result = run_eth_call(json!({
+            "from": SENDER,
+            "to": "0xc100000000000000000000000000000000000000",
+            "value": "0x1",
+            "nonce": "0x0",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x".to_string()));
+    }
+}

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2942,6 +2942,7 @@ impl LEVM {
             is_privileged: matches!(tx, Transaction::PrivilegedL2Transaction(_)),
             fee_token: tx.fee_token(),
             disable_balance_check: false,
+            disable_nonce_check: false,
             is_system_call: false,
         };
 
@@ -3805,6 +3806,12 @@ fn env_from_generic(
         is_privileged: false,
         fee_token: tx.fee_token,
         disable_balance_check: false,
+        // Every `env_from_generic` caller is a simulation RPC (eth_call,
+        // eth_estimateGas, eth_createAccessList). Those run relaxed messages
+        // with no nonce enforcement: a call object without `nonce` defaults
+        // `tx_nonce` to 0 above, which the hook would otherwise reject for
+        // any sender whose nonce is nonzero.
+        disable_nonce_check: true,
         is_system_call: false,
     })
 }

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -44,6 +44,11 @@ pub struct Environment {
     /// When true, skip balance deduction in `deduct_caller`. Used by the prewarmer
     /// to avoid early reverts on insufficient balance so that warming touches more storage.
     pub disable_balance_check: bool,
+    /// When true, skip the sender nonce-mismatch validation. Used by the simulation
+    /// RPCs (eth_call, eth_estimateGas, eth_createAccessList): call objects may omit
+    /// the nonce, and no client enforces it there. The account nonce still increments
+    /// during execution.
+    pub disable_nonce_check: bool,
     /// When true, the tx is a pre-execution system contract call (EIP-2935, EIP-4788,
     /// EIP-7002, EIP-7251 etc.). Skips the block-level gas-allowance check since system
     /// calls are allowed to exceed `block_gas_limit` (their 30M cap is a separate rule).

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -112,7 +112,7 @@ impl Hook for DefaultHook {
             .map_err(|_| TxValidationError::NonceIsMax)?;
 
         // check for nonce mismatch
-        if sender_info.nonce != vm.env.tx_nonce {
+        if !vm.env.disable_nonce_check && sender_info.nonce != vm.env.tx_nonce {
             return Err(TxValidationError::NonceMismatch {
                 expected: sender_info.nonce,
                 actual: vm.env.tx_nonce,

--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -641,7 +641,7 @@ fn prepare_execution_fee_token(vm: &mut VM<'_>) -> Result<U256, crate::errors::V
         .map_err(|_| TxValidationError::NonceIsMax)?;
 
     // check for nonce mismatch
-    if sender_info.nonce != vm.env.tx_nonce {
+    if !vm.env.disable_nonce_check && sender_info.nonce != vm.env.tx_nonce {
         return Err(TxValidationError::NonceMismatch {
             expected: sender_info.nonce,
             actual: vm.env.tx_nonce,

--- a/test/tests/levm/bal_selfdestruct_reads_tests.rs
+++ b/test/tests/levm/bal_selfdestruct_reads_tests.rs
@@ -161,6 +161,7 @@ fn selfdestruct_does_not_record_warm_unread_slots_as_bal_reads() {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/destroyed_refault_tests.rs
+++ b/test/tests/levm/destroyed_refault_tests.rs
@@ -103,6 +103,7 @@ fn env(fork: Fork) -> Environment {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: true,
+        disable_nonce_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip2780_tests.rs
+++ b/test/tests/levm/eip2780_tests.rs
@@ -123,6 +123,7 @@ fn intrinsic_env(fork: Fork) -> Environment {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: true,
+        disable_nonce_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip7708_tests.rs
+++ b/test/tests/levm/eip7708_tests.rs
@@ -202,6 +202,7 @@ impl TestBuilder {
             is_privileged: false,
             fee_token: None,
             disable_balance_check: false,
+            disable_nonce_check: false,
             is_system_call: false,
         };
 

--- a/test/tests/levm/eip8037_tests.rs
+++ b/test/tests/levm/eip8037_tests.rs
@@ -102,6 +102,7 @@ fn parity_env(fork: Fork, block_gas_limit: u64) -> Environment {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: true,
+        disable_nonce_check: false,
         is_system_call: false,
     }
 }
@@ -325,6 +326,7 @@ fn exec_env(fork: Fork) -> Environment {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: true,
+        disable_nonce_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip8038_tests.rs
+++ b/test/tests/levm/eip8038_tests.rs
@@ -278,6 +278,7 @@ fn sstore_env(fork: Fork) -> Environment {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: true,
+        disable_nonce_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip8246_tests.rs
+++ b/test/tests/levm/eip8246_tests.rs
@@ -224,6 +224,7 @@ fn execute_call(
         is_privileged: false,
         fee_token: None,
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/l2_fee_token_tests.rs
+++ b/test/tests/levm/l2_fee_token_tests.rs
@@ -185,6 +185,7 @@ fn fee_token_lock_reverted_on_validation_failure() {
         is_privileged: false,
         fee_token: Some(fee_token),
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/l2_gas_reservation_tests.rs
+++ b/test/tests/levm/l2_gas_reservation_tests.rs
@@ -156,6 +156,7 @@ fn make_env(gas_limit: u64) -> Environment {
         is_privileged: false,
         fee_token: None,
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/l2_hook_tests.rs
+++ b/test/tests/levm/l2_hook_tests.rs
@@ -238,6 +238,7 @@ fn fee_token_storage_rolled_back_on_validation_failure() {
         is_privileged: false,
         fee_token: Some(fee_token_addr),
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     };
 
@@ -445,6 +446,7 @@ fn fee_token_revert_during_finalize_triggers_rollback() {
         is_privileged: false,
         fee_token: Some(fee_token_addr),
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     };
 
@@ -553,6 +555,7 @@ fn privileged_tx_intrinsic_gas_failure_preserves_sender_balance() {
         is_privileged: true,
         fee_token: None,
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     };
 

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -329,6 +329,7 @@ pub fn prepare_vm_for_tx<'a>(
             is_privileged: false,
             fee_token: None,
             disable_balance_check: false,
+            disable_nonce_check: false,
             is_system_call: false,
         },
         db,

--- a/tooling/ef_tests/state_v2/src/modules/runner.rs
+++ b/tooling/ef_tests/state_v2/src/modules/runner.rs
@@ -222,6 +222,7 @@ pub fn get_vm_env_for_test(
         is_privileged: false,
         fee_token: None,
         disable_balance_check: false,
+        disable_nonce_check: false,
         is_system_call: false,
     })
 }


### PR DESCRIPTION
**Motivation**

`eth_call` with only `from` set fails with a nonce mismatch (code `-32015`) for any sender whose account nonce is nonzero: `env_from_generic` defaults the tx nonce to 0 when the call object carries none, and the pre-execution hooks enforce it against the state nonce unconditionally. No other client validates the sender nonce on these RPCs — geth and erigon skip the check unconditionally, while reth and nethermind overwrite the message nonce with the account's state nonce — and the execution-apis spec characterizes non-validating simulation ("behaves like `eth_call`") as nonce-unchecked. This breaks SDK dry-run flows that issue `eth_call` without a nonce before sending. `eth_createAccessList` shared the bug; `eth_estimateGas` only avoided it by pre-filling the nonce from storage.

**Description**

- Introduces `Environment::disable_nonce_check` and guards the nonce-mismatch validation in both the default hook and the L2 fee-token hook.
- `env_from_generic` — used exclusively by the simulation RPCs (`eth_call`, `eth_estimateGas`, `eth_createAccessList`) — now sets the flag. An explicit stale nonce in the call object is accepted too, matching all other clients.
- Consensus and mempool paths are unchanged: block execution (`setup_env`) and the EF-test runners keep the flag off, and `eth_sendRawTransaction` admission validates through a separate path.
- The account nonce still increments from the state nonce during simulated execution, so CREATE address derivation is unaffected.

Previously stacked on #6951 (which introduced the flag for `eth_simulateV1`); reworked to be standalone on `main` so it can land independently. #6951 drops its own copy of the flag on rebase.

**How to Test**

```
cargo test -p ethrex-rpc --lib call_nonce_tests
```

Two regression tests drive `eth_call` through the HTTP dispatch against a genesis where the sender's account nonce is 5: one with no nonce in the call object, one with an explicit stale nonce (`0x0`). Both fail with the old behavior.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A, no Store schema changes.
