### PR TITLE
test(l1): bump Amsterdam fixtures to glamsterdam-devnet v8.1.1

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,7 +1,7 @@
 # Amsterdam (BAL) hive test configuration
-# Pinned to tests-glamsterdam-devnet@v8.1.0 (execution-specs `devnets/glamsterdam/8`).
-# Keep this in lock-step with `tooling/ef_tests/.fixtures_url_amsterdam`: v8.1.0 carries
-# the revised EIP-8038 gas values, so grading a v8.1.0 client against the v8.0.0 bundle
-# fails every gas-sensitive fixture.
-fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.0/fixtures_glamsterdam-devnet.tar.gz
-eels_commit: 864fa03a155f2403653f828236b97d9131ca0228
+# Pinned to tests-glamsterdam-devnet@v8.1.1 (execution-specs `devnets/glamsterdam/8`).
+# Keep this in lock-step with `tooling/ef_tests/.fixtures_url_amsterdam`: the two pins
+# grade the same client, so a release that only one of them follows fails every fixture
+# the other release changed.
+fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.1/fixtures_glamsterdam-devnet.tar.gz
+eels_commit: 32f597f7e56e3843198a83c7cf437a0b49aa6c0e

--- a/docs/roadmaps/forks-roadmap.md
+++ b/docs/roadmaps/forks-roadmap.md
@@ -17,16 +17,24 @@ Next fork: **Glamsterdam** (CL Gloas, EL Amsterdam). Mainnet date not yet schedu
 **glamsterdam-devnet-8**
 
 - Spec baseline: [`devnets/glamsterdam/8`](https://github.com/ethereum/execution-specs/tree/devnets/glamsterdam/8)
-- Fixtures: [`tests-glamsterdam-devnet@v8.0.0`](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet@v8.0.0)
-- EELS commit: `d681ca4fd019ee80099dd1899bdbee419cab8e0b`
-- Status: 🟢 aligned — blockchain, state and engine ef-tests green on the v8.0.0 bundle
+- Fixtures: [`tests-glamsterdam-devnet@v8.1.1`](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet@v8.1.1)
+- EELS commit: `32f597f7e56e3843198a83c7cf437a0b49aa6c0e` (the v8.1.1 tag, also the tip of `devnets/glamsterdam/8`)
+- Status: 🟢 aligned — blockchain, state and engine ef-tests green on the v8.1.1 bundle
 - Tracking: [#6583]
 
 **Bumping to a new bundle:** edit `tooling/ef_tests/.fixtures_url_amsterdam` and
-`.github/config/hive/amsterdam.yaml` (`fixtures` + `eels_commit`), then re-run the three
-ef-test suites and hive `eels/consume-engine` Amsterdam. Upstream expects at least two
-follow-up releases on this devnet (v8.1.0, v8.2.0) carrying coverage rather than new
-semantics.
+`.github/config/hive/amsterdam.yaml` (`fixtures` + `eels_commit`) — both, always, since
+grading one release's client against another's bundle fails every fixture the releases
+disagree on — then re-run the three ef-test suites and hive `eels/consume-engine`
+Amsterdam. Upstream expects at least two follow-up releases on this devnet; v8.1.0 and
+v8.1.1 have shipped, carrying coverage rather than new semantics.
+
+v8.1.1 was announced as coverage-only, which holds for the numbers: the amsterdam fork
+diff is a `Uint` -> `ExecutionGas` type-wrapper refactor with every value unchanged. One
+behaviour did change — `calculate_excess_blob_gas` now reads the blob fields from a
+`PreviousHeader` as well as a `Header` ([specs#3352]), so accumulated excess blob gas
+survives a fork transition instead of resetting to zero at the fork block. ethrex already
+matched, since `calc_excess_blob_gas` reads the parent unconditionally.
 
 ## Next up
 
@@ -138,6 +146,7 @@ Agendas and notes for both: [ethereum/pm](https://github.com/ethereum/pm).
 
 [#9619]: https://github.com/NethermindEth/nethermind/pull/9619
 [hive#1365]: https://github.com/ethereum/hive/pull/1365
+[specs#3352]: https://github.com/ethereum/execution-specs/pull/3352
 [#6212]: https://github.com/lambdaclass/ethrex/issues/6212
 [#6361]: https://github.com/lambdaclass/ethrex/pull/6361
 [#6583]: https://github.com/lambdaclass/ethrex/issues/6583

--- a/tooling/ef_tests/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.0/fixtures_glamsterdam-devnet.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.1/fixtures_glamsterdam-devnet.tar.gz


### PR DESCRIPTION
**Motivation**

`tests-glamsterdam-devnet@v8.1.1` is out — a coverage and fixture-exception-mapping follow-up to v8.1.0, [announced with no spec changes](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet@v8.1.1).

**Description**

Moves `tooling/ef_tests/.fixtures_url_amsterdam` and `.github/config/hive/amsterdam.yaml` (`fixtures` + `eels_commit`) to v8.1.1. Both, together: grading one release's client against another release's bundle fails every fixture the two disagree on, which is what produced 2168 hive failures when only the ef-test pin moved to v8.1.0. `eels_commit` is `32f597f7`, which is both the v8.1.1 tag and the tip of `devnets/glamsterdam/8`.

No client change was needed.

**Verified the "no spec changes" claim rather than assuming it.** For the numbers it holds — the `forks/amsterdam` diff is a `Uint` → `ExecutionGas(Uint(..))` type-wrapper refactor with every value identical. One behaviour did change:

```python
-    if isinstance(parent_header, Header):
-        # After the fork block, read them from the parent header.
+    if isinstance(parent_header, (Header, PreviousHeader)):
+        # Read them from any parent that carries the fields, so
+        # accumulated excess blob gas survives a fork transition.
```

`calculate_excess_blob_gas` no longer resets excess blob gas to zero at a fork block ([specs#3352](https://github.com/ethereum/execution-specs/pull/3352)). ethrex already behaved that way — `calc_excess_blob_gas` reads the parent's blob fields unconditionally, with no fork-boundary case — so this is the spec catching up to clients, and the `for_bpo2toamsterdamattime15k` transition fixtures pass unchanged.

**How to test**

```
make -C tooling/ef_tests/blockchain test-levm
make -C tooling/ef_tests/engine test
make -C tooling/ef_tests/state run-evm-ef-tests-ci
```

Results on this branch:

| suite | result |
|---|---|
| blockchain | **11752 passed, 0 failed** |
| engine | **11020 passed, 0 failed** |
| state | **64740 passed, 0 failed** (8983 groups, 201792/201792 vectors, none below 100%) |

The coverage this release adds passes as filled, including the new BAL storage-slot numeric-ordering fixture ([specs#3382](https://github.com/ethereum/execution-specs/pull/3382)) and the un-skipped Amsterdam ported-static create-OOG and depth-recursion tests ([specs#3320](https://github.com/ethereum/execution-specs/pull/3320), [specs#3264](https://github.com/ethereum/execution-specs/pull/3264)).

Already live on `glamsterdam-devnet-8` (`59befe28d`).

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched.
