### PR TITLE
ci(l1): bump hive eels_commit pins to grade bad_v_r_s as INVALID_SIGNATURE_VRS

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,4 +1,4 @@
 # Amsterdam (BAL) hive test configuration
 # Pinned to tests-glamsterdam-devnet@v6.1.1 (execution-specs `devnets/glamsterdam/6`)
 fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v6.1.1/fixtures_glamsterdam-devnet.tar.gz
-eels_commit: d0338f5615a8e8c66caf89e514718c5a6f10b95b
+eels_commit: 988ccb52b60497b16ac1b57a9c8230da63767e96

--- a/.github/config/hive/mainnet.yaml
+++ b/.github/config/hive/mainnet.yaml
@@ -3,4 +3,4 @@
 # Osaka + BPO1 + BPO2). Replaces the archived
 # ethereum/execution-spec-tests `fixtures_develop` bundle.
 fixtures: https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0/fixtures.tar.gz
-eels_commit: b6956dbe42a64d143569d5e9b20a0e7f7b9d0ac9
+eels_commit: 376414e07c4642574b38c4bb97eab2f2f719436b

--- a/docs/eip-8025.md
+++ b/docs/eip-8025.md
@@ -514,7 +514,7 @@ When compiled **without** the feature:
 
 ### Approach
 
-The `zkevm@v0.2.0` release from ethereum/execution-spec-tests provides ~12,000 Amsterdam-fork fixtures, each with a pre-filled `executionWitness` in the standard format (flat MPT nodes, bytecodes, ancestor headers). This tests the real EIP-8025 scenario: a consensus layer provides a witness, and our execution layer validates the block with it.
+The `tests-zkevm@v0.5.0` release from [ethereum/execution-specs](https://github.com/ethereum/execution-specs) provides ~12,000 Amsterdam-fork fixtures, each with a pre-filled `executionWitness` in the standard format (flat MPT nodes, bytecodes, ancestor headers). This tests the real EIP-8025 scenario: a consensus layer provides a witness, and our execution layer validates the block with it.
 
 ### Two Test Paths
 
@@ -563,7 +563,7 @@ make test-stateless-zkevm
 
 ### zkevm Amsterdam Fork Compatibility
 
-The `zkevm@v0.2.0` Amsterdam fork definition differs from ethrex's:
+The `tests-zkevm@v0.5.0` Amsterdam fork definition differs from ethrex's:
 
 | EIP | zkevm Amsterdam | ethrex Amsterdam |
 |-----|-----------------|-----------------|
@@ -600,7 +600,7 @@ The Engine API spec ([PR #735](https://github.com/ethereum/execution-apis/pull/7
 - Guest program modification for EIP-8025 public input format
 - SSZ types via libssz for `hash_tree_root` computation
 - Shared prover infrastructure extracted from `crates/l2/prover/`
-- zkevm@v0.2.0 execution-spec-tests support (~12,000 fixtures)
+- tests-zkevm@v0.5.0 (execution-specs) support (~12,000 fixtures)
 
 ### Out of Scope
 


### PR DESCRIPTION
Daily Hive Report showed all green, but consume-engine had 80 failing `tests/frontier/validation/test_transaction.py::test_bad_v_r_s` cases (Prague 20, Amsterdam 20, Paris/Shanghai/Cancun 40). The job step only greps for `"simulation .* finished"`, so failures don't fail the job.

Not a consensus bug: ethrex correctly rejects the invalid-signature blocks. The failures are exception-classification mismatches in eels' `EthrexExceptionMapper`. The pinned `eels_commit` values predated execution-specs PR #3104 (ecd94a47), which added:
- legacy tx: "Couldn't recover addresses with error: invalid signature" -> `INVALID_SIGNATURE_VRS`
- typed tx: "Error decoding field 'signature_y_parity' of type bool: MalformedBoolean" -> `INVALID_SIGNATURE_VRS`

This is the upstream twin of ethrex's own commit 8752df602 which added the same mappings to `tooling/ef_tests/engine/src/exception_mapper.rs`.

Changes:
- `.github/config/hive/mainnet.yaml`: `eels_commit` b6956dbe -> 376414e0 (forks/amsterdam tip, carries the mapping)
- `.github/config/hive/amsterdam.yaml`: `eels_commit` d0338f56 -> 988ccb52 (devnets/glamsterdam/6 tip, carries the mapping)
- Both new pins are branch tips descending from the mapping commit; fixture releases (tests@v20.0.0, tests-glamsterdam-devnet@v6.1.1) are unchanged.
- `docs/eip-8025.md`: fix stale zkevm references, archived `ethereum/execution-spec-tests` repo and `zkevm@v0.2.0` -> `tests-zkevm@v0.5.0` on `ethereum/execution-specs`, matching the live `tooling/ef_tests/.fixtures_url_zkevm`.