### PR TITLE
chore(l1,l2): bump version to 20.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-benches"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "criterion 0.5.1",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors)",
  "bytes",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum 0.8.9",
  "ethrex-common",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-monitor"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4207,7 +4207,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-repl"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "clap",
  "colored 2.2.0",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "criterion 0.7.0",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-test"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = "2"
 default-members = ["cmd/ethrex"]
 
 [workspace.package]
-version = "19.0.0"
+version = "20.0.0"
 edition = "2024"
 authors = ["LambdaClass"]
 documentation = "https://docs.ethrex.xyz"
@@ -68,27 +68,27 @@ debug = "line-tables-only"
 incremental = true
 
 [workspace.dependencies]
-ethrex-blockchain = { path = "./crates/blockchain", version = "19.0.0", default-features = false }
-ethrex-common = { path = "./crates/common", version = "19.0.0", default-features = false }
+ethrex-blockchain = { path = "./crates/blockchain", version = "20.0.0", default-features = false }
+ethrex-common = { path = "./crates/common", version = "20.0.0", default-features = false }
 ethrex-config = { path = "./crates/common/config" }
-ethrex-p2p = { path = "./crates/networking/p2p", version = "19.0.0" }
-ethrex-rpc = { path = "./crates/networking/rpc", version = "19.0.0" }
-ethrex-storage = { path = "./crates/storage", version = "19.0.0" }
-ethrex-vm = { path = "./crates/vm", version = "19.0.0", default-features = false }
-ethrex-levm = { path = "./crates/vm/levm", version = "19.0.0" }
-ethrex-trie = { path = "./crates/common/trie", version = "19.0.0" }
-ethrex-rlp = { path = "./crates/common/rlp", version = "19.0.0" }
-ethrex-crypto = { path = "./crates/common/crypto", version = "19.0.0", default-features = false }
-ethrex-metrics = { path = "./crates/blockchain/metrics", version = "19.0.0" }
+ethrex-p2p = { path = "./crates/networking/p2p", version = "20.0.0" }
+ethrex-rpc = { path = "./crates/networking/rpc", version = "20.0.0" }
+ethrex-storage = { path = "./crates/storage", version = "20.0.0" }
+ethrex-vm = { path = "./crates/vm", version = "20.0.0", default-features = false }
+ethrex-levm = { path = "./crates/vm/levm", version = "20.0.0" }
+ethrex-trie = { path = "./crates/common/trie", version = "20.0.0" }
+ethrex-rlp = { path = "./crates/common/rlp", version = "20.0.0" }
+ethrex-crypto = { path = "./crates/common/crypto", version = "20.0.0", default-features = false }
+ethrex-metrics = { path = "./crates/blockchain/metrics", version = "20.0.0" }
 ethrex-l2 = { path = "./crates/l2" }
-ethrex-l2-common = { path = "./crates/l2/common", version = "19.0.0" }
-ethrex-sdk = { path = "./crates/l2/sdk", version = "19.0.0" }
+ethrex-l2-common = { path = "./crates/l2/common", version = "20.0.0" }
+ethrex-sdk = { path = "./crates/l2/sdk", version = "20.0.0" }
 ethrex-l2-prover = { path = "./crates/l2/prover" }
 ethrex-prover = { path = "./crates/prover" }
 ethrex-guest-program = { path = "./crates/guest-program", default-features = false }
-ethrex-storage-rollup = { path = "./crates/l2/storage", version = "19.0.0" }
+ethrex-storage-rollup = { path = "./crates/l2/storage", version = "20.0.0" }
 ethrex = { path = "./cmd/ethrex" }
-ethrex-l2-rpc = { path = "./crates/l2/networking/rpc", version = "19.0.0" }
+ethrex-l2-rpc = { path = "./crates/l2/networking/rpc", version = "20.0.0" }
 ethrex-monitor = { path = "./tooling/monitor" }
 ethrex-repl = { path = "./tooling/repl" }
 

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -17,7 +17,7 @@ ethrex-crypto.workspace = true
 ethrex-storage.workspace = true
 ethrex-trie.workspace = true
 ethrex-vm.workspace = true
-ethrex-metrics = { path = "./metrics", version = "19.0.0", default-features = false }
+ethrex-metrics = { path = "./metrics", version = "20.0.0", default-features = false }
 
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }

--- a/crates/guest-program/bin/openvm/Cargo.lock
+++ b/crates/guest-program/bin/openvm/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-openvm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors)",
  "bytes",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/openvm/Cargo.toml
+++ b/crates/guest-program/bin/openvm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "19.0.0"
+version = "20.0.0"
 name = "ethrex-guest-openvm"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/guest-program/bin/risc0/Cargo.lock
+++ b/crates/guest-program/bin/risc0/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bls12_381",
  "bytes",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-risc0"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "c-kzg",
  "ethrex-common",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/crates/guest-program/bin/risc0/Cargo.toml
+++ b/crates/guest-program/bin/risc0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-risc0"
-version = "19.0.0"
+version = "20.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/sp1/Cargo.lock
+++ b/crates/guest-program/bin/sp1/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bls12_381",
  "bytes",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-sp1"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ethrex-guest-program",
  "ethrex-vm",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/sp1/Cargo.toml
+++ b/crates/guest-program/bin/sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-sp1"
-version = "19.0.0"
+version = "20.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/zisk/Cargo.lock
+++ b/crates/guest-program/bin/zisk/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-zisk"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/zisk/Cargo.toml
+++ b/crates/guest-program/bin/zisk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "19.0.0"
+version = "20.0.0"
 name = "ethrex-guest-zisk"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/l2/sdk/Cargo.toml
+++ b/crates/l2/sdk/Cargo.toml
@@ -13,7 +13,7 @@ ethrex-common.workspace = true
 ethrex-rpc.workspace = true
 ethrex-l2-common.workspace = true
 ethrex-l2-rpc.workspace = true
-ethrex-sdk-contract-utils = { path = "contract_utils", version = "19.0.0" }
+ethrex-sdk-contract-utils = { path = "contract_utils", version = "20.0.0" }
 
 ethereum-types.workspace = true
 tokio.workspace = true
@@ -34,7 +34,7 @@ name = "ethrex_l2_sdk"
 path = "src/sdk.rs"
 
 [build-dependencies]
-ethrex-sdk-contract-utils = { path = "contract_utils", version = "19.0.0" }
+ethrex-sdk-contract-utils = { path = "contract_utils", version = "20.0.0" }
 hex.workspace = true
 
 [lints.clippy]

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "quote-gen"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "configfs-tsm",
  "ethrex-blockchain",

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote-gen"
-version = "19.0.0"
+version = "20.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [dependencies]
 ethrex-common = { workspace = true, default-features = false }
 ethrex-crypto.workspace = true
-ethrex-levm = { path = "./levm", version = "19.0.0", default-features = false }
+ethrex-levm = { path = "./levm", version = "20.0.0", default-features = false }
 ethrex-rlp.workspace = true
 
 derive_more = { version = "1.0.0", features = ["full"] }

--- a/crates/vm/levm/bench/revm_comparison/Cargo.lock
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.lock
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -253,7 +253,7 @@ Block building options:
           Block extra data message.
           
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 19.0.0"]
+          [default: "ethrex 20.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
@@ -463,7 +463,7 @@ Block building options:
           Block extra data message.
 
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 19.0.0"]
+          [default: "ethrex 20.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -836,11 +836,11 @@ dependencies = [
  "clap 4.6.0",
  "clap_complete",
  "ethrex",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "eyre",
  "hex",
  "lazy_static",
@@ -2914,12 +2914,12 @@ dependencies = [
  "bytes",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-prover",
- "ethrex-rlp 19.0.0",
- "ethrex-storage 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-vm",
  "hex",
  "lazy_static",
@@ -2939,12 +2939,12 @@ dependencies = [
  "ctor",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-p2p",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "hex",
  "rayon",
  "regex",
@@ -2964,11 +2964,11 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 19.0.0",
- "ethrex-storage 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-vm",
  "hex",
  "itertools 0.13.0",
@@ -2993,12 +2993,12 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-l2-rpc",
  "ethrex-levm",
- "ethrex-rlp 19.0.0",
- "ethrex-storage 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-vm",
  "hex",
  "prettytable-rs",
@@ -3230,14 +3230,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "clap 4.6.0",
  "directories",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-config",
  "ethrex-crypto",
  "ethrex-dev",
@@ -3248,10 +3248,10 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-p2p",
  "ethrex-repl",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-storage-rollup",
  "ethrex-vm",
  "eyre",
@@ -3281,16 +3281,16 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
- "ethrex-rlp 19.0.0",
- "ethrex-storage 19.0.0",
- "ethrex-trie 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-storage 20.0.0",
+ "ethrex-trie 20.0.0",
  "ethrex-vm",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3329,14 +3329,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 19.0.0",
- "ethrex-trie 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-trie 20.0.0",
  "hex",
  "hex-literal",
  "hex-simd",
@@ -3362,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-p2p",
  "hex",
  "serde",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "envy",
@@ -3416,15 +3416,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bls12_381 0.8.0",
  "bytes",
  "ethereum-types",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-vm",
  "ff 0.13.1",
  "hex",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3457,7 +3457,7 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
@@ -3465,12 +3465,12 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-monitor",
  "ethrex-p2p",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 19.0.0",
+ "ethrex-trie 20.0.0",
  "ethrex-vm",
  "futures",
  "hex",
@@ -3495,11 +3495,11 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambdaworks-crypto 0.13.0",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3521,14 +3521,14 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-guest-program",
  "ethrex-l2",
  "ethrex-l2-common",
  "ethrex-prover",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-sdk",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-vm",
  "hex",
  "rkyv",
@@ -3544,19 +3544,19 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum 0.8.8",
  "bytes",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-p2p",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-storage-rollup",
  "hex",
  "reqwest 0.12.28",
@@ -3574,13 +3574,13 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "malachite",
  "rayon",
  "rustc-hash 2.1.2",
@@ -3591,10 +3591,10 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum 0.8.8",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -3611,13 +3611,13 @@ dependencies = [
  "bytes",
  "chrono",
  "crossterm 0.29.0",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-config",
  "ethrex-l2-common",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-storage-rollup",
  "futures",
  "hex",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3645,14 +3645,14 @@ dependencies = [
  "ctr",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-metrics",
- "ethrex-rlp 19.0.0",
- "ethrex-storage 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-storage 20.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 19.0.0",
+ "ethrex-trie 20.0.0",
  "futures",
  "hex",
  "hkdf",
@@ -3680,14 +3680,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bincode",
  "bytes",
  "clap 4.6.0",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-guest-program",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-vm",
  "rkyv",
  "serde",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -3752,13 +3752,13 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
  "ethrex-p2p",
- "ethrex-rlp 19.0.0",
- "ethrex-storage 19.0.0",
- "ethrex-trie 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-storage 20.0.0",
+ "ethrex-trie 20.0.0",
  "ethrex-vm",
  "hex",
  "hex-literal",
@@ -3783,14 +3783,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "ethrex-rpc",
  "ethrex-sdk-contract-utils",
  "hex",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -3838,14 +3838,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
- "ethrex-rlp 19.0.0",
- "ethrex-trie 19.0.0",
+ "ethrex-rlp 20.0.0",
+ "ethrex-trie 20.0.0",
  "fastbloom",
  "lru 0.16.3",
  "rayon",
@@ -3860,12 +3860,12 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "async-trait",
  "bincode",
  "ethereum-types",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-l2-common",
  "futures",
  "rkyv",
@@ -3896,14 +3896,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "lazy_static",
  "rayon",
  "rkyv",
@@ -3914,15 +3914,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "19.0.0"
+version = "20.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "dyn-clone",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 19.0.0",
+ "ethrex-rlp 20.0.0",
  "rayon",
  "rustc-hash 2.1.2",
  "serde",
@@ -5607,7 +5607,7 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
  "ethrex-rpc",
@@ -5811,9 +5811,9 @@ dependencies = [
  "clap 4.6.0",
  "ethrex-blockchain",
  "ethrex-common 1.0.0",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-storage 1.0.0",
- "ethrex-storage 19.0.0",
+ "ethrex-storage 20.0.0",
  "libc",
  "rocksdb",
  "tokio",
@@ -7656,7 +7656,7 @@ version = "4.0.0"
 dependencies = [
  "ethrex",
  "ethrex-blockchain",
- "ethrex-common 19.0.0",
+ "ethrex-common 20.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",


### PR DESCRIPTION
**Motivation**

Prepare the 20.0.0 release by bumping the workspace version to 20.0.0 and merging the release branch back to main.

**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.


