### PR TITLE
fix(l1): resume full sync from the durable frontier

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1015,6 +1015,28 @@ pub fn migrate_datadir_if_needed(
 
 /// Re-apply blocks from the last on-disk state root up to the head block,
 /// rebuilding the in-memory trie diff-layers lost across a restart.
+/// Resolve a full block by number, falling back to the full-sync header table.
+///
+/// Same reason as [`header_by_number`]: blocks executed during full sync but not yet
+/// canonicalized have no `CANONICAL_BLOCK_HASHES` entry, so the canonical lookup misses
+/// them. The body is stored by hash and is durable up to `flushed_upto`, so once the
+/// header resolves the body is there.
+async fn block_by_number(
+    store: &Store,
+    number: ethrex_common::types::BlockNumber,
+) -> eyre::Result<Option<ethrex_common::types::Block>> {
+    if let Some(block) = store.get_block_by_number(number).await? {
+        return Ok(Some(block));
+    }
+    let Some(header) = header_by_number(store, number).await? else {
+        return Ok(None);
+    };
+    let Some(body) = store.get_block_body_by_hash(header.hash()).await? else {
+        return Ok(None);
+    };
+    Ok(Some(ethrex_common::types::Block { header, body }))
+}
+
 /// Resolve a header by block number, falling back to the full-sync header table.
 ///
 /// `get_block_header` goes through `CANONICAL_BLOCK_HASHES`, which only `forkchoice_update`
@@ -1111,8 +1133,7 @@ pub async fn regenerate_head_state(
     for i in (last_state_number + 1)..=head_block_number {
         debug!("Re-applying block {i} to regenerate state");
 
-        let block = store
-            .get_block_by_number(i)
+        let block = block_by_number(store, i)
             .await?
             .ok_or_else(|| eyre::eyre!("Block {i} not found"))?;
 

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1015,19 +1015,65 @@ pub fn migrate_datadir_if_needed(
 
 /// Re-apply blocks from the last on-disk state root up to the head block,
 /// rebuilding the in-memory trie diff-layers lost across a restart.
+/// Resolve a header by block number, falling back to the full-sync header table.
+///
+/// `get_block_header` goes through `CANONICAL_BLOCK_HASHES`, which only `forkchoice_update`
+/// writes — so blocks that were executed during full sync but not yet canonicalized are
+/// invisible to it. Full sync keeps the headers it downloaded keyed by number, which covers
+/// exactly that range. A miss is normal (the table is cleared between cycles) and simply
+/// means the block cannot be resolved that way.
+async fn header_by_number(
+    store: &Store,
+    number: ethrex_common::types::BlockNumber,
+) -> eyre::Result<Option<ethrex_common::types::BlockHeader>> {
+    if let Some(header) = store.get_block_header(number)? {
+        return Ok(Some(header));
+    }
+    Ok(store
+        .read_fullsync_batch(number, 1)
+        .await?
+        .into_iter()
+        .next()
+        .flatten())
+}
+
 pub async fn regenerate_head_state(
     store: &Store,
     blockchain: &Arc<Blockchain>,
 ) -> eyre::Result<()> {
-    // Precondition: the store was opened via `add_initial_state`/`load_initial_state`,
-    // which clamp `LatestBlockNumber` to `flushed_upto`. All blocks up to
-    // `head_block_number` are therefore on disk; callers that skip that clamp
-    // would break this assumption.
-    let head_block_number = store.get_latest_block_number().await?;
-    debug!("regenerate_head_state head clamped to durable block {head_block_number}");
+    // Resume from the durability frontier, not from the canonical head.
+    //
+    // The two drift apart in both directions. After a crash `LatestBlockNumber` can be
+    // *ahead* of `flushed_upto` (forkchoice writes the head synchronously while bodies are
+    // still buffered), and during full sync it is *behind*, because blocks execute and their
+    // trie state commits long before a forkchoice update canonicalizes them.
+    //
+    // That second case is fatal if we start here from the canonical head: the on-disk trie is
+    // single-version, so the commits made above the canonical head have already overwritten
+    // the canonical head's own state. Walking back from it can never find a root, and the
+    // node reports "Unknown state found in DB" on a database that is perfectly recoverable.
+    //
+    // `flushed_upto` is the right answer for both: it is exactly how far block data is
+    // durable, so it is exactly how far we can replay. An absent marker means a legacy or
+    // fresh database where everything is durable, so fall back to the canonical head.
+    let canonical_head = store.get_latest_block_number().await?;
+    let head_block_number = match store.read_flushed_upto_opt()? {
+        Some(flushed) => flushed,
+        None => canonical_head,
+    };
+    debug!(
+        "regenerate_head_state resuming from durable block {head_block_number}          (canonical head {canonical_head})"
+    );
 
-    let Some(last_header) = store.get_block_header(head_block_number)? else {
-        unreachable!("Database is empty, genesis block should be present");
+    // Blocks executed during full sync but not yet canonicalized have no
+    // CANONICAL_BLOCK_HASHES entry, so resolve headers through the full-sync table too.
+    let last_header = match header_by_number(store, head_block_number).await? {
+        Some(header) => header,
+        // The full-sync header table is cleared between sync cycles, so the durable frontier
+        // is not always resolvable. Fall back to the canonical head rather than failing.
+        None => store.get_block_header(canonical_head)?.ok_or_else(|| {
+            eyre::eyre!("no header for canonical head {canonical_head}; database is corrupt")
+        })?,
     };
 
     let mut current_last_header = last_header;
@@ -1043,7 +1089,7 @@ pub async fn regenerate_head_state(
 
         debug!("Need to regenerate state for block {parent_number}");
 
-        let Some(parent_header) = store.get_block_header(parent_number)? else {
+        let Some(parent_header) = header_by_number(store, parent_number).await? else {
             return Err(eyre::eyre!(
                 "Parent header for block {parent_number} not found"
             ));

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1079,24 +1079,28 @@ pub async fn regenerate_head_state(
     // durable, so it is exactly how far we can replay. An absent marker means a legacy or
     // fresh database where everything is durable, so fall back to the canonical head.
     let canonical_head = store.get_latest_block_number().await?;
-    let head_block_number = match store.read_flushed_upto_opt()? {
-        Some(flushed) => flushed,
-        None => canonical_head,
-    };
-    debug!(
-        "regenerate_head_state resuming from durable block {head_block_number}          (canonical head {canonical_head})"
-    );
-
+    let frontier = store.read_flushed_upto_opt()?;
+    let head_block_number = frontier.unwrap_or(canonical_head);
     // Blocks executed during full sync but not yet canonicalized have no
     // CANONICAL_BLOCK_HASHES entry, so resolve headers through the full-sync table too.
     let last_header = match header_by_number(store, head_block_number).await? {
         Some(header) => header,
-        // The full-sync header table is cleared between sync cycles, so the durable frontier
-        // is not always resolvable. Fall back to the canonical head rather than failing.
+        // The full-sync header table is cleared between sync cycles, so the frontier is not
+        // always resolvable — a reorg that lowers the canonical head below an older frontier
+        // lands here too. Fall back to the canonical head rather than failing.
         None => store.get_block_header(canonical_head)?.ok_or_else(|| {
             eyre::eyre!("no header for canonical head {canonical_head}; database is corrupt")
         })?,
     };
+
+    // Take the replay target from the header we actually resolved, never from the frontier
+    // we hoped to resolve. Tracking them separately lets the fallback above leave the target
+    // at an unreachable height, and the replay loop then aborts on `Block {i} not found`.
+    let head_block_number = last_header.number;
+    debug!(
+        "regenerate_head_state resuming from block {head_block_number} \
+         (durable frontier {frontier:?}, canonical head {canonical_head})"
+    );
 
     let mut current_last_header = last_header;
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -4340,7 +4340,15 @@ impl Store {
         // durable baseline, and a walked-down head lowers the marker so a later
         // crash clamps against a hash known to resolve.
         let reanchor = head != latest;
-        let rewrite_marker = marker != Some(head);
+        // Seed an absent marker, and lower it only when the loop actually walked the head
+        // down (a reorg inside the flush window). Do NOT lower it merely because the
+        // canonical head sits behind the durable frontier: during full sync, execution and
+        // its trie commits run ahead of canonicalization, and this marker is the only record
+        // of how far the database is really durable. Overwriting it here destroys the
+        // information `regenerate_head_state` needs to find a state root to resume from —
+        // the clamp itself still applies via `min(marker, latest)` above, so nothing is
+        // trusted that should not be.
+        let rewrite_marker = marker.is_none() || head < start;
         if reanchor || rewrite_marker {
             let mut tx = self.backend.begin_write()?;
             if reanchor {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -6694,3 +6694,78 @@ mod flatkeyvalue_completeness_tests {
         ])));
     }
 }
+
+#[cfg(test)]
+mod durable_head_tests {
+    use super::*;
+    use crate::backend::in_memory::InMemoryBackend;
+    use ethrex_common::types::{BlockBody, BlockHeader};
+
+    fn block_at(number: BlockNumber, parent_hash: H256) -> Block {
+        Block::new(
+            BlockHeader {
+                number,
+                parent_hash,
+                state_root: H256::repeat_byte(number as u8),
+                ..Default::default()
+            },
+            BlockBody::default(),
+        )
+    }
+
+    /// The startup clamp SHALL NOT lower `flushed_upto`.
+    ///
+    /// During full sync the canonical head lags execution: blocks are executed and their
+    /// trie state committed long before a forkchoice update canonicalizes them, so the
+    /// durable frontier is legitimately *ahead* of `LatestBlockNumber`. Clamping the head
+    /// to the lower of the two is correct, but persisting that lower value over the marker
+    /// throws away the only record of how far the database is actually durable.
+    ///
+    /// The consequence is not cosmetic. `regenerate_head_state` resumes from the frontier;
+    /// with it destroyed it resumes from the canonical head, whose state the single-version
+    /// on-disk trie has already overwritten. The node then reports "Unknown state found in
+    /// DB. Please run `ethrex removedb`" on a database that was perfectly recoverable.
+    #[tokio::test]
+    async fn clamp_does_not_lower_the_durable_frontier() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::from_backend(
+            backend.clone(),
+            dir.path().to_path_buf(),
+            1,
+            DEFAULT_PERSIST_CHANNEL_CAPACITY,
+        )
+        .unwrap();
+
+        // Two blocks on disk, only the first canonicalized — the shape full sync leaves
+        // behind when it is stopped mid-batch.
+        let block1 = block_at(1, H256::zero());
+        let block1_hash = block1.hash();
+        let block2 = block_at(2, block1_hash);
+        store.add_block(block1).await.unwrap();
+        store.add_block(block2).await.unwrap();
+        store
+            .forkchoice_update(vec![(1, block1_hash)], 1, block1_hash, None, None)
+            .await
+            .unwrap();
+
+        // Block data is durable through block 2, while the canonical head is still 1.
+        let mut tx = backend.begin_write().unwrap();
+        write_flushed_upto(tx.as_mut(), 2).unwrap();
+        tx.commit().unwrap();
+
+        store.anchor_to_durable_head(1).await.unwrap();
+
+        assert_eq!(
+            store.read_flushed_upto_opt().unwrap(),
+            Some(2),
+            "the clamp must leave the durable frontier intact; lowering it here is what \
+             makes a mid-sync restart unrecoverable"
+        );
+        assert_eq!(
+            store.get_latest_block_number().await.unwrap(),
+            1,
+            "the head itself is still clamped to the canonical head"
+        );
+    }
+}

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -4222,7 +4222,7 @@ impl Store {
 
     /// Returns `None` when the marker has never been written — a legacy or fresh
     /// DB where everything is durable and the head must not be clamped to 0.
-    fn read_flushed_upto_opt(&self) -> Result<Option<BlockNumber>, StoreError> {
+    pub fn read_flushed_upto_opt(&self) -> Result<Option<BlockNumber>, StoreError> {
         let tx = self.backend.begin_read()?;
         match tx.get(MISC_VALUES, FLUSHED_UPTO_KEY)? {
             Some(bytes) => Ok(Some(decode_flushed_upto(&bytes)?)),


### PR DESCRIPTION
**Motivation**

Restarting a node while it is full-syncing can leave a database that will not reopen:

```
Error: Unknown state found in DB. Please run `ethrex removedb` and restart node
    cmd/ethrex/initializers.rs:1038
```

The node then exits 1 on every subsequent start and the only recovery is `removedb` plus a
full re-sync. It does not need a crash or a SIGKILL — a clean `docker stop -t 300` with exit
code 0 is enough, and it reproduces on mainnet and hoodi alike.

The database is not actually corrupt. The startup path deletes the one piece of information
needed to recover it.

During full sync, blocks execute and their trie state commits well ahead of
canonicalization: `LatestBlockNumber` only advances when `forkchoice_update` runs at the end
of each ~1024-block batch. That is fine while running. On restart, `anchor_to_durable_head`
clamps the head to `min(flushed_upto, latest)` — correct — but then **persists that lower
value over the `flushed_upto` marker**. Since the on-disk trie is single-version and
path-keyed, the commits made above the canonical head have already overwritten the canonical
head's own state, so `regenerate_head_state` starts from a block whose state no longer
exists, walks back to genesis, and gives up. The durable frontier that would have let it
resume was overwritten moments earlier.

Instrumented trace from a failing run (hoodi):

```
during the leg:
  flush_block_data flushed_upto=3362294 -> commit_to_disk root=0x5bdef854   <- head's root
  ...
  flush_block_data flushed_upto=3362299 -> commit_to_disk root=0x88c0d8ee   <- last one wins

on restart:
  regenerate_head_state: searching from head=3362166 root=0x5bdef854
  Error: Unknown state found in DB
```

This is the same failure mode #6930 fixed for the live path — state committed ahead of
canonicalization overwriting the single path-keyed root — reappearing on a path that PR
deliberately carved out. `get_commitable_by_depth`'s doc reasons that full sync, block import
and startup regeneration "never execute competing forks", which is true, but the hazard also
exists on the one true chain: committing block N's state destroys block N-k's, and N-k is
where a restart begins. The same doc also states those paths "never advance" the safe-commit
root; full sync does, once per batch.

Found while building the full-sync throughput regression watch (#7111), whose measurement
cycle stops a syncing node on purpose. It is not specific to that tooling — it affects any
node restarted while full-syncing.

**Description**

Three changes, all the same underlying problem: **anything that resolves a block by number
breaks above the canonical head**, because only `forkchoice_update` writes
`CANONICAL_BLOCK_HASHES`.

1. **Keep the durable frontier when clamping** (`store.rs`). `rewrite_marker` becomes
   `marker.is_none() || head < start`, so the marker is seeded when absent and lowered only
   when the loop actually walked the head down — the reorg-inside-flush-window case its
   comment describes. It is no longer lowered merely because the canonical head sits behind
   the frontier. The clamp itself is unchanged: `min(marker, latest)` still decides what the
   head resolves to, so nothing untrusted is adopted.

2. **Resume from `flushed_upto`, not `LatestBlockNumber`** (`initializers.rs`). The frontier
   is the correct definition of how far a database can be replayed, and it is right in both
   drift directions: after a crash `latest` runs ahead of it (forkchoice writes the head
   while bodies are still buffered) and the clamp picks the frontier anyway; during full sync
   `latest` lags it. An absent marker means a legacy or fresh database where everything is
   durable, so that falls back to the canonical head.

3. **Resolve blocks above the canonical head through `FULLSYNC_HEADERS`**
   (`initializers.rs`), which full sync already maintains keyed by number, in both the
   backward walk and the forward replay. A miss is expected — that table is cleared between
   sync cycles — and falls back to previous behaviour rather than failing. The
   `unreachable!()` on the initial header lookup is now genuinely reachable and has been
   replaced with an error.

Plus a regression test, `clamp_does_not_lower_the_durable_frontier`, which builds the shape
full sync leaves behind (two blocks durable, only the first canonicalized) and asserts the
marker survives the clamp while the head is still clamped. Verified to fail without change 1.

**Validation**

The failure is timing-dependent: it needs execution to be more than `DB_COMMIT_THRESHOLD`
(128) blocks past the last forkchoice update at the moment of shutdown. Left to chance it
reproduces 30-45% of the time; dwelling after the stop target makes it deterministic
(13/13 failures on unpatched `main`).

| network | control (`main`) | with this PR |
|---|---|---|
| mainnet | fails 2/2 | **passes 2/2** |
| hoodi | fails 3/3 | **passes 3/3** |

Mainnet log, resuming 446 blocks above the canonical head (25693695):

```
Regenerating state from block 25694013 to 25694141
Finished regenerating state
HTTP-RPC server listening on 0.0.0.0:8545
```

Reproducer, ~5 minutes on hoodi: restore a snap-synced datadir, point it at a beacon node a
few thousand blocks ahead so it full-syncs in 1024-block batches, let it run ~2000 blocks,
wait ~25s (hoodi) or ~60s (mainnet) so execution passes the commit threshold beyond the last
forkchoice update, `docker stop -t 300`, restart.

**Notes for review**

- Costs nothing at runtime: no extra trie-layer retention, no extra forkchoice updates.
- Also covers paths a sync-side fix would not: `ethrex import` performs a single forkchoice
  update at the very end, so an interrupted import runs entirely above the canonical head,
  and L2 `regenerate_state` uses the same depth-gated entry point.
- Does not touch `add_blocks_in_batch`, which #6493 is currently rewriting.
- It repairs a database that is broken but has not yet been reopened. Once a node has started
  on a broken datadir under the current code, that startup has already overwritten the marker
  and the frontier is gone permanently.
- Two alternatives were measured and rejected. Applying #6930's canonical gate to full sync
  works but takes mainnet peak RSS from ~11.6 GiB to ~35.8 GiB, above the documented 32 GB
  minimum. Canonicalizing every 128 blocks during sync also works and costs ~+1.6 GiB, but
  restructures the sync loop for no benefit this PR does not already provide. Either remains
  viable as defence in depth, since preventing the inconsistent state is stricter than
  recovering from it.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

No schema change: the on-disk format is untouched. The only difference is that an existing
marker is no longer overwritten with a lower value, which older binaries read the same way.
