### PR TITLE
fix(l1): report the block's real gas limit to GASLIMIT in debug_traceCall

### DIFF
--- a/crates/vm/backends/levm/tracing.rs
+++ b/crates/vm/backends/levm/tracing.rs
@@ -453,8 +453,8 @@ fn block_trace_env_config(
 /// Builds the call-style [`Environment`] and concrete [`Transaction`] for tracing a
 /// synthetic `eth_call`-shaped request (`debug_traceCall`). Mirrors
 /// `simulate_tx_from_generic`: the sender is taken from `tx.from` (no signature
-/// recovery), the block gas limit is disabled, and the base fee is relaxed when no gas
-/// price is provided.
+/// recovery), the block gas-allowance check is skipped, and the base fee is relaxed when
+/// no gas price is provided.
 fn prepare_call_env(
     tx: &GenericTransaction,
     block_header: &BlockHeader,
@@ -462,7 +462,10 @@ fn prepare_call_env(
     vm_type: VMType,
 ) -> Result<(Environment, Transaction), EvmError> {
     let mut env = env_from_generic(tx, block_header, db, vm_type)?;
-    env.block_gas_limit = i64::MAX as u64; // disable block gas limit
+    // Skip the allowance check without touching `block_gas_limit`; see
+    // `simulate_tx_from_generic`. A trace must report the same GASLIMIT the traced block
+    // executed with.
+    env.disable_gas_allowance_check = true;
     adjust_disabled_base_fee(&mut env);
     let converted_tx = generic_tx_to_transaction(tx)?;
     Ok((env, converted_tx))

--- a/test/tests/levm/trace_call_tests.rs
+++ b/test/tests/levm/trace_call_tests.rs
@@ -521,3 +521,42 @@ fn trace_call_calls_drops_logs_when_the_top_frame_reverts() {
         frame.logs
     );
 }
+
+/// `GASLIMIT; PUSH1 0x00; MSTORE; PUSH1 0x20; PUSH1 0x00; RETURN` — returns the
+/// block gas limit as a 32-byte word. Byte-for-byte the probe used to report the
+/// divergence against the other five clients (`0x4560005260206000f3`).
+fn gas_limit_reader_bytecode() -> Vec<u8> {
+    vec![0x45, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xF3]
+}
+
+/// Regression: `debug_traceCall` must report the traced block's own gas limit
+/// through opcode 0x45. The call env used to raise `block_gas_limit` to
+/// `i64::MAX` to skip the block gas-allowance check, so a trace reported
+/// 2^63-1 — the same divergence seen in `eth_call`, since both paths share
+/// `env_from_generic`. The bypass now has a dedicated flag.
+#[test]
+fn trace_call_reports_the_header_gas_limit_to_gaslimit() {
+    let mut db = db_with_contract(gas_limit_reader_bytecode());
+    let header = default_header();
+    let tx = call_tx();
+
+    let trace = LEVM::trace_call_calls(
+        &mut db,
+        &header,
+        &tx,
+        false,
+        false,
+        0,
+        VMType::L1,
+        &NativeCrypto,
+    )
+    .expect("trace_call_calls should succeed");
+
+    let output = &trace[0].output;
+    assert_eq!(output.len(), 32, "probe returns one word");
+    assert_eq!(
+        U256::from_big_endian(output),
+        U256::from(header.gas_limit),
+        "GASLIMIT under debug_traceCall must equal the header's gas limit"
+    );
+}


### PR DESCRIPTION
**Motivation**

`debug_traceCall` reports a `GASLIMIT` (opcode `0x45`) of `9223372036854775807` (`2^63−1`) where geth, besu, nethermind, reth and erigon all report the block header's limit. Reproduce with the probe `0x4560005260206000f3` (`GASLIMIT; PUSH1 0x00; MSTORE; PUSH1 0x20; PUSH1 0x00; RETURN`).

**Description**

`prepare_call_env` set `env.block_gas_limit = i64::MAX` so a trace request asking for more gas than a block can hold would still run. That field is what opcode `0x45` pushes, so the traced value was one no block ever had.

`simulate_tx_from_generic` had the identical line. #7141 fixed that half for `eth_call` / `eth_estimateGas` and introduced `Environment::disable_gas_allowance_check`, which is now on main; this applies the same flag to the one remaining call site, which exists only on this branch.

That leaves a two-file diff — the `prepare_call_env` line and its regression test.

**Why this targets `feat/debug-trace-call-alt`**

`prepare_call_env` and `test/tests/levm/trace_call_tests.rs` do not exist on `main`; they arrive with #6931. Stacking here keeps #6931 from landing a method that reports `2^63−1` on day one. Both halves of the fix are already live on `glamsterdam-devnet-8`, where `debug_traceCall` is in use.

**How to test**

```
cargo test --manifest-path test/Cargo.toml --test ethrex_tests levm::trace_call_tests
```

`trace_call_reports_the_header_gas_limit_to_gaslimit` asserts the top frame's output equals the header's `gas_limit`. Reverting the one line reproduces the report:

```
assertion `left == right` failed: GASLIMIT under debug_traceCall must equal the header's gas limit
  left: 9223372036854775807
 right: 30000000
```

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched.
