### PR TITLE
fix(l1): box forkchoiceUpdated engine handlers

### DIFF
--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1457,10 +1457,10 @@ pub async fn map_engine_requests(
 ) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "engine_exchangeCapabilities" => ExchangeCapabilitiesRequest::call(req, context).await,
-        "engine_forkchoiceUpdatedV1" => ForkChoiceUpdatedV1::call(req, context).await,
-        "engine_forkchoiceUpdatedV2" => ForkChoiceUpdatedV2::call(req, context).await,
-        "engine_forkchoiceUpdatedV3" => ForkChoiceUpdatedV3::call(req, context).await,
-        "engine_forkchoiceUpdatedV4" => ForkChoiceUpdatedV4::call(req, context).await,
+        "engine_forkchoiceUpdatedV1" => Box::pin(ForkChoiceUpdatedV1::call(req, context)).await,
+        "engine_forkchoiceUpdatedV2" => Box::pin(ForkChoiceUpdatedV2::call(req, context)).await,
+        "engine_forkchoiceUpdatedV3" => Box::pin(ForkChoiceUpdatedV3::call(req, context)).await,
+        "engine_forkchoiceUpdatedV4" => Box::pin(ForkChoiceUpdatedV4::call(req, context)).await,
         // The newPayload handlers carry the largest futures of any engine arm
         // (block execution + optional witness collection). Because this `match`
         // awaits each arm inline, the future of `map_engine_requests` is sized to


### PR DESCRIPTION
`map_engine_requests` awaits each match arm inline, so its future is sized to the largest arm and shared by every engine request. The `forkchoiceUpdated` arms weren't boxed like the `newPayload` arms; box them so a lightweight `forkchoiceUpdated` poll doesn't have to reserve the full frame.
