### PR TITLE
perf(l1): give branch-node hashing a monomorphic RLP encoder

### DIFF
--- a/crates/common/trie/node/branch.rs
+++ b/crates/common/trie/node/branch.rs
@@ -281,7 +281,7 @@ impl BranchNode {
     /// Computes the node's hash, using the provided buffer
     pub fn compute_hash_no_alloc(&self, buf: &mut Vec<u8>, crypto: &dyn Crypto) -> NodeHash {
         buf.clear();
-        self.encode(buf);
+        self.encode_into_vec(buf);
         let hash = NodeHash::from_encoded(buf, crypto);
         buf.clear();
         hash

--- a/crates/common/trie/rlp.rs
+++ b/crates/common/trie/rlp.rs
@@ -27,14 +27,19 @@ use crate::{Nibbles, NodeHash};
 // where `NativeCrypto` is the correct provider.
 impl RLPEncode for BranchNode {
     fn encode(&self, buf: &mut dyn bytes::BufMut) {
+        // Resolve each child's hash once: the length pass and the encode pass
+        // both needed it, so a 16-choice branch was paying 32 resolutions.
+        let hashes: [&NodeHash; 16] =
+            array::from_fn(|i| self.choices[i].compute_hash_ref(&NativeCrypto));
+
         let value_len = <[u8] as RLPEncode>::length(&self.value);
-        let payload_len = self.choices.iter().fold(value_len, |acc, child| {
-            acc + RLPEncode::length(child.compute_hash_ref(&NativeCrypto))
-        });
+        let payload_len = hashes
+            .iter()
+            .fold(value_len, |acc, hash| acc + RLPEncode::length(*hash));
 
         encode_length(payload_len, buf);
-        for child in self.choices.iter() {
-            match child.compute_hash_ref(&NativeCrypto) {
+        for hash in hashes {
+            match hash {
                 NodeHash::Hashed(hash) => hash.0.encode(buf),
                 NodeHash::Inline((_, 0)) => buf.put_u8(RLP_NULL),
                 NodeHash::Inline((encoded, len)) => buf.put_slice(&encoded[..*len as usize]),
@@ -66,6 +71,38 @@ impl RLPEncode for BranchNode {
         <[u8] as RLPEncode>::encode(&self.value, &mut buf);
 
         buf
+    }
+}
+
+impl BranchNode {
+    /// Concrete-typed sibling of `<Self as RLPEncode>::encode`, appending into a
+    /// `Vec<u8>` rather than a `&mut dyn BufMut`.
+    ///
+    /// `RLPEncode::encode` must take a trait object, so hashing a branch paid a
+    /// vtable dispatch for each of its ~41 `put_u8`/`put_slice` calls. Hashing is
+    /// the hot consumer (every `memoize_hashes` walk re-encodes each dirty
+    /// branch), so it gets a monomorphic path; `RLPEncode::encode` is untouched
+    /// for every other caller.
+    pub fn encode_into_vec(&self, buf: &mut Vec<u8>) {
+        let hashes: [&NodeHash; 16] =
+            array::from_fn(|i| self.choices[i].compute_hash_ref(&NativeCrypto));
+
+        let value_len = <[u8] as RLPEncode>::length(&self.value);
+        let payload_len = hashes
+            .iter()
+            .fold(value_len, |acc, hash| acc + RLPEncode::length(*hash));
+
+        encode_length(payload_len, buf);
+        for hash in hashes {
+            match hash {
+                NodeHash::Hashed(hash) => hash.0.encode(&mut *buf),
+                NodeHash::Inline((_, 0)) => buf.push(RLP_NULL),
+                NodeHash::Inline((encoded, len)) => {
+                    buf.extend_from_slice(&encoded[..*len as usize])
+                }
+            }
+        }
+        <[u8] as RLPEncode>::encode(&self.value, buf);
     }
 }
 


### PR DESCRIPTION
**Motivation**

`RLPEncode::encode` takes `&mut dyn bytes::BufMut`. Encoding a branch node writes ~41 items through that trait object (16 children — each an RLP length byte plus a 32-byte hash — plus the header and value), so each one is a vtable dispatch.

That lands on the hashing path: `BranchNode::compute_hash_no_alloc` encodes into a `Vec<u8>` before keccak, and every `memoize_hashes` walk re-encodes each dirty branch. Note `encode_to_vec` directly below it is *already* monomorphic (`buf.push` / `extend_from_slice`) — it just allocates a fresh buffer each call, so the hashing path can't use it.

**Description**

Add `BranchNode::encode_into_vec(&self, buf: &mut Vec<u8>)`, a concrete-typed sibling that appends into a caller-owned `Vec<u8>`, and point `compute_hash_no_alloc` at it. `RLPEncode::encode` is untouched for every other caller.

Also resolve each child's hash once rather than twice — the payload-length pass and the encode pass each called `compute_hash_ref`, so a 16-choice branch performed 32 resolutions.

`cargo test -p ethrex-trie` (61 tests), `fmt` and `clippy` are clean.

**Effect**

The win scales with how poorly indirect calls are amortised. These numbers come from the [LambdaVM](https://github.com/yetanotherco/lambda_vm) zkVM guest executing mainnet block 25368371, where every RISC-V instruction is proven and there is no out-of-order core to hide a vtable dispatch:

| | cycles |
|---|---|
| `BranchNode::encode` + `put_slice` + `put_u8` | 2,122,427 → 1,312,210 (**−38%**) |
| `memcpy` | 908,885 → 586,969 |
| whole-block execution | 20,544,222 → 19,408,617 (**−5.53%**) |

`memcpy` drops as well because `extend_from_slice` into a `Vec` with known capacity beats the trait object's `put_slice`.

Native gains will be considerably smaller — a modern core predicts and pipelines these calls well — but the change strictly removes indirection, so it should not regress. Happy to add a native benchmark before merging if you'd like a number for that path.

Companion to #7101 (same guest, same profiling run).
