### PR TITLE
feat(l1): charge EIP-8141 arbitrary frame signatures their own gas

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2023,14 +2023,13 @@ impl FrameTransaction {
         keccak(&buf)
     }
 
-    /// Per EIP-8141 (spec commit fe0940cae2): 2800 gas per SECP256K1 signature,
-    /// 6700 per P256. Unknown schemes are rejected by static validation, so
-    /// they are treated as 0 here (validation runs first).
+    /// Per EIP-8141: 100 gas per ARBITRARY signature, 2800 per SECP256K1, and
+    /// 6700 per P256. Unknown schemes are rejected by static validation.
     pub fn signature_verification_cost(&self) -> u64 {
         self.signatures
             .iter()
             .map(|s| match s.scheme {
-                FRAME_SIG_SCHEME_ARBITRARY => 0u64,
+                FRAME_SIG_SCHEME_ARBITRARY => 100u64,
                 FRAME_SIG_SCHEME_SECP256K1 => 2800u64,
                 FRAME_SIG_SCHEME_P256 => 6700u64,
                 _ => 0,
@@ -5485,11 +5484,11 @@ mod tests {
     #[test]
     fn static_validation_accepts_arbitrary_with_empty_signer() {
         let mut tx = make_test_frame_tx();
-        // ARBITRARY (scheme 0) requires an empty signer and costs no verify gas.
+        // ARBITRARY requires an empty signer and charges 100 verification gas.
         tx.signatures[0].scheme = FRAME_SIG_SCHEME_ARBITRARY;
         tx.signatures[0].signer = None;
         assert!(tx.validate_static_constraints().is_ok());
-        assert_eq!(tx.signature_verification_cost(), 0);
+        assert_eq!(tx.signature_verification_cost(), 100);
     }
 
     #[test]
@@ -5572,6 +5571,50 @@ mod tests {
         });
         assert!(tx.total_gas_limit() >= base + 6700);
         assert_eq!(tx.signature_verification_cost(), 2800 + 6700);
+    }
+
+    #[test]
+    fn total_gas_limit_charges_arbitrary_signature_100_gas() {
+        let mut arb = make_test_frame_tx();
+        arb.signatures[0].scheme = FRAME_SIG_SCHEME_ARBITRARY;
+        arb.signatures[0].signer = None;
+        let mut secp = make_test_frame_tx();
+        secp.signatures[0].signer = None;
+
+        let sig_rlp = |sigs: &Vec<FrameSignature>| -> (usize, usize) {
+            let mut buf = Vec::new();
+            sigs.encode(&mut buf);
+            (buf.len(), buf.iter().filter(|b| **b == 0).count())
+        };
+        assert_eq!(sig_rlp(&arb.signatures), sig_rlp(&secp.signatures));
+
+        assert_eq!(arb.signature_verification_cost(), 100);
+        assert_eq!(secp.signature_verification_cost(), 2800);
+        assert_eq!(secp.total_gas_limit() - arb.total_gas_limit(), 2800 - 100);
+    }
+
+    #[test]
+    fn prefix_gas_budget_counts_arbitrary_signature_cost_at_boundary() {
+        let mut tx = make_test_frame_tx();
+        tx.signatures[0].scheme = FRAME_SIG_SCHEME_ARBITRARY;
+        tx.signatures[0].signer = None;
+        assert!(tx.validate_static_constraints().is_ok());
+
+        tx.frames[0].gas_limit = FRAME_TX_MAX_VERIFY_GAS - 100;
+        let prefix = tx.validation_prefix().unwrap();
+        assert_eq!(prefix.shape, PrefixShape::SelfVerify);
+        assert_eq!(prefix.frame_indices, vec![0]);
+        assert!(tx.validate_prefix_structure(&prefix).is_ok());
+
+        tx.frames[0].gas_limit = FRAME_TX_MAX_VERIFY_GAS - 99;
+        let prefix = tx.validation_prefix().unwrap();
+        assert_eq!(
+            tx.validate_prefix_structure(&prefix).unwrap_err(),
+            FrameValidationError::VerifyGasBudgetExceeded {
+                actual: FRAME_TX_MAX_VERIFY_GAS + 1,
+                limit: FRAME_TX_MAX_VERIFY_GAS,
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The EIP-8141 signature scheme table assigns a verification gas cost to every scheme, including `ARBITRARY`:

| scheme byte | scheme | verification gas |
|---|---|---|
| 0x0 | ARBITRARY | 100 |
| 0x1 | SECP256K1 | 2800 |
| 0x2 | P256 | 6700 |

`FrameTransaction::signature_verification_cost` charged 0 for `ARBITRARY` entries (it was written against an older spec snapshot that predates the 100-gas entry). That under-charges `total_gas_limit` by 100 per `ARBITRARY` signature and also under-counts the validation-prefix verify-gas budget, so the `MAX_VERIFY_GAS` boundary sits 100 gas away from where a conformant client puts it.

## Change

- Charge 100 gas per `ARBITRARY` signature in `signature_verification_cost`.
- Tests: `total_gas_limit` differs by exactly `2800 - 100` between an otherwise-identical SECP256K1 and ARBITRARY transaction (with an RLP-shape guard so the comparison isolates verification cost), and the prefix verify-gas budget flips from valid to `VerifyGasBudgetExceeded` exactly at the 100-gas boundary.

## Evidence

Commands run on this branch:

```
cargo check -p ethrex-common                                # pass
cargo check -p ethrex-levm                                  # pass
cargo test -p ethrex-common transaction::tests
# 69 passed; 0 failed; 74 filtered out
cargo test -p ethrex-test --test ethrex_tests levm::eip8141_tests
# 75 passed; 0 failed; 751 filtered out
cargo fmt --all -- --check                                  # pass
git diff --check                                            # pass
```

## Stack

Targets `frames-devnet-0`. Part of a series of independent EIP-8141 fixes, one PR per logical change, each standing alone against the same base. Siblings: #7040 (canonical low-s), #7043 (recovery id at ecrecover boundary), #7044 (intrinsic gas over payload bytes), #7046 (frame gas refunds), #7047 (frame receipt storage encoding), #7048 (skipped-frame status 2), #7049 (EIP-7623 calldata floor).

## Consensus risk / limits

Consensus-affecting: it raises `total_gas_limit` (and the verify-gas budget accounting) for any frame transaction carrying `ARBITRARY` signatures. Covered by unit tests only; no cross-client conformance fixture yet.
