### PR TITLE
ci(l1): harden docs link check (cache, retries, exclude SUMMARY.md drafts)

### DIFF
--- a/.github/workflows/pr-main_mdbook.yml
+++ b/.github/workflows/pr-main_mdbook.yml
@@ -50,10 +50,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Persist lychee's per-URL result cache so unchanged links aren't
+      # re-fetched on every run (config lives in lychee.toml).
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --exclude 'localhost' --exclude 'medium.com' --exclude 'mirror.xyz' --exclude 'etherscan.io' docs/
+          args: --no-progress --config lychee.toml docs/
           fail: true
 
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ core.*
 *.log
 
 __pycache__/
+.lycheecache

--- a/docs/developers/l2/dev-mode.md
+++ b/docs/developers/l2/dev-mode.md
@@ -26,7 +26,3 @@ The default port of the L2 JSON-RPC is 1729 you can test it by running
 ```sh
 rex block-number http://localhost:1729
 ```
-
-## Guides
-
-For more information on how to perform certain operations, go to [Guides]().

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,28 @@
+# Configuration for the lychee link checker (Link Check CI job).
+# https://lychee.cli.rs/usage/config/
+
+# Cache per-URL results between runs; persisted across CI runs via actions/cache.
+cache = true
+max_cache_age = "2d"
+
+# Retry transient network failures before declaring a link dead.
+max_retries = 3
+retry_wait_time = 2
+
+# Don't fail the build on rate-limiting / transient upstream errors.
+# 2xx are the successes; 429 (too many requests) and 503 (service
+# unavailable) are almost always flaky hosts rather than broken links.
+accept = ["200..=299", "429", "503"]
+
+# Hosts that are unreliable for automated checking or block bots outright.
+exclude = [
+  "localhost",
+  "medium\\.com",
+  "mirror\\.xyz",
+  "etherscan\\.io",
+]
+
+# SUMMARY.md uses intentional mdBook draft chapters (empty links), which
+# lychee reports as errors. Its structure is already validated by
+# `mdbook build` in the Lint job, so link-checking it is redundant.
+exclude_path = ["docs/SUMMARY.md"]


### PR DESCRIPTION
The Link Check job was failing deterministically on 9 empty markdown links. 8 are intentional mdBook draft chapters in `docs/SUMMARY.md` (entries like `[Metrics]()` render as greyed-out placeholder chapters — legit mdBook feature, but lychee flags them as "Empty URL"). The 9th, `[Guides]()` in `docs/developers/l2/dev-mode.md`, was a genuinely dead placeholder pointing nowhere; removed it.

Added `lychee.toml` to centralize config and exclude `docs/SUMMARY.md` from checking — its structure is already validated by `mdbook build` in the Lint job, so re-checking it is redundant and just produces false positives on the drafts. Also hardened against real network flakiness: per-URL caching (`cache = true` + an `actions/cache` step persisting `.lycheecache` across runs), `max_retries = 3` / `retry_wait_time = 2`, and accepting 429/503 so rate-limited or momentarily-down hosts don't fail the build. `.lycheecache` added to `.gitignore`.

Verified locally with lychee 0.24.2: config parses, offline run over `docs/` reports 0 errors.