### PR TITLE
build(l2): unify duplicate crate sources via [patch.crates-io]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,19 +1903,6 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
-dependencies = [
- "ff 0.13.1",
- "group 0.13.0",
- "pairing 0.23.0",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.8.0"
 source = "git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors#78cad0378b17fc3157b83f514be192bf46edf9a1"
 dependencies = [
  "digest 0.10.7",
@@ -3978,7 +3965,7 @@ dependencies = [
 name = "ethrex-guest-program"
 version = "21.0.0"
 dependencies = [
- "bls12_381 0.8.0 (git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors)",
+ "bls12_381 0.8.0",
  "bytes",
  "ethereum-types 0.15.1",
  "ethrex-common",
@@ -5188,7 +5175,7 @@ dependencies = [
  "crossbeam",
  "ff 0.13.1",
  "group 0.13.0",
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "halo2curves-axiom",
  "itertools 0.11.0",
  "maybe-rayon",
  "pairing 0.23.0",
@@ -5272,34 +5259,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pairing 0.23.0",
- "paste",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rayon",
- "serde",
- "serde_arrays 0.1.0",
- "sha2",
- "static_assertions",
- "subtle",
- "unroll",
-]
-
-[[package]]
-name = "halo2curves-axiom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0cd39c0df23c8b72cb7158ccb106341b078d5019b5478b3bfdaf14e898177d3"
-dependencies = [
- "blake2b_simd",
- "digest 0.10.7",
- "ff 0.13.1",
- "group 0.13.0",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "num-traits",
- "pairing 0.23.0",
- "pasta_curves 0.5.1",
  "paste",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -7758,7 +7717,7 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
+ "halo2curves-axiom",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-transpiler",
@@ -7806,7 +7765,7 @@ name = "openvm-algebra-guest"
 version = "1.4.1"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.1#05cb6a11bbd7ac3ac8a00c3fc56391b06f54baa2"
 dependencies = [
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "halo2curves-axiom",
  "num-bigint 0.4.6",
  "once_cell",
  "openvm-algebra-complex-macros 1.4.1",
@@ -7822,7 +7781,7 @@ name = "openvm-algebra-guest"
 version = "1.5.0"
 source = "git+https://github.com/openvm-org/openvm.git#69373ff1d06b613025fe4e7a02d735a1609412c4"
 dependencies = [
- "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
+ "halo2curves-axiom",
  "num-bigint 0.4.6",
  "once_cell",
  "openvm-algebra-complex-macros 1.5.0",
@@ -8111,7 +8070,7 @@ dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
  "derive_more 1.0.0",
- "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
+ "halo2curves-axiom",
  "hex-literal 0.4.1",
  "lazy_static",
  "num-bigint 0.4.6",
@@ -8143,7 +8102,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "group 0.13.0",
- "halo2curves-axiom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "halo2curves-axiom",
  "once_cell",
  "openvm 1.4.1",
  "openvm-algebra-guest 1.4.1",
@@ -8162,7 +8121,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "group 0.13.0",
- "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
+ "halo2curves-axiom",
  "once_cell",
  "openvm 1.5.0",
  "openvm-algebra-guest 1.5.0",
@@ -8288,7 +8247,7 @@ name = "openvm-kzg"
 version = "0.2.0-alpha"
 source = "git+https://github.com/axiom-crypto/openvm-kzg.git?rev=530a6ed413def5296b7e4967650ba4fc8fd92ea1#530a6ed413def5296b7e4967650ba4fc8fd92ea1"
 dependencies = [
- "bls12_381 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bls12_381 0.8.0",
  "hex",
  "hex-literal 1.1.0",
  "openvm-algebra-guest 1.4.1",
@@ -8388,7 +8347,7 @@ dependencies = [
  "snark-verifier-sdk",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
+ "zkhash",
 ]
 
 [[package]]
@@ -8471,7 +8430,7 @@ dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
- "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
+ "halo2curves-axiom",
  "num-bigint 0.4.6",
  "num-traits",
  "openvm-algebra-circuit",
@@ -8519,7 +8478,7 @@ version = "1.5.0"
 source = "git+https://github.com/openvm-org/openvm.git#69373ff1d06b613025fe4e7a02d735a1609412c4"
 dependencies = [
  "blstrs",
- "halo2curves-axiom 0.7.2 (git+https://github.com/axiom-crypto/halo2curves.git?tag=v0.7.2)",
+ "halo2curves-axiom",
  "hex-literal 0.4.1",
  "itertools 0.14.0",
  "lazy_static",
@@ -8581,7 +8540,7 @@ dependencies = [
  "p3-poseidon2-air",
  "p3-symmetric 0.4.1",
  "rand 0.9.4",
- "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
+ "zkhash",
 ]
 
 [[package]]
@@ -8869,7 +8828,7 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.23",
- "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
+ "zkhash",
 ]
 
 [[package]]
@@ -8907,7 +8866,7 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber 0.3.23",
- "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
+ "zkhash",
 ]
 
 [[package]]
@@ -12754,7 +12713,7 @@ dependencies = [
  "slop-challenger",
  "slop-poseidon2",
  "slop-symmetric",
- "zkhash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zkhash",
 ]
 
 [[package]]
@@ -13260,7 +13219,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "vec_map",
- "zkhash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zkhash",
 ]
 
 [[package]]
@@ -15812,33 +15771,6 @@ dependencies = [
  "zisk-definitions",
  "zisk-verifier",
  "zkvm-interface",
-]
-
-[[package]]
-name = "zkhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bitvec",
- "blake2",
- "bls12_381 0.7.1",
- "byteorder",
- "cfg-if",
- "group 0.12.1",
- "group 0.13.0",
- "halo2",
- "hex",
- "jubjub",
- "lazy_static",
- "pasta_curves 0.5.1",
- "rand 0.8.5",
- "serde",
- "sha2",
- "sha3",
- "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,3 +158,13 @@ libssz-derive = "0.2.2"
 
 [workspace.lints.clippy]
 redundant_clone = "warn"
+
+# Unify crates that otherwise appear in Cargo.lock from both crates.io and git
+# with the same name and version (registry copies pulled in transitively by
+# openvm-kzg, halo2-axiom, and slop-bn254). Duplicate sources break vendoring
+# tools such as `cargo vendor` and Nix's `importCargoLock`. The git refs below
+# must match the ones already used by the direct/transitive git dependencies.
+[patch.crates-io]
+bls12_381 = { git = "https://github.com/lambdaclass/bls12_381", branch = "expose-affine-constructors" }
+halo2curves-axiom = { git = "https://github.com/axiom-crypto/halo2curves.git", tag = "v0.7.2" }
+zkhash = { git = "https://github.com/HorizenLabs/poseidon2.git", rev = "bb476b9" }


### PR DESCRIPTION
**Motivation**

Downstream packagers cannot vendor the workspace. `bls12_381 0.8.0`, `halo2curves-axiom 0.7.2`, and `zkhash 0.2.0` appear in `Cargo.lock` from both crates.io and git with the same name and version, and vendoring tools (`cargo vendor`, Nix's `importCargoLock`) reject two sources for one package. Reported in #6234 while packaging ethrex for [nix-community/ethereum.nix#944](https://github.com/nix-community/ethereum.nix/pull/944).

**Description**

Adds a `[patch.crates-io]` section redirecting the three registry copies to the git sources already used elsewhere in the tree (registry copies come in transitively via `openvm-kzg`, `halo2-axiom`, and `slop-bn254`). The lockfile loses the three registry entries; no crate versions change.

Safety notes:
- The halo2curves-axiom tag and the poseidon2 rev are byte-identical to the registry releases (the registry tarballs were published from those exact commits).
- The bls12_381 fork adds constructors on top of registry 0.8.0; its only behavior change (`hash_to_curve` rewrite for digest 0.10) sits behind the `experimental` feature, which `openvm-kzg` does not enable.
- The halo2curves patch must use `tag = "v0.7.2"` (not a rev) so cargo unifies it with the transitive `?tag=v0.7.2` source ID.

Known residual: `openvm-custom-insn 0.1.0` still appears from two refs of openvm.git (the guest pins tag v1.4.1, the prover tracks a branch). Cargo cannot patch a git URL with itself, so fixing that requires a pin change in the openvm dependencies.

Verified with `make check-cargo-lock`, a duplicate scan of the lockfile, `cargo check -p ethrex-guest-program --features sp1,openvm`, and `cargo check -p ethrex-prover --features sp1`.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A, no store changes

Closes #6234