### PR TITLE
refactor(l1): build the local ENR outside the discovery server

### DIFF
--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -106,16 +106,6 @@ impl std::fmt::Debug for DiscoveryServer {
 impl DiscoveryServer {
     /// Starts the discovery actor, advertising `local_node_record` as this
     /// node's ENR.
-    ///
-    /// The record is supplied rather than derived from `local_node`, because
-    /// what a node publishes is the caller's to decide: which entries it
-    /// carries beyond the addresses, and what `seq` it resumes from. Deriving
-    /// it here also forced a panic on a failure the caller is better placed to
-    /// report.
-    ///
-    /// This was the last reader of the `Store` `spawn` used to take: with the
-    /// fork-id screening moved behind `PeerFilter`, discovery no longer touches
-    /// our chain at all.
     pub async fn spawn(
         local_node: Node,
         local_node_record: NodeRecord,

--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -8,11 +8,10 @@ use crate::{
         server::{Discv5Message, Discv5State, update_local_ip},
     },
     peer_table::{DiscoveryProtocol, PeerTable, PeerTableServerProtocol as _},
-    types::{INITIAL_ENR_SEQ, Node, NodeRecord},
+    types::{Node, NodeRecord},
 };
 use bytes::BytesMut;
 use ethrex_common::utils::keccak;
-use ethrex_storage::Store;
 use futures::StreamExt;
 use secp256k1::SecretKey;
 use spawned_concurrency::{
@@ -105,9 +104,21 @@ impl std::fmt::Debug for DiscoveryServer {
 
 #[actor(protocol = DiscoveryServerProtocol)]
 impl DiscoveryServer {
+    /// Starts the discovery actor, advertising `local_node_record` as this
+    /// node's ENR.
+    ///
+    /// The record is supplied rather than derived from `local_node`, because
+    /// what a node publishes is the caller's to decide: which entries it
+    /// carries beyond the addresses, and what `seq` it resumes from. Deriving
+    /// it here also forced a panic on a failure the caller is better placed to
+    /// report.
+    ///
+    /// This was the last reader of the `Store` `spawn` used to take: with the
+    /// fork-id screening moved behind `PeerFilter`, discovery no longer touches
+    /// our chain at all.
     pub async fn spawn(
-        storage: Store,
         local_node: Node,
+        local_node_record: NodeRecord,
         signer: SecretKey,
         udp_socket: Arc<UdpSocket>,
         peer_table: PeerTable,
@@ -115,14 +126,6 @@ impl DiscoveryServer {
         config: DiscoveryConfig,
     ) -> Result<(), DiscoveryServerError> {
         debug!("Starting discovery server");
-
-        let mut local_node_record = NodeRecord::from_node(&local_node, INITIAL_ENR_SEQ, &signer)
-            .expect("Failed to create local node record");
-        if let Ok(fork_id) = storage.get_fork_id().await {
-            local_node_record
-                .set_fork_id(fork_id, &signer)
-                .expect("Failed to set fork_id on local node record");
-        }
 
         let discv4 = if config.discv4_enabled {
             info!(

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -13,7 +13,7 @@ use crate::{
         p2p::SUPPORTED_SNAP_CAPABILITIES,
     },
     tx_broadcaster::{TxBroadcaster, TxBroadcasterError},
-    types::{NetworkConfig, Node},
+    types::{INITIAL_ENR_SEQ, NetworkConfig, Node, NodeError, NodeRecord},
 };
 use ethrex_blockchain::Blockchain;
 use ethrex_common::H256;
@@ -117,6 +117,26 @@ pub enum NetworkError {
     TxBroadcasterError(#[from] TxBroadcasterError),
     #[error("Failed to bind UDP socket: {0}")]
     UdpSocketError(std::io::Error),
+    #[error("Failed to build the local node record: {0}")]
+    LocalNodeRecordError(#[from] NodeError),
+}
+
+/// The ENR this node publishes: whatever `local_node` advertises, plus our own
+/// EIP-2124 fork id.
+///
+/// Built here rather than inside discovery, which has no say in what this node
+/// announces about itself.
+///
+/// A chain that cannot supply a fork id leaves the entry out instead of failing
+/// startup. The record is still usable for discovery, and a peer that requires
+/// `eth` simply passes us over until we republish with it. A record we cannot
+/// sign is different, and is reported.
+async fn build_local_node_record(context: &P2PContext) -> Result<NodeRecord, NodeError> {
+    let mut record = NodeRecord::from_node(&context.local_node, INITIAL_ENR_SEQ, &context.signer)?;
+    if let Ok(fork_id) = context.storage.get_fork_id().await {
+        record.set_fork_id(fork_id, &context.signer)?;
+    }
+    Ok(record)
 }
 
 pub async fn start_network(
@@ -130,9 +150,11 @@ pub async fn start_network(
             .map_err(NetworkError::UdpSocketError)?,
     );
 
+    let local_node_record = build_local_node_record(&context).await?;
+
     DiscoveryServer::spawn(
-        context.storage.clone(),
         context.local_node.clone(),
+        local_node_record,
         context.signer,
         udp_socket,
         context.table.clone(),


### PR DESCRIPTION
**Motivation**

`DiscoveryServer::spawn` derived the record it advertises from `local_node`,
then stamped our own fork id onto it. Neither is discovery's decision to make.
What a node publishes about itself belongs to the caller: which entries the
record carries beyond the addresses, and what `seq` it resumes from. Deriving it
inside `spawn` left no way to say either.

It also forced a `panic` on a failure the caller reports as an error, via two
`expect`s on the signing path.

**Description**

`spawn` takes a `NodeRecord` instead of building one, and the construction moves
to `start_network`, which already holds the node, the signer and the store.

The resulting record is byte-identical to what `spawn` produced: `from_node` at
`INITIAL_ENR_SEQ` followed by `set_fork_id`, which bumps `seq` once. No entry,
sequence number or signature changes.

That was the last reader of the `Store` `spawn` took. #7145 moved the fork-id
screening behind `PeerFilter` and removed the `DiscoveryServer::store` field it
fed; with the ENR built elsewhere, discovery no longer touches our chain at all,
so the parameter goes too. Neither change could drop it alone, which is why this
sits on top of #7145 rather than on `main`.

The two `expect`s become a `NetworkError`. `init_network` ends in
`.expect("Network starts")`, so an unsignable record still aborts startup rather
than leaving a node running without discovery; it now does so from one place and
with the underlying `NodeError` attached. A chain that cannot supply a fork id
still leaves the entry out and starts, since the record is usable for discovery
and a peer that requires `eth` simply passes us over until we republish.

**What this unblocks**

`cmd/ethrex` already builds a local record, in `get_local_node_record`. That one
resumes from a `seq` persisted in the node config file (or a unix timestamp on
first run), and is the record `admin_nodeInfo` reports and that shutdown writes
back. Discovery never saw it, and gossiped its own starting from
`INITIAL_ENR_SEQ`, so the ENR peers receive and the ENR the node reports have
different sequence numbers, and only the gossiped one carries `eth`.

Restarting therefore re-announces at `seq` 2 no matter how high the previous
run climbed, and a peer holding a cached higher `seq` treats the new record as
stale. Handing discovery the record that already exists fixes that, but it is a
behaviour change and wants its own PR; this one only makes it expressible.

**Tests**

No new ones: the record is built from the same two calls in the same order, so
there is no new behaviour to pin. Existing `p2p` unit and integration tests pass.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
