### PR TITLE
ci(l1): bump sepolia snapsync timeout to 4h30m

### DIFF
--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           event_name="${GITHUB_EVENT_NAME}"
           if [[ "$event_name" == "schedule" ]]; then
-            json='[{"network":"hoodi","timeout":"1h"},{"network":"sepolia","timeout":"3h30m"}]'
+            json='[{"network":"hoodi","timeout":"1h"},{"network":"sepolia","timeout":"4h30m"}]'
           elif [[ "$event_name" == "pull_request" ]]; then
             json='[{"network":"hoodi","timeout":"1h"}]'
           else
@@ -48,7 +48,7 @@ jobs:
                 json='[{"network":"hoodi","timeout":"1h"}]'
                 ;;
               sepolia)
-                json='[{"network":"sepolia","timeout":"3h30m"}]'
+                json='[{"network":"sepolia","timeout":"4h30m"}]'
                 ;;
               *)
                 echo "::error::Unsupported network value '$network'. Allowed values: hoodi, sepolia."


### PR DESCRIPTION
**Motivation**

The sepolia snapsync CI check timed out, but didn't stall. We want to avoid flaky behavior.

**Description**

Bumps the timeout to 4h30m which even in degraded network conditions should be enough.

