### PR TITLE
perf(l1): read-through cache for committed on-disk state values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Perf
 
+### 2026-07-08
+
+- Add a bounded read-through cache of committed on-disk state values beneath the diff-layer overlay, so repeated cold reads of hot-but-unwritten accounts/slots (read every block but not recently written) hit memory instead of re-reading disk each block [#6979](https://github.com/lambdaclass/ethrex/pull/6979)
+
 ### 2026-07-06
 
 - Warm state caches between blocks by speculatively executing top-of-mempool transactions [#6967](https://github.com/lambdaclass/ethrex/pull/6967)

--- a/crates/storage/clean_cache.rs
+++ b/crates/storage/clean_cache.rs
@@ -1,0 +1,295 @@
+//! Read-through value cache for committed on-disk state.
+//!
+//! # What it is
+//!
+//! A bounded, sharded LRU that memoizes the result of a trie/flat-KV point
+//! lookup against the on-disk state (the `*_trie_nodes` / `*_flatkeyvalue`
+//! column families). It sits *beneath* the in-memory diff-layer overlay
+//! ([`crate::layering::TrieLayerCache`]) in the read cascade:
+//!
+//! ```text
+//! TrieWrapper::get
+//!   → TrieLayerCache overlay   (last ~128 blocks of writes)
+//!   → CleanCache               (this: committed on-disk values)
+//!   → disk (RocksDB)           (fill CleanCache on miss)
+//! ```
+//!
+//! # Why it is correct by construction
+//!
+//! The on-disk state is a single-version, path-keyed store, and
+//! [`crate::backend`]'s `get` ignores the state root: it is a plain point get on
+//! the prefixed path. So an entry here is just a memoization of that call and is
+//! independent of which state root a trie was opened at. The overlay always
+//! shadows any key written in the recent window, so a stale entry can never be
+//! observed for a recently-written key.
+//!
+//! The only invalidation needed is at the points that mutate the on-disk state
+//! CFs. In the synced regime (the only regime where this cache is active, see
+//! the gate in `store.rs`) that is exactly two writers:
+//! - `commit_trie_layers` folds an overlay layer to disk — it invalidates each
+//!   committed key.
+//! - `write_storage_trie_nodes_batch` (bulk healing path) — it clears the cache.
+//!
+//! # Memory
+//!
+//! Memory is hard-bounded by bytes, not entry count. The budget is split evenly
+//! across [`SHARD_COUNT`] shards; each shard evicts its LRU tail until it is
+//! under its share. The accounted weight of an entry is
+//! `key.len() + value.len() + ENTRY_OVERHEAD_BYTES`, so the reported figure
+//! tracks real resident memory rather than just payload. See
+//! [`CleanCache::used_bytes`] and [`CleanCache::max_bytes`].
+
+use lru::LruCache;
+use rustc_hash::FxBuildHasher;
+use std::fmt;
+use std::sync::Mutex;
+
+/// Fixed per-entry bookkeeping overhead added to key+value bytes: the LRU node,
+/// the two boxed slices, and the hash-map slot. Approximate on purpose; it only
+/// needs to keep the byte bound from undercounting real memory.
+const ENTRY_OVERHEAD_BYTES: usize = 64;
+
+/// Number of independently-locked shards. Reads take a per-shard lock, so more
+/// shards means less contention when the executor and prefetch workers hit the
+/// cache in parallel. Must be a power of two (used as a mask).
+const SHARD_COUNT: usize = 64;
+
+type Key = Box<[u8]>;
+type Val = Box<[u8]>;
+
+struct Shard {
+    map: LruCache<Key, Val, FxBuildHasher>,
+    used_bytes: usize,
+    max_bytes: usize,
+}
+
+impl Shard {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            map: LruCache::unbounded_with_hasher(FxBuildHasher),
+            used_bytes: 0,
+            max_bytes,
+        }
+    }
+
+    fn weight(key_len: usize, val_len: usize) -> usize {
+        key_len + val_len + ENTRY_OVERHEAD_BYTES
+    }
+
+    fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        self.map.get(key).map(|v| v.to_vec())
+    }
+
+    fn insert(&mut self, key: Key, val: &[u8]) {
+        let key_len = key.len();
+        let weight = Self::weight(key_len, val.len());
+        // Never cache a single entry larger than the whole shard budget: it
+        // would evict everything and then itself on the next insert.
+        if weight > self.max_bytes {
+            return;
+        }
+        if let Some(old) = self.map.put(key, val.into()) {
+            // Same key, so the old entry's key length equals `key_len`.
+            let old_weight = Self::weight(key_len, old.len());
+            self.used_bytes = self.used_bytes.saturating_sub(old_weight);
+        }
+        self.used_bytes += weight;
+        while self.used_bytes > self.max_bytes {
+            match self.map.pop_lru() {
+                Some((k, v)) => {
+                    let w = Self::weight(k.len(), v.len());
+                    self.used_bytes = self.used_bytes.saturating_sub(w);
+                }
+                None => break,
+            }
+        }
+    }
+
+    fn invalidate(&mut self, key: &[u8]) {
+        if let Some(old) = self.map.pop(key) {
+            let w = Self::weight(key.len(), old.len());
+            self.used_bytes = self.used_bytes.saturating_sub(w);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+        self.used_bytes = 0;
+    }
+}
+
+/// Bounded, sharded, read-through cache of committed on-disk state values.
+///
+/// Cloneable-by-`Arc` in [`crate::store::Store`]; every trie opened on the
+/// synced read path shares one instance.
+pub struct CleanCache {
+    shards: Box<[Mutex<Shard>]>,
+    /// Total byte budget across all shards (sum of per-shard `max_bytes`).
+    max_bytes: usize,
+}
+
+impl fmt::Debug for CleanCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CleanCache")
+            .field("shards", &self.shards.len())
+            .field("max_bytes", &self.max_bytes)
+            .field("used_bytes", &self.used_bytes())
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl CleanCache {
+    /// Creates a cache with the given total byte budget, split evenly across
+    /// [`SHARD_COUNT`] shards. A budget of `0` yields a cache whose shards can
+    /// hold nothing (every insert is a no-op); prefer gating with `None` at the
+    /// call site instead of relying on this.
+    pub fn new(total_max_bytes: usize) -> Self {
+        let per_shard = total_max_bytes / SHARD_COUNT;
+        let shards = (0..SHARD_COUNT)
+            .map(|_| Mutex::new(Shard::new(per_shard)))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            shards,
+            max_bytes: per_shard * SHARD_COUNT,
+        }
+    }
+
+    /// Selects a shard from the leading bytes of the key. Keys are keccak-derived
+    /// nibble paths, so the leading nibbles are uniformly distributed.
+    fn shard(&self, key: &[u8]) -> &Mutex<Shard> {
+        let a = key.first().copied().unwrap_or(0) as usize;
+        let b = key.get(1).copied().unwrap_or(0) as usize;
+        let idx = ((a << 4) | b) & (self.shards.len() - 1);
+        &self.shards[idx]
+    }
+
+    /// Returns the cached value for `key`, promoting it to most-recently-used.
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.shard(key).lock().ok()?.get(key)
+    }
+
+    /// Inserts (or refreshes) `key -> value`, evicting the shard's LRU tail if
+    /// the shard is over budget. `key` is consumed to avoid a second allocation
+    /// (the caller already built the prefixed path).
+    pub fn insert(&self, key: Key, value: &[u8]) {
+        if let Ok(mut shard) = self.shard(&key).lock() {
+            shard.insert(key, value);
+        }
+    }
+
+    /// Removes `key`. Called for every key mutated on disk by `commit_trie_layers`.
+    pub fn invalidate(&self, key: &[u8]) {
+        if let Ok(mut shard) = self.shard(key).lock() {
+            shard.invalidate(key);
+        }
+    }
+
+    /// Drops every entry. Used by bulk on-disk mutations that bypass the normal
+    /// commit path (`write_storage_trie_nodes_batch`).
+    pub fn clear(&self) {
+        for shard in self.shards.iter() {
+            if let Ok(mut shard) = shard.lock() {
+                shard.clear();
+            }
+        }
+    }
+
+    /// Total byte budget (upper bound on resident memory for cached entries).
+    pub fn max_bytes(&self) -> usize {
+        self.max_bytes
+    }
+
+    /// Currently accounted resident bytes across all shards.
+    pub fn used_bytes(&self) -> usize {
+        self.shards
+            .iter()
+            .filter_map(|s| s.lock().ok().map(|s| s.used_bytes))
+            .sum()
+    }
+
+    /// Number of cached entries across all shards.
+    pub fn len(&self) -> usize {
+        self.shards
+            .iter()
+            .filter_map(|s| s.lock().ok().map(|s| s.map.len()))
+            .sum()
+    }
+
+    /// Returns true if no entries are cached.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(n: u8) -> Vec<u8> {
+        // Distinct across shards: vary the leading bytes.
+        vec![n, n.wrapping_mul(7), n.wrapping_add(3), 0xaa]
+    }
+
+    #[test]
+    fn get_after_insert_hits() {
+        let c = CleanCache::new(1 << 20);
+        c.insert(key(1).into_boxed_slice(), b"value-1");
+        assert_eq!(c.get(&key(1)), Some(b"value-1".to_vec()));
+        assert_eq!(c.get(&key(2)), None);
+    }
+
+    #[test]
+    fn invalidate_removes_entry() {
+        let c = CleanCache::new(1 << 20);
+        c.insert(key(1).into_boxed_slice(), b"v");
+        c.invalidate(&key(1));
+        assert_eq!(c.get(&key(1)), None);
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn clear_drops_all() {
+        let c = CleanCache::new(1 << 20);
+        for i in 0..50u8 {
+            c.insert(key(i).into_boxed_slice(), b"v");
+        }
+        assert!(!c.is_empty());
+        c.clear();
+        assert!(c.is_empty());
+        assert_eq!(c.used_bytes(), 0);
+    }
+
+    #[test]
+    fn memory_is_bounded_by_budget() {
+        // Small budget; hammer one shard with many entries and assert the
+        // per-shard byte bound is never exceeded and old entries are evicted.
+        let total = SHARD_COUNT * 4096; // 4 KiB per shard
+        let c = CleanCache::new(total);
+        // All these keys land in the same shard (identical leading two bytes).
+        for i in 0..10_000u32 {
+            let mut k = vec![0u8, 0u8];
+            k.extend_from_slice(&i.to_le_bytes());
+            c.insert(k.into_boxed_slice(), &[7u8; 256]);
+        }
+        assert!(
+            c.used_bytes() <= c.max_bytes(),
+            "used {} must not exceed budget {}",
+            c.used_bytes(),
+            c.max_bytes()
+        );
+        // The most recently inserted key must still be present (LRU keeps the tail).
+        let mut last = vec![0u8, 0u8];
+        last.extend_from_slice(&9_999u32.to_le_bytes());
+        assert_eq!(c.get(&last), Some(vec![7u8; 256]));
+    }
+
+    #[test]
+    fn oversized_entry_is_not_cached() {
+        let c = CleanCache::new(SHARD_COUNT * 128); // 128 B per shard
+        c.insert(key(1).into_boxed_slice(), &[0u8; 4096]);
+        assert_eq!(c.get(&key(1)), None);
+        assert_eq!(c.used_bytes(), 0);
+    }
+}

--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -6,6 +6,8 @@ use std::{fmt, sync::Arc};
 
 use ethrex_trie::{Nibbles, TrieDB, TrieError};
 
+use crate::clean_cache::CleanCache;
+
 const BLOOM_SIZE: usize = 1_000_000;
 const FALSE_POSITIVE_RATE: f64 = 0.02;
 
@@ -271,6 +273,10 @@ pub struct TrieWrapper {
     pub state_root: H256,
     pub inner: Arc<TrieLayerCache>,
     pub db: Box<dyn TrieDB>,
+    /// Read-through cache of committed on-disk values, consulted after the
+    /// overlay and before disk. `None` disables it (locked/snap-sync tries and
+    /// any not-yet-synced regime, see the gate in `store.rs`).
+    clean: Option<Arc<CleanCache>>,
     /// Pre-computed prefix nibbles for storage tries.
     /// For state tries this is None; for storage tries this is
     /// `Nibbles::from_bytes(address.as_bytes()).append_new(17)`.
@@ -283,12 +289,14 @@ impl TrieWrapper {
         inner: Arc<TrieLayerCache>,
         db: Box<dyn TrieDB>,
         prefix: Option<H256>,
+        clean: Option<Arc<CleanCache>>,
     ) -> Self {
         let prefix_nibbles = prefix.map(|p| Nibbles::from_bytes(p.as_bytes()).append_new(17));
         Self {
             state_root,
             inner,
             db,
+            clean,
             prefix_nibbles,
         }
     }
@@ -322,10 +330,24 @@ impl TrieDB for TrieWrapper {
             Some(prefix) => prefix.concat(&key),
             None => key,
         };
+        // Tier 1: in-memory diff-layer overlay (recent writes).
         if let Some(value) = self.inner.get(self.state_root, key.as_ref()) {
             return Ok(Some(value));
         }
-        self.db.get(key)
+        // Tier 2: read-through cache of committed on-disk values.
+        let Some(clean) = &self.clean else {
+            return self.db.get(key);
+        };
+        let cache_key: Box<[u8]> = key.as_ref().into();
+        if let Some(value) = clean.get(&cache_key) {
+            return Ok(Some(value));
+        }
+        // Tier 3: disk. Fill the cache on a hit (positive-only caching).
+        let value = self.db.get(key)?;
+        if let Some(ref v) = value {
+            clean.insert(cache_key, v);
+        }
+        Ok(value)
     }
 
     fn put_batch(&self, _key_values: Vec<(Nibbles, Vec<u8>)>) -> Result<(), TrieError> {

--- a/crates/storage/lib.rs
+++ b/crates/storage/lib.rs
@@ -67,6 +67,7 @@
 pub mod api;
 pub mod backend;
 pub mod block_data_buffer;
+pub mod clean_cache;
 pub mod error;
 mod layering;
 pub mod migrations;

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -15,6 +15,7 @@ use crate::{
     apply_prefix,
     backend::in_memory::InMemoryBackend,
     block_data_buffer::BlockDataBuffer,
+    clean_cache::CleanCache,
     error::StoreError,
     layering::{TrieLayerCache, TrieWrapper},
     rlp::{BlockBodyRLP, BlockHeaderRLP, BlockRLP},
@@ -82,6 +83,17 @@ const BATCH_COMMIT_THRESHOLD: usize = 4;
 /// with larger giving no gain (the OS page cache backstops the uncompressed state
 /// CFs) and ~8 GiB the floor where the filter set starts to thrash.
 pub const DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_BYTES: usize = 12 * 1024 * 1024 * 1024;
+
+/// Total byte budget for the read-through [`CleanCache`] of committed on-disk
+/// state values: 512 MiB.
+///
+/// This is resident memory *in addition to* the RocksDB block cache, but far
+/// denser: it stores decoded-path values (~40-130 B each) rather than whole
+/// 4-16 KB SST blocks, so for random hashed-key access it holds far more of the
+/// working set per byte. The cache is hard-bounded to this figure (see
+/// [`CleanCache`]). Only active once the node is synced (FKV fully built).
+// TODO: make this configurable via `StoreConfig`.
+pub const DEFAULT_CLEAN_CACHE_MAX_BYTES: usize = 512 * 1024 * 1024;
 
 /// Tunable configuration for [`Store::new_with_config`] and related constructors.
 ///
@@ -197,6 +209,11 @@ pub struct Store {
     latest_block_header: LatestBlockHeaderCache,
     /// Last computed FlatKeyValue for incremental updates.
     last_computed_flatkeyvalue: Arc<RwLock<Vec<u8>>>,
+
+    /// Read-through cache of committed on-disk state values, sitting beneath the
+    /// diff-layer overlay in the read cascade. Only consulted once the node is
+    /// synced (FKV fully built); see [`Store::clean_cache_if_synced`].
+    clean_cache: Arc<CleanCache>,
 
     /// Cache for account bytecodes, keyed by the bytecode hash.
     /// Note that we don't remove entries on account code changes, since
@@ -1411,7 +1428,11 @@ impl Store {
             txn.commit()
         })
         .await
-        .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?
+        .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))??;
+        // This path mutates on-disk state outside `commit_trie_layers`, so drop
+        // the read-through cache wholesale rather than tracking per-key changes.
+        self.clean_cache.clear();
+        Ok(())
     }
 
     /// CAUTION: This method writes directly to the underlying database, bypassing any caching layer.
@@ -1820,6 +1841,7 @@ impl Store {
             persist_tx,
             pending_trie_roots: Arc::new(PendingTrieRoots::default()),
             last_computed_flatkeyvalue: Arc::new(RwLock::new(last_written)),
+            clean_cache: Arc::new(CleanCache::new(DEFAULT_CLEAN_CACHE_MAX_BYTES)),
             account_code_cache: Arc::new(Mutex::new(CodeCache::default())),
             code_metadata_cache: Arc::new(Mutex::new(rustc_hash::FxHashMap::default())),
             fcu_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -1851,6 +1873,7 @@ impl Store {
         let persist_trie_cache = store.trie_cache.clone();
         let persist_pending_roots = store.pending_trie_roots.clone();
         let persist_fkv_ctl = store.flatkeyvalue_control_tx.clone();
+        let persist_clean_cache = store.clean_cache.clone();
         background_threads.push(std::thread::spawn(move || {
             let rx = persist_rx;
             // Carries the prior flush result: the live path acks after staging,
@@ -1914,6 +1937,7 @@ impl Store {
                                     persist_backend.as_ref(),
                                     &persist_trie_cache,
                                     &persist_fkv_ctl,
+                                    &persist_clean_cache,
                                     bp.parent_state_root,
                                     bp.wait_for_flush,
                                 )
@@ -3130,6 +3154,7 @@ impl Store {
                 self.last_written()?,
             )?),
             None,
+            self.clean_cache_if_synced(),
         );
         Ok(Trie::open(Box::new(trie_db), state_root))
     }
@@ -3159,6 +3184,8 @@ impl Store {
                 self.last_written()?,
             )?),
             None,
+            // Locked/snap-sync tries read a point-in-time snapshot; never cache.
+            None,
         );
         Ok(Trie::open(Box::new(trie_db), state_root))
     }
@@ -3179,6 +3206,7 @@ impl Store {
                 self.last_written()?,
             )?),
             Some(account_hash),
+            self.clean_cache_if_synced(),
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
     }
@@ -3202,6 +3230,7 @@ impl Store {
                 last_written,
             )?),
             None,
+            self.clean_cache_if_synced(),
         );
         Ok(Trie::open(Box::new(trie_db), state_root))
     }
@@ -3225,6 +3254,7 @@ impl Store {
                 last_written,
             )?),
             Some(account_hash),
+            self.clean_cache_if_synced(),
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
     }
@@ -3262,6 +3292,8 @@ impl Store {
                 self.last_written()?,
             )?),
             Some(account_hash),
+            // Locked/snap-sync tries read a point-in-time snapshot; never cache.
+            None,
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
     }
@@ -3385,6 +3417,33 @@ impl Store {
     fn flatkeyvalue_computed_with_last_written(account: H256, last_written: &[u8]) -> bool {
         let account_nibbles = Nibbles::from_bytes(account.as_bytes());
         &last_written[0..64] > account_nibbles.as_ref()
+    }
+
+    /// Returns the read-through [`CleanCache`] only when the node is synced, i.e.
+    /// FKV generation is complete.
+    ///
+    /// Before that point, several code paths mutate the on-disk state CFs outside
+    /// `commit_trie_layers` (genesis, snap-sync healing, FKV backfill) without
+    /// invalidating the cache. Gating on FKV-complete restricts the cache to the
+    /// regime where `commit_trie_layers` and `write_storage_trie_nodes_batch` are
+    /// the only writers, both of which do invalidate. This is also exactly the
+    /// workload the cache targets (steady-state head-following).
+    fn clean_cache_if_synced(&self) -> Option<Arc<CleanCache>> {
+        let synced = self
+            .last_written()
+            .map(|lw| fkv_fully_built(&lw))
+            .unwrap_or(false);
+        synced.then(|| self.clean_cache.clone())
+    }
+
+    /// Snapshot of the read-through cache's memory usage: `(used_bytes,
+    /// max_bytes, entries)`. Intended for observability / debugging.
+    pub fn clean_cache_stats(&self) -> (usize, usize, usize) {
+        (
+            self.clean_cache.used_bytes(),
+            self.clean_cache.max_bytes(),
+            self.clean_cache.len(),
+        )
     }
 
     /// Returns the highest block number durably flushed to disk, or `0` when
@@ -3770,6 +3829,14 @@ fn apply_trie_phase1(
     build
 }
 
+/// True when the FKV watermark indicates a complete flat-key-value store, i.e.
+/// the node is synced. The watermark is a trie nibble path, whose bytes are all
+/// `< 0x11`, so an all-`0xff` value can only be the completion sentinel (see the
+/// FKV generator and `from_backend`). Used to gate the read-through cache.
+fn fkv_fully_built(last_written: &[u8]) -> bool {
+    !last_written.is_empty() && last_written.iter().all(|&b| b == 0xff)
+}
+
 /// When the diff-layer chain is deep enough, flush the bottom layer to disk and
 /// RCU-evict it. `is_batch` selects `BATCH_COMMIT_THRESHOLD` (full sync) over
 /// the default per-block threshold. No-ops when nothing is committable.
@@ -3777,6 +3844,7 @@ fn commit_trie_if_due(
     backend: &dyn StorageBackend,
     trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
     fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
+    clean_cache: &CleanCache,
     parent_state_root: H256,
     is_batch: bool,
 ) -> Result<(), StoreError> {
@@ -3794,7 +3862,7 @@ fn commit_trie_if_due(
         // Nothing to commit to disk, move on.
         return Ok(());
     };
-    commit_trie_layers(backend, trie_cache, fkv_ctl, &trie, root)
+    commit_trie_layers(backend, trie_cache, fkv_ctl, clean_cache, &trie, root)
 }
 
 /// Writes the layer at `root` and all of its ancestors to disk in one tx, then
@@ -3805,6 +3873,7 @@ fn commit_trie_layers(
     backend: &dyn StorageBackend,
     trie_cache: &Arc<RwLock<Arc<TrieLayerCache>>>,
     fkv_ctl: &SyncSender<FKVGeneratorControlMessage>,
+    clean_cache: &CleanCache,
     trie: &Arc<TrieLayerCache>,
     root: H256,
 ) -> Result<(), StoreError> {
@@ -3831,6 +3900,12 @@ fn commit_trie_layers(
     for (key, value) in nodes {
         let is_leaf = key.len() == 65 || key.len() == 131;
         let is_account = key.len() <= 65;
+
+        // This key's on-disk value is about to change, drop any stale
+        // read-through entry. Safe against concurrent readers: the overlay still
+        // shadows this key until the RCU swap below, so the clean cache is not
+        // consulted for it during this window.
+        clean_cache.invalidate(&key);
 
         if is_leaf && key > last_written {
             continue;

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -9,6 +9,7 @@ This directory is the source of truth for ethrex performance optimization work.
 | [methodology.md](methodology.md) | Complete benchmarking workflow |
 | [ideas.md](ideas.md) | All performance ideas with status tracking |
 | [architecture.md](architecture.md) | Code architecture and bottleneck analysis |
+| [storage-cold-paths.md](storage-cold-paths.md) | Storage read paths: cold access, accounts, trie, FKV, caches, RocksDB tuning |
 | [tracking.md](tracking.md) | Session and historical tracking formats |
 | [observability.md](observability.md) | Dashboard and notification setup |
 | [zkvm-guidelines.md](zkvm-guidelines.md) | zkVM-specific benchmarking guidance |

--- a/docs/perf/storage-cold-paths.md
+++ b/docs/perf/storage-cold-paths.md
@@ -1,0 +1,301 @@
+# Storage: cold paths, accounts, trie, FKV, caches
+
+Audience: perf analyzers. This documents how ethrex reads state, what makes a
+read hot or cold, and the knobs that move the boundary. All references are to
+`crates/storage/` and `crates/common/trie/` on `main`. Line numbers drift; grep
+the named symbols.
+
+## TL;DR
+
+- State lives in RocksDB as a **single-version, path-keyed** trie plus a
+  redundant **flat key-value (FKV)** copy of the leaves. Four column families:
+  `account_trie_nodes`, `storage_trie_nodes`, `account_flatkeyvalue`,
+  `storage_flatkeyvalue`.
+- A read is resolved through three tiers, hottest first:
+  1. **In-memory diff-layer overlay** (`TrieLayerCache`) holding the newest
+     **128 blocks** of trie diffs.
+  2. **FKV point lookup** (one RocksDB get at the full path) when the FKV
+     watermark covers the key.
+  3. **Trie-node walk** (root to leaf, `depth` gets) when FKV is not yet built
+     for that key or the key was written in this trie instance.
+- Each tier-2/3 get then resolves inside RocksDB: memtable -> shared block cache
+  -> SST on disk. **Truly cold** = not in the 128-layer overlay, not in the
+  block cache, not in a memtable, so it costs physical disk I/O.
+- The 128-layer window bounds how far back state is in RAM. Anything older than
+  ~128 blocks is disk-only.
+
+## Data model: how state is keyed on disk
+
+The trie is **path-keyed**, not hash-keyed. On commit, each node is written at
+its trie path (nibbles), and each leaf is written **twice**:
+`NodeRef::commit` (`crates/common/trie/node.rs`) pushes `(full_path, value)` for
+the leaf and `(node_path, encoded_node)` for the node itself. The `(full_path,
+value)` pair is the FKV entry. (`tables.rs` still comments "node_hash.as_ref()"
+for these CFs; that is stale, the key is the path.)
+
+Routing to a CF is by **key length** (`BackendTrieDB::table_for_key` in
+`trie.rs`, mirrored in `commit_trie_layers` in `store.rs`):
+
+| Key length (nibbles) | Meaning | Column family |
+|---|---|---|
+| `<= 64` | account-side internal/branch/extension node | `account_trie_nodes` |
+| `== 65` | account leaf full path (keccak(addr) 64 + leaf term 16) | `account_flatkeyvalue` |
+| `66..=130` | storage-side internal node | `storage_trie_nodes` |
+| `== 131` | storage leaf full path | `storage_flatkeyvalue` |
+
+`is_leaf = len == 65 || len == 131`, `is_account = len <= 65`.
+
+Storage keys carry an address prefix (`apply_prefix` in `layering.rs`):
+`Nibbles::from_bytes(addr) [65] .append_new(17) [66] .concat(slot_path)`. The
+`17` is an invalid nibble used as a separator, so a storage leaf path is
+`66 + 65 = 131` nibbles.
+
+Other CFs relevant to account access:
+
+| CF | Key | Value | Notes |
+|---|---|---|---|
+| `account_codes` | code hash | bytecode | RocksDB blob files, `min_blob_size=32`, lz4 |
+| `account_code_metadata` | code hash | code length (u64) | tiny, for size-only queries |
+| `misc_values` | `"last_written"` | FKV watermark | see FKV section |
+
+## Read path (one account or one storage slot)
+
+Entry points: `get_account_info` / `get_account_state` / `get_account_info_by_hash`
+/ `get_storage_at` / `get_storage_at_root` (`store.rs`). They open a trie and
+call `Trie::get`, which routes through the tiers below.
+
+```
+Trie::get(path)                                  crates/common/trie/trie.rs
+  │
+  ├─ if path is dirty in this trie ─────────────► trie-node walk (tier 3)
+  │
+  ├─ if db.flatkeyvalue_computed(path):           TIER 2  (FKV fast path)
+  │     db.get(full_path)  ── one point get
+  │        │
+  │        └─ TrieWrapper::get                    crates/storage/layering.rs
+  │              ├─ TrieLayerCache.get  ────────► TIER 1  (in-memory overlay)
+  │              └─ BackendTrieDB.get   ────────► RocksDB point get on *_flatkeyvalue
+  │
+  └─ else:                                        TIER 3  (structural walk)
+        root → branch/extension → … → leaf
+        each hop = TrieWrapper::get on a node path
+        (TIER 1 overlay, then RocksDB point get on *_trie_nodes)
+```
+
+### Tier 1: in-memory diff-layer overlay (`TrieLayerCache`)
+
+`crates/storage/layering.rs`. Held on `Store` as
+`trie_cache: Arc<RwLock<Arc<TrieLayerCache>>>` and RCU-swapped by the persist
+worker. It is a chain of per-block diff layers keyed by state root, linked
+newest -> oldest by `parent`:
+
+```
+newest_root -> parent_1 -> … -> oldest_root -> (on-disk trie)
+```
+
+- Each `TrieLayer` is an `FxHashMap<path_bytes, node_bytes>` of one block's trie
+  diffs (one batch of ~1024 blocks in full sync).
+- `get(state_root, key)` checks a **global bloom filter** first (1,000,000
+  items, 2% FP, `FxBuildHasher`). Bloom miss returns `None` immediately, so the
+  caller falls through to RocksDB without walking the chain. Bloom hit walks the
+  parent chain and returns the first (newest) layer that has the key.
+- `commit_threshold` decides how many layers stay resident:
+  - **128** for regular block-by-block execution (`DB_COMMIT_THRESHOLD`).
+  - **4** for full sync / batch mode (`BATCH_COMMIT_THRESHOLD`, each layer ≈
+    1024 blocks ≈ 1 GB).
+  - **10000** for the in-memory backend (`IN_MEMORY_COMMIT_THRESHOLD`, tests
+    need deep history).
+
+This is pure RAM (FxHashMap lookups), the hottest tier. An account touched in
+the last 128 blocks is served here with no RocksDB access.
+
+The `open_direct_*` trie constructors (`store.rs`) skip the `TrieWrapper`
+overlay and read straight from `BackendTrieDB` (used by genesis and the FKV
+generator). Reads through those do not consult Tier 1.
+
+### Tier 2: FKV fast path
+
+`Trie::get` (`trie.rs`) takes the flat path when the key is not dirty **and**
+`db.flatkeyvalue_computed(path)` is true. It then does a single `db.get` on the
+full leaf path, which hits the `*_flatkeyvalue` CF directly. One logical point
+lookup, no structural traversal.
+
+`flatkeyvalue_computed` is a **watermark** check
+(`BackendTrieDB::flatkeyvalue_computed`, `last_computed_flatkeyvalue >= key`;
+`Store::flatkeyvalue_computed_with_last_written` uses `last_written[0..64] >
+account_nibbles`). See the FKV section for what advances the watermark.
+
+`get_storage_at_root` (`store.rs`) shows the intent: when FKV covers the
+account, it skips the state-trie account lookup entirely and opens the storage
+trie against `EMPTY_TRIE_HASH`, letting the FKV point lookup return the slot.
+`get_account_states_batch_by_root` batches the FKV-covered addresses into one
+RocksDB `multi_get` on `account_flatkeyvalue`.
+
+### Tier 3: trie-node walk (structural, colder)
+
+Taken when FKV is not yet built for the key range (during/after snap sync,
+before the FKV generator reaches it) or the key was modified in this trie
+instance (`dirty`). The walk descends root -> branch/extension -> leaf, doing
+one `TrieWrapper::get` per hop. On mainnet the account trie is ~7-9 nodes deep,
+so this is `depth` point lookups instead of one, each independently subject to
+the overlay/block-cache/disk hierarchy. When cold, this multiplies disk seeks by
+trie depth and is the most expensive read shape.
+
+## What "truly cold" means
+
+Every tier-2/3 get bottoms out in RocksDB (`backend/rocksdb.rs`), which resolves
+in order:
+
+1. **Memtable** (in-flight writes, RAM).
+2. **Shared block cache** (LRU, default **12 GiB**). Holds data blocks **and**
+   index + bloom-filter blocks (`cache_index_and_filter_blocks(true)`), with L0
+   filter/index pinned.
+3. **SST files on disk**, one probe per LSM level not pruned by a bloom filter.
+
+A read is **truly cold** when the key is:
+
+- not in any of the ≤128 in-memory diff-layers (account not touched in ~128
+  blocks), and
+- not in a memtable, and
+- its data block (and the index/filter blocks needed to find it) are not
+  resident in the block cache.
+
+Then it costs real I/O: a random NVMe read per SST level touched (index block +
+data block), reduced by bloom filters that skip SSTs which cannot hold the key.
+State/trie/FKV CFs are stored **uncompressed** (see tuning), so the OS page
+cache also backstops these reads.
+
+Cost ranking of a single account/slot read:
+
+| Situation | Cost |
+|---|---|
+| Touched in last 128 blocks | 1 FxHashMap lookup (Tier 1), no I/O |
+| FKV-covered, block cache warm | 1 point get, cache hit |
+| FKV-covered, cold | 1 point get, ~1 disk data-block read (+ filter/index if uncached) |
+| FKV not built or dirty, cold | `depth` point gets, up to `depth` cold reads |
+
+## The 128-block window (diff-layers to disk)
+
+The overlay holds the newest `commit_threshold` blocks in RAM; older state is
+disk-only. Commit is driven by the persist worker
+(`commit_trie_if_due` -> `commit_trie_layers`, `store.rs`):
+
+1. `get_commitable(state_root)` walks the layer chain; once ≥128 layers are
+   stacked it returns the 128-deep ancestor root.
+2. `TrieLayerCache::commit(root)` removes that layer and all older ancestors,
+   merges their diffs oldest-first, prunes orphaned layers, and rebuilds the
+   bloom.
+3. The merged diffs are written to RocksDB in one write batch (routed to the
+   four CFs by key length), then the trimmed cache is RCU-swapped in.
+
+Implications for perf and correctness:
+
+- **Reorg depth is bounded by the window.** Once a layer is folded into the
+  single-version on-disk trie the overwritten ancestor node is gone.
+- **Shutdown deliberately drops the uncommitted tail** (`Store::shutdown`). The
+  on-disk path store cannot reconstruct overwritten ancestors, so the recent
+  (< 128) layers are dropped and re-executed from the deep on-disk base on the
+  next start. Block data (headers/bodies/receipts) is flushed; trie diffs are
+  not.
+- Full sync trades window depth for memory: 4 fat layers instead of 128 thin
+  ones.
+
+## FKV generation and the watermark
+
+The FKV is not present after snap sync; it is **backfilled** by a background
+thread (`flatkeyvalue_generator`, `store.rs`) and gated by a watermark stored in
+`misc_values["last_written"]` and mirrored in
+`Store::last_computed_flatkeyvalue: Arc<RwLock<Vec<u8>>>`.
+
+Watermark semantics:
+
+- Absent / `vec![0u8; 64]` -> FKV empty, every read falls to the trie-node walk.
+- Partial value -> FKV built for keys `<= watermark` (sorted order); reads below
+  the watermark use FKV, reads above walk the trie.
+- Sentinel `[0xff]` on disk -> expanded to all-`0xff` in memory -> **FKV fully
+  built**, every account/slot read takes the one-get FKV fast path. This is the
+  steady state of a synced node.
+
+Genesis writes state only to the trie-node CFs (`setup_genesis_state_trie` via
+`open_direct_*`), never to FKV. So immediately after genesis the FKV is empty and
+every read walks trie nodes until the generator backfills.
+
+Generator behavior:
+
+- On first run it clears both FKV CFs, then iterates the account trie in sorted
+  order (and each account's storage trie), writing leaf values to the FKV CFs
+  and advancing `last_written`, committing every 10,000 entries.
+- It is **paused** (`FKVGeneratorControlMessage::Stop`) around each
+  `commit_trie_layers` (the underlying trie is changing) and **resumed**
+  (`Continue`) after. It re-reads a fresh view each iteration and restarts from
+  the watermark on `PivotChanged`.
+- `commit_trie_layers` skips writing FKV leaf entries whose key is beyond the
+  watermark (`is_leaf && key > last_written`); the leaf value still persists
+  inside its trie node, and the generator backfills the flat entry later.
+
+Perf reading: on a fully synced node FKV is complete, so account/storage reads
+are single point lookups. During or right after snap sync, the un-migrated key
+range still pays the deeper trie-node walk, so cold-path cost is higher until
+the generator finishes.
+
+## Store-level in-memory caches
+
+Fields on `Store` (`store.rs`) that absorb reads before disk:
+
+| Field | Type | Role |
+|---|---|---|
+| `trie_cache` | `Arc<RwLock<Arc<TrieLayerCache>>>` | 128-layer trie diff overlay (Tier 1) |
+| `block_data_buffer` | `Arc<RwLock<Arc<BlockDataBuffer>>>` | headers/bodies/receipts/codes/tx-index for not-yet-flushed blocks |
+| `last_computed_flatkeyvalue` | `Arc<RwLock<Vec<u8>>>` | FKV watermark |
+| `account_code_cache` | `Arc<Mutex<CodeCache>>` | LRU bytecode cache, 64 MiB (`CODE_CACHE_MAX_SIZE`) |
+| `code_metadata_cache` | `Arc<Mutex<FxHashMap<H256, CodeMetadata>>>` | code lengths only |
+| `latest_block_header` | `LatestBlockHeaderCache` | cached canonical head header |
+| `pending_trie_roots` | `Arc<PendingTrieRoots>` | gate so a reader blocks until a just-added block's layer is installed (`gated_snapshot`) |
+
+`BlockDataBuffer` (`block_data_buffer.rs`) is an RCU overlay: readers clone the
+inner `Arc` under a brief read lock then work lock-free; the single persist
+worker mutates a clone and swaps it in. It is consulted before disk for
+headers, bodies, numbers, receipts, codes, and tx locations, and evicted after
+the block data is durably flushed (`evict_flushed`, tracked by `flushed_upto`).
+
+## RocksDB tuning that moves the cold boundary
+
+From `RocksDBBackend::open` (`backend/rocksdb.rs`). What matters for read cost:
+
+- **Shared LRU block cache**, default **12 GiB**
+  (`DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_BYTES`, override with
+  `--rocksdb.block-cache-size`). With `cache_index_and_filter_blocks(true)` +
+  `pin_l0_filter_and_index_blocks_in_cache(true)`, this cache is the **effective
+  ceiling on resident memory**. It holds data + index + filter blocks. Too small
+  relative to the filter working set and filter blocks evict data blocks, so EVM
+  reads spill to disk. (Rationale in code: under `max_open_files=-1` the default
+  pins every SST's index+filter in heap, ~6 GB on a 490 GB mainnet DB.)
+- **`max_open_files=-1`**: keep all SSTs open (no open/close churn on reads).
+- **Compression off for state**: `account/storage_trie_nodes` and
+  `account/storage_flatkeyvalue` use `None` -> uncompressed blocks, so reads are
+  CPU-free and the OS page cache backstops them. `lz4` only for
+  headers/bodies/receipts/block-numbers/tx-locations/fullsync-headers.
+- **Bloom filters, 10 bits/key**, on all four state CFs, plus
+  `memtable_prefix_bloom_ratio(0.2)`. These prune SSTs on point lookups, which
+  is exactly the cold-read shape. No bloom on `transaction_locations` (it uses a
+  merge operator; negative reads are rare).
+- **Block size**: 16 KB for state CFs, 32 KB for headers/bodies/codes/receipts.
+- **Large state write buffers**: 512 MB memtable x up to 6, target file 256 MB,
+  L1 base 2 GB, dynamic level bytes. Fewer, larger levels -> fewer SSTs to probe
+  per read, less write amplification.
+- **`account_codes` blob files** (`min_blob_size=32`, lz4): large bytecodes go
+  to blobs, keeping the LSM small and code point lookups cheap; delegation
+  indicators (< 32 B) stay inline.
+- **WAL**: PointInTime recovery, `fdatasync` (not fsync), `bytes_per_sync=32MB`.
+  `flush()` on shutdown flushes memtables + WAL so the next open is
+  recovery-free.
+
+Tuning takeaways for a perf run:
+
+- The block cache size is the single biggest lever on cold-read rate. Measure
+  cache hit ratio before assuming disk latency is the problem.
+- On a synced node, expect account/slot reads to be one FKV point get. If you
+  see multi-node trie walks in a profile, check the FKV watermark
+  (`last_written`) and whether the keys are dirty.
+- Anything older than ~128 blocks bypasses Tier 1 entirely, so historical-state
+  queries (RPC at old blocks) are inherently colder than head-following reads.


### PR DESCRIPTION
## What

Adds a read-through value cache (`CleanCache`) beneath the in-memory diff-layer overlay in the trie read cascade:

```
TrieWrapper::get
  → TrieLayerCache overlay   (last ~128 blocks of writes)
  → CleanCache               (this: committed on-disk values)  ← new
  → disk (RocksDB)           (fill CleanCache on a hit)
```

## Why

Today there are only two things that keep a state read off disk:
- the **128-block overlay**, which holds *writes* from recent blocks, and
- **per-block memoization** (`StoreVmDatabase.account_state_cache`, `CachingDatabase`), rebuilt and thrown away every block.

So an account or slot that is **read a lot but not written** (a popular router/token/proxy) is not in the overlay and the per-block scratch is gone next block, it re-reads disk **every block**. This cache absorbs those repeats. It also composes with the BAL/prefetch work (#6872/#6873/#6878): prefetch handles first-touch-this-block, this handles repeat-across-blocks.

## Correctness

The on-disk state is a **single-version, path-keyed** store and `BackendTrieDB::get` ignores the state root, so a cache entry is just a memoization of that root-independent point get. The overlay always shadows any recently-written key, so a stale entry can never be observed for a recently-written key.

To keep invalidation trivial, the cache is **gated on FKV-complete (synced)** via `clean_cache_if_synced()`. In that regime the only writers of the four state CFs are:
- `commit_trie_layers` — invalidates each committed key (done in the write loop; race-free because the overlay still shadows those keys until the RCU swap);
- `write_storage_trie_nodes_batch` — bulk clear.

Before sync (genesis, snap-sync healing, FKV backfill) other paths mutate on-disk state without invalidating, so the cache simply stays off. Locked/snap-sync tries also never use it.

## Memory (bounded)

Hard-bounded **by bytes, not entry count** (the thing you asked about):
- default budget **512 MiB** (`DEFAULT_CLEAN_CACHE_MAX_BYTES`), split evenly across **64 shards**;
- each shard evicts its LRU tail until under its share; accounted weight = `key.len() + value.len() + 64 B` overhead, so the figure tracks real resident memory, not just payload;
- it is resident memory *in addition to* the RocksDB block cache, but far denser: it stores ~40-130 B decoded-path values instead of whole 4-16 KB SST blocks, so for random hashed-key access it holds far more of the working set per byte.

Observability: `Store::clean_cache_stats() -> (used_bytes, max_bytes, entries)`.

Sharding uses per-shard `Mutex` (keyed by the uniform leading nibbles) to avoid a global lock under the parallel executor + prefetch workers.

## Scope / limits

- Wins on **steady-state mainnet head-following** (Zipfian repeated reads). Does **not** help the `sload_bloated` / large-state suite (read-once slots never hit a cache) — that is what the parallel-prefetch PRs target.
- Positive-only caching in v1 (no negative caching); raw RLP bytes (skips the disk seek, not the decode — a typed decode-skipping cache at `Store::get_*` is a possible follow-up).
- Budget is a `const` for now; `TODO` to move to `StoreConfig`.

## Tests

- `crates/storage/clean_cache.rs`: get/insert/invalidate/clear, **byte-bound never exceeded under hammering**, oversized-entry rejection.
- Full `ethrex-storage` suite passes (27 tests), no read/commit-path regression. `cargo fmt` + `cargo clippy` clean.

## Follow-ups (not in this PR)

- End-to-end synced-path test driving the FKV generator to completion.
- `state-bench` (#6973) scenario: repeated hot-contract reads across N blocks to measure the delta.
- Frequency-pinning + persist-hot-set-on-shutdown to also kill the restart cold-start cliff.

Draft: correctness-reviewed and unit-tested, but not yet benchmarked on a synced node.

## Docs

- `docs/perf/storage-cold-paths.md` (new): reference for perf analyzers on how cold storage access and accounts work — the read tiers (overlay -> FKV point get -> trie-node walk), what makes a read truly cold, the 128-block window, FKV watermark, Store caches, and the RocksDB tuning that moves the cold boundary. Linked from `docs/perf/README.md`.
- `CHANGELOG.md`: entry under Perf.
