### PR TITLE
feat(l1): make the engine-API max reorg depth configurable (--max-reorg-depth)

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -119,6 +119,30 @@ pub struct Options {
         env = "ETHREX_ROCKSDB_BLOCK_CACHE_SIZE",
     )]
     pub rocksdb_block_cache_size: usize,
+    #[arg(
+        long = "max-reorg-depth",
+        value_name = "BLOCKS",
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..),
+        help = "Maximum reorg depth the node can unwind, in blocks (default: 128). \
+                Deeper forkchoiceUpdated rewinds are rejected with -38006 Too deep reorg.",
+        long_help = "Maximum number of canonical blocks a single forkchoiceUpdated can revert. \
+                     Rewinds deeper than this are rejected with engine API error -38006 \
+                     (Too deep reorg).\n\
+                     \n\
+                     The limit equals the store's state-history retention: ethrex keeps one \
+                     in-memory trie diff-layer per block and folds older layers into the \
+                     single-version on-disk trie, after which they can no longer be unwound. \
+                     Raising the limit retains more layers, each costing roughly one block's \
+                     worth of trie updates in memory, so values above the default are mainly \
+                     intended for testing environments that rewind deep chains (e.g. hive \
+                     simulators resetting a shared client to genesis between tests).\n\
+                     \n\
+                     Defaults to 128 with the RocksDB backend and 10000 with the in-memory \
+                     backend. ETHREX_MAX_REORG_DEPTH sets the same value.",
+        help_heading = "Storage options",
+        env = "ETHREX_MAX_REORG_DEPTH",
+    )]
+    pub max_reorg_depth: Option<usize>,
     #[arg(long = "syncmode", default_value = "snap", value_name = "SYNC_MODE", value_parser = utils::parse_sync_mode, help = "The way in which the node will sync its state.", long_help = "Can be either \"full\" or \"snap\" with \"snap\" as default value.", help_heading = "P2P options", env = "ETHREX_SYNCMODE")]
     pub syncmode: SyncMode,
     #[arg(
@@ -521,6 +545,7 @@ impl Default for Options {
             bootnodes: Default::default(),
             datadir: Default::default(),
             rocksdb_block_cache_size: ethrex_storage::DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_BYTES,
+            max_reorg_depth: None,
             syncmode: Default::default(),
             metrics_addr: "0.0.0.0".to_owned(),
             metrics_port: Default::default(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -740,6 +740,7 @@ pub async fn init_l1(
 
     let store_config = StoreConfig {
         rocksdb_block_cache_size: opts.rocksdb_block_cache_size,
+        max_reorg_depth: opts.max_reorg_depth,
         ..StoreConfig::default()
     };
     let store_result = if opts.skip_genesis_validation {

--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -11,22 +11,6 @@ use crate::{
     is_canonical,
 };
 
-/// Maximum number of canonical blocks ethrex can revert in a single forkchoice update.
-///
-/// This is an implementation cap, not a spec policy. ethrex's state-history retention
-/// keeps the last ~128 blocks of state diffs, so reorgs deeper than this cannot be
-/// undone regardless of finalization status — the data simply isn't there.
-///
-/// The spec (execution-apis PR 786, "engine: Restrict no-reorg to the prefix of known
-/// finalized") only forbids reorging past the finalized prefix. The finalized check is
-/// applied first; this cap is a secondary guard for the implementation limit.
-///
-/// Reference values across ELs (devnet branches, 2026-04-30):
-/// - besu (main): 90_000 — effectively unlimited
-/// - erigon (glamsterdam-devnet-0): 96, env-configurable via `MAX_REORG_DEPTH`
-/// - geth / nethermind / reth: no engine-API rejection; trust the CL's fork choice
-pub const REORG_DEPTH_LIMIT: u64 = 128;
-
 /// Applies new fork choice data to the current blockchain. It performs validity checks:
 /// - The finalized, safe and head hashes must correspond to already saved blocks.
 /// - The saved blocks should be in the correct order (finalized <= safe <= head).
@@ -127,12 +111,21 @@ pub async fn apply_fork_choice(
 
     // execution-apis PR 786 point 6: -38006 TooDeepReorg is returned when the reorg
     // depth exceeds the limitation specific to the client software. ethrex's limit
-    // is its state-history retention: we keep the last REORG_DEPTH_LIMIT blocks of
-    // state diffs, so reorgs deeper than that cannot be unwound. We do not reject
+    // is its state-history retention: the store keeps one in-memory trie diff-layer
+    // per block before folding it into the single-version on-disk trie, so reorgs
+    // deeper than the retained layers cannot be unwound — the data simply isn't
+    // there. The limit is therefore derived from the store (128 by default,
+    // configurable via `--max-reorg-depth` / `StoreConfig::max_reorg_depth`), which
+    // keeps the check and the retention from drifting apart. We do not reject
     // reorgs that would cross the finalized prefix — the spec's only requirement on
     // finalized is point 2 (skip-when-ancestor-of-finalized, handled above) and
     // point 5 (-38002 for disconnected safe/finalized). The CL is authoritative on
     // fork choice and an EL must honor what the CL sends if it physically can.
+    //
+    // Reference values across ELs (devnet branches, 2026-04-30):
+    // - besu (main): 90_000 — effectively unlimited
+    // - erigon (glamsterdam-devnet-0): 96, env-configurable via `MAX_REORG_DEPTH`
+    // - geth / nethermind / reth: no engine-API rejection; trust the CL's fork choice
     //
     // The shared canonical ancestor is `head` itself when head is canonical (the
     // FCU truncates the canonical chain), or one below the lowest sidechain block
@@ -147,10 +140,11 @@ pub async fn apply_fork_choice(
             .saturating_sub(1)
     };
     let reorg_depth = latest.saturating_sub(canonical_link_height);
-    if reorg_depth > REORG_DEPTH_LIMIT {
+    let max_reorg_depth = store.max_reorg_depth()?;
+    if reorg_depth > max_reorg_depth {
         return Err(InvalidForkChoice::TooDeepReorg {
             reorg_depth,
-            limit: REORG_DEPTH_LIMIT,
+            limit: max_reorg_depth,
         });
     }
 

--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -128,6 +128,13 @@ impl TrieLayerCache {
         None
     }
 
+    /// Number of layers retained before a disk flush is triggered — equivalently,
+    /// the depth of state history this cache keeps unwindable (one layer per block
+    /// during regular per-block execution).
+    pub fn commit_threshold(&self) -> usize {
+        self.commit_threshold
+    }
+
     /// Returns the state root from which to start a disk commit, using the cache's
     /// default `commit_threshold`.
     ///

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -61,8 +61,10 @@ use tracing::{debug, error, info, warn};
 /// Maximum number of execution witnesses to keep in the database
 pub const MAX_WITNESSES: u64 = 128;
 
-// We use one constant for in-memory and another for on-disk backends.
-// This is due to tests requiring state older than 128 blocks.
+// Default trie diff-layer retention per backend, overridable via
+// `StoreConfig::max_reorg_depth`. We use one constant for in-memory and
+// another for on-disk backends because tests require state older than
+// 128 blocks.
 // TODO: unify these
 #[allow(unused)]
 const DB_COMMIT_THRESHOLD: usize = 128;
@@ -99,6 +101,18 @@ pub struct StoreConfig {
     /// blocks — that is the backpressure that throttles `newPayload`.
     /// Clamped to `max(1)` at construction (0 would make a rendezvous channel).
     pub persist_channel_capacity: usize,
+    /// Maximum reorg depth the store can serve, in blocks. Sets the in-memory
+    /// trie diff-layer retention (the [`TrieLayerCache`] commit threshold):
+    /// during live per-block execution one layer holds one block's state diff,
+    /// and once a layer is folded into the single-version on-disk trie the
+    /// ancestor state it replaced can no longer be unwound. Fork choice derives
+    /// its -38006 "too deep reorg" limit from this value (see
+    /// [`Store::max_reorg_depth`]), so the limit and the retention cannot drift
+    /// apart. `None` keeps the backend default: `DB_COMMIT_THRESHOLD` (128) for
+    /// RocksDB, `IN_MEMORY_COMMIT_THRESHOLD` (10000) for in-memory. Each
+    /// retained layer costs memory (one block's trie updates), so raising this
+    /// is mainly intended for testing environments with deep reorgs.
+    pub max_reorg_depth: Option<usize>,
 }
 
 impl Default for StoreConfig {
@@ -106,6 +120,7 @@ impl Default for StoreConfig {
         Self {
             rocksdb_block_cache_size: DEFAULT_ROCKSDB_BLOCK_CACHE_SIZE_BYTES,
             persist_channel_capacity: DEFAULT_PERSIST_CHANNEL_CAPACITY,
+            max_reorg_depth: None,
         }
     }
 }
@@ -1688,8 +1703,7 @@ impl Store {
     pub fn new_with_config(
         path: impl AsRef<Path>,
         engine_type: EngineType,
-        // `config` only feeds the RocksDB backend; without that feature it is unused.
-        #[cfg_attr(not(feature = "rocksdb"), allow(unused_variables))] config: StoreConfig,
+        config: StoreConfig,
     ) -> Result<Self, StoreError> {
         let db_path = path.as_ref().to_path_buf();
 
@@ -1740,7 +1754,7 @@ impl Store {
                     return Self::from_backend(
                         backend,
                         db_path,
-                        DB_COMMIT_THRESHOLD,
+                        config.max_reorg_depth.unwrap_or(DB_COMMIT_THRESHOLD),
                         config.persist_channel_capacity,
                     );
                 }
@@ -1762,7 +1776,7 @@ impl Store {
                 Self::from_backend(
                     backend,
                     db_path,
-                    DB_COMMIT_THRESHOLD,
+                    config.max_reorg_depth.unwrap_or(DB_COMMIT_THRESHOLD),
                     config.persist_channel_capacity,
                 )
             }
@@ -1771,7 +1785,7 @@ impl Store {
                 Self::from_backend(
                     backend,
                     db_path,
-                    IN_MEMORY_COMMIT_THRESHOLD,
+                    config.max_reorg_depth.unwrap_or(IN_MEMORY_COMMIT_THRESHOLD),
                     config.persist_channel_capacity,
                 )
             }
@@ -3264,6 +3278,20 @@ impl Store {
             Some(account_hash),
         );
         Ok(Trie::open(Box::new(trie_db), storage_root))
+    }
+
+    /// Maximum reorg depth this store can serve: the number of in-memory trie
+    /// diff-layers retained (one per block during live sync) before they are
+    /// folded into the single-version on-disk trie. Ancestor states deeper than
+    /// this are unrecoverable, so fork choice rejects deeper rewinds with
+    /// -38006 (see `apply_fork_choice`). Configurable via
+    /// [`StoreConfig::max_reorg_depth`] (`--max-reorg-depth`).
+    pub fn max_reorg_depth(&self) -> Result<u64, StoreError> {
+        Ok(self
+            .trie_cache
+            .read()
+            .map_err(|_| StoreError::LockError)?
+            .commit_threshold() as u64)
     }
 
     pub fn has_state_root(&self, state_root: H256) -> Result<bool, StoreError> {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -200,6 +200,15 @@ Storage options:
           [env: ETHREX_ROCKSDB_BLOCK_CACHE_SIZE=]
           [default: 12884901888]
 
+      --max-reorg-depth <BLOCKS>
+          Maximum number of canonical blocks a single forkchoiceUpdated can revert. Rewinds deeper than this are rejected with engine API error -38006 (Too deep reorg).
+          
+          The limit equals the store's state-history retention: ethrex keeps one in-memory trie diff-layer per block and folds older layers into the single-version on-disk trie, after which they can no longer be unwound. Raising the limit retains more layers, each costing roughly one block's worth of trie updates in memory, so values above the default are mainly intended for testing environments that rewind deep chains (e.g. hive simulators resetting a shared client to genesis between tests).
+          
+          Defaults to 128 with the RocksDB backend and 10000 with the in-memory backend. ETHREX_MAX_REORG_DEPTH sets the same value.
+          
+          [env: ETHREX_MAX_REORG_DEPTH=]
+
 RPC options:
       --http.addr <ADDRESS>
           Listening address for the HTTP JSON-RPC server. Defaults to 127.0.0.1 so the endpoint is only reachable from localhost; pass 0.0.0.0 to bind on all interfaces (only recommended when the node sits behind a trusted firewall or reverse proxy).

--- a/test/tests/blockchain/smoke_tests.rs
+++ b/test/tests/blockchain/smoke_tests.rs
@@ -12,7 +12,7 @@ use ethrex_common::{
     H160, H256,
     types::{Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, ELASTICITY_MULTIPLIER},
 };
-use ethrex_storage::{EngineType, Store};
+use ethrex_storage::{EngineType, Store, StoreConfig};
 
 #[tokio::test]
 async fn test_small_to_long_reorg() {
@@ -290,10 +290,10 @@ async fn latest_block_number_should_always_be_the_canonical_head() {
 async fn unfinalized_reorg_deeper_than_32_is_allowed() {
     // Per execution-apis PR 786 point 6, -38006 TooDeepReorg fires when the reorg
     // depth exceeds the implementation-specific limit. ethrex defines that limit as
-    // its state-history retention (REORG_DEPTH_LIMIT = 128), matching the stance of
-    // Erigon/Nethermind/Besu/geth — the EL trusts the CL's fork choice and only
-    // rejects when it physically cannot unwind. A 33-block reorg from genesis is
-    // well under the cap and must succeed.
+    // its state-history retention (`Store::max_reorg_depth`, 128 by default on
+    // RocksDB), matching the stance of Erigon/Nethermind/Besu/geth — the EL trusts
+    // the CL's fork choice and only rejects when it physically cannot unwind. A
+    // 33-block reorg from genesis is well under the cap and must succeed.
 
     let store = test_store().await;
     let genesis_header = store.get_block_header(0).unwrap().unwrap();
@@ -345,6 +345,66 @@ async fn unfinalized_reorg_deeper_than_32_is_allowed() {
     }
 }
 
+#[tokio::test]
+async fn reorg_depth_limit_follows_store_retention() {
+    // The -38006 TooDeepReorg limit is derived from the store's state-history
+    // retention (`StoreConfig::max_reorg_depth`), so configuring the store moves
+    // the fork-choice limit with it. A small retention keeps the test fast; the
+    // rewind-to-genesis models how EEST's consume-enginex simulator resets a
+    // shared client between tests.
+    let store = test_store_with_config(StoreConfig {
+        max_reorg_depth: Some(8),
+        ..StoreConfig::default()
+    })
+    .await;
+    assert_eq!(store.max_reorg_depth().unwrap(), 8);
+
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let genesis_hash = genesis_header.hash();
+    let blockchain = Blockchain::default_with_store(store.clone());
+
+    // Build a 10-block canonical chain: genesis → A1 → ... → A10.
+    let mut parent = genesis_header.clone();
+    let mut hashes = Vec::new();
+    for _ in 0..10 {
+        let block = new_block(&store, &parent).await;
+        parent = block.header.clone();
+        hashes.push(block.hash());
+        blockchain.add_block(block).unwrap();
+    }
+    let head = *hashes.last().unwrap();
+    apply_fork_choice(&store, head, H256::zero(), H256::zero())
+        .await
+        .expect("FCU to chain head should succeed");
+
+    // Rewinding to genesis is 10 blocks deep: over the configured limit of 8.
+    let result = apply_fork_choice(&store, genesis_hash, H256::zero(), H256::zero()).await;
+    assert!(
+        matches!(
+            result,
+            Err(InvalidForkChoice::TooDeepReorg {
+                reorg_depth: 10,
+                limit: 8
+            })
+        ),
+        "expected TooDeepReorg {{ reorg_depth: 10, limit: 8 }}, got {result:?}"
+    );
+    // The refused rewind must leave the head untouched.
+    assert_eq!(store.get_latest_block_number().await.unwrap(), 10);
+
+    // A rewind of exactly the configured depth is allowed (the check is exclusive)
+    // and the target state is still retained, so the FCU succeeds end-to-end.
+    apply_fork_choice(&store, hashes[1], H256::zero(), H256::zero())
+        .await
+        .expect("rewind at the configured limit should succeed");
+    assert_eq!(store.get_latest_block_number().await.unwrap(), 2);
+
+    // Without an explicit override the limit is the backend default rather than
+    // a hardcoded fork-choice constant (10000 for the in-memory backend).
+    let store = test_store().await;
+    assert_eq!(store.max_reorg_depth().unwrap(), 10000);
+}
+
 async fn new_block(store: &Store, parent: &BlockHeader) -> Block {
     let args = BuildPayloadArgs {
         parent: parent.hash(),
@@ -372,6 +432,10 @@ fn workspace_root() -> PathBuf {
 }
 
 async fn test_store() -> Store {
+    test_store_with_config(StoreConfig::default()).await
+}
+
+async fn test_store_with_config(config: StoreConfig) -> Store {
     // Get genesis
     let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
         .expect("Failed to open genesis file");
@@ -379,8 +443,8 @@ async fn test_store() -> Store {
     let genesis = serde_json::from_reader(reader).expect("Failed to deserialize genesis file");
 
     // Build store with genesis
-    let mut store =
-        Store::new("store.db", EngineType::InMemory).expect("Failed to build DB for testing");
+    let mut store = Store::new_with_config("store.db", EngineType::InMemory, config)
+        .expect("Failed to build DB for testing");
 
     store
         .add_initial_state(genesis)


### PR DESCRIPTION

## TLDR

We added the `enginex` simulator to the [Hive Generic dashboard](https://hive.ethpandaops.io/#/group/generic?suites=eels%2Fconsume-enginex%2Ceels%2Fconsume-engine) this week. This simulator runs multiple tests against a single client instance; for each test, the simulator FCUs to genesis and then after each payload in the test. This triggers reorgs larger than ethrex's 128-block limit. More details in the [enginex docs](https://github.com/danceratopz/execution-specs/blob/a5da2157f765ef3b64f556f40438a1dbe01ec72d/docs/running_tests/running.md#enginex). The simulator's FCU behavior was designed to be consistent with the original `engine` simulator; an alternative would be to change the simulator to only verify payloads without FCU, but I think it's cleaner as it is currently (per docs above).

Feel free to close this PR/re-implement as you see fit; whatever's easiest. Thanks!

## Motivation

EEST's `consume enginex` simulator (via hive) reuses one client per pre-allocation group across many tests, and each test starts by sending a forkchoiceUpdated with `head = genesis` to reset the shared client:

- That reset is a canonical-ancestor rewind whose depth equals the chain height left by the previous test. As soon as one test's chain grows deeper than 128 blocks (e.g. `test_genesis_hash_available[...-256_empty_blocks]` leaves the head at block 257), the reset is refused with `-38006 Too deep reorg: Reorg depth 257 exceeds the client's limit of 128`.
- Because the refused rewind leaves the head in place, every subsequent test on that client fails identically — a single deep test permanently poisons the shared client. Importing the deep chain itself is fine; only the deep canonical-ancestor rewind trips the limit.

Erigon has the same kind of cap but reads it from the `MAX_REORG_DEPTH` environment variable, which is how hive already works around it for enginex runs (ethereum/hive#1568, raising it to 512); go-ethereum is gaining the equivalent knob in ethereum/go-ethereum#35335. ethrex currently offers no knob.

## Why not just bump the constant

Unlike geth's cap (an arbitrary safety margin), ethrex's 128 is anchored to real state retention: the store keeps one in-memory trie diff-layer per block (`TrieLayerCache`, commit threshold 128) and folds older layers into the single-version on-disk trie, after which the replaced ancestor states are unrecoverable. Raising only the fork-choice constant would let a deep rewind pass the depth check and then fail the `has_state_root` reachability check, degrading the FCU into `SYNCING` and a sync toward the head that can never complete in an isolated test network. The knob has to raise the retention and the fork-choice limit **together**.

## Changes

- Derive the fork-choice limit from the store's actual retention, and make the retention configurable — a single source of truth, so the limit and the retention cannot drift apart:
  - `StoreConfig::max_reorg_depth: Option<usize>` sets the trie diff-layer commit threshold. `None` (the default) keeps the existing per-backend defaults: 128 for RocksDB, 10000 for the in-memory backend.
  - `Store::max_reorg_depth()` exposes the configured retention; `apply_fork_choice` now reads the limit from the store instead of the hardcoded `REORG_DEPTH_LIMIT` const (removed). No call-site signature changes anywhere.
- New CLI flag `--max-reorg-depth <BLOCKS>` (env `ETHREX_MAX_REORG_DEPTH`, values ≥ 1), plumbed through `StoreConfig` like the existing `--rocksdb.block-cache-size`.
- Added `reorg_depth_limit_follows_store_retention` (test/tests/blockchain/smoke_tests.rs): a 10-block chain on a store configured with `max_reorg_depth = 8` refuses the genesis reset with `TooDeepReorg { reorg_depth: 10, limit: 8 }` and leaves the head untouched (the poisoning dynamic); a rewind of exactly the configured depth succeeds end-to-end (the retained state is really served, not just depth-checked); an unconfigured store reports its backend default as the limit.

### Semantics

- Default behavior is unchanged: a persistent (RocksDB) node still refuses rewinds deeper than 128 with `-38006 Too deep reorg`.
- `--max-reorg-depth 512` retains 512 diff-layers and accepts rewinds up to 512 blocks. Each retained layer costs roughly one block's worth of trie updates in memory, so large values are intended for testing environments.
- In-memory (`--datadir memory`) nodes now report their true retention (10000) as the limit instead of the over-strict 128 — they were already physically able to serve those rewinds.
- There is no "0 = unlimited" mode (unlike geth): unlimited retention is not free in ethrex's architecture, so the limit is always explicit.
- Batch import (`ethrex import`, full sync) intentionally keeps its aggressive flush threshold; the retention setting governs live per-block execution, which is what the engine-API scenario exercises.

## Notes

- Hive-side companion (required for enginex runs to benefit): ethereum/hive#1571 sets `ETHREX_MAX_REORG_DEPTH=512` in `clients/ethrex/ethrex.sh` when the simulator requests deep reorgs (`HIVE_EXPECT_DEEP_REORGS`, set by the enginex multi-test client environment as of ethereum/execution-specs#3145), mirroring the erigon fix in ethereum/hive#1568. clap only reads env vars for args it declares, so ethrex builds without this flag silently ignore the variable — safe to set for older releases.

## Verification

Verified against EEST's `consume enginex` in hive `--dev` mode and via the standalone hive command, using the minimal failing pair: a 257-block test followed by any test on the same shared client (the second test's reset-to-genesis forkchoiceUpdated is a depth-257 canonical rewind). Note the pair differs from the one used to verify the equivalent geth fix (ethereum/go-ethereum#35335): geth's limit is 32, so a 37-block chain trips it; ethrex's 128-block limit needs the deeper `test_genesis_hash_available[...-256_empty_blocks]` chain.

Setup, in a hive checkout: build this branch on the host (`cargo build --release --locked --bin ethrex`), copy the binary to `clients/ethrex/ethrex-local/ethrex`, add a `clients/ethrex/Dockerfile.binlocal` that COPYs it into the stock ethrex client image (same layout as `clients/reth/Dockerfile.binlocal`; the image's glibc must be >= the host's), add `export ETHREX_MAX_REORG_DEPTH=512` to `clients/ethrex/ethrex.sh` (this is what ethereum/hive#1571 does, gated on the simulator opting in via `HIVE_EXPECT_DEEP_REORGS` — that PR is required for enginex runs to pick this fix up), and create `ethrex-local.yaml`:

```yaml
- client: ethrex
  nametag: maxreorg-local
  dockerfile: binlocal
  build_args:
    local_path: ethrex-local
```

Fastest: run hive in `--dev` mode and drive it with consume from an execution-specs (EEST) checkout, filling the two fixtures locally instead of downloading the release:

```bash
./hive --dev --client ethrex --client-file ethrex-local.yaml \
  --docker.output --dev.addr 127.0.0.1:3012
```

```bash
uv run fill --generate-all-formats -m blockchain_test_engine_x --output=fixtures/ --clean \
  --regex='.*fork_Osaka.*(256_empty_blocks|program_INVALID-debug).*' \
  tests/frontier/opcodes/test_blockhash.py tests/frontier/scenarios/test_scenarios.py -v

export HIVE_SIMULATOR=http://127.0.0.1:3012
uv run consume enginex --input=fixtures/ -v
```

Alternatively, run the two tests with a single standalone hive command (the first run builds the simulator image, which downloads the `tests@v20.0.0` fixture release):

```bash
./hive --sim ethereum/eels/consume-enginex \
  --sim.buildarg fixtures=tests@v20.0.0 \
  --client ethrex --client-file ethrex-local.yaml \
  --sim.limit '.*fork_Osaka-blockchain_test_engine_x-(256_empty_blocks|test_program_program_INVALID-debug).*' \
  --docker.output
```

Both fixtures land in the same pre-allocation group (`0x8d9f55744d74a1de`), so one client is reused across them, with the 256-block test running first.

Results (identical in both modes):

- Control (this branch, `ETHREX_MAX_REORG_DEPTH` unset, default 128 — identical to current main): `test_genesis_hash_available` passes leaving the head at block 257; `test_scenarios[...program_INVALID-debug]` fails its initial forkchoice update with `-38006 Too deep reorg: Reorg depth 257 exceeds the client's limit of 128`.
- With `ETHREX_MAX_REORG_DEPTH=512`: both tests pass.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — not needed: no on-disk format change; the retention knob only affects how many in-memory diff-layers are kept, and restarts already drop and re-execute the non-flushed tail.
