### PR TITLE
docs(l1): correct the BlockPersist::block_number batch-journaling comment

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -3779,9 +3779,15 @@ struct BlockPersist {
     wait_for_flush: bool,
     /// Number of the block whose layer this update represents (the last block in
     /// the batch, matching `child_state_root`). Threaded into the trie layer so
-    /// the committed-layer identity is available for the journal write path;
-    /// harmless for batch updates, since journal writes are skipped when
-    /// `wait_for_flush` (batch mode) is set.
+    /// the committed-layer identity is available for the journal write path.
+    ///
+    /// On a multi-block batch this names only the LAST block, which is NOT a usable
+    /// journal identity for the batch's layer. `wait_for_flush` does not make that
+    /// safe: it decides when THIS message acks, whereas the layer it creates is
+    /// journaled or not by whichever LATER commit sweeps it — `TrieLayerCache::commit`
+    /// takes the target layer and every ancestor, so a per-block commit can reach a
+    /// batch layer. Any journal entry must therefore be gated on the committed
+    /// layer covering exactly one block, not on this message's ack mode.
     block_number: BlockNumber,
     /// Hash of the block whose layer this update represents (see `block_number`).
     block_hash: H256,


### PR DESCRIPTION
**Motivation**

The `BlockPersist::block_number` doc says that naming only the batch's last block is "harmless for batch updates, since journal writes are skipped when `wait_for_flush` (batch mode) is set".

That reasoning does not hold. `wait_for_flush` decides when the message that *creates* a layer acks; whether that layer is journaled is decided by whichever *later* commit sweeps it. `TrieLayerCache::commit` takes the target layer **and every ancestor**, so a per-block commit can reach a batch layer and journal it as though it covered one block — writing one entry keyed at block N whose reverse diff undoes the whole batch.

The comment is what made that defect invisible on review, which is why it is worth fixing on its own.

**Description**

Doc-only. No behaviour change. Replaces the incorrect justification with the actual constraint: a journal entry must be gated on the committed layer covering exactly one block, not on the creating message's ack mode.

Split out of #7030, which is closed — #7008 removes the only producer of multi-block layers, so the guard that PR added is no longer needed. This comment is wrong independent of that, and would mislead again if batching were ever reintroduced.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A, comment-only change.
