### PR TITLE
fix(levm): convert EIP-8141 recovery id to EVM ecrecover v at precompile boundary

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -748,6 +748,16 @@ pub fn validate_frame_signatures(
                 let v = sig.signature[0];
                 let r = &sig.signature[1..33];
                 let s = &sig.signature[33..65];
+                // EIP-8141 defines `signature[0]` as the RECOVERY ID (0 or 1),
+                // matching EIP-2718 typed transactions - not the EVM `ecrecover`
+                // `v` (27/28). Anything above 1 is invalid, so reject it here
+                // rather than letting the precompile's own 27/28 mapping decide:
+                // forwarding the byte verbatim both rejected conformant 0/1
+                // signatures and accepted non-conformant 27/28 ones, which is a
+                // consensus split against a spec-conformant client.
+                if v > 1 {
+                    return false;
+                }
                 // EIP-8141 defines verification as `signer == ecrecover(msg, v, r, s)`
                 // and does NOT mandate EIP-2 low-s, so a high-s frame signature is
                 // spec-valid and MUST be accepted here (this is the consensus
@@ -757,7 +767,13 @@ pub fn validate_frame_signatures(
                 // client that accepts it.
                 let mut calldata = vec![0u8; 128];
                 calldata[..32].copy_from_slice(&msg);
-                calldata[63] = v;
+                // Translate the recovery id to the EVM `ecrecover` `v` only at
+                // the precompile boundary. `v` is 0 or 1 (checked above), so
+                // this mapping is total and exact.
+                calldata[63] = match v {
+                    0 => 27,
+                    _ => 28,
+                };
                 calldata[64..96].copy_from_slice(r);
                 calldata[96..128].copy_from_slice(s);
                 let Ok(result) = crate::precompiles::ecrecover(

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -2757,6 +2757,139 @@ mod frame_sig_validation_tests {
         }
     }
 
+    /// Sign `msg_hash` with a fixed devnet key and return
+    /// `(recovery_id, r || s, signer)`. `sign_prehash_recoverable` normalizes
+    /// `s` to low-s, so every vector produced here is canonical per EIP-8141.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "fixed-size buffers with well-known bounds in test code"
+    )]
+    fn secp256k1_vector(msg_hash: H256) -> (u8, [u8; 64], Address) {
+        use k256::ecdsa::SigningKey;
+
+        let pk_hex = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
+        let pk_bytes: Vec<u8> = (0..pk_hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&pk_hex[i..i + 2], 16).unwrap())
+            .collect();
+        let private_key: [u8; 32] = pk_bytes.try_into().unwrap();
+        let signing_key = SigningKey::from_bytes(&private_key.into()).unwrap();
+
+        let (raw_sig, recovery_id) = signing_key
+            .sign_prehash_recoverable(msg_hash.as_bytes())
+            .unwrap();
+
+        // Signer address = keccak(uncompressed pubkey without the 0x04 tag)[12..].
+        let uncompressed = signing_key.verifying_key().to_encoded_point(false);
+        let pub_hash = ethrex_crypto::keccak::keccak_hash(&uncompressed.as_bytes()[1..]);
+        let signer = Address::from_slice(&pub_hash[12..]);
+
+        let mut rs = [0u8; 64];
+        rs.copy_from_slice(&raw_sig.to_bytes());
+        (recovery_id.to_byte(), rs, signer)
+    }
+
+    /// The `[v | r | s]` frame signature for [`secp256k1_vector`] over
+    /// `msg_hash`, with `signature[0]` forced to `v_byte` so the encoding of
+    /// that single byte is the only variable under test.
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "fixed-size buffers with well-known bounds in test code"
+    )]
+    fn secp_frame_sig(msg_hash: H256, v_byte: u8, signer: Option<Address>) -> FrameSignature {
+        let (_, rs, _) = secp256k1_vector(msg_hash);
+        let mut bytes = vec![0u8; 65];
+        bytes[0] = v_byte;
+        bytes[1..65].copy_from_slice(&rs);
+        FrameSignature {
+            scheme: FRAME_SIG_SCHEME_SECP256K1,
+            signer,
+            msg: Bytes::new(), // empty -> the signature is over `sig_hash`
+            signature: Bytes::from(bytes),
+        }
+    }
+
+    /// Deterministically pick a prehash whose RFC-6979 signature has the
+    /// requested recovery id, so both `v = 0` and `v = 1` are exercised with
+    /// real signatures rather than one arbitrary parity.
+    fn msg_hash_with_recovery_id(want: u8) -> H256 {
+        (1u64..64)
+            .map(H256::from_low_u64_be)
+            .find(|h| secp256k1_vector(*h).0 == want)
+            .expect("no prehash in range yields the requested recovery id")
+    }
+
+    #[test]
+    fn secp256k1_spec_recovery_id_is_accepted() {
+        // EIP-8141 (spec commit fe0940cae2) Signature Validation: `signature[0]`
+        // is the recovery id `0`/`1`, matching EIP-2718 typed transactions, not
+        // the EVM `ecrecover` `v` (`27`/`28`). A conformant, canonical low-s
+        // signature must authenticate on the block-validation path.
+        for want_v in [0u8, 1u8] {
+            let msg_hash = msg_hash_with_recovery_id(want_v);
+            let (v, _, signer) = secp256k1_vector(msg_hash);
+            assert_eq!(v, want_v, "vector must have the requested recovery id");
+            let sig = secp_frame_sig(msg_hash, want_v, Some(signer));
+            assert!(
+                frame_signatures_are_low_s(std::slice::from_ref(&sig)),
+                "k256 normalizes to low-s; v = {want_v} vector must be canonical"
+            );
+            assert!(
+                validate_frame_signatures(
+                    &[sig],
+                    msg_hash,
+                    Address::zero(),
+                    hegota(),
+                    &ethrex_crypto::NativeCrypto
+                ),
+                "spec-encoded recovery id v = {want_v} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn secp256k1_evm_v_encoding_is_rejected() {
+        // `27`/`28` is the EVM `ecrecover` encoding. EIP-8141 rejects any
+        // `v > 1`, so the legacy encoding must never authenticate a frame tx,
+        // otherwise this client accepts blocks a conformant client rejects.
+        for v in [27u8, 28u8] {
+            let msg_hash = msg_hash_with_recovery_id(v - 27);
+            let (_, _, signer) = secp256k1_vector(msg_hash);
+            let sig = secp_frame_sig(msg_hash, v, Some(signer));
+            assert!(
+                !validate_frame_signatures(
+                    &[sig],
+                    msg_hash,
+                    Address::zero(),
+                    hegota(),
+                    &ethrex_crypto::NativeCrypto
+                ),
+                "EVM ecrecover encoding v = {v} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn secp256k1_out_of_range_v_is_rejected() {
+        // Everything else above the recovery-id range is invalid too: the
+        // neighbours of `27`/`28`, the EIP-155 chain-id forms, and 0xFF.
+        let msg_hash = msg_hash_with_recovery_id(0);
+        let (_, _, signer) = secp256k1_vector(msg_hash);
+        for v in [2u8, 3, 26, 29, 35, 36, 0xFF] {
+            let sig = secp_frame_sig(msg_hash, v, Some(signer));
+            assert!(
+                !validate_frame_signatures(
+                    &[sig],
+                    msg_hash,
+                    Address::zero(),
+                    hegota(),
+                    &ethrex_crypto::NativeCrypto
+                ),
+                "out-of-range v = {v} must be rejected"
+            );
+        }
+    }
+
     fn p256_sig_with_s(s: &[u8; 32]) -> FrameSignature {
         // [r(32) | s(32) | qx(32) | qy(32)]
         let mut bytes = vec![0u8; 128];
@@ -2920,46 +3053,14 @@ mod frame_sig_validation_tests {
     }
 
     #[test]
-    #[expect(
-        clippy::indexing_slicing,
-        reason = "fixed-size buffers with well-known bounds in test code"
-    )]
     fn secp256k1_positive_and_tampered() {
-        // Build a real secp256k1 signature vector using k256.
-        use k256::ecdsa::SigningKey;
-
-        let pk_hex = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318";
-        let pk_bytes: Vec<u8> = (0..pk_hex.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&pk_hex[i..i + 2], 16).unwrap())
-            .collect();
-        let private_key: [u8; 32] = pk_bytes.try_into().unwrap();
-        let signing_key = SigningKey::from_bytes(&private_key.into()).unwrap();
-
+        // Build a real secp256k1 signature vector using k256. The outer
+        // signature is `v || r || s` (65 bytes) where `v` is the EIP-8141
+        // recovery id (0/1), NOT the EVM ecrecover `v` (27/28).
         let msg_hash: H256 = H256::from_low_u64_be(0xDEADBEEF_CAFEBABE);
+        let (recovery_id, _, expected_signer) = secp256k1_vector(msg_hash);
 
-        let (raw_sig, recovery_id) = signing_key
-            .sign_prehash_recoverable(msg_hash.as_bytes())
-            .unwrap();
-
-        // Derive the expected signer address
-        let uncompressed = signing_key.verifying_key().to_encoded_point(false);
-        let pub_hash = ethrex_crypto::keccak::keccak_hash(&uncompressed.as_bytes()[1..]);
-        let expected_signer = Address::from_slice(&pub_hash[12..]);
-
-        // Build the outer signature: v || r || s  (65 bytes).
-        // EVM ecrecover expects v ∈ {27, 28}, so add 27 to the raw recovery id.
-        let mut sig_bytes = vec![0u8; 65];
-        sig_bytes[0] = 27 + recovery_id.to_byte();
-        sig_bytes[1..33].copy_from_slice(&raw_sig.to_bytes()[..32]); // r
-        sig_bytes[33..65].copy_from_slice(&raw_sig.to_bytes()[32..]); // s
-
-        let valid_sig = FrameSignature {
-            scheme: FRAME_SIG_SCHEME_SECP256K1,
-            signer: Some(expected_signer),
-            msg: Bytes::new(), // empty → use sig_hash
-            signature: Bytes::from(sig_bytes.clone()),
-        };
+        let valid_sig = secp_frame_sig(msg_hash, recovery_id, Some(expected_signer));
 
         // Positive: correct signer → valid
         assert!(
@@ -2991,12 +3092,7 @@ mod frame_sig_validation_tests {
         );
 
         // Empty signer (None) resolves to tx.sender: valid iff sender == recovered.
-        let empty_signer_sig = FrameSignature {
-            scheme: FRAME_SIG_SCHEME_SECP256K1,
-            signer: None,
-            msg: Bytes::new(),
-            signature: Bytes::from(sig_bytes.clone()),
-        };
+        let empty_signer_sig = secp_frame_sig(msg_hash, recovery_id, None);
         assert!(
             validate_frame_signatures(
                 std::slice::from_ref(&empty_signer_sig),


### PR DESCRIPTION
## Problem

EIP-8141 defines `signature[0]` of a SECP256K1 frame signature as the recovery id, 0 or 1, "matching EIP-2718 typed transactions", and validates with `resolved_signer == ecrecover(msg, v, r, s)` (spec, Signature Validation pseudocode). The EVM `ecrecover` precompile, which ethrex uses to implement this check, expects `v` in {27, 28}.

ethrex forwarded the recovery id byte to the precompile verbatim. A spec-conformant signature with `v = 0` or `v = 1` therefore failed recovery (empty result) and was rejected, while nothing rejected out-of-range values explicitly. This diverges from clients that implement the spec encoding (observed against Nethermind in devnet interop).

## Change

- `validate_frame_signatures` now rejects `v > 1` up front and converts `v` from the spec's 0/1 recovery id to 27/28 only at the precompile call boundary.
- Tests cover: spec encoding 0/1 accepted, legacy EVM encoding 27/28 rejected, and out-of-range values (2, 3, 26, 29, 35, 36, 0xFF) rejected, using real k256 signatures for both parities.

## Evidence

Commands run on this branch:

```
cargo check -p ethrex-levm                                  # pass
cargo test -p ethrex-test --test ethrex_tests levm::eip8141_tests
# 78 passed; 0 failed; 0 ignored; 751 filtered out
cargo fmt --all -- --check                                  # pass
git diff --check                                            # pass
```

RED/GREEN: before this commit `secp256k1_spec_recovery_id_is_accepted` fails (spec-encoded `v = 0` and `v = 1` are rejected by recovery returning empty) and `secp256k1_evm_v_encoding_is_rejected` fails (`v = 27`/`28` authenticate); the pre-existing `secp256k1_positive_and_tampered` was itself written against the 27/28 encoding and is rewritten here onto the spec encoding. After the commit all three pass together with the rest of the suite.

## Cross-client interop evidence

Mixed-client Kurtosis enclave, Nethermind + ethrex, two lighthouse v8.2.1 CLs, chainId 3151908.

- Images: `ethrex:local` `sha256:c3f3cae6c5014ebbc4bd39eae115f5c3e24db4c41d398face442ba530f9d0866`, built from ethrex `503855613`, which has this PR's commit `aed92df38` as an ancestor; `nethermind:frames-local` `sha256:e0d4aee7651f5a181e2cf07a516c922921316a1a2552eb9cf837f7d9db578d13`.
- Reference frame transaction `0x6f505ce40ce8e2c61b88a8dd10a17f3b7396b3fa823aa290d4ee1f91686528fa` (single SECP256K1 low-s signature, spec recovery id) was accepted at RPC by both clients, returning the same hash, and included in block `#52` `0x8a0fafff525f2cd75f2cf9edf34c18357bb95ec7222b07f2ff8d057d315cff4c` with status `0x1` and `gasUsed 21260` on both.
- Block `#52` matches field-for-field across clients: `hash`, `parentHash`, `stateRoot`, `receiptsRoot`, `transactionsRoot`, `logsBloom`, `gasUsed`, and `blockAccessListHash 0xa6648aab4360a8fc68c2b84125dc67c8208a57a4977459e716cc82bfe0a17bbd`.
- Mutual inclusion in both directions: 12 Nethermind-proposed frame-tx blocks `#96`-`#108` were executed and accepted by ethrex over the engine API; the ethrex-proposed blocks `#52` and a fresh `#181` `0xb74c10cbe1ded12588f6fa36ecef5dfea75504350fe21bc1f57698394b67c401` were accepted by Nethermind.
- 25-slot soak: all 14 frame-tx blocks stayed canonical on both clients with heads in lockstep, and neither EL logged an invalid block over the whole run.

## Consensus risk / limits

Consensus-affecting: it flips acceptance of frame signatures with `v` in {0, 1} (now valid) and {27, 28} (now invalid) on the block-validation path.

Limits of the evidence above:

- The replay image carries the full EIP-8141 fix stack (siblings below), not this commit in isolation, so it shows the fixed encoding interoperating, not this change attributed alone.
- The interop run exercises only the positive direction: frames signed with the spec recovery id are now accepted by both clients. The negative cases (`v` in {27, 28} and out-of-range `v`) are covered by unit tests only; there is still no cross-client conformance fixture for them.
- One mid-run chain split was traced to the two CLs losing P2P connectivity (peer count 0/0), not to EL disagreement: no invalid-block marker appeared on either side, and the chains reconverged after resyncing one beacon node.

## Stack

Targets `frames-devnet-0`. Part of a series of independent EIP-8141 fixes, one PR per logical change, each standing alone against the same base. Siblings: #7040 (canonical low-s), #7044 (intrinsic gas over payload bytes), #7045 (arbitrary-scheme verification gas), #7046 (frame gas refunds), #7047 (frame receipt storage encoding), #7048 (skipped-frame status 2), #7049 (EIP-7623 calldata floor).
