### PR TITLE
docs(l1): resolve leftover merge-conflict markers in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,13 @@
 
 ## Perf
 
-<<<<<<< perf/shard-storage-merkleization
-### 2026-06-19
-
-- Parallelize single-account storage-trie merkleization: shard a hot account's (>=2048 slot updates) storage-root computation across 16 nibble-keyed workers, so one bloated contract no longer serializes its trie inserts on a single thread [#6845](https://github.com/lambdaclass/ethrex/pull/6845)
-=======
 ### 2026-06-29
 
 - Thread `Arc<BlockAccessList>` through the block pipeline to avoid an O(BAL-size) deep clone of the Block Access List (and its validation index) per block on the parallel execution path [#6829](https://github.com/lambdaclass/ethrex/pull/6829)
->>>>>>> main
+
+### 2026-06-19
+
+- Parallelize single-account storage-trie merkleization: shard a hot account's (>=2048 slot updates) storage-root computation across 16 nibble-keyed workers, so one bloated contract no longer serializes its trie inserts on a single thread [#6845](https://github.com/lambdaclass/ethrex/pull/6845)
 
 ### 2026-06-18
 


### PR DESCRIPTION
**Motivation**

`CHANGELOG.md` on `main` contains committed, unresolved merge-conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in the `## Perf` section, left over from a merge of `perf/shard-storage-merkleization`. Because they're committed on `main`, every branch that merges `main` inherits them, and each PR author has to strip them by hand during their own merge (seen recently across several mempool PRs).

**Description**

Removes the three conflict markers and keeps both perf entries — #6829 (2026-06-29) and #6845 (2026-06-19) — in reverse-chronological order, consistent with the rest of the section. Content-only; no code changes.

**Checklist**

- [x] Verified no conflict markers remain in `CHANGELOG.md`.
