### PR TITLE
ci(l1,l2): key the Rust cache by runner image so pools cannot span glibc versions

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -37,6 +37,27 @@ runs:
         toolchain: ${{ steps.rustver.outputs.rust_version }}
         components: ${{ inputs.components }}
 
+    # rust-cache keys on `runner.os` and `runner.arch` only, which are `Linux`
+    # and `x64` for both ubuntu-22.04 and ubuntu-24.04 — so a pool shared by
+    # jobs on different images resolves to one entry spanning both. Cached
+    # proc-macro `.so`s are dynamically linked against the glibc of whichever
+    # image built them, so restoring a 24.04 entry into a 22.04 job produces
+    # `GLIBC_2.39 not found` when rustc dlopens the macro, and the crate fails
+    # with a wall of unresolved-import errors that name the dependency rather
+    # than the cache.
+    #
+    # `ImageOS` (ubuntu22 / ubuntu24 / macos15) is the image family, so it
+    # separates the glibc floors without keying on `ImageVersion`, which
+    # changes with every runner image release and would evict the pool weekly.
+    # Read via `$GITHUB_OUTPUT` rather than `env.ImageOS` directly: the `env`
+    # context is not reliably available to `with:` on a `uses:` step inside a
+    # composite action. Self-hosted runners may not set it; they then share one
+    # `unknown` bucket, which is still consistent within itself.
+    - name: Identify the runner image family
+      id: image
+      shell: bash
+      run: echo "family=${ImageOS:-unknown}" >>"$GITHUB_OUTPUT"
+
     # The Actions cache budget defaults to 10GB per repository and is evicted
     # LRU, while one target dir here runs 1.2-2.75GB, so the budget holds only a
     # handful of entries. Two rules keep them from evicting each other:
@@ -59,6 +80,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ inputs.cache-pool }}
+        key: ${{ steps.image.outputs.family }}
         save-if: ${{ inputs.save-cache == 'true' && github.ref == 'refs/heads/main' }}
         workspaces: |
           .

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Extract Rust version from rust-toolchain.toml
+    - name: Extract Rust version and runner image family
       id: rustver
       shell: bash
       run: |
@@ -30,6 +30,12 @@ runs:
                  | sed -E 's/.*"([^"]+)".*/\1/')
         echo "rust_version=${rust_version}" >>"$GITHUB_OUTPUT"
         echo "Rust version: ${rust_version}"
+        # Folded into this step rather than its own: `pr_loc.yaml` checks out two
+        # revisions in one job and runs this action from each, and a differing
+        # step list between them trips the runner's post-step bookkeeping with
+        # "Index was out of range".
+        echo "image_family=${ImageOS:-unknown}" >>"$GITHUB_OUTPUT"
+        echo "Runner image family: ${ImageOS:-unknown}"
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
@@ -53,11 +59,6 @@ runs:
     # context is not reliably available to `with:` on a `uses:` step inside a
     # composite action. Self-hosted runners may not set it; they then share one
     # `unknown` bucket, which is still consistent within itself.
-    - name: Identify the runner image family
-      id: image
-      shell: bash
-      run: echo "family=${ImageOS:-unknown}" >>"$GITHUB_OUTPUT"
-
     # The Actions cache budget defaults to 10GB per repository and is evicted
     # LRU, while one target dir here runs 1.2-2.75GB, so the budget holds only a
     # handful of entries. Two rules keep them from evicting each other:
@@ -80,7 +81,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ inputs.cache-pool }}
-        key: ${{ steps.image.outputs.family }}
+        key: ${{ steps.rustver.outputs.image_family }}
         save-if: ${{ inputs.save-cache == 'true' && github.ref == 'refs/heads/main' }}
         workspaces: |
           .


### PR DESCRIPTION
**Motivation**

`Ethrex Release` has been red on `main` since 2026-08-12, failing in `build-ethrex (ubuntu-22.04, l2)` while `parity-scale-codec` reports eighteen unresolved imports of its own re-exports. The dependency is not at fault — the first error in the log is:

```
error: …/libparity_scale_codec_derive-….so: /lib/x86_64-linux-gnu/libc.so.6:
       version `GLIBC_2.39' not found
```

The proc-macro `.so` came out of the Actions cache, built on a runner with a newer glibc than the one restoring it. `rustc` cannot dlopen it, so `extern crate parity_scale_codec_derive` fails and every `crate::Decode` / `Encode` / `Error` re-export collapses behind it. The wall of `E0432`s names the dependency rather than the cache, which is what made this look like a dependency-resolution problem.

This is not caused by any recent PR. The commit immediately before the most recent merge, `06773cee4`, fails identically, and `tag_release.yaml` only triggers on push-to-main and tags — never `pull_request` — so no PR can catch it.

**Description**

`Swatinem/rust-cache` composes its key from `runner.os` and `runner.arch`, which are `Linux` and `x64` for both ubuntu-22.04 and ubuntu-24.04. The observed restore was:

```
Restored from cache key "v0-rust-l2-Linux-x64-73d6c353-e089dd43" full match: false.
```

Nothing in that key distinguishes the image, so a pool shared by jobs on different images resolves to one entry:

| pool | writer (`save-cache`) | image | readers on another image |
| --- | --- | --- | --- |
| `l2` | `pr-main_l2.yaml:integration-test` | `ubuntu-latest` → **24.04**, glibc 2.39 | `tag_release.yaml:build-ethrex` on **22.04**, glibc 2.35 |
| `l1` | `pr-main_l1.yaml:test` | **22.04**, glibc 2.35 | `lint`, `daily_hive_report`, `daily_loc_report`, `deep_reorg`, `pr_lint_readme`, `pr_loc`, `pr_perf_levm` on `ubuntu-latest` |

`l2` is the one failing: newer glibc into older runner. `l1` has the same flaw pointing the other way, which is forward-compatible and so has not broken — but it would the moment that writer matrix moves to 24.04.

The fix folds `ImageOS` into the cache key. Image *family* (`ubuntu22` / `ubuntu24` / `macos15`) rather than `ImageVersion`, which changes with every runner image release and would evict the pools weekly; family is exactly the granularity that separates glibc floors. It is read via `$GITHUB_OUTPUT` rather than `env.ImageOS` directly, because the `env` context is not reliably available to `with:` on a `uses:` step inside a composite action.

Fixing it in the shared action rather than at the call site means no pool can ever span images, including pools added later.

**Note on rollout**

Changing the key invalidates every existing entry once. Pools refill on the next `main` build; the first run after merge is a cold build.

**How to test**

The failure only reproduces on `main` (the workflow has no `pull_request` trigger), so the real check is that `build-ethrex (ubuntu-22.04, l2)` goes green on the next push to `main`. Before then, the key change is visible in any job's log — the restore line should carry the image family:

```
v0-rust-l2-ubuntu22-Linux-x64-…
```

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
