### PR TITLE
feat(levm): apply the EIP-7623 calldata floor to frame transactions

### DIFF
--- a/crates/vm/levm/src/utils.rs
+++ b/crates/vm/levm/src/utils.rs
@@ -1035,6 +1035,81 @@ pub fn intrinsic_gas_floor(tx: &Transaction, sender: Address, fork: Fork) -> Res
         .ok_or(InternalError::Overflow.into())
 }
 
+/// EIP-7623 `tokens_in`: `zero_bytes * 1 + nonzero_bytes * 4`, which is exactly
+/// the weighted calldata cost divided by `STANDARD_TOKEN_COST`.
+fn floor_tokens_in_bytes(data: &[u8]) -> Result<u64, VMError> {
+    Ok(gas_cost::tx_calldata(data)? / STANDARD_TOKEN_COST)
+}
+
+/// EIP-8141 Gas Accounting (spec commit c0c9f639): the floor arm of a frame
+/// transaction's `charged_gas`, i.e. the minimum gas the payer can be charged.
+///
+/// ```text
+/// calldata_tokens = sum(tokens_in(frame.data) for frame in tx.frames)
+///                 + sum(tokens_in(sig.signer) + tokens_in(sig.msg)
+///                       + tokens_in(sig.signature) for sig in tx.signatures)
+///
+/// returns FRAME_TX_INTRINSIC_COST
+///       + len(tx.frames) * FRAME_TX_PER_FRAME_COST
+///       + signature_verification_cost
+///       + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens
+/// ```
+///
+/// `tokens_in` and `TOTAL_COST_FLOOR_PER_TOKEN` are the EIP-7623 definitions the
+/// spec names verbatim (weighted tokens, 10 gas each) - NOT the EIP-7976
+/// Amsterdam overrides that other tx types use at this fork.
+///
+/// The mandatory costs sit OUTSIDE the spec's `max(...)`, so they are common to
+/// both arms; including them here lets a caller write `charged_gas` as
+/// `max(unfloored_charge, this)`.
+///
+/// Tokens are counted over the DECODED payload byte fields, never over the RLP
+/// envelope that `FrameTransaction::total_gas_limit` charges as calldata.
+///
+/// A frame tx whose `total_gas_limit()` is below this value is invalid: the
+/// floor is reserved independently of execution.
+pub fn frame_tx_floor_charged_gas(
+    tx: &ethrex_common::types::FrameTransaction,
+) -> Result<u64, VMError> {
+    let mut tokens: u64 = 0;
+    for frame in &tx.frames {
+        tokens = tokens
+            .checked_add(floor_tokens_in_bytes(&frame.data)?)
+            .ok_or(InternalError::Overflow)?;
+    }
+    for sig in &tx.signatures {
+        // An absent `signer` contributes no payload bytes.
+        let signer_bytes: &[u8] = match sig.signer {
+            Some(ref address) => address.as_bytes(),
+            None => &[],
+        };
+        for field in [signer_bytes, sig.msg.as_ref(), sig.signature.as_ref()] {
+            tokens = tokens
+                .checked_add(floor_tokens_in_bytes(field)?)
+                .ok_or(InternalError::Overflow)?;
+        }
+    }
+
+    let frame_count: u64 = tx
+        .frames
+        .len()
+        .try_into()
+        .map_err(|_| InternalError::TypeConversion)?;
+    let mandatory = frame_count
+        .checked_mul(ethrex_common::types::FRAME_TX_PER_FRAME_COST)
+        .ok_or(InternalError::Overflow)?
+        .checked_add(ethrex_common::types::FRAME_TX_INTRINSIC_COST)
+        .ok_or(InternalError::Overflow)?
+        .checked_add(tx.signature_verification_cost())
+        .ok_or(InternalError::Overflow)?;
+
+    tokens
+        .checked_mul(gas_cost::TOTAL_COST_FLOOR_PER_TOKEN)
+        .ok_or(InternalError::Overflow)?
+        .checked_add(mandatory)
+        .ok_or(InternalError::Overflow.into())
+}
+
 /// Converts Account to LevmAccount
 /// The problem with this is that we don't have the storage root.
 pub fn account_to_levm_account(account: Account) -> (LevmAccount, Code) {

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1618,6 +1618,18 @@ impl<'a> VM<'a> {
         // Initialize FrameTxContext
         let sig_hash = frame_tx.compute_sig_hash();
         let total_gas_limit = frame_tx.total_gas_limit();
+
+        // EIP-8141 Gas Accounting: the EIP-7623 calldata floor is reserved
+        // independently of execution, so a frame tx whose gas limit cannot cover
+        // the mandatory costs plus the floor is invalid. This also bounds the
+        // post-execution floor below by what the payer is debited at APPROVE.
+        let floor_charged_gas = crate::utils::frame_tx_floor_charged_gas(&frame_tx)?;
+        if total_gas_limit < floor_charged_gas {
+            return Err(VMError::TxValidation(
+                crate::errors::TxValidationError::IntrinsicGasBelowFloorGasCost,
+            ));
+        }
+
         self.frame_tx_context = Some(FrameTxContext {
             sender_approved: false,
             payer_address: None,
@@ -2166,6 +2178,14 @@ impl<'a> VM<'a> {
             )))?;
         let payer = ctx.payer_address.unwrap_or(sender);
 
+        // EIP-8141 Gas Accounting: charged gas is
+        //   mandatory + max(frame_data_cost + signature_data_cost + exec_gas, floor)
+        // `total_gas_used` is already `mandatory + data_cost + exec_gas` and
+        // `floor_charged_gas` is `mandatory + floor`, so the spec's max (whose
+        // mandatory term is common to both arms) reduces to this one. Applied
+        // before the refund is computed so the EIP-7623 floor bounds the charge.
+        total_gas_used = total_gas_used.max(floor_charged_gas);
+
         // Gas refunds: the payer was debited the transaction's MAXIMUM cost at
         // APPROVE (max_fee-based gas + max-rate blob cost, `compute_tx_max_cost`,
         // spec line 387). What the payer owes is the effective-rate cost of the
@@ -2391,6 +2411,15 @@ impl<'a> VM<'a> {
 
         let sig_hash = frame_tx.compute_sig_hash();
         let total_gas_limit = frame_tx.total_gas_limit();
+
+        // Same EIP-8141 floor reservation as `execute_frame_tx`, so a tx that
+        // could never be included is rejected at admission rather than pooled.
+        if total_gas_limit < crate::utils::frame_tx_floor_charged_gas(&frame_tx)? {
+            return Err(VMError::TxValidation(
+                crate::errors::TxValidationError::IntrinsicGasBelowFloorGasCost,
+            ));
+        }
+
         self.frame_tx_context = Some(FrameTxContext {
             sender_approved: false,
             payer_address: None,

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -1212,6 +1212,198 @@ fn state_gas_reservoir_does_not_leak_across_frames() {
     );
 }
 
+// ============ EIP-7623 calldata floor (EIP-8141 Gas Accounting) ============
+//
+// EIP-8141 (spec commit c0c9f639) floors a frame tx's calldata cost against
+// execution, over the frame and signature PAYLOAD bytes:
+//
+//   calldata_tokens = sum(tokens_in(frame.data))
+//                   + sum(tokens_in(sig.signer) + tokens_in(sig.msg)
+//                         + tokens_in(sig.signature))
+//
+//   charged_gas = mandatory
+//               + max(frame_data_cost + signature_data_cost + total_gas_used,
+//                     TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens)
+//
+// where `mandatory` (intrinsic + per-frame + signature verification) sits
+// OUTSIDE the max. A tx whose gas limit cannot reserve `mandatory + floor` is
+// invalid.
+
+/// EIP-7623 `TOTAL_COST_FLOOR_PER_TOKEN`. EIP-8141 names the EIP-7623 value
+/// verbatim, so EIP-7976's Amsterdam raise to 16 does NOT apply to frame txs.
+const FLOOR_GAS_PER_TOKEN: u64 = 10;
+
+/// EIP-7623 `tokens_in`: zero bytes count 1 token, non-zero bytes count 4.
+fn floor_tokens(data: &[u8]) -> u64 {
+    data.iter().map(|byte| if *byte == 0 { 1 } else { 4 }).sum()
+}
+
+/// EIP-8141 mandatory (outside-the-max) gas for a signature-less frame tx.
+fn mandatory_gas(frame_count: u64) -> u64 {
+    ethrex_common::types::FRAME_TX_INTRINSIC_COST
+        + frame_count * ethrex_common::types::FRAME_TX_PER_FRAME_COST
+}
+
+/// A SENDER frame targeting `target` with `data` as calldata.
+fn sender_frame(target: Address, gas_limit: u64, data: Bytes) -> Frame {
+    Frame {
+        mode: u8::from(FrameMode::Sender),
+        flags: 0,
+        target: Some(target),
+        gas_limit,
+        value: U256::zero(),
+        data,
+    }
+}
+
+/// Floor-dominant: a frame carrying 1000 non-zero payload bytes is 4000 EIP-7623
+/// tokens, i.e. a 40_000 gas floor, which dwarfs the 16_000 those bytes cost at
+/// the standard rate plus the handful of gas a STOP frame burns. The payer must
+/// be charged `mandatory + floor`, not the (much smaller) execution arm.
+#[test]
+fn floor_dominant_frame_tx_charges_the_calldata_floor() {
+    let stop_contract = Address::from_low_u64_be(0xF100);
+    let payload = vec![0xFFu8; 1000];
+
+    let tx = frame_tx_with_frames(vec![
+        verify_frame(FUNDED_SENDER),
+        sender_frame(stop_contract, 100_000, Bytes::from(payload.clone())),
+    ]);
+    let total_gas_limit = tx.total_gas_limit();
+    let sum_frame_limits: u64 = tx.frames.iter().map(|frame| frame.gas_limit).sum();
+
+    let accounts = [
+        (
+            FUNDED_SENDER,
+            AUTO_SEED_SENDER_BALANCE,
+            0,
+            Bytes::from(APPROVE_BOTH_CODE.to_vec()),
+        ),
+        (stop_contract, U256::zero(), 0, Bytes::from(vec![0x00u8])), // STOP
+    ];
+
+    let (result, _db) = run_frame_tx(&accounts, tx);
+    let report = result.expect("floor-dominant frame tx reserves the floor and is valid");
+
+    let floor = floor_tokens(&payload) * FLOOR_GAS_PER_TOKEN;
+    let expected = mandatory_gas(2) + floor;
+    assert_eq!(
+        report.gas_used,
+        expected,
+        "charged gas must be mandatory ({}) + EIP-7623 floor ({floor})",
+        mandatory_gas(2),
+    );
+
+    // The floor really is the dominant arm here: the un-floored charge
+    // (intrinsic gas plus the frame gas the frames actually burned) is strictly
+    // lower. Computed from the per-frame report so it does not depend on how
+    // `gas_refunded` is defined.
+    let frame_gas: u64 = report
+        .frame_results
+        .as_ref()
+        .expect("frame tx report must carry per-frame results")
+        .iter()
+        .map(|(_, gas, _)| *gas)
+        .sum();
+    let unfloored = total_gas_limit - sum_frame_limits + frame_gas;
+    assert!(
+        unfloored < expected,
+        "test is not floor-dominant: unfloored charge {unfloored} >= floor charge {expected}",
+    );
+}
+
+/// Execution-dominant: 8 non-zero payload bytes put the floor at 320 gas, far
+/// below the ~100k an EIP-8037 new-slot SSTORE burns. The execution arm must
+/// win, i.e. the floor must be a `max` and not an unconditional charge.
+#[test]
+fn execution_dominant_frame_tx_is_not_raised_by_the_calldata_floor() {
+    let worker = Address::from_low_u64_be(0xF200);
+    let payload = vec![0xFFu8; 8];
+
+    let tx = frame_tx_with_frames(vec![
+        verify_frame(FUNDED_SENDER),
+        sender_frame(worker, 300_000, Bytes::from(payload.clone())),
+    ]);
+    let total_gas_limit = tx.total_gas_limit();
+
+    let accounts = [
+        (
+            FUNDED_SENDER,
+            AUTO_SEED_SENDER_BALANCE,
+            0,
+            Bytes::from(APPROVE_BOTH_CODE.to_vec()),
+        ),
+        (
+            worker,
+            U256::zero(),
+            0,
+            Bytes::from(SSTORE_THEN_STOP_CODE.to_vec()),
+        ),
+    ];
+
+    let (result, _db) = run_frame_tx(&accounts, tx);
+    let report = result.expect("execution-dominant frame tx must succeed");
+
+    let floor_charge = mandatory_gas(2) + floor_tokens(&payload) * FLOOR_GAS_PER_TOKEN;
+    assert!(
+        report.gas_used > floor_charge,
+        "test is not execution-dominant: charged {} <= floor charge {floor_charge}",
+        report.gas_used,
+    );
+    // Charged gas is the execution arm verbatim: no floor uplift, so the charge
+    // plus the unburned frame gas still reconciles to the tx gas limit.
+    assert_eq!(
+        report.gas_used + report.gas_refunded,
+        total_gas_limit,
+        "floor must not raise the charge when execution dominates",
+    );
+}
+
+/// EIP-8141: the floor is reserved independently of execution, so a frame tx
+/// whose gas limit cannot cover `mandatory + floor` is invalid. Same 40_000 gas
+/// floor as above, but the frames reserve only 2_000 gas on top of the ~16_400
+/// the payload costs at the standard rate, leaving the tx short of the floor.
+/// The rejection happens before any frame runs.
+#[test]
+fn frame_tx_that_cannot_reserve_the_calldata_floor_is_invalid() {
+    let stop_contract = Address::from_low_u64_be(0xF300);
+    let payload = vec![0xFFu8; 1000];
+
+    let mut tx = frame_tx_with_frames(vec![
+        verify_frame(FUNDED_SENDER),
+        sender_frame(stop_contract, 1_000, Bytes::from(payload.clone())),
+    ]);
+    tx.frames[0].gas_limit = 1_000;
+    assert!(
+        tx.total_gas_limit() < mandatory_gas(2) + floor_tokens(&payload) * FLOOR_GAS_PER_TOKEN,
+        "test setup must be sub-floor: tx gas limit {}",
+        tx.total_gas_limit(),
+    );
+
+    let accounts = [
+        (
+            FUNDED_SENDER,
+            AUTO_SEED_SENDER_BALANCE,
+            0,
+            Bytes::from(APPROVE_BOTH_CODE.to_vec()),
+        ),
+        (stop_contract, U256::zero(), 0, Bytes::from(vec![0x00u8])), // STOP
+    ];
+
+    let (result, db) = run_frame_tx(&accounts, tx);
+    assert!(
+        matches!(
+            result,
+            Err(VMError::TxValidation(
+                ethrex_levm::errors::TxValidationError::IntrinsicGasBelowFloorGasCost
+            ))
+        ),
+        "expected IntrinsicGasBelowFloorGasCost, got {result:?}",
+    );
+    // Rejected before any frame ran, so the shared cache must be untouched.
+    assert_db_cache_unchanged(&db, &accounts);
+}
+
 // ==================== frame_tx opcode handler unit tests ====================
 // (migrated from crates/vm/levm/src/opcode_handlers/frame_tx.rs)
 


### PR DESCRIPTION
## Problem

EIP-8141 (Gas accounting) applies the EIP-7623 calldata floor to a frame transaction's frame and signature data:

```
calldata_tokens = sum(tokens_in(frame.data) for frame in tx.frames)
                + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature)
                      for sig in tx.signatures)

charged_gas = mandatory_costs + max(frame_data_cost + signature_data_cost + execution_gas,
                                    TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens)
```

and "A transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution".

ethrex applied no calldata floor to frame transactions at all: a data-heavy frame tx with little execution paid only the standard per-token calldata cost, and a tx whose gas limit cannot cover the floor was accepted. Both diverge from a conformant client (reference tx gasUsed target: 18750 mandatory + 10 * 251 tokens = 21260).

## Change

- New `frame_tx_floor_charged_gas` helper in levm utils: `mandatory + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens`, with tokens counted over the decoded payload byte fields (frame data; signature signer/msg/signature) per EIP-7623's `tokens_in`, at 10 gas per token (the EIP-7623 constant, not the EIP-7976 override; frame-tx path only).
- Reject a frame tx whose `total_gas_limit()` cannot reserve the floor, on both the execution path and the admission/simulation path (`IntrinsicGasBelowFloorGasCost`).
- At finalization, charge `max(total_gas_used, floor_charged_gas)` before the refund split.

Tests cover a floor-dominant tx charging exactly the floor, an execution-dominant tx unaffected by the floor, and a sub-floor gas limit being invalid.

Note on the floor-dominant test: its sanity guard (proving the execution arm really is the smaller one) originally derived the un-floored charge from `gas_refunded`. That derivation is circular against this branch's report semantics and also does not hold once #7046 redefines `gas_refunded` as the EIP-3529 refund. The guard here computes the un-floored charge from the per-frame gas in the execution report instead, which is well defined in both worlds. The assertions on the charged gas are unchanged.

## Evidence

Commands run on this branch:

```
cargo check -p ethrex-levm                                  # pass
cargo test -p ethrex-test --test ethrex_tests levm::eip8141_tests
# 78 passed; 0 failed; 0 ignored; 751 filtered out (incl. all 3 floor tests)
cargo fmt --all -- --check                                  # pass
git diff --check                                            # pass
```

## Stack

Targets `frames-devnet-0`. Part of a series of independent EIP-8141 fixes, one PR per logical change, each standing alone against the same base. Siblings: #7040 (canonical low-s), #7043 (recovery id at ecrecover boundary), #7044 (intrinsic gas over payload bytes), #7045 (arbitrary-scheme verification gas), #7046 (frame gas refunds), #7047 (frame receipt storage encoding), #7048 (skipped-frame status 2).

## Consensus risk / limits

Consensus-affecting: it changes gas charged for data-heavy frame transactions and rejects sub-floor gas limits. The floor interacts with the refund change in #7046: there the floored charge feeds the EIP-3529 refund split; on this standalone branch the max() applies to the unrefunded charge (the cherry-pick onto `frames-devnet-0` was resolved to keep only the floor logic, dropping the #7046 hunks it was stacked on). Covered by unit tests only; no cross-client conformance fixture yet.
