### PR TITLE
ci(l1): build the reorg-test ethrex binary with release-fast

### DIFF
--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -504,9 +504,13 @@ jobs:
       # Built with release-grade optimization: an unoptimized ethrex overflows
       # the 2 MiB tokio worker stack while building a payload, since every
       # `.await` in the block-building chain keeps its locals live in a future
-      # that no inlining collapses. `release-fast` keeps opt-level 3 without
-      # thin-LTO, so the job also spends far less time compiling.
+      # that no inlining collapses. The profile keys re-enable the checks that
+      # `release-fast` inherits as off from `release`, so reorg invariants
+      # guarded by `debug_assert!` still panic instead of being skipped.
       - name: Compile ethrex binary
+        env:
+          CARGO_PROFILE_RELEASE_FAST_DEBUG_ASSERTIONS: "true"
+          CARGO_PROFILE_RELEASE_FAST_OVERFLOW_CHECKS: "true"
         run: cargo build --profile release-fast --bin ethrex
 
       - name: Run reorg tests

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -501,8 +501,13 @@ jobs:
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust
 
+      # Built with release-grade optimization: an unoptimized ethrex overflows
+      # the 2 MiB tokio worker stack while building a payload, since every
+      # `.await` in the block-building chain keeps its locals live in a future
+      # that no inlining collapses. `release-fast` keeps opt-level 3 without
+      # thin-LTO, so the job also spends far less time compiling.
       - name: Compile ethrex binary
-        run: cargo build --bin ethrex
+        run: cargo build --profile release-fast --bin ethrex
 
       - name: Run reorg tests
-        run: cd tooling/reorgs && cargo run
+        run: cd tooling/reorgs && cargo run -- ../../target/release-fast/ethrex


### PR DESCRIPTION
Reorg Tests builds `ethrex` unoptimized, and an unoptimized node overflows the 2 MiB tokio worker stack while serving `engine_getPayload`:

```
INFO Requested payload with id=0x0309d34b7a476e9f
thread 'tokio-rt-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

The node aborts, the harness sees a non-zero exit, and the job fails. Which scenario trips it varies per run, hence the flakiness.

Not a recursion bug: the 150/200/300-block deep-reorg scenarios pass in every configuration, so depth does not scale with chain length. It is debug frame bloat.

| Build | Worker stack | Result |
|---|---|---|
| `dev` | 2 MiB | overflows |
| `dev` | `RUST_MIN_STACK=32M` | passes |
| `release-fast` | 2 MiB | passes |

Reproduced on `main` itself, independently of any feature branch. `release-fast` also cuts build time (`opt-level = 3`, no thin-LTO). `deep_reorg.yaml` is unaffected, it already builds `--release`.