### PR TITLE
fix(levm): trace every frame of an EIP-8141 frame transaction

### DIFF
--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -2363,6 +2363,22 @@ impl<'a> VM<'a> {
             // every slot, a single such frame halts block production.
             let mut frame_bal_checkpoint = self.db.bal_recorder.as_ref().map(|r| r.checkpoint());
 
+            // Frames run through `run_execution`, which neither opens nor closes a tracer context,
+            // and the shortcut branches below never reach it at all. Opening here covers all three
+            // paths; the matching close follows the branch.
+            self.tracer.enter(
+                if is_static {
+                    CallType::STATICCALL
+                } else {
+                    CallType::CALL
+                },
+                caller,
+                target,
+                frame.value,
+                frame.gas_limit,
+                &frame.data,
+            );
+
             let (frame_success, frame_gas_used, frame_logs) = if value_transfer_reverted {
                 self.substate.revert_backup();
                 self.restore_cache_state()?;
@@ -2509,6 +2525,11 @@ impl<'a> VM<'a> {
 
                 result
             };
+
+            self.tracer.exit_early(
+                frame_gas_used,
+                (!frame_success).then(|| "frame reverted".to_string()),
+            )?;
 
             // EIP-8037: a failed frame's state changes were reverted above, so it
             // creates no state and must contribute zero state gas. Roll the shared
@@ -3052,6 +3073,16 @@ impl<'a> VM<'a> {
         // refund above (which also returns the max-vs-effective fee delta).
         let frame_gas_used = total_gas_used.saturating_sub(intrinsic_gas);
         let gas_refund = sum_frame_gas_limits.saturating_sub(frame_gas_used);
+
+        // The frame loop bypasses `finalize_execution`, so close the transaction's tracer
+        // context here; without it the top call reports no gas and no result.
+        let tx_ctx_result = ContextResult {
+            result: result.clone(),
+            gas_used: total_gas_used,
+            gas_spent: total_gas_used,
+            output: Bytes::new(),
+        };
+        self.tracer.exit_context(&tx_ctx_result, true)?;
 
         let report = ExecutionReport {
             result,

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -188,6 +188,42 @@ fn run_frame_tx(
     (result, db)
 }
 
+/// Like `run_frame_tx`, but with `callTracer` active, returning the trace the
+/// `debug_traceTransaction` handler would serve alongside the report.
+fn trace_frame_tx(
+    accounts: &[SeededAccount],
+    tx: FrameTransaction,
+) -> (ExecutionReport, ethrex_common::tracing::CallTraceFrame) {
+    let mut seeded: Vec<SeededAccount> = accounts.to_vec();
+    if !seeded.iter().any(|(addr, ..)| *addr == tx.sender) {
+        seeded.push((
+            tx.sender,
+            AUTO_SEED_SENDER_BALANCE,
+            tx.nonce_seq,
+            Bytes::new(),
+        ));
+    }
+
+    let mut db = seeded_db(&seeded);
+    let env = frame_tx_env(&tx);
+    let transaction = Transaction::FrameTransaction(tx);
+
+    let mut vm = VM::new(
+        env,
+        &mut db,
+        &transaction,
+        LevmCallTracer::new(false, true),
+        VMType::L1,
+        &NativeCrypto,
+        None,
+    )
+    .expect("VM::new should succeed for a frame tx");
+    let report = vm.execute().expect("frame tx must execute");
+    let trace = vm.get_trace_result().expect("trace must be available");
+
+    (report, trace)
+}
+
 /// Like `run_frame_tx`, but builds the env with the given block `base_fee`
 /// instead of `HARNESS_BASE_FEE`. The env's effective `gas_price` is derived
 /// from the tx the same way production does (`calculate_gas_price_for_tx`):
@@ -917,6 +953,65 @@ fn frame_tx_happy_path_sstore_and_log() {
         nonce_of(&db, FUNDED_SENDER),
         1,
         "sender nonce must be 1 after APPROVE (scope 3 increments nonce once)"
+    );
+}
+
+/// `callTracer` must report the transaction's gas and one subcall per executed
+/// frame. Regression: the frame loop opened no tracer context per frame and never
+/// closed the transaction's own, so the top call came back with `gas_used` 0 and
+/// only the first frame's callees under it.
+#[test]
+fn call_tracer_records_every_frame() {
+    let worker = Address::from_low_u64_be(0xC0FFEE);
+    let codeless = Address::from_low_u64_be(0xDECAF);
+
+    let tx = frame_tx_with_frames(vec![
+        verify_frame(FUNDED_SENDER),
+        Frame {
+            mode: u8::from(FrameMode::Sender),
+            flags: 0,
+            target: Some(worker),
+            gas_limit: 300_000,
+            value: U256::zero(),
+            data: Bytes::new(),
+        },
+        Frame {
+            mode: u8::from(FrameMode::Sender),
+            flags: 0,
+            target: Some(codeless),
+            gas_limit: 100_000,
+            value: U256::zero(),
+            data: Bytes::new(),
+        },
+    ]);
+
+    let accounts = [
+        (
+            FUNDED_SENDER,
+            AUTO_SEED_SENDER_BALANCE,
+            0,
+            Bytes::from(APPROVE_BOTH_CODE.to_vec()),
+        ),
+        (
+            worker,
+            U256::zero(),
+            0,
+            Bytes::from(SSTORE_AND_LOG_CODE.to_vec()),
+        ),
+    ];
+
+    let (report, trace) = trace_frame_tx(&accounts, tx);
+
+    assert_eq!(
+        trace.gas_used, report.gas_used,
+        "top call must report the transaction's gas"
+    );
+    assert_eq!(trace.calls.len(), 3, "one subcall per executed frame");
+    assert_eq!(trace.calls[0].to, FUNDED_SENDER);
+    assert_eq!(trace.calls[1].to, worker);
+    assert_eq!(
+        trace.calls[2].to, codeless,
+        "a frame served by default code never reaches the interpreter and is traced all the same"
     );
 }
 


### PR DESCRIPTION
`callTracer` on an EIP-8141 frame transaction returned a top call with `gasUsed` 0 whose only child was the validation prefix: frames run through `run_execution`, which neither opens nor closes a tracer context, and the frame loop bypasses `finalize_execution`, where the transaction's own context is normally closed.

Each frame now opens and closes its own tracer context, and `execute_frame_tx` closes the transaction's before building the report. Observed on a two-client devnet: tracing a privacy-pool withdrawal returned no payload-frame work at all, so the frame's storage writes had to be recovered by reading slots before and after the block.

## Testing

`call_tracer_records_every_frame` in `test/tests/levm/eip8141_tests.rs` traces the two-frame happy path and asserts the top call reports the transaction's gas and carries one subcall per frame. Fails on master with `gas_used` 0.

Full suite: 1008 passed, 0 failed.
