### PR TITLE
fix(levm): enforce EIP-8141 canonical low-s for frame signatures

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -3340,9 +3340,9 @@ impl Blockchain {
                 return Err(MempoolError::InvalidFrameSignature);
             }
 
-            // Local anti-malleability policy (NOT consensus): reject high-s
-            // signatures at admission. EIP-8141 accepts high-s at block execution
-            // (`signer == ecrecover`), but the raw signature bytes are committed to
+            // Anti-malleability policy (now also consensus): reject high-s
+            // signatures early at admission. EIP-8141 `verify_signature` (spec commit
+            // fc016d59c5) now rejects high-s too, and the raw signature bytes are committed to
             // the tx identity hash while elided from the sig hash, so a malleated
             // `(v,r,s) -> (v^1, r, n-s)` form would produce a second valid tx hash
             // for the same logical tx and bypass pool dedup.

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -706,7 +706,7 @@ pub struct VM<'a> {
     pub crypto: &'a dyn Crypto,
 }
 
-/// Validate every EIP-8141 outer signature (spec commit fe0940cae2) against
+/// Validate every EIP-8141 outer signature (spec commit fc016d59c5) against
 /// the canonical `sig_hash`. Returns false if any signature is malformed or
 /// invalid. Verification gas is intrinsic (already in `total_gas_limit`), so a
 /// scratch budget is used for the crypto precompiles and their deduction is
@@ -726,7 +726,6 @@ pub fn validate_frame_signatures(
         FRAME_SIG_SCHEME_ARBITRARY, FRAME_SIG_SCHEME_P256, FRAME_SIG_SCHEME_SECP256K1,
     };
     for sig in signatures {
-        // Resolve the signed message.
         let msg: [u8; 32] = match sig.msg.len() {
             0 => sig_hash.0,
             32 => {
@@ -746,18 +745,21 @@ pub fn validate_frame_signatures(
                     return false;
                 }
                 let v = sig.signature[0];
+                if v > 1 {
+                    return false;
+                }
                 let r = &sig.signature[1..33];
                 let s = &sig.signature[33..65];
                 // EIP-8141 defines verification as `signer == ecrecover(msg, v, r, s)`
-                // and does NOT mandate EIP-2 low-s, so a high-s frame signature is
-                // spec-valid and MUST be accepted here (this is the consensus
-                // block-execution path). Anti-malleability (low-s) is enforced as
-                // local mempool policy in `frame_signatures_are_low_s`, never at
-                // consensus — rejecting high-s here would diverge from a conformant
-                // client that accepts it.
+                // and now also mandates EIP-2 low-s (spec commit fc016d59c5:
+                // `verify_signature` rejects s > n/2). The consensus low-s check
+                // lives in `frame_signatures_are_low_s`, which mempool admission
+                // also applies as an early reject.
+                // EIP-8141 encodes v as the recovery id (0 or 1), while the
+                // ECRECOVER precompile expects 27 or 28.
                 let mut calldata = vec![0u8; 128];
                 calldata[..32].copy_from_slice(&msg);
-                calldata[63] = v;
+                calldata[63] = v.saturating_add(27);
                 calldata[64..96].copy_from_slice(r);
                 calldata[96..128].copy_from_slice(s);
                 let Ok(result) = crate::precompiles::ecrecover(
@@ -830,17 +832,17 @@ pub fn validate_frame_signatures(
     true
 }
 
-/// Local mempool anti-malleability policy (NOT consensus): returns `false` if any
-/// frame signature is high-s (`s > n/2`).
+/// Consensus anti-malleability rule (spec commit fc016d59c5): returns `false` if
+/// any frame signature is high-s (`s > n/2`).
 ///
-/// EIP-8141 verification is `signer == ecrecover(msg, v, r, s)` and does not
-/// mandate EIP-2 low-s, so a high-s signature is spec-valid and is accepted on the
-/// consensus block-execution path. But the raw signature bytes are committed to the
+/// EIP-8141 verification is `signer == ecrecover(msg, v, r, s)` and now
+/// mandates EIP-2 low-s for SECP256K1 and P256, so a high-s signature is
+/// rejected on the consensus block-execution path. The raw signature bytes are committed to the
 /// transaction identity hash while being elided from the sig hash, so the malleated
-/// form `(v, r, s) -> (v^1, r, n-s)` (and the P256 `s -> n-s`) yields a second valid
-/// tx hash for the same logical transaction — a mempool dedup bypass. Admission
-/// rejects high-s so a malleated duplicate never occupies a pool slot; this gates
-/// only what this node admits/relays, never what it accepts in a block.
+/// form `(v, r, s) -> (v^1, r, n-s)` (and the P256 `s -> n-s`) would yield a second
+/// valid tx hash for the same logical transaction, a mempool dedup bypass;
+/// admission rejects high-s early so a malleated duplicate never occupies a pool
+/// slot.
 ///
 /// Signatures are assumed already structurally validated by
 /// [`validate_frame_signatures`]; malformed inputs conservatively return `false`.
@@ -1629,7 +1631,7 @@ impl<'a> VM<'a> {
             total_gas_limit,
         });
 
-        // EIP-8141 (spec commit fe0940cae2): every outer signature must validate
+        // EIP-8141 (spec commit fc016d59c5): every outer signature must validate
         // before any frame executes; otherwise the whole transaction is invalid.
         if !validate_frame_signatures(
             &frame_tx.signatures,
@@ -1638,6 +1640,12 @@ impl<'a> VM<'a> {
             self.env.config.fork,
             self.crypto,
         ) {
+            return Err(VMError::TxValidation(
+                crate::errors::TxValidationError::InvalidFrameTransaction,
+            ));
+        }
+
+        if !frame_signatures_are_low_s(&frame_tx.signatures) {
             return Err(VMError::TxValidation(
                 crate::errors::TxValidationError::InvalidFrameTransaction,
             ));

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -1158,6 +1158,92 @@ fn frame_tx_below_base_blob_fee_is_rejected() {
 }
 
 #[test]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "fixed-size 65-byte signature buffers with well-known bounds in test code"
+)]
+fn frame_tx_high_s_signature_is_rejected_at_block_validation() {
+    use ethrex_common::types::{FRAME_SIG_SCHEME_SECP256K1, FrameSignature};
+    use k256::ecdsa::SigningKey;
+
+    const SECP256K1_N: [u8; 32] =
+        hex_literal::hex!("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+    const SIGNER_KEY: [u8; 32] =
+        hex_literal::hex!("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318");
+
+    let signing_key = SigningKey::from_bytes(&SIGNER_KEY.into()).unwrap();
+    let uncompressed = signing_key.verifying_key().to_encoded_point(false);
+    let pub_hash = ethrex_crypto::keccak::keccak_hash(&uncompressed.as_bytes()[1..]);
+    let signer = Address::from_slice(&pub_hash[12..]);
+
+    // The sig hash elides the raw signature bytes (EIP-8141), so a placeholder
+    // signature is enough to derive the digest that gets signed.
+    let build_tx = |signature: Vec<u8>| {
+        let mut tx = frame_tx_with_frames(vec![verify_frame(FUNDED_SENDER)]);
+        tx.signatures = vec![FrameSignature {
+            scheme: FRAME_SIG_SCHEME_SECP256K1,
+            signer: Some(signer),
+            msg: Bytes::new(),
+            signature: Bytes::from(signature),
+        }];
+        tx
+    };
+
+    let sig_hash = build_tx(vec![0u8; 65]).compute_sig_hash();
+    let (raw_sig, recovery_id) = signing_key
+        .sign_prehash_recoverable(sig_hash.as_bytes())
+        .unwrap();
+    assert!(recovery_id.to_byte() < 2);
+
+    let mut low_s = vec![0u8; 65];
+    low_s[0] = recovery_id.to_byte();
+    low_s[1..65].copy_from_slice(&raw_sig.to_bytes());
+
+    let mut high_s = low_s.clone();
+    high_s[0] = recovery_id.to_byte() ^ 1;
+    let s = U256::from_big_endian(&low_s[33..65]);
+    let n = U256::from_big_endian(&SECP256K1_N);
+    high_s[33..65].copy_from_slice(&(n - s).to_big_endian());
+
+    let low_tx = build_tx(low_s);
+    let high_tx = build_tx(high_s);
+    assert_eq!(low_tx.compute_sig_hash(), high_tx.compute_sig_hash());
+    assert_ne!(
+        Transaction::FrameTransaction(low_tx.clone()).hash(&NativeCrypto),
+        Transaction::FrameTransaction(high_tx.clone()).hash(&NativeCrypto)
+    );
+    assert!(ethrex_levm::vm::validate_frame_signatures(
+        &high_tx.signatures,
+        high_tx.compute_sig_hash(),
+        high_tx.sender,
+        Fork::Hegota,
+        &NativeCrypto
+    ));
+
+    let accounts = [(
+        FUNDED_SENDER,
+        AUTO_SEED_SENDER_BALANCE,
+        0u64,
+        Bytes::from(APPROVE_BOTH_CODE.to_vec()),
+    )];
+
+    let (low_result, _db) = run_frame_tx(&accounts, low_tx);
+    low_result.expect("canonical low-s frame tx must be accepted at block validation");
+
+    let (high_result, high_db) = run_frame_tx(&accounts, high_tx);
+    assert!(
+        matches!(
+            high_result,
+            Err(VMError::TxValidation(
+                ethrex_levm::errors::TxValidationError::InvalidFrameTransaction
+            ))
+        ),
+        "high-s frame signature must be rejected at block validation, got {high_result:?}"
+    );
+    assert_db_cache_unchanged(&high_db, &accounts);
+}
+
+#[test]
 fn state_gas_reservoir_does_not_leak_across_frames() {
     // Frame A creates then clears a slot (0 -> 5 -> 0), which credits the EIP-8037
     // state-gas reservoir. Frame B then creates a fresh slot. Because frames are
@@ -2947,10 +3033,8 @@ mod frame_sig_validation_tests {
         let pub_hash = ethrex_crypto::keccak::keccak_hash(&uncompressed.as_bytes()[1..]);
         let expected_signer = Address::from_slice(&pub_hash[12..]);
 
-        // Build the outer signature: v || r || s  (65 bytes).
-        // EVM ecrecover expects v ∈ {27, 28}, so add 27 to the raw recovery id.
         let mut sig_bytes = vec![0u8; 65];
-        sig_bytes[0] = 27 + recovery_id.to_byte();
+        sig_bytes[0] = recovery_id.to_byte();
         sig_bytes[1..33].copy_from_slice(&raw_sig.to_bytes()[..32]); // r
         sig_bytes[33..65].copy_from_slice(&raw_sig.to_bytes()[32..]); // s
 


### PR DESCRIPTION
## Rationale

EIP-8141 commits the raw signature bytes to the transaction identity hash while eliding them from `sig_hash`. Without a canonical-s rule, a malleated `(v^1, r, n-s)` counterpart of a valid SECP256K1 signature (and the `n-s` counterpart for P256) still verifies against the same `sig_hash` but yields a second valid tx hash for the same logical transaction, bypassing pool dedup and any tx-hash-based tracking.

This PR enforces the canonical low-s form (`s <= n/2`) at block validation, so a high-s frame signature invalidates the whole transaction, and again at mempool admission as an early reject so a malleated duplicate never occupies a pool slot.

It also maps the EIP-8141 signature encoding, where `v` is the raw recovery id (0 or 1), to the 27/28 form expected by the ECRECOVER precompile; any other `v` byte is rejected outright.

Code comments are intentionally minimal; this description and the commit message carry the full rationale.

## Testing

```
cargo test -p ethrex-test --test ethrex_tests levm::eip8141_tests -- --nocapture
```

Result: 76 passed, 0 failed, 0 ignored (751 filtered out). Includes a new test, `frame_tx_high_s_signature_is_rejected_at_block_validation`, which asserts that the low-s and high-s forms share a `sig_hash` but have distinct tx hashes, that the low-s tx is accepted, and that the high-s tx is rejected at block validation with no state leakage.

## Status

Draft-only: cross-client Kurtosis interop evidence is still pending.
