### PR TITLE
refactor(l1): edit a NodeRecord in place instead of rebuilding it

### DIFF
--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -450,15 +450,25 @@ impl NodeRecord {
     }
 
     pub fn set_fork_id(&mut self, fork_id: ForkId, signer: &SecretKey) -> Result<(), NodeError> {
-        self.pairs.eth = Some(fork_id);
-        self.update(signer)
+        self.edit(signer, |pairs| pairs.eth = Some(fork_id))
     }
 
     pub fn get_fork_id(&self) -> Option<&ForkId> {
         self.pairs.eth.as_ref()
     }
 
-    fn update(&mut self, signer: &SecretKey) -> Result<(), NodeError> {
+    /// The single path for changing a local record: apply `apply_edit` to the
+    /// entry set, bump `seq` once, and re-sign.
+    ///
+    /// Prefer this over rebuilding a record from a [`Node`]. A rebuild only
+    /// carries the entries [`Self::from_node`] knows how to derive, so anything
+    /// the caller added separately is silently lost, and stitching the lost
+    /// entries back on afterwards bumps `seq` a second time.
+    pub fn edit<F>(&mut self, signer: &SecretKey, apply_edit: F) -> Result<(), NodeError>
+    where
+        F: FnOnce(&mut NodeRecordPairs),
+    {
+        apply_edit(&mut self.pairs);
         self.seq += 1;
         self.signature = self.sign_record(signer)?;
         Ok(())

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -460,6 +460,12 @@ impl NodeRecord {
     /// The single path for changing a local record: apply `apply_edit` to the
     /// entry set, bump `seq` once, and re-sign.
     ///
+    /// All or nothing. The edit lands on a copy that is committed only once the
+    /// new signature is in hand, so a failure leaves the record exactly as it
+    /// was instead of at a bumped `seq` its signature no longer covers. A
+    /// half-updated record is worse than an unchanged one: it verifies nowhere,
+    /// and the next edit bumps past the `seq` peers have already seen.
+    ///
     /// Prefer this over rebuilding a record from a [`Node`]. A rebuild only
     /// carries the entries [`Self::from_node`] knows how to derive, so anything
     /// the caller added separately is silently lost, and stitching the lost
@@ -468,9 +474,12 @@ impl NodeRecord {
     where
         F: FnOnce(&mut NodeRecordPairs),
     {
-        apply_edit(&mut self.pairs);
-        self.seq += 1;
-        self.signature = self.sign_record(signer)?;
+        let mut edited = self.clone();
+        apply_edit(&mut edited.pairs);
+        edited.seq += 1;
+        edited.signature = edited.sign_record(signer)?;
+
+        *self = edited;
         Ok(())
     }
 

--- a/test/tests/p2p/types_tests.rs
+++ b/test/tests/p2p/types_tests.rs
@@ -6,7 +6,10 @@ use ethrex_rlp::decode::RLPDecode;
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
-use std::{net::SocketAddr, str::FromStr};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
+};
 
 const TEST_GENESIS: &str = include_str!("../../../fixtures/genesis/l1.json");
 
@@ -182,4 +185,38 @@ fn verify_enr_signature_fails_when_decode_drops_unknown_pairs() {
     assert_eq!(decoded.pairs().tcp_port, Some(13000));
     assert_eq!(decoded.encode_to_vec(), raw_record);
     assert!(decoded.verify_signature());
+}
+
+#[test]
+fn edit_bumps_seq_once_and_preserves_untouched_entries() {
+    // What `edit` buys over rebuilding a record from its `Node`: entries the
+    // closure never mentions survive, and the record is re-signed exactly once.
+    let signer = SecretKey::from_slice(&[
+        16, 125, 177, 238, 167, 212, 168, 215, 239, 165, 77, 224, 199, 143, 55, 205, 9, 194, 87,
+        139, 92, 46, 30, 191, 74, 37, 68, 242, 38, 225, 104, 246,
+    ])
+    .unwrap();
+    let node = Node::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        30303,
+        30304,
+        public_key_from_signing_key(&signer),
+    );
+    let mut record = NodeRecord::from_node(&node, 1, &signer).unwrap();
+
+    let new_ip = Ipv4Addr::new(203, 0, 113, 7);
+    record
+        .edit(&signer, |pairs| pairs.ip = Some(new_ip))
+        .unwrap();
+
+    assert_eq!(record.seq, 2, "exactly one seq bump");
+    assert!(
+        record.verify_signature(),
+        "must be re-signed after the edit"
+    );
+
+    let pairs = record.pairs();
+    assert_eq!(pairs.ip, Some(new_ip));
+    assert_eq!(pairs.udp_port, Some(30303));
+    assert_eq!(pairs.tcp_port, Some(30304));
 }


### PR DESCRIPTION
## Motivation

Changing a local ENR meant setting a field on `NodeRecordPairs` and remembering to call the private `update` to bump `seq` and re-sign. The alternative callers reach for is worse: rebuilding the record from its `Node`. A rebuild only carries the entries `NodeRecord::from_node` knows how to derive, so anything the caller added separately (a consensus client's `eth2`/`attnets`, a `quic` port) is silently dropped, and stitching those entries back on afterwards bumps `seq` a second time. Every extra bump is a wasted signature and a spurious re-gossip.

## Description

`NodeRecord::update` becomes `NodeRecord::edit`, taking the change as a closure over the entry set:

```rust
record.edit(&signer, |pairs| pairs.ip = Some(new_ip))?;
```

Entries the closure never mentions survive, `seq` moves once, and the record is re-signed once. `set_fork_id` is now one line on top of it.

The edit is applied to a copy and committed only once the new signature is in hand, so a failure leaves the record untouched rather than sitting at a bumped `seq` its signature no longer covers. The old `update` bumped first and signed second. (Thanks @kimi for catching this.)

Split out of the discv5 peer-requirements work, where `update_local_ip` is the caller that needs it.

**Test:** `edit_bumps_seq_once_and_preserves_untouched_entries` pins one `seq` bump, a signature that still verifies, and the untouched `tcp`/`udp` entries still present.