### PR TITLE
perf(l1): keep the memoize_hashes guard out of the recursive call

### DIFF
--- a/crates/common/trie/node.rs
+++ b/crates/common/trie/node.rs
@@ -323,13 +323,34 @@ impl NodeRef {
         }
     }
 
+    /// Memoizes this reference's subtrie hash, if there is anything to do.
+    ///
+    /// The guard is deliberately split from the recursive body. A branch node
+    /// visits all 16 of its children, but the vast majority of child references
+    /// are `NodeRef::Hash` or empty slots with nothing to memoize (measured on a
+    /// mainnet block witness: ~93%). Because the body is recursive LLVM will not
+    /// inline it, so keeping the guard in a separate `#[inline]` shell makes the
+    /// overwhelmingly common no-op case a load and a branch at the call site
+    /// instead of a full call.
+    #[inline]
     pub fn memoize_hashes(&self, buf: &mut Vec<u8>, crypto: &dyn Crypto) {
         if let NodeRef::Node(node, hash) = &self
             && hash.get().is_none()
         {
-            node.memoize_hashes(buf, crypto);
-            let _ = hash.set(node.compute_hash_no_alloc(buf, crypto));
+            Self::memoize_hashes_uncached(node, hash, buf, crypto);
         }
+    }
+
+    /// Cold path of [`Self::memoize_hashes`]: this reference is an embedded node
+    /// whose hash is not memoized yet, so descend into it and compute it.
+    fn memoize_hashes_uncached(
+        node: &Arc<Node>,
+        hash: &OnceLock<NodeHash>,
+        buf: &mut Vec<u8>,
+        crypto: &dyn Crypto,
+    ) {
+        node.memoize_hashes(buf, crypto);
+        let _ = hash.set(node.compute_hash_no_alloc(buf, crypto));
     }
 
     /// Resets the memoized hash of this Node


### PR DESCRIPTION
**Motivation**

`NodeRef::memoize_hashes` already skips subtries whose hash is memoized, and `NodeRef::Hash` references have nothing to memoize at all. The problem is where that check lives: `Node::memoize_hashes` visits all 16 children of a branch node, and because the body is recursive LLVM will not inline it — so every child costs a real function call even when the answer is immediately "nothing to do".

How lopsided that is, measured on a real mainnet block execution witness (block 25368371):

| child references | count | share |
|---|---|---|
| `NodeRef::Node` (embedded, must be hashed) | 1,273 | **7.3%** |
| `NodeRef::Hash` (hash only, nothing to do) | 13,102 | **75.1%** |
| empty slots | 3,086 | 17.6% |

So ~93% of the references a branch iterates over have no work behind them. Counting actual calls during a stateless execution of that block:

```
NodeRef::memoize_hashes entered   54,810 times
hash actually computed             2,094 times   -> 96.2% of calls were no-ops
```

**Description**

Split the guard into an `#[inline]` shell and move the recursive body into a separate function, so the overwhelmingly common no-op case becomes a load and a branch at the call site instead of a call.

Behaviour is unchanged — this is purely about where the code lives. `cargo test -p ethrex-trie` passes (61 tests), `fmt` and `clippy` are clean.

**Effect**

The win scales with how poorly the call overhead is amortised. The measurement above comes from the [LambdaVM](https://github.com/yetanotherco/lambda_vm) zkVM guest, where every executed RISC-V instruction is proven and there is no out-of-order core to hide the call:

| | cycles |
|---|---|
| before | 26,794,880 |
| after | 25,314,781 |
| | **−1,480,099 (−5.52% of total block execution)** |

`memoize_hashes` disappeared from the guest profile entirely (1,786,030 → 0 self cycles), and the trie went from 20.5% to 15.9% of the block.

Native gains will be considerably smaller — a modern core predicts and pipelines these calls well — but the change strictly removes work, so it should not regress anywhere. Happy to add a native benchmark if you'd like a number for that path before merging.
