### PR TITLE
fix(l1): ssz limit conform with execution-specs@tests-zkevm@0.6.2

### DIFF
--- a/crates/common/types/eip8025_ssz.rs
+++ b/crates/common/types/eip8025_ssz.rs
@@ -34,8 +34,6 @@ const MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: usize = 64;
 const MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD: usize = 16;
 /// `MAX_BLOB_COMMITMENTS_PER_BLOCK` (Electra).
 const MAX_BLOB_COMMITMENTS_PER_BLOCK: usize = 4096;
-/// `MAX_BLOCK_ACCESS_LIST_BYTES` (Amsterdam).
-const MAX_BLOCK_ACCESS_LIST_BYTES: usize = 16777216;
 
 // ── EIP-7685 request type prefixes ─────────────────────────────────
 
@@ -214,7 +212,7 @@ pub struct ExecutionPayloadV4 {
     pub withdrawals: SszList<Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD>,
     pub blob_gas_used: u64,
     pub excess_blob_gas: u64,
-    pub block_access_list: SszList<u8, MAX_BLOCK_ACCESS_LIST_BYTES>,
+    pub block_access_list: SszList<u8, MAX_BYTES_PER_TRANSACTION>,
     pub slot_number: u64,
 }
 

--- a/crates/guest-program/src/l1/input.rs
+++ b/crates/guest-program/src/l1/input.rs
@@ -111,19 +111,19 @@ pub fn encode_eip8025(
 // ── canonical SSZ schema ───────────────────────────────────────────
 
 #[cfg(feature = "eip-8025")]
-const MAX_WITNESS_NODES: usize = 1 << 20;
+const MAX_WITNESS_NODES: usize = 1 << 22;
 #[cfg(feature = "eip-8025")]
-const MAX_WITNESS_CODES: usize = 1 << 16;
+const MAX_WITNESS_CODES: usize = 1 << 18;
 #[cfg(feature = "eip-8025")]
 const MAX_WITNESS_HEADERS: usize = 256;
 #[cfg(feature = "eip-8025")]
-const MAX_BYTES_PER_WITNESS_NODE: usize = 1 << 20;
+const MAX_BYTES_PER_WITNESS_NODE: usize = 1 << 10;
 #[cfg(feature = "eip-8025")]
-const MAX_BYTES_PER_CODE: usize = 1 << 24;
+const MAX_BYTES_PER_CODE: usize = 1 << 16;
 #[cfg(feature = "eip-8025")]
 const MAX_BYTES_PER_HEADER: usize = 1 << 10;
 #[cfg(feature = "eip-8025")]
-const MAX_PUBLIC_KEYS: usize = 1 << 20;
+const MAX_PUBLIC_KEYS: usize = 1 << 15;
 #[cfg(feature = "eip-8025")]
 const BYTES_PER_PUBLIC_KEY: usize = 65;
 


### PR DESCRIPTION
**Motivation**

Update SSZ limit to conform with `execution-specs@tests-zkevm@0.6.2`, tho most of them don't affect the `hash_tree_root` result (only the size of `block_access_list` affects), but if any `statelessInputBytes` ever cross the limit the SSZ decode result will diverge.

**Description**

- Update `MAX_WITNESS_NODES` to `1 << 22` ([ref](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/src/ethereum/forks/amsterdam/stateless_ssz.py#L66))
- Update `MAX_WITNESS_CODES` to `1 << 18` ([ref](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/src/ethereum/forks/amsterdam/stateless_ssz.py#L70))
- Update `MAX_BYTES_PER_WITNESS_NODE` to `1 << 10` ([ref](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/src/ethereum/forks/amsterdam/stateless_ssz.py#L80))
- Update `MAX_BYTES_PER_CODE` to `1 << 16` ([ref](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/src/ethereum/forks/amsterdam/stateless_ssz.py#L75))
- Update `MAX_PUBLIC_KEYS` to `1 << 15` ([ref](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/src/ethereum/forks/amsterdam/stateless_ssz.py#L86))
- Remove `MAX_BLOCK_ACCESS_LIST_BYTES` and use `MAX_BYTES_PER_TRANSACTION` for `block_access_list` ([ref](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.6.2/src/ethereum/forks/amsterdam/stateless_ssz.py#L144))

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #issue_number

