### PR TITLE
fix(l1): iterate from the seek key in the in-memory backend

### DIFF
--- a/crates/storage/backend/in_memory.rs
+++ b/crates/storage/backend/in_memory.rs
@@ -126,7 +126,7 @@ impl StorageReadView for InMemoryReadTx {
 
         let mut entries: Vec<(Vec<u8>, Vec<u8>)> = table_data
             .into_iter()
-            .filter(|(key, _)| key.starts_with(&prefix_vec))
+            .filter(|(key, _)| key.as_slice() >= prefix_vec.as_slice())
             .collect();
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
 

--- a/test/tests/storage/store_tests.rs
+++ b/test/tests/storage/store_tests.rs
@@ -50,6 +50,7 @@ async fn test_store_suite(engine_type: EngineType) {
     run_test(test_store_block, engine_type).await;
     run_test(test_store_block_number, engine_type).await;
     run_test(test_store_block_receipt, engine_type).await;
+    run_test(test_get_receipts_for_block_returns_every_index, engine_type).await;
     run_test(test_store_account_code, engine_type).await;
     run_test(test_store_block_tags, engine_type).await;
     run_test(test_chain_config_storage, engine_type).await;
@@ -376,6 +377,43 @@ async fn test_store_block_receipt(store: Store) {
         .unwrap();
 
     assert_eq!(stored_receipt, receipt);
+}
+
+async fn test_get_receipts_for_block_returns_every_index(store: Store) {
+    let block_header = BlockHeader::default();
+    let block_hash = block_header.hash();
+    let receipts: Vec<Receipt> = (0..4)
+        .map(|i| Receipt::new(TxType::EIP1559, i % 2 == 0, (i as u64 + 1) * 21_000, vec![]))
+        .collect();
+
+    store
+        .add_receipts(block_hash, receipts.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.get_receipts_for_block(&block_hash).await.unwrap(),
+        receipts,
+        "every receipt of the block must be returned, not just the first"
+    );
+
+    assert_eq!(
+        store
+            .get_receipts_for_block_from_index(&block_hash, 2, None)
+            .await
+            .unwrap(),
+        receipts[2..],
+        "a non-zero start index must yield that receipt and all later ones"
+    );
+
+    assert_eq!(
+        store
+            .get_receipts_for_block_from_index(&block_hash, 1, Some(2))
+            .await
+            .unwrap(),
+        receipts[1..3],
+        "max_count must bound the number of receipts returned"
+    );
 }
 
 async fn test_store_account_code(store: Store) {


### PR DESCRIPTION
**Motivation**

`Store::get_receipts_for_block_from_index` builds a `block_hash || start_index` seek key and hands it to `prefix_iterator`, relying on the backend to position there and iterate forward:

```rust
let mut seek_key = prefix.clone();               // block_hash, 32 bytes
seek_key.extend_from_slice(&start_index.to_be_bytes());
let iter = txn.prefix_iterator(RECEIPTS_V2, &seek_key)?;
```

RocksDB's `prefix_iterator_cf` does exactly that, and the loop stops itself once the 32-byte block hash stops matching. The in-memory backend instead filtered on a literal `key.starts_with(seek_key)`, so only the key *equal* to `block_hash || start_index` survived.

On `EngineType::InMemory`, `get_receipts_for_block` therefore returned a single receipt per block, no matter how many were stored — so `eth_getTransactionReceipt` could only ever resolve transaction index 0. `EngineType::InMemory` is reachable outside tests via `cmd/ethrex/initializers.rs:212`.

`cleanup_old_witnesses` is affected the same way: it iterates from the oldest witness block number and breaks past a threshold, intending to prune the whole range, but under the old filter only ever saw one block number's keys.

**Description**

Changes the in-memory backend's `prefix_iterator` to seek semantics — retain keys `>= prefix`, then sort — matching RocksDB. Entries were already sorted afterwards, and every caller either passes an empty prefix (the migrations, unaffected) or bounds its own scan, so no caller relies on the old truncating behaviour.

The regression test goes in the `store_tests` suite, which runs against every engine, so it pins in-memory/RocksDB parity rather than just in-memory correctness. It covers all three read shapes: the whole block, a non-zero start index, and a bounded count.

**Question for reviewers:** is `EngineType::InMemory` intended to be production-reachable, or is it considered test-only? That determines whether this is a user-facing RPC bug or "only" a backend-parity defect that made in-memory tests unable to observe more than one receipt per block. Either way the backends should agree, but it affects how this should be prioritised and whether it warrants a backport.

**Testing**

- `cargo test -p ethrex-storage` — 87 passed, 0 failed
- `cargo test -p ethrex-test --test ethrex_tests storage::` — 24 passed, 0 failed
- Negative control: with the one-line fix reverted, the new test fails exactly as predicted — 4 receipts written, 1 returned
- `cargo fmt --all -- --check` clean; `cargo clippy -p ethrex-storage --all-targets` clean

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Not applicable — this changes read-path iteration only. No stored bytes, key schema, or table layout change, so no re-sync is required.
