### PR TITLE
docs(l1,l2): fix dead steel docs links and exclude bot-blocked hosts

### DIFF
--- a/docs/developers/l1/testing/ef-tests.md
+++ b/docs/developers/l1/testing/ef-tests.md
@@ -5,7 +5,7 @@ These are the official execution spec tests. There are two kinds: `state tests` 
 ### State tests
 
 The state tests are individual transactions not related one to each other that test particular behavior of the EVM. Tests are usually run for multiple forks and the result of execution may vary between forks.
-See [docs](https://steel.ethereum.foundation/docs/execution-specs/mainnet/running_tests/test_formats/state_test/).
+See [docs](https://steel.ethereum.foundation/docs/execution-specs/running_tests/test_formats/state_test/).
 
 To run the test first:
 
@@ -29,7 +29,7 @@ make run-evm-ef-tests
 
 
 The blockchain tests test block validation and the consensus rules of the Ethereum blockchain. Tests are usually run for multiple forks.
-See [docs](https://steel.ethereum.foundation/docs/execution-specs/mainnet/running_tests/test_formats/blockchain_test/).
+See [docs](https://steel.ethereum.foundation/docs/execution-specs/running_tests/test_formats/blockchain_test/).
 
 To run the tests first:
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,6 +20,10 @@ exclude = [
   "medium\\.com",
   "mirror\\.xyz",
   "etherscan\\.io",
+  # Bot-blocked hosts: reachable in a browser, reject or fail automated checks.
+  "discord\\.com/channels",
+  "ethereum\\.stackexchange\\.com",
+  "hive\\.ethpandaops\\.io",
 ]
 
 # SUMMARY.md uses intentional mdBook draft chapters (empty links), which


### PR DESCRIPTION
`Link Check` fails on every PR since the docs merged links that automated checkers can't pass:

- Two `steel.ethereum.foundation` execution-specs links 404 — upstream dropped the `mainnet/` path segment; updated to the new locations (verified 200).
- `discord.com/channels/…` deep links (auth wall), `ethereum.stackexchange.com` (403 bot-blocking) and `hive.ethpandaops.io` (rejects checkers) — added to `lychee.toml` excludes, matching the existing etherscan/medium precedent.

Verified locally with the pinned lychee v0.24.2: **942 links, 0 errors**. Found blocking the v24.0.0 merge-back (#7133); cherry-picked there too.