### PR TITLE
fix(l1): don't pay for a full extra block build in engine_getPayload (glamsterdam-devnet-7)

### DIFF
--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -467,7 +467,20 @@ impl Blockchain {
         // an in-progress rebuild via `run_until_cancelled`, and (b) the slot-
         // timeout `select!` arm winning over a simultaneous `tx_added`
         // notification near the slot boundary.
-        if self.mempool.tx_seq() > last_built_seq {
+        //
+        // When the loop was cancelled, `engine_getPayload` is blocked on this
+        // task and must answer within the Engine API deadline (1s), while a
+        // full rebuild of a large block can exceed that deadline on its own —
+        // under sustained mempool inflow `tx_seq() > last_built_seq` is true
+        // on essentially every call, so an unconditional rebuild here puts one
+        // whole extra block build on the proposal critical path. In that case
+        // only rebuild when the payload we hold is empty: returning a slightly
+        // stale block is fine (geth/reth return best-so-far too), but
+        // proposing an empty block while the mempool has transactions is not
+        // (race (a) with no completed rebuild yet).
+        if self.mempool.tx_seq() > last_built_seq
+            && (!cancel_token.is_cancelled() || res.payload.body.transactions.is_empty())
+        {
             let blockchain = self.clone();
             match tokio::task::spawn_blocking(move || blockchain.build_payload(payload)).await {
                 Ok(Ok(final_res)) => res = final_res,


### PR DESCRIPTION
**Motivation**

Cherry-pick of the `engine_getPayload` deadline fix for the running glamsterdam-devnet-7 deployment (`ethpandaops/ethrex:glamsterdam-devnet-7`, currently at 86dd79fef). The devnet's ethrex nodes miss proposals because every `engine_getPayload` pays for one full extra block build after cancellation (`getPayloadV6` p90 = 834ms / p99 = 986ms against the 1s Engine API deadline). Details and analysis in the main PR: https://github.com/lambdaclass/ethrex/pull/7019.

**Description**

Single cherry-picked commit: skip the post-loop final mempool re-drain in `build_payload_loop` when the loop was cancelled and the held payload already contains transactions. The empty-payload case still re-drains (preserves the #6596 empty-payload fix), and the slot-timeout path is unchanged. The `crates/blockchain/payload.rs` region is identical between `main` and this branch, so the cherry-pick applies cleanly. The regression tests stay on the main PR; this branch only takes the production change.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
