### PR TITLE
fix(l1): charge EIP-8141 intrinsic gas over payload bytes only

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2038,21 +2038,24 @@ impl FrameTransaction {
             .sum()
     }
 
-    /// Compute total gas limit: intrinsic + calldata cost (frames + signatures)
-    /// + signature verification cost + sum of frame gas limits.
+    /// Computes the total gas limit defined by EIP-8141.
     pub fn total_gas_limit(&self) -> u64 {
-        let mut calldata_gas: u64 = 0;
-        // RLP-encode frames to compute calldata cost
-        let mut frames_buf = Vec::new();
-        self.frames.encode(&mut frames_buf);
-        for byte in &frames_buf {
-            calldata_gas = calldata_gas.saturating_add(if *byte == 0 { 4 } else { 16 });
+        fn add_calldata_gas(calldata_gas: u64, bytes: &[u8]) -> u64 {
+            bytes.iter().fold(calldata_gas, |acc, byte| {
+                acc.saturating_add(if *byte == 0 { 4 } else { 16 })
+            })
         }
-        // RLP-encode signatures to compute their calldata cost
-        let mut sigs_buf = Vec::new();
-        self.signatures.encode(&mut sigs_buf);
-        for byte in &sigs_buf {
-            calldata_gas = calldata_gas.saturating_add(if *byte == 0 { 4 } else { 16 });
+
+        let mut calldata_gas: u64 = 0;
+        for frame in &self.frames {
+            calldata_gas = add_calldata_gas(calldata_gas, &frame.data);
+        }
+        for signature in &self.signatures {
+            if let Some(signer) = signature.signer {
+                calldata_gas = add_calldata_gas(calldata_gas, signer.as_bytes());
+            }
+            calldata_gas = add_calldata_gas(calldata_gas, &signature.msg);
+            calldata_gas = add_calldata_gas(calldata_gas, &signature.signature);
         }
         FRAME_TX_INTRINSIC_COST
             .saturating_add((self.frames.len() as u64).saturating_mul(FRAME_TX_PER_FRAME_COST))

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -3193,3 +3193,79 @@ mod expiry_verifier_tests {
         );
     }
 }
+
+mod intrinsic_gas_accounting_tests {
+    use ethrex_common::U256;
+    use ethrex_common::types::{
+        FRAME_TX_INTRINSIC_COST, FRAME_TX_PER_FRAME_COST, FrameTransaction, Transaction,
+    };
+
+    fn interop_reference_tx() -> FrameTransaction {
+        let raw = hex::decode(
+            "06f89f833018248094e25583099ba105d9ec0a67f5ae86d90e50036425eec801038082c3508080e40280941111111111111111111111111111111111111111830186a08701c6bf5263400080f848f846018080b84100376dfea0d3368d1e0e7914b727a934f20e4fb134752d4bbcd994db1246c2197553a566aec5941b337df2fb25be8fd2c367ad19b34526656704997b25eda17a80843b9aca00847735940080c0",
+        )
+        .unwrap();
+        match Transaction::decode_canonical(&raw).unwrap() {
+            Transaction::FrameTransaction(tx) => tx,
+            _ => panic!("expected frame transaction"),
+        }
+    }
+
+    fn intrinsic_gas(tx: &FrameTransaction) -> u64 {
+        let frame_gas = tx
+            .frames
+            .iter()
+            .map(|f| f.gas_limit)
+            .fold(0u64, |acc, g| acc.saturating_add(g));
+        tx.total_gas_limit().saturating_sub(frame_gas)
+    }
+
+    #[test]
+    fn interop_reference_tx_intrinsic_gas_charges_payload_bytes_only() {
+        const ZERO_BYTE_GAS: u64 = 4;
+        const NONZERO_BYTE_GAS: u64 = 16;
+        const SECP256K1_VERIFY_GAS: u64 = 2_800;
+        const FRAME_COUNT: u64 = 2;
+        const SIGNATURE_ZERO_BYTES: u64 = 1;
+        const SIGNATURE_NONZERO_BYTES: u64 = 64;
+        const FRAME_GAS_LIMITS: u64 = 50_000 + 100_000;
+
+        let payload_calldata_gas =
+            SIGNATURE_NONZERO_BYTES * NONZERO_BYTE_GAS + SIGNATURE_ZERO_BYTES * ZERO_BYTE_GAS;
+        let expected_intrinsic_gas = FRAME_TX_INTRINSIC_COST
+            + FRAME_COUNT * FRAME_TX_PER_FRAME_COST
+            + SECP256K1_VERIFY_GAS
+            + payload_calldata_gas;
+
+        let tx = interop_reference_tx();
+        assert_eq!(tx.frames.len() as u64, FRAME_COUNT);
+        assert_eq!(intrinsic_gas(&tx), expected_intrinsic_gas);
+        assert_eq!(
+            tx.total_gas_limit(),
+            expected_intrinsic_gas + FRAME_GAS_LIMITS
+        );
+    }
+
+    #[test]
+    fn intrinsic_gas_is_insensitive_to_structural_frame_fields() {
+        let baseline = interop_reference_tx();
+
+        let mut restructured = interop_reference_tx();
+        restructured.frames[0].gas_limit = 1;
+        restructured.frames[1].gas_limit = 4_000_000_000;
+        restructured.frames[1].value = U256::from(1u64);
+
+        assert_eq!(
+            restructured.frames[0].data, baseline.frames[0].data,
+            "payload bytes must be unchanged for this test to be meaningful",
+        );
+        assert_eq!(restructured.frames[1].data, baseline.frames[1].data);
+        assert_eq!(restructured.signatures, baseline.signatures);
+
+        assert_eq!(
+            intrinsic_gas(&restructured),
+            intrinsic_gas(&baseline),
+            "structural frame fields (gas_limit, value) must not change intrinsic gas",
+        );
+    }
+}


### PR DESCRIPTION
## Problem

EIP-8141 (Gas accounting) defines the calldata component of a frame transaction's intrinsic gas over the payload byte strings only:

```
frame_data_cost = sum(calldata_cost(frame.data) for frame in tx.frames)
signature_data_cost = sum(
    calldata_cost(sig.signer) + calldata_cost(sig.msg) + calldata_cost(sig.signature)
    for sig in tx.signatures)
```

with `calldata_cost` per standard EIP-7623 rules (4 per zero byte, 16 per nonzero byte).

`FrameTransaction::total_gas_limit` instead RLP-encoded the whole `frames` and `signatures` lists and charged calldata gas over every byte of the encoding, including RLP length prefixes and structural fields (`gas_limit`, `value`, `to`, `mode`, `flags`, `scheme`). That over-charges every frame transaction. In devnet interop replay against Nethermind, the 162-byte reference type-0x06 transaction came out at intrinsic 20662 in ethrex vs the spec value 19778 (delta 884), which makes ethrex reject exact-gas blocks other clients accept.

## Change

Replace whole-RLP charging with per-field charging over the payload byte arrays (`frame.data`, and each signature's `signer`, `msg`, `signature`), keeping saturating arithmetic. Adds regression tests that pin the reference transaction's exact intrinsic gas and assert the intrinsic cost is insensitive to structural frame fields (`gas_limit`, `value`).

## Evidence

Commands run on this branch:

```
cargo check -p ethrex-common                                # pass
cargo check -p ethrex-levm                                  # pass
cargo test -p ethrex-test --test ethrex_tests levm::eip8141_tests
# 77 passed; 0 failed; 0 ignored; 751 filtered out
cargo fmt --all -- --check                                  # pass
git diff --check                                            # pass
```

## Stack

Targets `frames-devnet-0`. Part of a series of independent EIP-8141 fixes, one PR per logical change, each standing alone against the same base. Siblings: #7040 (canonical low-s), #7043 (recovery id at ecrecover boundary), #7045 (arbitrary-scheme verification gas), #7046 (frame gas refunds), #7047 (frame receipt storage encoding), #7048 (skipped-frame status 2), #7049 (EIP-7623 calldata floor).

## Consensus risk / limits

Consensus-affecting: it lowers intrinsic gas for every frame transaction, changing gas accounting and block validity. Covered by unit tests pinning the reference vector; no cross-client conformance fixture yet.
