### PR TITLE
fix(l1): reject non-canonical single-byte RLP in u8 decoding

### DIFF
--- a/crates/common/rlp/decode.rs
+++ b/crates/common/rlp/decode.rs
@@ -72,6 +72,11 @@ impl RLPDecode for u8 {
 
             // Two bytes, where the first byte is RLP_NULL + 1
             x if rlp.len() >= 2 && *x == RLP_NULL + 1 => {
+                // Canonical RLP: a single byte in 0x00..=0x7f is its own
+                // encoding, so it must never be wrapped in a 1-byte string.
+                if rlp[1] < RLP_NULL {
+                    return Err(RLPDecodeError::MalformedData);
+                }
                 let rest = rlp.get(2..).ok_or(RLPDecodeError::MalformedData)?;
                 Ok((rlp[1], rest))
             }
@@ -559,4 +564,36 @@ pub fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N], RLPDecode
         .ok_or(RLPDecodeError::InvalidLength)?
         .copy_from_slice(data);
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn u8_rejects_non_canonical_wrapped_single_byte() {
+        // Canonical RLP: a single byte in 0x00..=0x7f is its own encoding, so
+        // wrapping it in a 1-byte string (0x81 prefix) is non-canonical and
+        // must be rejected, exactly like the other uint decoders do.
+        assert_eq!(
+            u8::decode(&[0x81, 0x01]),
+            Err(RLPDecodeError::MalformedData)
+        );
+        assert_eq!(
+            u8::decode(&[0x81, 0x7f]),
+            Err(RLPDecodeError::MalformedData)
+        );
+        // Canonical zero is the empty string (0x80), not a wrapped 0x00.
+        assert_eq!(
+            u8::decode(&[0x81, 0x00]),
+            Err(RLPDecodeError::MalformedData)
+        );
+
+        // Canonical encodings still decode.
+        assert_eq!(u8::decode(&[0x05]), Ok(5));
+        assert_eq!(u8::decode(&[0x7f]), Ok(0x7f));
+        assert_eq!(u8::decode(&[0x80]), Ok(0));
+        assert_eq!(u8::decode(&[0x81, 0x80]), Ok(0x80));
+        assert_eq!(u8::decode(&[0x81, 0xff]), Ok(0xff));
+    }
 }


### PR DESCRIPTION
Generated by claude: I was experimenting with FV and it spotted this.

**Motivation**

Canonical RLP requires a single byte in 0x00..=0x7f to be its own encoding; wrapping it in a 1-byte string is non-canonical. #6818 made decode_rlp_item reject this, but the hand-rolled u8 fast path skips those checks, so u8::decode accepted [0x81, 0x01] -> 1 and [0x81, 0x00] -> 0 while u16/u32/u64 reject the same bytes.

**Description**

Reject a wrapped second byte below 0x80 in the u8 two-byte arm, matching the canonicality rules the general decode path already enforces, and add a regression test.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

