### PR TITLE
fix(l1): restore deep-reorg pivot state reachability

### DIFF
--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -461,6 +461,13 @@ async fn reorg_apply_deep(
 
     let pivot_number = match new_canonical_blocks.last() {
         Some((n, _)) => n.saturating_sub(1),
+        // Case 1 (head already canonical): the fix is unwinding the blocks ABOVE
+        // head, so the pivot is head itself — the overlay range [head+1, edge]
+        // captures `serves_root = head.state_root`, making head's state readable
+        // again. Using head - 1 here would serve head's PARENT root while head is
+        // never re-executed, leaving head's state unreachable forever.
+        None if head_is_canonical => head.number,
+        // Case 2 (parent canonical, head not): serve the parent's root and replay head.
         None => head.number.saturating_sub(1),
     };
 

--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -261,6 +261,19 @@ impl TrieLayerCache {
         self.commit_threshold
     }
 
+    /// Whether `state_root` has a diff layer. Not every canonical root does: [`Self::put_batch`]
+    /// skips blocks whose state root equals their parent's, and flushed roots are pruned. Callers
+    /// holding a root from outside the cache must check this before treating it as committable.
+    pub fn has_layer(&self, state_root: H256) -> bool {
+        self.layers.contains_key(&state_root)
+    }
+
+    /// Number of diff layers held in memory. Diagnostic only: distinguishes a pruned root from
+    /// an empty cache.
+    pub fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
+
     fn create_filter(expected_items: usize) -> AtomicBloomFilter<FxBuildHasher> {
         AtomicBloomFilter::with_false_pos(FALSE_POSITIVE_RATE)
             .hasher(FxBuildHasher)
@@ -1450,6 +1463,29 @@ mod tests {
         cache.put_batch(c, b, 20, b, vec![(key(20), vec![20])]);
         // Walking from C must terminate (start-of-walk + bounded-walk guards) and yield None.
         assert_eq!(cache.get_commitable(c), None);
+    }
+
+    /// `has_layer` is the guard the forkchoice-driven flush uses before treating a root it
+    /// holds from outside the cache as committable: a root that was already flushed, or one
+    /// whose cache was swapped out from under it (what a deep-reorg overlay install does),
+    /// has no layer and must be skipped rather than passed to `commit`.
+    #[test]
+    fn has_layer_tracks_layer_residency() {
+        let safe = h256(2);
+        let (mut cache, cell) = cache_with_cell(4, safe);
+        build_chain(&mut cache, 4);
+        assert!(cache.has_layer(safe));
+
+        cache.commit(safe).expect("resident root commits");
+        assert!(!cache.has_layer(safe), "the flushed root's layer is pruned");
+        assert!(cache.commit(safe).is_none());
+
+        let fresh = TrieLayerCache::new_with_safe_commit(4, cell);
+        assert!(
+            !fresh.has_layer(safe),
+            "the root's layer did not survive the cache swap"
+        );
+        assert_eq!(fresh.layer_count(), 0);
     }
 
     /// (f) commit(safe_root) removes the safe layer and all older ones, retaining layers above it.

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -17,7 +17,7 @@ use crate::{
     block_data_buffer::BlockDataBuffer,
     error::StoreError,
     journal::{FlatDiff, JournalEntry},
-    layering::{Overlay, TrieLayerCache, TrieWrapper},
+    layering::{Overlay, OverlayCf, TrieLayerCache, TrieWrapper},
     rlp::{BlockBodyRLP, BlockHeaderRLP, BlockRLP},
     trie::{BackendTrieDB, BackendTrieDBLocked, classify_trie_key},
     utils::{ChainDataIndex, SnapStateIndex},
@@ -4514,6 +4514,20 @@ fn commit_to_disk(
     root: H256,
     is_batch: bool,
 ) -> Result<(), StoreError> {
+    // `root` need not have a layer: the forkchoice `PersistMessage::Commit(root)` path
+    // forwards the safe-commit root without consulting the cache, and `put_batch` skips
+    // blocks whose state root equals their parent's. Bail before the side effects below.
+    if !trie.has_layer(root) {
+        debug!(
+            root = ?root,
+            layers = trie.layer_count(),
+            is_batch,
+            "Skipping trie commit: state root has no in-memory layer. Expected when the block \
+             did not change the state root (empty L2 blocks) or the root was already flushed."
+        );
+        return Ok(());
+    }
+
     // Stop the flat-key-value generator thread, as the underlying trie is about to change.
     // Ignore the error, if the channel is closed it means there is no worker to notify.
     let _ = fkv_ctl.send(FKVGeneratorControlMessage::Stop);
@@ -4549,10 +4563,12 @@ fn commit_to_disk(
     // accumulated backlog (e.g. block import) can return several layers at once, so we
     // write one journal entry per block below rather than merging diffs across blocks.
     //
-    // `root` was returned by a `get_commitable*` gate above, which found it by walking
-    // `trie.layers`. `trie_mut` is a `Clone` of `trie`, which preserves the layer map
-    // intact, so `commit(root)` should always return `Some` here. Surface a hard error
-    // if that invariant ever breaks rather than silently committing nothing.
+    // `root` was resolved against this same `trie` snapshot by the caller's gate
+    // (`get_commitable` on the per-block path, `commitable_safe_root` on the
+    // forkchoice-driven flush), so it names a resident layer. `trie_mut` is a `Clone` of
+    // `trie`, which preserves the layer map intact, so `commit(root)` should always return
+    // `Some` here. Surface a hard error if that invariant ever breaks rather than silently
+    // committing nothing.
     //
     // Snapshot the overlay (if any) BEFORE commit so reconciliation can fold its entries
     // into this write batch. Issue #6685 Section 9: after a deep reorg, the first
@@ -4640,6 +4656,17 @@ fn commit_to_disk(
             &[]
         };
 
+        // Pre-images for the reconciliation layer must be taken at the pivot, not at the
+        // old chain's edge `D`. `T`'s journal entry has to reverse disk back to the pivot
+        // state, but this batch is built while disk still holds `D`, so `read_view` yields
+        // `D`'s values for every key the old chain rewrote in `[T, D]`. The overlay *is*
+        // the pivot-vs-`D` difference, so it wins over `read_view` for any key it carries.
+        // `None` in the overlay means "absent at the pivot", which is exactly the journal's
+        // "delete on rollback" entry.
+        let pivot_overlay = is_reconciliation_layer
+            .then_some(overlay_for_reconciliation.as_ref())
+            .flatten();
+
         for (key, value) in layer.nodes.iter().chain(extra.iter()) {
             let (is_leaf, is_account) = classify_trie_key(key.len());
 
@@ -4662,17 +4689,23 @@ fn commit_to_disk(
                 &STORAGE_TRIE_NODES
             };
 
-            // Pre-image: the intra-batch overlay wins over disk so multi-layer commits
-            // record each block's true pre-state. Skipped for batch (full-sync) commits.
+            // Pre-image: the intra-batch overlay wins over the pivot overlay, which wins
+            // over disk, so multi-layer commits record each block's true pre-state and the
+            // reconciliation layer records the pivot's. Skipped for batch (full-sync) commits.
             let prev_value = if !is_batch {
                 match overlay.get(key) {
                     Some(v) => Some(v.clone()),
-                    None => match read_view.get(table, key) {
-                        Ok(v) => Some(v),
-                        Err(e) => {
-                            result = Err(e);
-                            break 'layers;
-                        }
+                    None => match pivot_overlay
+                        .and_then(|ov| ov.lookup(OverlayCf::classify_by_key_length(key.len()), key))
+                    {
+                        Some(v) => Some(v),
+                        None => match read_view.get(table, key) {
+                            Ok(v) => Some(v),
+                            Err(e) => {
+                                result = Err(e);
+                                break 'layers;
+                            }
+                        },
                     },
                 }
             } else {

--- a/test/tests/blockchain/deep_reorg_state_tests.rs
+++ b/test/tests/blockchain/deep_reorg_state_tests.rs
@@ -1,0 +1,232 @@
+//! Deep-reorg state reachability: after a deep-reorg apply the pivot's state must stay
+//! reconstructible, and an already-canonical head whose state was evicted must become
+//! readable again.
+//!
+//! Both properties are about what `STATE_HISTORY` + disk can reproduce once the layer
+//! cache has been swapped out, so they need the backend that actually reaches the commit
+//! cadence: RocksDB (`DB_COMMIT_THRESHOLD` = 128). The InMemory threshold is 10 000,
+//! far past what a test can build.
+
+#![cfg(feature = "rocksdb")]
+
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use bytes::Bytes;
+use ethrex_blockchain::{
+    Blockchain,
+    fork_choice::apply_fork_choice_with_deep_reorg,
+    payload::{BuildPayloadArgs, create_payload},
+};
+use ethrex_common::{
+    H160, H256,
+    types::{BlockHeader, BlockNumber, DEFAULT_BUILDER_GAS_CEIL, ELASTICITY_MULTIPLIER, Genesis},
+};
+use ethrex_storage::{EngineType, Store};
+use tempfile::TempDir;
+
+/// Blocks on the original chain. Strictly greater than `DB_COMMIT_THRESHOLD` (128) so the
+/// forkchoice update flushes blocks 1 and 2 to disk and evicts their layers.
+const CHAIN_LEN: BlockNumber = 130;
+
+/// The pivot for both tests: block 1's state is flushed to disk by the chain-A forkchoice
+/// update and then overwritten by block 2's commit, so it is reachable only through the
+/// journal.
+const PIVOT: BlockNumber = 1;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn load_genesis() -> Genesis {
+    let file = File::open(workspace_root().join("fixtures/genesis/execution-api.json"))
+        .expect("open genesis file");
+    serde_json::from_reader(BufReader::new(file)).expect("deserialize genesis file")
+}
+
+/// Open a RocksDB store in a temporary directory. The returned `TempDir` owns the data
+/// directory; keep it alive for as long as the store is used.
+async fn setup_store() -> (Store, TempDir) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let mut store = Store::new(dir.path(), EngineType::RocksDB).expect("build RocksDB store");
+    store
+        .add_initial_state(load_genesis())
+        .await
+        .expect("add genesis state");
+
+    // Drive flat-KV generation to completion before any block commits, exactly as the node
+    // initializer does. Journal entries written while generation is still running omit
+    // past-frontier flat-KV pre-images, so an overlay built from them serves stale values
+    // and the deep-reorg path refuses to run at all (issue #7001).
+    store
+        .generate_flatkeyvalue()
+        .expect("trigger flat-KV generation");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while !store
+        .flatkeyvalue_fully_generated()
+        .expect("read flat-KV completion marker")
+    {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "flat-KV generation did not finish within 30s"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    (store, dir)
+}
+
+/// Build and execute blocks `parent.number + 1 ..= up_to` on top of `parent`, returning the
+/// headers in ascending order.
+///
+/// `timestamp_step` distinguishes forks: the EIP-4788 beacon-roots contract keys its ring
+/// buffer by timestamp, so two forks built with different steps write different slots and
+/// therefore reach different state roots from the same parent.
+async fn extend_fork(
+    store: &Store,
+    blockchain: &Blockchain,
+    parent: &BlockHeader,
+    up_to: BlockNumber,
+    timestamp_step: u64,
+) -> Vec<BlockHeader> {
+    let mut parent = parent.clone();
+    let mut built = Vec::new();
+    while parent.number < up_to {
+        let args = BuildPayloadArgs {
+            parent: parent.hash(),
+            timestamp: parent.timestamp + timestamp_step,
+            fee_recipient: H160::zero(),
+            random: H256::zero(),
+            withdrawals: Some(Vec::new()),
+            beacon_root: Some(H256::zero()),
+            slot_number: None,
+            version: 1,
+            elasticity_multiplier: ELASTICITY_MULTIPLIER,
+            gas_ceil: DEFAULT_BUILDER_GAS_CEIL,
+        };
+        let payload = create_payload(&args, store, Bytes::new()).expect("create payload");
+        let block = blockchain
+            .build_payload(payload)
+            .expect("build payload")
+            .payload;
+        blockchain.add_block(block.clone()).expect("execute block");
+        parent = block.header.clone();
+        built.push(block.header);
+    }
+    built
+}
+
+fn as_canonical(headers: &[BlockHeader]) -> Vec<(BlockNumber, H256)> {
+    headers.iter().map(|h| (h.number, h.hash())).collect()
+}
+
+/// Common setup for both tests: build chain A to `CHAIN_LEN`, canonicalize it with a single
+/// forkchoice update, and wait for the flush. On return, block `PIVOT`'s state is on neither
+/// disk (block 2's commit overwrote it) nor the layer cache (it was pruned by the commit),
+/// so it is reachable only by reversing the journal.
+async fn chain_a_with_evicted_pivot(
+    store: &Store,
+    blockchain: &Blockchain,
+) -> (Vec<BlockHeader>, BlockHeader) {
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let chain_a = extend_fork(store, blockchain, &genesis_header, CHAIN_LEN, 12).await;
+    let head = chain_a.last().expect("chain A non-empty").clone();
+
+    let mut canonical = as_canonical(&chain_a);
+    canonical.pop();
+    store
+        .forkchoice_update(canonical, head.number, head.hash(), None, None)
+        .await
+        .expect("canonicalize chain A");
+    store
+        .wait_for_persistence_idle()
+        .await
+        .expect("flush chain A");
+
+    let pivot = &chain_a[(PIVOT - 1) as usize];
+    assert!(
+        !store.has_state_root(pivot.state_root).unwrap(),
+        "precondition: the pivot's state must be evicted from disk and cache, \
+         otherwise neither test exercises the journal"
+    );
+    (chain_a, head)
+}
+
+/// The journal entry written by the deep-reorg reconciliation commit must reverse disk back
+/// to the *pivot's* state.
+///
+/// The reconciliation commit advances disk from the old chain's edge `D` straight to the new
+/// chain's `T = pivot + 1` in one batch, folding the overlay in. Its journal entry is the
+/// only way back to the pivot afterwards, so its pre-images have to be the pivot's values —
+/// not the values disk happened to hold at `D` while the batch was being built. Recording
+/// `D`'s values makes the entry reverse to the *old* chain's state instead, and every later
+/// deep reorg through that pivot dies with `state root missing for block <pivot>`.
+#[tokio::test]
+async fn reconciliation_journal_entry_reverses_to_pivot_state() {
+    let (store, _dir) = setup_store().await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+
+    // Chain B is built before chain A so that chain A's commit prunes B's layers: the
+    // replay below must read the pivot through the overlay, not through a stale layer.
+    let genesis_header = store.get_block_header(0).unwrap().unwrap();
+    let block1 = extend_fork(&store, &blockchain, &genesis_header, PIVOT, 12).await;
+    let pivot_header = block1.last().expect("block 1 built").clone();
+    let chain_b = extend_fork(&store, &blockchain, &pivot_header, CHAIN_LEN, 13).await;
+    let head_b = chain_b.last().expect("chain B non-empty").clone();
+
+    let (_chain_a, head_a) = chain_a_with_evicted_pivot(&store, &blockchain).await;
+    assert_ne!(
+        head_a.hash(),
+        head_b.hash(),
+        "the two forks must differ or there is no reorg to apply"
+    );
+
+    // Deep reorg onto chain B: pivot = block 1, T = 2, and the first commit on the new
+    // chain is the reconciliation that folds the overlay into disk.
+    apply_fork_choice_with_deep_reorg(&blockchain, head_b.hash(), H256::zero(), H256::zero())
+        .await
+        .expect("deep reorg onto chain B");
+    store
+        .wait_for_persistence_idle()
+        .await
+        .expect("flush chain B");
+
+    // Rebuilding the overlay from the reconciliation entry alone must expose the pivot's
+    // state again. This is what the next deep reorg through this pivot does, and it is the
+    // step that failed before the fix.
+    let t = PIVOT + 1;
+    let t_hash = chain_b[0].hash();
+    assert_eq!(chain_b[0].number, t, "chain B must start at T");
+    store
+        .install_overlay_for_reorg(t, t, |n| (n == t).then_some(t_hash))
+        .expect("rebuild overlay from the reconciliation journal entry");
+    assert!(
+        store.has_state_root(pivot_header.state_root).unwrap(),
+        "the reconciliation journal entry must reverse disk to the pivot's state; \
+         pre-images taken at the old chain's edge reverse to the old chain instead"
+    );
+}
+
+/// A forkchoice update onto an already-canonical head whose state was evicted must make that
+/// head's state readable again.
+///
+/// There is no side chain to replay in this case, so the overlay install *is* the whole fix:
+/// it has to expose head's own post-state. Building it one block lower leaves head's state
+/// unreachable, every payload built on head is stashed as ACCEPTED, and the node bounces
+/// through a second deep reorg on the next forkchoice update.
+#[tokio::test]
+async fn canonical_head_with_evicted_state_becomes_readable() {
+    let (store, _dir) = setup_store().await;
+    let blockchain = Blockchain::default_with_store(store.clone());
+
+    let (chain_a, _head_a) = chain_a_with_evicted_pivot(&store, &blockchain).await;
+    let pivot_header = chain_a[(PIVOT - 1) as usize].clone();
+
+    apply_fork_choice_with_deep_reorg(&blockchain, pivot_header.hash(), H256::zero(), H256::zero())
+        .await
+        .expect("forkchoice update onto the canonical, state-evicted head");
+
+    assert!(
+        store.has_state_root(pivot_header.state_root).unwrap(),
+        "the deep-reorg apply must expose the canonical head's own post-state, \
+         not its parent's"
+    );
+}

--- a/test/tests/blockchain/mod.rs
+++ b/test/tests/blockchain/mod.rs
@@ -1,6 +1,7 @@
 mod bal_hash_parallel_skip;
 mod batch_tests;
 mod canonical_commit_gate_tests;
+mod deep_reorg_state_tests;
 mod eip7702_revert_authority_tests;
 mod eip7702_zero_transfer_tests;
 mod explicit_blob_tx_tests;


### PR DESCRIPTION
Targets `glamsterdam-devnet-7`. Same reconciliation fix as #7041 (against `main`), plus two backports this branch is missing because it sits 39 commits behind.

**Motivation**

The benchmarkoor `ethrex-bal-full` run on the `glamsterdam-devnet-7` image (`072c0c705`) wedged after 628 of 4773 Amsterdam engine fixtures: `628 passed, 4145 failed`. Every failure from #629 on was the same line, 21 856 times:

```
ERROR deep-reorg: side-chain block execution failed number=2
  error=EVM error: DB error: state root missing for block 1 (state_root 0xca4a…9e52)
```

plus three of these earlier in the run:

```
ERROR commit_to_disk failed: commit(0x5b30…b6e7) returned None; layer cache invariant violated
```

That workload replays every fixture from the same genesis, so each fixture switch is a deep reorg through a pivot near block 1. Three distinct defects compound:

1. **Reconciliation journal pre-images are taken at the old chain's edge, not the pivot** — the wedge. Still present on `main`; fixed here and in #7041.
2. **The pivot for an already-canonical head is computed as `head - 1`** — the overlay serves the parent's state and head's own state is never re-materialized, so `reorg_apply_deep` reports success while leaving head unreachable. Every payload built on head is then stashed as ACCEPTED and drives another deep reorg. Visible in the log as `deep-reorg apply succeeded head_number=1 pivot_number=0` immediately followed by `newPayload status is ACCEPTED`. Already fixed on `main`.
3. **A commit whose target root has no layer errors instead of skipping** — the `PersistMessage::Commit(root)` path forwards the safe-commit root without consulting the cache, so a root that was already flushed (or whose cache a reorg replaced) produces the hard error above. Already fixed on `main`.

**Description**

The reconciliation fix (1): `commit_to_disk` advances disk from the old chain's edge `D` straight to `T = pivot + 1` in one batch and `delete_range`s the old `[T, D]` journal entries, so `T`'s entry is the only route back to the pivot. Its pre-images came from `read_view` — disk as of `D` — so reversing `T` landed on the old chain's state and the reconstructed root did not hash to the pivot's. The overlay is precisely the pivot-vs-`D` difference, so it now supplies the pre-image for any key it carries, with `read_view` as the fallback for keys unchanged since the pivot.

(2) and (3) are copied verbatim from `main` (`None if head_is_canonical => head.number` in `reorg_apply_deep`, and the `has_layer` / `layer_count` skip guard at the top of `commit_to_disk`) so merging `main` into this branch later is conflict-free.

**Testing**

Branch gate — `make -C tooling/ef_tests/engine test`:

```
fixture result: ok. 74362 passed; 0 failed; 0 skipped; 0 filtered; 74362 total
```

Two new RocksDB integration tests in `test/tests/blockchain/deep_reorg_state_tests.rs`, both driving real execution through `apply_fork_choice_with_deep_reorg`:

- `reconciliation_journal_entry_reverses_to_pivot_state` — two 130-block forks off block 1; canonicalize one so block 1's state is evicted from disk and cache, deep-reorg onto the other (triggering the reconciliation commit at `T = 2`), then rebuild the overlay from that single journal entry and assert the pivot's state root is serveable. This is the step the run above died on.
- `canonical_head_with_evicted_state_becomes_readable` — pins (2): a forkchoice update onto a canonical, state-evicted head must expose head's own post-state.

Plus `has_layer_tracks_layer_residency` in `crates/storage/layering.rs` covering the guard from (3).

Verified non-vacuous: forcing `pivot_overlay` to `None` fails the first test, and reverting the canonical-head arm fails the second. `ethrex-storage` (81) and `ethrex-blockchain` suites pass; fmt and clippy clean.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — N/A: no on-disk schema change.
