### PR TITLE
fix(l1): reject legacy transactions with out-of-range v

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -1182,9 +1182,21 @@ impl Transaction {
         let (buf, sig) = match self {
             Transaction::LegacyTransaction(tx) => {
                 let v = u64::try_from(tx.v).map_err(|_| CryptoError::InvalidSignature)?;
+                // EIP-155: valid legacy `v` is 27/28 (pre-155) or
+                // {35,36} + chain_id * 2. Any other value is a malformed
+                // signature and must be rejected rather than coerced into a
+                // parity bit (which would recover a bogus sender).
                 let signature_y_parity = match self.chain_id() {
-                    Some(chain_id) => v.saturating_sub(35 + chain_id * 2) != 0,
-                    None => v.saturating_sub(27) != 0,
+                    Some(chain_id) => match v.checked_sub(35 + chain_id * 2) {
+                        Some(0) => false,
+                        Some(1) => true,
+                        _ => return Err(CryptoError::InvalidSignature),
+                    },
+                    None => match v {
+                        27 => false,
+                        28 => true,
+                        _ => return Err(CryptoError::InvalidSignature),
+                    },
                 };
                 let mut buf = vec![];
                 match self.chain_id() {

--- a/test/tests/common/legacy_signature_tests.rs
+++ b/test/tests/common/legacy_signature_tests.rs
@@ -1,0 +1,56 @@
+//! Regression tests for legacy transaction `v` validation.
+//!
+//! EIP-155: a legacy signature's `v` must be 27/28 (pre-155) or
+//! `{35,36} + chain_id * 2`. Any other value is malformed. ethrex used to
+//! coerce an out-of-range `v` into a parity bit via `saturating_sub`, which
+//! recovered a bogus sender (then failing later with an unrelated error such
+//! as "insufficient account funds") instead of rejecting the signature.
+use ethrex_common::U256;
+use ethrex_common::types::{LegacyTransaction, Transaction};
+use ethrex_crypto::{CryptoError, NativeCrypto};
+use hex_literal::hex;
+
+/// A real pre-EIP-155 legacy signature (v = 27). Only `v` is varied per case.
+fn tx_with_v(v: u64) -> Transaction {
+    Transaction::LegacyTransaction(LegacyTransaction {
+        nonce: 0,
+        gas_price: U256::from(0x0au64),
+        gas: 0x05f5e100,
+        value: 0.into(),
+        v: U256::from(v),
+        r: U256::from_big_endian(&hex!(
+            "7e09e26678ed4fac08a249ebe8ed680bf9051a5e14ad223e4b2b9d26e0208f37"
+        )),
+        s: U256::from_big_endian(&hex!(
+            "5f6e3f188e3e6eab7d7d3b6568f5eac7d687b08d307d3154ccd8c87b4630509b"
+        )),
+        ..Default::default()
+    })
+}
+
+#[test]
+fn valid_legacy_v_recovers_a_sender() {
+    // 27/28 (pre-155) and {35,36}+chain_id*2 (EIP-155) are all well-formed and
+    // must recover successfully.
+    for v in [27u64, 28, 35, 36, 37, 38] {
+        assert!(
+            tx_with_v(v).sender(&NativeCrypto).is_ok(),
+            "v={v} is a valid legacy signature and should recover a sender",
+        );
+    }
+}
+
+#[test]
+fn out_of_range_legacy_v_is_rejected() {
+    // Everything below 35 that isn't 27/28 is a malformed pre-155 `v` and must
+    // be rejected as an invalid signature, not coerced into a parity bit.
+    for v in [0u64, 1, 26, 29, 30, 34] {
+        assert!(
+            matches!(
+                tx_with_v(v).sender(&NativeCrypto),
+                Err(CryptoError::InvalidSignature)
+            ),
+            "v={v} is not a valid legacy signature and must be rejected",
+        );
+    }
+}

--- a/test/tests/common/mod.rs
+++ b/test/tests/common/mod.rs
@@ -4,6 +4,7 @@ mod blobs_bundle_tests;
 mod code_serde_tests;
 mod eip7702_authorization_tests;
 mod frame_tx_validation_tests;
+mod legacy_signature_tests;
 mod logs_bloom_validation_tests;
 mod requests_eip8282_tests;
 mod rkyv_utils_tests;


### PR DESCRIPTION
**Motivation**

A legacy transaction's `v` must be `27`/`28` (pre-155) or `{35,36} + chain_id * 2` (EIP-155). `compute_sender` derived the parity bit with `v.saturating_sub(..) != 0`, which silently coerces any out-of-range `v` into a `0`/`1` parity. For e.g. `v = 34` it recovered a valid-but-wrong sender, which then failed downstream with an unrelated error (`Insufficient account funds`) instead of being rejected as a bad signature.

This surfaced on the glamsterdam-devnet-6 engine fixtures: `test_bad_v_r_s[...tx_type_0...v_34-r_1-s_1]` expects `TransactionException.INVALID_SIGNATURE_VRS` but ethrex reported insufficient funds.

**Description**

Replace the lenient `saturating_sub` parity derivation with an explicit match that rejects any `v` outside the two valid encodings, returning `CryptoError::InvalidSignature`. The EIP-155 branch is unchanged in behavior (for `v >= 35`, `(v - 35) mod 2` is always `0`/`1`); the fix matters for the pre-155 branch where anything other than `27`/`28` was previously accepted.

Adds integration tests covering valid (`27, 28, 35, 36, 37, 38`) and invalid (`0, 1, 26, 29, 30, 34`) `v` values.