### PR TITLE
fix(l1): allow EIP-8141 VERIFY frame to target an approved non-sender account

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2494,8 +2494,10 @@ impl FrameTransaction {
     /// - Deploy frame (if any) is at index 0 and uses DEFAULT execution mode.
     /// - At most one deploy frame exists in the prefix.
     /// - self_verify / only_verify / pay frames use VERIFY execution mode.
-    /// - Resolved target of each VERIFY frame matches `tx.sender` (target == None
-    ///   means sender; a non-None target must equal sender).
+    /// - Resolved target of each self_verify / only_verify frame matches
+    ///   `tx.sender` (target == None means sender). The pay frame of the
+    ///   OnlyVerifyPay / DeployOnlyVerifyPay shapes has no target restriction
+    ///   (EIP-8141 structural rule 4): it may target a non-sender sponsor.
     /// - Scope restriction matches the frame's role:
     ///   self_verify → `APPROVE_EXECUTION_AND_PAYMENT`, only_verify → `APPROVE_EXECUTION`,
     ///   pay → `APPROVE_PAYMENT`.
@@ -2542,10 +2544,19 @@ impl FrameTransaction {
                         });
                     }
 
-                    // Resolved target must be tx.sender (None means sender).
+                    // EIP-8141 structural rule 3 restricts the target to
+                    // tx.sender (None means sender) only for self_verify /
+                    // only_verify frames. Rule 4 places no target requirement
+                    // on the pay frame: it may target a non-sender sponsor,
+                    // which approves payment via APPROVE(APPROVE_PAYMENT)
+                    // when the frame executes.
+                    let is_pay_frame = matches!(
+                        prefix.shape,
+                        PrefixShape::OnlyVerifyPay | PrefixShape::DeployOnlyVerifyPay
+                    ) && prefix.pay_index == Some(idx);
                     let target_ok = match frame.target {
                         None => true,
-                        Some(addr) => addr == self.sender,
+                        Some(addr) => addr == self.sender || is_pay_frame,
                     };
                     if !target_ok {
                         return Err(FrameValidationError::VerifyTargetNotSender {

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2491,6 +2491,11 @@ impl FrameTransaction {
                     // on the pay frame: it may target a non-sender sponsor,
                     // which approves payment via APPROVE(APPROVE_PAYMENT)
                     // when the frame executes.
+                    // The shape guard is load-bearing: every shape populates
+                    // `pay_index`, and for SelfVerify / DeploySelfVerify it points
+                    // at the self_verify frame, which carries
+                    // APPROVE_EXECUTION_AND_PAYMENT and does require the sender as
+                    // its target. Matching on `pay_index` alone would exempt it.
                     let is_pay_frame = matches!(
                         prefix.shape,
                         PrefixShape::OnlyVerifyPay | PrefixShape::DeployOnlyVerifyPay

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2550,6 +2550,11 @@ impl FrameTransaction {
                     // on the pay frame: it may target a non-sender sponsor,
                     // which approves payment via APPROVE(APPROVE_PAYMENT)
                     // when the frame executes.
+                    // The shape guard is load-bearing: every shape populates
+                    // `pay_index`, and for SelfVerify / DeploySelfVerify it points
+                    // at the self_verify frame, which carries
+                    // APPROVE_EXECUTION_AND_PAYMENT and does require the sender as
+                    // its target. Matching on `pay_index` alone would exempt it.
                     let is_pay_frame = matches!(
                         prefix.shape,
                         PrefixShape::OnlyVerifyPay | PrefixShape::DeployOnlyVerifyPay

--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2435,8 +2435,10 @@ impl FrameTransaction {
     /// - Deploy frame (if any) is at index 0 and uses DEFAULT execution mode.
     /// - At most one deploy frame exists in the prefix.
     /// - self_verify / only_verify / pay frames use VERIFY execution mode.
-    /// - Resolved target of each VERIFY frame matches `tx.sender` (target == None
-    ///   means sender; a non-None target must equal sender).
+    /// - Resolved target of each self_verify / only_verify frame matches
+    ///   `tx.sender` (target == None means sender). The pay frame of the
+    ///   OnlyVerifyPay / DeployOnlyVerifyPay shapes has no target restriction
+    ///   (EIP-8141 structural rule 4): it may target a non-sender sponsor.
     /// - Scope restriction matches the frame's role:
     ///   self_verify → `APPROVE_EXECUTION_AND_PAYMENT`, only_verify → `APPROVE_EXECUTION`,
     ///   pay → `APPROVE_PAYMENT`.
@@ -2483,10 +2485,19 @@ impl FrameTransaction {
                         });
                     }
 
-                    // Resolved target must be tx.sender (None means sender).
+                    // EIP-8141 structural rule 3 restricts the target to
+                    // tx.sender (None means sender) only for self_verify /
+                    // only_verify frames. Rule 4 places no target requirement
+                    // on the pay frame: it may target a non-sender sponsor,
+                    // which approves payment via APPROVE(APPROVE_PAYMENT)
+                    // when the frame executes.
+                    let is_pay_frame = matches!(
+                        prefix.shape,
+                        PrefixShape::OnlyVerifyPay | PrefixShape::DeployOnlyVerifyPay
+                    ) && prefix.pay_index == Some(idx);
                     let target_ok = match frame.target {
                         None => true,
-                        Some(addr) => addr == self.sender,
+                        Some(addr) => addr == self.sender || is_pay_frame,
                     };
                     if !target_ok {
                         return Err(FrameValidationError::VerifyTargetNotSender {

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -2616,6 +2616,58 @@ mod frame_validation_prefix_tests {
         );
         assert_eq!(outcome.accessed_paymaster, Some((sender, false)));
     }
+
+    /// A sponsored OnlyVerifyPay prefix whose pay frame targets a non-sender
+    /// sponsor. EIP-8141 structural rule 3 restricts only self_verify /
+    /// only_verify targets to `tx.sender`; rule 4 places no target requirement
+    /// on `pay`, so the sponsor may approve payment for the sender. The prefix
+    /// must pass structural validation and the simulation must establish the
+    /// sponsor as the paymaster.
+    #[test]
+    fn sponsored_pay_frame_may_target_non_sender() {
+        let sender = addr(0x5E_11_02);
+        let sponsor = addr(0x42_D9_3E);
+        let frames = vec![
+            frame(1, 0x02, sender, 40_000),  // only_verify -> sender
+            frame(1, 0x01, sponsor, 40_000), // pay -> sponsor
+        ];
+        let tx = frame_tx_prefix(sender, frames);
+        let Transaction::FrameTransaction(frame_tx) = &tx else {
+            unreachable!("frame_tx_prefix builds a frame transaction")
+        };
+        let prefix = frame_tx
+            .validation_prefix()
+            .expect("OnlyVerifyPay shape recognized");
+        assert_eq!(prefix.shape, PrefixShape::OnlyVerifyPay);
+        frame_tx
+            .validate_prefix_structure(&prefix)
+            .expect("a pay frame may target a non-sender sponsor (EIP-8141 structural rule 4)");
+
+        let mut db = db_with(vec![
+            (sender, account(0, approve_code(0x02))),
+            (sponsor, account(0, approve_code(0x01))),
+        ]);
+        let outcome = LEVM::simulate_frame_validation_prefix(
+            &tx,
+            &header(),
+            &mut db,
+            VMType::L1,
+            &NativeCrypto,
+            &prefix,
+            None,
+        )
+        .expect("simulation runs");
+        assert!(
+            outcome.passed,
+            "a sponsored prefix must pass validation, got {:?}",
+            outcome.violation
+        );
+        assert_eq!(
+            outcome.accessed_paymaster,
+            Some((sponsor, false)),
+            "the sponsor must be identified as the paymaster"
+        );
+    }
 }
 
 // ==================== Relocated from crates/vm/levm/src/vm.rs ====================

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -2674,6 +2674,58 @@ mod frame_validation_prefix_tests {
             "the reservation must price the blob at max_fee_per_blob_gas"
         );
     }
+
+    /// A sponsored OnlyVerifyPay prefix whose pay frame targets a non-sender
+    /// sponsor. EIP-8141 structural rule 3 restricts only self_verify /
+    /// only_verify targets to `tx.sender`; rule 4 places no target requirement
+    /// on `pay`, so the sponsor may approve payment for the sender. The prefix
+    /// must pass structural validation and the simulation must establish the
+    /// sponsor as the paymaster.
+    #[test]
+    fn sponsored_pay_frame_may_target_non_sender() {
+        let sender = addr(0x5E_11_02);
+        let sponsor = addr(0x42_D9_3E);
+        let frames = vec![
+            frame(1, 0x02, sender, 40_000),  // only_verify -> sender
+            frame(1, 0x01, sponsor, 40_000), // pay -> sponsor
+        ];
+        let tx = frame_tx_prefix(sender, frames);
+        let Transaction::FrameTransaction(frame_tx) = &tx else {
+            unreachable!("frame_tx_prefix builds a frame transaction")
+        };
+        let prefix = frame_tx
+            .validation_prefix()
+            .expect("OnlyVerifyPay shape recognized");
+        assert_eq!(prefix.shape, PrefixShape::OnlyVerifyPay);
+        frame_tx
+            .validate_prefix_structure(&prefix)
+            .expect("a pay frame may target a non-sender sponsor (EIP-8141 structural rule 4)");
+
+        let mut db = db_with(vec![
+            (sender, account(0, approve_code(0x02))),
+            (sponsor, account(0, approve_code(0x01))),
+        ]);
+        let outcome = LEVM::simulate_frame_validation_prefix(
+            &tx,
+            &header(),
+            &mut db,
+            VMType::L1,
+            &NativeCrypto,
+            &prefix,
+            None,
+        )
+        .expect("simulation runs");
+        assert!(
+            outcome.passed,
+            "a sponsored prefix must pass validation, got {:?}",
+            outcome.violation
+        );
+        assert_eq!(
+            outcome.accessed_paymaster,
+            Some((sponsor, false)),
+            "the sponsor must be identified as the paymaster"
+        );
+    }
 }
 
 // ==================== Relocated from crates/vm/levm/src/vm.rs ====================


### PR DESCRIPTION
**Motivation**

ethrex rejects a sponsored EIP-8141 frame transaction whose `pay` frame targets an account other than `tx.sender`, with `frame N: VERIFY frame target is not tx.sender`. This blocks the canonical `[only_verify, pay]` sponsorship prefix, which exists precisely so that an account other than the sender can pay.

This was reproduced cross-client in a Nethermind + ethrex Kurtosis run: for a sponsored transaction (`only_verify` + `pay` targeting a sponsor EOA + a SENDER transfer, sponsor signature at index 1), Nethermind accepted and executed it - all frames succeeded and the sponsor was charged as payer - while ethrex rejected it at RPC admission with the error above.

**Description**

`FrameTransaction::validate_prefix_structure` applied the target-must-be-`tx.sender` check to every VERIFY frame of the validation prefix. The current EIP-8141 structural rules restrict the target this way only for `self_verify` and `only_verify` frames (rule 3: they "must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target)"). Rule 4 places no target requirement on the `pay` frame: it "must execute in `VERIFY` mode, have flags set to `APPROVE_PAYMENT`, and must successfully call `APPROVE(APPROVE_PAYMENT)`". The `APPROVE(APPROVE_PAYMENT)` semantics set `payer = resolved_target` with no sender-equality requirement, so a non-sender sponsor targeted by the `pay` frame approves payment when the frame executes.

Changes:

- `crates/common/types/transaction.rs`: in `validate_prefix_structure`, exempt the `pay` frame of the `OnlyVerifyPay` / `DeployOnlyVerifyPay` shapes from the `VerifyTargetNotSender` check. `self_verify` and `only_verify` frames (including the `pay_index` frame of the `SelfVerify` shapes, which is the `self_verify` frame) keep it. No other structural check is touched.
- `test/tests/levm/eip8141_tests.rs`: regression test `sponsored_pay_frame_may_target_non_sender` - an `OnlyVerifyPay` prefix whose `pay` frame targets a non-sender sponsor must pass `validation_prefix` + `validate_prefix_structure` and simulate to a passing outcome with the sponsor identified as the paymaster. The test fails on `main` with `VerifyTargetNotSender { frame_index: 1 }` and passes with this change.

Verification (all local):

- `cargo check -p ethrex-levm` - clean
- `cargo test -p ethrex-test --test ethrex_tests levm::eip8141_tests` - 85 passed, 0 failed
- `cargo test -p ethrex-test --test ethrex_tests common::frame_tx_validation_tests` - 25 passed, 0 failed
- `cargo fmt --all -- --check` and `git diff --check` - clean
