### PR TITLE
perf(levm): monomorphize the dispatch loop on the validation observer

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -2769,10 +2769,11 @@ impl<'a> VM<'a> {
         // Specialize the dispatch loop on whether a struct-log tracer is active.
         // The `!TRACED` variant compiles out every tracer branch and capture call,
         // leaving a minimal hot loop (the common, non-traced case).
-        if self.opcode_tracer.active {
-            self.run_dispatch::<true>()
-        } else {
-            self.run_dispatch::<false>()
+        match (self.opcode_tracer.active, self.validation_observer.active) {
+            (false, false) => self.run_dispatch::<false, false>(),
+            (false, true) => self.run_dispatch::<false, true>(),
+            (true, false) => self.run_dispatch::<true, false>(),
+            (true, true) => self.run_dispatch::<true, true>(),
         }
     }
 
@@ -2780,7 +2781,9 @@ impl<'a> VM<'a> {
     /// active. With `TRACED = false` the compiler eliminates the tracer branches
     /// and the cold `trace_*_step` calls entirely, so the hot loop body stays
     /// minimal; the traced variant keeps the cold helpers out of line.
-    fn run_dispatch<const TRACED: bool>(&mut self) -> Result<ContextResult, VMError> {
+    fn run_dispatch<const TRACED: bool, const VALIDATING: bool>(
+        &mut self,
+    ) -> Result<ContextResult, VMError> {
         let mut error = OnceCell::<VMError>::new();
 
         #[cfg(feature = "perf_opcode_timings")]
@@ -2799,7 +2802,7 @@ impl<'a> VM<'a> {
             // EIP-8141 mempool validation-trace observer (single branch on the
             // fast path when inactive). Enforces the banned-opcode set and the
             // sequential `GAS`-before-`*CALL` rule before the handler runs.
-            if self.validation_observer.active {
+            if VALIDATING {
                 self.check_validation_banned_opcode(opcode);
             }
 


### PR DESCRIPTION
**Motivation**

`run_dispatch` is already specialized on whether a struct-log tracer is active, so with `TRACED = false` the compiler eliminates every tracer branch and the cold `trace_*_step` calls — the comment on the function says as much.

The EIP-8141 validation observer sits in the same hot loop but was left as a runtime field check:

```rust
if self.validation_observer.active {
    self.check_validation_banned_opcode(opcode);
}
```

It is inactive for all real block execution (it only runs for mempool validation simulation), yet it still costs a load and a branch on every dispatch iteration.

**Description**

Extend the existing specialization with a second const generic, so the observer compiles out exactly the way the tracer already does. Four instantiations instead of two; the hot `(false, false)` path loses the branch.

`cargo test -p ethrex-levm`, `fmt` and `clippy` are clean.

**Effect**

Measured in the [LambdaVM](https://github.com/yetanotherco/lambda_vm) zkVM guest executing mainnet block 25368371, **98,893 opcodes**:

| | cycles |
|---|---|
| `run_execution` | 1,494,353 → 1,296,439 (−197,914) |
| whole-block execution | 24,717,407 → 24,519,513 (**−0.80%**) |

That works out to **2.0 cycles per opcode** — one load plus one branch, precisely what the change removes, which is a good sign the attribution is right.

Native gains will be smaller: the branch is perfectly predicted and the field is hot in cache. But it is strictly less work per opcode, and it makes the loop's specialization uniform across its two observers rather than handling one of them at compile time and the other at run time.
