### PR TITLE
fix(l1): report the block's real gas limit to GASLIMIT under simulation

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2998,6 +2998,7 @@ impl LEVM {
             fee_token: tx.fee_token(),
             disable_balance_check: false,
             disable_nonce_check: false,
+            disable_gas_allowance_check: false,
             is_system_call: false,
         };
 
@@ -3098,7 +3099,10 @@ impl LEVM {
     ) -> Result<ExecutionResult, EvmError> {
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
 
-        env.block_gas_limit = i64::MAX as u64; // disable block gas limit
+        // Let the call run with a `gas` above the block's limit, but leave
+        // `block_gas_limit` at the block's real value: the GASLIMIT opcode reads it, so
+        // overwriting it makes 0x45 return a number that appears nowhere on chain.
+        env.disable_gas_allowance_check = true;
 
         adjust_disabled_base_fee(&mut env);
 
@@ -3897,6 +3901,9 @@ fn env_from_generic(
         // `tx_nonce` to 0 above, which the hook would otherwise reject for
         // any sender whose nonce is nonzero.
         disable_nonce_check: true,
+        // Opt-in per caller: `simulate_tx_from_generic` and `debug_traceCall` relax it so
+        // an over-limit `gas` still runs, while `create_access_list` keeps enforcing it.
+        disable_gas_allowance_check: false,
         is_system_call: false,
     })
 }

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -49,6 +49,13 @@ pub struct Environment {
     /// the nonce, and no client enforces it there. The account nonce still increments
     /// during execution.
     pub disable_nonce_check: bool,
+    /// When true, skip the block-level gas-allowance check. Used by the simulation RPCs
+    /// (eth_call, eth_estimateGas, eth_createAccessList, debug_traceCall), whose callers
+    /// may pass a `gas` above the block's limit and expect the call to run anyway.
+    /// This exists so `block_gas_limit` can keep the block's real value: that field is
+    /// observable through the GASLIMIT opcode and feeds the EIP-8037 cost-per-state-byte
+    /// formula, so raising it to bypass this check corrupts both.
+    pub disable_gas_allowance_check: bool,
     /// When true, the tx is a pre-execution system contract call (EIP-2935, EIP-4788,
     /// EIP-7002, EIP-7251 etc.). Skips the block-level gas-allowance check since system
     /// calls are allowed to exceed `block_gas_limit` (their 30M cap is a separate rule).

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -823,7 +823,7 @@ pub fn validate_gas_allowance(vm: &mut VM<'_>) -> Result<(), TxValidationError> 
     // System contract calls (EIP-2935, EIP-4788, EIP-7002, EIP-7251) bypass the
     // block-level gas-allowance check — their 30M gas budget is a protocol rule
     // independent of `block_gas_limit`.
-    if vm.env.is_system_call {
+    if vm.env.is_system_call || vm.env.disable_gas_allowance_check {
         return Ok(());
     }
     if vm.env.gas_limit > vm.env.block_gas_limit {

--- a/test/tests/levm/bal_selfdestruct_reads_tests.rs
+++ b/test/tests/levm/bal_selfdestruct_reads_tests.rs
@@ -162,6 +162,7 @@ fn selfdestruct_does_not_record_warm_unread_slots_as_bal_reads() {
         fee_token: None,
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/destroyed_refault_tests.rs
+++ b/test/tests/levm/destroyed_refault_tests.rs
@@ -104,6 +104,7 @@ fn env(fork: Fork) -> Environment {
         fee_token: None,
         disable_balance_check: true,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip2780_tests.rs
+++ b/test/tests/levm/eip2780_tests.rs
@@ -124,6 +124,7 @@ fn intrinsic_env(fork: Fork) -> Environment {
         fee_token: None,
         disable_balance_check: true,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip7708_tests.rs
+++ b/test/tests/levm/eip7708_tests.rs
@@ -203,6 +203,7 @@ impl TestBuilder {
             fee_token: None,
             disable_balance_check: false,
             disable_nonce_check: false,
+            disable_gas_allowance_check: false,
             is_system_call: false,
         };
 

--- a/test/tests/levm/eip8037_tests.rs
+++ b/test/tests/levm/eip8037_tests.rs
@@ -103,6 +103,7 @@ fn parity_env(fork: Fork, block_gas_limit: u64) -> Environment {
         fee_token: None,
         disable_balance_check: true,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     }
 }
@@ -329,6 +330,7 @@ fn exec_env(fork: Fork) -> Environment {
         fee_token: None,
         disable_balance_check: true,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip8038_tests.rs
+++ b/test/tests/levm/eip8038_tests.rs
@@ -279,6 +279,7 @@ fn sstore_env(fork: Fork) -> Environment {
         fee_token: None,
         disable_balance_check: true,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip8246_tests.rs
+++ b/test/tests/levm/eip8246_tests.rs
@@ -225,6 +225,7 @@ fn execute_call(
         fee_token: None,
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/l2_fee_token_tests.rs
+++ b/test/tests/levm/l2_fee_token_tests.rs
@@ -186,6 +186,7 @@ fn fee_token_lock_reverted_on_validation_failure() {
         fee_token: Some(fee_token),
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/l2_gas_reservation_tests.rs
+++ b/test/tests/levm/l2_gas_reservation_tests.rs
@@ -157,6 +157,7 @@ fn make_env(gas_limit: u64) -> Environment {
         fee_token: None,
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/l2_hook_tests.rs
+++ b/test/tests/levm/l2_hook_tests.rs
@@ -239,6 +239,7 @@ fn fee_token_storage_rolled_back_on_validation_failure() {
         fee_token: Some(fee_token_addr),
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     };
 
@@ -449,6 +450,7 @@ fn fee_token_revert_during_finalize_triggers_rollback() {
         fee_token: Some(fee_token_addr),
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     };
 
@@ -559,6 +561,7 @@ fn privileged_tx_intrinsic_gas_failure_preserves_sender_balance() {
         fee_token: None,
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/simulation_env_tests.rs
+++ b/test/tests/levm/simulation_env_tests.rs
@@ -33,9 +33,21 @@ const SENDER: Address = Address::repeat_byte(0xAA);
 /// actually reached the environment from one that was silently dropped.
 const SLOTNUM_READER: Address = Address::repeat_byte(0xBB);
 
+/// Holds `GASLIMIT_READER_CODE`, so calling it returns the block gas limit the
+/// environment was built with.
+const GASLIMIT_READER: Address = Address::repeat_byte(0xCC);
+
 /// `SLOTNUM; PUSH0; MSTORE; PUSH1 0x20; PUSH0; RETURN` — returns the slot
 /// number as a 32-byte word.
 const SLOTNUM_READER_CODE: [u8; 7] = [0x4B, 0x5F, 0x52, 0x60, 0x20, 0x5F, 0xF3];
+
+/// `GASLIMIT; PUSH1 0x00; MSTORE; PUSH1 0x20; PUSH1 0x00; RETURN` — returns the
+/// block gas limit as a 32-byte word. Byte-for-byte the probe used to report the
+/// divergence against the other five clients (`0x4560005260206000f3`).
+const GASLIMIT_READER_CODE: [u8; 9] = [0x45, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xF3];
+
+/// The header gas limit every test in this file builds its block with.
+const BLOCK_GAS_LIMIT: u64 = 30_000_000;
 
 fn amsterdam_db_and_header(slot_number: Option<u64>) -> (GeneralizedDatabase, BlockHeader) {
     let mut store = Store::new("", EngineType::InMemory).unwrap();
@@ -57,7 +69,7 @@ fn amsterdam_db_and_header(slot_number: Option<u64>) -> (GeneralizedDatabase, Bl
     let header = BlockHeader {
         number: 1,
         timestamp: 1,
-        gas_limit: 30_000_000,
+        gas_limit: BLOCK_GAS_LIMIT,
         base_fee_per_gas: Some(7),
         state_root: *EMPTY_TRIE_HASH,
         slot_number,
@@ -80,6 +92,15 @@ fn amsterdam_db_and_header(slot_number: Option<u64>) -> (GeneralizedDatabase, Bl
         Account::new(
             U256::zero(),
             Code::from_bytecode(Bytes::from_static(&SLOTNUM_READER_CODE), &NativeCrypto),
+            0,
+            FxHashMap::default(),
+        ),
+    );
+    cache.insert(
+        GASLIMIT_READER,
+        Account::new(
+            U256::zero(),
+            Code::from_bytecode(Bytes::from_static(&GASLIMIT_READER_CODE), &NativeCrypto),
             0,
             FxHashMap::default(),
         ),
@@ -136,5 +157,51 @@ fn simulation_uses_the_slot_number_when_present() {
         simulated_slot_number(Some(1234)),
         U256::from(1234u64),
         "SLOTNUM must read the header's slot_number"
+    );
+}
+
+/// Simulates a call to `GASLIMIT_READER` and returns the block gas limit the
+/// environment ended up with. `gas` is the call object's own gas field, left
+/// unset when `None`.
+fn simulated_block_gas_limit(gas: Option<u64>) -> U256 {
+    let (mut db, header) = amsterdam_db_and_header(Some(0));
+    let tx = GenericTransaction {
+        from: SENDER,
+        to: ethrex_common::types::TxKind::Call(GASLIMIT_READER),
+        gas,
+        ..Default::default()
+    };
+    let result =
+        LEVM::simulate_tx_from_generic(&tx, &header, &mut db, VMType::L1, &NativeCrypto, None)
+            .expect("simulation must not error");
+    match result {
+        ExecutionResult::Success { output, .. } => U256::from_big_endian(&output),
+        other => panic!("expected GASLIMIT call to succeed, got {other:?}"),
+    }
+}
+
+#[test]
+fn simulation_reports_the_header_gas_limit_to_gaslimit() {
+    // The simulation env used to set `block_gas_limit` to `i64::MAX` in order to
+    // skip the block gas-allowance check. That field is what opcode 0x45 pushes,
+    // so eth_call reported 2^63-1 where the other five clients reported the
+    // header's limit, and any contract budgeting against GASLIMIT read nonsense
+    // under simulation. The bypass now has its own flag.
+    assert_eq!(
+        simulated_block_gas_limit(Some(0x200000)),
+        U256::from(BLOCK_GAS_LIMIT),
+        "GASLIMIT under eth_call must equal the header's gas limit"
+    );
+}
+
+#[test]
+fn simulation_still_runs_a_call_asking_for_more_gas_than_the_block_allows() {
+    // The other half of the contract: keeping `block_gas_limit` honest must not
+    // reintroduce the gas-allowance rejection that the `i64::MAX` hack was there
+    // to avoid. A call may ask for more gas than a block could ever hold.
+    assert_eq!(
+        simulated_block_gas_limit(Some(BLOCK_GAS_LIMIT * 2)),
+        U256::from(BLOCK_GAS_LIMIT),
+        "an over-limit `gas` must still run, and still see the real GASLIMIT"
     );
 }

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -330,6 +330,7 @@ pub fn prepare_vm_for_tx<'a>(
             fee_token: None,
             disable_balance_check: false,
             disable_nonce_check: false,
+            disable_gas_allowance_check: false,
             is_system_call: false,
         },
         db,

--- a/tooling/ef_tests/state_v2/src/modules/runner.rs
+++ b/tooling/ef_tests/state_v2/src/modules/runner.rs
@@ -223,6 +223,7 @@ pub fn get_vm_env_for_test(
         fee_token: None,
         disable_balance_check: false,
         disable_nonce_check: false,
+        disable_gas_allowance_check: false,
         is_system_call: false,
     })
 }


### PR DESCRIPTION
**Motivation**

`eth_call` and `eth_estimateGas` report a `GASLIMIT` (opcode `0x45`) that appears nowhere on chain. Against a devnet block whose header gas limit is 300,000,000:

| client | `GASLIMIT` (0x45) | header `gasLimit` |
|---|---|---|
| geth, besu, nethermind, reth, erigon | 300,000,000 | 300,000,000 ✓ |
| ethrex | 9,223,372,036,854,775,807 (`2^63−1`) | 300,000,000 ✗ |

Reproduce against any node:

```
eth_call [{"data":"0x4560005260206000f3","gas":"0x200000","gasPrice":"0x3b9aca00"},"latest"]
```

The value is stable across blocks and independent of the call's own `gas` parameter, so it is not an echo of the request — the simulation environment is populating the block gas limit with `i64::MAX`.

Block execution is unaffected: it builds its environment from the header, which is why nodes agree on state roots and the chain finalizes. But any contract that reads `GASLIMIT` — gas-budgeting logic, batch sizing, DoS guards — gets a nonsense value when simulated against ethrex, and any tool comparing simulated to on-chain behaviour diverges.

**Description**

`simulate_tx_from_generic` set `env.block_gas_limit = i64::MAX` to skip the block-level gas-allowance check, so a call asking for more gas than a block can hold would still run. That conflated two different things: `block_gas_limit` is also what opcode `0x45` pushes.

The bypass now has its own flag, `Environment::disable_gas_allowance_check`, honoured by `validate_gas_allowance` next to the existing `is_system_call` escape. `block_gas_limit` keeps the header's value on every path.

The system-call environment already drew exactly this distinction — it feeds the real header limit and skips the check via `is_system_call`, with a comment noting that `i64::MAX` there would inflate the EIP-8037 `cost_per_state_byte` formula and out-of-gas any state-charging SSTORE. Simulation reads that same formula (`crates/vm/levm/src/vm.rs`), so this also closes a latent Amsterdam mispricing; it is inert today only because `cost_per_state_byte` is pinned to 1530 and ignores its argument.

`create_access_list` shares `env_from_generic` but never had the override, so it still enforces the allowance — behaviour unchanged. Worth noting it is now the one simulation RPC that rejects an over-limit `gas`; aligning that is out of scope here.

`debug_traceCall` has the same override in `prepare_call_env` and the same symptom. That path does not exist on `main` yet, so the fix for it is not in this PR — it is on `glamsterdam-devnet-8` and should ride along with the `debug_traceCall` PR (#6931).

**How to test**

```
cargo test --manifest-path test/Cargo.toml --test ethrex_tests levm::simulation_env
```

Two new tests, using the reported probe bytecode `0x4560005260206000f3` verbatim:

- `simulation_reports_the_header_gas_limit_to_gaslimit` — pins `GASLIMIT` to the header's limit. Reverting the fix reproduces the report exactly:
  ```
  assertion `left == right` failed: GASLIMIT under eth_call must equal the header's gas limit
    left: 9223372036854775807
   right: 30000000
  ```
- `simulation_still_runs_a_call_asking_for_more_gas_than_the_block_allows` — pins the other half of the contract, so the allowance rejection is not reintroduced later.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched.
