### PR TITLE
fix(l1): flush frame receipts with the storage codec

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -4503,7 +4503,7 @@ fn flush_block_data(
             tx.put(
                 RECEIPTS_V2,
                 &receipt_key(&hash, index as u64),
-                &receipt.encode_to_vec(),
+                &receipt.encode_storage(),
             )?;
         }
         max_number = max_number.max(b.number);

--- a/test/tests/storage/deferred_persistence_tests.rs
+++ b/test/tests/storage/deferred_persistence_tests.rs
@@ -1,6 +1,6 @@
 use ethrex_common::{
-    H256,
-    types::{Block, BlockBody, BlockHeader, BlockNumber},
+    Address, H256,
+    types::{Block, BlockBody, BlockHeader, BlockNumber, FrameReceipt, Receipt, TxType},
 };
 use ethrex_storage::{EngineType, Store, UpdateBatch};
 // Only the `rocksdb`-gated batch test below references the commit threshold. Keep the
@@ -66,6 +66,69 @@ async fn buffered_header_is_readable_before_flush() {
             .map(|h| h.number),
         Some(9)
     );
+}
+
+/// The buffer flush must persist receipts with the storage codec, the same one the
+/// read path decodes with. A frame receipt's consensus encoding omits `succeeded`
+/// and leads with `cumulative_gas_used`, so a receipt written through the wire codec
+/// is undecodable once the buffer drops it and `eth_getTransactionReceipt` starts
+/// answering with nothing for every frame transaction in a flushed block.
+#[tokio::test]
+async fn flushed_frame_receipt_survives_the_storage_codec() {
+    let store = Store::new("", EngineType::InMemory).expect("store");
+    let header = BlockHeader {
+        number: 1,
+        ..Default::default()
+    };
+    let block = Block::new(header.clone(), BlockBody::default());
+    let hash = block.hash();
+    let receipt = Receipt {
+        tx_type: TxType::Frame,
+        succeeded: false,
+        cumulative_gas_used: 22_910,
+        logs: vec![],
+        payer: Some(Address::repeat_byte(0x11)),
+        frame_receipts: Some(vec![
+            FrameReceipt {
+                status: 1,
+                gas_used: 0,
+                logs: vec![],
+            },
+            FrameReceipt {
+                status: 0,
+                gas_used: 100_000,
+                logs: vec![],
+            },
+        ]),
+    };
+
+    store
+        .store_block_updates(UpdateBatch {
+            account_updates: vec![],
+            storage_updates: vec![],
+            receipts: vec![(hash, vec![receipt.clone()])],
+            blocks: vec![block],
+            code_updates: vec![],
+            commit_depth: None,
+            wait_for_flush: false,
+        })
+        .expect("store updates");
+    store.flush_block_data_for_test().expect("flush");
+    store
+        .add_block_header(hash, header)
+        .await
+        .expect("add header");
+    store
+        .forkchoice_update(vec![], 1, hash, None, None)
+        .await
+        .expect("fcu");
+
+    let stored = store
+        .get_receipt(1, 0)
+        .await
+        .expect("read receipt")
+        .expect("receipt present after flush");
+    assert_eq!(stored, receipt);
 }
 
 /// Helper: build a minimal UpdateBatch for a single block at `number` whose


### PR DESCRIPTION
**Motivation**

The block-data buffer flush writes receipts with the consensus codec (`encode_to_vec`), while `add_receipt`, `add_receipts` and the read path (`get_receipt_by_block_hash`) all use the storage codec. For non-frame receipts the two encodings coincide, so the mismatch never showed.

An EIP-8141 frame receipt is different: its consensus layout omits the top-level `succeeded` and leads with `cumulative_gas_used`. `decode_storage` therefore reads a gas value where it expects a bool and fails with `MalformedBoolean`. The receipt is served correctly from the buffer and becomes permanently unreadable the moment the block is flushed.

**Description**

One line: the flush path now uses `encode_storage()`, matching every other writer and the reader.

**How was it found**

On a Nethermind + ethrex devnet. Both clients agreed on block 69 byte for byte — same block hash, state root, receipts root and block access list hash — and both served `eth_getTransactionByHash` for the frame transaction in it, but `eth_getTransactionReceipt` returned `null` on ethrex. `eth_getBlockReceipts` surfaced the real cause:

```
Internal Error: Error decoding field 'succeeded' of type bool: MalformedBoolean
```

**Tests**

`flushed_frame_receipt_survives_the_storage_codec` stores a frame receipt through `store_block_updates`, forces a flush so the buffer can no longer answer, and reads it back. Verified in both directions: it fails with `MalformedBoolean` on the previous line and passes with the fix.

The fix is forward-only. Frame receipts already written by the old path stay on disk in the consensus encoding and keep failing to decode, so `eth_getTransactionReceipt` still returns null for those blocks until the node resyncs. Non-frame receipts encode identically under both codecs, so nothing before Hegota is affected.