### PR TITLE
docs(l1,l2): correct stale network, sync-mode and GPU binary references

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -315,7 +315,7 @@ Options:
 
 Node options:
       --network <GENESIS_FILE_PATH>
-          Alternatively, the name of a known network can be provided instead to use its preset genesis file and include its preset bootnodes. The networks currently supported include holesky, sepolia, hoodi and mainnet. If not specified, defaults to mainnet.
+          Alternatively, the name of a known network can be provided instead to use its preset genesis file and include its preset bootnodes. The networks currently supported include sepolia, hoodi and mainnet. If not specified, defaults to mainnet.
 
           [env: ETHREX_NETWORK=]
 

--- a/docs/developers/l1/importing-blocks.md
+++ b/docs/developers/l1/importing-blocks.md
@@ -14,7 +14,7 @@ This guide assumes you've read the dev [installation guide](../installing.md)
 ethrex --network fixtures/genesis/perf-ci.json import  fixtures/blockchain/l2-1k-erc20.rlp
 ```
 
-- The network argument is common to all ethrex commands. It specifies the genesis file, or a public network like holesky. This is the starting state of the blockchain.
+- The network argument is common to all ethrex commands. It specifies the genesis file, or a public network like hoodi. This is the starting state of the blockchain.
 - The import command means that this node will not start rpc endpoints or peer to peer communication. It will just read a file, parse the blocks, execute them, and save the EVM state (accounts info and storage) after each execution.
 - The file is an RLP encoded file with a list of blocks.
 

--- a/docs/developers/l1/profiling.md
+++ b/docs/developers/l1/profiling.md
@@ -36,7 +36,7 @@ The `cpu_profiling` feature is opt-in (not in `default`) so normal builds are un
 1. Start the node as usual:
 
    ```bash
-   ./target/release/ethrex --authrpc.jwtsecret ./secrets/jwt.hex --network holesky
+   ./target/release/ethrex --authrpc.jwtsecret ./secrets/jwt.hex --network hoodi
    ```
 
    You should see this log line near startup:

--- a/docs/getting-started/installation/binary_distribution.md
+++ b/docs/getting-started/installation/binary_distribution.md
@@ -18,10 +18,10 @@ curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-li
 
 #### Linux x86_64 with GPU support (for L2 prover)
 
-If you want to run an L2 prover with GPU acceleration, download the GPU-enabled binary:
+If you want to run an L2 prover with GPU acceleration, download the GPU-enabled L2 binary:
 
 ```sh
-curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-linux-x86_64-gpu -o ethrex
+curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-l2-linux-x86_64-gpu -o ethrex
 ```
 
 ### Linux ARM (aarch64)
@@ -32,10 +32,10 @@ curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-li
 
 #### Linux ARM (aarch64) with GPU support (for L2 prover)
 
-If you want to run an L2 prover with GPU acceleration, download the GPU-enabled binary:
+If you want to run an L2 prover with GPU acceleration, download the GPU-enabled L2 binary:
 
 ```sh
-curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-linux-aarch64-gpu -o ethrex
+curl -L https://github.com/lambdaclass/ethrex/releases/latest/download/ethrex-l2-linux-aarch64-gpu -o ethrex
 ```
 
 ### macOS (Apple Silicon, aarch64)

--- a/docs/internal/l1/syncing_hoodi.md
+++ b/docs/internal/l1/syncing_hoodi.md
@@ -1,4 +1,4 @@
-## Syncing with Holesky
+## Syncing with Hoodi
 
 ### Step 1: Set up a jwt secret for both clients
 
@@ -13,11 +13,11 @@ We will pass this new file’s path as an argument for both clients.
 
 ### Step 2: Launch Ethrex
 
-Pass holesky as a network and the jwt secret we set in the previous step.
-This will launch the node in full sync mode, in order to test out snap sync you can add the flag `--syncmode snap`.
+Pass hoodi as a network and the jwt secret we set in the previous step.
+This will launch the node in snap sync mode, which is the default; to test out full sync you can add the flag `--syncmode full`.
 
 ```bash
-cargo run --release --bin ethrex -- --network holesky --authrpc.jwtsecret ~/secrets/jwt.hex
+cargo run --release --bin ethrex -- --network hoodi --authrpc.jwtsecret ~/secrets/jwt.hex
 ```
 
 The HTTP JSON-RPC server binds to `127.0.0.1` by default and only serves the `eth,net,web3` namespaces. To call `debug_*` methods during sync from the same machine, pass `--http.api eth,net,web3,debug`. To reach the RPC port from another host, pass `--http.addr 0.0.0.0`.
@@ -29,12 +29,12 @@ For this quick tutorial we will be using lighthouse, but you can learn how to in
 You can choose your preferred installation method from [lighthouse's installation guide](https://lighthouse-book.sigmaprime.io/installation.html) and then run the following command to launch the node and sync it from a public endpoint
 
 ```bash
-lighthouse bn --network holesky --execution-endpoint http://localhost:8551 --execution-jwt ~/secrets/jwt.hex --http --checkpoint-sync-url https://checkpoint-sync.holesky.ethpandaops.io
+lighthouse bn --network hoodi --execution-endpoint http://localhost:8551 --execution-jwt ~/secrets/jwt.hex --http --checkpoint-sync-url https://checkpoint-sync.hoodi.ethpandaops.io
 ```
 
 When using lighthouse directly from its repository, replace `lighthouse bn` with `cargo run --bin lighthouse -- bn`
 
-Aside from holesky, these steps can also be used to connect to other supported networks by replacing the `--network` argument by another supported network and looking up a checkpoint sync endpoint for that network [in this community-maintained list](https://eth-clients.github.io/checkpoint-sync-endpoints/)
+Aside from hoodi, these steps can also be used to connect to other supported networks by replacing the `--network` argument by another supported network and looking up a checkpoint sync endpoint for that network [in this community-maintained list](https://eth-clients.github.io/checkpoint-sync-endpoints/)
 
 If you have a running execution node that you want to connect to your ethrex node you can do so by passing its enode as a bootnode using the `--bootnodes` flag
 

--- a/docs/l1/running/configuration.md
+++ b/docs/l1/running/configuration.md
@@ -7,12 +7,12 @@ This page covers the basic configuration options for running an L1 node with eth
 Ethrex supports different sync modes for node operation:
 
 - **full**: Downloads and verifies the entire chain.
-- **snap**: Fast sync using state snapshots (recommended for most users).
+- **snap**: Fast sync using state snapshots (default, recommended for most users).
 
 Set the sync mode with:
 
 ```sh
-ethrex --sync <mode>
+ethrex --syncmode <mode>
 ```
 
 ## File Locations

--- a/docs/l1/running/configuration.md
+++ b/docs/l1/running/configuration.md
@@ -6,8 +6,8 @@ This page covers the basic configuration options for running an L1 node with eth
 
 Ethrex supports different sync modes for node operation:
 
+- **snap** (default): Fast sync using state snapshots (recommended for most users).
 - **full**: Downloads and verifies the entire chain.
-- **snap**: Fast sync using state snapshots (default, recommended for most users).
 
 Set the sync mode with:
 

--- a/docs/l1/running/startup.md
+++ b/docs/l1/running/startup.md
@@ -8,10 +8,11 @@ Ethrex is designed to support Ethereum mainnet and its testnets
 | ------- | -------- | -------------------- |
 | mainnet | 1        | snap                 |
 | sepolia | 11155111 | snap                 |
-| holesky | 17000    | full, snap           |
 | hoodi   | 560048   | full, snap           |
 
-For more information about sync modes please read the [sync modes document](../fundamentals/sync_modes.md). Full syncing is the default, to switch to snap sync use the flag `--syncmode snap`
+These are the only names `--network` accepts. Any other value is treated as a path to a genesis file, so a network without a preset must be started with `--network <genesis.json> --bootnodes <enode,...>`.
+
+For more information about sync modes please read the [sync modes document](../fundamentals/sync_modes.md). Snap syncing is the default; to switch to full sync use the flag `--syncmode full`. Full sync is not possible on a fresh mainnet or sepolia database, since ethrex only executes post-merge blocks.
 
 ## Run an Ethereum node
 
@@ -20,19 +21,13 @@ This guide will assume that you already [installed ethrex](../../getting-started
 To sync with mainnet
 
 ```
-ethrex --syncmode snap
+ethrex
 ```
 
 To sync with sepolia
 
 ```
-ethrex --network sepolia --syncmode snap
-```
-
-To sync with holesky
-
-```
-ethrex --network holesky
+ethrex --network sepolia
 ```
 
 To sync with hoodi

--- a/docs/l2/deployment/validium.md
+++ b/docs/l2/deployment/validium.md
@@ -1,6 +1,6 @@
 # Deploying a validium ethrex L2
 
-In this section, we'll cover how to deploy a validium ethrex L2 on a public network such as Holesky, Sepolia, or Mainnet.
+In this section, we'll cover how to deploy a validium ethrex L2 on a public network such as Hoodi, Sepolia, or Mainnet.
 
 ## Prerequisites
 

--- a/docs/l2/deployment/vanilla.md
+++ b/docs/l2/deployment/vanilla.md
@@ -1,6 +1,6 @@
 # Deploying a vanilla ethrex L2
 
-In this section, we'll cover how to deploy a vanilla ethrex L2 on a public network such as Holesky, Sepolia, or Mainnet.
+In this section, we'll cover how to deploy a vanilla ethrex L2 on a public network such as Hoodi, Sepolia, or Mainnet.
 
 ## Prerequisites
 


### PR DESCRIPTION
**Motivation**

Several operator-facing docs describe behavior the CLI no longer has. Following them verbatim fails: `--network holesky` does not start, `ethrex --sync <mode>` is not a valid flag, and two documented download URLs 404. One of the dead links also fails the Link Check CI job.

**Description**

- **Holesky is not a recognized network.** `Network::from` (`crates/common/config/networks.rs:48`) maps only `mainnet`, `hoodi` and `sepolia`; anything else becomes a genesis *file path*, so `--network holesky` tries to open a file named `holesky` and fails. There are zero `holesky` references left in the Rust source. Dropped it from the supported-networks table and the startup example, and retargeted the syncing walkthrough, profiling guide and importing-blocks note to Hoodi. `docs/CLI.md`'s `ethrex l2` section also advertised holesky — that block is an outdated snapshot of the same `long_help` in `cmd/ethrex/cli.rs:75`, which is already correct (it is outside the CI-verified `BEGIN_CLI_HELP` markers, which is why the drift went unnoticed).
- **Also unblocks Link Check.** `checkpoint-sync.holesky.ethpandaops.io` no longer resolves in DNS, and `lychee.toml` accepts only 2xx/429/503 with no exclusion for that host, so any PR touching `docs/**` fails on it.
- **`--syncmode` defaults to `snap`, not `full`** (`cmd/ethrex/cli.rs:123`). Fixed the inverted claim in `startup.md` and dropped the now-redundant `--syncmode snap` from the mainnet/sepolia examples.
- **`configuration.md` documented the flag as `--sync`**, which the CLI rejects.
- **GPU binary URLs pointed at assets that are never published.** The release workflow builds `-gpu` binaries only for the `l2` stack, so the real names are `ethrex-l2-linux-{x86_64,aarch64}-gpu`. Confirmed the documented URLs return 404 and the corrected ones resolve.
- Renamed `syncing_holesky.md` → `syncing_hoodi.md`. The page is absent from `SUMMARY.md` and nothing links to it, so no references break.

Verified with `mdbook build` (html + linkcheck2 backends) using the CI-pinned preprocessor versions — clean, no errors.

Left alone deliberately: `docs/crate_reviews/ethrex_common_review.md` (a dated, commit-pinned review snapshot referencing a `holesky_test_cases` fn that no longer exists) and `docs/roadmaps/forks-roadmap.md` (historical roadmap citing a since-removed genesis path). Both are point-in-time records, not instructions.

Separate issue noticed but not touched here: `docs` is not in the `Makefile`'s `.PHONY` list, so `make docs` resolves against the `docs/` *directory*. Locally it printed `make: 'docs' is up to date.` and built nothing — `mdbook build` had to be invoked directly. In CI this depends on checkout mtimes relative to `mermaid-init.js`/`mermaid.min.js`, so the Lint job may not actually be building the book. Worth a one-line Makefile fix in its own PR.

**Checklist**

- [ ] ~Updated `STORE_SCHEMA_VERSION`~ — not applicable, docs-only change.
