### PR TITLE
fix(trie): reject over-32-byte node child reference instead of panicking

### DIFF
--- a/crates/common/trie/rlp.rs
+++ b/crates/common/trie/rlp.rs
@@ -1,5 +1,3 @@
-use std::array;
-
 // Contains RLP encoding and decoding implementations for Trie Nodes
 // This encoding is only used to store the nodes in the DB, it is not the encoding used for hash computation
 use ethrex_rlp::{
@@ -12,7 +10,7 @@ use ethrex_rlp::{
 
 use ethrex_crypto::NativeCrypto;
 
-use super::node::{BranchNode, ExtensionNode, LeafNode, Node};
+use super::node::{BranchNode, ExtensionNode, LeafNode, Node, NodeRef};
 use crate::{Nibbles, NodeHash};
 
 // SAFETY: `NativeCrypto` is used here instead of a `&dyn Crypto` parameter because
@@ -132,7 +130,7 @@ impl RLPDecode for Node {
                     // Decode as Extension
                     ExtensionNode {
                         prefix: path,
-                        child: decode_child(rlp_items[1].expect("we already checked the length"))
+                        child: decode_child(rlp_items[1].expect("we already checked the length"))?
                             .into(),
                     }
                     .into()
@@ -140,9 +138,11 @@ impl RLPDecode for Node {
             }
             // Branch Node
             17 => {
-                let choices = array::from_fn(|i| {
-                    decode_child(rlp_items[i].expect("we already checked the length")).into()
-                });
+                let mut choices: [NodeRef; 16] = Default::default();
+                for (i, choice) in choices.iter_mut().enumerate() {
+                    *choice =
+                        decode_child(rlp_items[i].expect("we already checked the length"))?.into();
+                }
                 let (value, _) =
                     decode_bytes(rlp_items[16].expect("we already checked the length"))?;
                 BranchNode {
@@ -161,10 +161,13 @@ impl RLPDecode for Node {
     }
 }
 
-fn decode_child(rlp: &[u8]) -> NodeHash {
+fn decode_child(rlp: &[u8]) -> Result<NodeHash, RLPDecodeError> {
     match decode_bytes(rlp) {
-        Ok((hash, &[])) if hash.len() == 32 => NodeHash::from_slice(hash),
-        Ok((&[], &[])) => NodeHash::default(),
-        _ => NodeHash::from_slice(rlp),
+        Ok((hash, &[])) if hash.len() == 32 => Ok(NodeHash::from_slice(hash)),
+        Ok((&[], &[])) => Ok(NodeHash::default()),
+        _ if rlp.len() < 32 => Ok(NodeHash::from_slice(rlp)),
+        _ => Err(RLPDecodeError::Custom(
+            "invalid trie node child reference".to_string(),
+        )),
     }
 }

--- a/crates/common/trie/rlp.rs
+++ b/crates/common/trie/rlp.rs
@@ -166,8 +166,6 @@ fn decode_child(rlp: &[u8]) -> Result<NodeHash, RLPDecodeError> {
         Ok((hash, &[])) if hash.len() == 32 => Ok(NodeHash::from_slice(hash)),
         Ok((&[], &[])) => Ok(NodeHash::default()),
         _ if rlp.len() < 32 => Ok(NodeHash::from_slice(rlp)),
-        _ => Err(RLPDecodeError::Custom(
-            "invalid trie node child reference".to_string(),
-        )),
+        _ => Err(RLPDecodeError::InvalidLength),
     }
 }

--- a/crates/common/types/block_execution_witness.rs
+++ b/crates/common/types/block_execution_witness.rs
@@ -827,3 +827,44 @@ fn set_hash_or_validate(header: &BlockHeader, hash: H256) -> Result<(), GuestPro
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethrex_crypto::NativeCrypto;
+
+    /// Ingesting an untrusted witness must never abort the guest on a malformed
+    /// node. `decode_child` used to route a child field of 32 bytes or more into
+    /// `NodeHash::from_slice`, which panics on slices over 32 bytes, so a single
+    /// crafted node in `state` (even an unused one, since every entry is decoded)
+    /// could crash the prover.
+    #[test]
+    fn into_execution_witness_rejects_oversized_child_without_panicking() {
+        // A "branch" node whose first child field is a 34-byte RLP string: not
+        // empty, not a 32-byte hash reference, and not a sub-32-byte inline node.
+        // A well-formed trie never contains this.
+        let mut payload = vec![0xa1u8]; // RLP string, content length 33
+        payload.extend_from_slice(&[0u8; 33]);
+        payload.extend_from_slice(&[0x80u8; 16]); // 15 empty children + empty value
+        let mut malformed_node = vec![0xc0u8 + payload.len() as u8];
+        malformed_node.extend_from_slice(&payload);
+
+        let witness = RpcExecutionWitness {
+            state: vec![Bytes::from(malformed_node)],
+            ..Default::default()
+        };
+
+        // Parent header with an empty state root, so ingestion's only work is
+        // decoding the (unused) malformed node.
+        let parent = BlockHeader {
+            number: 0,
+            state_root: *EMPTY_TRIE_HASH,
+            ..Default::default()
+        };
+
+        // The unused malformed node is dropped and ingestion completes cleanly.
+        witness
+            .into_execution_witness(ChainConfig::default(), 1, &[parent], &NativeCrypto)
+            .unwrap();
+    }
+}


### PR DESCRIPTION
**Motivation**

A branch/extension child reference is canonically either a 32-byte hash or an inline node under 32 bytes. `decode_child` routed anything that was neither a clean 32-byte hash nor empty into `NodeHash::from_slice`, which panics on slices over 32 bytes, so a malformed child field of over 32 bytes would panic. This is unreachable for nodes read from the DB, which are well-formed by construction, but in the guest program the `ExecutionWitness` is untrusted and may be malformed, so a single crafted node could abort the prover.

**Description**

This PR makes `decode_child` return an error when such a fallthrough child reference is 32 bytes or more (neither a 32-byte hash nor a sub-32-byte inline node), which is not a canonical encoding, instead of passing it to `NodeHash::from_slice` and panicking.

Ran the benchmark `cargo bench -p ethrex-rlp --bench decode -- 'Node::(Extension|Branch)'` and no significant performance change:

```
# Without the fix

decode_trie/Node::Extension/1000
                        time:   [47.607 µs 47.702 µs 47.824 µs]
decode_trie/Node::Branch/1000
                        time:   [255.04 µs 258.11 µs 262.82 µs]

# With the fix

decode_trie/Node::Extension/1000
                        time:   [47.454 µs 47.644 µs 47.830 µs]
decode_trie/Node::Branch/1000
                        time:   [255.80 µs 257.27 µs 258.66 µs]
```

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

