### PR TITLE
fix(l1): don't pay for a full extra block build in engine_getPayload under sustained mempool inflow

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -467,7 +467,20 @@ impl Blockchain {
         // an in-progress rebuild via `run_until_cancelled`, and (b) the slot-
         // timeout `select!` arm winning over a simultaneous `tx_added`
         // notification near the slot boundary.
-        if self.mempool.tx_seq() > last_built_seq {
+        //
+        // When the loop was cancelled, `engine_getPayload` is blocked on this
+        // task and must answer within the Engine API deadline (1s), while a
+        // full rebuild of a large block can exceed that deadline on its own —
+        // under sustained mempool inflow `tx_seq() > last_built_seq` is true
+        // on essentially every call, so an unconditional rebuild here puts one
+        // whole extra block build on the proposal critical path. In that case
+        // only rebuild when the payload we hold is empty: returning a slightly
+        // stale block is fine (geth/reth return best-so-far too), but
+        // proposing an empty block while the mempool has transactions is not
+        // (race (a) with no completed rebuild yet).
+        if self.mempool.tx_seq() > last_built_seq
+            && (!cancel_token.is_cancelled() || res.payload.body.transactions.is_empty())
+        {
             let blockchain = self.clone();
             match tokio::task::spawn_blocking(move || blockchain.build_payload(payload)).await {
                 Ok(Ok(final_res)) => res = final_res,

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -478,6 +478,17 @@ impl Blockchain {
         // stale block is fine (geth/reth return best-so-far too), but
         // proposing an empty block while the mempool has transactions is not
         // (race (a) with no completed rebuild yet).
+        //
+        // TODO(#5011): two paths below can still put a full build on the
+        // critical path, so this narrows the exposure rather than removing it.
+        // First, the empty-payload case still rebuilds over the whole mempool;
+        // that has to stay correct (it is the race this guard exists for), but
+        // a large mempool of txs that never make it into a block — low-fee or
+        // nonce-gapped — can make even that approach the deadline. Second, this
+        // rebuild is not cancellable: unlike the in-loop build it runs as a
+        // plain `spawn_blocking(..).await`, so a `getPayload` arriving while a
+        // slot-timeout rebuild is in flight waits for it to finish. Bounding
+        // either needs a time-boxed or partial build, not a guard here.
         if self.mempool.tx_seq() > last_built_seq
             && (!cancel_token.is_cancelled() || res.payload.body.transactions.is_empty())
         {

--- a/test/tests/blockchain/mod.rs
+++ b/test/tests/blockchain/mod.rs
@@ -9,6 +9,7 @@ mod explicit_blob_tx_tests;
 mod l1_tx_type_tests;
 mod logs_bloom_tests;
 mod mempool_tests;
+mod payload_build_loop_tests;
 mod payload_tests;
 mod smoke_tests;
 mod storage_sharding_tests;

--- a/test/tests/blockchain/payload_build_loop_tests.rs
+++ b/test/tests/blockchain/payload_build_loop_tests.rs
@@ -1,0 +1,301 @@
+//! Regression tests for `build_payload_loop`'s post-loop final mempool
+//! re-drain and its interaction with cancellation (`engine_getPayload`).
+//!
+//! Two properties must hold at the same time:
+//!
+//! - a transaction that lands in the tight window between the loop's last
+//!   completed build and a `getPayload`-triggered cancellation must still be
+//!   included when the held payload is empty — otherwise the builder returns
+//!   an empty block while the mempool has transactions (the Hive
+//!   "Invalid Missing Ancestor Syncing ReOrg" flake family);
+//! - once cancelled with a non-empty payload in hand, the loop must NOT pay
+//!   for one more full block build: `engine_getPayload` is blocked on it and
+//!   a full rebuild of a large block can exceed the Engine API 1s deadline
+//!   by itself (observed as missed proposals under sustained mempool inflow,
+//!   where `tx_seq()` has always advanced and the re-drain guard never
+//!   short-circuits).
+//!
+//! The tests drive the `build_payload_loop` future manually (its initial
+//! build runs synchronously up to the first `await`) so the ordering between
+//! builds, cancellation, and late-arriving transactions is fully
+//! deterministic — no sleeps, no timing assumptions.
+
+use std::{
+    collections::BTreeMap,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain, BlockchainOptions, BlockchainType,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    Address, H160, U256,
+    types::{
+        Block, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, Genesis, GenesisAccount, Transaction,
+        TxKind,
+    },
+};
+use ethrex_crypto::NativeCrypto;
+use ethrex_l2_rpc::signer::{LocalSigner, Signable, Signer};
+use ethrex_storage::{EngineType, Store};
+use secp256k1::SecretKey;
+use tokio_util::sync::CancellationToken;
+
+const L1_CHAIN_ID: u64 = 9;
+
+fn read_private_keys(amount: usize) -> Vec<SecretKey> {
+    let file = include_str!("../../../fixtures/keys/private_keys_l1.txt");
+    file.lines()
+        .take(amount)
+        .map(|line| {
+            let line = line.trim().strip_prefix("0x").unwrap();
+            SecretKey::from_str(line).unwrap()
+        })
+        .collect()
+}
+
+fn address_for(sk: &SecretKey) -> Address {
+    Signer::Local(LocalSigner::new(*sk)).address()
+}
+
+async fn setup_store(accounts: &[Address]) -> Store {
+    let genesis_file = include_bytes!("../../../fixtures/genesis/l1.json");
+    let mut genesis: Genesis = serde_json::from_slice(genesis_file).unwrap();
+    for address in accounts {
+        genesis.alloc.insert(
+            *address,
+            GenesisAccount {
+                code: Bytes::new(),
+                storage: BTreeMap::new(),
+                balance: U256::MAX,
+                nonce: 0,
+            },
+        );
+    }
+    let mut store = Store::new("store.db", EngineType::InMemory).unwrap();
+    store.add_initial_state(genesis).await.unwrap();
+    store
+}
+
+fn blockchain_for(store: &Store) -> Arc<Blockchain> {
+    Arc::new(Blockchain::new(
+        store.clone(),
+        BlockchainOptions {
+            r#type: BlockchainType::L1,
+            perf_logs_enabled: false,
+            ..Default::default()
+        },
+    ))
+}
+
+fn payload_block(store: &Store) -> Block {
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let args = BuildPayloadArgs {
+        parent: genesis_header.hash(),
+        timestamp: genesis_header.timestamp + 12,
+        fee_recipient: H160::random(),
+        random: genesis_header.prev_randao,
+        withdrawals: None,
+        beacon_root: genesis_header.parent_beacon_block_root,
+        slot_number: None,
+        version: 3,
+        elasticity_multiplier: 1,
+        gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+    };
+    create_payload(&args, store, Bytes::new()).unwrap()
+}
+
+async fn signed_transfer(sk: &SecretKey, nonce: u64) -> Transaction {
+    let signer = Signer::Local(LocalSigner::new(*sk));
+    let mut tx = Transaction::EIP1559Transaction(EIP1559Transaction {
+        nonce,
+        value: 1_u64.into(),
+        gas_limit: 250_000_u64,
+        max_fee_per_gas: 10_000_000_000_u64,
+        max_priority_fee_per_gas: 10_u64,
+        chain_id: L1_CHAIN_ID,
+        to: TxKind::Call(H160::random()),
+        ..Default::default()
+    });
+    tx.sign_inplace(&signer).await.unwrap();
+    tx
+}
+
+/// Polls the future exactly once, asserting it is still pending. For
+/// `build_payload_loop` this runs the initial synchronous build and parks the
+/// loop in its `select!`, with the `tx_added` waiter already registered.
+macro_rules! poll_once_pending {
+    ($fut:expr) => {
+        std::future::poll_fn(|cx| {
+            assert!(
+                $fut.as_mut().poll(cx).is_pending(),
+                "build loop finished before it was cancelled"
+            );
+            std::task::Poll::Ready(())
+        })
+        .await
+    };
+}
+
+/// A tx that lands between the last completed build (here: the initial empty
+/// build) and cancellation must be included in the returned payload. This is
+/// the property the final re-drain exists for; losing it re-introduces the
+/// empty-payload race on quick FCU → getPayload sequences.
+#[tokio::test]
+async fn cancelled_loop_still_drains_mempool_when_payload_is_empty() {
+    let keys = read_private_keys(1);
+    let accounts: Vec<Address> = keys.iter().map(address_for).collect();
+    let store = setup_store(&accounts).await;
+    let blockchain = blockchain_for(&store);
+
+    // Mempool is empty: the initial build produces an empty payload.
+    let token = CancellationToken::new();
+    let mut fut = std::pin::pin!(
+        blockchain
+            .clone()
+            .build_payload_loop(payload_block(&store), token.clone())
+    );
+    poll_once_pending!(fut);
+
+    // The tx lands, then getPayload cancels before any rebuild completes.
+    let tx = signed_transfer(&keys[0], 0).await;
+    let tx_hash = blockchain.add_transaction_to_pool(tx).await.unwrap();
+    token.cancel();
+
+    let res = fut.await.unwrap();
+    assert!(
+        res.payload
+            .body
+            .transactions
+            .iter()
+            .any(|tx| tx.hash(&NativeCrypto) == tx_hash),
+        "tx that landed before cancellation is missing from the payload"
+    );
+}
+
+/// Once cancelled with a non-empty payload in hand, the loop must return that
+/// payload as-is instead of paying for one more full build: a tx that lands
+/// strictly after cancellation must NOT appear (its inclusion would prove the
+/// post-cancellation re-drain ran, which is what breaches the getPayload
+/// deadline under sustained mempool inflow).
+#[tokio::test]
+async fn cancelled_loop_returns_held_payload_without_final_rebuild() {
+    let keys = read_private_keys(2);
+    let accounts: Vec<Address> = keys.iter().map(address_for).collect();
+    let store = setup_store(&accounts).await;
+    let blockchain = blockchain_for(&store);
+
+    // One tx in the mempool before the loop starts: the initial build holds it.
+    let early_tx = signed_transfer(&keys[0], 0).await;
+    let early_hash = blockchain.add_transaction_to_pool(early_tx).await.unwrap();
+
+    let token = CancellationToken::new();
+    let mut fut = std::pin::pin!(
+        blockchain
+            .clone()
+            .build_payload_loop(payload_block(&store), token.clone())
+    );
+    poll_once_pending!(fut);
+
+    // getPayload cancels; only afterwards does another tx land.
+    token.cancel();
+    let late_tx = signed_transfer(&keys[1], 0).await;
+    let late_hash = blockchain.add_transaction_to_pool(late_tx).await.unwrap();
+
+    let res = fut.await.unwrap();
+    let hashes: Vec<_> = res
+        .payload
+        .body
+        .transactions
+        .iter()
+        .map(|tx| tx.hash(&NativeCrypto))
+        .collect();
+    assert!(
+        hashes.contains(&early_hash),
+        "tx built before cancellation is missing from the payload"
+    );
+    assert!(
+        !hashes.contains(&late_hash),
+        "tx that landed after cancellation was included: the loop paid for a \
+         full post-cancellation rebuild on the getPayload critical path"
+    );
+}
+
+/// Manual reproduction of the `engine_getPayload` deadline breach seen on
+/// glamsterdam-devnet-7: with sustained mempool inflow, every `getPayload`
+/// paid for one full extra block build after cancellation. Run with:
+/// `cargo test -p ethrex-test getpayload_latency -- --ignored --nocapture`
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "manual latency reproduction; timing-based"]
+async fn getpayload_latency_under_sustained_mempool_inflow() {
+    const SENDERS: usize = 8;
+    const TXS_PER_SENDER: u64 = 400;
+
+    let keys = read_private_keys(SENDERS + 1);
+    let accounts: Vec<Address> = keys.iter().map(address_for).collect();
+    let store = setup_store(&accounts).await;
+    let blockchain = blockchain_for(&store);
+
+    for sk in &keys[..SENDERS] {
+        for nonce in 0..TXS_PER_SENDER {
+            let tx = signed_transfer(sk, nonce).await;
+            blockchain.add_transaction_to_pool(tx).await.unwrap();
+        }
+    }
+
+    // Reference cost of one full build over this mempool.
+    let start = Instant::now();
+    let reference = blockchain.build_payload(payload_block(&store)).unwrap();
+    let build_time = start.elapsed();
+    println!(
+        "one full build: {build_time:?} ({} txs)",
+        reference.payload.body.transactions.len()
+    );
+
+    // FCU with attributes: the loop builds and rebuilds for the slot while a
+    // feeder keeps txs flowing (spamoor-style), so `tx_seq` always advances.
+    let payload_id = 1;
+    blockchain
+        .clone()
+        .initiate_payload_build(payload_block(&store), payload_id)
+        .await;
+    let feeder_blockchain = blockchain.clone();
+    let feeder_key = keys[SENDERS];
+    let feeder = tokio::spawn(async move {
+        for nonce in 0.. {
+            let tx = signed_transfer(&feeder_key, nonce).await;
+            if feeder_blockchain.add_transaction_to_pool(tx).await.is_err() {
+                break;
+            }
+            // Inter-arrival below one build time, like the devnet's sustained
+            // inflow: some tx always lands while a rebuild is in flight, so
+            // `tx_seq()` is ahead of `last_built_seq` at cancellation time.
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    });
+
+    // The CL requests the payload late in the slot.
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    let start = Instant::now();
+    let res = blockchain.get_payload(payload_id).await.unwrap();
+    let get_payload_time = start.elapsed();
+    feeder.abort();
+
+    println!(
+        "get_payload: {get_payload_time:?} ({} txs in payload)",
+        res.payload.body.transactions.len()
+    );
+    assert!(
+        !res.payload.body.transactions.is_empty(),
+        "payload must not be empty under a loaded mempool"
+    );
+    assert!(
+        get_payload_time < build_time / 2,
+        "get_payload ({get_payload_time:?}) paid for a full extra block build \
+         (one build: {build_time:?}) after cancellation"
+    );
+}


### PR DESCRIPTION
**Motivation**

ethrex on glamsterdam-devnet-7 misses block proposals because `engine_getPayload` breaches the Engine API 1s deadline: `engine_getPayloadV6` p90 = 834ms / p99 = 986ms over a 4-hour window, with Prysm missing 6 of 31 proposal duties. An engine-API capture on `prysm-ethrex-1` ties one 1000ms `getPayload` response (consensus-client disconnect) to the FCU for slot 50774, which dora shows as Missed. Full analysis: [ethrex getPayload deadline report](https://panda-uploads-production.devops-539.workers.dev/panda/uploads/f8f36e/ethrex-getpayload-deadline-report.html).

**Description**

`PayloadBuildTask::finish()` cancels `build_payload_loop` and awaits it. After the loop exits, the final mempool re-drain introduced in #6596 runs one more **full block build**, gated only on `tx_seq() > last_built_seq`. Under sustained mempool inflow (spamoor keeps ~5,000 txs pending on the devnet) that guard never short-circuits, so every `engine_getPayload` pays for one complete extra block build after cancellation — 0.5–1.0s on 300M-gas EIP-8037 blocks, sitting directly on the proposal critical path.

This PR skips the post-cancellation re-drain when the payload already in hand contains transactions. The re-drain still runs when the held payload is empty — which is exactly the race #6596 closed (a quick FCU → `getPayload` sequence with the tx landing mid-build must not return an empty payload). The slot-timeout path is unchanged. Returning the best-so-far payload on `getPayload` matches the reference clients: geth's `Payload.Resolve()` never waits on or triggers another build once a full payload exists, and reth resolves `PayloadKind::Earliest` without blocking, with an in-source comment citing the 1s deadline as the rationale.

Two deterministic regression tests drive the `build_payload_loop` future manually (no sleeps, no timing assumptions):

- `cancelled_loop_still_drains_mempool_when_payload_is_empty` locks the #6596 property;
- `cancelled_loop_returns_held_payload_without_final_rebuild` fails on current `main` (a tx that lands strictly after cancellation shows up in the payload, proving the extra rebuild ran) and passes with the fix.

An ignored, manual latency reproduction (`getpayload_latency_under_sustained_mempool_inflow`) simulates the devnet's inflow regime: on unfixed `main`, `get_payload` costs one full build (8.4ms vs 8.2ms per build locally; 0.5–1.0s on the devnet's workload); with the fix it returns in ~0.2ms with the same payload size.

`TODO(#5011)` (the detached `spawn_blocking` build keeps running after cancellation) is adjacent but out of scope: this PR removes the extra build from the response path; making in-flight builds cancellable remains follow-up work.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
