### PR TITLE
ci(l1): exclude etherscan.io from docs link check

### DIFF
--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --exclude 'localhost' --exclude 'medium.com' --exclude 'mirror.xyz' docs/
+          args: --no-progress --exclude 'localhost' --exclude 'medium.com' --exclude 'mirror.xyz' --exclude 'etherscan.io' docs/
           fail: true
 
   deploy:


### PR DESCRIPTION
Etherscan returns `403` to CI runners (anti-bot protection), which makes the `Link Check` job flake on PRs that don't touch the linked files (e.g. the etherscan tx links in `docs/internal/l1/delete_accounts.md`).

Exclude `etherscan.io` from the lychee run, matching the existing `localhost` / `medium.com` / `mirror.xyz` exclusions.