### PR TITLE
fix(l1): populate blockTimestamp on RPC log objects

### DIFF
--- a/.github/scripts/check-hive-results.sh
+++ b/.github/scripts/check-hive-results.sh
@@ -59,7 +59,23 @@ mkdir -p "${failed_logs_root}"
 
 # Tests excluded from the failure count (substring match against test case
 # name).
+#
+# The rpc-compat cases below are the ones whose recorded response contains at
+# least one log object. That corpus is pinned to execution-apis d08382ae, which
+# predates `blockTimestamp` on log objects, and rpc-compat compares byte-exactly,
+# so emitting the field (as every other client does) cannot match. The pin cannot
+# move: the field only reaches those fixtures in revisions that also carry a
+# pre-merge test chain, which ethrex does not support by design. See
+# docs/known_issues.md.
 KNOWN_EXCLUDED_TESTS=(
+  "eth_getLogs/contract-addr"
+  "eth_getLogs/no-topics"
+  "eth_getLogs/topic-exact-match"
+  "eth_getLogs/topic-wildcard"
+  "eth_getBlockReceipts/get-block-receipts-latest"
+  "eth_getTransactionReceipt/get-access-list"
+  "eth_getTransactionReceipt/get-blob-tx"
+  "eth_getTransactionReceipt/get-dynamic-fee"
 )
 
 # Build a jq filter that excludes the known-excluded tests.

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -356,6 +356,7 @@ pub async fn get_all_block_rpc_receipts(
         .map_err(|_| RpcErr::Internal("blob_base_fee does not fit in u64".to_owned()))?;
     // Fetch receipt info from block
     let block_hash = header.hash();
+    let block_timestamp = header.timestamp;
     let block_info = RpcReceiptBlockInfo::from_block_header(header);
     // Fetch receipts: only up to target_index+1 when set, otherwise all
     let fetch_count = target_index
@@ -395,6 +396,7 @@ pub async fn get_all_block_rpc_receipts(
             tx_info,
             block_info.clone(),
             current_log_index,
+            block_timestamp,
         );
         last_cumulative_gas_used += gas_used;
         current_log_index += receipt.logs.len() as u64;

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -316,6 +316,7 @@ async fn collect_block_logs(
                         transaction_index: tx_index as u64,
                         block_number: block_num,
                         block_hash,
+                        block_timestamp: block_header.timestamp,
                         removed: false,
                     });
                 }

--- a/crates/networking/rpc/types/receipt.rs
+++ b/crates/networking/rpc/types/receipt.rs
@@ -58,11 +58,18 @@ impl RpcReceipt {
         tx_info: RpcReceiptTxInfo,
         block_info: RpcReceiptBlockInfo,
         init_log_index: u64,
+        block_timestamp: u64,
     ) -> Self {
         let mut logs = vec![];
         let mut log_index = init_log_index;
         for log in receipt.logs.clone() {
-            logs.push(RpcLog::new(log, log_index, &tx_info, &block_info));
+            logs.push(RpcLog::new(
+                log,
+                log_index,
+                &tx_info,
+                &block_info,
+                block_timestamp,
+            ));
             log_index += 1;
         }
         let payer = receipt.payer;
@@ -118,6 +125,18 @@ pub struct RpcLog {
     pub block_hash: BlockHash,
     #[serde(with = "serde_utils::u64::hex_str")]
     pub block_number: BlockNumber,
+    /// Timestamp of the block this log was emitted in. Optional in the
+    /// execution-apis `Log` schema, but every other client populates it, and
+    /// indexers that read it off the log would otherwise need a separate block
+    /// lookup per receipt. Passed in rather than taken from
+    /// `RpcReceiptBlockInfo`, which is flattened into `RpcReceipt` and so must
+    /// not gain a serialized field: `blockTimestamp` belongs on the log object
+    /// only, not alongside the receipt's own keys.
+    ///
+    /// Defaulted on the way in: the schema marks it optional, so a peer that
+    /// omits it must still decode rather than fail the whole response.
+    #[serde(with = "serde_utils::u64::hex_str", default)]
+    pub block_timestamp: u64,
 }
 
 impl RpcLog {
@@ -126,6 +145,7 @@ impl RpcLog {
         log_index: u64,
         tx_info: &RpcReceiptTxInfo,
         block_info: &RpcReceiptBlockInfo,
+        block_timestamp: u64,
     ) -> RpcLog {
         Self {
             log: log.into(),
@@ -135,6 +155,7 @@ impl RpcLog {
             transaction_index: tx_info.transaction_index,
             block_hash: block_info.block_hash,
             block_number: block_info.block_number,
+            block_timestamp,
         }
     }
 }
@@ -285,8 +306,63 @@ mod tests {
                 block_number: 3,
             },
             0,
+            1786901200,
         );
-        let expected = r#"{"type":"0x3","status":"0x1","cumulativeGasUsed":"0x93","logsBloom":"0x00000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","logs":[{"address":"0x0000000000000000000000000000000000000000","topics":[],"data":"0x73747261776265727279","logIndex":"0x0","removed":false,"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3"}],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","from":"0x0000000000000000000000000000000000000000","to":"0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f","contractAddress":null,"gasUsed":"0x93","effectiveGasPrice":"0x9d","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3"}"#;
+        let expected = r#"{"type":"0x3","status":"0x1","cumulativeGasUsed":"0x93","logsBloom":"0x00000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","logs":[{"address":"0x0000000000000000000000000000000000000000","topics":[],"data":"0x73747261776265727279","logIndex":"0x0","removed":false,"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3","blockTimestamp":"0x6a81f2d0"}],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","from":"0x0000000000000000000000000000000000000000","to":"0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f","contractAddress":null,"gasUsed":"0x93","effectiveGasPrice":"0x9d","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3"}"#;
         assert_eq!(serde_json::to_string(&receipt).unwrap(), expected);
+    }
+
+    /// `blockTimestamp` belongs on the log object and nowhere else. Every other
+    /// client populates it there, and indexers reading it off a receipt's logs
+    /// otherwise need a separate block lookup per receipt. The placement half
+    /// matters just as much: `RpcReceiptBlockInfo` is `#[serde(flatten)]`-ed into
+    /// `RpcReceipt`, so sourcing the timestamp from it would also emit a
+    /// receipt-level `blockTimestamp` that no other client sends.
+    #[test]
+    fn block_timestamp_is_on_the_log_and_not_on_the_receipt() {
+        let receipt = RpcReceipt::new(
+            Receipt {
+                tx_type: TxType::EIP1559,
+                succeeded: true,
+                cumulative_gas_used: 21_000,
+                logs: vec![Log {
+                    address: Address::zero(),
+                    topics: vec![],
+                    data: Bytes::new(),
+                }],
+                payer: None,
+                frame_receipts: None,
+            },
+            RpcReceiptTxInfo {
+                transaction_hash: H256::zero(),
+                transaction_index: 0,
+                from: Address::zero(),
+                to: None,
+                contract_address: None,
+                gas_used: 21_000,
+                effective_gas_price: 1,
+                blob_gas_price: None,
+                blob_gas_used: None,
+            },
+            RpcReceiptBlockInfo {
+                block_hash: BlockHash::zero(),
+                block_number: 3,
+            },
+            0,
+            1786901200,
+        );
+
+        let json = serde_json::to_value(&receipt).expect("serialize");
+        let obj = json.as_object().expect("receipt is an object");
+        assert!(
+            !obj.contains_key("blockTimestamp"),
+            "receipt-level keys must stay byte-for-byte what they were"
+        );
+        let log = json["logs"][0].as_object().expect("log is an object");
+        assert_eq!(
+            log.get("blockTimestamp").and_then(|v| v.as_str()),
+            Some("0x6a81f2d0"),
+            "each log must carry the block's timestamp"
+        );
     }
 }

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -1,3 +1,36 @@
+### rpc-compat log-bearing cases excluded
+
+**Where:** `KNOWN_EXCLUDED_TESTS` in `.github/scripts/check-hive-results.sh` counts out
+eight hive `rpc-compat` cases — the four `eth_getLogs` cases, `eth_getBlockReceipts/get-block-receipts-latest`,
+and three `eth_getTransactionReceipt` cases. They are exactly the cases whose recorded
+response contains at least one log object; every case with an empty log array still runs.
+Note this leaves `eth_getLogs` with no rpc-compat coverage at all, since all four of its
+cases are in the set.
+
+**Why:** ethrex populates `blockTimestamp` on log objects, as geth, besu, nethermind, reth
+and erigon all do. hive's rpc-compat compares responses byte-exactly (`jsondiff.FullMatch`;
+the lenient `checkJSONStructure` path applies only to cases upstream marks `speconly`), and
+the corpus is pinned to execution-apis `d08382ae` (2025-02-10), whose recordings predate the
+field — it entered the schema in execution-apis#639 and the fixtures in #846 (2026-07-22).
+So the extra key cannot match, and this is a property of the pin rather than of the response.
+
+**The pin cannot move, and this is not temporary.** The pin sits one commit before
+execution-apis#627, which moved the test chain to a pre-merge genesis: the current corpus has
+~36 proof-of-work blocks before its terminal total difficulty. ethrex does not support
+pre-merge chains and will not, so importing that `chain.rlp` fails at block 1 —
+`validate_block_header` has no pre-London base-fee path. Every revision carrying
+`blockTimestamp` in its fixtures also carries that chain, so there is no revision that
+satisfies both. Nor can the corpus be patched locally: rpc-compat's Dockerfile clones
+`ethereum/execution-apis` by hard-coded URL, so the `branch` buildarg cannot point at a fork.
+
+**Coverage:** the field itself is pinned by
+`block_timestamp_is_on_the_log_and_not_on_the_receipt` in
+`crates/networking/rpc/types/receipt.rs`, which asserts it is present on each log and absent
+from the receipt level.
+
+**Removal:** delete the entries if ethrex ever gains pre-merge chain import, or if upstream
+marks these cases `speconly` so they are type-checked instead of compared byte-for-byte.
+
 ### Stateless (zkEVM) Amsterdam+ EF tests skipped
 
 **Where:** `tooling/ef_tests/blockchain/test_runner.rs` — `parse_and_execute` skips


### PR DESCRIPTION
**Motivation**

Log objects returned by `eth_getBlockReceipts`, `eth_getTransactionReceipt` and `eth_getLogs` omit `blockTimestamp`. Comparing a devnet block's receipts against geth: same receipt count, same receipt-level keys, but **156 differing fields across 226 receipts** — all from one missing key inside each log.

```
receipt[8].logs[0]  blockTimestamp:  geth "0x6a7cf6d0"   ethrex <absent>
```

geth, besu, nethermind, reth and erigon all populate it on every log object. Indexers that read the timestamp straight off a receipt's logs get nothing from ethrex and must fall back to a separate block lookup per receipt.

The field is defined on the `Log` object in the execution-apis schema (`src/schemas/receipt.yaml`) but only `transactionHash` is required, so omitting it is schema-legal. This is a convention divergence rather than a spec violation — the argument for fixing it is the per-receipt lookup every consumer otherwise pays.

**Description**

Adds `block_timestamp` to `RpcLog`. One struct change covers all three endpoints, since `eth_getLogs` and the receipt getters build the same type.

The timestamp is threaded in as an explicit parameter rather than read from `RpcReceiptBlockInfo`. That struct is `#[serde(flatten)]`-ed into `RpcReceipt`, so sourcing it from there would also have emitted a **receipt-level** `blockTimestamp` that no other client sends — and the receipt-level keys already match geth exactly. `blockTimestamp` belongs on the log object and nowhere else.

Decoding defaults the field, so a peer that legitimately omits it (the schema permits it) still parses instead of failing the whole response.

**How to test**

```
cargo test -p ethrex-rpc --lib receipt
```

- `serialize_receipt` — updated expected JSON, pinning `blockTimestamp` inside the log object.
- `block_timestamp_is_on_the_log_and_not_on_the_receipt` — new; asserts both halves, so the flatten hazard above cannot regress silently.

End to end, against a synced node:

```
curl -s -X POST -H 'content-type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockReceipts","params":["latest"]}' \
  http://localhost:8545 | jq '.result[0].logs[0].blockTimestamp'
```

`blockTimestamp` should be present on every log and equal the block's `timestamp`, and must **not** appear at the receipt level.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched.

### rpc-compat: eight cases excluded, permanently

The first CI run failed 8 rpc-compat cases — exactly the ones whose recorded response contains at least one log object (`eth_getLogs/no-topics` with 15 logs down to the three single-log `eth_getTransactionReceipt` cases). All 13 cases with an empty log array passed, which places the cause on the one added key rather than on a wrong value.

hive's rpc-compat compares responses byte-exactly: `runTest` requires `jsondiff.FullMatch`, and the lenient `checkJSONStructure` path applies only to cases upstream marks `speconly`. The corpus is pinned to execution-apis `d08382ae` (2025-02-10), whose recordings predate `blockTimestamp` — it entered the schema in [#639](https://github.com/ethereum/execution-apis/pull/639) and those fixtures in [#846](https://github.com/ethereum/execution-apis/pull/846). So the field cannot match, no matter that the other five clients all send it.

**The pin cannot move.** It sits one commit before [#627](https://github.com/ethereum/execution-apis/pull/627), which moved the test chain to a pre-merge genesis — the current corpus carries ~36 proof-of-work blocks before its terminal total difficulty. ethrex does not support pre-merge chains and will not, so that `chain.rlp` fails to import at block 1 (`validate_block_header` has no pre-London base-fee path). I tried the bump: the job went from 8 failures to `tests=1 failed=1`, the single failure being `client launch`, with no method test executing at all. Every revision that has `blockTimestamp` in its fixtures also has that chain, so no revision satisfies both, and the corpus cannot be patched locally either — rpc-compat's Dockerfile clones `ethereum/execution-apis` by hard-coded URL, so the `branch` buildarg cannot point at a fork.

So the eight cases are counted out in `KNOWN_EXCLUDED_TESTS`, which prints `Ignoring N known-excluded test(s)` rather than passing silently, and the reasoning is recorded in `docs/known_issues.md` — which CI posts as a sticky comment on every PR.

Worth being explicit about the cost: all four `eth_getLogs` cases are in the set, so that method keeps no rpc-compat coverage. The field itself is pinned instead by `block_timestamp_is_on_the_log_and_not_on_the_receipt`, which asserts it is present on each log and absent from the receipt level.
