### PR TITLE
fix(l1): keep ENR entries when discv5 updates the local IP

### DIFF
--- a/crates/networking/p2p/discv5/server.rs
+++ b/crates/networking/p2p/discv5/server.rs
@@ -210,28 +210,38 @@ impl Discv5State {
     }
 }
 
-/// Updates local node IP and re-signs the ENR with incremented seq.
+/// Points `local_node` and its ENR at `new_ip`, bumping `seq` once and re-signing.
+///
+/// Sets whichever of the record's `ip`/`ip6` entries matches `new_ip` and clears
+/// the other. ENRs may carry both, but a [`Node`] holds a single [`IpAddr`], so
+/// the record ethrex owns describes one address and a leftover entry from the
+/// family we just moved away from would send peers to an address we dropped.
+/// Every other entry is left as it is.
+///
+/// [`NodeRecord::edit`] commits only once the new signature is in hand, so a
+/// failed re-sign leaves both the node and the record untouched.
 pub(crate) fn update_local_ip(
     local_node: &mut Node,
     local_node_record: &mut NodeRecord,
     signer: &secp256k1::SecretKey,
     new_ip: IpAddr,
 ) {
-    let mut updated_node = local_node.clone();
-    updated_node.ip = new_ip;
-    let new_seq = local_node_record.seq + 1;
-    let Ok(mut new_record) = NodeRecord::from_node(&updated_node, new_seq, signer) else {
-        tracing::error!(%new_ip, "Failed to create new ENR for IP update");
-        return;
-    };
-    if let Some(fork_id) = local_node_record.get_fork_id().cloned()
-        && new_record.set_fork_id(fork_id, signer).is_err()
-    {
-        tracing::error!(%new_ip, "Failed to set fork_id in new ENR, aborting IP update");
+    let edited = local_node_record.edit(signer, |pairs| match new_ip.to_canonical() {
+        IpAddr::V4(ip) => {
+            pairs.ip = Some(ip);
+            pairs.ip6 = None;
+        }
+        IpAddr::V6(ip) => {
+            pairs.ip6 = Some(ip);
+            pairs.ip = None;
+        }
+    });
+    if let Err(err) = edited {
+        tracing::error!(%new_ip, %err, "Failed to re-sign ENR for IP update");
         return;
     }
+
     local_node.ip = new_ip;
-    *local_node_record = new_record;
 }
 
 #[derive(Debug, Clone)]
@@ -249,10 +259,117 @@ impl Discv5Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::public_key_from_signing_key;
+    use bytes::Bytes;
+    use ethrex_common::types::ForkId;
+    use ethrex_rlp::encode::RLPEncode;
     use rand::{SeedableRng, rngs::StdRng};
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     fn make_test_state() -> Discv5State {
         Discv5State::default()
+    }
+
+    const NEW_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+    const QUIC_PORT: u16 = 9001;
+
+    /// A local identity whose record advertises `quic`, an entry
+    /// [`NodeRecord::from_node`] cannot derive and an IP update must not destroy.
+    fn local_identity(eth: Option<ForkId>) -> (Node, NodeRecord, secp256k1::SecretKey) {
+        let signer = secp256k1::SecretKey::from_slice(&[
+            16, 125, 177, 238, 167, 212, 168, 215, 239, 165, 77, 224, 199, 143, 55, 205, 9, 194,
+            87, 139, 92, 46, 30, 191, 74, 37, 68, 242, 38, 225, 104, 246,
+        ])
+        .unwrap();
+        let node = Node::new(
+            IpAddr::from(Ipv4Addr::LOCALHOST),
+            30303,
+            30303,
+            public_key_from_signing_key(&signer),
+        );
+        let mut record = NodeRecord::from_node(&node, 1, &signer).unwrap();
+        record
+            .edit(&signer, |pairs| {
+                pairs.eth = eth;
+                pairs.other.push((
+                    Bytes::from_static(b"quic"),
+                    QUIC_PORT.encode_to_vec().into(),
+                ));
+            })
+            .unwrap();
+        (node, record, signer)
+    }
+
+    fn quic_entry(record: &NodeRecord) -> Option<&Bytes> {
+        record
+            .pairs()
+            .other
+            .iter()
+            .find(|(key, _)| key.as_ref() == b"quic")
+            .map(|(_, value)| value)
+    }
+
+    #[test]
+    fn update_local_ip_preserves_entries_it_does_not_touch() {
+        // Rebuilding the record from the `Node` carries only what `from_node`
+        // knows how to derive, so a `quic` entry the caller added separately was
+        // silently dropped the first time discv5's IP voting fired.
+        let (mut node, mut record, signer) = local_identity(None);
+
+        update_local_ip(&mut node, &mut record, &signer, NEW_IP);
+
+        assert_eq!(node.ip, NEW_IP);
+        assert_eq!(record.pairs().ip, Some(Ipv4Addr::new(203, 0, 113, 7)));
+        assert_eq!(
+            quic_entry(&record).map(|value| value.as_ref()),
+            Some(QUIC_PORT.encode_to_vec().as_slice()),
+            "an entry the update never mentions must survive it"
+        );
+        assert!(
+            record.verify_signature(),
+            "must be re-signed after the edit"
+        );
+    }
+
+    #[test]
+    fn update_local_ip_bumps_seq_exactly_once() {
+        // With a fork id present the rebuild path bumped twice: once for the
+        // record built at `seq + 1`, then again inside `set_fork_id`. Every extra
+        // bump is a wasted signature and a spurious re-gossip.
+        let fork_id = ForkId {
+            fork_hash: ethrex_common::H32::from_low_u64_be(0xdead_beef),
+            fork_next: 42,
+        };
+        let (mut node, mut record, signer) = local_identity(Some(fork_id.clone()));
+        let seq_before = record.seq;
+
+        update_local_ip(&mut node, &mut record, &signer, NEW_IP);
+
+        assert_eq!(record.seq, seq_before + 1);
+        assert_eq!(record.get_fork_id(), Some(&fork_id));
+    }
+
+    #[test]
+    fn update_local_ip_clears_the_address_family_it_moves_away_from() {
+        // The only case where clearing the other entry is load-bearing: both
+        // tests above start from an `ip`-only record, so `pairs.ip6 = None` runs
+        // but can never be seen to change anything. Left behind, the stale `ip6`
+        // would keep pointing peers at an address we no longer answer on.
+        let (mut node, mut record, signer) = local_identity(None);
+        let old_ipv6 = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        record
+            .edit(&signer, |pairs| {
+                pairs.ip = None;
+                pairs.ip6 = Some(old_ipv6);
+            })
+            .unwrap();
+        assert_eq!(record.pairs().ip6, Some(old_ipv6));
+
+        update_local_ip(&mut node, &mut record, &signer, NEW_IP);
+
+        assert_eq!(record.pairs().ip, Some(Ipv4Addr::new(203, 0, 113, 7)));
+        assert_eq!(record.pairs().ip6, None, "the stale entry must be cleared");
+        assert!(record.verify_signature());
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Motivation**

`update_local_ip` rebuilt the local ENR from `local_node`. A rebuild only carries
the entries `NodeRecord::from_node` knows how to derive (`ip`/`ip6`, `tcp`, `udp`,
`secp256k1`, `id`), so anything the record advertises beyond that is silently
dropped the first time discv5's IP voting fires. A `quic` port simply disappears
from the record we gossip.

Re-stamping the fork id onto the rebuilt record then bumped `seq` a second time:
once for the record built at `seq + 1`, once more inside `set_fork_id`. Every
extra bump is a wasted signature and a spurious re-gossip.

**Description**

Rewrite `update_local_ip` on top of `NodeRecord::edit` (#7135): set the `ip`/`ip6`
entry matching the new address, clear the other, and leave every other entry
alone. `seq` moves once and the record is signed once.

`edit` already applies the change to a copy and commits it only once the new
signature is in hand, so the all-or-nothing behaviour the old code assembled from
local variables is now the callee's. The old path was not half-updating anything;
what changes is that the failure is reported once, with the underlying `NodeError`
attached, rather than from two separate sites.

The doc comment is rewritten to state what the function does, rather than
describing it in terms of the implementation it replaces.

Split out of the discv5 peer-filter work, where this is a prerequisite.

**Tests**

Three new unit tests in `discv5::server::tests`. Each was confirmed to fail
against the implementation it replaces:

- `update_local_ip_preserves_entries_it_does_not_touch` pins a `quic` entry
  surviving an IP update. Before: the entry comes back `None`.
- `update_local_ip_bumps_seq_exactly_once` pins the single `seq` bump with a fork
  id present, and that the fork id is retained. Before: `seq` lands on 4 instead
  of 3.
- `update_local_ip_clears_the_address_family_it_moves_away_from` starts from an
  `ip6`-only record and moves to an IPv4 address. This is the only case where
  clearing the other entry does anything: the other two start `ip`-only, so
  `pairs.ip6 = None` runs but cannot be observed. Without the clear, the stale
  `ip6` keeps pointing peers at an address we no longer answer on.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
