### PR TITLE
fix(l1): resolve repl against the root workspace

### DIFF
--- a/tooling/repl/Cargo.toml
+++ b/tooling/repl/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+workspace = "../.."
 name = "ethrex-repl"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
**Motivation**

<!-- Why does this pull request exist? What are its goals? -->

`tooling/repl` is declared as a member of the root workspace, but Cargo discovers `tooling/Cargo.toml` first when the repl manifest is used directly.

Because the tooling workspace does not include `repl`, commands such as:

```console
cargo metadata --manifest-path tooling/repl/Cargo.toml --no-deps
```

fail with:

`current package believes it's in a workspace when it's not`



**Description**

<!-- A clear and concise general description of the changes this PR introduces -->

Explicitly set the package workspace to the repository root with:

`workspace = "../.."`

This makes manifest-relative Cargo invocations resolve `tooling/repl` against the workspace that already declares it as a member.

`tooling/runner` is not included in this change because it is not present under `tooling/` on the current main branch.



<!-- Link to issues: Resolves #111, Resolves #222 -->



**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Closes #7107

