### PR TITLE
ci(l1,l2): key pooled rust caches by runner image

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -58,7 +58,15 @@ runs:
     - name: Add Rust Cache
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ inputs.cache-pool }}
+        # ImageOS (e.g. ubuntu22, ubuntu24, macos14) keeps runner images from
+        # sharing one pool entry: rust-cache's default key only carries
+        # runner.os ("Linux"), so an ubuntu-latest job could save proc-macro
+        # dylibs linked against a newer glibc that ubuntu-22.04 jobs then
+        # restore and fail to load ("version `GLIBC_2.39' not found").
+        # Empty on self-hosted runners, which preserves the old key shape.
+        # Only pooled entries get the suffix: an empty shared-key must stay
+        # empty so pool-less jobs keep their per-job keys.
+        shared-key: ${{ inputs.cache-pool != '' && format('{0}-{1}', inputs.cache-pool, env.ImageOS) || '' }}
         save-if: ${{ inputs.save-cache == 'true' && github.ref == 'refs/heads/main' }}
         workspaces: |
           .


### PR DESCRIPTION
**Motivation**

The v24.0.0-rc.1 release build failed with:

```
libparity_scale_codec_derive-*.so: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.39' not found
```

Cache pools (`rust-cache`'s `shared-key`) are keyed only by `runner.os` ("Linux"), so `ubuntu-latest` (24.04) and `ubuntu-22.04` jobs in the same pool share one entry. The day's main push saved the `l2` pool entry from a 24.04 guest-build job; the tag run's 22.04 `build-ethrex` job restored it and could not load the glibc-2.39 proc-macro dylibs. Actions cache keys are immutable, so the poisoned entry persisted until deleted by hand (which is how the release was unblocked).

**Description**

Append `ImageOS` (`ubuntu22` / `ubuntu24` / `macos14`; empty on self-hosted runners) to the pooled `shared-key`, so different runner images never share dylib-bearing caches. The suffix is only applied when `cache-pool` is set — an empty `shared-key` must stay empty so pool-less jobs keep rust-cache's per-job keys.

Cost: one extra entry per (pool × image) actually in use; entries only save on `main`, unchanged.

**How to Test**

After merge, a main push saves `v0-rust-l2-ubuntu24-…` and 22.04 jobs restore/miss independently of it. The failure mode reproduced on [the v24.0.0-rc.1 run](https://github.com/lambdaclass/ethrex/actions/runs/30917441500) (attempt 1) and cleared after deleting cache key `v0-rust-l2-Linux-x64-1e811033-ba3f8f5a` and rerunning.