### PR TITLE
feat(l1): screen discovered peers through a PeerFilter

### DIFF
--- a/crates/networking/p2p/discovery/discv4_handlers.rs
+++ b/crates/networking/p2p/discovery/discv4_handlers.rs
@@ -1,5 +1,4 @@
 use crate::{
-    backend,
     discovery::lookup::{IterativeLookup, LOOKUP_ALPHA, LOOKUP_BUCKET_SIZE},
     discv4::{
         messages::{
@@ -10,13 +9,13 @@ use crate::{
     },
     metrics::METRICS,
     peer_table::{Contact, ContactValidation, DiscoveryProtocol, PeerTableServerProtocol as _},
-    types::{Endpoint, Node, NodeRecord},
+    types::{Endpoint, Node},
     utils::{
         get_msg_expiration_from_seconds, is_msg_expired, node_id, public_key_from_signing_key,
     },
 };
 use bytes::{Bytes, BytesMut};
-use ethrex_common::{H256, H512, types::ForkId};
+use ethrex_common::{H256, H512};
 use rand::rngs::OsRng;
 use secp256k1::SecretKey;
 use std::time::Duration;
@@ -494,56 +493,6 @@ impl DiscoveryServer {
             enr_response_message.request_hash,
             enr_response_message.node_record.clone(),
         )?;
-
-        self.discv4_validate_enr_fork_id(
-            node_id,
-            sender_public_key,
-            enr_response_message.node_record,
-        )?;
-
-        Ok(())
-    }
-
-    fn discv4_validate_enr_fork_id(
-        &mut self,
-        node_id: H256,
-        sender_public_key: H512,
-        node_record: NodeRecord,
-    ) -> Result<(), DiscoveryServerError> {
-        let node_fork_id = node_record.get_fork_id().cloned();
-
-        let Some(remote_fork_id) = node_fork_id else {
-            self.peer_table.set_is_fork_id_valid(node_id, false)?;
-            debug!(protocol = "discv4", received = "ENRResponse", from = %format!("{sender_public_key:#x}"), "missing fork id in ENR response, skipping");
-            return Ok(());
-        };
-
-        let chain_config = self.store.get_chain_config();
-        let genesis_header = self
-            .store
-            .get_block_header(0)?
-            .ok_or(DiscoveryServerError::InvalidContact)?;
-        let latest_block_number = self.store.get_latest_block_number()?;
-        let latest_block_header = self
-            .store
-            .get_block_header(latest_block_number)?
-            .ok_or(DiscoveryServerError::InvalidContact)?;
-
-        let local_fork_id = ForkId::new(
-            chain_config,
-            genesis_header,
-            latest_block_header.timestamp,
-            latest_block_number,
-        );
-
-        if !backend::is_fork_id_valid(&self.store, &remote_fork_id)? {
-            self.peer_table.set_is_fork_id_valid(node_id, false)?;
-            debug!(protocol = "discv4", received = "ENRResponse", from = %format!("{sender_public_key:#x}"), local_fork_id=%local_fork_id, remote_fork_id=%remote_fork_id, "fork id mismatch in ENR response, skipping");
-            return Ok(());
-        }
-
-        debug!(protocol = "discv4", received = "ENRResponse", from = %format!("{sender_public_key:#x}"), local_fork_id=%local_fork_id, remote_fork_id=%remote_fork_id, "valid fork id in ENR found");
-        self.peer_table.set_is_fork_id_valid(node_id, true)?;
 
         Ok(())
     }

--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -87,7 +87,6 @@ pub struct DiscoveryServer {
     pub local_node_record: NodeRecord,
     pub(crate) signer: SecretKey,
     pub(crate) udp_socket: Arc<UdpSocket>,
-    pub(crate) store: Store,
     pub peer_table: PeerTable,
     pub(crate) config: DiscoveryConfig,
     pub discv4: Option<Discv4State>,
@@ -154,7 +153,6 @@ impl DiscoveryServer {
             local_node_record,
             signer,
             udp_socket: udp_socket.clone(),
-            store: storage,
             peer_table: peer_table.clone(),
             config,
             discv4,
@@ -438,7 +436,7 @@ pub fn is_discv4_packet(data: &[u8]) -> bool {
 impl DiscoveryServer {
     /// Builds a DiscoveryServer suitable for unit tests of discv5 handlers.
     /// Only discv5 state is initialized; discv4 is disabled.
-    /// Uses an in-memory store and a dummy initial lookup interval.
+    /// Uses a dummy initial lookup interval.
     pub fn new_for_discv5_test(
         local_node: Node,
         local_node_record: NodeRecord,
@@ -451,8 +449,6 @@ impl DiscoveryServer {
             local_node_record,
             signer,
             udp_socket,
-            store: Store::new("", ethrex_storage::EngineType::InMemory)
-                .expect("Failed to create store"),
             peer_table,
             config: DiscoveryConfig {
                 discv4_enabled: false,

--- a/crates/networking/p2p/p2p.rs
+++ b/crates/networking/p2p/p2p.rs
@@ -68,6 +68,7 @@ pub mod discv4;
 pub mod discv5;
 pub(crate) mod metrics;
 pub mod network;
+pub mod peer_filter;
 pub mod peer_handler;
 pub mod peer_table;
 pub mod rlpx;

--- a/crates/networking/p2p/peer_filter.rs
+++ b/crates/networking/p2p/peer_filter.rs
@@ -1,0 +1,169 @@
+//! Which of the peers discovery finds are worth handing to a consumer.
+//!
+//! Discovery itself does not know what makes a peer worth dialing. An L1 node
+//! wants an EIP-2124 fork id compatible with its chain; another consumer of
+//! the same discovery stack judges a record by entirely different entries.
+//! Rather than teach discovery every such rule, a consumer supplies a
+//! [`PeerFilter`] and discovery runs each contact's ENR through it as that
+//! record arrives.
+
+use crate::backend;
+use crate::types::NodeRecord;
+use ethrex_storage::Store;
+use tracing::debug;
+
+/// Which of the peers discovery finds a consumer will accept.
+///
+/// Consulted for every contact that arrives with a record, over discv4 and
+/// discv5 alike. A contact discovered without an ENR is never filtered and stays
+/// dialable.
+///
+/// Implementations run inside the peer table's message loop, so a slow `accepts`
+/// stalls every other peer-table operation: keep it to work proportional to the
+/// record, and cache anything expensive at construction.
+///
+/// `accepts` is synchronous, which states that requirement in the type rather
+/// than in this comment. It also keeps the trait object-safe without boxing a
+/// future for every contact discovery hands over.
+///
+/// `Send` because the peer table owns the filter and its state is moved into an
+/// actor task. Not `Sync`: only that task ever touches it. `'static` in
+/// practice, since the table stores it as a `Box<dyn PeerFilter>` that outlives
+/// every caller.
+pub trait PeerFilter: Send {
+    /// Whether this peer is worth dialing, judged from the ENR it published.
+    ///
+    /// A `false` is never final: the peer table runs the contact through the
+    /// filter again as soon as the peer publishes a higher-`seq` record, so a
+    /// filter may reject on facts that later change, such as a fork id read
+    /// against a head we have not synced to yet.
+    ///
+    /// A filter that finds nothing it recognises in the record must still
+    /// decide. Answer `true` where indifference should not cost a dial, and
+    /// `false` where the absence itself disqualifies the peer, as a missing
+    /// `eth` entry does for an execution client.
+    fn accepts(&self, record: &NodeRecord) -> bool;
+}
+
+/// Ethereum's own requirement: the peer's EIP-2124 `eth` entry must be
+/// compatible with our chain, judged against the current head.
+pub struct EthForkIdFilter {
+    store: Store,
+}
+
+impl EthForkIdFilter {
+    pub fn new(store: Store) -> Self {
+        Self { store }
+    }
+}
+
+impl PeerFilter for EthForkIdFilter {
+    fn accepts(&self, record: &NodeRecord) -> bool {
+        // A record that never mentions `eth` is rejected rather than left
+        // unjudged: the discv5 DHT is shared with nodes running protocols this
+        // client does not speak, and those are not peers it can talk to. This
+        // mirrors the `Option<bool>` field it replaces, where a missing entry
+        // was `Some(false)`.
+        let Some(remote_fork_id) = record.get_fork_id() else {
+            debug!(
+                peer = ?record.pairs().secp256k1,
+                "Rejecting peer: ENR carries no eth entry"
+            );
+            return false;
+        };
+
+        match backend::is_fork_id_valid(&self.store, remote_fork_id) {
+            Ok(true) => true,
+            Ok(false) => {
+                // Our own fork id is deliberately not logged alongside:
+                // `is_fork_id_valid` already derives it and throws it away, and
+                // naming it here would mean a second genesis and head read for
+                // every record we turn down.
+                debug!(
+                    peer = ?record.pairs().secp256k1,
+                    %remote_fork_id,
+                    "Rejecting peer: fork id is not compatible with our chain"
+                );
+                false
+            }
+            // Reading our own chain failed, which says nothing about the peer.
+            // The `.ok().or(Some(false))` this replaces rejected here, punishing
+            // a peer for our unreadable DB and then not reconsidering until it
+            // happened to republish its ENR.
+            //
+            // Failing open is safe because this check is an optimisation, not a
+            // boundary: `backend::validate_status` re-checks the fork id during
+            // the RLPx handshake and `rlpx` marks the peer unwanted if it
+            // fails. The cost of being wrong here is one dial.
+            Err(err) => {
+                debug!(%err, "Could not evaluate remote fork id");
+                true
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::NodeRecordPairs;
+    use ethrex_common::types::ForkId;
+    use ethrex_storage::EngineType;
+    use std::{net::Ipv4Addr, path::Path};
+
+    const GENESIS: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../fixtures/genesis/l1.json"
+    );
+
+    /// A store holding the L1 genesis, so our own fork id is computable.
+    async fn store_at_genesis() -> Store {
+        Store::new_from_genesis(Path::new(""), EngineType::InMemory, GENESIS)
+            .await
+            .unwrap()
+    }
+
+    fn record_with_fork_id(eth: Option<ForkId>) -> NodeRecord {
+        let signer = secp256k1::SecretKey::new(&mut rand::rngs::OsRng);
+        NodeRecord::from_pairs(
+            1,
+            &signer,
+            NodeRecordPairs {
+                ip: Some(Ipv4Addr::LOCALHOST),
+                udp_port: Some(30303),
+                eth,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    fn foreign_fork_id() -> ForkId {
+        ForkId {
+            fork_hash: ethrex_common::H32::from_low_u64_be(0xdeadbeef),
+            fork_next: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn our_own_fork_id_is_accepted() {
+        let store = store_at_genesis().await;
+        let ours = store.get_fork_id().await.unwrap();
+
+        assert!(EthForkIdFilter::new(store).accepts(&record_with_fork_id(Some(ours))));
+    }
+
+    #[tokio::test]
+    async fn a_fork_id_from_another_chain_is_rejected() {
+        let filter = EthForkIdFilter::new(store_at_genesis().await);
+
+        assert!(!filter.accepts(&record_with_fork_id(Some(foreign_fork_id()))));
+    }
+
+    #[tokio::test]
+    async fn a_record_without_an_eth_entry_is_rejected() {
+        let filter = EthForkIdFilter::new(store_at_genesis().await);
+
+        assert!(!filter.accepts(&record_with_fork_id(None)));
+    }
+}

--- a/crates/networking/p2p/peer_table.rs
+++ b/crates/networking/p2p/peer_table.rs
@@ -10,8 +10,8 @@
 //! protocol-specific lookups to only query compatible contacts.
 
 use crate::{
-    backend,
     metrics::METRICS,
+    peer_filter::{EthForkIdFilter, PeerFilter},
     rlpx::{connection::server::PeerConnection, p2p::Capability},
     types::{Node, NodeRecord},
     utils::distance,
@@ -207,8 +207,14 @@ pub struct Contact {
     pub knows_us: bool,
     /// This is a known-bad peer (on another network, no matching capabilities, etc)
     pub unwanted: bool,
-    /// Whether the last known fork ID is valid, None if unknown.
-    pub is_fork_id_valid: Option<bool>,
+    /// Whether this contact's last known ENR made it through the consumer's
+    /// [`PeerFilter`], or `None` while it has never been filtered.
+    ///
+    /// Unfiltered stays dialable: a contact discovered without an ENR never
+    /// reaches the filter at all, and treating that as a rejection would leave
+    /// it permanently untriable. That is why bootnodes, which arrive as bare
+    /// endpoints, are dialable before they have published anything.
+    pub passes_filter: Option<bool>,
     /// Session information for discv5 (None for discv4 contacts)
     session: Option<Session>,
 }
@@ -231,15 +237,23 @@ impl Contact {
         self.enr_request_hash = Some(request_hash);
     }
 
-    // If hash does not match, ignore. Otherwise, reset enr_request_hash
-    pub fn record_enr_response_received(&mut self, request_hash: H256, record: NodeRecord) {
+    /// Stores `record` if it answers the ENR request we have outstanding.
+    ///
+    /// Returns whether it was stored, so the caller knows whether the contact's
+    /// cached [`Self::passes_filter`] still describes the record it holds. A
+    /// response whose hash does not match is ignored outright: letting it
+    /// through would let a peer restate its own standing from a record we
+    /// refused to keep.
+    pub fn record_enr_response_received(&mut self, request_hash: H256, record: NodeRecord) -> bool {
         if self
             .enr_request_hash
             .take_if(|h| *h == request_hash)
             .is_some()
         {
             self.record = Some(record);
+            return true;
         }
+        false
     }
 
     pub fn has_pending_enr_request(&self) -> bool {
@@ -260,7 +274,7 @@ impl Contact {
             disposable: false,
             knows_us: true,
             unwanted: false,
-            is_fork_id_valid: None,
+            passes_filter: None,
             session: None,
         }
     }
@@ -402,7 +416,6 @@ pub trait PeerTableServerProtocol: Send + Sync {
     fn remove_peer(&self, node_id: H256) -> Result<(), ActorError>;
     fn dec_requests(&self, node_id: H256) -> Result<(), ActorError>;
     fn set_unwanted(&self, node_id: H256) -> Result<(), ActorError>;
-    fn set_is_fork_id_valid(&self, node_id: H256, valid: bool) -> Result<(), ActorError>;
     fn record_success(&self, node_id: H256) -> Result<(), ActorError>;
     fn record_failure(&self, node_id: H256) -> Result<(), ActorError>;
     fn record_critical_failure(&self, node_id: H256) -> Result<(), ActorError>;
@@ -470,14 +483,16 @@ pub trait PeerTableServerProtocol: Send + Sync {
     fn get_peer_connection(&self, peer_id: H256) -> Response<Option<PeerConnection>>;
 }
 
-#[derive(Debug)]
 pub struct PeerTableServer {
     local_node_id: H256,
     buckets: Vec<KBucket>,
     peers: IndexMap<H256, PeerData>,
     already_tried_peers: FxHashSet<H256>,
     target_peers: usize,
-    store: Store,
+    /// What this consumer requires of a discovered peer. Judged as each ENR
+    /// arrives, over either discovery protocol; the answer is cached on the
+    /// contact as [`Contact::passes_filter`].
+    filter: Box<dyn PeerFilter>,
     /// Standalone session store, independent of contacts.
     /// Allows sessions to be stored even before the contact's ENR is known/parseable.
     sessions: FxHashMap<H256, Session>,
@@ -489,20 +504,53 @@ pub struct PeerTableServer {
     connection_pool: IndexMap<H256, Node>,
 }
 
+// Hand-written because `Box<dyn PeerFilter>` is not `Debug`, and requiring that
+// of every consumer's filter buys less than keeping the actor's state printable.
+impl std::fmt::Debug for PeerTableServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PeerTableServer")
+            .field("local_node_id", &self.local_node_id)
+            .field("peers", &self.peers)
+            .field("already_tried_peers", &self.already_tried_peers)
+            .field("target_peers", &self.target_peers)
+            .field("sessions", &self.sessions)
+            .field("connection_pool", &self.connection_pool)
+            .finish_non_exhaustive()
+    }
+}
+
 #[actor(protocol = PeerTableServerProtocol)]
 impl PeerTableServer {
+    /// Spawn a peer table for an Ethereum L1 node, screening every ENR it sees
+    /// for an EIP-2124 fork id compatible with our chain.
+    ///
+    /// A contact discovered without an ENR is never screened and stays dialable,
+    /// so bootnodes are usable before they have published anything. See
+    /// [`Self::spawn_with_filter`] for consumers on other networks.
     pub fn spawn(local_node_id: H256, target_peers: usize, store: Store) -> PeerTable {
-        PeerTableServer::new(local_node_id, target_peers, store).start()
+        Self::spawn_with_filter(local_node_id, target_peers, EthForkIdFilter::new(store))
     }
 
-    pub(crate) fn new(local_node_id: H256, target_peers: usize, store: Store) -> Self {
+    pub fn spawn_with_filter(
+        local_node_id: H256,
+        target_peers: usize,
+        filter: impl PeerFilter + 'static,
+    ) -> PeerTable {
+        PeerTableServer::new(local_node_id, target_peers, Box::new(filter)).start()
+    }
+
+    pub(crate) fn new(
+        local_node_id: H256,
+        target_peers: usize,
+        filter: Box<dyn PeerFilter>,
+    ) -> Self {
         Self {
             local_node_id,
             buckets: vec![KBucket::default(); NUMBER_OF_BUCKETS],
             peers: Default::default(),
             already_tried_peers: Default::default(),
             target_peers,
-            store,
+            filter,
             sessions: Default::default(),
             connection_pool: IndexMap::with_capacity(MAX_CONNECTION_POOL_SIZE),
         }
@@ -608,17 +656,6 @@ impl PeerTableServer {
     }
 
     #[send_handler]
-    async fn handle_set_is_fork_id_valid(
-        &mut self,
-        msg: peer_table_server_protocol::SetIsForkIdValid,
-        _ctx: &Context<Self>,
-    ) {
-        if let Some(contact) = self.get_contact_mut(&msg.node_id) {
-            contact.is_fork_id_valid = Some(msg.valid);
-        }
-    }
-
-    #[send_handler]
     async fn handle_record_success(
         &mut self,
         msg: peer_table_server_protocol::RecordSuccess,
@@ -690,9 +727,7 @@ impl PeerTableServer {
         msg: peer_table_server_protocol::RecordEnrRequestSent,
         _ctx: &Context<Self>,
     ) {
-        if let Some(contact) = self.get_contact_mut(&msg.node_id) {
-            contact.record_enr_request_sent(msg.request_hash);
-        }
+        self.do_record_enr_request_sent(msg.node_id, msg.request_hash);
     }
 
     #[send_handler]
@@ -701,9 +736,7 @@ impl PeerTableServer {
         msg: peer_table_server_protocol::RecordEnrResponseReceived,
         _ctx: &Context<Self>,
     ) {
-        if let Some(contact) = self.get_contact_mut(&msg.node_id) {
-            contact.record_enr_response_received(msg.request_hash, msg.record);
-        }
+        self.do_record_enr_response_received(msg.node_id, msg.request_hash, msg.record);
     }
 
     #[send_handler]
@@ -1288,7 +1321,7 @@ impl PeerTableServer {
                 || self.already_tried_peers.contains(&node_id)
                 || self
                     .get_contact_or_replacement(&node_id)
-                    .map(|c| !c.knows_us || c.unwanted || c.is_fork_id_valid == Some(false))
+                    .map(|c| !c.knows_us || c.unwanted || c.passes_filter == Some(false))
                     .unwrap_or(false)
             {
                 continue;
@@ -1455,6 +1488,30 @@ impl PeerTableServer {
         }
     }
 
+    fn do_record_enr_request_sent(&mut self, node_id: H256, request_hash: H256) {
+        if let Some(contact) = self.get_contact_mut(&node_id) {
+            contact.record_enr_request_sent(request_hash);
+        }
+    }
+
+    fn do_record_enr_response_received(
+        &mut self,
+        node_id: H256,
+        request_hash: H256,
+        record: NodeRecord,
+    ) {
+        // Filtered here, before the mutable borrow, so a record that reaches us
+        // over discv4 is judged by the same filter as one that arrives over
+        // discv5. The verdict is recorded only if the record was actually
+        // stored, so it always describes the record the contact holds.
+        let passes_filter = self.filter.accepts(&record);
+        if let Some(contact) = self.get_contact_mut(&node_id)
+            && contact.record_enr_response_received(request_hash, record)
+        {
+            contact.passes_filter = Some(passes_filter);
+        }
+    }
+
     async fn do_new_contact_records(&mut self, node_records: Vec<NodeRecord>) {
         for node_record in node_records {
             if !node_record.verify_signature() {
@@ -1479,11 +1536,9 @@ impl PeerTableServer {
                             Some(r) => node_record.seq > r.seq,
                         })
                         .unwrap_or(false);
-                    let is_fork_id_valid = if should_update {
-                        Self::evaluate_fork_id(&node_record, &self.store)
-                    } else {
-                        None
-                    };
+                    // Filtered here, before the mutable borrow, and only when
+                    // the record is newer than the one we already hold.
+                    let passes_filter = should_update.then(|| self.filter.accepts(&node_record));
                     if let Some(contact) = self.get_contact_or_replacement_mut(&node_id) {
                         contact.add_protocol(DiscoveryProtocol::Discv5);
                         if should_update {
@@ -1494,28 +1549,18 @@ impl PeerTableServer {
                             }
                             contact.node = node;
                             contact.record = Some(node_record);
-                            contact.is_fork_id_valid = is_fork_id_valid;
+                            contact.passes_filter = passes_filter;
                         }
                     }
                 } else {
-                    let is_fork_id_valid = Self::evaluate_fork_id(&node_record, &self.store);
+                    let passes_filter = self.filter.accepts(&node_record);
                     let mut contact = Contact::new(node, DiscoveryProtocol::Discv5);
-                    contact.is_fork_id_valid = is_fork_id_valid;
+                    contact.passes_filter = Some(passes_filter);
                     contact.record = Some(node_record);
                     self.insert_contact(node_id, contact);
                     METRICS.record_new_discovery().await;
                 }
             }
-        }
-    }
-
-    fn evaluate_fork_id(record: &NodeRecord, store: &Store) -> Option<bool> {
-        if let Some(remote_fork_id) = record.get_fork_id() {
-            backend::is_fork_id_valid(store, remote_fork_id)
-                .ok()
-                .or(Some(false))
-        } else {
-            Some(false)
         }
     }
 
@@ -1589,6 +1634,7 @@ pub type PeerTable = ActorRef<PeerTableServer>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::NodeRecordPairs;
     use ethrex_common::H512;
     use std::net::Ipv4Addr;
 
@@ -1599,6 +1645,190 @@ mod tests {
         let node_id = node.node_id();
         let contact = Contact::new(node, DiscoveryProtocol::Discv4);
         (node_id, contact)
+    }
+
+    /// A filter with a fixed answer, so peer-table behaviour can be exercised
+    /// without a storage engine or a real chain behind it.
+    struct FixedAnswer(bool);
+
+    impl PeerFilter for FixedAnswer {
+        fn accepts(&self, _record: &NodeRecord) -> bool {
+            self.0
+        }
+    }
+
+    fn table_with(filter: impl PeerFilter + 'static) -> PeerTableServer {
+        PeerTableServer::new(H256::zero(), 10, Box::new(filter))
+    }
+
+    /// A signed record for `seed`'s node at sequence number `seq`.
+    fn record_for(seed: u8, seq: u64) -> (H256, NodeRecord) {
+        let signer = secp256k1::SecretKey::from_slice(&[seed.max(1); 32]).unwrap();
+        let record = NodeRecord::from_pairs(
+            seq,
+            &signer,
+            NodeRecordPairs {
+                ip: Some(Ipv4Addr::new(127, 0, 0, seed)),
+                udp_port: Some(30303),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        (Node::from_enr(&record).unwrap().node_id(), record)
+    }
+
+    // --- the filter decides which contacts are dialable ---
+
+    #[tokio::test]
+    async fn an_arriving_record_is_run_through_the_filter() {
+        let mut table = table_with(FixedAnswer(false));
+        let (node_id, record) = record_for(1, 1);
+
+        table.do_new_contact_records(vec![record]).await;
+
+        let contact = table.get_contact(&node_id).expect("contact inserted");
+        assert_eq!(contact.passes_filter, Some(false));
+    }
+
+    #[tokio::test]
+    async fn a_rejected_contact_is_never_offered_for_dialing() {
+        let mut table = table_with(FixedAnswer(false));
+        let (node_id, record) = record_for(2, 1);
+
+        table.do_new_contact_records(vec![record]).await;
+        assert!(table.get_contact(&node_id).is_some(), "contact is present");
+
+        assert!(
+            table.do_get_contact_to_initiate().is_none(),
+            "a rejected contact must not be handed out to dial"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_accepted_contact_is_offered_for_dialing() {
+        let mut table = table_with(FixedAnswer(true));
+        let (node_id, record) = record_for(3, 1);
+
+        table.do_new_contact_records(vec![record]).await;
+
+        // Asserting the stored answer too, not just dialability: `None` is also
+        // dialable, so `is_some()` alone would pass even if the filter never ran.
+        assert_eq!(
+            table.get_contact(&node_id).unwrap().passes_filter,
+            Some(true)
+        );
+        assert!(table.do_get_contact_to_initiate().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_contact_discovered_without_a_record_is_never_filtered() {
+        // Bootnodes and discv4 neighbours arrive as bare endpoints. They have
+        // published nothing to judge, so they must stay dialable rather than be
+        // written off by a filter that never saw them.
+        let mut table = table_with(FixedAnswer(false));
+        let (node_id, record) = record_for(6, 1);
+        let node = Node::from_enr(&record).unwrap();
+
+        table
+            .do_new_contacts(vec![node], DiscoveryProtocol::Discv4)
+            .await;
+
+        assert_eq!(table.get_contact(&node_id).unwrap().passes_filter, None);
+        assert!(table.do_get_contact_to_initiate().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_discv4_enr_response_is_run_through_the_filter() {
+        // The discv4 path used to bypass the filter entirely and write a
+        // hardcoded fork-id verdict into the same field, so a consumer's own
+        // policy was overridden depending on which protocol found the peer.
+        let mut table = table_with(FixedAnswer(false));
+        let (node_id, record) = record_for(7, 1);
+        let node = Node::from_enr(&record).unwrap();
+        let request_hash = H256::repeat_byte(0xab);
+
+        table
+            .do_new_contacts(vec![node], DiscoveryProtocol::Discv4)
+            .await;
+        table.do_record_enr_request_sent(node_id, request_hash);
+        table.do_record_enr_response_received(node_id, request_hash, record);
+
+        assert_eq!(
+            table.get_contact(&node_id).unwrap().passes_filter,
+            Some(false)
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unsolicited_enr_response_does_not_set_the_verdict() {
+        // The record is not stored when the hash does not match, so recording a
+        // verdict from it would let a peer restate its own standing from a
+        // record the table refused to keep.
+        let mut table = table_with(FixedAnswer(true));
+        let (node_id, record) = record_for(8, 1);
+        let node = Node::from_enr(&record).unwrap();
+
+        table
+            .do_new_contacts(vec![node], DiscoveryProtocol::Discv4)
+            .await;
+        table.do_record_enr_request_sent(node_id, H256::repeat_byte(0x01));
+        table.do_record_enr_response_received(node_id, H256::repeat_byte(0x02), record);
+
+        let contact = table.get_contact(&node_id).unwrap();
+        assert_eq!(contact.passes_filter, None);
+        assert!(contact.record.is_none(), "the record must not be stored");
+    }
+
+    /// Rejects the first record it is shown and accepts every later one, so a
+    /// test can tell whether a second record was filtered at all.
+    #[derive(Default)]
+    struct AcceptsFromTheSecondRecordOn(std::sync::atomic::AtomicUsize);
+
+    impl PeerFilter for AcceptsFromTheSecondRecordOn {
+        fn accepts(&self, _record: &NodeRecord) -> bool {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0
+        }
+    }
+
+    #[tokio::test]
+    async fn a_rejection_is_reconsidered_on_a_newer_record() {
+        // The reason a rejection is stored rather than acted on once: the peer
+        // republishes and we look again, instead of writing it off for the life
+        // of the process over a fork id read against a head we had not synced.
+        let mut table = table_with(AcceptsFromTheSecondRecordOn::default());
+        let (node_id, first) = record_for(4, 1);
+        let (_, newer) = record_for(4, 2);
+
+        table.do_new_contact_records(vec![first]).await;
+        assert_eq!(
+            table.get_contact(&node_id).unwrap().passes_filter,
+            Some(false)
+        );
+
+        table.do_new_contact_records(vec![newer]).await;
+        assert_eq!(
+            table.get_contact(&node_id).unwrap().passes_filter,
+            Some(true),
+            "a higher-seq record must get a fresh hearing"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_older_record_does_not_re_filter_the_contact() {
+        // `should_update` false means the record has nothing new to say, so the
+        // answer already on the contact has to survive it.
+        let mut table = table_with(AcceptsFromTheSecondRecordOn::default());
+        let (node_id, first) = record_for(5, 2);
+        let (_, older) = record_for(5, 1);
+
+        table.do_new_contact_records(vec![first]).await;
+        table.do_new_contact_records(vec![older]).await;
+
+        assert_eq!(
+            table.get_contact(&node_id).unwrap().passes_filter,
+            Some(false),
+            "a stale record must not overwrite the answer we hold"
+        );
     }
 
     // --- KBucket::insert ---


### PR DESCRIPTION
> Stacked on #7144. Review the second commit; the first is that PR.

**Motivation**

The peer table judged every discovered ENR the same way: read the `eth` entry
and ask `backend::is_fork_id_valid`. That rule is Ethereum L1's, but it was
wired into the table itself, which held a `Store` for no other purpose. A
consumer of the same discovery stack on another network had no way to say what
it wanted of a peer.

discv4 had its own copy of the same rule in `discv4_validate_enr_fork_id`,
writing the verdict into the very field the table caches it in. So even with the
rule made injectable, a consumer's policy would have been silently overridden on
whichever contacts discv4 happened to find.

The rule also had a bug. `evaluate_fork_id` ended in `.ok().or(Some(false))`, so
a failed read of *our own* chain was recorded as the peer failing, and the
contact stayed undialable until it happened to republish its ENR.

**Description**

Move the rule behind a `PeerFilter` trait in a new `peer_filter` module, and
give `PeerTableServer` a `Box<dyn PeerFilter>` in place of its `Store`.
`PeerTableServer::spawn` still installs `EthForkIdFilter`, so an L1 node behaves
exactly as before; `spawn_with_filter` is for everyone else.
`Contact::is_fork_id_valid` becomes `passes_filter`, since the field no longer
names a fork id.

Both discovery protocols now go through that one filter. discv4's copy of the
fork-id rule is deleted and the judgment happens in
`do_record_enr_response_received`, inside the actor that owns the filter. That
leaves `DiscoveryServer::store` unused, so it goes too.

Moving it there closes a smaller hole on the way. `discv4_validate_enr_fork_id`
ran on any solicited ENRResponse, including one whose `request_hash` did not
match the outstanding request, so a peer could set its own standing from a record
the table had refused to store. `record_enr_response_received` now reports
whether it kept the record, and the verdict is recorded only when it did.

`accepts` is synchronous rather than async, which states in the type what a
comment would otherwise have to: it runs inside the peer table's message loop, so
awaiting in it stalls every other peer-table operation. It also keeps the trait
object-safe without boxing a future per contact.

`EthForkIdFilter` fails open when our own chain is unreadable. That check is an
optimisation, not a boundary: `backend::validate_status` re-checks the fork id
during the RLPx handshake and `rlpx` marks the peer unwanted if it fails, so the
cost of being wrong is one dial. discv4 already failed open here, so this makes
the two paths agree rather than diverge. A missing `eth` entry is still a
rejection, matching the `Option<bool>` field it replaces.

A rejection is stored rather than acted on once, so a peer that republishes with
a higher `seq` gets a fresh hearing instead of being written off for the life of
the process over a fork id read against a head we had not synced to yet. A
contact discovered without an ENR is never filtered and stays dialable, so
bootnodes are usable before they have published anything.

`PeerTableServer` keeps a hand-written `Debug`, since `Box<dyn PeerFilter>` has
none and requiring it of every consumer's filter buys less than a printable actor
state. This matches what `DiscoveryServer` already does.

**Tests**

`peer_filter::tests` exercises the filter against a store at L1 genesis: our own
fork id is accepted, one from another chain is rejected, and a record with no
`eth` entry is rejected.

`peer_table::tests` exercises the table's use of it against a stub filter, so no
storage engine or real chain is involved:

- `an_arriving_record_is_run_through_the_filter`
- `a_rejected_contact_is_never_offered_for_dialing`
- `an_accepted_contact_is_offered_for_dialing`
- `a_rejection_is_reconsidered_on_a_newer_record`
- `an_older_record_does_not_re_filter_the_contact`
- `a_contact_discovered_without_a_record_is_never_filtered`
- `a_discv4_enr_response_is_run_through_the_filter`, confirmed to fail against
  the bypassing version
- `an_unsolicited_enr_response_does_not_set_the_verdict`, confirmed to fail if
  the verdict is recorded without the store check

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
