### PR TITLE
ci(l1): retry snapsync local docker build on transient failures

### DIFF
--- a/.github/actions/snapsync-run/action.yml
+++ b/.github/actions/snapsync-run/action.yml
@@ -53,13 +53,26 @@ runs:
         GIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo unknown)
         GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
         VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
-        docker build \
-          --build-arg PROFILE="${BUILD_PROFILE}" \
-          --build-arg GIT_SHA="${GIT_SHA}" \
-          --build-arg GIT_BRANCH="${GIT_BRANCH}" \
-          --build-arg VERSION="${VERSION}" \
-          -t ethrex-local:${IMAGE_TAG} \
-          -f Dockerfile .
+        # Retry to ride out transient Docker Hub / DNS flakes on the self-hosted
+        # runner (e.g. fetching the docker/dockerfile BuildKit frontend or base images).
+        attempts=3
+        for i in $(seq 1 "$attempts"); do
+          if docker build \
+            --build-arg PROFILE="${BUILD_PROFILE}" \
+            --build-arg GIT_SHA="${GIT_SHA}" \
+            --build-arg GIT_BRANCH="${GIT_BRANCH}" \
+            --build-arg VERSION="${VERSION}" \
+            -t ethrex-local:${IMAGE_TAG} \
+            -f Dockerfile .; then
+            break
+          fi
+          if [ "$i" -eq "$attempts" ]; then
+            echo "docker build failed after ${attempts} attempts" >&2
+            exit 1
+          fi
+          echo "docker build attempt ${i}/${attempts} failed, retrying in 15s..." >&2
+          sleep 15
+        done
 
     - name: Generate Kurtosis args
       shell: bash


### PR DESCRIPTION
## Motivation

The *Daily Snapsync Check* workflow (`Sync hoodi - Lighthouse` and siblings) fails intermittently at the **Build local ethrex image** step, before any compilation. Example: [run 28848625969](https://github.com/lambdaclass/ethrex/actions/runs/28848625969/job/85558321539).

```
#2 ERROR: failed to authorize: failed to fetch anonymous token:
Get "https://auth.docker.io/token?...&service=registry.docker.io":
dial tcp: lookup auth.docker.io on [fd7a:115c:a1e0::53]:53: server misbehaving
Dockerfile:1
>>> # syntax=docker/dockerfile:1.10
```

Root cause is transient DNS flakiness on the self-hosted runner: the `# syntax=docker/dockerfile:1.10` directive makes BuildKit pull the frontend image from Docker Hub at build start, which requires resolving `auth.docker.io`. The runner's DNS resolver (Tailscale MagicDNS, `fd7a:115c:a1e0::53`) intermittently returns "server misbehaving", aborting the build on step #2. Not a code bug.

## Changes

Wrap `docker build` in the `snapsync-run` composite action in a 3-attempt retry loop with a 15s backoff. This rides out transient Docker Hub / DNS hiccups (frontend fetch and base-image pulls) instead of failing the whole daily run.

## Follow-up (infra, not in this PR)

The durable fix is on the runner host and can't be a repo change:
- Give the Docker daemon explicit resolvers in `/etc/docker/daemon.json` (`"dns": ["1.1.1.1", "8.8.8.8"]`), and/or
- Configure a Docker Hub registry mirror to avoid depending on `auth.docker.io` at build time.