### PR TITLE
fix(levm): reserve the calldata floor instead of rejecting the frame transaction

### DIFF
--- a/crates/common/types/transaction.rs
+++ b/crates/common/types/transaction.rs
@@ -2155,6 +2155,18 @@ impl FrameTransaction {
             )
     }
 
+    /// EIP-8141 `max_gas`: what the payer's maximum cost is reserved against.
+    ///
+    /// A transaction whose frames reserve less than its own calldata floor is not
+    /// invalid — the spec raises the reservation to the floor instead, so the payer
+    /// can always cover the floor-priced charge that settlement applies. The extra
+    /// headroom is never spendable by a frame (each keeps its own `gas_limit`); it
+    /// is reserved and refunded.
+    pub fn max_gas(&self) -> u64 {
+        self.total_gas_limit()
+            .max(self.mandatory_gas().saturating_add(self.calldata_floor_gas()))
+    }
+
     /// The expiry deadline (8-byte big-endian) of this transaction's expiry
     /// verifier frame, if one exists with well-formed data.
     pub fn expiry_deadline(&self) -> Option<u64> {
@@ -2320,15 +2332,6 @@ impl FrameTransaction {
                     Some(_) => {}
                 }
             }
-        }
-        // Per EIP-8141, the EIP-7623 calldata floor must be reserved independently
-        // of execution: the derived `tx_gas_limit` has to cover the mandatory costs
-        // plus the floor, or the transaction cannot pay for the data it carries.
-        let floor_gas = self.calldata_floor_gas();
-        if self.total_gas_limit() < self.mandatory_gas().saturating_add(floor_gas) {
-            return Err(format!(
-                "Total gas limit does not reserve the calldata floor of {floor_gas}"
-            ));
         }
         Ok(())
     }

--- a/crates/vm/levm/src/opcode_handlers/frame_tx.rs
+++ b/crates/vm/levm/src/opcode_handlers/frame_tx.rs
@@ -40,7 +40,7 @@ pub fn u256_to_offset(value: U256) -> Option<usize> {
 
 /// Compute the transaction's MAXIMUM cost (EIP-8141 §Gas Accounting: APPROVE must
 /// "collect the transaction's maximum cost from payer"):
-/// `max_cost = max_fee_per_gas * total_gas_limit
+/// `max_cost = max_fee_per_gas * max_gas
 ///           + len(blob_hashes) * 131072 * max_fee_per_blob_gas`.
 /// This is the single definition of "maximum cost": APPROVE (scopes 0x1/0x3)
 /// debits it from the payer, TXPARAM(0x06) reports it, and the
@@ -51,7 +51,7 @@ pub fn u256_to_offset(value: U256) -> Option<usize> {
 /// non-refundable).
 pub(crate) fn compute_tx_max_cost(ctx: &crate::vm::FrameTxContext) -> Result<U256, VMError> {
     let gas_cost = U256::from(ctx.tx.max_fee_per_gas)
-        .checked_mul(U256::from(ctx.total_gas_limit))
+        .checked_mul(U256::from(ctx.max_gas))
         .ok_or(ExceptionalHalt::InvalidOpcode)?;
     let blob_cost = U256::from(ctx.tx.blob_versioned_hashes.len())
         .checked_mul(U256::from(131072u64))
@@ -671,7 +671,7 @@ mod max_cost_tests {
     use crate::vm::FrameTxContext;
     use ethrex_common::{H256, U256, types::FrameTransaction};
 
-    fn ctx(max_fee: u64, blobs: usize, max_blob_fee: u64, total_gas_limit: u64) -> FrameTxContext {
+    fn ctx(max_fee: u64, blobs: usize, max_blob_fee: u64, max_gas: u64) -> FrameTxContext {
         let tx = FrameTransaction {
             max_fee_per_gas: max_fee,
             max_fee_per_blob_gas: U256::from(max_blob_fee),
@@ -686,7 +686,7 @@ mod max_cost_tests {
             sig_hash: H256::zero(),
             tx,
             approve_called_in_current_frame: false,
-            total_gas_limit,
+            max_gas,
         }
     }
 
@@ -695,7 +695,7 @@ mod max_cost_tests {
         // 10 * 100_000 + 2 * 131072 * 5 = 1_000_000 + 1_310_720
         let c = ctx(10, 2, 5, 100_000);
         assert_eq!(compute_tx_max_cost(&c).unwrap(), U256::from(2_310_720u64));
-        // No blobs: just max_fee * total_gas_limit.
+        // No blobs: just max_fee * max_gas.
         let c = ctx(7, 0, 999, 21_000);
         assert_eq!(compute_tx_max_cost(&c).unwrap(), U256::from(147_000u64));
     }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -518,10 +518,11 @@ pub struct FrameTxContext {
     pub tx: ethrex_common::types::FrameTransaction,
     /// Whether APPROVE was called in the current frame
     pub approve_called_in_current_frame: bool,
-    /// Cached `FrameTransaction::total_gas_limit()`. Computing it re-encodes
-    /// every frame and signature, so it must not run per-opcode (TXPARAM 0x06,
+    /// Cached `FrameTransaction::max_gas()`, the EIP-8141 `max_gas` the payer's
+    /// maximum cost is reserved against. Computing it re-encodes every frame and
+    /// signature, so it must not run per-opcode (TXPARAM 0x06,
     /// compute_tx_max_cost). Computed once at tx entry.
-    pub total_gas_limit: u64,
+    pub max_gas: u64,
 }
 
 impl FrameTxContext {
@@ -1597,6 +1598,7 @@ impl<'a> VM<'a> {
         // Initialize FrameTxContext
         let sig_hash = frame_tx.compute_sig_hash();
         let total_gas_limit = frame_tx.total_gas_limit();
+        let max_gas = frame_tx.max_gas();
         self.frame_tx_context = Some(FrameTxContext {
             sender_approved: false,
             payer_address: None,
@@ -1605,7 +1607,7 @@ impl<'a> VM<'a> {
             sig_hash,
             tx: frame_tx.clone(),
             approve_called_in_current_frame: false,
-            total_gas_limit,
+            max_gas,
         });
 
         // EIP-8141: every outer signature must validate
@@ -2387,7 +2389,7 @@ impl<'a> VM<'a> {
         }
 
         let sig_hash = frame_tx.compute_sig_hash();
-        let total_gas_limit = frame_tx.total_gas_limit();
+        let max_gas = frame_tx.max_gas();
         self.frame_tx_context = Some(FrameTxContext {
             sender_approved: false,
             payer_address: None,
@@ -2396,7 +2398,7 @@ impl<'a> VM<'a> {
             sig_hash,
             tx: frame_tx.clone(),
             approve_called_in_current_frame: false,
-            total_gas_limit,
+            max_gas,
         });
 
         if !validate_frame_signatures(

--- a/test/tests/common/frame_tx_validation_tests.rs
+++ b/test/tests/common/frame_tx_validation_tests.rs
@@ -624,7 +624,7 @@ fn data_cost_covers_only_frame_and_signature_data() {
 }
 
 #[test]
-fn static_validation_requires_the_calldata_floor_to_be_reserved() {
+fn a_transaction_reserving_less_than_its_calldata_floor_raises_max_gas() {
     let mut tx = make_test_frame_tx();
     // 64 bytes of frame data need 4096 gas of floor, which frames carrying
     // 100 gas each cannot reserve.
@@ -633,12 +633,14 @@ fn static_validation_requires_the_calldata_floor_to_be_reserved() {
     tx.frames[1].data = Bytes::new();
     tx.frames[0].gas_limit = 100;
     tx.frames[1].gas_limit = 100;
-    assert!(
-        tx.validate_static_constraints()
-            .unwrap_err()
-            .contains("does not reserve the calldata floor of 4096"),
-    );
-    // Enough frame gas to cover the floor makes it valid again.
-    tx.frames[1].gas_limit = 4096;
+    // EIP-8141 resolves the shortfall by reserving `max(standard_gas_limit,
+    // calldata_floor_gas)`, not by invalidating the transaction: rejecting it here
+    // would fork away from any client that reserves the max.
     assert!(tx.validate_static_constraints().is_ok());
+    assert!(tx.total_gas_limit() < tx.mandatory_gas() + tx.calldata_floor_gas());
+    assert_eq!(tx.max_gas(), tx.mandatory_gas() + tx.calldata_floor_gas());
+
+    // Frames that already reserve more than the floor keep their own total.
+    tx.frames[1].gas_limit = 1_000_000;
+    assert_eq!(tx.max_gas(), tx.total_gas_limit());
 }


### PR DESCRIPTION
EIP-8141 resolves a frame transaction whose frames reserve less gas than its own calldata floor by raising the reservation, not by rejecting the transaction: the payer's maximum cost is taken against `max(standard_gas_limit, calldata_floor_gas)`.

`validate_static_constraints` rejected that transaction instead. A client that reserves the max accepts a block containing one, so the same block is valid for that client and invalid here — a consensus split rather than a difference in error text. Nethermind had the same bug independently; it is fixed there in NethermindEth/nethermind#12594.

This drops the rejection and adds `FrameTransaction::max_gas()`, which the reservation and the end-of-transaction refund read. The frames keep their own `gas_limit` allocations, so the extra headroom is never spendable — it is reserved and refunded.

The static-validation test that asserted the rejection is replaced by one asserting the raised reservation.
