### PR TITLE
feat(l1): give the ENR extras bag accessors

### DIFF
--- a/crates/networking/p2p/discv5/server.rs
+++ b/crates/networking/p2p/discv5/server.rs
@@ -260,9 +260,7 @@ impl Discv5Message {
 mod tests {
     use super::*;
     use crate::utils::public_key_from_signing_key;
-    use bytes::Bytes;
     use ethrex_common::types::ForkId;
-    use ethrex_rlp::encode::RLPEncode;
     use rand::{SeedableRng, rngs::StdRng};
     use std::net::{Ipv4Addr, Ipv6Addr};
 
@@ -291,22 +289,10 @@ mod tests {
         record
             .edit(&signer, |pairs| {
                 pairs.eth = eth;
-                pairs.other.push((
-                    Bytes::from_static(b"quic"),
-                    QUIC_PORT.encode_to_vec().into(),
-                ));
+                assert!(pairs.set_extra_int(b"quic", QUIC_PORT.into()));
             })
             .unwrap();
         (node, record, signer)
-    }
-
-    fn quic_entry(record: &NodeRecord) -> Option<&Bytes> {
-        record
-            .pairs()
-            .other
-            .iter()
-            .find(|(key, _)| key.as_ref() == b"quic")
-            .map(|(_, value)| value)
     }
 
     #[test]
@@ -321,8 +307,8 @@ mod tests {
         assert_eq!(node.ip, NEW_IP);
         assert_eq!(record.pairs().ip, Some(Ipv4Addr::new(203, 0, 113, 7)));
         assert_eq!(
-            quic_entry(&record).map(|value| value.as_ref()),
-            Some(QUIC_PORT.encode_to_vec().as_slice()),
+            record.pairs().extra_int::<u16>(b"quic"),
+            Some(QUIC_PORT),
             "an entry the update never mentions must survive it"
         );
         assert!(

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -315,7 +315,30 @@ pub struct NodeRecordPairs {
     pub eth: Option<ForkId>,
     // Snap entry is being used by some tests such as `test_encode_enr_response`.
     pub snap: Option<Vec<u32>>,
-    pub other: Vec<(Bytes, Bytes)>,
+    /// Entries outside the predefined dictionary, kept verbatim.
+    ///
+    /// Values are **already RLP-encoded**, and deliberately so. A record's
+    /// signature covers its encoded bytes, so an entry only survives a
+    /// decode/re-encode cycle if it comes back out exactly as it went in.
+    /// Holding decoded payloads instead would mean committing to a shape: a
+    /// value that is an RLP list rather than a byte string, which the dictionary
+    /// has no room for and peers do emit, could not be represented at all, and a
+    /// value that merely encodes unusually would be re-emitted canonically. In
+    /// both cases the bytes we re-emit stop matching the bytes we verified.
+    ///
+    /// Keys here must be outside the dictionary. A dictionary key would be
+    /// emitted twice by [`Self::encode_pairs`], once from its typed field and
+    /// once from here, and EIP-778 requires keys to be unique. Such a record
+    /// verifies locally, because both digests come from the same encoding, and
+    /// is rejected by every remote. [`Self::set_extra`] and its siblings refuse
+    /// those keys, and `encode_pairs` skips any that were written here directly,
+    /// so no record ethrex signs can carry a duplicate.
+    ///
+    /// Prefer the setters over pushing tuples: hand-rolling the value encoding
+    /// is easy to get wrong (see [`Self::set_extra`]). Pushing directly is for
+    /// the values they cannot express, such as the RLP list EIP-7636 `client`
+    /// carries, and then keeping the key unique is the caller's job.
+    pub extra_fields: Vec<(Bytes, Bytes)>,
     // TODO implement ipv6 specific ports
 }
 
@@ -344,9 +367,10 @@ impl NodeRecordPairs {
                     decoder.finish_unchecked();
                     decoded_pairs.eth = Some(fork_id);
                 }
-                // Key is some random bytes sequence which we don't care
+                // Any other key. Kept verbatim so an entry in a shape we did
+                // not expect cannot fail the decode of the whole record.
                 _ => {
-                    decoded_pairs.other.push((key, value));
+                    decoded_pairs.extra_fields.push((key, value));
                 }
             }
         }
@@ -381,16 +405,105 @@ impl NodeRecordPairs {
         if let Some(snap) = self.snap.as_ref() {
             pairs.push(("snap".into(), snap.encode_to_vec().into()));
         }
-
         if let Some(tcp) = self.tcp_port {
             pairs.push(("tcp".into(), tcp.encode_to_vec().into()));
         }
         if let Some(udp) = self.udp_port {
             pairs.push(("udp".into(), udp.encode_to_vec().into()));
         }
-        pairs.extend(self.other.clone());
+        // Skipped rather than trusted: a dictionary key here would be the second
+        // entry for a key a typed field already emitted. The setters refuse
+        // those, so this catches the two ways past them, an entry pushed onto
+        // the field directly and a record deserialized from an older or hostile
+        // representation of this struct.
+        pairs.extend(
+            self.extra_fields
+                .iter()
+                .filter(|(key, _)| !Self::is_dictionary_key(key))
+                .cloned(),
+        );
         pairs.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
         pairs
+    }
+
+    /// Whether `key` belongs to a typed field, and so may not be used for an
+    /// extra entry.
+    ///
+    /// Exactly the keys [`Self::try_from_raw_pairs`] decodes into typed fields
+    /// and [`Self::encode_pairs`] emits from them.
+    pub fn is_dictionary_key(key: &[u8]) -> bool {
+        matches!(
+            key,
+            b"id" | b"ip" | b"ip6" | b"tcp" | b"udp" | b"secp256k1" | b"snap" | b"eth"
+        )
+    }
+
+    /// The RLP-decoded payload of an entry outside the predefined dictionary.
+    ///
+    /// Returns `None` when the key is absent *or* when its value is not an RLP
+    /// byte string, so an entry whose shape we did not expect reads as missing
+    /// rather than poisoning the record.
+    pub fn extra(&self, key: &[u8]) -> Option<Bytes> {
+        let (_, value) = self.extra_fields.iter().find(|(k, _)| k.as_ref() == key)?;
+        Bytes::decode(value.as_ref()).ok()
+    }
+
+    /// An extra entry decoded as an integer, e.g. `quic`.
+    ///
+    /// `None` on an absent key or a value that is not a valid RLP integer,
+    /// which includes the non-minimal encodings some clients emit.
+    pub fn extra_int<T: RLPDecode>(&self, key: &[u8]) -> Option<T> {
+        let (_, value) = self.extra_fields.iter().find(|(k, _)| k.as_ref() == key)?;
+        T::decode(value.as_ref()).ok()
+    }
+
+    /// Advertise `payload` under `key`, replacing any existing entry. Returns
+    /// whether it was stored, i.e. whether `key` is outside the dictionary.
+    ///
+    /// Encodes through [`Bytes`], whose `RLPEncode` delegates to `[u8]` and so
+    /// emits a byte string. This is the step worth not hand-rolling: passing a
+    /// bare `Vec<u8>` hits the blanket `Vec<T>` impl and emits a *list* of
+    /// per-byte scalars, which is a well-formed ENR entry that no other client
+    /// can read, and nothing local ever complains.
+    pub fn set_extra(&mut self, key: &[u8], payload: impl Into<Bytes>) -> bool {
+        let encoded = Bytes::from(payload.into().encode_to_vec());
+        self.set_extra_encoded(key, encoded)
+    }
+
+    /// Advertise an integer under `key`, replacing any existing entry. Returns
+    /// whether it was stored, i.e. whether `key` is outside the dictionary.
+    ///
+    /// Takes a `u64` rather than any [`RLPEncode`] so this cannot become the
+    /// footgun [`Self::set_extra`] exists to close: a `Vec<u8>` passed to a
+    /// generic bound would encode as an RLP list, under a method named for
+    /// integers. Every ENR integer entry fits, being at most a uint64.
+    pub fn set_extra_int(&mut self, key: &[u8], value: u64) -> bool {
+        let encoded = Bytes::from(value.encode_to_vec());
+        self.set_extra_encoded(key, encoded)
+    }
+
+    /// The write both setters end in, once the value is encoded: the dictionary
+    /// guard and the replace-rather-than-append rule live here so neither can
+    /// be reached without them.
+    ///
+    /// Replacing matters because EIP-778 requires keys to be unique, and
+    /// appending a second entry for the same key yields a record that verifies
+    /// locally (both digests come from the same encoding) yet is rejected by
+    /// every remote, with no local symptom.
+    ///
+    /// Private: an already-encoded value is exactly the footgun the setters
+    /// above exist to close, so the escape hatch is not offered. A value the
+    /// typed setters cannot express, such as the RLP list EIP-7636 `client`
+    /// carries, has to go onto [`Self::extra_fields`] directly; `encode_pairs`
+    /// still refuses to emit a dictionary key from there.
+    fn set_extra_encoded(&mut self, key: &[u8], encoded: Bytes) -> bool {
+        if Self::is_dictionary_key(key) {
+            return false;
+        }
+        self.extra_fields.retain(|(k, _)| k.as_ref() != key);
+        self.extra_fields
+            .push((Bytes::copy_from_slice(key), encoded));
+        true
     }
 }
 
@@ -426,10 +539,6 @@ impl NodeRecord {
 
     pub fn from_node(node: &Node, seq: u64, signer: &SecretKey) -> Result<Self, NodeError> {
         let mut pairs = NodeRecordPairs {
-            id: Some("v4".to_string()),
-            secp256k1: Some(H264::from_slice(
-                &PublicKey::from_secret_key(secp256k1::SECP256K1, signer).serialize(),
-            )),
             tcp_port: Some(node.tcp_port),
             udp_port: Some(node.udp_port),
             ..Default::default()
@@ -438,6 +547,25 @@ impl NodeRecord {
             IpAddr::V4(ip) => pairs.ip = Some(ip),
             IpAddr::V6(ip) => pairs.ip6 = Some(ip),
         }
+
+        Self::from_pairs(seq, signer, pairs)
+    }
+
+    /// Builds a signed record from a fully specified entry set.
+    ///
+    /// `id` and `secp256k1` are always overwritten: both are fixed by the v4
+    /// identity scheme and the signer, not chosen by the caller. Every other
+    /// entry is taken verbatim, so a node with no TCP listener simply leaves
+    /// `tcp_port` unset rather than encoding that intent as a port of 0.
+    pub fn from_pairs(
+        seq: u64,
+        signer: &SecretKey,
+        mut pairs: NodeRecordPairs,
+    ) -> Result<Self, NodeError> {
+        pairs.id = Some("v4".to_string());
+        pairs.secp256k1 = Some(H264::from_slice(
+            &PublicKey::from_secret_key(secp256k1::SECP256K1, signer).serialize(),
+        ));
 
         let mut record = NodeRecord {
             seq,

--- a/crates/networking/p2p/types.rs
+++ b/crates/networking/p2p/types.rs
@@ -411,17 +411,14 @@ impl NodeRecordPairs {
         if let Some(udp) = self.udp_port {
             pairs.push(("udp".into(), udp.encode_to_vec().into()));
         }
-        // Skipped rather than trusted: a dictionary key here would be the second
-        // entry for a key a typed field already emitted. The setters refuse
-        // those, so this catches the two ways past them, an entry pushed onto
-        // the field directly and a record deserialized from an older or hostile
-        // representation of this struct.
-        pairs.extend(
-            self.extra_fields
-                .iter()
-                .filter(|(key, _)| !Self::is_dictionary_key(key))
-                .cloned(),
-        );
+        // Filter out any duplicate fields, keeping the first occurrence.
+        let extra_fields = self
+            .extra_fields
+            .iter()
+            .filter(|(key, _)| !Self::is_dictionary_key(key))
+            .cloned();
+        pairs.extend(extra_fields);
+        // Sort pairs by key to ensure they are in the correct order for RLP encoding.
         pairs.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
         pairs
     }

--- a/test/tests/p2p/discovery/discv5_messages_tests.rs
+++ b/test/tests/p2p/discovery/discv5_messages_tests.rs
@@ -358,9 +358,7 @@ fn encode_ping_handshake_packet_with_enr() {
             tcp_port: None,
             udp_port: None,
             secp256k1: Some(H264::from_str(key).unwrap()),
-            eth: None,
-            snap: None,
-            other: vec![],
+            ..Default::default()
         },
     );
 

--- a/test/tests/p2p/types_tests.rs
+++ b/test/tests/p2p/types_tests.rs
@@ -1,13 +1,13 @@
 use bytes::Bytes;
 use ethrex_common::H512;
-use ethrex_p2p::types::{Node, NodeRecord};
+use ethrex_p2p::types::{Node, NodeRecord, NodeRecordPairs};
 use ethrex_p2p::utils::public_key_from_signing_key;
 use ethrex_rlp::decode::RLPDecode;
 use ethrex_rlp::encode::RLPEncode;
 use ethrex_storage::{EngineType, Store};
 use secp256k1::SecretKey;
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{Ipv4Addr, SocketAddr},
     str::FromStr,
 };
 
@@ -169,54 +169,290 @@ fn verify_enr_signature_fails_when_decode_drops_unknown_pairs() {
     let decoded = NodeRecord::decode(&raw_record).unwrap();
     let pairs = decoded.pairs();
 
-    assert!(!pairs.other.is_empty());
+    assert!(!pairs.extra_fields.is_empty());
     assert!(
         pairs
-            .other
+            .extra_fields
             .iter()
             .any(|(key, _)| key == &Bytes::from_static(b"attnets"))
     );
     assert!(
         pairs
-            .other
+            .extra_fields
             .iter()
             .any(|(key, _)| key == &Bytes::from_static(b"eth2"))
     );
     assert_eq!(decoded.pairs().tcp_port, Some(13000));
     assert_eq!(decoded.encode_to_vec(), raw_record);
     assert!(decoded.verify_signature());
+
+    // The accessors hand the payloads back without ethrex having to know what
+    // shape they are meant to be in.
+    assert_eq!(pairs.extra(b"attnets"), Some(Bytes::from_static(&[0; 8])));
+    assert_eq!(
+        pairs.extra(b"eth2"),
+        Some(Bytes::from_static(&[
+            0xfd, 0xca, 0x39, 0xb0, 0x00, 0x00, 0x01, 0x21, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff,
+        ]))
+    );
+}
+
+#[test]
+fn unknown_pairs_survive_a_decode_encode_round_trip() {
+    // Same intent as the assertions above, on a key nothing will ever start
+    // recognising: an entry outside the dictionary has to come back verbatim
+    // through decode and re-encode, or the signature over it stops verifying.
+    let mut pairs = NodeRecordPairs {
+        ip: Some(Ipv4Addr::LOCALHOST),
+        udp_port: Some(30303),
+        ..Default::default()
+    };
+    assert!(pairs.set_extra(b"zzz-not-a-real-entry", Bytes::from_static(b"abc")));
+    let record = NodeRecord::from_pairs(1, &test_signer(), pairs).unwrap();
+
+    let decoded = through_enr_url(&record);
+    assert_eq!(decoded.pairs().extra_fields, record.pairs().extra_fields);
+    assert_eq!(decoded.encode_to_vec(), record.encode_to_vec());
+    assert!(decoded.verify_signature());
+}
+
+// --- extra ENR entries + `from_pairs` ---
+
+fn test_signer() -> SecretKey {
+    SecretKey::from_slice(&[
+        16, 125, 177, 238, 167, 212, 168, 215, 239, 165, 77, 224, 199, 143, 55, 205, 9, 194, 87,
+        139, 92, 46, 30, 191, 74, 37, 68, 242, 38, 225, 104, 246,
+    ])
+    .unwrap()
+}
+
+/// Round-trip a record through the `enr:` URL form, the way a remote peer
+/// would receive it.
+fn through_enr_url(record: &NodeRecord) -> NodeRecord {
+    let url = record.enr_url().unwrap();
+    let raw = ethrex_common::base64::decode(&url.as_bytes()[4..]);
+    NodeRecord::decode(&raw).unwrap()
+}
+
+/// An entry set covering both shapes the helpers encode: an opaque payload
+/// ethrex never interprets, and an integer.
+fn with_extra_entries(pairs: &mut NodeRecordPairs) {
+    pairs.set_extra(b"opaque", Bytes::from_static(&[0xfd, 0xca, 0x39, 0xb0]));
+    pairs.set_extra_int(b"quic", 9001);
+}
+
+#[test]
+fn set_extra_round_trips_every_extra_entry() {
+    let mut pairs = NodeRecordPairs {
+        ip: Some(Ipv4Addr::LOCALHOST),
+        udp_port: Some(30303),
+        ..Default::default()
+    };
+    with_extra_entries(&mut pairs);
+    let record = NodeRecord::from_pairs(1, &test_signer(), pairs).unwrap();
+
+    let decoded = through_enr_url(&record);
+    assert!(decoded.verify_signature());
+
+    let pairs = decoded.pairs();
+    assert_eq!(
+        pairs.extra(b"opaque"),
+        Some(Bytes::from_static(&[0xfd, 0xca, 0x39, 0xb0]))
+    );
+    assert_eq!(pairs.extra_int::<u16>(b"quic"), Some(9001));
+}
+
+#[test]
+fn set_extra_encodes_a_byte_string_not_a_list() {
+    // The footgun this helper exists to remove. A bare `Vec<u8>` hits the
+    // blanket `Vec<T>` impl and emits an RLP *list* of per-byte scalars, which
+    // round-trips fine locally and is unreadable to every other client. Pin the
+    // encoded bytes so the distinction cannot silently regress.
+    let mut pairs = NodeRecordPairs::default();
+    pairs.set_extra(b"opaque", Bytes::from_static(&[0xaa, 0xbb]));
+
+    let (_, value) = pairs
+        .extra_fields
+        .iter()
+        .find(|(key, _)| key.as_ref() == b"opaque")
+        .expect("opaque present");
+
+    // 0x82 = byte string of length 2. A list would be 0xc2.
+    assert_eq!(value.as_ref(), [0x82, 0xaa, 0xbb]);
+}
+
+#[test]
+fn a_malformed_extra_entry_reads_as_missing_and_keeps_the_record_usable() {
+    // Why the accessors answer `None` instead of propagating a decode error. A
+    // peer emitting `quic` as a non-minimal integer, or an opaque payload as an
+    // RLP list, must cost us that one entry and nothing more. Failing the whole
+    // decode would cost the record, and because a discv5 NODES response decodes
+    // `nodes` as a single field, every other peer in the batch with it.
+    let mut pairs = NodeRecordPairs {
+        ip: Some(Ipv4Addr::LOCALHOST),
+        udp_port: Some(30303),
+        ..Default::default()
+    };
+    // Pushed rather than set, because no setter will produce these: they are
+    // what arrives from a peer, and this record stands in for that one.
+    // 0x81 0x0a: non-minimal encoding of 10.
+    pairs.extra_fields.push((
+        Bytes::from_static(b"quic"),
+        Bytes::from_static(&[0x81, 0x0a]),
+    ));
+    // 0xc2 ...: a list where a byte string belongs.
+    pairs.extra_fields.push((
+        Bytes::from_static(b"opaque"),
+        Bytes::from_static(&[0xc2, 0x01, 0x02]),
+    ));
+    let record = NodeRecord::from_pairs(1, &test_signer(), pairs).unwrap();
+
+    // The record survives, byte-exact, signature intact.
+    let decoded = through_enr_url(&record);
+    assert!(decoded.verify_signature());
+    assert_eq!(decoded.encode_to_vec(), record.encode_to_vec());
+    assert_eq!(decoded.pairs().udp_port, Some(30303));
+
+    // Only the unreadable entries are unavailable.
+    assert_eq!(decoded.pairs().extra_int::<u16>(b"quic"), None);
+    assert_eq!(decoded.pairs().extra(b"opaque"), None);
+}
+
+#[test]
+fn set_extra_replaces_rather_than_duplicating_a_key() {
+    // EIP-778 requires unique keys and `encode_pairs` does not deduplicate, so
+    // an appended second entry would verify locally and be rejected by every
+    // remote, with no local symptom.
+    let mut pairs = NodeRecordPairs::default();
+    pairs.set_extra_int(b"quic", 9001);
+    pairs.set_extra_int(b"quic", 9002);
+
+    assert_eq!(pairs.extra_fields.len(), 1);
+    assert_eq!(pairs.extra_int::<u16>(b"quic"), Some(9002));
+}
+
+#[test]
+fn a_dictionary_key_is_refused_as_an_extra_entry() {
+    // The same unique-key rule, across the split rather than within the bag.
+    // `tcp` already comes from `tcp_port`, so a second one from here would be
+    // emitted twice: valid-looking locally, rejected by every remote.
+    let mut pairs = NodeRecordPairs {
+        ip: Some(Ipv4Addr::LOCALHOST),
+        tcp_port: Some(30303),
+        udp_port: Some(30303),
+        ..Default::default()
+    };
+
+    assert!(!pairs.set_extra_int(b"tcp", 9999));
+    assert!(!pairs.set_extra(b"id", Bytes::from_static(b"v5")));
+    assert!(!pairs.set_extra(b"secp256k1", Bytes::from_static(b"\x01")));
+    assert!(pairs.extra_fields.is_empty());
+
+    // ...and the one key that is genuinely ours still goes in.
+    assert!(pairs.set_extra_int(b"quic", 9001));
+
+    let record = NodeRecord::from_pairs(1, &test_signer(), pairs).unwrap();
+    let keys: Vec<_> = record
+        .pairs()
+        .encode_pairs()
+        .into_iter()
+        .map(|(key, _)| key)
+        .collect();
+    let mut unique = keys.clone();
+    unique.dedup();
+    assert_eq!(keys, unique, "EIP-778 requires keys to be unique");
+    assert_eq!(record.pairs().tcp_port, Some(30303));
+    assert!(through_enr_url(&record).verify_signature());
+}
+
+#[test]
+fn from_pairs_overwrites_the_identity_entries_it_owns() {
+    // `id` and `secp256k1` are fixed by the v4 scheme and the signer, so a
+    // caller stating them differently must not be able to sign a record that
+    // claims another identity.
+    let signer = test_signer();
+    let record = NodeRecord::from_pairs(
+        1,
+        &signer,
+        NodeRecordPairs {
+            id: Some("v5".to_string()),
+            secp256k1: Some(ethrex_common::H264::zero()),
+            ip: Some(Ipv4Addr::LOCALHOST),
+            udp_port: Some(30303),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(record.pairs().id.as_deref(), Some("v4"));
+    assert_ne!(record.pairs().secp256k1, Some(ethrex_common::H264::zero()));
+    assert_eq!(
+        Node::from_enr(&record).unwrap().public_key,
+        public_key_from_signing_key(&signer)
+    );
+    assert!(through_enr_url(&record).verify_signature());
 }
 
 #[test]
 fn edit_bumps_seq_once_and_preserves_untouched_entries() {
-    // What `edit` buys over rebuilding a record from its `Node`: entries the
-    // closure never mentions survive, and the record is re-signed exactly once.
-    let signer = SecretKey::from_slice(&[
-        16, 125, 177, 238, 167, 212, 168, 215, 239, 165, 77, 224, 199, 143, 55, 205, 9, 194, 87,
-        139, 92, 46, 30, 191, 74, 37, 68, 242, 38, 225, 104, 246,
-    ])
-    .unwrap();
-    let node = Node::new(
-        IpAddr::V4(Ipv4Addr::LOCALHOST),
-        30303,
-        30304,
-        public_key_from_signing_key(&signer),
-    );
-    let mut record = NodeRecord::from_node(&node, 1, &signer).unwrap();
+    // The whole point of `edit` over rebuilding from a `Node`: entries the
+    // closure never mentions have to survive, extra ones included, and the
+    // record must be re-signed exactly once.
+    let signer = test_signer();
+    let mut pairs = NodeRecordPairs {
+        ip: Some(Ipv4Addr::LOCALHOST),
+        udp_port: Some(30303),
+        ..Default::default()
+    };
+    with_extra_entries(&mut pairs);
+    let record = NodeRecord::from_pairs(1, &signer, pairs).unwrap();
 
+    let mut edited = record.clone();
     let new_ip = Ipv4Addr::new(203, 0, 113, 7);
-    record
+    edited
         .edit(&signer, |pairs| pairs.ip = Some(new_ip))
         .unwrap();
 
-    assert_eq!(record.seq, 2, "exactly one seq bump");
+    assert_eq!(edited.seq, record.seq + 1, "exactly one seq bump");
     assert!(
-        record.verify_signature(),
+        edited.verify_signature(),
         "must be re-signed after the edit"
     );
 
-    let pairs = record.pairs();
+    let pairs = through_enr_url(&edited).pairs().clone();
     assert_eq!(pairs.ip, Some(new_ip));
     assert_eq!(pairs.udp_port, Some(30303));
-    assert_eq!(pairs.tcp_port, Some(30304));
+    assert_eq!(pairs.extra_int::<u16>(b"quic"), Some(9001));
+    assert_eq!(
+        pairs.extra(b"opaque"),
+        Some(Bytes::from_static(&[0xfd, 0xca, 0x39, 0xb0]))
+    );
+}
+
+#[test]
+fn an_extra_int_of_zero_encodes_as_the_empty_byte_string() {
+    // ENR integers are big-endian with no leading zero bytes, so zero is the
+    // empty byte string. RLP's integer codec already does exactly that, so what
+    // this pins is that `set_extra_int` routes through it rather than padding
+    // the value to a fixed width.
+    let mut pairs = NodeRecordPairs::default();
+    pairs.set_extra_int(b"counter", 0);
+    let record = NodeRecord::from_pairs(1, &test_signer(), pairs).unwrap();
+
+    let (_, value) = record
+        .pairs()
+        .encode_pairs()
+        .into_iter()
+        .find(|(key, _)| key.as_ref() == b"counter")
+        .expect("counter entry present");
+    assert_eq!(value.as_ref(), [0x80], "RLP empty byte string");
+
+    // Zero must also stay distinguishable from an absent entry.
+    assert_eq!(
+        through_enr_url(&record)
+            .pairs()
+            .extra_int::<u64>(b"counter"),
+        Some(0)
+    );
 }


### PR DESCRIPTION
**Motivation**

`NodeRecordPairs::other` holds every ENR entry outside the predefined
dictionary, already RLP-encoded, and the only way to put something in it was to
push a tuple. That has three traps, none of which shows a local symptom:

- **Encoding by hand.** A bare `Vec<u8>` hits the blanket `Vec<T>` impl and emits
  an RLP *list* of per-byte scalars rather than a byte string. The record is
  well-formed, round-trips locally, and is unreadable to every other client.
- **Appending.** EIP-778 requires keys to be unique, so a second entry for the
  same key yields a record whose signature verifies locally (both digests come
  from the same encoding) and is rejected by every remote.
- **Colliding with the dictionary.** An entry keyed `tcp` is emitted alongside
  the one `tcp_port` already produces. Same duplicate-key break, reached from the
  other direction.

There was also no way to build a new record with such an entry in it:
`from_node` derives the entry set from a `Node` and nothing else.

**Description**

- `set_extra`/`set_extra_int` pick the codec once, so no call site can emit the
  RLP list, and they refuse a dictionary key, returning whether the entry was
  stored. Writes replace rather than append.
- `set_extra_int` takes a `u64` rather than any `RLPEncode`. A generic bound
  would accept a `Vec<u8>` and encode it as a list under a method named for
  integers, which is the very footgun `set_extra` exists to close. Every ENR
  integer entry fits in a uint64.
- Both end in a private `set_extra_encoded`, where the dictionary guard and the
  replace rule live, so neither can be reached without the other. It is not
  public: a setter taking pre-encoded bytes is the footgun itself, and offering
  it beside the two that close it would undo them.
- `encode_pairs` skips dictionary-keyed extras written to the field directly. The
  field stays `pub` so `..Default::default()` construction keeps working, so the
  uniqueness of the keys ethrex signs cannot depend on callers going through the
  setters. This also covers `NodeRecord::edit`, which is a second signing path
  that never passes through `from_pairs`. Pushing directly is the route for the
  values the setters cannot express, such as the RLP list EIP-7636 `client`
  carries; the key's uniqueness within the bag is then the caller's to keep.
- `extra`/`extra_int` read entries back and answer `None` on a value whose shape
  we did not expect. An entry we cannot parse costs us that entry and nothing
  more: failing the decode instead would cost the whole record, and since a
  discv5 NODES response decodes `nodes` as a single RLP field, every other peer
  in the batch with it.
- The field is renamed `other` -> `extra_fields` so it reads as the bag it is,
  and documents why the values stay pre-encoded: the signature covers the encoded
  bytes, so an entry only survives a decode/re-encode cycle if it comes back out
  exactly as it went in. Holding decoded payloads would mean committing to a
  shape, and a value that is an RLP list rather than a byte string could not be
  represented at all.
- `NodeRecord::from_pairs` lets a caller state the entry set outright, with
  `from_node` becoming a thin wrapper over it. `id` and `secp256k1` are still
  forced, both being fixed by the v4 identity scheme and the signer rather than
  chosen by the caller. As a side effect a node with no TCP listener can leave
  `tcp` unset instead of encoding that intent as a port of 0.

No behaviour changes for records ethrex already handles. Reserved keys are routed
to typed fields on decode, so a decoded record never carries one in the bag, and
a record with no extras encodes byte-for-byte as before.

Split out of the discv5 peer-filter work, where this is a prerequisite.

**Tests**

In `test/tests/p2p/types_tests.rs`:

- `set_extra_round_trips_every_extra_entry` covers both value shapes through the
  `enr:` URL form a remote peer would receive.
- `set_extra_encodes_a_byte_string_not_a_list` pins the encoded bytes
  (`0x82 ..`, not `0xc2 ..`) so the footgun cannot silently come back.
- `set_extra_replaces_rather_than_duplicating_a_key` covers the unique-key rule.
- `a_dictionary_key_is_refused_as_an_extra_entry` pins that `tcp`/`id`/`secp256k1`
  are refused, that a genuine extra still goes in, and that the signed record's
  keys are unique. Confirmed to fail without the guard.
- `from_pairs_overwrites_the_identity_entries_it_owns` pins that a caller cannot
  sign a record claiming another identity scheme or public key.
- `a_malformed_extra_entry_reads_as_missing_and_keeps_the_record_usable` feeds a
  non-minimal integer and a list-where-a-byte-string-belongs, and pins that the
  record still verifies byte-exact while only those two entries read as absent.
- `an_extra_int_of_zero_encodes_as_the_empty_byte_string` pins that
  `set_extra_int` routes through RLP's integer codec rather than padding, and
  that zero stays distinguishable from an absent entry.
- `unknown_pairs_survive_a_decode_encode_round_trip` and the extended
  `edit_bumps_seq_once_and_preserves_untouched_entries` cover preservation.

**Known gap, not addressed here**

A peer can publish an ENR that repeats a *non-dictionary* key. ethrex accepts it,
its signature verifies, `extra`/`extra_int` resolve to the first occurrence, and
discv5 relays it in NODES responses. That is pre-existing on `main` rather than
introduced here, and closing it means rejecting records in `try_from_raw_pairs`,
which is a behaviour change this PR is deliberately avoiding. Worth its own PR.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
