### PR TITLE
refactor(l1,l2): remove v0 blob sidecar support

### DIFF
--- a/cmd/ethrex/Cargo.toml
+++ b/cmd/ethrex/Cargo.toml
@@ -106,6 +106,7 @@ jemalloc_profiling = [
 sync-test = ["ethrex-p2p/sync-test"]
 
 l2 = [
+  "c-kzg",
   "ethrex-l2",
   "ethrex-l2-common",
   "ethrex-l2-rpc",

--- a/cmd/ethrex/l2/command.rs
+++ b/cmd/ethrex/l2/command.rs
@@ -149,7 +149,7 @@ pub enum Command {
         #[arg(
             short = 'o',
             long,
-            help = "Whether Osaka fork is activated or not. If None, it assumes it is active."
+            help = "Deprecated compatibility option; v1 blob sidecars are always used."
         )]
         osaka_activated: Option<bool>,
     },
@@ -381,6 +381,11 @@ impl Command {
                 store_path,
                 osaka_activated,
             } => {
+                if osaka_activated.is_some() {
+                    tracing::warn!(
+                        "--osaka-activated / -o is deprecated and ignored; ethrex always uses v1 (EIP-7594) blob sidecars"
+                    );
+                }
                 #[cfg(feature = "rocksdb")]
                 let store_type = EngineType::RocksDB;
 
@@ -501,16 +506,7 @@ impl Command {
                     let blob = blobs_bundle::blob_from_bytes(Bytes::copy_from_slice(&blob))
                         .expect("Failed to create blob from bytes; blob was just read from file");
 
-                    let wrapper_version = if let Some(activated) = osaka_activated
-                        && !activated
-                    {
-                        None
-                    } else {
-                        Some(1)
-                    };
-
-                    let blobs_bundle =
-                        BlobsBundle::create_from_blobs(&vec![blob], wrapper_version)?;
+                    let blobs_bundle = BlobsBundle::create_from_blobs(&vec![blob])?;
 
                     let batch = get_batch(
                         &store,

--- a/cmd/ethrex/l2/options.rs
+++ b/cmd/ethrex/l2/options.rs
@@ -166,6 +166,12 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
     type Error = SequencerOptionsError;
 
     fn try_from(opts: SequencerOptions) -> Result<Self, Self::Error> {
+        if opts.eth_opts.osaka_activation_time.is_some() {
+            tracing::warn!(
+                "--osaka-activation-time / ETHREX_OSAKA_ACTIVATION_TIME is deprecated and ignored; ethrex always uses v1 (EIP-7594) blob sidecars"
+            );
+        }
+
         let committer_signer = parse_signer(
             opts.committer_opts.committer_l1_private_key,
             opts.committer_opts.committer_remote_signer_url,
@@ -212,7 +218,6 @@ impl TryFrom<SequencerOptions> for SequencerConfig {
                 maximum_allowed_max_fee_per_blob_gas: opts
                     .eth_opts
                     .maximum_allowed_max_fee_per_blob_gas,
-                osaka_activation_time: opts.eth_opts.osaka_activation_time,
             },
             l1_watcher: L1WatcherConfig {
                 bridge_address: opts
@@ -315,6 +320,14 @@ impl SequencerOptions {
 #[derive(Parser, Debug)]
 pub struct EthOptions {
     #[arg(
+        long = "osaka-activation-time",
+        value_name = "UINT64",
+        env = "ETHREX_OSAKA_ACTIVATION_TIME",
+        help = "Deprecated compatibility option; v1 blob sidecars are always used.",
+        help_heading = "Eth options"
+    )]
+    pub osaka_activation_time: Option<u64>,
+    #[arg(
         long = "eth.rpc-url",
         value_name = "RPC_URL",
         env = "ETHREX_ETH_RPC_URL",
@@ -371,18 +384,12 @@ pub struct EthOptions {
         help_heading = "Eth options"
     )]
     pub max_retry_delay: u64,
-    #[clap(
-        long,
-        value_name = "UINT64",
-        env = "ETHREX_OSAKA_ACTIVATION_TIME",
-        help = "Block timestamp at which the Osaka fork is activated on L1. If not set, it will assume Osaka is already active."
-    )]
-    pub osaka_activation_time: Option<u64>,
 }
 
 impl Default for EthOptions {
     fn default() -> Self {
         Self {
+            osaka_activation_time: None,
             rpc_url: vec![
                 Url::parse("http://localhost:8545").expect("Unreachable error. URL is hardcoded"),
             ],
@@ -392,7 +399,6 @@ impl Default for EthOptions {
             backoff_factor: BACKOFF_FACTOR,
             min_retry_delay: MIN_RETRY_DELAY,
             max_retry_delay: MAX_RETRY_DELAY,
-            osaka_activation_time: None,
         }
     }
 }

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -3728,7 +3728,7 @@ impl Blockchain {
 
                 P2PTransaction::EIP4844TransactionWithBlobs(WrappedEIP4844Transaction {
                     tx: itx,
-                    wrapper_version: (bundle.version != 0).then_some(bundle.version),
+                    wrapper_version: Some(bundle.version),
                     blobs_bundle: bundle,
                 })
             }

--- a/crates/blockchain/mempool.rs
+++ b/crates/blockchain/mempool.rs
@@ -715,12 +715,19 @@ impl Mempool {
             .collect())
     }
 
-    /// Add a blobs bundle to the pool by its blob transaction hash
+    /// Add a blobs bundle to the pool by its blob transaction hash.
+    ///
+    /// Enforces the v1 cell-proof layout so direct inserts cannot weaken the
+    /// pool invariant enforced by `add_blob_transaction_to_pool`. Callers that
+    /// need synthetic fixtures must supply structurally valid v1 bundles.
     pub fn add_blobs_bundle(
         &self,
         tx_hash: H256,
         blobs_bundle: BlobsBundle,
     ) -> Result<(), StoreError> {
+        blobs_bundle
+            .validate_v1_structure()
+            .map_err(|err| StoreError::Custom(format!("invalid v1 blob bundle: {err}")))?;
         let mut mempool = self.write()?;
         for (i, c) in blobs_bundle.commitments.iter().enumerate() {
             let versioned_hash = kzg_commitment_to_versioned_hash(c);

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -924,15 +924,43 @@ impl Blockchain {
             // This error will only be used for debug tracing
             return Err(EvmError::Custom("max data blobs reached".to_string()).into());
         };
+        // Validate sidecar shape before execution so an invalid/corrupt accumulator
+        // is rejected without including the tx. append_v1 still runs after apply as
+        // a fail-closed check; it is expected to succeed after these pre-checks.
+        if let Some(ref blobs_bundle) = bundle {
+            blobs_bundle.validate_v1_structure().map_err(|err| {
+                ChainError::Custom(format!(
+                    "invalid v1 blob bundle while building payload: {err}"
+                ))
+            })?;
+            if !context.blobs_bundle.is_empty() {
+                context
+                    .blobs_bundle
+                    .validate_v1_structure()
+                    .map_err(|err| {
+                        ChainError::Custom(format!(
+                            "corrupt payload blob accumulator while building payload: {err}"
+                        ))
+                    })?;
+            }
+        }
         // Apply transaction
         let receipt = apply_plain_transaction(head, context)?;
-        // Update context with blob data
+        // Append sidecar before bumping blob gas so a defensive append failure
+        // cannot leave inflated blob_gas_used on an excluded tx.
+        if let Some(blobs_bundle) = bundle {
+            context
+                .blobs_bundle
+                .append_v1(blobs_bundle)
+                .map_err(|err| {
+                    ChainError::Custom(format!(
+                        "invalid v1 blob bundle while building payload: {err}"
+                    ))
+                })?;
+        }
         let prev_blob_gas = context.payload.header.blob_gas_used.unwrap_or_default();
         context.payload.header.blob_gas_used =
             Some(prev_blob_gas + (blob_count * GAS_PER_BLOB as usize) as u64);
-        if let Some(blobs_bundle) = bundle {
-            context.blobs_bundle += blobs_bundle;
-        }
         Ok(receipt)
     }
 

--- a/crates/common/types/blobs_bundle.rs
+++ b/crates/common/types/blobs_bundle.rs
@@ -1,5 +1,3 @@
-use std::ops::AddAssign;
-
 use crate::serde_utils;
 #[cfg(feature = "c-kzg")]
 use crate::types::Fork;
@@ -22,7 +20,7 @@ pub type Commitment = Bytes48;
 pub type Proof = Bytes48;
 pub type BlobTuple = (Box<Blob>, Commitment, Vec<Proof>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 /// Struct containing all the blobs for a blob transaction, along with the corresponding commitments and proofs
 pub struct BlobsBundle {
@@ -32,8 +30,25 @@ pub struct BlobsBundle {
     pub commitments: Vec<Commitment>,
     #[serde(with = "serde_utils::bytes48::vec")]
     pub proofs: Vec<Proof>,
-    #[serde(skip, default)]
+    /// Sidecar wrapper version. Empty accumulators default to v1 so payload
+    /// builders and validium paths stay consistent with the v1-only policy.
+    #[serde(skip, default = "default_blob_sidecar_version")]
     pub version: u8,
+}
+
+fn default_blob_sidecar_version() -> u8 {
+    1
+}
+
+impl Default for BlobsBundle {
+    fn default() -> Self {
+        Self {
+            blobs: Vec::new(),
+            commitments: Vec::new(),
+            proofs: Vec::new(),
+            version: default_blob_sidecar_version(),
+        }
+    }
 }
 
 pub fn blob_from_bytes(bytes: Bytes) -> Result<Blob, BlobsBundleError> {
@@ -76,6 +91,18 @@ pub fn kzg_commitment_to_versioned_hash(data: &Commitment) -> H256 {
     versioned_hash.into()
 }
 
+/// Compute a single EIP-4844 KZG polynomial proof for `blob`.
+///
+/// This is intentionally separate from `create_from_blobs` (which always produces
+/// v1 cell-proof sidecars). Use this only when a single KZG proof is needed for a
+/// non-P2P purpose, such as supplying `ProverInputData.blob_proof` to the ZK prover.
+#[cfg(feature = "c-kzg")]
+pub fn blob_to_kzg_proof(blob: &Blob) -> Result<Proof, BlobsBundleError> {
+    use ethrex_crypto::kzg::blob_to_kzg_commitment_and_proof;
+    let (_, proof) = blob_to_kzg_commitment_and_proof(blob)?;
+    Ok(proof)
+}
+
 impl BlobsBundle {
     pub fn empty() -> Self {
         Self::default()
@@ -87,34 +114,23 @@ impl BlobsBundle {
 
     // In the future we might want to provide a new method that calculates the commitments and proofs using the following.
     #[cfg(feature = "c-kzg")]
-    pub fn create_from_blobs(
-        blobs: &Vec<Blob>,
-        wrapper_version: Option<u8>,
-    ) -> Result<Self, BlobsBundleError> {
-        use ethrex_crypto::kzg::{
-            blob_to_commitment_and_cell_proofs, blob_to_kzg_commitment_and_proof,
-        };
+    pub fn create_from_blobs(blobs: &Vec<Blob>) -> Result<Self, BlobsBundleError> {
+        use ethrex_crypto::kzg::blob_to_commitment_and_cell_proofs;
         let mut commitments = Vec::new();
         let mut proofs = Vec::new();
 
-        // Populate the commitments and proofs
+        // Always produce v1 (EIP-7594) cell-proof sidecars.
         for blob in blobs {
-            if wrapper_version.unwrap_or(0) == 0 {
-                let (commitment, proof) = blob_to_kzg_commitment_and_proof(blob)?;
-                commitments.push(commitment);
-                proofs.push(proof);
-            } else {
-                let (commitment, cell_proofs) = blob_to_commitment_and_cell_proofs(blob)?;
-                commitments.push(commitment);
-                proofs.extend(cell_proofs);
-            }
+            let (commitment, cell_proofs) = blob_to_commitment_and_cell_proofs(blob)?;
+            commitments.push(commitment);
+            proofs.extend(cell_proofs);
         }
 
         Ok(Self {
             blobs: blobs.clone(),
             commitments,
             proofs,
-            version: wrapper_version.unwrap_or(0),
+            version: 1,
         })
     }
 
@@ -130,12 +146,48 @@ impl BlobsBundle {
     pub fn get_blob_tuple_by_index(&self, index: usize) -> Option<BlobTuple> {
         let blob = Box::new(*self.blobs.get(index)?);
         let commitment = *self.commitments.get(index)?;
-        let proofs = if self.version == 0 {
-            vec![*self.proofs.get(index)?]
-        } else {
-            self.proofs.chunks(CELLS_PER_EXT_BLOB).nth(index)?.to_vec()
-        };
+        let proofs = self.proofs.chunks(CELLS_PER_EXT_BLOB).nth(index)?.to_vec();
         Some((blob, commitment, proofs))
+    }
+
+    /// Validates the canonical v1 sidecar layout without performing KZG verification.
+    ///
+    /// Empty bundles are structurally valid here because L2 validium batches and
+    /// payload accumulators may legitimately contain no sidecar. Callers that
+    /// require at least one blob must enforce that separately.
+    pub fn validate_v1_structure(&self) -> Result<(), BlobsBundleError> {
+        if self.version != 1 {
+            return Err(BlobsBundleError::InvalidBlobVersionForFork);
+        }
+        if self.blobs.len() != self.commitments.len()
+            || self.blobs.len() * CELLS_PER_EXT_BLOB != self.proofs.len()
+        {
+            return Err(BlobsBundleError::BlobsBundleWrongLen);
+        }
+        Ok(())
+    }
+
+    /// Appends a canonical v1 sidecar to this bundle.
+    ///
+    /// A completely empty bundle is treated as an accumulator regardless of its
+    /// default version. Non-empty bundles must have the v1 cell-proof layout.
+    pub fn append_v1(&mut self, other: Self) -> Result<(), BlobsBundleError> {
+        if other.is_empty() {
+            return Ok(());
+        }
+        other.validate_v1_structure()?;
+
+        if self.is_empty() {
+            *self = other;
+            return Ok(());
+        }
+        self.validate_v1_structure()?;
+
+        self.blobs.extend(other.blobs);
+        self.commitments.extend(other.commitments);
+        self.proofs.extend(other.proofs);
+        self.version = 1;
+        Ok(())
     }
 
     /// Full blob bundle validation: structural checks + KZG cryptographic proof verification.
@@ -149,23 +201,15 @@ impl BlobsBundle {
         self.verify_kzg_proofs()
     }
 
-    /// Verifies KZG cryptographic proofs against the blobs and commitments.
-    /// Dispatches to cell-proof or standard verification based on bundle version.
+    /// Verifies EIP-7594 cell KZG proofs against the blobs and commitments.
     #[cfg(feature = "c-kzg")]
-    fn verify_kzg_proofs(&self) -> Result<(), BlobsBundleError> {
-        let valid = if self.version != 0 {
-            ethrex_crypto::kzg::verify_cell_kzg_proof_batch(
-                &self.blobs,
-                &self.commitments,
-                &self.proofs,
-            )?
-        } else {
-            ethrex_crypto::kzg::verify_kzg_proof_batch(
-                &self.blobs,
-                &self.commitments,
-                &self.proofs,
-            )?
-        };
+    pub fn verify_kzg_proofs(&self) -> Result<(), BlobsBundleError> {
+        self.validate_v1_structure()?;
+        let valid = ethrex_crypto::kzg::verify_cell_kzg_proof_batch(
+            &self.blobs,
+            &self.commitments,
+            &self.proofs,
+        )?;
         if !valid {
             return Err(BlobsBundleError::BlobToCommitmentAndProofError);
         }
@@ -182,8 +226,6 @@ impl BlobsBundle {
         tx: &super::EIP4844Transaction,
         fork: super::Fork,
     ) -> Result<(), BlobsBundleError> {
-        use super::CELLS_PER_EXT_BLOB;
-
         let max_blobs = max_blobs_per_block(fork);
         let blob_count = self.blobs.len();
 
@@ -201,30 +243,11 @@ impl BlobsBundle {
             return Err(BlobsBundleError::BlobBundleEmptyError);
         }
 
-        // Blob sidecar wrapper version: 0 = EIP-4844 blob proofs, 1 = EIP-7594 cell proofs.
-        // The sidecar is a mempool/propagation-only artifact (never included in a block) and
-        // both formats are cryptographically verifiable at any fork.
-        //
-        // Acceptance criteria:
-        //   - pre-Osaka: accept BOTH v0 and v1. Peers are migrating to cell proofs at
-        //     different times (e.g. post go-ethereum#35191 geth sends v1 even pre-Osaka,
-        //     while older peers still send v0), so rejecting either would needlessly
-        //     disconnect otherwise-valid peers.
-        //   - Osaka+: only v1 (cell proofs) is valid.
-        let version_ok = if fork >= Fork::Osaka {
-            self.version == 1
-        } else {
-            self.version <= 1
-        };
-        if !version_ok {
-            return Err(BlobsBundleError::InvalidBlobVersionForFork);
-        }
+        // Only v1 (EIP-7594 cell-proof) sidecars are accepted. v0 (EIP-4844 blob-proof)
+        // sidecars are no longer valid at any fork, following go-ethereum#35191.
+        self.validate_v1_structure()?;
 
-        if blob_count != self.commitments.len()
-            || (self.version == 0 && blob_count != self.proofs.len())
-            || (self.version != 0 && blob_count * CELLS_PER_EXT_BLOB != self.proofs.len())
-            || blob_count != tx.blob_versioned_hashes.len()
-        {
+        if blob_count != tx.blob_versioned_hashes.len() {
             return Err(BlobsBundleError::BlobsBundleWrongLen);
         };
 
@@ -275,18 +298,10 @@ impl RLPDecode for BlobsBundle {
                 blobs,
                 commitments,
                 proofs,
-                version: version.unwrap_or_default(),
+                version: version.unwrap_or_else(default_blob_sidecar_version),
             },
             decoder.finish()?,
         ))
-    }
-}
-
-impl AddAssign for BlobsBundle {
-    fn add_assign(&mut self, rhs: Self) {
-        self.blobs.extend_from_slice(&rhs.blobs);
-        self.commitments.extend_from_slice(&rhs.commitments);
-        self.proofs.extend_from_slice(&rhs.proofs);
     }
 }
 
@@ -328,6 +343,15 @@ pub enum BlobsBundleError {
 #[cfg(test)]
 mod tests {
     mod shared {
+        pub fn dummy_v1_bundle(blob_count: usize) -> crate::types::BlobsBundle {
+            crate::types::BlobsBundle {
+                blobs: vec![[0; crate::types::BYTES_PER_BLOB]; blob_count],
+                commitments: vec![[0; 48]; blob_count],
+                proofs: vec![[0; 48]; blob_count * crate::types::CELLS_PER_EXT_BLOB],
+                version: 1,
+            }
+        }
+
         #[cfg(feature = "c-kzg")]
         pub fn convert_str_to_bytes48(s: &str) -> [u8; 48] {
             let bytes = hex::decode(s).expect("Invalid hex string");
@@ -335,6 +359,85 @@ mod tests {
             array.copy_from_slice(&bytes[..48]);
             array
         }
+    }
+
+    #[test]
+    fn append_v1_sets_the_accumulator_version() {
+        let mut aggregate = crate::types::BlobsBundle::empty();
+        let first = shared::dummy_v1_bundle(1);
+        let second = shared::dummy_v1_bundle(1);
+
+        aggregate.append_v1(first).expect("valid first bundle");
+        aggregate.append_v1(second).expect("valid second bundle");
+
+        assert_eq!(aggregate.version, 1);
+        assert_eq!(aggregate.blobs.len(), 2);
+        assert_eq!(aggregate.commitments.len(), 2);
+        assert_eq!(aggregate.proofs.len(), 2 * crate::types::CELLS_PER_EXT_BLOB);
+    }
+
+    #[test]
+    fn append_v1_rejects_legacy_or_malformed_bundles() {
+        let mut aggregate = shared::dummy_v1_bundle(1);
+        let original = aggregate.clone();
+        let mut legacy = shared::dummy_v1_bundle(1);
+        legacy.version = 0;
+
+        assert!(matches!(
+            aggregate.append_v1(legacy),
+            Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
+        ));
+        assert_eq!(aggregate, original);
+
+        let mut malformed = shared::dummy_v1_bundle(1);
+        malformed.proofs.pop();
+        assert!(matches!(
+            aggregate.append_v1(malformed),
+            Err(crate::types::BlobsBundleError::BlobsBundleWrongLen)
+        ));
+        assert_eq!(aggregate, original);
+    }
+
+    #[test]
+    fn empty_v1_bundle_is_structurally_valid_for_validium() {
+        let bundle = crate::types::BlobsBundle::default();
+        assert_eq!(bundle.version, 1);
+        assert!(bundle.validate_v1_structure().is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "c-kzg")]
+    fn invalid_v1_cell_proofs_are_rejected() {
+        let bundle = shared::dummy_v1_bundle(1);
+        assert!(bundle.verify_kzg_proofs().is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "c-kzg")]
+    fn blob_to_kzg_proof_verifies_for_prover_path() {
+        let blob = crate::types::blobs_bundle::blob_from_bytes("prover blob".as_bytes().into())
+            .expect("blob");
+        let commitment = ethrex_crypto::kzg::blob_to_kzg_commitment_and_proof(&blob)
+            .expect("commitment")
+            .0;
+        let proof = crate::types::blobs_bundle::blob_to_kzg_proof(&blob).expect("single proof");
+        assert!(
+            ethrex_crypto::kzg::verify_blob_kzg_proof(blob, commitment, proof).expect("verify"),
+            "committer prover path must produce a valid EIP-4844 proof"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "c-kzg")]
+    fn create_from_blobs_regenerates_v1_cell_proof_layout() {
+        let blob = crate::types::blobs_bundle::blob_from_bytes("stored blob".as_bytes().into())
+            .expect("blob");
+        let bundle = crate::types::BlobsBundle::create_from_blobs(&vec![blob])
+            .expect("regenerate like Store::get_batch");
+        assert_eq!(bundle.version, 1);
+        assert_eq!(bundle.proofs.len(), crate::types::CELLS_PER_EXT_BLOB);
+        assert!(bundle.validate_v1_structure().is_ok());
+        assert!(bundle.verify_kzg_proofs().is_ok());
     }
 
     #[test]
@@ -348,7 +451,7 @@ mod tests {
             })
             .collect();
 
-        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, None)
+        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs)
             .expect("Failed to create blobs bundle");
 
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
@@ -384,7 +487,7 @@ mod tests {
             })
             .collect();
 
-        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, Some(1))
+        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs)
             .expect("Failed to create blobs bundle");
 
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
@@ -409,12 +512,11 @@ mod tests {
         ));
     }
 
-    // v1 (cell-proof) sidecars are accepted pre-Osaka (network is mid-migration to cell
-    // proofs; some peers send v1 even before Osaka), but v0 (blob-proof) sidecars are
-    // rejected on Osaka+.
+    // v1 (EIP-7594 cell-proof) is now the only accepted sidecar version at all forks,
+    // following go-ethereum#35191.
     #[test]
     #[cfg(feature = "c-kzg")]
-    fn v1_sidecar_is_accepted_pre_osaka() {
+    fn v1_sidecar_is_accepted_at_all_forks() {
         let blobs = vec!["Hello, world!".as_bytes(), "Goodbye, world!".as_bytes()]
             .into_iter()
             .map(|data| {
@@ -423,7 +525,7 @@ mod tests {
             })
             .collect();
 
-        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, Some(1))
+        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs)
             .expect("Failed to create blobs bundle");
 
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
@@ -450,37 +552,41 @@ mod tests {
 
     #[test]
     #[cfg(feature = "c-kzg")]
-    fn v0_sidecar_is_rejected_on_osaka() {
+    fn v0_sidecar_is_rejected_at_all_forks() {
+        // v0 (EIP-4844 KZG-proof) sidecars are no longer valid at any fork,
+        // following go-ethereum#35191. Only v1 (EIP-7594 cell-proof) is accepted.
         let blobs = vec!["Hello, world!".as_bytes(), "Goodbye, world!".as_bytes()]
             .into_iter()
             .map(|data| {
                 crate::types::blobs_bundle::blob_from_bytes(data.into())
                     .expect("Failed to create blob")
             })
-            .collect();
+            .collect::<Vec<_>>();
 
-        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, Some(0))
+        // Build a v1 bundle to get valid commitments/hashes, then manually construct
+        // a v0-shaped bundle (one proof per blob, version 0).
+        let v1 = crate::types::BlobsBundle::create_from_blobs(&blobs)
             .expect("Failed to create blobs bundle");
-
-        let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
+        let blob_versioned_hashes = v1.generate_versioned_hashes();
+        let v0_bundle = crate::types::BlobsBundle {
+            blobs: v1.blobs,
+            commitments: v1.commitments,
+            proofs: vec![[0u8; 48]; blobs.len()], // one dummy proof per blob (v0 shape)
+            version: 0,
+        };
 
         let tx = crate::types::transaction::EIP4844Transaction {
-            nonce: 3,
-            max_priority_fee_per_gas: 0,
-            max_fee_per_gas: 0,
-            max_fee_per_blob_gas: 0.into(),
-            gas: 15_000_000,
-            to: crate::Address::from_low_u64_be(1), // Normal tx
-            value: crate::U256::zero(),             // Value zero
-            data: crate::Bytes::default(),          // No data
-            access_list: Default::default(),        // No access list
             blob_versioned_hashes,
             ..Default::default()
         };
 
-        assert!(!matches!(
-            blobs_bundle.validate(&tx, crate::types::Fork::Osaka),
-            Ok(())
+        assert!(matches!(
+            v0_bundle.validate_cheap(&tx, crate::types::Fork::Prague),
+            Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
+        ));
+        assert!(matches!(
+            v0_bundle.validate_cheap(&tx, crate::types::Fork::Osaka),
+            Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
         ));
     }
 
@@ -504,6 +610,7 @@ mod tests {
                                 shared::convert_str_to_bytes48(s)
                             })
                             .collect(),
+                            // v0 is now rejected at the version check before KZG verification.
                             version: 0,
         };
 
@@ -532,7 +639,7 @@ mod tests {
 
         assert!(matches!(
             blobs_bundle.validate(&tx, crate::types::Fork::Prague),
-            Err(crate::types::BlobsBundleError::BlobToCommitmentAndProofError)
+            Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
         ));
     }
 
@@ -556,6 +663,7 @@ mod tests {
                                 shared::convert_str_to_bytes48(s)
                               })
                               .collect(),
+                              // v0 is now rejected at the version check before commitment hash verification.
                               version: 0,
         };
 
@@ -584,7 +692,7 @@ mod tests {
 
         assert!(matches!(
             blobs_bundle.validate(&tx, crate::types::Fork::Prague),
-            Err(crate::types::BlobsBundleError::BlobVersionedHashesError)
+            Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
         ));
     }
 
@@ -596,7 +704,7 @@ mod tests {
         let blobs =
             std::iter::repeat_n(blob, super::MAX_BLOB_COUNT_ELECTRA + 1).collect::<Vec<_>>();
 
-        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, None)
+        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs)
             .expect("Failed to create blobs bundle");
 
         let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
@@ -623,39 +731,47 @@ mod tests {
 
     #[test]
     #[cfg(feature = "c-kzg")]
-    fn transaction_with_version_0_blobs_should_fail_on_amsterdam() {
-        // Version 0 blobs should be invalid on Amsterdam fork (which comes after Osaka)
-        // The validation requires version 0 only on Osaka; Amsterdam >= Osaka so version 0 is rejected
+    fn transaction_with_version_0_blobs_should_fail_on_all_forks() {
+        // v0 blobs are rejected at every fork now that only v1 (cell-proof) sidecars
+        // are accepted, following go-ethereum#35191.
         let blobs = vec!["Hello, world!".as_bytes(), "Goodbye, world!".as_bytes()]
             .into_iter()
             .map(|data| {
                 crate::types::blobs_bundle::blob_from_bytes(data.into())
                     .expect("Failed to create blob")
             })
-            .collect();
+            .collect::<Vec<_>>();
 
-        let blobs_bundle = crate::types::BlobsBundle::create_from_blobs(&blobs, None)
+        // Build a v1 bundle to obtain valid commitments and versioned hashes, then
+        // manually downgrade to version 0 to simulate a legacy v0 sidecar.
+        let v1 = crate::types::BlobsBundle::create_from_blobs(&blobs)
             .expect("Failed to create blobs bundle");
-
-        let blob_versioned_hashes = blobs_bundle.generate_versioned_hashes();
+        let blob_versioned_hashes = v1.generate_versioned_hashes();
+        let v0_bundle = crate::types::BlobsBundle {
+            blobs: v1.blobs,
+            commitments: v1.commitments,
+            proofs: vec![[0u8; 48]; blobs.len()],
+            version: 0,
+        };
 
         let tx = crate::types::transaction::EIP4844Transaction {
-            nonce: 3,
-            max_priority_fee_per_gas: 0,
-            max_fee_per_gas: 0,
-            max_fee_per_blob_gas: 0.into(),
-            gas: 15_000_000,
-            to: crate::Address::from_low_u64_be(1), // Normal tx
-            value: crate::U256::zero(),             // Value zero
-            data: crate::Bytes::default(),          // No data
-            access_list: Default::default(),        // No access list
             blob_versioned_hashes,
             ..Default::default()
         };
 
-        assert!(matches!(
-            blobs_bundle.validate(&tx, crate::types::Fork::Amsterdam),
-            Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
-        ));
+        for fork in [
+            crate::types::Fork::Prague,
+            crate::types::Fork::Osaka,
+            crate::types::Fork::Amsterdam,
+        ] {
+            assert!(
+                matches!(
+                    v0_bundle.validate_cheap(&tx, fork),
+                    Err(crate::types::BlobsBundleError::InvalidBlobVersionForFork)
+                ),
+                "v0 bundle should be rejected on fork {:?}",
+                fork
+            );
+        }
     }
 }

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -3681,11 +3681,11 @@ mod serde_impl {
                 })
                 .collect();
 
-            let wrapper_version = value.wrapper_version;
+            let blobs_bundle = BlobsBundle::create_from_blobs(&blobs)?;
             Ok(Self {
                 tx: value.try_into()?,
-                wrapper_version,
-                blobs_bundle: BlobsBundle::create_from_blobs(&blobs, wrapper_version)?,
+                wrapper_version: Some(blobs_bundle.version),
+                blobs_bundle,
             })
         }
     }

--- a/crates/l2/networking/rpc/l2/batch.rs
+++ b/crates/l2/networking/rpc/l2/batch.rs
@@ -93,12 +93,7 @@ impl RpcHandler for GetBatchByBatchNumberRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Requested batch with number: {}", self.batch_number);
-        let l1_fork = context.l1_ctx.blockchain.current_fork().await?;
-        let Some(batch) = context
-            .rollup_store
-            .get_batch(self.batch_number, l1_fork)
-            .await?
-        else {
+        let Some(batch) = context.rollup_store.get_batch(self.batch_number).await? else {
             return Ok(Value::Null);
         };
         let rpc_batch = RpcBatch::build(batch, self.block_hashes, &context.l1_ctx.storage)?;
@@ -126,8 +121,6 @@ impl RpcHandler for GetBatchByBatchBlockNumberRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Requested batch with block: {}", self.block);
-        let l1_fork = context.l1_ctx.blockchain.current_fork().await?;
-
         let block_number = self
             .block
             .resolve_block_number(&context.l1_ctx.storage)
@@ -147,11 +140,7 @@ impl RpcHandler for GetBatchByBatchBlockNumberRequest {
             _ => return Ok(Value::Null),
         };
 
-        let Some(batch) = context
-            .rollup_store
-            .get_batch(batch_number, l1_fork)
-            .await?
-        else {
+        let Some(batch) = context.rollup_store.get_batch(batch_number).await? else {
             return Err(RpcErr::Internal(format!(
                 "Batch not found for batch number: {}",
                 batch_number

--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -3,7 +3,6 @@ use calldata::encode_calldata;
 use ethereum_types::{H160, H256, U256};
 use ethrex_common::types::EIP7702Transaction;
 use ethrex_common::types::FeeTokenTransaction;
-use ethrex_common::types::Fork;
 use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address,
@@ -1306,26 +1305,6 @@ pub async fn get_pending_l2_messages(
         .await?;
 
     from_hex_string_to_h256_array(&response)
-}
-
-// TODO: This is a work around for now, issue: https://github.com/lambdaclass/ethrex/issues/4828
-pub async fn get_l1_active_fork(
-    client: &EthClient,
-    activation_time: Option<u64>,
-) -> Result<Fork, EthClientError> {
-    let Some(osaka_activation_time) = activation_time else {
-        return Ok(Fork::Osaka);
-    };
-    let current_timestamp = client
-        .get_block_by_number(BlockIdentifier::Tag(BlockTag::Latest), false)
-        .await?
-        .header
-        .timestamp;
-    if current_timestamp < osaka_activation_time {
-        Ok(Fork::Prague)
-    } else {
-        Ok(Fork::Osaka)
-    }
 }
 
 async fn _generic_call(

--- a/crates/l2/sequencer/configs.rs
+++ b/crates/l2/sequencer/configs.rs
@@ -50,7 +50,6 @@ pub struct EthConfig {
     pub backoff_factor: u64,
     pub min_retry_delay: u64,
     pub max_retry_delay: u64,
-    pub osaka_activation_time: Option<u64>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -16,7 +16,7 @@ use ethrex_common::utils::keccak;
 use ethrex_common::{
     Address, H256, U256,
     types::{
-        BLOB_BASE_FEE_UPDATE_FRACTION, BlobsBundle, Block, BlockNumber, Fork, Genesis,
+        BLOB_BASE_FEE_UPDATE_FRACTION, BlobsBundle, Block, BlockNumber, Genesis,
         MIN_BASE_FEE_PER_BLOB_GAS, TxType, batch::Batch, blobs_bundle, fake_exponential,
         fee_config::FeeConfig,
     },
@@ -37,7 +37,7 @@ use ethrex_l2_common::{
 };
 use ethrex_l2_rpc::signer::{Signer, SignerHealth};
 use ethrex_l2_sdk::{
-    build_generic_tx, calldata::encode_calldata, get_l1_active_fork, get_last_committed_batch,
+    build_generic_tx, calldata::encode_calldata, get_last_committed_batch,
     send_tx_bump_gas_exponential_backoff,
 };
 #[cfg(feature = "metrics")]
@@ -110,8 +110,6 @@ pub struct L1Committer {
     last_committed_batch: u64,
     /// Cancellation token for the next inbound Commit message
     cancellation_token: Option<CancellationToken>,
-    /// Timestamp for Osaka activation on L1. This is used to determine which fork to use when generating blobs proofs.
-    osaka_activation_time: Option<u64>,
     /// Elasticity multiplier for prover input generation
     elasticity_multiplier: u64,
     /// Git commit hash of the build
@@ -218,7 +216,6 @@ impl L1Committer {
             last_committed_batch_timestamp: 0,
             last_committed_batch,
             cancellation_token: None,
-            osaka_activation_time: eth_config.osaka_activation_time,
             elasticity_multiplier: proposer_config.elasticity_multiplier,
             git_commit_hash: get_git_commit_hash(),
             current_checkpoint_store,
@@ -389,7 +386,6 @@ impl L1Committer {
     async fn ensure_checkpoint_for_committed_batch(
         &mut self,
         last_committed_batch: u64,
-        l1_fork: Fork,
     ) -> Result<bool, CommitterError> {
         if last_committed_batch == 0 {
             return Ok(true);
@@ -420,11 +416,7 @@ impl L1Committer {
             return Ok(true);
         }
 
-        let Some(batch) = self
-            .rollup_store
-            .get_batch(last_committed_batch, l1_fork)
-            .await?
-        else {
+        let Some(batch) = self.rollup_store.get_batch(last_committed_batch).await? else {
             warn!(
                 "Missing sealed batch {} in rollup store; cannot rebuild checkpoint yet",
                 last_committed_batch
@@ -455,22 +447,14 @@ impl L1Committer {
             get_last_committed_batch(&self.eth_client, self.on_chain_proposer_address).await?;
         let batch_to_commit = last_committed_batch_number + 1;
 
-        let l1_fork = get_l1_active_fork(&self.eth_client, self.osaka_activation_time)
-            .await
-            .map_err(CommitterError::EthClientError)?;
-
         if !self
-            .ensure_checkpoint_for_committed_batch(last_committed_batch_number, l1_fork)
+            .ensure_checkpoint_for_committed_batch(last_committed_batch_number)
             .await?
         {
             return Ok(());
         }
 
-        let batch = match self
-            .rollup_store
-            .get_batch(batch_to_commit, l1_fork)
-            .await?
-        {
+        let batch = match self.rollup_store.get_batch(batch_to_commit).await? {
             Some(batch) => {
                 // If we have the batch already sealed, we need to ensure the checkpoint
                 // is available.
@@ -1002,10 +986,8 @@ impl L1Committer {
 
                 current_blocks.push(potential_batch_block.clone());
                 current_fee_configs.push(fee_config);
-                let l1_fork =
-                    get_l1_active_fork(&self.eth_client, self.osaka_activation_time).await?;
 
-                generate_blobs_bundle(&current_blocks, &current_fee_configs, l1_fork)
+                generate_blobs_bundle(&current_blocks, &current_fee_configs)
             } else {
                 Ok((BlobsBundle::default(), 0_usize))
             };
@@ -1183,39 +1165,22 @@ impl L1Committer {
             ([0; 48], [0; 48])
         } else {
             let BlobsBundle {
-                commitments,
-                proofs,
-                blobs,
-                ..
+                commitments, blobs, ..
             } = &batch.blobs_bundle;
-
-            let l1_fork = get_l1_active_fork(&self.eth_client, self.osaka_activation_time)
-                .await
-                .map_err(CommitterError::EthClientError)?;
 
             let commitment = commitments
                 .last()
                 .cloned()
                 .ok_or_else(|| CommitterError::MissingBlob(batch.number))?;
 
-            // The prover takes a single proof even for Osaka type proofs, so if
-            // the committer generated Osaka type proofs (cell proofs), we need
-            // to create a BlobsBundle from the blobs specifying a pre-Osaka
-            // fork to get a single proof for the entire blob.
-            // If we are pre-Osaka, we already have a single proof in the
-            // previously generated bundle
-            let proof = if l1_fork < Fork::Osaka {
-                proofs
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| CommitterError::MissingBlob(batch.number))?
-            } else {
-                BlobsBundle::create_from_blobs(blobs, Some(0))?
-                    .proofs
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| CommitterError::MissingBlob(batch.number))?
-            };
+            // The ZK prover verifier (guest program) uses verify_blob_kzg_proof, which
+            // requires a single EIP-4844 KZG proof, not EIP-7594 cell proofs.
+            // Since create_from_blobs now always produces v1 (cell proofs), compute
+            // the KZG proof directly from the blob via the crypto primitive.
+            let last_blob = blobs
+                .last()
+                .ok_or_else(|| CommitterError::MissingBlob(batch.number))?;
+            let proof = blobs_bundle::blob_to_kzg_proof(last_blob)?;
 
             (commitment, proof)
         };
@@ -1489,7 +1454,6 @@ impl L1Committer {
 pub fn generate_blobs_bundle(
     blocks: &[Block],
     fee_configs: &[FeeConfig],
-    fork: Fork,
 ) -> Result<(BlobsBundle, usize), CommitterError> {
     let blocks_len: u64 = blocks.len().try_into()?;
     let fee_configs_len: u64 = fee_configs.len().try_into()?;
@@ -1516,11 +1480,9 @@ pub fn generate_blobs_bundle(
 
     let blob =
         blobs_bundle::blob_from_bytes(Bytes::from(blob_data)).map_err(CommitterError::from)?;
-    let wrapper_version = if fork <= Fork::Prague { None } else { Some(1) };
 
     Ok((
-        BlobsBundle::create_from_blobs(&vec![blob], wrapper_version)
-            .map_err(CommitterError::from)?,
+        BlobsBundle::create_from_blobs(&vec![blob]).map_err(CommitterError::from)?,
         blob_size,
     ))
 }

--- a/crates/l2/sequencer/mod.rs
+++ b/crates/l2/sequencer/mod.rs
@@ -282,7 +282,6 @@ fn monitor_config_from(cfg: &SequencerConfig) -> ExternalMonitorConfig {
         sequencer_registry_address,
         rpc_urls: cfg.eth.rpc_url.clone(),
         is_based: cfg.based.enabled,
-        osaka_activation_time: cfg.eth.osaka_activation_time,
     }
 }
 

--- a/crates/l2/storage/src/store.rs
+++ b/crates/l2/storage/src/store.rs
@@ -8,8 +8,8 @@ use crate::store_db::sql::SQLStore;
 use ethrex_common::{
     H256,
     types::{
-        AccountUpdate, Blob, BlobsBundle, BlockNumber, Fork, balance_diff::BalanceDiff,
-        batch::Batch, fee_config::FeeConfig,
+        AccountUpdate, Blob, BlobsBundle, BlockNumber, balance_diff::BalanceDiff, batch::Batch,
+        fee_config::FeeConfig,
     },
 };
 use ethrex_l2_common::prover::{ProverInputData, ProverOutput, ProverType};
@@ -184,11 +184,7 @@ impl Store {
         self.engine.get_last_batch_number().await
     }
 
-    pub async fn get_batch(
-        &self,
-        batch_number: u64,
-        fork: Fork,
-    ) -> Result<Option<Batch>, RollupStoreError> {
+    pub async fn get_batch(&self, batch_number: u64) -> Result<Option<Batch>, RollupStoreError> {
         let Some(blocks) = self.get_block_numbers_by_batch(batch_number).await? else {
             return Ok(None);
         };
@@ -217,8 +213,8 @@ impl Store {
                 .get_blobs_by_batch(batch_number)
                 .await?
                 .unwrap_or_default(),
-                if fork <= Fork::Prague { None } else { Some(1) },
-        ).map_err(|e| {
+        )
+        .map_err(|e| {
             RollupStoreError::Custom(format!("Failed to create blobs bundle from blob while getting batch from database: {e}. This is a bug"))
         })?;
 

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -70,7 +70,8 @@ path = "./p2p.rs"
 default = ["c-kzg"]
 c-kzg = ["ethrex-blockchain/c-kzg", "ethrex-common/c-kzg"]
 sync-test = []
-l2 = ["dep:ethrex-storage-rollup", "dep:ethrex-l2-common"]
+# L2 BatchSealed ingress verifies cell proofs; require c-kzg whenever l2 is enabled.
+l2 = ["dep:ethrex-storage-rollup", "dep:ethrex-l2-common", "c-kzg"]
 test-utils = []
 metrics = ["dep:ethrex-metrics"]
 

--- a/crates/networking/p2p/metrics.rs
+++ b/crates/networking/p2p/metrics.rs
@@ -495,6 +495,12 @@ impl Metrics {
                     .and_modify(|e| *e += 1)
                     .or_insert(1);
             }
+            PeerConnectionError::BlobsBundleError(error) => {
+                failures_grouped_by_reason
+                    .entry(format!("BlobsBundleError - {error}"))
+                    .and_modify(|e| *e += 1)
+                    .or_insert(1);
+            }
             PeerConnectionError::IoError(error) => {
                 failures_grouped_by_reason
                     .entry(format!("IoError - {error}"))

--- a/crates/networking/p2p/rlpx/error.rs
+++ b/crates/networking/p2p/rlpx/error.rs
@@ -73,6 +73,8 @@ pub enum PeerConnectionError {
     SendMessage(String),
     #[error("Error when inserting transaction in the mempool: {0}")]
     MempoolError(#[from] MempoolError),
+    #[error("Invalid blob bundle: {0}")]
+    BlobsBundleError(#[from] ethrex_common::types::BlobsBundleError),
     #[error("Error when adding a block to the blockchain: {0}")]
     BlockchainError(#[from] ChainError),
     #[error("Io Error: {0}")]

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -121,8 +121,7 @@ impl NewPooledTransactionHashes {
                     let p2p_tx =
                         P2PTransaction::EIP4844TransactionWithBlobs(WrappedEIP4844Transaction {
                             tx: eip4844_tx,
-                            wrapper_version: (tx_blobs_bundle.version != 0)
-                                .then_some(tx_blobs_bundle.version),
+                            wrapper_version: Some(tx_blobs_bundle.version),
                             blobs_bundle: tx_blobs_bundle,
                         });
                     p2p_tx.encode_canonical_to_vec().len()

--- a/crates/networking/p2p/rlpx/l2/l2_connection.rs
+++ b/crates/networking/p2p/rlpx/l2/l2_connection.rs
@@ -393,6 +393,30 @@ async fn should_process_batch_sealed(
         debug!("Batch {} already sealed, ignoring it", msg.batch.number);
         return Ok(false);
     }
+
+    let blobs_bundle = &msg.batch.blobs_bundle;
+    // Soft-ignore malformed / legacy sidecars so an old sequencer emitting
+    // one-proof-per-blob BatchSealed under based/1 does not tear down the peer.
+    if let Err(err) = blobs_bundle.validate_v1_structure() {
+        warn!(
+            peer=%established.node,
+            batch=msg.batch.number,
+            error=%err,
+            "Ignoring BatchSealed with invalid v1 blob sidecar"
+        );
+        return Ok(false);
+    }
+    // Rollup batches are encoded into one blob; validium batches carry none.
+    if blobs_bundle.blobs.len() > 1 {
+        warn!(
+            peer=%established.node,
+            batch=msg.batch.number,
+            blobs=blobs_bundle.blobs.len(),
+            "Ignoring BatchSealed with unexpected blob count"
+        );
+        return Ok(false);
+    }
+
     let hash = batch_hash(&msg.batch);
 
     let recovered_lead_sequencer = NativeCrypto
@@ -409,6 +433,31 @@ async fn should_process_batch_sealed(
     if !validate_signature(recovered_lead_sequencer) {
         return Ok(false);
     }
+
+    // KZG verification is CPU-heavy, so run it off the connection task after
+    // cheap structure, duplicate, and signer checks. Empty validium bundles
+    // have no proofs to verify.
+    #[cfg(feature = "c-kzg")]
+    if !blobs_bundle.is_empty() {
+        let blobs_bundle = blobs_bundle.clone();
+        let verify_result = tokio::task::spawn_blocking(move || blobs_bundle.verify_kzg_proofs())
+            .await
+            .map_err(|err| {
+                PeerConnectionError::InternalError(format!(
+                    "Blob proof verification task failed: {err}"
+                ))
+            })?;
+        if let Err(err) = verify_result {
+            warn!(
+                peer=%established.node,
+                batch=msg.batch.number,
+                error=%err,
+                "Ignoring BatchSealed with invalid blob KZG proofs"
+            );
+            return Ok(false);
+        }
+    }
+
     l2_state
         .store_rollup
         .store_signature_by_batch(msg.batch.number, msg.signature)
@@ -423,10 +472,7 @@ pub async fn process_blocks_on_queue(
 
     let mut next_block_to_add = l2_state.latest_block_added + 1;
     if let Some(latest_batch_number) = l2_state.store_rollup.get_batch_number().await?
-        && let Some(latest_batch) = l2_state
-            .store_rollup
-            .get_batch(latest_batch_number, ethrex_common::types::Fork::Prague)
-            .await?
+        && let Some(latest_batch) = l2_state.store_rollup.get_batch(latest_batch_number).await?
     {
         next_block_to_add = next_block_to_add.max(latest_batch.last_block + 1);
     }
@@ -514,12 +560,7 @@ pub(crate) async fn send_sealed_batch(
         {
             return Ok(());
         }
-        let l1_fork = established.blockchain.current_fork().await?;
-        let Some(batch) = l2_state
-            .store_rollup
-            .get_batch(next_batch_to_send, l1_fork)
-            .await?
-        else {
+        let Some(batch) = l2_state.store_rollup.get_batch(next_batch_to_send).await? else {
             return Ok(());
         };
         match l2_state

--- a/crates/networking/p2p/rlpx/l2/messages.rs
+++ b/crates/networking/p2p/rlpx/l2/messages.rs
@@ -168,7 +168,10 @@ impl RLPxMessage for BatchSealed {
                 blobs,
                 commitments,
                 proofs,
-                version: 0,
+                // `based/1` predates the sidecar version field, so keep its wire
+                // schema unchanged for rolling upgrades. New nodes are v1-only
+                // and validate the proof shape before accepting the batch.
+                version: 1,
             },
             commit_tx,
             verify_tx,
@@ -202,5 +205,91 @@ impl From<NewBlock> for crate::rlpx::message::Message {
 impl From<L2Message> for crate::rlpx::message::Message {
     fn from(value: L2Message) -> Self {
         Message::L2(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethrex_common::types::BlobsBundle;
+
+    #[test]
+    fn batch_sealed_keeps_the_based_1_wire_schema() {
+        let batch = Batch {
+            number: 7,
+            first_block: 11,
+            last_block: 13,
+            blobs_bundle: BlobsBundle {
+                version: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let message = BatchSealed::new(batch, Signature::from_slice(&[0; 65]));
+
+        let mut actual = Vec::new();
+        message.encode(&mut actual).expect("encode BatchSealed");
+
+        // Encode the original based/1 field list explicitly. A version field
+        // must not be appended because older peers reject trailing RLP data.
+        let mut legacy_payload = Vec::new();
+        Encoder::new(&mut legacy_payload)
+            .encode_field(&message.batch.number)
+            .encode_field(&message.batch.first_block)
+            .encode_field(&message.batch.last_block)
+            .encode_field(&message.batch.state_root)
+            .encode_field(&message.batch.l1_in_messages_rolling_hash)
+            .encode_field(&message.batch.l2_in_message_rolling_hashes)
+            .encode_field(&message.batch.non_privileged_transactions)
+            .encode_field(&message.batch.l1_out_message_hashes)
+            .encode_field(&message.batch.blobs_bundle.blobs)
+            .encode_field(&message.batch.blobs_bundle.commitments)
+            .encode_field(&message.batch.blobs_bundle.proofs)
+            .encode_optional_field(&message.batch.commit_tx)
+            .encode_optional_field(&message.batch.verify_tx)
+            .encode_field(&message.signature)
+            .encode_field(&message.batch.balance_diffs)
+            .finish();
+        let expected = snappy_compress(legacy_payload).expect("compress based/1 message");
+
+        assert_eq!(actual, expected);
+
+        let decoded = BatchSealed::decode(&actual).expect("decode based/1 message");
+        assert_eq!(decoded.batch.blobs_bundle.version, 1);
+    }
+
+    #[test]
+    fn batch_sealed_rejects_legacy_v0_proof_shape() {
+        use ethrex_common::types::{BYTES_PER_BLOB, CELLS_PER_EXT_BLOB};
+
+        // Wire format has no version field. Decode stamps version=1, then the
+        // proof-count invariant must reject a legacy one-proof-per-blob sidecar.
+        let batch = Batch {
+            number: 9,
+            first_block: 1,
+            last_block: 2,
+            blobs_bundle: BlobsBundle {
+                blobs: vec![[7u8; BYTES_PER_BLOB]],
+                commitments: vec![[8u8; 48]],
+                proofs: vec![[9u8; 48]], // v0 shape: one proof
+                version: 1,
+            },
+            ..Default::default()
+        };
+        let message = BatchSealed::new(batch, Signature::from_slice(&[0; 65]));
+
+        let mut encoded = Vec::new();
+        message.encode(&mut encoded).expect("encode");
+        let decoded = BatchSealed::decode(&encoded).expect("decode stamps version 1");
+        assert_eq!(decoded.batch.blobs_bundle.version, 1);
+        assert_ne!(
+            decoded.batch.blobs_bundle.proofs.len(),
+            CELLS_PER_EXT_BLOB,
+            "fixture must use the legacy one-proof layout"
+        );
+        assert!(
+            decoded.batch.blobs_bundle.validate_v1_structure().is_err(),
+            "followers must reject legacy v0-shaped BatchSealed proofs"
+        );
     }
 }

--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -94,12 +94,12 @@ impl RpcHandler for BlobsV1Request {
             .into_iter()
             .map(|b| {
                 b.and_then(|(blob, _, proofs)| {
-                    // getBlobsV1 serves the single EIP-4844 blob proof. A v0 bundle yields
-                    // exactly one proof here (see `get_blob_tuple_by_index`); a v1 (EIP-7594)
-                    // sidecar yields 128 cell proofs per blob and can now reach a pre-Osaka
-                    // mempool. Cell proofs can't be represented as a single blob proof, so
-                    // report the blob as unavailable (the CL re-fetches it from gossip)
-                    // rather than returning a cell proof in the blob-proof field.
+                    // getBlobsV1 serves the single EIP-4844 blob proof. After the
+                    // v1-only sidecar cleanup (go-ethereum#35191 / #6927), the
+                    // mempool only admits v1 (128 cell proofs per blob), so this
+                    // length check never succeeds for pool-admitted bundles and
+                    // always reports null — matching geth's decline-don't-derive
+                    // behavior.
                     (proofs.len() == 1).then(|| BlobAndProofV1 {
                         blob: *blob,
                         proof: proofs[0],
@@ -350,33 +350,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn blobs_v1_returns_v0_proof_before_osaka() {
+    async fn blobs_v1_pool_rejects_v0_injection() {
+        // After #6927 the mempool insert path requires the v1 cell-proof layout.
+        // getBlobsV1 therefore never sees a single-proof sidecar from the pool and
+        // returns null for admitted (v1) bundles — see the next test.
         let context = context_with_chain_config(false).await;
-        let (bundle, hashes) = sample_v0_bundle(1);
-        context
+        let (bundle, _) = sample_v0_bundle(1);
+        let err = context
             .blockchain
             .mempool
-            .add_blobs_bundle(H256::from_low_u64_be(1), bundle.clone())
-            .unwrap();
-
-        let request = BlobsV1Request {
-            blob_versioned_hashes: hashes,
-        };
-
-        let result = request.handle(context).await.unwrap();
-        let expected = serde_json::to_value(vec![Some(BlobAndProofV1 {
-            blob: bundle.blobs[0],
-            proof: bundle.proofs[0],
-        })])
-        .unwrap();
-        assert_eq!(result, expected);
+            .add_blobs_bundle(H256::from_low_u64_be(1), bundle)
+            .expect_err("v0 bundles must not enter the pool");
+        assert!(
+            err.to_string().contains("invalid v1 blob bundle"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]
     async fn blobs_v1_returns_null_for_v1_sidecar_before_osaka() {
-        // A v1 (cell-proof) sidecar can reach a pre-Osaka mempool, but getBlobsV1 can only
-        // serve a single EIP-4844 blob proof, so it must report the blob as unavailable
-        // rather than returning a cell proof in the blob-proof field.
+        // Post go-ethereum#35191 / #6927 the mempool is v1-only. getBlobsV1 cannot
+        // convert cell proofs to a single EIP-4844 blob proof, so it reports the
+        // blob unavailable (null) rather than returning a cell proof in the
+        // blob-proof field — matching geth's decline-don't-derive behavior.
         let context = context_with_chain_config(false).await;
         let (bundle, hashes) = sample_bundle(1);
         context

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -292,7 +292,8 @@ Commands:
 
 Options:
       --osaka-activation-time <UINT64>
-          Block timestamp at which the Osaka fork is activated on L1. If not set, it will assume Osaka is already active.
+          Deprecated compatibility option; ignored. Ethrex always produces and
+          accepts v1 (EIP-7594 cell-proof) blob sidecars.
 
           [env: ETHREX_OSAKA_ACTIVATION_TIME=]
 

--- a/test/tests/blockchain/mempool_tests.rs
+++ b/test/tests/blockchain/mempool_tests.rs
@@ -12,13 +12,13 @@ use ethrex_crypto::NativeCrypto;
 use rustc_hash::FxHashMap;
 
 use ethrex_common::types::{
-    APPROVE_EXECUTION_AND_PAYMENT, AuthorizationTuple, BYTES_PER_BLOB, BlobsBundle, Block,
-    BlockBody, BlockHeader, ChainConfig, EIP1559Transaction, EIP4844Transaction,
-    EIP7702Transaction, FRAME_SIG_SCHEME_P256, FRAME_SIG_SCHEME_SECP256K1,
-    FRAME_TX_EXPIRY_DATA_LENGTH, FRAME_TX_MAX_VERIFY_GAS, FeeTokenTransaction, Frame, FrameMode,
-    FrameSignature, FrameTransaction, Genesis, GenesisAccount, MAX_TX_SIZE, MempoolTransaction,
-    PrivilegedL2Transaction, Transaction, TxKind, frame_tx_expiry_verifier,
-    kzg_commitment_to_versioned_hash,
+    APPROVE_EXECUTION_AND_PAYMENT, AuthorizationTuple, BYTES_PER_BLOB, BlobsBundle,
+    BlobsBundleError, Block, BlockBody, BlockHeader, CELLS_PER_EXT_BLOB, ChainConfig,
+    EIP1559Transaction, EIP4844Transaction, EIP7702Transaction, FRAME_SIG_SCHEME_P256,
+    FRAME_SIG_SCHEME_SECP256K1, FRAME_TX_EXPIRY_DATA_LENGTH, FRAME_TX_MAX_VERIFY_GAS,
+    FeeTokenTransaction, Frame, FrameMode, FrameSignature, FrameTransaction, Genesis,
+    GenesisAccount, MAX_TX_SIZE, MempoolTransaction, PrivilegedL2Transaction, Transaction, TxKind,
+    blobs_bundle::blob_from_bytes, frame_tx_expiry_verifier, kzg_commitment_to_versioned_hash,
 };
 use ethrex_common::{Address, Bytes, H160, H256, U256};
 use ethrex_storage::error::StoreError;
@@ -26,6 +26,18 @@ use ethrex_storage::{EngineType, Store};
 use std::collections::BTreeMap;
 
 const MEMPOOL_MAX_SIZE_TEST: usize = 10_000;
+
+/// Structurally valid v1 dummy sidecar for mempool bookkeeping tests.
+/// Proofs are not cryptographically valid; admission via
+/// `add_blob_transaction_to_pool` still requires full KZG verification.
+fn dummy_v1_bundle(blob_count: usize, fill: u8) -> BlobsBundle {
+    BlobsBundle {
+        blobs: vec![[fill; BYTES_PER_BLOB]; blob_count],
+        commitments: vec![[fill; 48]; blob_count],
+        proofs: vec![[fill; 48]; blob_count * CELLS_PER_EXT_BLOB],
+        version: 1,
+    }
+}
 
 async fn setup_storage(config: ChainConfig, header: BlockHeader) -> Result<Store, StoreError> {
     let mut store = Store::new("test", EngineType::InMemory)?;
@@ -459,22 +471,83 @@ fn test_filter_mempool_transactions() {
     );
 }
 
+#[tokio::test]
+async fn add_blob_transaction_to_pool_rejects_v0_sidecar() {
+    let config = ChainConfig {
+        cancun_time: Some(0),
+        prague_time: Some(0),
+        ..Default::default()
+    };
+    let header = BlockHeader {
+        number: 5,
+        timestamp: 5,
+        gas_limit: 100_000_000,
+        ..Default::default()
+    };
+    let store = setup_storage(config, header).await.expect("Storage setup");
+    let blockchain = Blockchain::default_with_store(store);
+
+    let blobs = vec![blob_from_bytes("Hello, world!".as_bytes().into()).unwrap()];
+    let v1 = BlobsBundle::create_from_blobs(&blobs).expect("create v1 bundle");
+    let blob_versioned_hashes = v1.generate_versioned_hashes();
+    let v0 = BlobsBundle {
+        blobs: v1.blobs,
+        commitments: v1.commitments,
+        proofs: vec![[0u8; 48]; blob_versioned_hashes.len()],
+        version: 0,
+    };
+    let tx = EIP4844Transaction {
+        blob_versioned_hashes,
+        gas: 21_000,
+        to: Address::from_low_u64_be(1),
+        ..Default::default()
+    };
+
+    let err = blockchain
+        .add_blob_transaction_to_pool(tx, v0)
+        .await
+        .expect_err("v0 sidecars must be rejected at admission");
+    assert!(
+        matches!(
+            err,
+            MempoolError::BlobsBundleError(BlobsBundleError::InvalidBlobVersionForFork)
+        ),
+        "unexpected admission error: {err:?}"
+    );
+    assert_eq!(
+        blockchain.mempool.blob_txs().expect("read blob txs").len(),
+        0,
+        "rejected v0 sidecar must leave the pool empty"
+    );
+}
+
+#[test]
+fn add_blobs_bundle_rejects_v0_structural_layout() {
+    let mempool = Mempool::new(MEMPOOL_MAX_SIZE_TEST);
+    let v0 = BlobsBundle {
+        blobs: vec![[0u8; BYTES_PER_BLOB]],
+        commitments: vec![[0u8; 48]],
+        proofs: vec![[0u8; 48]],
+        version: 0,
+    };
+    let err = mempool
+        .add_blobs_bundle(H256::random(), v0)
+        .expect_err("direct inserts must also enforce v1 layout");
+    assert!(
+        err.to_string().contains("invalid v1 blob bundle"),
+        "unexpected error: {err}"
+    );
+}
+
 #[test]
 fn blobs_bundle_loadtest() {
-    // Write a bundle of 6 blobs 10 times
-    // If this test fails please adjust the max_size in the DB config
+    // Write a bundle of 6 blobs 300 times.
+    // If this test fails please adjust the max_size in the DB config.
     let mempool = Mempool::new(MEMPOOL_MAX_SIZE_TEST);
     for i in 0..300 {
-        let blobs = [[i as u8; BYTES_PER_BLOB]; 6];
-        let commitments = [[i as u8; 48]; 6];
-        let proofs = [[i as u8; 48]; 6];
-        let bundle = BlobsBundle {
-            blobs: blobs.to_vec(),
-            commitments: commitments.to_vec(),
-            proofs: proofs.to_vec(),
-            version: 0,
-        };
-        mempool.add_blobs_bundle(H256::random(), bundle).unwrap();
+        mempool
+            .add_blobs_bundle(H256::random(), dummy_v1_bundle(6, i as u8))
+            .unwrap();
     }
 }
 
@@ -976,20 +1049,16 @@ fn blobs_bundle_insert_and_remove() {
     // Then remove one bundle making sure that blob-version-hash to tx-hash cache still points to
     // the other txn. And finally remove second bundle as well.
     let mempool = Mempool::new(MEMPOOL_MAX_SIZE_TEST);
-    let (blob, commitment, proof) = ([255u8; BYTES_PER_BLOB], [255u8; 48], [255u8; 48]);
+    let (blob, commitment) = ([255u8; BYTES_PER_BLOB], [255u8; 48]);
     let versioned_hash = kzg_commitment_to_versioned_hash(&commitment);
     let mut txn_hash = vec![];
 
     for i in 1..=2 {
-        let blobs = [blob, [i as u8; BYTES_PER_BLOB]];
-        let commitments = [commitment, [i as u8; 48]];
-        let proofs = [proof, [i as u8; 48]];
-        let bundle = BlobsBundle {
-            blobs: blobs.to_vec(),
-            commitments: commitments.to_vec(),
-            proofs: proofs.to_vec(),
-            version: 0,
-        };
+        let mut bundle = dummy_v1_bundle(2, i as u8);
+        // Share one commitment/blob across both txs so the versioned-hash index
+        // must keep pointing at the remaining txn after the first is removed.
+        bundle.blobs[0] = blob;
+        bundle.commitments[0] = commitment;
         let tx = EIP4844Transaction {
             nonce: 3,
             max_priority_fee_per_gas: 0,
@@ -1058,12 +1127,7 @@ fn blob_txs_are_not_evicted_by_regular_tx_flood() {
     let blob_count = regular_cap + 2;
     let mut blob_hashes = Vec::new();
     for i in 0..blob_count {
-        let bundle = BlobsBundle {
-            blobs: vec![[i as u8; BYTES_PER_BLOB]],
-            commitments: vec![[i as u8; 48]],
-            proofs: vec![[i as u8; 48]],
-            version: 0,
-        };
+        let bundle = dummy_v1_bundle(1, i as u8);
         let blob_tx = Transaction::EIP4844Transaction(EIP4844Transaction {
             gas: 21_000,
             to: Address::from_low_u64_be(1),
@@ -1130,15 +1194,10 @@ fn blob_txs_are_not_evicted_by_regular_tx_flood() {
     }
 }
 
-// Inserts a 1-blob tx straight into the pool (bypassing validation) with the
+// Inserts a 1-blob tx straight into the pool (bypassing crypto validation) with the
 // given nonce and blob fee; returns its hash.
 fn add_blob_tx(mempool: &Mempool, nonce: u64, blob_fee: u64) -> H256 {
-    let bundle = BlobsBundle {
-        blobs: vec![[0u8; BYTES_PER_BLOB]],
-        commitments: vec![[0u8; 48]],
-        proofs: vec![[0u8; 48]],
-        version: 0,
-    };
+    let bundle = dummy_v1_bundle(1, 0);
     let tx = Transaction::EIP4844Transaction(EIP4844Transaction {
         nonce,
         gas: 21_000,
@@ -1163,12 +1222,7 @@ fn add_blob_tx(mempool: &Mempool, nonce: u64, blob_fee: u64) -> H256 {
 
 // Like `add_blob_tx` but with an explicit sender; returns its hash.
 fn add_blob_tx_with_sender(mempool: &Mempool, sender: Address, nonce: u64) -> H256 {
-    let bundle = BlobsBundle {
-        blobs: vec![[0u8; BYTES_PER_BLOB]],
-        commitments: vec![[0u8; 48]],
-        proofs: vec![[0u8; 48]],
-        version: 0,
-    };
+    let bundle = dummy_v1_bundle(1, 0);
     let tx = Transaction::EIP4844Transaction(EIP4844Transaction {
         nonce,
         gas: 21_000,

--- a/test/tests/common/blobs_bundle_tests.rs
+++ b/test/tests/common/blobs_bundle_tests.rs
@@ -1,11 +1,12 @@
 use ethrex_common::types::{
-    BYTES_PER_BLOB, BlobsBundle, BlobsBundleError, Fork, blobs_bundle::blob_from_bytes,
+    BYTES_PER_BLOB, BlobsBundle, BlobsBundleError, CELLS_PER_EXT_BLOB, Fork,
+    blobs_bundle::blob_from_bytes,
 };
 
-/// Helper: create a valid blob bundle with one blob for pre-Osaka (version 0).
+/// Helper: create a valid v1 blob bundle with one blob.
 fn valid_bundle_and_tx() -> (BlobsBundle, ethrex_common::types::EIP4844Transaction) {
     let blobs = vec![blob_from_bytes("Hello, world!".as_bytes().into()).unwrap()];
-    let bundle = BlobsBundle::create_from_blobs(&blobs, None).unwrap();
+    let bundle = BlobsBundle::create_from_blobs(&blobs).unwrap();
     let blob_versioned_hashes = bundle.generate_versioned_hashes();
 
     let tx = ethrex_common::types::EIP4844Transaction {
@@ -36,7 +37,7 @@ fn validate_cheap_rejects_empty_bundle() {
 fn validate_cheap_rejects_wrong_lengths() {
     // Bundle with 1 blob but 2 commitments
     let blobs = vec![blob_from_bytes("data".as_bytes().into()).unwrap()];
-    let mut bundle = BlobsBundle::create_from_blobs(&blobs, None).unwrap();
+    let mut bundle = BlobsBundle::create_from_blobs(&blobs).unwrap();
     let blob_versioned_hashes = bundle.generate_versioned_hashes();
 
     let tx = ethrex_common::types::EIP4844Transaction {
@@ -55,8 +56,27 @@ fn validate_cheap_rejects_wrong_lengths() {
 
 #[test]
 fn validate_cheap_rejects_version_fork_mismatch() {
-    // version-0 bundle on Osaka fork should fail
-    let (bundle, tx) = valid_bundle_and_tx();
+    // v0 bundles are always rejected — only version 1 is valid regardless of fork.
+    let blobs = vec![blob_from_bytes("Hello, world!".as_bytes().into()).unwrap()];
+    let v1_bundle = BlobsBundle::create_from_blobs(&blobs).unwrap();
+    // Manually construct a v0 bundle (single proof per blob).
+    let bundle = BlobsBundle {
+        blobs: v1_bundle.blobs.clone(),
+        commitments: v1_bundle.commitments.clone(),
+        proofs: vec![[0u8; 48]],
+        version: 0,
+    };
+    let blob_versioned_hashes = bundle.generate_versioned_hashes();
+    let tx = ethrex_common::types::EIP4844Transaction {
+        blob_versioned_hashes,
+        ..Default::default()
+    };
+    // Rejected on Prague
+    assert!(matches!(
+        bundle.validate_cheap(&tx, Fork::Prague),
+        Err(BlobsBundleError::InvalidBlobVersionForFork)
+    ));
+    // Also rejected on Osaka
     assert!(matches!(
         bundle.validate_cheap(&tx, Fork::Osaka),
         Err(BlobsBundleError::InvalidBlobVersionForFork)
@@ -77,17 +97,17 @@ fn validate_cheap_rejects_wrong_versioned_hashes() {
 
 #[test]
 fn validate_cheap_passes_with_invalid_kzg_proofs() {
-    // Create a bundle with valid structure but invalid KZG proofs.
-    // validate_cheap() should pass (KZG skipped), validate() should fail.
+    // Create a v1 bundle with valid structure but zeroed-out cell proofs.
+    // validate_cheap() should pass (no KZG check), validate() should fail.
     let blobs = vec![[0u8; BYTES_PER_BLOB]];
-    let valid_bundle = BlobsBundle::create_from_blobs(&blobs, None).unwrap();
+    let valid_bundle = BlobsBundle::create_from_blobs(&blobs).unwrap();
 
-    // Use valid commitments but zero out proofs to make KZG invalid
+    // Use valid commitments (versioned hashes remain correct) but zero all 128 cell proofs.
     let bundle = BlobsBundle {
         blobs: blobs.clone(),
         commitments: valid_bundle.commitments.clone(),
-        proofs: vec![[0u8; 48]], // invalid proof
-        version: 0,
+        proofs: vec![[0u8; 48]; CELLS_PER_EXT_BLOB],
+        version: 1,
     };
 
     let blob_versioned_hashes = bundle.generate_versioned_hashes();
@@ -96,13 +116,13 @@ fn validate_cheap_passes_with_invalid_kzg_proofs() {
         ..Default::default()
     };
 
-    // Cheap validation passes (no KZG check)
+    // Cheap validation passes (correct version, correct lengths, correct hashes).
     assert!(
         bundle.validate_cheap(&tx, Fork::Prague).is_ok(),
         "validate_cheap should pass with structurally valid but KZG-invalid bundle"
     );
 
-    // Full validation fails on KZG proof
+    // Full validation fails on KZG cell proof verification.
     let result = bundle.validate(&tx, Fork::Prague);
     assert!(
         result.is_err(),
@@ -126,7 +146,7 @@ fn validate_cheap_rejects_more_than_six_blobs_per_tx_on_osaka() {
     // Build one valid Osaka (version 1) blob, then replicate it to 7 blobs so the
     // bundle stays structurally valid (matching commitments / cell-proofs / hashes)
     // and the only thing wrong is the per-transaction blob count.
-    let one = BlobsBundle::create_from_blobs(&vec![[0u8; BYTES_PER_BLOB]], Some(1)).unwrap();
+    let one = BlobsBundle::create_from_blobs(&vec![[0u8; BYTES_PER_BLOB]]).unwrap();
     let bundle = BlobsBundle {
         blobs: vec![one.blobs[0]; 7],
         commitments: vec![one.commitments[0]; 7],
@@ -148,7 +168,13 @@ fn validate_cheap_rejects_more_than_six_blobs_per_tx_on_osaka() {
 /// version is 1. A version-2 bundle must be rejected, not merely any non-zero version.
 #[test]
 fn validate_cheap_rejects_noncanonical_wrapper_version_on_osaka() {
-    let bundle = BlobsBundle::create_from_blobs(&vec![[0u8; BYTES_PER_BLOB]], Some(2)).unwrap();
+    // Build a structurally valid v1 bundle then bump version to 2.
+    let blobs = vec![[0u8; BYTES_PER_BLOB]];
+    let v1_bundle = BlobsBundle::create_from_blobs(&blobs).unwrap();
+    let bundle = BlobsBundle {
+        version: 2,
+        ..v1_bundle
+    };
     let tx = ethrex_common::types::EIP4844Transaction {
         blob_versioned_hashes: bundle.generate_versioned_hashes(),
         ..Default::default()

--- a/tooling/monitor/src/app.rs
+++ b/tooling/monitor/src/app.rs
@@ -69,7 +69,6 @@ pub struct EthrexMonitorWidget {
     pub last_scroll: Instant,
     pub overview_selected_widget: usize,
 
-    pub osaka_activation_time: Option<u64>,
     pub mouse_captured: bool,
 }
 
@@ -221,7 +220,6 @@ impl EthrexMonitorWidget {
             rollup_store,
             last_scroll: Instant::now(),
             overview_selected_widget: 0,
-            osaka_activation_time: cfg.osaka_activation_time,
             mouse_captured: true,
         };
         monitor_widget.selected_table().selected(true);
@@ -346,11 +344,7 @@ impl EthrexMonitorWidget {
             .await?;
         self.mempool.on_tick(&self.rollup_client).await?;
         self.batches_table
-            .on_tick(
-                &self.eth_client,
-                &self.rollup_store,
-                self.osaka_activation_time,
-            )
+            .on_tick(&self.eth_client, &self.rollup_store)
             .await?;
         self.blocks_table.on_tick(&self.store).await?;
         self.l1_to_l2_messages

--- a/tooling/monitor/src/config.rs
+++ b/tooling/monitor/src/config.rs
@@ -10,5 +10,4 @@ pub struct MonitorConfig {
     pub sequencer_registry_address: Option<ethrex_common::Address>,
     pub rpc_urls: Vec<reqwest::Url>,
     pub is_based: bool,
-    pub osaka_activation_time: Option<u64>,
 }

--- a/tooling/monitor/src/widget/batches.rs
+++ b/tooling/monitor/src/widget/batches.rs
@@ -1,8 +1,5 @@
-use ethrex_common::{
-    Address, H256,
-    types::{Fork, batch::Batch},
-};
-use ethrex_l2_sdk::{get_l1_active_fork, get_last_committed_batch};
+use ethrex_common::{Address, H256, types::batch::Batch};
+use ethrex_l2_sdk::get_last_committed_batch;
 use ethrex_rpc::EthClient;
 use ethrex_storage_rollup::StoreRollup;
 use ratatui::{
@@ -51,37 +48,27 @@ impl BatchesTable {
         &mut self,
         eth_client: &EthClient,
         rollup_store: &StoreRollup,
-        osaka_activation_time: Option<u64>,
     ) -> Result<(), MonitorError> {
         let mut new_latest_batches = Self::fetch_new_items(
             &mut self.last_l1_block_fetched,
             self.on_chain_proposer_address,
             eth_client,
             rollup_store,
-            osaka_activation_time,
         )
         .await?;
         new_latest_batches.truncate(BATCH_WINDOW_SIZE);
 
-        let l1_fork = get_l1_active_fork(eth_client, osaka_activation_time)
-            .await
-            .map_err(MonitorError::EthClientError)?;
-
         let n_new_latest_batches = new_latest_batches.len();
         self.items
             .truncate(BATCH_WINDOW_SIZE - n_new_latest_batches);
-        self.refresh_items(rollup_store, l1_fork).await?;
+        self.refresh_items(rollup_store).await?;
         self.items.extend_from_slice(&new_latest_batches);
         self.items.rotate_right(n_new_latest_batches);
 
         Ok(())
     }
 
-    async fn refresh_items(
-        &mut self,
-        rollup_store: &StoreRollup,
-        fork: Fork,
-    ) -> Result<(), MonitorError> {
+    async fn refresh_items(&mut self, rollup_store: &StoreRollup) -> Result<(), MonitorError> {
         if self.items.is_empty() {
             return Ok(());
         }
@@ -94,7 +81,7 @@ impl BatchesTable {
             } else {
                 let batch_number = batch.number;
                 let new_batch = rollup_store
-                    .get_batch(batch_number, fork)
+                    .get_batch(batch_number)
                     .await
                     .map_err(|e| MonitorError::GetBatchByNumber(batch_number, e))?
                     .ok_or(MonitorError::BatchNotFound(batch_number))?;
@@ -115,7 +102,6 @@ impl BatchesTable {
         on_chain_proposer_address: Address,
         eth_client: &EthClient,
         rollup_store: &StoreRollup,
-        osaka_activation_time: Option<u64>,
     ) -> Result<Vec<BatchLine>, MonitorError> {
         let last_l2_batch_number = get_last_committed_batch(eth_client, on_chain_proposer_address)
             .await
@@ -128,17 +114,9 @@ impl BatchesTable {
                     .map_err(|_| MonitorError::BatchWindow)?,
             ),
         );
-        let l1_fork = get_l1_active_fork(eth_client, osaka_activation_time)
-            .await
-            .map_err(MonitorError::EthClientError)?;
 
-        let new_batches = Self::get_batches(
-            last_l2_batch_fetched,
-            last_l2_batch_number,
-            rollup_store,
-            l1_fork,
-        )
-        .await?;
+        let new_batches =
+            Self::get_batches(last_l2_batch_fetched, last_l2_batch_number, rollup_store).await?;
 
         Ok(Self::process_batches(new_batches))
     }
@@ -147,13 +125,12 @@ impl BatchesTable {
         from: &mut u64,
         to: u64,
         rollup_store: &StoreRollup,
-        fork: Fork,
     ) -> Result<Vec<Batch>, MonitorError> {
         let mut new_batches = Vec::new();
 
         for batch_number in *from + 1..=to {
             let batch = rollup_store
-                .get_batch(batch_number, fork)
+                .get_batch(batch_number)
                 .await
                 .map_err(|e| MonitorError::GetBatchByNumber(batch_number, e))?
                 .ok_or(MonitorError::BatchNotFound(batch_number))?;


### PR DESCRIPTION
Closes #6927

## Summary

Stop producing and accepting v0 blob sidecars. Match geth (#35191):
always use v1 (EIP-7594 cell-proof) sidecars.

## What changed

- `create_from_blobs` always builds v1 sidecars
- mempool validation rejects v0
- dead v0 proof/verify paths removed
- payload merge uses a fallible v1 append (avoids version/label mismatch)
- L2 store/committer regenerate v1 from stored blobs
- prover still gets a separate single EIP-4844 proof where needed
- `engine_getBlobsV1` stays decline-don’t-derive (null for v1 pool data)
- `based/1` `BatchSealed` wire format unchanged
- L2 networking requires `c-kzg`
- Osaka CLI flags kept as deprecated no-ops (warn + ignore)
- regression tests for admission, merge, prover proof, and BatchSealed

## Tested

- blob-bundle unit tests
- mempool v0 rejection tests
- Engine `blobs_v1` tests
- BatchSealed wire/legacy-shape tests
- `cargo check` on affected crates (incl. `ethrex-p2p` with `l2`)

Not run yet: Hive / EF / full L2 integration from #6927.