### PR TITLE
feat(l1): add EIP-1459 DNS discovery for bootstrap resilience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,6 +2252,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4246,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 0.4.1",
+ "hickory-resolver",
  "hkdf",
  "hmac",
  "indexmap 2.14.0",
@@ -5012,6 +5024,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -5535,6 +5548,76 @@ checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
 dependencies = [
  "outref",
  "vsimd",
+]
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.2",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6090,10 +6173,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -6228,6 +6327,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7164,6 +7293,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid 1.23.0",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7221,6 +7367,12 @@ dependencies = [
  "rawpointer",
  "rayon",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "neli"
@@ -7658,6 +7810,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -10465,6 +10621,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10975,6 +11142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11012,6 +11190,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -11315,6 +11499,12 @@ dependencies = [
  "thiserror 1.0.69",
  "tower-service",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -12035,7 +12225,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.38",
@@ -12692,6 +12882,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -13707,6 +13907,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -15050,6 +15256,12 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,13 @@ hex-literal = "0.4.1"
 crc32fast = "1.4.2"
 lazy_static = "1.5.0"
 lru = "0.16.2"
+# TXT lookups for EIP-1459 DNS node lists. `system-config` reads the platform
+# resolver settings; the TLS/DoH transports are left off since the node lists
+# are served over plain DNS and their contents are signature-verified anyway.
+hickory-resolver = { version = "0.26.1", default-features = false, features = [
+  "system-config",
+  "tokio",
+] }
 sha2 = "0.10.9"
 sha3 = "0.10.8"
 tokio-util = { version = "0.7.15", features = ["rt"] }

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -398,6 +398,14 @@ pub struct Options {
     )]
     pub discv5_enabled: bool,
     #[arg(
+        long = "discovery.dns",
+        value_name = "ENRTREE_URLS",
+        help = "Comma separated enrtree:// URLs for EIP-1459 DNS discovery. Defaults to the known network list; pass an empty string to disable.",
+        help_heading = "P2P options",
+        env = "ETHREX_DISCOVERY_DNS"
+    )]
+    pub discovery_dns: Option<String>,
+    #[arg(
         long = "p2p.tx-broadcasting-interval",
         default_value_t = BROADCAST_INTERVAL_MS,
         value_name = "INTERVAL_MS",
@@ -486,6 +494,7 @@ impl Options {
             discovery_port: "30303".into(),
             discv4_enabled: true,
             discv5_enabled: true,
+            discovery_dns: None,
             mempool_max_size: 10_000,
             ..Default::default()
         }
@@ -508,6 +517,7 @@ impl Options {
             discovery_port: "30303".into(),
             discv4_enabled: true,
             discv5_enabled: true,
+            discovery_dns: None,
             mempool_max_size: 10_000,
             ..Default::default()
         }
@@ -536,6 +546,7 @@ impl Default for Options {
             discovery_port: Default::default(),
             discv4_enabled: true,
             discv5_enabled: true,
+            discovery_dns: None,
             network: Default::default(),
             bootnodes: Default::default(),
             datadir: Default::default(),

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -17,6 +17,7 @@ use ethrex_metrics::rpc::initialize_rpc_metrics;
 use ethrex_p2p::rlpx::initiator::RLPxInitiator;
 use ethrex_p2p::{
     DiscoveryConfig,
+    discovery::dns::EnrTreeLink,
     network::P2PContext,
     peer_handler::PeerHandler,
     peer_table::{PeerTable, PeerTableServer},
@@ -382,6 +383,7 @@ pub async fn init_network(
     let discovery_config = DiscoveryConfig {
         discv4_enabled: opts.discv4_enabled,
         discv5_enabled: opts.discv5_enabled,
+        dns_discovery_links: get_dns_discovery_links(opts, network),
         ..Default::default()
     };
 
@@ -464,6 +466,30 @@ pub fn get_bootnodes(opts: &Options, network: &Network, datadir: &Path) -> Vec<N
     }
 
     bootnodes
+}
+
+/// Resolves the EIP-1459 trees to use: the CLI value if given (an empty string
+/// disables DNS discovery), otherwise the network's known list.
+pub fn get_dns_discovery_links(opts: &Options, network: &Network) -> Vec<EnrTreeLink> {
+    let urls = match opts.discovery_dns.as_deref() {
+        Some(urls) => urls
+            .split(',')
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(str::to_string)
+            .collect(),
+        None => network.get_dns_discovery_links(),
+    };
+
+    urls.iter()
+        .filter_map(|url| match url.parse() {
+            Ok(link) => Some(link),
+            Err(e) => {
+                warn!("Ignoring invalid DNS discovery URL {url}: {e}");
+                None
+            }
+        })
+        .collect()
 }
 
 pub fn get_signer(datadir: &Path) -> SecretKey {

--- a/crates/common/config/networks.rs
+++ b/crates/common/config/networks.rs
@@ -160,7 +160,27 @@ impl Network {
         };
         serde_json::from_str(bootnodes).expect("bootnodes file should be valid JSON")
     }
+
+    /// EIP-1459 node lists for this network.
+    ///
+    /// These are a second, independent way into the network: the hardcoded
+    /// bootnodes are a handful of hosts, and when they stop answering a node
+    /// with an empty peer table has no other way to bootstrap discovery.
+    pub fn get_dns_discovery_links(&self) -> Vec<String> {
+        let network = match self {
+            Network::PublicNetwork(PublicNetwork::Hoodi) => "hoodi",
+            Network::PublicNetwork(PublicNetwork::Mainnet) => "mainnet",
+            Network::PublicNetwork(PublicNetwork::Sepolia) => "sepolia",
+            _ => return vec![],
+        };
+        vec![format!("{ETHDISCO_TREE_KEY}@all.{network}.ethdisco.net")]
+    }
 }
+
+/// Public key of the EF DevOps trees published under `*.ethdisco.net`. Every
+/// network's list is signed by this key, so a hijacked resolver cannot inject
+/// nodes — the root signature check will reject them.
+const ETHDISCO_TREE_KEY: &str = "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE";
 
 fn get_genesis_contents(network: PublicNetwork) -> &'static str {
     match network {

--- a/crates/networking/p2p/Cargo.toml
+++ b/crates/networking/p2p/Cargo.toml
@@ -58,6 +58,9 @@ lru.workspace = true
 rayon = "1.10.0"
 crossbeam.workspace = true
 
+# EIP-1459 DNS discovery
+hickory-resolver.workspace = true
+
 [dev-dependencies]
 hex-literal.workspace = true
 tempfile = "3"

--- a/crates/networking/p2p/discovery/dns.rs
+++ b/crates/networking/p2p/discovery/dns.rs
@@ -1,0 +1,829 @@
+//! EIP-1459 DNS-based node discovery.
+//!
+//! Discovery bootstrapping normally relies on a small hardcoded bootnode list.
+//! When those hosts stop answering, a node starting with an empty peer table has
+//! no way into the DHT at all and stays at zero peers indefinitely. A DNS node
+//! list is the independent bootstrap path the other clients use for exactly that
+//! case: a signed, DNS-hosted Merkle tree of ENRs that can be refreshed without
+//! shipping a new binary.
+//!
+//! The tree is described by an `enrtree://<base32-pubkey>@<domain>` URL. Its root
+//! lives in a TXT record at `<domain>` and is signed by the tree's key, so a
+//! hijacked resolver cannot inject nodes. Interior nodes are TXT records at
+//! `<base32-hash>.<domain>`, where the label is
+//! `base32(keccak256(child_record_text)[..16])` — verified on every fetch, which
+//! makes the whole tree tamper-evident under one signature.
+//!
+//! See <https://eips.ethereum.org/EIPS/eip-1459>.
+
+use std::{collections::HashSet, future::Future, str::FromStr, time::Duration};
+
+use ethrex_crypto::keccak::keccak_hash;
+use ethrex_rlp::decode::RLPDecode;
+use rand::seq::SliceRandom;
+use secp256k1::{PublicKey, ecdsa::Signature};
+use thiserror::Error;
+use tracing::{debug, info, warn};
+
+use crate::{
+    peer_table::{DiscoveryProtocol, PeerTable, PeerTableServerProtocol as _},
+    types::{Node, NodeRecord},
+};
+
+/// Prefix of a root record, which also fixes the version we accept.
+const ROOT_PREFIX: &str = "enrtree-root:v1";
+/// Prefix of an interior (branch) record.
+const BRANCH_PREFIX: &str = "enrtree-branch:";
+/// Prefix of a leaf record holding a base64url-encoded ENR.
+const ENR_PREFIX: &str = "enr:";
+/// Prefix of a record (or URL) linking to another tree.
+const LINK_PREFIX: &str = "enrtree://";
+
+/// Bytes of the record hash that the DNS label encodes.
+const HASH_ABBREV_BYTES: usize = 16;
+
+/// How many nodes to accept from a single sync. Bounds both memory and the
+/// number of DNS queries a malicious tree can make us perform.
+pub const DEFAULT_MAX_NODES: usize = 256;
+/// Hard ceiling on TXT lookups per sync, independent of tree shape. A tree that
+/// keeps handing back branches can otherwise walk us forever.
+pub const DEFAULT_MAX_REQUESTS: usize = 512;
+/// How deep we follow `enrtree://` links into other trees.
+const MAX_LINK_DEPTH: usize = 1;
+
+/// Interval between DNS re-syncs. The published trees change on the order of
+/// minutes, and this path only needs to keep a *bootstrap* supply of contacts
+/// available, so a slow poll is enough.
+pub const DNS_SYNC_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Debug, Error)]
+pub enum DnsDiscoveryError {
+    #[error("DNS lookup for {name} failed: {source}")]
+    Lookup {
+        name: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("no TXT record at {0}")]
+    NoRecord(String),
+    #[error("malformed enrtree URL: {0}")]
+    InvalidUrl(String),
+    #[error("malformed {kind} record: {reason}")]
+    InvalidRecord { kind: &'static str, reason: String },
+    #[error("root signature verification failed for {0}")]
+    InvalidRootSignature(String),
+}
+
+/// Resolves TXT records. Abstracted so the tree walk can be tested without DNS.
+pub trait TxtResolver: Send + Sync + 'static {
+    /// Returns the TXT record at `name` with all character-strings concatenated.
+    fn lookup_txt(
+        &self,
+        name: String,
+    ) -> impl Future<Output = Result<String, DnsDiscoveryError>> + Send;
+}
+
+/// A parsed `enrtree://<base32-pubkey>@<domain>` URL.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EnrTreeLink {
+    pub public_key: PublicKey,
+    pub domain: String,
+}
+
+impl FromStr for EnrTreeLink {
+    type Err = DnsDiscoveryError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rest = s
+            .strip_prefix(LINK_PREFIX)
+            .ok_or_else(|| DnsDiscoveryError::InvalidUrl(s.to_string()))?;
+        let (key, domain) = rest
+            .split_once('@')
+            .ok_or_else(|| DnsDiscoveryError::InvalidUrl(s.to_string()))?;
+        if domain.is_empty() {
+            return Err(DnsDiscoveryError::InvalidUrl(s.to_string()));
+        }
+        let key_bytes =
+            base32_decode(key).ok_or_else(|| DnsDiscoveryError::InvalidUrl(s.to_string()))?;
+        let public_key = PublicKey::from_slice(&key_bytes)
+            .map_err(|_| DnsDiscoveryError::InvalidUrl(s.to_string()))?;
+        Ok(Self {
+            public_key,
+            domain: domain.to_string(),
+        })
+    }
+}
+
+/// The signed root of a tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RootEntry {
+    /// Label of the subtree holding ENRs.
+    enr_root: String,
+    /// Label of the subtree holding links to other trees.
+    link_root: String,
+    seq: u64,
+    signature: Vec<u8>,
+}
+
+impl RootEntry {
+    fn parse(record: &str) -> Result<Self, DnsDiscoveryError> {
+        let invalid = |reason: &str| DnsDiscoveryError::InvalidRecord {
+            kind: "enrtree-root",
+            reason: reason.to_string(),
+        };
+        let body = record
+            .strip_prefix(ROOT_PREFIX)
+            .ok_or_else(|| invalid("unsupported version or prefix"))?;
+
+        let (mut enr_root, mut link_root, mut seq, mut signature) = (None, None, None, None);
+        for token in body.split_whitespace() {
+            let Some((key, value)) = token.split_once('=') else {
+                continue;
+            };
+            match key {
+                "e" => enr_root = Some(value.to_string()),
+                "l" => link_root = Some(value.to_string()),
+                "seq" => {
+                    seq = Some(
+                        value
+                            .parse::<u64>()
+                            .map_err(|_| invalid("seq is not a number"))?,
+                    )
+                }
+                // Signatures are base64url without padding, matching ENR encoding.
+                "sig" => signature = Some(ethrex_common::base64::decode(value.as_bytes())),
+                _ => {}
+            }
+        }
+
+        Ok(Self {
+            enr_root: enr_root.ok_or_else(|| invalid("missing e="))?,
+            link_root: link_root.ok_or_else(|| invalid("missing l="))?,
+            seq: seq.ok_or_else(|| invalid("missing seq="))?,
+            signature: signature.ok_or_else(|| invalid("missing sig="))?,
+        })
+    }
+
+    /// The exact string the tree owner signed: the record without its `sig=`
+    /// field, with fields in canonical order.
+    fn signed_content(&self) -> String {
+        format!(
+            "{ROOT_PREFIX} e={} l={} seq={}",
+            self.enr_root, self.link_root, self.seq
+        )
+    }
+
+    fn verify_signature(&self, public_key: &PublicKey) -> bool {
+        // The signature is 65 bytes (r || s || recovery id); only r || s is verified.
+        let Some(compact) = self.signature.get(..64) else {
+            return false;
+        };
+        let Ok(signature) = Signature::from_compact(compact) else {
+            return false;
+        };
+        let digest = keccak_hash(self.signed_content().as_bytes());
+        let Ok(message) = secp256k1::Message::from_digest_slice(&digest) else {
+            return false;
+        };
+        secp256k1::SECP256K1
+            .verify_ecdsa(&message, &signature, public_key)
+            .is_ok()
+    }
+}
+
+/// A non-root record in the tree.
+enum TreeEntry {
+    Branch(Vec<String>),
+    Enr(Box<NodeRecord>),
+    Link(EnrTreeLink),
+}
+
+impl TreeEntry {
+    fn parse(record: &str) -> Result<Self, DnsDiscoveryError> {
+        if let Some(children) = record.strip_prefix(BRANCH_PREFIX) {
+            // An empty branch is legal and simply terminates that path.
+            let children = children
+                .split(',')
+                .filter(|hash| !hash.is_empty())
+                .map(str::to_string)
+                .collect();
+            return Ok(Self::Branch(children));
+        }
+        if let Some(encoded) = record.strip_prefix(ENR_PREFIX) {
+            let rlp = ethrex_common::base64::decode(encoded.as_bytes());
+            let node_record =
+                NodeRecord::decode(&rlp).map_err(|e| DnsDiscoveryError::InvalidRecord {
+                    kind: "enr",
+                    reason: e.to_string(),
+                })?;
+            return Ok(Self::Enr(Box::new(node_record)));
+        }
+        if record.starts_with(LINK_PREFIX) {
+            return Ok(Self::Link(record.parse()?));
+        }
+        Err(DnsDiscoveryError::InvalidRecord {
+            kind: "tree entry",
+            reason: format!("unrecognized prefix in {:.32}", record),
+        })
+    }
+}
+
+/// Walks EIP-1459 trees and yields the nodes found in them.
+pub struct DnsDiscovery<R: TxtResolver> {
+    resolver: R,
+    links: Vec<EnrTreeLink>,
+    max_nodes: usize,
+    max_requests: usize,
+}
+
+impl<R: TxtResolver> DnsDiscovery<R> {
+    pub fn new(resolver: R, links: Vec<EnrTreeLink>) -> Self {
+        Self {
+            resolver,
+            links,
+            max_nodes: DEFAULT_MAX_NODES,
+            max_requests: DEFAULT_MAX_REQUESTS,
+        }
+    }
+
+    pub fn with_limits(mut self, max_nodes: usize, max_requests: usize) -> Self {
+        self.max_nodes = max_nodes;
+        self.max_requests = max_requests;
+        self
+    }
+
+    /// Resolves every configured tree, returning the union of their nodes.
+    ///
+    /// A tree that fails to resolve is logged and skipped: one broken or
+    /// unreachable tree must not take down the others.
+    pub async fn sync(&self) -> Vec<Node> {
+        let mut nodes = Vec::new();
+        let mut seen_node_ids = HashSet::new();
+        let mut requests = 0usize;
+
+        // (link, depth); depth counts how many `enrtree://` hops we followed.
+        let mut pending: Vec<(EnrTreeLink, usize)> =
+            self.links.iter().cloned().map(|l| (l, 0)).collect();
+        let mut visited_domains = HashSet::new();
+
+        while let Some((link, depth)) = pending.pop() {
+            if nodes.len() >= self.max_nodes || requests >= self.max_requests {
+                break;
+            }
+            if !visited_domains.insert(link.domain.clone()) {
+                continue;
+            }
+            match self
+                .sync_tree(
+                    &link,
+                    depth,
+                    &mut nodes,
+                    &mut seen_node_ids,
+                    &mut requests,
+                    &mut pending,
+                )
+                .await
+            {
+                Ok(()) => {}
+                Err(e) => warn!(domain = %link.domain, "DNS discovery tree sync failed: {e}"),
+            }
+        }
+
+        nodes
+    }
+
+    async fn sync_tree(
+        &self,
+        link: &EnrTreeLink,
+        depth: usize,
+        nodes: &mut Vec<Node>,
+        seen_node_ids: &mut HashSet<ethrex_common::H256>,
+        requests: &mut usize,
+        pending: &mut Vec<(EnrTreeLink, usize)>,
+    ) -> Result<(), DnsDiscoveryError> {
+        let root_record = self.lookup(&link.domain, requests).await?;
+        let root = RootEntry::parse(&root_record)?;
+        if !root.verify_signature(&link.public_key) {
+            return Err(DnsDiscoveryError::InvalidRootSignature(link.domain.clone()));
+        }
+        debug!(
+            domain = %link.domain,
+            seq = root.seq,
+            "DNS discovery: verified tree root"
+        );
+
+        // Only descend into the link subtree while we still have hops left.
+        let mut stack = vec![root.enr_root.clone()];
+        if depth < MAX_LINK_DEPTH {
+            stack.push(root.link_root.clone());
+        }
+        let mut visited_labels = HashSet::new();
+
+        while let Some(label) = stack.pop() {
+            if nodes.len() >= self.max_nodes || *requests >= self.max_requests {
+                break;
+            }
+            if label.is_empty() || !visited_labels.insert(label.clone()) {
+                continue;
+            }
+
+            let name = format!("{label}.{}", link.domain);
+            let record = match self.lookup(&name, requests).await {
+                Ok(record) => record,
+                // A single missing or broken subtree shouldn't abort the walk;
+                // other branches may still hold usable nodes.
+                Err(e) => {
+                    debug!("DNS discovery: skipping {name}: {e}");
+                    continue;
+                }
+            };
+
+            if !label_matches_record(&label, &record) {
+                warn!(%name, "DNS discovery: record hash does not match its label, skipping");
+                continue;
+            }
+
+            match TreeEntry::parse(&record) {
+                Ok(TreeEntry::Branch(mut children)) => {
+                    // Randomize so restarts and different nodes don't all walk
+                    // the tree in the same order and converge on one subset.
+                    children.shuffle(&mut rand::thread_rng());
+                    stack.extend(children);
+                }
+                Ok(TreeEntry::Enr(record)) => {
+                    // The ENR carries its own signature; reject anything the
+                    // tree owner (or a tampered subtree) got wrong.
+                    if !record.verify_signature() {
+                        warn!(%name, "DNS discovery: ENR signature invalid, skipping");
+                        continue;
+                    }
+                    match Node::from_enr(&record) {
+                        Ok(node) => {
+                            if seen_node_ids.insert(node.node_id()) {
+                                nodes.push(node);
+                            }
+                        }
+                        Err(e) => debug!(%name, "DNS discovery: unusable ENR: {e}"),
+                    }
+                }
+                Ok(TreeEntry::Link(link)) => pending.push((link, depth + 1)),
+                Err(e) => debug!(%name, "DNS discovery: {e}"),
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn lookup(&self, name: &str, requests: &mut usize) -> Result<String, DnsDiscoveryError> {
+        *requests += 1;
+        self.resolver.lookup_txt(name.to_string()).await
+    }
+}
+
+/// Checks that a record is the one its DNS label commits to, i.e. that the label
+/// is `base32(keccak256(record)[..HASH_ABBREV_BYTES])`.
+fn label_matches_record(label: &str, record: &str) -> bool {
+    let digest = keccak_hash(record.as_bytes());
+    let Some(abbrev) = digest.get(..HASH_ABBREV_BYTES) else {
+        return false;
+    };
+    base32_encode(abbrev).eq_ignore_ascii_case(label)
+}
+
+/// Decodes unpadded RFC 4648 base32 (the alphabet EIP-1459 uses for labels and
+/// tree public keys). Returns `None` on any character outside the alphabet.
+fn base32_decode(input: &str) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(input.len() * 5 / 8);
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for byte in input.bytes() {
+        if byte == b'=' {
+            break;
+        }
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a',
+            b'2'..=b'7' => byte - b'2' + 26,
+            _ => return None,
+        } as u32;
+        buffer = (buffer << 5) | value;
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buffer >> bits) as u8);
+            buffer &= (1 << bits) - 1;
+        }
+    }
+    Some(out)
+}
+
+/// Encodes bytes as unpadded RFC 4648 base32.
+fn base32_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    let mut out = String::with_capacity(input.len().saturating_mul(8).div_ceil(5));
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for &byte in input {
+        buffer = (buffer << 8) | byte as u32;
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            out.push(ALPHABET[((buffer >> bits) & 0x1f) as usize] as char);
+            buffer &= (1 << bits) - 1;
+        }
+    }
+    if bits > 0 {
+        out.push(ALPHABET[((buffer << (5 - bits)) & 0x1f) as usize] as char);
+    }
+    out
+}
+
+/// TXT resolver backed by the platform's configured DNS servers.
+pub struct SystemResolver(hickory_resolver::TokioResolver);
+
+impl SystemResolver {
+    pub fn new() -> Result<Self, DnsDiscoveryError> {
+        let resolver = hickory_resolver::Resolver::builder_tokio()
+            .map_err(|e| DnsDiscoveryError::Lookup {
+                name: "<resolver init>".to_string(),
+                source: Box::new(e),
+            })?
+            .build()
+            .map_err(|e| DnsDiscoveryError::Lookup {
+                name: "<resolver init>".to_string(),
+                source: Box::new(e),
+            })?;
+        Ok(Self(resolver))
+    }
+}
+
+impl TxtResolver for SystemResolver {
+    async fn lookup_txt(&self, name: String) -> Result<String, DnsDiscoveryError> {
+        use hickory_resolver::proto::rr::{RData, RecordType};
+
+        let lookup = self
+            .0
+            .lookup(name.clone(), RecordType::TXT)
+            .await
+            .map_err(|e| DnsDiscoveryError::Lookup {
+                name: name.clone(),
+                source: Box::new(e),
+            })?;
+
+        // A TXT record longer than 255 bytes is split into several
+        // character-strings that have to be concatenated back together; root and
+        // ENR records routinely exceed that.
+        let record = lookup
+            .answers()
+            .iter()
+            .find_map(|record| match &record.data {
+                RData::TXT(txt) => Some(
+                    txt.txt_data
+                        .iter()
+                        .flat_map(|chunk| chunk.iter().copied())
+                        .collect::<Vec<u8>>(),
+                ),
+                _ => None,
+            })
+            .ok_or_else(|| DnsDiscoveryError::NoRecord(name.clone()))?;
+
+        String::from_utf8(record).map_err(|e| DnsDiscoveryError::Lookup {
+            name,
+            source: Box::new(e),
+        })
+    }
+}
+
+/// Periodically syncs the configured DNS node lists into the peer table.
+///
+/// Runs alongside discv4/discv5 rather than gating startup on it: DNS is a
+/// bootstrap *supplement*, and a slow or unreachable resolver must never delay
+/// the node coming up. Contacts are added exactly the way bootnodes are, so they
+/// get pinged, validated and dialed through the existing paths.
+pub async fn run_dns_discovery(
+    peer_table: PeerTable,
+    links: Vec<EnrTreeLink>,
+    protocols: Vec<DiscoveryProtocol>,
+) {
+    let resolver = match SystemResolver::new() {
+        Ok(resolver) => resolver,
+        Err(e) => {
+            warn!("DNS discovery disabled, could not build resolver: {e}");
+            return;
+        }
+    };
+    let domains = links
+        .iter()
+        .map(|link| link.domain.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    info!(trees = %domains, "Starting DNS discovery");
+
+    let discovery = DnsDiscovery::new(resolver, links);
+    loop {
+        let nodes = discovery.sync().await;
+        if nodes.is_empty() {
+            warn!("DNS discovery sync returned no nodes");
+        } else {
+            info!(count = nodes.len(), "DNS discovery: adding contacts");
+            for protocol in &protocols {
+                if let Err(e) = peer_table.new_contacts(nodes.clone(), *protocol) {
+                    debug!("DNS discovery could not add contacts: {e}");
+                }
+            }
+        }
+        tokio::time::sleep(DNS_SYNC_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    /// The tree key EF DevOps publishes every `*.ethdisco.net` list under.
+    const ETHDISCO_KEY: &str = "AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE";
+
+    struct MockResolver(HashMap<String, String>);
+
+    impl TxtResolver for MockResolver {
+        async fn lookup_txt(&self, name: String) -> Result<String, DnsDiscoveryError> {
+            self.0
+                .get(&name)
+                .cloned()
+                .ok_or(DnsDiscoveryError::NoRecord(name))
+        }
+    }
+
+    /// Builds a tree whose labels are computed the same way a real publisher
+    /// would, so the walk exercises label verification for real.
+    fn tree(domain: &str, records: Vec<String>) -> (HashMap<String, String>, Vec<String>) {
+        let mut dns = HashMap::new();
+        let mut labels = Vec::new();
+        for record in records {
+            let digest = keccak_hash(record.as_bytes());
+            let label = base32_encode(&digest[..HASH_ABBREV_BYTES]);
+            dns.insert(format!("{label}.{domain}"), record);
+            labels.push(label);
+        }
+        (dns, labels)
+    }
+
+    #[test]
+    fn base32_roundtrip() {
+        for len in 1..=32 {
+            let bytes: Vec<u8> = (0..len).map(|i| (i * 7 + 3) as u8).collect();
+            let encoded = base32_encode(&bytes);
+            assert_eq!(base32_decode(&encoded).as_deref(), Some(&bytes[..]));
+        }
+    }
+
+    #[test]
+    fn base32_label_length_matches_eip1459() {
+        // A 16-byte abbreviated hash must encode to the 26-char labels used in DNS.
+        assert_eq!(base32_encode(&[0xab; HASH_ABBREV_BYTES]).len(), 26);
+    }
+
+    #[test]
+    fn base32_decode_rejects_invalid_characters() {
+        assert!(base32_decode("ABC1").is_none()); // '1' is not in the alphabet
+        assert!(base32_decode("A B").is_none());
+    }
+
+    #[test]
+    fn parses_enrtree_link() {
+        let link: EnrTreeLink = format!("enrtree://{ETHDISCO_KEY}@all.sepolia.ethdisco.net")
+            .parse()
+            .expect("valid link");
+        assert_eq!(link.domain, "all.sepolia.ethdisco.net");
+    }
+
+    #[test]
+    fn rejects_malformed_links() {
+        for bad in [
+            "enrtree://nokey",
+            "enrtree://@all.sepolia.ethdisco.net",
+            "https://all.sepolia.ethdisco.net",
+            &format!("enrtree://{ETHDISCO_KEY}@"),
+        ] {
+            assert!(
+                bad.parse::<EnrTreeLink>().is_err(),
+                "should have rejected {bad}"
+            );
+        }
+    }
+
+    /// Live root of `all.sepolia.ethdisco.net`, captured 2026-07-31. Pins the
+    /// signed preimage: the signature covers the record *without* its `sig=`
+    /// field, so a change in how `signed_content` is built breaks this test.
+    const SEPOLIA_ROOT: &str = "enrtree-root:v1 e=HB5O4I23N7IDSXPDD2DVKYC4TY l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=5211 sig=S3ReY3w2hrJRQ2pM2jE0ZguIYtYq8r_zrAwA7uy3CF9DhUgg-7EsDrQ3llPPgEsBLUSA1np4mxEYR5FD0XxEtQE";
+
+    #[test]
+    fn verifies_real_root_signature() {
+        let link: EnrTreeLink = format!("enrtree://{ETHDISCO_KEY}@all.sepolia.ethdisco.net")
+            .parse()
+            .expect("valid link");
+        let root = RootEntry::parse(SEPOLIA_ROOT).expect("valid root");
+        assert_eq!(root.seq, 5211);
+        assert_eq!(root.enr_root, "HB5O4I23N7IDSXPDD2DVKYC4TY");
+        assert_eq!(
+            root.signed_content(),
+            "enrtree-root:v1 e=HB5O4I23N7IDSXPDD2DVKYC4TY l=FDXN3SN67NA5DKA4J2GOK7BVQI seq=5211"
+        );
+        assert!(root.verify_signature(&link.public_key));
+    }
+
+    #[test]
+    fn rejects_root_signed_by_another_key() {
+        // Same record, different tree key: must not verify.
+        let other_key = PublicKey::from_secret_key(
+            secp256k1::SECP256K1,
+            &secp256k1::SecretKey::from_slice(&[7u8; 32]).expect("valid key"),
+        );
+        let root = RootEntry::parse(SEPOLIA_ROOT).expect("valid root");
+        assert!(!root.verify_signature(&other_key));
+    }
+
+    #[test]
+    fn rejects_tampered_root() {
+        // Bump seq but keep the signature: verification must fail.
+        let tampered = SEPOLIA_ROOT.replace("seq=5211", "seq=5212");
+        let link: EnrTreeLink = format!("enrtree://{ETHDISCO_KEY}@all.sepolia.ethdisco.net")
+            .parse()
+            .expect("valid link");
+        let root = RootEntry::parse(&tampered).expect("parses");
+        assert!(!root.verify_signature(&link.public_key));
+    }
+
+    #[test]
+    fn rejects_root_with_missing_fields() {
+        assert!(RootEntry::parse("enrtree-root:v1 e=AAA l=BBB sig=CCC").is_err());
+        assert!(RootEntry::parse("enrtree-root:v2 e=AAA l=BBB seq=1 sig=CCC").is_err());
+    }
+
+    #[test]
+    fn label_verification_detects_substitution() {
+        let record = "enrtree-branch:";
+        let digest = keccak_hash(record.as_bytes());
+        let label = base32_encode(&digest[..HASH_ABBREV_BYTES]);
+        assert!(label_matches_record(&label, record));
+        assert!(!label_matches_record(&label, "enrtree-branch:AAAA"));
+    }
+
+    // A locally-signed tree lets the walk be tested end to end without DNS.
+    fn signed_root(secret: &secp256k1::SecretKey, enr_root: &str, link_root: &str) -> String {
+        let content = format!("{ROOT_PREFIX} e={enr_root} l={link_root} seq=1");
+        let digest = keccak_hash(content.as_bytes());
+        let message = secp256k1::Message::from_digest_slice(&digest).expect("32 bytes");
+        let (recovery_id, sig) = secp256k1::SECP256K1
+            .sign_ecdsa_recoverable(&message, secret)
+            .serialize_compact();
+        let mut full = sig.to_vec();
+        full.push(i32::from(recovery_id) as u8);
+        let encoded = String::from_utf8(ethrex_common::base64::encode(&full)).expect("ascii");
+        format!("{content} sig={}", encoded.trim_end_matches('='))
+    }
+
+    /// Real sepolia ENRs pulled from `all.sepolia.ethdisco.net` on 2026-07-31.
+    /// Using genuine records means the test also covers ENR self-signature
+    /// verification, not just the tree walk.
+    const ENR_A: &str = "enr:-KO4QKgAqcMkgAQnYWG9dYUuRdH6D-2uSGw98ABfq_fAou49RmH-527_WvKj0VIgXpt_wa19KVWkUAE50mVVdJPqoNGGAZXSmWFXg2V0aMfGhCaJVraAgmlkgnY0gmlwhMApTdiJc2VjcDI1NmsxoQPIXgr6uOZRUK3f9hySAd4hlqBhCzXDq8bB5hARPbaBIIRzbmFwwIN0Y3CCdl-DdWRwgnZf";
+    const ENR_B: &str = "enr:-J24QFSMwERNztHqJdAF86e2y_j6LqiB4Ma0yMFahPuolCopJE9san-5fFsjvtos3R3QCPo-q8wLP-fFO3SVVzSmAKKGAZ17xbL4g2V0aMfGhCaJVraAgmlkgnY0gmlwhFwFA2-Jc2VjcDI1NmsxoQJgJXtzDmONKBJiQEncZR_acBwzZ0m3ae1HqmkYFbHkToN0Y3CCdl-DdWRwgnZf";
+
+    #[test]
+    fn parses_and_verifies_real_enr_leaves() {
+        for enr in [ENR_A, ENR_B] {
+            match TreeEntry::parse(enr) {
+                Ok(TreeEntry::Enr(record)) => {
+                    assert!(record.verify_signature(), "ENR signature should verify");
+                    assert!(Node::from_enr(&record).is_ok(), "ENR should yield a node");
+                }
+                _ => panic!("expected an ENR leaf"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn walks_tree_and_collects_nodes() {
+        let secret = secp256k1::SecretKey::from_slice(&[3u8; 32]).expect("valid key");
+        let public_key = PublicKey::from_secret_key(secp256k1::SECP256K1, &secret);
+        let domain = "nodes.test";
+
+        // Leaves first, then a branch pointing at them, then the root.
+        let (mut dns, leaf_labels) = tree(domain, vec![ENR_A.to_string(), ENR_B.to_string()]);
+        let branch = format!("{BRANCH_PREFIX}{}", leaf_labels.join(","));
+        let (branch_dns, branch_labels) = tree(domain, vec![branch]);
+        dns.extend(branch_dns);
+        let empty_links = BRANCH_PREFIX.to_string();
+        let (links_dns, link_labels) = tree(domain, vec![empty_links]);
+        dns.extend(links_dns);
+        dns.insert(
+            domain.to_string(),
+            signed_root(&secret, &branch_labels[0], &link_labels[0]),
+        );
+
+        let discovery = DnsDiscovery::new(
+            MockResolver(dns),
+            vec![EnrTreeLink {
+                public_key,
+                domain: domain.to_string(),
+            }],
+        );
+        let nodes = discovery.sync().await;
+        assert_eq!(nodes.len(), 2, "should have found both ENR leaves");
+    }
+
+    #[tokio::test]
+    async fn rejects_tree_whose_root_is_signed_by_another_key() {
+        let signing_secret = secp256k1::SecretKey::from_slice(&[3u8; 32]).expect("valid key");
+        let expected_key = PublicKey::from_secret_key(
+            secp256k1::SECP256K1,
+            &secp256k1::SecretKey::from_slice(&[4u8; 32]).expect("valid key"),
+        );
+        let domain = "nodes.test";
+
+        let (mut dns, leaf_labels) = tree(domain, vec![ENR_A.to_string()]);
+        let branch = format!("{BRANCH_PREFIX}{}", leaf_labels.join(","));
+        let (branch_dns, branch_labels) = tree(domain, vec![branch]);
+        dns.extend(branch_dns);
+        dns.insert(
+            domain.to_string(),
+            signed_root(&signing_secret, &branch_labels[0], ""),
+        );
+
+        let discovery = DnsDiscovery::new(
+            MockResolver(dns),
+            vec![EnrTreeLink {
+                public_key: expected_key,
+                domain: domain.to_string(),
+            }],
+        );
+        assert!(
+            discovery.sync().await.is_empty(),
+            "a root signed by the wrong key must yield no nodes"
+        );
+    }
+
+    #[tokio::test]
+    async fn stops_at_request_budget_on_a_cyclic_tree() {
+        // A branch that lists its own label would loop forever without the
+        // visited set; the budget is the backstop if a tree fans out instead.
+        let secret = secp256k1::SecretKey::from_slice(&[3u8; 32]).expect("valid key");
+        let public_key = PublicKey::from_secret_key(secp256k1::SECP256K1, &secret);
+        let domain = "loop.test";
+
+        let mut dns = HashMap::new();
+        // Self-referential branch: label(record) is inside record's own child list.
+        // Build it by fixpoint: a branch listing a label we then make resolve to itself.
+        let placeholder = BRANCH_PREFIX.to_string();
+        let digest = keccak_hash(placeholder.as_bytes());
+        let self_label = base32_encode(&digest[..HASH_ABBREV_BYTES]);
+        dns.insert(format!("{self_label}.{domain}"), placeholder);
+        dns.insert(
+            domain.to_string(),
+            signed_root(&secret, &self_label, &self_label),
+        );
+
+        let discovery = DnsDiscovery::new(
+            MockResolver(dns),
+            vec![EnrTreeLink {
+                public_key,
+                domain: domain.to_string(),
+            }],
+        )
+        .with_limits(8, 8);
+        assert!(discovery.sync().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_unreachable_tree_does_not_block_the_others() {
+        let secret = secp256k1::SecretKey::from_slice(&[3u8; 32]).expect("valid key");
+        let public_key = PublicKey::from_secret_key(secp256k1::SECP256K1, &secret);
+        let domain = "nodes.test";
+
+        let (mut dns, leaf_labels) = tree(domain, vec![ENR_A.to_string()]);
+        let branch = format!("{BRANCH_PREFIX}{}", leaf_labels.join(","));
+        let (branch_dns, branch_labels) = tree(domain, vec![branch]);
+        dns.extend(branch_dns);
+        dns.insert(
+            domain.to_string(),
+            signed_root(&secret, &branch_labels[0], ""),
+        );
+
+        let discovery = DnsDiscovery::new(
+            MockResolver(dns),
+            vec![
+                EnrTreeLink {
+                    public_key,
+                    domain: "does-not-resolve.test".to_string(),
+                },
+                EnrTreeLink {
+                    public_key,
+                    domain: domain.to_string(),
+                },
+            ],
+        );
+        assert_eq!(discovery.sync().await.len(), 1);
+    }
+}

--- a/crates/networking/p2p/discovery/dns.rs
+++ b/crates/networking/p2p/discovery/dns.rs
@@ -14,6 +14,13 @@
 //! `base32(keccak256(child_record_text)[..16])` — verified on every fetch, which
 //! makes the whole tree tamper-evident under one signature.
 //!
+//! Note that a bundled list of discv5 ENRs is *not* an equivalent fallback, even
+//! though other clients ship one: theirs hold only consensus-layer records (an
+//! `eth2`/`attnets` key, no `eth` key, and a TCP port of 0 or a beacon port), so
+//! none of those nodes can ever become an execution-layer peer. A DNS node list
+//! is the only bootstrap source that is both independent of the bootnodes and
+//! actually made of execution-layer nodes.
+//!
 //! See <https://eips.ethereum.org/EIPS/eip-1459>.
 
 use std::{collections::HashSet, future::Future, str::FromStr, time::Duration};
@@ -51,10 +58,13 @@ pub const DEFAULT_MAX_REQUESTS: usize = 512;
 /// How deep we follow `enrtree://` links into other trees.
 const MAX_LINK_DEPTH: usize = 1;
 
-/// Interval between DNS re-syncs. The published trees change on the order of
-/// minutes, and this path only needs to keep a *bootstrap* supply of contacts
-/// available, so a slow poll is enough.
+/// Interval between DNS re-syncs once a sync has succeeded. The published trees
+/// change on the order of minutes, and this path only needs to keep a
+/// *bootstrap* supply of contacts available, so a slow poll is enough.
 pub const DNS_SYNC_INTERVAL: Duration = Duration::from_secs(30 * 60);
+/// First retry delay after a sync that produced no nodes. Doubles up to
+/// [`DNS_SYNC_INTERVAL`]; see [`next_sync_delay`].
+pub const DNS_RETRY_MIN_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Error)]
 pub enum DnsDiscoveryError {
@@ -494,12 +504,29 @@ impl TxtResolver for SystemResolver {
     }
 }
 
+/// Delay before the next sync, given how many syncs in a row produced nothing.
+///
+/// A sync that yields no nodes retries quickly and backs off toward the
+/// steady-state interval. This matters because DNS is not merely a supplement in
+/// practice: when the bootnodes are unreachable it is the *only* way in, so
+/// waiting a full interval after a transient resolver failure would leave the
+/// node peerless for that whole time.
+fn next_sync_delay(consecutive_empty_syncs: u32) -> Duration {
+    let Some(attempt) = consecutive_empty_syncs.checked_sub(1) else {
+        return DNS_SYNC_INTERVAL;
+    };
+    // Shift is clamped well below u32's width, so the doubling cannot overflow.
+    DNS_RETRY_MIN_INTERVAL
+        .saturating_mul(1u32 << attempt.min(16))
+        .min(DNS_SYNC_INTERVAL)
+}
+
 /// Periodically syncs the configured DNS node lists into the peer table.
 ///
-/// Runs alongside discv4/discv5 rather than gating startup on it: DNS is a
-/// bootstrap *supplement*, and a slow or unreachable resolver must never delay
-/// the node coming up. Contacts are added exactly the way bootnodes are, so they
-/// get pinged, validated and dialed through the existing paths.
+/// Runs alongside discv4/discv5 rather than gating startup on it, so a slow or
+/// unreachable resolver never delays the node coming up. Contacts are added
+/// exactly the way bootnodes are, so they get pinged, validated and dialed
+/// through the existing paths.
 pub async fn run_dns_discovery(
     peer_table: PeerTable,
     links: Vec<EnrTreeLink>,
@@ -520,11 +547,17 @@ pub async fn run_dns_discovery(
     info!(trees = %domains, "Starting DNS discovery");
 
     let discovery = DnsDiscovery::new(resolver, links);
+    let mut consecutive_empty_syncs = 0u32;
     loop {
         let nodes = discovery.sync().await;
         if nodes.is_empty() {
-            warn!("DNS discovery sync returned no nodes");
+            consecutive_empty_syncs = consecutive_empty_syncs.saturating_add(1);
+            warn!(
+                attempt = consecutive_empty_syncs,
+                "DNS discovery sync returned no nodes"
+            );
         } else {
+            consecutive_empty_syncs = 0;
             info!(count = nodes.len(), "DNS discovery: adding contacts");
             for protocol in &protocols {
                 if let Err(e) = peer_table.new_contacts(nodes.clone(), *protocol) {
@@ -532,7 +565,9 @@ pub async fn run_dns_discovery(
                 }
             }
         }
-        tokio::time::sleep(DNS_SYNC_INTERVAL).await;
+        let delay = next_sync_delay(consecutive_empty_syncs);
+        debug!(?delay, "DNS discovery: sleeping until next sync");
+        tokio::time::sleep(delay).await;
     }
 }
 
@@ -568,6 +603,27 @@ mod tests {
             labels.push(label);
         }
         (dns, labels)
+    }
+
+    #[test]
+    fn retries_quickly_after_an_empty_sync_then_backs_off() {
+        // A successful sync waits the full steady-state interval.
+        assert_eq!(next_sync_delay(0), DNS_SYNC_INTERVAL);
+        // The first empty sync must retry soon, not an interval later: with the
+        // bootnodes unreachable this is the only path to a peer.
+        assert_eq!(next_sync_delay(1), DNS_RETRY_MIN_INTERVAL);
+        assert_eq!(next_sync_delay(2), DNS_RETRY_MIN_INTERVAL * 2);
+        assert_eq!(next_sync_delay(3), DNS_RETRY_MIN_INTERVAL * 4);
+        // Backoff is monotonic and never exceeds the steady-state interval.
+        let mut previous = Duration::ZERO;
+        for attempt in 0..64 {
+            let delay = next_sync_delay(attempt + 1);
+            assert!(delay <= DNS_SYNC_INTERVAL, "attempt {attempt} overshot");
+            assert!(delay >= previous, "attempt {attempt} went backwards");
+            previous = delay;
+        }
+        // Deep into the backoff it has saturated rather than overflowed.
+        assert_eq!(next_sync_delay(u32::MAX), DNS_SYNC_INTERVAL);
     }
 
     #[test]

--- a/crates/networking/p2p/discovery/mod.rs
+++ b/crates/networking/p2p/discovery/mod.rs
@@ -13,6 +13,7 @@
 pub mod codec;
 mod discv4_handlers;
 mod discv5_handlers;
+pub mod dns;
 pub mod lookup;
 pub mod server;
 
@@ -26,6 +27,8 @@ pub struct DiscoveryConfig {
     pub discv4_enabled: bool,
     pub discv5_enabled: bool,
     pub initial_lookup_interval: f64,
+    /// EIP-1459 trees to pull bootstrap nodes from. Empty disables DNS discovery.
+    pub dns_discovery_links: Vec<dns::EnrTreeLink>,
 }
 
 impl Default for DiscoveryConfig {
@@ -34,6 +37,7 @@ impl Default for DiscoveryConfig {
             discv4_enabled: true,
             discv5_enabled: true,
             initial_lookup_interval: INITIAL_LOOKUP_INTERVAL_MS,
+            dns_discovery_links: Vec::new(),
         }
     }
 }

--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -458,6 +458,7 @@ impl DiscoveryServer {
                 discv4_enabled: false,
                 discv5_enabled: true,
                 initial_lookup_interval: 1000.0,
+                dns_discovery_links: Vec::new(),
             },
             discv4: None,
             discv5: Some(Discv5State::default()),

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -4,9 +4,9 @@ use crate::rlpx::l2::l2_connection::P2PBasedContext;
 #[derive(Clone, Debug)]
 pub struct P2PBasedContext;
 use crate::{
-    discovery::{DiscoveryConfig, DiscoveryServer, DiscoveryServerError},
+    discovery::{DiscoveryConfig, DiscoveryServer, DiscoveryServerError, dns},
     metrics::{CurrentStepValue, METRICS},
-    peer_table::{PeerData, PeerTable, PeerTableServerProtocol as _},
+    peer_table::{DiscoveryProtocol, PeerData, PeerTable, PeerTableServerProtocol as _},
     rlpx::{
         connection::server::{PeerConnBroadcastSender, PeerConnection},
         message::Message,
@@ -130,6 +130,16 @@ pub async fn start_network(
             .map_err(NetworkError::UdpSocketError)?,
     );
 
+    // Read what the DNS task needs before `config` is moved into the server.
+    let dns_discovery_links = config.dns_discovery_links.clone();
+    let dns_discovery_protocols = [
+        (config.discv4_enabled, DiscoveryProtocol::Discv4),
+        (config.discv5_enabled, DiscoveryProtocol::Discv5),
+    ]
+    .into_iter()
+    .filter_map(|(enabled, protocol)| enabled.then_some(protocol))
+    .collect::<Vec<_>>();
+
     DiscoveryServer::spawn(
         context.storage.clone(),
         context.local_node.clone(),
@@ -146,6 +156,16 @@ pub async fn start_network(
     .inspect_err(|e| {
         error!("Failed to start discovery server: {e}");
     })?;
+
+    // An independent bootstrap path: if the hardcoded bootnodes stop answering,
+    // this is what still gets a node with an empty peer table into the network.
+    if !dns_discovery_links.is_empty() && !dns_discovery_protocols.is_empty() {
+        context.tracker.spawn(dns::run_dns_discovery(
+            context.table.clone(),
+            dns_discovery_links,
+            dns_discovery_protocols,
+        ));
+    }
 
     context.tracker.spawn(serve_p2p_requests(context.clone()));
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -182,6 +182,11 @@ P2P options:
           [default: true]
           [possible values: true, false]
 
+      --discovery.dns <ENRTREE_URLS>
+          Comma separated enrtree:// URLs for EIP-1459 DNS discovery. Defaults to the known network list; pass an empty string to disable.
+          
+          [env: ETHREX_DISCOVERY_DNS=]
+
       --p2p.tx-broadcasting-interval <INTERVAL_MS>
           Transaction Broadcasting Time Interval (ms) for batching transactions before broadcasting them.
           


### PR DESCRIPTION
**Motivation**

Discovery bootstrapping relies entirely on the bootnodes compiled into the binary: **4** for mainnet, 5 for sepolia, 16 for hoodi. When those hosts stop answering, a node whose peer table is empty has no path into the DHT at all — it re-pings the same dead addresses forever and sits at zero peers.

That is not hypothetical. All five of sepolia's EF execution-layer bootnodes stopped answering UDP discovery on 2026-07-30 and have not come back, and every fresh sepolia node has been stuck at zero peers since, unable to start snap sync even though the network itself is healthy and the consensus client peers normally. Reproduced on two unrelated hosts and networks: ~9.9k RLPx handshake timeouts and zero inbound discv4 messages from those five addresses, while a hoodi node on the same box peered normally.

Every other client survives this because it ships a DNS node list as a second, independent bootstrap source. ethrex was the only one without one. Note that mainnet is the *more* exposed network here, with one fewer bootnode than sepolia.

A bundled list of discv5 ENRs is **not** an equivalent fallback, even though it looks like one. go-ethereum's `V5Bootnodes` and Nethermind's `discv5-bootnodes.json` are the same 15 records in both clients, and all 15 are consensus-layer nodes: an `eth2`/`attnets` key, no `eth` key, and a TCP port of either 0 or a beacon port. None of them can ever become an execution-layer peer. A DNS node list is the only bootstrap source that is both independent of the bootnodes and actually made of execution-layer nodes. This is recorded in the module docs so the option isn't mistaken for a fix later.

**Description**

Implements EIP-1459 DNS-based node discovery in a new `crates/networking/p2p/discovery/dns.rs`.

A node list is a DNS-hosted Merkle tree of ENRs described by an `enrtree://<base32-pubkey>@<domain>` URL, so it can be refreshed without shipping a new binary:

- The root TXT record is **signature-verified** against the tree's public key, so a hijacked resolver cannot inject nodes. The signed preimage is the record without its `sig=` field; a test pins this against the real sepolia root so a change in how it is constructed fails loudly.
- Every interior record is addressed by `base32(keccak256(record)[..16])`, and that label is **verified on fetch**, which makes the whole tree tamper-evident under the one root signature.
- Each ENR's own signature is verified before its node is accepted.
- Both the node count and the DNS request count per sync are bounded, so a cyclic or adversarial tree cannot walk us indefinitely. Links to other trees are followed one level deep.

The walk runs as a background task rather than gating startup, since a slow resolver must never delay the node coming up. Nodes are added to the peer table exactly the way bootnodes are, so they get pinged, validated and dialed through the existing paths. A sync that yields nothing retries after a minute and backs off toward the 30-minute steady-state interval — when the bootnodes are unreachable this is the only way in, so waiting a full interval over a momentary resolver failure would leave the node peerless for that whole time.

Trees for mainnet, sepolia and hoodi are enabled by default. `--discovery.dns` / `ETHREX_DISCOVERY_DNS` overrides them; passing an empty string disables the feature.

Deliberately uses `new_contacts` rather than `new_contact_records`: the record path runs `evaluate_fork_id`, which returns `Some(false)` for an ENR carrying no `eth` key, and `is_fork_id_valid == Some(false)` marks a contact for pruning — routing DNS-discovered ENRs through it would silently discard them.

Adds one dependency, `hickory-resolver` (default features off, `system-config` + `tokio`), for TXT lookups. It sits behind a `TxtResolver` trait, so the tree walk is tested without DNS and the backend is a one-line swap.

**Testing**

16 unit tests covering base32 round-tripping and label lengths, enrtree URL parsing, root parsing and signature verification against the real sepolia root, rejection of a root signed by another key and of a tampered root, label-substitution detection, real ENR leaf parsing plus signature verification, an end-to-end walk over a locally-signed tree, request-budget termination on a cyclic tree, one unreachable tree not blocking the others, and the retry backoff schedule.

Validated A/B on sepolia while the bootnodes were still unreachable:

| | contacts from DNS | peers @30s | peers @35min |
|---|---|---|---|
| DNS discovery on | 250 | 3 | 5 |
| off (`--discovery.dns ""`) | — | 0 | 0 |

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Not applicable — no storage format change, and no resync is required.

---

Stopgap that unblocks CI while this is reviewed: #7076. That PR should be reverted once this lands.
