### PR TITLE
refactor(l1): remove useless `async` in `Store::get_latest_block_number`

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -1259,7 +1259,7 @@ pub async fn export_blocks(
     let start = first_number.unwrap_or_default();
 
     // If we have no latest block then we don't have any blocks to export
-    let latest_number = match store.get_latest_block_number().await {
+    let latest_number = match store.get_latest_block_number() {
         Ok(number) => number,
         Err(StoreError::MissingLatestBlockNumber) => {
             warn!("No blocks in the current chain, nothing to export!");

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -407,7 +407,7 @@ pub async fn init_dev_network(
     let chain_config = store.get_chain_config();
 
     let (head_block_hash, target_gas_limit) = {
-        let current_block_number = store.get_latest_block_number().await.unwrap();
+        let current_block_number = store.get_latest_block_number().unwrap();
         let head_block_hash = store
             .get_canonical_block_hash(current_block_number)
             .await
@@ -1023,7 +1023,7 @@ pub async fn regenerate_head_state(
     // which clamp `LatestBlockNumber` to `flushed_upto`. All blocks up to
     // `head_block_number` are therefore on disk; callers that skip that clamp
     // would break this assumption.
-    let head_block_number = store.get_latest_block_number().await?;
+    let head_block_number = store.get_latest_block_number()?;
     debug!("regenerate_head_state head clamped to durable block {head_block_number}");
 
     let Some(last_header) = store.get_block_header(head_block_number)? else {

--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -3023,7 +3023,7 @@ impl Blockchain {
         blobs_bundle: BlobsBundle,
         broadcast: bool,
     ) -> Result<H256, MempoolError> {
-        let fork = self.current_fork().await?;
+        let fork = self.current_fork()?;
 
         let transaction = Transaction::EIP4844Transaction(transaction);
         let hash = transaction.hash(&NativeCrypto);
@@ -3437,7 +3437,7 @@ impl Blockchain {
         // Frame transactions: skip balance/EOA checks (payer unknown until execution)
         let is_frame_tx = matches!(tx, Transaction::FrameTransaction(_));
 
-        let header_no = self.storage.get_latest_block_number().await?;
+        let header_no = self.storage.get_latest_block_number()?;
         let header = self
             .storage
             .get_block_header(header_no)?
@@ -3989,9 +3989,9 @@ impl Blockchain {
     }
 
     /// Get the current fork of the chain, based on the latest block's timestamp
-    pub async fn current_fork(&self) -> Result<Fork, StoreError> {
+    pub fn current_fork(&self) -> Result<Fork, StoreError> {
         let chain_config = self.storage.get_chain_config();
-        let latest_block_number = self.storage.get_latest_block_number().await?;
+        let latest_block_number = self.storage.get_latest_block_number()?;
         let latest_block = self
             .storage
             .get_block_header(latest_block_number)?
@@ -4519,8 +4519,8 @@ pub fn validate_state_root(
 }
 
 // Returns the hash of the head of the canonical chain (the latest valid hash).
-pub async fn latest_canonical_block_hash(storage: &Store) -> Result<H256, ChainError> {
-    let latest_block_number = storage.get_latest_block_number().await?;
+pub fn latest_canonical_block_hash(storage: &Store) -> Result<H256, ChainError> {
+    let latest_block_number = storage.get_latest_block_number()?;
     if let Some(latest_valid_header) = storage.get_block_header(latest_block_number)? {
         let latest_valid_hash = latest_valid_header.hash();
         return Ok(latest_valid_hash);

--- a/crates/blockchain/fork_choice.rs
+++ b/crates/blockchain/fork_choice.rs
@@ -110,7 +110,7 @@ pub async fn apply_fork_choice(
         return Err(InvalidForkChoice::Syncing);
     };
 
-    let latest = store.get_latest_block_number().await?;
+    let latest = store.get_latest_block_number()?;
     let head_is_canonical = is_canonical(store, head.number, head_hash).await?;
 
     // execution-apis PR 786: the no-reorg skip is only allowed when there is a known
@@ -489,7 +489,7 @@ async fn reorg_apply_deep(
         // Reverted depth (old-chain blocks unwound), matching the TooDeepReorg
         // gate's definition. `head - pivot` would report ~0/1 for the
         // canonical-head case no matter how deep the unwind.
-        let latest = store.get_latest_block_number().await.unwrap_or(head.number);
+        let latest = store.get_latest_block_number().unwrap_or(head.number);
         let reorg_depth = latest.saturating_sub(pivot_number);
         METRICS_REORG.reorg_depth_hist.observe(reorg_depth as f64);
     );

--- a/crates/l2/based/block_fetcher.rs
+++ b/crates/l2/based/block_fetcher.rs
@@ -117,7 +117,7 @@ impl BlockFetcher {
         {
             info!("Node is not up to date. Syncing via L1");
 
-            let last_l2_block_number_known = self.store.get_latest_block_number().await?;
+            let last_l2_block_number_known = self.store.get_latest_block_number()?;
 
             let last_l2_batch_number_known = self
                 .rollup_store

--- a/crates/l2/networking/rpc/l2/batch.rs
+++ b/crates/l2/networking/rpc/l2/batch.rs
@@ -93,7 +93,7 @@ impl RpcHandler for GetBatchByBatchNumberRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Requested batch with number: {}", self.batch_number);
-        let l1_fork = context.l1_ctx.blockchain.current_fork().await?;
+        let l1_fork = context.l1_ctx.blockchain.current_fork()?;
         let Some(batch) = context
             .rollup_store
             .get_batch(self.batch_number, l1_fork)
@@ -126,7 +126,7 @@ impl RpcHandler for GetBatchByBatchBlockNumberRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Requested batch with block: {}", self.block);
-        let l1_fork = context.l1_ctx.blockchain.current_fork().await?;
+        let l1_fork = context.l1_ctx.blockchain.current_fork()?;
 
         let block_number = self
             .block

--- a/crates/l2/networking/rpc/l2/transaction.rs
+++ b/crates/l2/networking/rpc/l2/transaction.rs
@@ -85,7 +85,6 @@ impl RpcHandler for SponsoredTx {
                         .l1_ctx
                         .storage
                         .get_latest_block_number()
-                        .await
                         .map_err(RpcErr::from)?,
                     self.to,
                 )
@@ -125,7 +124,6 @@ impl RpcHandler for SponsoredTx {
             .l1_ctx
             .storage
             .get_latest_block_number()
-            .await
             .map_err(RpcErr::from)?;
         let chain_config = context.l1_ctx.storage.get_chain_config();
 

--- a/crates/l2/sequencer/block_producer.rs
+++ b/crates/l2/sequencer/block_producer.rs
@@ -133,7 +133,7 @@ impl BlockProducer {
     pub async fn produce_block(&mut self) -> Result<(), BlockProducerError> {
         let version = 3;
         let head_header = {
-            let current_block_number = self.store.get_latest_block_number().await?;
+            let current_block_number = self.store.get_latest_block_number()?;
             self.store
                 .get_block_header(current_block_number)?
                 .ok_or(BlockProducerError::StorageDataIsNone)?

--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -125,7 +125,7 @@ pub async fn fill_transactions(
 
     debug!("Fetching transactions from mempool");
     // Fetch mempool transactions
-    let latest_block_number = store.get_latest_block_number().await?;
+    let latest_block_number = store.get_latest_block_number()?;
     let mut txs = fetch_mempool_transactions(blockchain.as_ref(), context)?;
 
     // Execute and add transactions to payload (if suitable)

--- a/crates/l2/sequencer/l1_committer.rs
+++ b/crates/l2/sequencer/l1_committer.rs
@@ -1627,7 +1627,7 @@ pub async fn regenerate_state(
     let target_block_number = match target_block_number {
         Some(0) => return Ok(()),
         Some(n) => n - 1,
-        None => store.get_latest_block_number().await?,
+        None => store.get_latest_block_number()?,
     };
     if target_block_number == 0 {
         return Ok(());

--- a/crates/l2/sequencer/native_rollup/block_producer.rs
+++ b/crates/l2/sequencer/native_rollup/block_producer.rs
@@ -148,7 +148,7 @@ impl NativeBlockProducer {
 
         // 2. Create initial payload (same as L2 block producer)
         let head_header = {
-            let current_block_number = self.store.get_latest_block_number().await?;
+            let current_block_number = self.store.get_latest_block_number()?;
             self.store
                 .get_block_header(current_block_number)?
                 .ok_or(NativeBlockProducerError::MissingParentHeader)?
@@ -298,7 +298,7 @@ impl NativeBlockProducer {
         let relayer_address = self.config.relayer_signer.address();
 
         // Get relayer nonce from store
-        let latest_block_number = self.store.get_latest_block_number().await?;
+        let latest_block_number = self.store.get_latest_block_number()?;
         let start_nonce = self
             .store
             .get_account_state(latest_block_number, relayer_address)

--- a/crates/l2/sequencer/state_updater.rs
+++ b/crates/l2/sequencer/state_updater.rs
@@ -143,7 +143,7 @@ impl StateUpdater {
     pub async fn update_state(&mut self) -> Result<(), StateUpdaterError> {
         let current_state = self.sequencer_state.status();
         if !self.based {
-            let current_block: U256 = self.store.get_latest_block_number().await?.into();
+            let current_block: U256 = self.store.get_latest_block_number()?.into();
             let mut new_state = current_state;
 
             // The node if set to stop sequencing at a specific block we will set it to Following once we reach it.

--- a/crates/l2/utils/test_data_io.rs
+++ b/crates/l2/utils/test_data_io.rs
@@ -32,7 +32,7 @@ pub async fn generate_rlp(
     up_to_block_number: u64,
     store: &Store,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if store.get_latest_block_number().await? == up_to_block_number {
+    if store.get_latest_block_number()? == up_to_block_number {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let file_name = "l2-test.rlp";
 

--- a/crates/networking/p2p/backend.rs
+++ b/crates/networking/p2p/backend.rs
@@ -3,7 +3,7 @@ use ethrex_storage::{Store, error::StoreError};
 
 use crate::rlpx::{error::PeerConnectionError, eth::status::StatusMessage, p2p::Capability};
 
-pub async fn validate_status<ST: StatusMessage>(
+pub fn validate_status<ST: StatusMessage>(
     msg_data: ST,
     storage: &Store,
     eth_capability: &Capability,
@@ -32,7 +32,7 @@ pub async fn validate_status<ST: StatusMessage>(
         ));
     }
     // Check ForkID
-    if !is_fork_id_valid(storage, &msg_data.get_fork_id()).await? {
+    if !is_fork_id_valid(storage, &msg_data.get_fork_id())? {
         return Err(PeerConnectionError::HandshakeError(
             "Invalid Fork Id".to_string(),
         ));
@@ -41,15 +41,12 @@ pub async fn validate_status<ST: StatusMessage>(
 }
 
 /// Validates the fork id from a remote node is valid.
-pub async fn is_fork_id_valid(
-    storage: &Store,
-    remote_fork_id: &ForkId,
-) -> Result<bool, StoreError> {
+pub fn is_fork_id_valid(storage: &Store, remote_fork_id: &ForkId) -> Result<bool, StoreError> {
     let chain_config = storage.get_chain_config();
     let genesis_header = storage
         .get_block_header(0)?
         .ok_or(StoreError::Custom("Latest block not in DB".to_string()))?;
-    let latest_block_number = storage.get_latest_block_number().await?;
+    let latest_block_number = storage.get_latest_block_number()?;
     let latest_block_header = storage
         .get_block_header(latest_block_number)?
         .ok_or(StoreError::Custom("Latest block not in DB".to_string()))?;

--- a/crates/networking/p2p/discovery/discv4_handlers.rs
+++ b/crates/networking/p2p/discovery/discv4_handlers.rs
@@ -531,7 +531,7 @@ impl DiscoveryServer {
 
         let local_fork_id = ForkId::new(
             chain_config,
-            genesis_header.clone(),
+            genesis_header,
             latest_block_header.timestamp,
             latest_block_number,
         );

--- a/crates/networking/p2p/discovery/discv4_handlers.rs
+++ b/crates/networking/p2p/discovery/discv4_handlers.rs
@@ -499,13 +499,12 @@ impl DiscoveryServer {
             node_id,
             sender_public_key,
             enr_response_message.node_record,
-        )
-        .await?;
+        )?;
 
         Ok(())
     }
 
-    async fn discv4_validate_enr_fork_id(
+    fn discv4_validate_enr_fork_id(
         &mut self,
         node_id: H256,
         sender_public_key: H512,
@@ -524,7 +523,7 @@ impl DiscoveryServer {
             .store
             .get_block_header(0)?
             .ok_or(DiscoveryServerError::InvalidContact)?;
-        let latest_block_number = self.store.get_latest_block_number().await?;
+        let latest_block_number = self.store.get_latest_block_number()?;
         let latest_block_header = self
             .store
             .get_block_header(latest_block_number)?
@@ -537,7 +536,7 @@ impl DiscoveryServer {
             latest_block_number,
         );
 
-        if !backend::is_fork_id_valid(&self.store, &remote_fork_id).await? {
+        if !backend::is_fork_id_valid(&self.store, &remote_fork_id)? {
             self.peer_table.set_is_fork_id_valid(node_id, false)?;
             debug!(protocol = "discv4", received = "ENRResponse", from = %format!("{sender_public_key:#x}"), local_fork_id=%local_fork_id, remote_fork_id=%remote_fork_id, "fork id mismatch in ENR response, skipping");
             return Ok(());

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -1480,7 +1480,7 @@ impl PeerTableServer {
                         })
                         .unwrap_or(false);
                     let is_fork_id_valid = if should_update {
-                        Self::evaluate_fork_id(&node_record, &self.store).await
+                        Self::evaluate_fork_id(&node_record, &self.store)
                     } else {
                         None
                     };
@@ -1498,7 +1498,7 @@ impl PeerTableServer {
                         }
                     }
                 } else {
-                    let is_fork_id_valid = Self::evaluate_fork_id(&node_record, &self.store).await;
+                    let is_fork_id_valid = Self::evaluate_fork_id(&node_record, &self.store);
                     let mut contact = Contact::new(node, DiscoveryProtocol::Discv5);
                     contact.is_fork_id_valid = is_fork_id_valid;
                     contact.record = Some(node_record);
@@ -1509,10 +1509,9 @@ impl PeerTableServer {
         }
     }
 
-    async fn evaluate_fork_id(record: &NodeRecord, store: &Store) -> Option<bool> {
+    fn evaluate_fork_id(record: &NodeRecord, store: &Store) -> Option<bool> {
         if let Some(remote_fork_id) = record.get_fork_id() {
             backend::is_fork_id_valid(store, remote_fork_id)
-                .await
                 .ok()
                 .or(Some(false))
         } else {

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -937,7 +937,7 @@ async fn send_block_range_update(state: &mut Established) -> Result<(), PeerConn
         .is_some_and(|eth| eth.version >= 69)
     {
         trace!(peer=%state.node, "Sending BlockRangeUpdate");
-        let update = BlockRangeUpdate::new(&state.storage).await?;
+        let update = BlockRangeUpdate::new(&state.storage)?;
         let lastet_block = update.latest_block;
         send(state, Message::BlockRangeUpdate(update)).await?;
         state.last_block_range_update_block = lastet_block - (lastet_block % 32);
@@ -945,8 +945,8 @@ async fn send_block_range_update(state: &mut Established) -> Result<(), PeerConn
     Ok(())
 }
 
-async fn should_send_block_range_update(state: &Established) -> Result<bool, PeerConnectionError> {
-    let latest_block = state.storage.get_latest_block_number().await?;
+fn should_send_block_range_update(state: &Established) -> Result<bool, PeerConnectionError> {
+    let latest_block = state.storage.get_latest_block_number()?;
     if latest_block < state.last_block_range_update_block
         || latest_block - state.last_block_range_update_block >= 32
     {
@@ -965,10 +965,10 @@ where
     // Sending eth Status if peer supports it
     if let Some(eth) = state.negotiated_eth_capability.clone() {
         let status = match eth.version {
-            68 => Message::Status68(StatusMessage68::new(&state.storage).await?),
-            69 => Message::Status69(StatusMessage69::new(&state.storage).await?),
-            70 => Message::Status70(StatusMessage70::new(&state.storage).await?),
-            71 => Message::Status71(StatusMessage71::new(&state.storage).await?),
+            68 => Message::Status68(StatusMessage68::new(&state.storage)?),
+            69 => Message::Status69(StatusMessage69::new(&state.storage)?),
+            70 => Message::Status70(StatusMessage70::new(&state.storage)?),
+            71 => Message::Status71(StatusMessage71::new(&state.storage)?),
             ver => {
                 return Err(PeerConnectionError::HandshakeError(format!(
                     "Invalid eth version {ver}"
@@ -987,19 +987,19 @@ where
         match msg {
             Message::Status68(msg_data) => {
                 trace!(peer=%state.node, "Received Status(68)");
-                backend::validate_status(msg_data, &state.storage, &eth).await?
+                backend::validate_status(msg_data, &state.storage, &eth)?
             }
             Message::Status69(msg_data) => {
                 trace!(peer=%state.node, "Received Status(69)");
-                backend::validate_status(msg_data, &state.storage, &eth).await?
+                backend::validate_status(msg_data, &state.storage, &eth)?
             }
             Message::Status70(msg_data) => {
                 trace!(peer=%state.node, "Received Status(70)");
-                backend::validate_status(msg_data, &state.storage, &eth).await?
+                backend::validate_status(msg_data, &state.storage, &eth)?
             }
             Message::Status71(msg_data) => {
                 trace!(peer=%state.node, "Received Status(71)");
-                backend::validate_status(msg_data, &state.storage, &eth).await?
+                backend::validate_status(msg_data, &state.storage, &eth)?
             }
             Message::Disconnect(disconnect) => {
                 return Err(PeerConnectionError::HandshakeError(format!(
@@ -1348,22 +1348,22 @@ async fn handle_incoming_message(
         }
         Message::Status68(msg_data) => {
             if let Some(eth) = &state.negotiated_eth_capability {
-                backend::validate_status(msg_data, &state.storage, eth).await?
+                backend::validate_status(msg_data, &state.storage, eth)?
             };
         }
         Message::Status69(msg_data) => {
             if let Some(eth) = &state.negotiated_eth_capability {
-                backend::validate_status(msg_data, &state.storage, eth).await?
+                backend::validate_status(msg_data, &state.storage, eth)?
             };
         }
         Message::Status70(msg_data) => {
             if let Some(eth) = &state.negotiated_eth_capability {
-                backend::validate_status(msg_data, &state.storage, eth).await?
+                backend::validate_status(msg_data, &state.storage, eth)?
             };
         }
         Message::Status71(msg_data) => {
             if let Some(eth) = &state.negotiated_eth_capability {
-                backend::validate_status(msg_data, &state.storage, eth).await?
+                backend::validate_status(msg_data, &state.storage, eth)?
             };
         }
         Message::GetAccountRange(req) => {
@@ -1639,7 +1639,7 @@ async fn handle_incoming_message(
             }
             if state.blockchain.is_synced() {
                 if let Some((announced, requested_hashes, _)) = &removed_request {
-                    let fork = state.blockchain.current_fork().await?;
+                    let fork = state.blockchain.current_fork()?;
                     if let Err(error) = msg.validate_requested(announced, fork) {
                         debug!(
                             peer=%state.node,
@@ -1799,7 +1799,7 @@ async fn handle_broadcast(
 }
 
 async fn handle_block_range_update(state: &mut Established) -> Result<(), PeerConnectionError> {
-    if should_send_block_range_update(state).await? {
+    if should_send_block_range_update(state)? {
         send_block_range_update(state).await
     } else {
         Ok(())

--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -938,9 +938,9 @@ async fn send_block_range_update(state: &mut Established) -> Result<(), PeerConn
     {
         trace!(peer=%state.node, "Sending BlockRangeUpdate");
         let update = BlockRangeUpdate::new(&state.storage)?;
-        let lastet_block = update.latest_block;
+        let latest_block = update.latest_block;
         send(state, Message::BlockRangeUpdate(update)).await?;
-        state.last_block_range_update_block = lastet_block - (lastet_block % 32);
+        state.last_block_range_update_block = latest_block - (latest_block % 32);
     }
     Ok(())
 }

--- a/crates/networking/p2p/rlpx/eth/eth68/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth68/status.rs
@@ -75,7 +75,7 @@ impl RLPxMessage for StatusMessage68 {
 }
 
 impl StatusMessage68 {
-    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
         let chain_config = storage.get_chain_config();
         let total_difficulty =
             U256::from(chain_config.terminal_total_difficulty.unwrap_or_default());
@@ -85,7 +85,7 @@ impl StatusMessage68 {
         let genesis_header = storage
             .get_block_header(0)?
             .ok_or(PeerConnectionError::NotFound("Genesis Block".to_string()))?;
-        let latest_block = storage.get_latest_block_number().await?;
+        let latest_block = storage.get_latest_block_number()?;
         let block_header =
             storage
                 .get_block_header(latest_block)?

--- a/crates/networking/p2p/rlpx/eth/eth69/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth69/status.rs
@@ -24,8 +24,8 @@ impl RLPxMessage for StatusMessage69 {
 }
 
 impl StatusMessage69 {
-    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
-        StatusDataPost68::new(69, storage).await.map(Self)
+    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+        StatusDataPost68::new(69, storage).map(Self)
     }
 }
 

--- a/crates/networking/p2p/rlpx/eth/eth70/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth70/status.rs
@@ -76,14 +76,14 @@ impl RLPxMessage for StatusMessage70 {
 }
 
 impl StatusMessage70 {
-    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
         let chain_config = storage.get_chain_config();
         let network_id = chain_config.chain_id;
 
         let genesis_header = storage
             .get_block_header(0)?
             .ok_or(PeerConnectionError::NotFound("Genesis Block".to_string()))?;
-        let latest_block = storage.get_latest_block_number().await?;
+        let latest_block = storage.get_latest_block_number()?;
         let block_header =
             storage
                 .get_block_header(latest_block)?

--- a/crates/networking/p2p/rlpx/eth/eth71/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth71/status.rs
@@ -24,8 +24,8 @@ impl RLPxMessage for StatusMessage71 {
 }
 
 impl StatusMessage71 {
-    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
-        StatusDataPost68::new(71, storage).await.map(Self)
+    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+        StatusDataPost68::new(71, storage).map(Self)
     }
 }
 

--- a/crates/networking/p2p/rlpx/eth/status.rs
+++ b/crates/networking/p2p/rlpx/eth/status.rs
@@ -38,14 +38,14 @@ pub struct StatusDataPost68 {
 }
 
 impl StatusDataPost68 {
-    pub async fn new(eth_version: u8, storage: &Store) -> Result<Self, PeerConnectionError> {
+    pub fn new(eth_version: u8, storage: &Store) -> Result<Self, PeerConnectionError> {
         let chain_config = storage.get_chain_config();
         let network_id = chain_config.chain_id;
 
         let genesis_header = storage
             .get_block_header(0)?
             .ok_or(PeerConnectionError::NotFound("Genesis Block".to_string()))?;
-        let latest_block = storage.get_latest_block_number().await?;
+        let latest_block = storage.get_latest_block_number()?;
         let block_header =
             storage
                 .get_block_header(latest_block)?

--- a/crates/networking/p2p/rlpx/eth/update.rs
+++ b/crates/networking/p2p/rlpx/eth/update.rs
@@ -19,8 +19,8 @@ pub struct BlockRangeUpdate {
 }
 
 impl BlockRangeUpdate {
-    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
-        let latest_block = storage.get_latest_block_number().await?;
+    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+        let latest_block = storage.get_latest_block_number()?;
         let block_header =
             storage
                 .get_block_header(latest_block)?

--- a/crates/networking/p2p/rlpx/l2/l2_connection.rs
+++ b/crates/networking/p2p/rlpx/l2/l2_connection.rs
@@ -227,7 +227,7 @@ pub(crate) fn broadcast_l2_message(
 pub(crate) async fn send_new_block(
     established: &mut Established,
 ) -> Result<(), PeerConnectionError> {
-    let latest_block_number = established.storage.get_latest_block_number().await?;
+    let latest_block_number = established.storage.get_latest_block_number()?;
     let latest_block_sent = established
         .l2_state
         .connection_state_mut()?
@@ -520,7 +520,7 @@ pub(crate) async fn send_sealed_batch(
         {
             return Ok(());
         }
-        let l1_fork = established.blockchain.current_fork().await?;
+        let l1_fork = established.blockchain.current_fork()?;
         let Some(batch) = l2_state
             .store_rollup
             .get_batch(next_batch_to_send, l1_fork)

--- a/crates/networking/p2p/sync/full.rs
+++ b/crates/networking/p2p/sync/full.rs
@@ -151,7 +151,7 @@ pub async fn sync_cycle_full(
     store: Store,
     diagnostics: &Arc<RwLock<SyncDiagnostics>>,
 ) -> Result<(), SyncError> {
-    let local_head = store.get_latest_block_number().await?;
+    let local_head = store.get_latest_block_number()?;
     let eth_capable_peers = peers.eth_capable_peer_count().await;
     info!(
         local_head,
@@ -280,7 +280,7 @@ pub async fn sync_cycle_full(
             sync_target_logged = true;
             let (target, target_ts) =
                 fcu_head.unwrap_or((first_header.number, first_header.timestamp));
-            let local_head = store.get_latest_block_number().await?;
+            let local_head = store.get_latest_block_number()?;
             let behind = target.saturating_sub(local_head);
             if behind > FOLLOW_DISTANCE {
                 started_behind = true;
@@ -359,7 +359,7 @@ pub async fn sync_cycle_full(
                 None => false,
             };
             if !resume_parent_has_state {
-                let local_head = store.get_latest_block_number().await?;
+                let local_head = store.get_latest_block_number()?;
                 warn!(
                     resume_parent_number,
                     local_head,
@@ -376,7 +376,7 @@ pub async fn sync_cycle_full(
             // past the executed-state head: an FCU canonicalized blocks before their state
             // was computed. Surface it explicitly; these canonical-but-stateless blocks are
             // re-executed below, and the warning flags the underlying gap for investigation.
-            let canonical_head = store.get_latest_block_number().await?;
+            let canonical_head = store.get_latest_block_number()?;
             // `start_block_number - 1` is the highest block whose post-state is on
             // disk (the executed/state head). Record it so `eth_syncing` reports real
             // progress instead of the canonical pointer, which an FCU may have advanced
@@ -564,7 +564,7 @@ pub async fn sync_cycle_full(
                 None => false,
             };
         if !parent_has_state {
-            let local_head = store.get_latest_block_number().await?;
+            let local_head = store.get_latest_block_number()?;
             warn!(
                 local_head,
                 "Skipping {} pending block(s): the downloaded chain they build on was not fully executed (parent state absent); will retry on the next forkchoice update",
@@ -594,7 +594,7 @@ pub async fn sync_cycle_full(
     // from a hang. Only claim we caught up if we actually executed through to the target;
     // if body downloads gave up early we say so instead of falsely reporting success.
     if started_behind {
-        let local_head = store.get_latest_block_number().await?;
+        let local_head = store.get_latest_block_number()?;
         if reached_target {
             info!(
                 "Reached consensus-provided head at block {local_head}. Waiting for the next forkchoice update from the consensus client."

--- a/crates/networking/p2p/sync/snap_sync.rs
+++ b/crates/networking/p2p/sync/snap_sync.rs
@@ -233,7 +233,7 @@ pub async fn sync_cycle_snap(
         current_head_number = last_block_number;
 
         // If the sync head is not 0 we search to fullsync
-        let head_found = sync_head_found && store.get_latest_block_number().await? > 0;
+        let head_found = sync_head_found && store.get_latest_block_number()? > 0;
         // Or the head is very close to 0. A pre-check in `sync.rs::sync_cycle`
         // also gates on `< MIN_FULL_BLOCKS`; keep both — this one stays as a
         // safety net for callers that enter `sync_cycle_snap` directly.

--- a/crates/networking/p2p/sync_manager.rs
+++ b/crates/networking/p2p/sync_manager.rs
@@ -59,7 +59,7 @@ impl SyncManager {
         // block > 0 means the node has previously synced. For pre-merge networks,
         // use merge_netsplit_block as threshold to avoid false positives in hive tests.
         if snap_enabled.load(Ordering::Relaxed) {
-            let latest_block = store.get_latest_block_number().await.unwrap_or(0);
+            let latest_block = store.get_latest_block_number().unwrap_or(0);
             let chain_config = store.get_chain_config();
             let is_synced = if chain_config.terminal_total_difficulty_passed {
                 latest_block > 0

--- a/crates/networking/rpc/engine/blobs.rs
+++ b/crates/networking/rpc/engine/blobs.rs
@@ -68,7 +68,7 @@ impl RpcHandler for BlobsV1Request {
         // block timestamp to compare against Osaka, so the node is treated as pre-Osaka.
         if let Some(current_block_header) = context
             .storage
-            .get_block_header(context.storage.get_latest_block_number().await?)?
+            .get_block_header(context.storage.get_latest_block_number()?)?
             && context
                 .storage
                 .get_chain_config()
@@ -127,7 +127,7 @@ impl RpcHandler for BlobsV2Request {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Received new engine request: Requested Blobs V2");
-        let res = get_blobs_and_proof(&self.blob_versioned_hashes, context).await?;
+        let res = get_blobs_and_proof(&self.blob_versioned_hashes, context)?;
         if res.iter().any(|blob| blob.is_none()) {
             return Ok(Value::Null);
         }
@@ -150,13 +150,13 @@ impl RpcHandler for BlobsV3Request {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Received new engine request: Requested Blobs V3");
-        let res = get_blobs_and_proof(&self.blob_versioned_hashes, context).await?;
+        let res = get_blobs_and_proof(&self.blob_versioned_hashes, context)?;
         serde_json::to_value(res).map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
 /// Get blob data and proofs for a given list of blob versioned hashes.
-async fn get_blobs_and_proof(
+fn get_blobs_and_proof(
     blob_versioned_hashes: &[H256],
     context: RpcApiContext,
 ) -> Result<Vec<Option<BlobAndProofV2>>, RpcErr> {
@@ -173,7 +173,7 @@ async fn get_blobs_and_proof(
     // (the spec likewise prescribes `null` while syncing).
     let head_is_osaka = match context
         .storage
-        .get_block_header(context.storage.get_latest_block_number().await?)?
+        .get_block_header(context.storage.get_latest_block_number()?)?
     {
         Some(current_block_header) => context
             .storage

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -754,7 +754,7 @@ impl RpcHandler for GetPayloadBodiesByRangeV1Request {
         if self.count > GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
-        let latest_block_number = context.storage.get_latest_block_number().await?;
+        let latest_block_number = context.storage.get_latest_block_number()?;
         // NOTE: we truncate the range because the spec says we "MUST NOT return trailing
         // null values if the request extends past the current latest known block"
         let last = latest_block_number.min(self.start + self.count - 1);
@@ -888,7 +888,7 @@ impl RpcHandler for GetPayloadBodiesByRangeV2Request {
         if self.count > GET_PAYLOAD_BODIES_REQUEST_MAX_SIZE {
             return Err(RpcErr::TooLargeRequest);
         }
-        let latest_block_number = context.storage.get_latest_block_number().await?;
+        let latest_block_number = context.storage.get_latest_block_number()?;
         // NOTE: we truncate the range because the spec says we "MUST NOT return trailing
         // null values if the request extends past the current latest known block"
         let last = latest_block_number.min(self.start + self.count - 1);

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -293,11 +293,8 @@ impl RpcHandler for BlockNumberRequest {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Requested latest block number");
-        serde_json::to_value(format!(
-            "{:#x}",
-            context.storage.get_latest_block_number().await?
-        ))
-        .map_err(|error| RpcErr::Internal(error.to_string()))
+        serde_json::to_value(format!("{:#x}", context.storage.get_latest_block_number()?))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 
@@ -308,7 +305,7 @@ impl RpcHandler for GetBlobBaseFee {
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
         debug!("Requested blob gas price");
-        let block_number = context.storage.get_latest_block_number().await?;
+        let block_number = context.storage.get_latest_block_number()?;
         let header = match context.storage.get_block_header(block_number)? {
             Some(header) => header,
             _ => return Err(RpcErr::Internal("Could not get block header".to_owned())),

--- a/crates/networking/rpc/eth/client.rs
+++ b/crates/networking/rpc/eth/client.rs
@@ -70,7 +70,7 @@ impl RpcHandler for Syncing {
         // near-synced while it has no state up to the tip. Use the canonical head
         // only when its post-state is on disk; otherwise report the executed head
         // recorded by the sync cycle.
-        let canonical_head = context.storage.get_latest_block_number().await?;
+        let canonical_head = context.storage.get_latest_block_number()?;
         let current_block = match context.storage.get_block_header(canonical_head)? {
             Some(header) if context.storage.has_state_root(header.state_root)? => canonical_head,
             _ => syncer
@@ -150,7 +150,7 @@ impl RpcHandler for Config {
         let chain_config = context.storage.get_chain_config();
         let Some(latest_block) = context
             .storage
-            .get_block_by_number(context.storage.get_latest_block_number().await?)
+            .get_block_by_number(context.storage.get_latest_block_number()?)
             .await?
         else {
             return Err(RpcErr::Internal("Failed to fetch latest block".to_string()));
@@ -199,7 +199,7 @@ async fn get_config_for_fork(
         .await?
         .expect("Failed to get genesis block. This should not happen.")
         .header;
-    let block_number = context.storage.get_latest_block_number().await?;
+    let block_number = context.storage.get_latest_block_number()?;
     let fork_id = if let Some(timestamp) = activation_time {
         ForkId::new(chain_config, genesis_header, timestamp, block_number).fork_hash
     } else {

--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -219,7 +219,7 @@ async fn get_range(
     // Get earliest block
     let earliest_block_num = storage.get_earliest_block_number().await?;
     // Get latest block
-    let latest_block_num = storage.get_latest_block_number().await?;
+    let latest_block_num = storage.get_latest_block_number()?;
     // Get the expected finish block number from the parameter
     let expected_finish_block_num = expected_finish_block
         .resolve_block_number(storage)

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -95,7 +95,7 @@ impl NewFilterRequest {
             return Err(RpcErr::BadParams("Invalid block range".to_string()));
         }
 
-        let last_block_number = storage.get_latest_block_number().await?;
+        let last_block_number = storage.get_latest_block_number()?;
         let id: u64 = rand::random();
         let timestamp = Instant::now();
         let mut active_filters_guard = filters.lock().unwrap_or_else(|mut poisoned_guard| {
@@ -195,7 +195,7 @@ impl FilterChangesRequest {
         storage: ethrex_storage::Store,
         filters: ActiveFilters,
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
-        let latest_block_num = storage.get_latest_block_number().await?;
+        let latest_block_num = storage.get_latest_block_number()?;
         // Box needed to keep the future Sync
         // https://github.com/rust-lang/rust/issues/128095
         let mut active_filters_guard =

--- a/crates/networking/rpc/eth/gas_price.rs
+++ b/crates/networking/rpc/eth/gas_price.rs
@@ -33,7 +33,7 @@ impl RpcHandler for GasPrice {
     }
 
     async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
-        let latest_block_number = context.storage.get_latest_block_number().await?;
+        let latest_block_number = context.storage.get_latest_block_number()?;
         let latest_header = context
             .storage
             .get_block_header(latest_block_number)?

--- a/crates/networking/rpc/eth/gas_tip_estimator.rs
+++ b/crates/networking/rpc/eth/gas_tip_estimator.rs
@@ -47,7 +47,7 @@ impl GasTipEstimator {
     /// Estimate Gas Price based on already accepted transactions,
     /// as per the spec, this will be returned in wei.
     pub async fn estimate_gas_tip(&mut self, storage: &Store) -> Result<u64, RpcErr> {
-        let latest_block_number = storage.get_latest_block_number().await?;
+        let latest_block_number = storage.get_latest_block_number()?;
         let latest_block_hash = storage
             .get_canonical_block_hash(latest_block_number)
             .await?

--- a/crates/networking/rpc/types/block_identifier.rs
+++ b/crates/networking/rpc/types/block_identifier.rs
@@ -41,7 +41,7 @@ impl BlockIdentifier {
                 BlockTag::Earliest => Ok(Some(storage.get_earliest_block_number().await?)),
                 BlockTag::Finalized => storage.get_finalized_block_number().await,
                 BlockTag::Safe => storage.get_safe_block_number().await,
-                BlockTag::Latest => Ok(Some(storage.get_latest_block_number().await?)),
+                BlockTag::Latest => Ok(Some(storage.get_latest_block_number()?)),
                 BlockTag::Pending => {
                     // TODO(#1112): We need to check individual intrincacies of the pending tag for
                     // each RPC method that uses it.
@@ -49,7 +49,7 @@ impl BlockIdentifier {
                         Ok(Some(pending_block_number))
                     } else {
                         // If there are no pending blocks, we return the latest block number
-                        Ok(Some(storage.get_latest_block_number().await?))
+                        Ok(Some(storage.get_latest_block_number()?))
                     }
                 }
             },
@@ -155,7 +155,7 @@ impl BlockIdentifierOrHash {
         }
 
         let result = self.resolve_block_number(storage).await?;
-        let latest = storage.get_latest_block_number().await?;
+        let latest = storage.get_latest_block_number()?;
 
         Ok(result.is_some_and(|res| res == latest))
     }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1207,7 +1207,7 @@ impl Store {
     }
 
     /// Obtain latest block number
-    pub async fn get_latest_block_number(&self) -> Result<BlockNumber, StoreError> {
+    pub fn get_latest_block_number(&self) -> Result<BlockNumber, StoreError> {
         Ok(self.latest_block_header.get().number)
     }
 

--- a/test/tests/blockchain/canonical_commit_gate_tests.rs
+++ b/test/tests/blockchain/canonical_commit_gate_tests.rs
@@ -171,7 +171,7 @@ async fn non_canonical_blocks_do_not_prune_genesis() {
     // Precondition that makes the property load-bearing: no FCU ran, so the canonical
     // head is still genesis (block 0). safe_commit_root is therefore still zero.
     assert_eq!(
-        store.get_latest_block_number().await.unwrap(),
+        store.get_latest_block_number().unwrap(),
         0,
         "canonical head must stay at genesis when no forkchoice_update is called"
     );
@@ -400,7 +400,7 @@ async fn bounded_reexec_without_fcu_bounds_memory_and_serves_window() {
     // No FCU ever ran: the canonical head is still genesis, so the safe-commit cell stayed
     // zero — the canonical gate would have committed nothing.
     assert_eq!(
-        store.get_latest_block_number().await.unwrap(),
+        store.get_latest_block_number().unwrap(),
         0,
         "precondition: no forkchoice_update was issued, canonical head stays at genesis"
     );

--- a/test/tests/blockchain/smoke_tests.rs
+++ b/test/tests/blockchain/smoke_tests.rs
@@ -144,7 +144,7 @@ async fn test_reorg_from_long_to_short_chain() {
     assert_ne!(retrieved_1a, retrieved_1b);
     assert_eq!(retrieved_1b, block_1b.header);
     assert!(is_canonical(&store, 1, hash_1b).await.unwrap());
-    assert_eq!(latest_canonical_block_hash(&store).await.unwrap(), hash_1b);
+    assert_eq!(latest_canonical_block_hash(&store).unwrap(), hash_1b);
 
     // Add a third block at height 2, child to the canonical one.
     let block_2 = new_block(&store, &block_1b.header).await;
@@ -156,7 +156,7 @@ async fn test_reorg_from_long_to_short_chain() {
         .await
         .unwrap();
     let retrieved_2 = store.get_block_header_by_hash(hash_2).unwrap();
-    assert_eq!(latest_canonical_block_hash(&store).await.unwrap(), hash_2);
+    assert_eq!(latest_canonical_block_hash(&store).unwrap(), hash_2);
 
     assert!(retrieved_2.is_some());
     assert!(is_canonical(&store, 2, hash_2).await.unwrap());
@@ -230,7 +230,7 @@ async fn new_head_ancestor_of_finalized_should_skip() {
     // State must be unchanged after the skip.
     assert_eq!(store.get_finalized_block_number().await.unwrap(), Some(2));
     assert_eq!(store.get_safe_block_number().await.unwrap(), Some(2));
-    assert_eq!(store.get_latest_block_number().await.unwrap(), 3);
+    assert_eq!(store.get_latest_block_number().unwrap(), 3);
 }
 
 #[tokio::test]
@@ -259,17 +259,14 @@ async fn latest_block_number_should_always_be_the_canonical_head() {
         .add_block(block_2.clone())
         .expect("Could not add block 2.");
 
-    assert_eq!(
-        latest_canonical_block_hash(&store).await.unwrap(),
-        genesis_hash
-    );
+    assert_eq!(latest_canonical_block_hash(&store).unwrap(), genesis_hash);
 
     // Make that chain the canonical one.
     apply_fork_choice(&store, hash_2, genesis_hash, genesis_hash, None)
         .await
         .unwrap();
 
-    assert_eq!(latest_canonical_block_hash(&store).await.unwrap(), hash_2);
+    assert_eq!(latest_canonical_block_hash(&store).unwrap(), hash_2);
 
     // Add a new, non canonical block, starting from genesis.
     let block_1b = new_block(&store, &genesis_header).await;
@@ -279,7 +276,7 @@ async fn latest_block_number_should_always_be_the_canonical_head() {
         .expect("Could not add block b.");
 
     // The latest block should be the same.
-    assert_eq!(latest_canonical_block_hash(&store).await.unwrap(), hash_2);
+    assert_eq!(latest_canonical_block_hash(&store).unwrap(), hash_2);
 
     // if we apply fork choice to the new one, then we should
     apply_fork_choice(&store, hash_b, genesis_hash, genesis_hash, None)
@@ -287,7 +284,7 @@ async fn latest_block_number_should_always_be_the_canonical_head() {
         .unwrap();
 
     // The latest block should now be the new head.
-    assert_eq!(latest_canonical_block_hash(&store).await.unwrap(), hash_b);
+    assert_eq!(latest_canonical_block_hash(&store).unwrap(), hash_b);
 }
 
 #[tokio::test]

--- a/test/tests/p2p/backend_tests.rs
+++ b/test/tests/p2p/backend_tests.rs
@@ -41,6 +41,6 @@ async fn test_validate_status() {
         genesis: genesis_hash,
         fork_id,
     };
-    let result = validate_status(message, &storage, &eth).await;
+    let result = validate_status(message, &storage, &eth);
     assert!(result.is_ok());
 }

--- a/test/tests/storage/deferred_persistence_tests.rs
+++ b/test/tests/storage/deferred_persistence_tests.rs
@@ -363,7 +363,7 @@ async fn boot_clamps_head_to_flushed_upto() {
         .expect("boot must not brick: head clamped to durable block 10");
 
     assert_eq!(
-        store.get_latest_block_number().await.expect("head"),
+        store.get_latest_block_number().expect("head"),
         10,
         "boot must clamp LatestBlockNumber to the durable head"
     );
@@ -429,7 +429,7 @@ async fn boot_on_legacy_db_without_marker_keeps_head() {
 
     // Head must be preserved at 10, NOT rewound to genesis.
     assert_eq!(
-        store.get_latest_block_number().await.expect("head"),
+        store.get_latest_block_number().expect("head"),
         10,
         "legacy DB must keep its head, not clamp to genesis"
     );
@@ -937,7 +937,7 @@ async fn boot_walks_past_reorged_unflushed_head() {
         .expect("boot must not brick: head walks down to durable block 9");
 
     assert_eq!(
-        store.get_latest_block_number().await.expect("head"),
+        store.get_latest_block_number().expect("head"),
         9,
         "boot must re-anchor LatestBlockNumber to the highest resolvable head"
     );
@@ -1011,7 +1011,7 @@ async fn shutdown_flushes_buffered_block_a_crash_would_lose() {
         "shutdown must have flushed the buffered block to disk"
     );
     assert_eq!(
-        store.get_latest_block_number().await.expect("head"),
+        store.get_latest_block_number().expect("head"),
         10,
         "head must stay at the durable block after a clean shutdown"
     );

--- a/test/tests/storage/store_tests.rs
+++ b/test/tests/storage/store_tests.rs
@@ -430,7 +430,7 @@ async fn test_store_block_tags(store: Store) {
 
     let stored_earliest_block_number = store.get_earliest_block_number().await.unwrap();
     let stored_finalized_block_number = store.get_finalized_block_number().await.unwrap().unwrap();
-    let stored_latest_block_number = store.get_latest_block_number().await.unwrap();
+    let stored_latest_block_number = store.get_latest_block_number().unwrap();
     let stored_safe_block_number = store.get_safe_block_number().await.unwrap().unwrap();
     let stored_pending_block_number = store.get_pending_block_number().await.unwrap().unwrap();
 

--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -488,7 +488,7 @@ fn check_prestate_against_db(test_key: &str, test: &TestUnit, db: &Store) {
 /// Panics if any comparison fails
 /// Tests that previously failed the validation stage shouldn't be executed with this function.
 async fn check_poststate_against_db(test_key: &str, test: &TestUnit, db: &Store) {
-    let latest_block_number = db.get_latest_block_number().await.unwrap();
+    let latest_block_number = db.get_latest_block_number().unwrap();
     if let Some(post_state) = &test.post_state {
         for (addr, account) in post_state {
             let expected_account: CoreAccount = account.clone().into();
@@ -537,7 +537,7 @@ async fn check_poststate_against_db(test_key: &str, test: &TestUnit, db: &Store)
         }
     }
     // Check lastblockhash is in store
-    let last_block_number = db.get_latest_block_number().await.unwrap();
+    let last_block_number = db.get_latest_block_number().unwrap();
     let last_block_header = db.get_block_header(last_block_number).unwrap().unwrap();
     let last_block_hash = last_block_header.hash();
     assert_eq!(

--- a/tooling/migrations/src/cli.rs
+++ b/tooling/migrations/src/cli.rs
@@ -87,13 +87,13 @@ async fn migrate_libmdbx_to_rocksdb(
     .await
     .expect("Cannot create rocksdb store");
 
+    // `old_store` is the pinned v1.0.0 libmdbx store, where this accessor is still async.
     let last_block_number = old_store
         .get_latest_block_number()
         .await
         .expect("Cannot get latest block from libmdbx store");
     let last_known_block = new_store
         .get_latest_block_number()
-        .await
         .expect("Cannot get latest known block from rocksdb store");
 
     if last_known_block >= last_block_number {

--- a/tooling/monitor/src/widget/blocks.rs
+++ b/tooling/monitor/src/widget/blocks.rs
@@ -106,7 +106,6 @@ impl BlocksTable {
     ) -> Result<Vec<Block>, MonitorError> {
         let last_l2_block_number = store
             .get_latest_block_number()
-            .await
             .map_err(|_| MonitorError::GetLatestBlock)?;
 
         let mut new_blocks = Vec::new();

--- a/tooling/monitor/src/widget/chain_status.rs
+++ b/tooling/monitor/src/widget/chain_status.rs
@@ -113,7 +113,6 @@ impl GlobalChainStatusTable {
 
         let current_block = store
             .get_latest_block_number()
-            .await
             .map_err(|_| MonitorError::GetLatestBlock)?
             + 1;
 

--- a/tooling/monitor/src/widget/node_status.rs
+++ b/tooling/monitor/src/widget/node_status.rs
@@ -50,7 +50,6 @@ impl NodeStatusTable {
         let last_known_batch = "NaN"; // TODO: Implement last known batch retrieval
         let last_known_block = store
             .get_latest_block_number()
-            .await
             .map_err(|_| MonitorError::GetLatestBlock)?;
         let peers = if is_based {
             Some(l2_client.peer_count().await?)


### PR DESCRIPTION
**Motivation**

`Store::get_latest_block_number` is a pure in-memory read (`self.latest_block_header.get().number`), yet it was declared `async`. Every caller had to `.await` a value that was already available, and that forced a long tail of otherwise-synchronous functions to be `async` too: reading a cached `u64` was generating futures all the way up through the RLPx handshake, discovery fork-id validation, and several RPC/blockchain helpers.

**Description**

Made `Store::get_latest_block_number` synchronous and dropped the `.await` at all ~65 call sites. Then walked the call graph upwards and removed `async` from every function whose only remaining `.await` was this call:

| Function | File |
| --- | --- |
| `Blockchain::current_fork` | `crates/blockchain/blockchain.rs` |
| `latest_canonical_block_hash` | `crates/blockchain/blockchain.rs` |
| `backend::is_fork_id_valid` | `crates/networking/p2p/backend.rs` |
| `backend::validate_status` | `crates/networking/p2p/backend.rs` |
| `PeerTableServer::evaluate_fork_id` | `crates/networking/p2p/peer_table.rs` |
| `DiscoveryServer::discv4_validate_enr_fork_id` | `crates/networking/p2p/discovery/discv4_handlers.rs` |
| `should_send_block_range_update` | `crates/networking/p2p/rlpx/connection/server.rs` |
| `StatusDataPost68::new` | `crates/networking/p2p/rlpx/eth/status.rs` |
| `StatusMessage68/69/70/71::new` | `crates/networking/p2p/rlpx/eth/eth6{8,9}/status.rs`, `eth7{0,1}/status.rs` |
| `BlockRangeUpdate::new` | `crates/networking/p2p/rlpx/eth/update.rs` |
| `get_blobs_and_proof` | `crates/networking/rpc/engine/blobs.rs` |

Iterated to a fixed point, so nothing further up the stack became await-free. The propagation stops there for two reasons:

- `BlockIdentifier::resolve_block_number` stays `async`: the other block tags (`earliest`/`safe`/`finalized`/`pending`) still hit the async store, so the whole `eth_*` RPC surface is unaffected.
- `RpcHandler::handle` impls that became await-free (`eth_blockNumber`, `eth_blobBaseFee`, `engine_getBlobsV1/V2/V3`) keep `async`, since the signature comes from the trait.

One call site keeps its `.await`: `tooling/migrations` reads the *old* store through `ethrex-storage-libmdbx`, a pin of `ethrex-storage` at tag `v1.0.0`, where the method is still `async`.

No behavioural change: the body of `get_latest_block_number` never awaited anything.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
