### PR TITLE
fix(l1): return the executable minimum from eth_estimateGas

### DIFF
--- a/crates/l2/sdk/src/sdk.rs
+++ b/crates/l2/sdk/src/sdk.rs
@@ -1039,10 +1039,35 @@ pub async fn build_generic_tx(
     }
     tx.gas = Some(match overrides.gas_limit {
         Some(gas) => gas,
-        None => client.estimate_gas(tx.clone()).await?,
+        // `eth_estimateGas` answers what the transaction needs against the state it was
+        // asked about. By the time this transaction is mined that state has moved, so the
+        // estimate is a floor, not a safe limit: a cross-chain commitment in particular is
+        // built against one head and included against another. Headroom belongs here, in
+        // the sender, rather than in the estimator — an estimator that pads cannot be asked
+        // for the minimum, while a sender that pads costs nothing extra, since unused gas is
+        // not charged. This mirrors what wallets do (geth's estimator comments cite a 20-25%
+        // bump) and restores the slack every caller here previously got for free from the
+        // estimator's own 1.5% tolerance.
+        None => estimate_gas_with_headroom(client, tx.clone()).await?,
     });
 
     Ok(tx)
+}
+
+/// Fraction of the estimate added as headroom before submission. Unused gas is refunded,
+/// so the only cost is a larger up-front balance requirement.
+const GAS_LIMIT_HEADROOM_PERCENT: u64 = 20;
+
+async fn estimate_gas_with_headroom(
+    client: &EthClient,
+    tx: GenericTransaction,
+) -> Result<u64, EthClientError> {
+    let estimate = client.estimate_gas(tx).await?;
+    Ok(estimate.saturating_add(
+        estimate
+            .saturating_mul(GAS_LIMIT_HEADROOM_PERCENT)
+            .saturating_div(100),
+    ))
 }
 
 pub fn add_blobs_to_generic_tx(tx: &mut GenericTransaction, bundle: &BlobsBundle) {

--- a/crates/networking/rpc/clients/eth/mod.rs
+++ b/crates/networking/rpc/clients/eth/mod.rs
@@ -68,6 +68,97 @@ pub const MAX_RETRY_DELAY: u64 = 1800;
 // 0x08c379a0 == Error(String)
 pub const ERROR_FUNCTION_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
 
+/// Builds the call object `eth_estimateGas` is asked about.
+///
+/// Split out from [`EthClient::estimate_gas`] so the field set can be asserted on: an
+/// omitted field is not a smaller question, it is a different one.
+pub fn estimate_gas_call_object(transaction: GenericTransaction) -> Result<Value, EthClientError> {
+    let to = match transaction.to {
+        TxKind::Call(addr) => Some(format!("{addr:#x}")),
+        TxKind::Create => None,
+    };
+
+    let mut data = json!({
+        "to": to,
+        "input": format!("0x{:#x}", transaction.input),
+        "from": format!("{:#x}", transaction.from),
+        "value": format!("{:#x}", transaction.value),
+
+    });
+
+    if !transaction.blob_versioned_hashes.is_empty() {
+        let blob_versioned_hashes_str: Vec<_> = transaction
+            .blob_versioned_hashes
+            .into_iter()
+            .map(|hash| format!("{hash:#x}"))
+            .collect();
+
+        data.as_object_mut()
+            .ok_or_else(|| {
+                EthClientError::Custom("Failed to mutate data in estimate_gas".to_owned())
+            })?
+            .insert(
+                "blobVersionedHashes".to_owned(),
+                json!(blob_versioned_hashes_str),
+            );
+    }
+
+    if !transaction.blobs.is_empty() {
+        let blobs_str: Vec<_> = transaction
+            .blobs
+            .into_iter()
+            .map(|blob| format!("0x{}", hex::encode(blob)))
+            .collect();
+
+        data.as_object_mut()
+            .ok_or_else(|| {
+                EthClientError::Custom("Failed to mutate data in estimate_gas".to_owned())
+            })?
+            .insert("blobs".to_owned(), json!(blobs_str));
+    }
+
+    // Add the nonce just if present, otherwise the RPC will use the latest nonce
+    if let Some(nonce) = transaction.nonce
+        && let Value::Object(ref mut map) = data
+    {
+        map.insert("nonce".to_owned(), json!(format!("{nonce:#x}")));
+    }
+
+    // Send the fees the transaction will actually carry. Omitting them leaves the
+    // server simulating at a zero gas price, and on an L2 a zero gas price disables
+    // the fee configs entirely (`adjust_disabled_l2_fees`), so the estimate comes back
+    // without the L1 data fee gas that the submitted transaction is charged — and the
+    // transaction then runs out of gas at exactly its estimate.
+    if let Value::Object(ref mut map) = data {
+        if let Some(max_fee_per_gas) = transaction.max_fee_per_gas {
+            map.insert(
+                "maxFeePerGas".to_owned(),
+                json!(format!("{max_fee_per_gas:#x}")),
+            );
+        }
+        if let Some(max_priority_fee_per_gas) = transaction.max_priority_fee_per_gas {
+            map.insert(
+                "maxPriorityFeePerGas".to_owned(),
+                json!(format!("{max_priority_fee_per_gas:#x}")),
+            );
+        }
+        if !transaction.gas_price.is_zero() {
+            map.insert(
+                "gasPrice".to_owned(),
+                json!(format!("{:#x}", transaction.gas_price)),
+            );
+        }
+        if let Some(max_fee_per_blob_gas) = transaction.max_fee_per_blob_gas {
+            map.insert(
+                "maxFeePerBlobGas".to_owned(),
+                json!(format!("{max_fee_per_blob_gas:#x}")),
+            );
+        }
+    }
+
+    Ok(data)
+}
+
 impl EthClient {
     pub fn new(url: Url) -> Result<EthClient, EthClientError> {
         Self::new_with_config(
@@ -243,57 +334,7 @@ impl EthClient {
         &self,
         transaction: GenericTransaction,
     ) -> Result<u64, EthClientError> {
-        let to = match transaction.to {
-            TxKind::Call(addr) => Some(format!("{addr:#x}")),
-            TxKind::Create => None,
-        };
-
-        let mut data = json!({
-            "to": to,
-            "input": format!("0x{:#x}", transaction.input),
-            "from": format!("{:#x}", transaction.from),
-            "value": format!("{:#x}", transaction.value),
-
-        });
-
-        if !transaction.blob_versioned_hashes.is_empty() {
-            let blob_versioned_hashes_str: Vec<_> = transaction
-                .blob_versioned_hashes
-                .into_iter()
-                .map(|hash| format!("{hash:#x}"))
-                .collect();
-
-            data.as_object_mut()
-                .ok_or_else(|| {
-                    EthClientError::Custom("Failed to mutate data in estimate_gas".to_owned())
-                })?
-                .insert(
-                    "blobVersionedHashes".to_owned(),
-                    json!(blob_versioned_hashes_str),
-                );
-        }
-
-        if !transaction.blobs.is_empty() {
-            let blobs_str: Vec<_> = transaction
-                .blobs
-                .into_iter()
-                .map(|blob| format!("0x{}", hex::encode(blob)))
-                .collect();
-
-            data.as_object_mut()
-                .ok_or_else(|| {
-                    EthClientError::Custom("Failed to mutate data in estimate_gas".to_owned())
-                })?
-                .insert("blobs".to_owned(), json!(blobs_str));
-        }
-
-        // Add the nonce just if present, otherwise the RPC will use the latest nonce
-        if let Some(nonce) = transaction.nonce
-            && let Value::Object(ref mut map) = data
-        {
-            map.insert("nonce".to_owned(), json!(format!("{nonce:#x}")));
-        }
-
+        let data = estimate_gas_call_object(transaction)?;
         let request = RpcRequest::new("eth_estimateGas", Some(vec![data, json!("latest")]));
 
         match self.send_request(request).await? {
@@ -653,5 +694,69 @@ impl EthClient {
             map.insert(url.to_string(), response);
         }
         map
+    }
+}
+
+#[cfg(test)]
+mod estimate_gas_call_object_tests {
+    //! The call object `eth_estimateGas` is asked about must carry the fees the
+    //! transaction will actually pay.
+    //!
+    //! Omitting them leaves the server simulating at a zero gas price, and on an L2 a
+    //! zero gas price disables the fee configs outright
+    //! (`adjust_disabled_l2_fees`), so the estimate comes back with no L1 data fee gas
+    //! at all. Since the SDK submits the estimate verbatim, the transaction then runs
+    //! out of gas at exactly its own estimate — which is how the L2 fee-token
+    //! integration test failed.
+    use super::*;
+
+    fn eip1559_tx() -> GenericTransaction {
+        GenericTransaction {
+            to: TxKind::Create,
+            from: Address::repeat_byte(0xaa),
+            max_fee_per_gas: Some(2_000_000_000),
+            max_priority_fee_per_gas: Some(1_000_000_000),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn carries_the_fees_the_transaction_will_pay() {
+        let data = estimate_gas_call_object(eip1559_tx()).expect("call object should build");
+        let object = data.as_object().expect("call object is a JSON object");
+
+        assert_eq!(
+            object.get("maxFeePerGas").and_then(|v| v.as_str()),
+            Some("0x77359400"),
+            "maxFeePerGas must be sent, or the server simulates at a zero gas price: {data}"
+        );
+        assert_eq!(
+            object.get("maxPriorityFeePerGas").and_then(|v| v.as_str()),
+            Some("0x3b9aca00"),
+            "maxPriorityFeePerGas must be sent: {data}"
+        );
+    }
+
+    /// A legacy transaction carries `gasPrice` instead, and a zero one is left out so a
+    /// genuinely fee-less call still reaches the relaxed path.
+    #[test]
+    fn carries_gas_price_only_when_set() {
+        let with_price = GenericTransaction {
+            gas_price: U256::from(7u64),
+            ..eip1559_tx()
+        };
+        let data = estimate_gas_call_object(with_price).expect("call object should build");
+        assert_eq!(
+            data.as_object()
+                .and_then(|o| o.get("gasPrice"))
+                .and_then(|v| v.as_str()),
+            Some("0x7"),
+        );
+
+        let data = estimate_gas_call_object(eip1559_tx()).expect("call object should build");
+        assert!(
+            data.as_object().expect("object").get("gasPrice").is_none(),
+            "a zero gasPrice must be omitted rather than sent as 0x0: {data}"
+        );
     }
 }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -515,6 +515,23 @@ impl RpcHandler for EstimateGasRequest {
         let gas_used = result.gas_used();
         let gas_refunded = result.gas_refunded();
 
+        // Most transactions execute identically at their own `gas_used` as they do with
+        // the whole block's gas available, and nothing can succeed below what an
+        // unconstrained run consumed — so if that one re-run succeeds it *is* the minimum,
+        // and the search can be skipped entirely. Two simulations, exact. Only gas-observing
+        // callers (an explicit `GAS` check, or a subcall needing 63/64 headroom the
+        // consumed total does not imply) fall through to the search below.
+        transaction.gas = Some(gas_used);
+        if let Ok(ExecutionResult::Success { .. }) = simulate_tx(
+            &transaction,
+            &block_header,
+            storage.clone(),
+            blockchain.clone(),
+        ) {
+            return serde_json::to_value(format!("{gas_used:#x}"))
+                .map_err(|error| RpcErr::Internal(error.to_string()));
+        }
+
         // Choose an optimistic start limit. See https://github.com/ethereum/go-ethereum/blob/a5a4fa7032bb248f5a7c40f4e8df2b131c4186a4/eth/gasestimator/gasestimator.go#L135
         let optimistic_limit = (gas_used + gas_refunded + CALL_STIPEND) * 64 / 63;
         let mut lowest_gas_limit = gas_used.saturating_sub(1);

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -24,6 +24,13 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::debug;
 
+/// Allowed upward overestimation before the estimate's binary search stops, matching
+/// geth's `estimateGasErrorRatio` (`internal/ethapi/api.go`). geth's rationale is that a
+/// perfect estimate is not worth extra execution when callers bump by 20-25% anyway, and
+/// that for a transaction which inspects its own remaining gas the true minimum is not
+/// even the useful answer. Only reached when the fast path below cannot answer.
+pub const ESTIMATE_ERROR_RATIO: f64 = 0.015;
+
 pub const CALL_STIPEND: u64 = 2_300; // Free gas given at beginning of call.
 pub const TRANSACTION_GAS: u64 = 21_000; // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
 
@@ -537,14 +544,18 @@ impl RpcHandler for EstimateGasRequest {
         let mut lowest_gas_limit = gas_used.saturating_sub(1);
         let mut middle_gas_limit = (optimistic_limit + lowest_gas_limit) / 2;
 
-        // Converge all the way to `lowest + 1 == highest`, so the returned
-        // `highest_gas_limit` is the least gas the transaction actually executes with.
-        // This used to stop once the bracket was within 1.5% of the upper bound (geth's
-        // `estimateGasErrorRatio`) and return that bound, which reported a plain transfer
-        // as 21165 instead of 21000 and, on the EIP-2780 paths where the intrinsic cost is
-        // lower, a self-send as 12156 instead of 12000. Callers that want headroom can add
-        // it; a caller that wants the minimum cannot recover it from an upper bound.
+        // Reached only by a transaction whose result depends on the gas it is given: an
+        // explicit `GAS` check, or a subcall needing 63/64 headroom the consumed total does
+        // not imply. Bisect as geth does, stopping within `ESTIMATE_ERROR_RATIO` of the
+        // upper bound rather than converging exactly — the same transactions geth's comment
+        // says do not want their true minimum returned.
         while lowest_gas_limit + 1 < highest_gas_limit {
+            if (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64)
+                < ESTIMATE_ERROR_RATIO
+            {
+                break;
+            };
+
             if middle_gas_limit > lowest_gas_limit * 2 {
                 // Favor the low side, since most transactions don't need much higher gas limit than their gas used.
                 middle_gas_limit = lowest_gas_limit * 2;

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -24,7 +24,6 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::debug;
 
-pub const ESTIMATE_ERROR_RATIO: f64 = 0.015;
 pub const CALL_STIPEND: u64 = 2_300; // Free gas given at beginning of call.
 pub const TRANSACTION_GAS: u64 = 21_000; // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
 
@@ -521,13 +520,14 @@ impl RpcHandler for EstimateGasRequest {
         let mut lowest_gas_limit = gas_used.saturating_sub(1);
         let mut middle_gas_limit = (optimistic_limit + lowest_gas_limit) / 2;
 
+        // Converge all the way to `lowest + 1 == highest`, so the returned
+        // `highest_gas_limit` is the least gas the transaction actually executes with.
+        // This used to stop once the bracket was within 1.5% of the upper bound (geth's
+        // `estimateGasErrorRatio`) and return that bound, which reported a plain transfer
+        // as 21165 instead of 21000 and, on the EIP-2780 paths where the intrinsic cost is
+        // lower, a self-send as 12156 instead of 12000. Callers that want headroom can add
+        // it; a caller that wants the minimum cannot recover it from an upper bound.
         while lowest_gas_limit + 1 < highest_gas_limit {
-            if (highest_gas_limit - lowest_gas_limit) as f64 / (highest_gas_limit as f64)
-                < ESTIMATE_ERROR_RATIO
-            {
-                break;
-            };
-
             if middle_gas_limit > lowest_gas_limit * 2 {
                 // Favor the low side, since most transactions don't need much higher gas limit than their gas used.
                 middle_gas_limit = lowest_gas_limit * 2;

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -3923,7 +3923,26 @@ fn env_from_generic(
 ///
 /// Split out from `vm_from_generic` so the caller owns the resulting `Transaction` for at least
 /// the VM's lifetime — `VM` now borrows its tx (`&'a Transaction`) instead of cloning it.
+///
+/// The envelope fields are carried over even though execution reads almost none of them,
+/// because the L2 prices its L1 data fee from `Transaction::length()` — the RLP-encoded byte
+/// count — and reserves that as gas before execution. Leaving them at their defaults made a
+/// simulated transaction encode up to ~104 bytes shorter than the signed one it stands for
+/// (a zero `U256` is one RLP byte, a real signature component is 33), so `eth_estimateGas`
+/// under-reserved the L1 fee and the transaction it was estimating ran out of gas. The
+/// signature is stamped at full width for the same reason, and deliberately at the maximum:
+/// a real component can be shorter after leading-zero trimming, and over-reserving the L1
+/// fee is safe where under-reserving is not.
 fn generic_tx_to_transaction(tx: &GenericTransaction) -> Result<Transaction, VMError> {
+    // Not read during execution — the sender comes from `env.origin` — so this only has to
+    // encode to the same width as a real signature.
+    let (signature_r, signature_s) = (U256::MAX, U256::MAX);
+    let nonce = tx.nonce.unwrap_or_default();
+    let gas_limit = tx.gas.unwrap_or_default();
+    let max_fee_per_gas = tx.max_fee_per_gas.unwrap_or_default();
+    let max_priority_fee_per_gas = tx.max_priority_fee_per_gas.unwrap_or_default();
+    let chain_id = tx.chain_id.unwrap_or_default();
+
     Ok(match &tx.authorization_list {
         Some(authorization_list) => Transaction::EIP7702Transaction(EIP7702Transaction {
             to: match tx.to {
@@ -3943,6 +3962,13 @@ fn generic_tx_to_transaction(tx: &GenericTransaction) -> Result<Transaction, VME
                 .iter()
                 .map(|auth| Into::<AuthorizationTuple>::into(auth.clone()))
                 .collect(),
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            chain_id,
+            signature_r,
+            signature_s,
             ..Default::default()
         }),
         None => Transaction::EIP1559Transaction(EIP1559Transaction {
@@ -3954,6 +3980,13 @@ fn generic_tx_to_transaction(tx: &GenericTransaction) -> Result<Transaction, VME
                 .iter()
                 .map(|list| (list.address, list.storage_keys.clone()))
                 .collect(),
+            nonce,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            chain_id,
+            signature_r,
+            signature_s,
             ..Default::default()
         }),
     })
@@ -4955,5 +4988,76 @@ mod burned_fees_tests {
             result_d.burned_fees, None,
             "pre-LStar: burned_fees must be None"
         );
+    }
+}
+
+#[cfg(test)]
+mod simulated_tx_encoding_tests {
+    //! The L2 prices its L1 data fee from `Transaction::length()` and reserves that
+    //! as gas before execution, so a simulated transaction must never encode shorter
+    //! than the signed one it stands for — otherwise `eth_estimateGas` reserves less
+    //! L1 fee gas than the transaction it is estimating will need, and that
+    //! transaction runs out of gas at exactly the estimate.
+    //!
+    //! This was reached through the L2 fee-token integration test, which submits the
+    //! estimate verbatim. It only surfaced once the estimate became exact; the search's
+    //! former 1.5% tolerance had been absorbing the shortfall.
+    use super::*;
+    use ethrex_common::types::GenericTransaction;
+    use ethrex_rlp::encode::RLPEncode;
+
+    /// The transaction the SDK signs and sends after estimating, with signature
+    /// components at the width secp256k1 actually produces.
+    fn signed_equivalent(gas_limit: u64, data: Bytes) -> Transaction {
+        Transaction::EIP1559Transaction(EIP1559Transaction {
+            chain_id: 9_999,
+            nonce: 42,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 2_000_000_000,
+            gas_limit,
+            to: TxKind::Create,
+            value: U256::from(1u64),
+            data,
+            access_list: vec![],
+            signature_y_parity: true,
+            signature_r: U256::MAX,
+            signature_s: U256::MAX,
+            ..Default::default()
+        })
+    }
+
+    fn generic(gas_limit: u64, data: Bytes) -> GenericTransaction {
+        GenericTransaction {
+            to: TxKind::Create,
+            value: U256::from(1u64),
+            input: data,
+            nonce: Some(42),
+            gas: Some(gas_limit),
+            max_fee_per_gas: Some(2_000_000_000),
+            max_priority_fee_per_gas: Some(1_000_000_000),
+            chain_id: Some(9_999),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn simulated_tx_never_encodes_shorter_than_the_signed_one() {
+        for (gas_limit, data) in [
+            (21_000u64, Bytes::new()),
+            (150_000, Bytes::from_static(&[0x60, 0x00, 0x60, 0x00])),
+            (5_000_000, Bytes::from(vec![0xab; 4_096])),
+        ] {
+            let simulated = generic_tx_to_transaction(&generic(gas_limit, data.clone()))
+                .expect("conversion should succeed");
+            let signed = signed_equivalent(gas_limit, data.clone());
+            assert!(
+                simulated.length() >= signed.length(),
+                "simulated tx encodes {} bytes, signed one {} — the L2 would under-reserve \
+                 the L1 fee by the difference (gas_limit {gas_limit}, {} data bytes)",
+                simulated.length(),
+                signed.length(),
+                data.len(),
+            );
+        }
     }
 }

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -52,12 +52,14 @@ pub struct Environment {
     /// mid-block state (`txIndex`) whose nonce differs from the value the caller
     /// supplied, so enforcing the check would spuriously reject the trace.
     pub disable_nonce_check: bool,
-    /// When true, skip the block-level gas-allowance check. Used by the simulation RPCs
-    /// (eth_call, eth_estimateGas, eth_createAccessList, debug_traceCall), whose callers
-    /// may pass a `gas` above the block's limit and expect the call to run anyway.
+    /// When true, skip the gas limits that gate a transaction's *admission* rather than
+    /// its execution: the block-level gas allowance and the EIP-7825 per-transaction cap.
+    /// Used by the simulation RPCs (eth_call, eth_estimateGas, debug_traceCall), whose
+    /// callers routinely pass a `gas` above either bound — tools commonly pass the block
+    /// gas limit — and still expect an answer, since nothing is being submitted.
     /// This exists so `block_gas_limit` can keep the block's real value: that field is
     /// observable through the GASLIMIT opcode and feeds the EIP-8037 cost-per-state-byte
-    /// formula, so raising it to bypass this check corrupts both.
+    /// formula, so raising it to bypass the allowance corrupts both.
     pub disable_gas_allowance_check: bool,
     /// When true, the tx is a pre-execution system contract call (EIP-2935, EIP-4788,
     /// EIP-7002, EIP-7251 etc.). Skips the block-level gas-allowance check since system

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -66,7 +66,8 @@ impl Hook for DefaultHook {
             validate_min_gas_limit(vm, &intrinsic)?;
             // EIP-7825 (Osaka to pre-Amsterdam): reject tx if gas_limit > POST_OSAKA_GAS_LIMIT_CAP.
             // Amsterdam removes this restriction (EIP-8037 reservoir model).
-            if vm.env.config.fork >= Fork::Osaka
+            if !vm.env.disable_gas_allowance_check
+                && vm.env.config.fork >= Fork::Osaka
                 && vm.env.config.fork < Fork::Amsterdam
                 && vm.tx.gas_limit() > POST_OSAKA_GAS_LIMIT_CAP
             {

--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -598,7 +598,10 @@ fn prepare_execution_fee_token(vm: &mut VM<'_>) -> Result<U256, crate::errors::V
         default_hook::validate_min_gas_limit(vm, &intrinsic)?;
         // EIP-7825 (Prague to pre-Amsterdam): reject tx if gas_limit > TX_MAX_GAS_LIMIT_AMSTERDAM.
         // Amsterdam removes this restriction (EIP-8037 reservoir model).
-        if vm.env.config.fork < Fork::Amsterdam && vm.tx.gas_limit() > TX_MAX_GAS_LIMIT_AMSTERDAM {
+        if !vm.env.disable_gas_allowance_check
+            && vm.env.config.fork < Fork::Amsterdam
+            && vm.tx.gas_limit() > TX_MAX_GAS_LIMIT_AMSTERDAM
+        {
             return Err(VMError::TxValidation(
                 TxValidationError::TxMaxGasLimitExceeded {
                     tx_hash: vm.tx.hash(vm.crypto),
@@ -606,7 +609,8 @@ fn prepare_execution_fee_token(vm: &mut VM<'_>) -> Result<U256, crate::errors::V
                 },
             ));
         }
-        if vm.env.config.fork >= Fork::Osaka
+        if !vm.env.disable_gas_allowance_check
+            && vm.env.config.fork >= Fork::Osaka
             && vm.env.config.fork < Fork::Amsterdam
             && vm.tx.gas_limit() > POST_OSAKA_GAS_LIMIT_CAP
         {

--- a/test/tests/rpc/create_access_list_tests.rs
+++ b/test/tests/rpc/create_access_list_tests.rs
@@ -1,0 +1,41 @@
+//! `eth_createAccessList` must return the list that *minimises* gas.
+//!
+//! Under the EIP-8038 repricing an access-list entry costs the cold charge minus
+//! `WARM_ACCESS`, so prepaying is gas-neutral for a single access — while the
+//! entry's floor tokens still raise the EIP-7623 calldata floor. The minimal
+//! list for an access that touches an account but no storage slot is therefore
+//! the empty one, and differential testing found four of six clients returning a
+//! costlier list because their heuristic predates the repricing.
+//!
+//! ethrex gets this right, but incidentally: `Substate::make_access_list` derives
+//! entries from `accessed_storage_slots`, so an address with no storage access
+//! cannot appear, and there is no profitability heuristic to keep in step with
+//! pricing. This test is what makes the behaviour durable.
+
+use ethrex_rpc::test_utils::{call_http, default_context_with_storage, setup_store};
+
+/// A genesis-funded EOA, so the call is not rejected for insufficient balance.
+const RICH: &str = "0x3f1eae7d46d88f08fc2f8ed27fcb2ab183eb2d0e";
+
+/// A plain value transfer touches the recipient account and no storage, so the
+/// gas-minimal access list is empty.
+#[tokio::test]
+async fn create_access_list_omits_an_account_only_access() {
+    let context = default_context_with_storage(setup_store().await).await;
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_createAccessList","params":[{{"from":"{RICH}","to":"{RICH}","value":"0x1"}},"latest"],"id":1}}"#
+    );
+    let response = call_http(context, body).await;
+    let result = &response["result"];
+    assert!(
+        result.get("error").is_none(),
+        "eth_createAccessList should not report an execution error: {response}"
+    );
+    let access_list = result["accessList"]
+        .as_array()
+        .unwrap_or_else(|| panic!("accessList should be an array, got {response}"));
+    assert!(
+        access_list.is_empty(),
+        "an account-only access must yield an empty access list, got {access_list:?}"
+    );
+}

--- a/test/tests/rpc/estimate_gas_tests.rs
+++ b/test/tests/rpc/estimate_gas_tests.rs
@@ -88,30 +88,61 @@ async fn store_with_gas_observer() -> Store {
 }
 
 /// The fast path only answers when re-running at the consumed gas succeeds. A
-/// gas-observing callee fails there, so this exercises the binary search — which
-/// must still land on the exact minimum, not an upper bound near it.
+/// gas-observing callee fails there, so this exercises the binary search, which
+/// stops within `ESTIMATE_ERROR_RATIO` of its upper bound exactly as geth's does.
+/// The contract that search must honour is one-sided: the estimate has to be
+/// executable, and may sit above the true minimum but never below it.
 #[tokio::test]
-async fn estimate_gas_is_exact_for_a_gas_observing_call() {
+async fn estimate_gas_for_a_gas_observing_call_is_executable_and_within_the_tolerance() {
+    /// Mirror of the crate-private constant; the `eth` module is not exported.
+    const ESTIMATE_ERROR_RATIO: f64 = 0.015;
+
     let context = default_context_with_storage(store_with_gas_observer().await).await;
+    let call = format!(r#"{{"from":"{RICH}","to":"{OBSERVER:#x}"}}"#);
+
     let body = format!(
-        r#"{{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{{"from":"{RICH}","to":"{OBSERVER:#x}"}},"latest"],"id":1}}"#
+        r#"{{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{call},"latest"],"id":1}}"#
     );
-    let response = call_http(context.clone(), body.clone()).await;
+    let response = call_http(context.clone(), body).await;
     let hex = response["result"]
         .as_str()
         .unwrap_or_else(|| panic!("eth_estimateGas should succeed, got {response}"));
     let estimate = u64::from_str_radix(hex.trim_start_matches("0x"), 16).expect("hex");
 
-    // Exactness means the estimate succeeds and one gas less does not.
-    for (gas, should_succeed) in [(estimate, true), (estimate - 1, false)] {
-        let probe = format!(
-            r#"{{"jsonrpc":"2.0","method":"eth_call","params":[{{"from":"{RICH}","to":"{OBSERVER:#x}","gas":"{gas:#x}"}},"latest"],"id":1}}"#
-        );
-        let got = call_http(context.clone(), probe).await;
-        assert_eq!(
-            got.get("result").is_some(),
-            should_succeed,
-            "at gas={gas} expected success={should_succeed}, got {got}"
-        );
+    let succeeds = |gas: u64| {
+        let context = context.clone();
+        async move {
+            let probe = format!(
+                r#"{{"jsonrpc":"2.0","method":"eth_call","params":[{{"from":"{RICH}","to":"{OBSERVER:#x}","gas":"{gas:#x}"}},"latest"],"id":1}}"#
+            );
+            call_http(context, probe).await.get("result").is_some()
+        }
+    };
+
+    assert!(
+        succeeds(estimate).await,
+        "the estimate must be executable, {estimate} was not"
+    );
+
+    // Find the true minimum by bisection, then check the estimate is at or above it
+    // and no further above than the tolerance allows.
+    let (mut lo, mut hi) = (21_000_u64, estimate);
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        if succeeds(mid).await {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
     }
+    let minimum = hi;
+    assert!(
+        estimate >= minimum,
+        "the estimate must never sit below the minimum: {estimate} < {minimum}"
+    );
+    let over = (estimate - minimum) as f64 / estimate as f64;
+    assert!(
+        over < ESTIMATE_ERROR_RATIO,
+        "overestimate {over:.4} (est {estimate}, min {minimum}) must stay within the tolerance"
+    );
 }

--- a/test/tests/rpc/estimate_gas_tests.rs
+++ b/test/tests/rpc/estimate_gas_tests.rs
@@ -1,0 +1,52 @@
+//! `eth_estimateGas` must return the transaction's executable minimum, not an
+//! upper bound near it.
+//!
+//! The search used to stop as soon as its bracket was within
+//! `ESTIMATE_ERROR_RATIO` (1.5%) of the upper bound and then return that upper
+//! bound, so every estimate came back up to ~1.5% high. Differential testing
+//! against the other clients surfaced it on the EIP-2780 paths, where the
+//! intrinsic cost is low enough for the relative error to be most visible: a
+//! self-send whose minimum is 12000 was reported as 12156.
+
+use ethrex_rpc::test_utils::{call_http, default_context_with_storage, setup_store};
+
+/// A genesis-funded EOA, so the estimate is not capped by the sender's balance.
+const RICH: &str = "0x3f1eae7d46d88f08fc2f8ed27fcb2ab183eb2d0e";
+
+async fn estimate(call_object: &str) -> u64 {
+    let context = default_context_with_storage(setup_store().await).await;
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{call_object},"latest"],"id":1}}"#
+    );
+    let response = call_http(context, body).await;
+    let hex = response["result"]
+        .as_str()
+        .unwrap_or_else(|| panic!("eth_estimateGas should succeed, got {response}"));
+    u64::from_str_radix(hex.trim_start_matches("0x"), 16).expect("estimate is hex")
+}
+
+/// A value transfer between existing accounts costs exactly the 21000 intrinsic
+/// on this genesis, with nothing to execute on top. The estimate must be that
+/// number, not 21000 plus the search tolerance.
+#[tokio::test]
+async fn estimate_gas_returns_the_exact_minimum_for_a_transfer() {
+    let got = estimate(&format!(
+        r#"{{"from":"{RICH}","to":"{RICH}","value":"0x1"}}"#
+    ))
+    .await;
+    assert_eq!(
+        got, 21_000,
+        "a plain transfer's estimate must be its executable minimum, got {got}"
+    );
+}
+
+/// Same for a zero-value call: no execution, so the estimate is the bare
+/// intrinsic cost.
+#[tokio::test]
+async fn estimate_gas_returns_the_exact_minimum_for_a_zero_value_call() {
+    let got = estimate(&format!(r#"{{"from":"{RICH}","to":"{RICH}"}}"#)).await;
+    assert_eq!(
+        got, 21_000,
+        "a zero-value call's estimate must be its executable minimum, got {got}"
+    );
+}

--- a/test/tests/rpc/estimate_gas_tests.rs
+++ b/test/tests/rpc/estimate_gas_tests.rs
@@ -8,7 +8,11 @@
 //! intrinsic cost is low enough for the relative error to be most visible: a
 //! self-send whose minimum is 12000 was reported as 12156.
 
-use ethrex_rpc::test_utils::{call_http, default_context_with_storage, setup_store};
+use bytes::Bytes;
+use ethrex_common::Address;
+use ethrex_common::types::{Genesis, GenesisAccount};
+use ethrex_rpc::test_utils::{TEST_GENESIS, call_http, default_context_with_storage, setup_store};
+use ethrex_storage::{EngineType, Store};
 
 /// A genesis-funded EOA, so the estimate is not capped by the sender's balance.
 const RICH: &str = "0x3f1eae7d46d88f08fc2f8ed27fcb2ab183eb2d0e";
@@ -49,4 +53,65 @@ async fn estimate_gas_returns_the_exact_minimum_for_a_zero_value_call() {
         got, 21_000,
         "a zero-value call's estimate must be its executable minimum, got {got}"
     );
+}
+
+/// `GAS; PUSH2 0x2710; GT; PUSH1 0x0a; JUMPI; STOP; <pad>; JUMPDEST; INVALID`
+///
+/// Succeeds while more than 10000 gas remains at entry and hits `INVALID`
+/// otherwise, so it is a transaction whose *result* depends on the gas it is
+/// given. Running it at exactly the gas an unconstrained run consumed fails,
+/// which is what forces the estimate off the fast path and into the search.
+const GAS_OBSERVER_CODE: [u8; 12] = [
+    0x5a, 0x61, 0x27, 0x10, 0x11, 0x60, 0x0a, 0x57, 0x00, 0x00, 0x5b, 0xfe,
+];
+
+const OBSERVER: Address = Address::repeat_byte(0x0b);
+
+async fn store_with_gas_observer() -> Store {
+    let mut genesis: Genesis = serde_json::from_str(TEST_GENESIS).expect("test genesis is valid");
+    genesis.alloc.insert(
+        OBSERVER,
+        GenesisAccount {
+            code: Bytes::from_static(&GAS_OBSERVER_CODE),
+            storage: Default::default(),
+            balance: Default::default(),
+            nonce: 0,
+        },
+    );
+    let mut store = Store::new("estimate-gas-observer", EngineType::InMemory)
+        .expect("in-memory store should build");
+    store
+        .add_initial_state(genesis)
+        .await
+        .expect("genesis should load");
+    store
+}
+
+/// The fast path only answers when re-running at the consumed gas succeeds. A
+/// gas-observing callee fails there, so this exercises the binary search — which
+/// must still land on the exact minimum, not an upper bound near it.
+#[tokio::test]
+async fn estimate_gas_is_exact_for_a_gas_observing_call() {
+    let context = default_context_with_storage(store_with_gas_observer().await).await;
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{{"from":"{RICH}","to":"{OBSERVER:#x}"}},"latest"],"id":1}}"#
+    );
+    let response = call_http(context.clone(), body.clone()).await;
+    let hex = response["result"]
+        .as_str()
+        .unwrap_or_else(|| panic!("eth_estimateGas should succeed, got {response}"));
+    let estimate = u64::from_str_radix(hex.trim_start_matches("0x"), 16).expect("hex");
+
+    // Exactness means the estimate succeeds and one gas less does not.
+    for (gas, should_succeed) in [(estimate, true), (estimate - 1, false)] {
+        let probe = format!(
+            r#"{{"jsonrpc":"2.0","method":"eth_call","params":[{{"from":"{RICH}","to":"{OBSERVER:#x}","gas":"{gas:#x}"}},"latest"],"id":1}}"#
+        );
+        let got = call_http(context.clone(), probe).await;
+        assert_eq!(
+            got.get("result").is_some(),
+            should_succeed,
+            "at gas={gas} expected success={should_succeed}, got {got}"
+        );
+    }
 }

--- a/test/tests/rpc/estimate_gas_tests.rs
+++ b/test/tests/rpc/estimate_gas_tests.rs
@@ -146,3 +146,23 @@ async fn estimate_gas_for_a_gas_observing_call_is_executable_and_within_the_tole
         "overestimate {over:.4} (est {estimate}, min {minimum}) must stay within the tolerance"
     );
 }
+
+/// `eth_call` is a simulation, not a submission: a caller passing a gas value above
+/// the EIP-7825 per-transaction cap (tools routinely pass the block gas limit) must
+/// still get an answer. Populating the simulated transaction's envelope for the L2's
+/// L1-fee sizing must not make the hooks' transaction-gas-cap validation fire here.
+#[tokio::test]
+async fn eth_call_tolerates_gas_above_the_per_tx_cap() {
+    // POST_OSAKA_GAS_LIMIT_CAP is 1 << 24; the test genesis activates Osaka.
+    const ABOVE_CAP: u64 = (1 << 24) + 1;
+
+    let context = default_context_with_storage(setup_store().await).await;
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","method":"eth_call","params":[{{"from":"{RICH}","to":"{RICH}","gas":"{ABOVE_CAP:#x}"}},"latest"],"id":1}}"#
+    );
+    let response = call_http(context, body).await;
+    assert!(
+        response.get("result").is_some(),
+        "eth_call above the per-tx gas cap should still simulate, got {response}"
+    );
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -1,6 +1,8 @@
 mod authrpc_batch_tests;
 mod block_access_list_tests;
 mod client_version_tests;
+mod create_access_list_tests;
+mod estimate_gas_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod send_raw_transaction_tests;


### PR DESCRIPTION
**Motivation**

Differential testing across the six clients found `eth_estimateGas` reporting above the
executable minimum on every path:

| case | minimum | ethrex reported | over |
| --- | --- | --- | --- |
| EIP-2780 self-send | 12 000 | 12 156 | +156 |
| zero-value → existing | 15 000 | 15 159 | +159 |
| transfer → existing | 21 000 | 21 165 | +165 |
| transfer → fresh | 204 600 | 207 391 | +2 791 |

The report attributed the margin to `COLD_ACCOUNT_ACCESS`, but it is not repricing-related.
The tests below reproduce the identical +165 on the Osaka test genesis, which has neither
EIP-2780 nor EIP-8038, and replaying the search arithmetic reproduces all four numbers
exactly. The cause is that the search stopped once its bracket was within
`ESTIMATE_ERROR_RATIO` (1.5%) of the upper bound and then returned that upper bound. The
error is proportional, so it was simply most visible where EIP-2780 made the intrinsic cost
small — which is that EIP's whole point.

geth runs the same loop with the same constant, and returns the same 207 391 on the last
row. What hides it on the first three is a short circuit before the estimator:

```go
// If the transaction is a plain value transfer, short circuit estimation and
// directly try 21000.
if len(call.Data) == 0 {
    if call.To != nil && opts.State.GetCodeSize(*call.To) == 0 {
        failed, _, err := execute(ctx, call, opts, params.TxGas)
        if !failed && err == nil {
            return params.TxGas, nil, nil
        }
    }
}
```

That is a hardcoded `params.TxGas`, which is exactly what EIP-2780 invalidated: it is why
geth answers a self-send with 21 000 when the minimum is 12 000, a 75% overestimate. So the
report's "legacy 21000 floor" is right about the symptom but not the mechanism — nothing
clamps upward, the estimator simply never runs.

**Description**

Nothing can succeed below what an unconstrained run consumed, and most transactions execute
identically at their own `gas_used` as with the whole block's gas available. So the estimate
re-runs once at exactly `gas_used` and returns it when that succeeds: two simulations, exact
by construction, no search. Measured on a plain transfer:

| | simulations | answer |
| --- | --- | --- |
| before | 5 | 21 165 |
| this PR | **2** | **21 000** |

Cheaper than the behaviour it replaces, and correct — which answers the review question
about added iterations.

This is the same idea as geth's short circuit, generalised. geth probes a fixed
`params.TxGas` and only for a data-less call to a codeless account; probing the run's own
`gas_used` costs the same single simulation, is correct at any fork, and covers every
transaction shape.

The fallback search keeps geth's tolerance. `ESTIMATE_ERROR_RATIO` is deliberate there, and
geth writes down why: a perfect estimate is not worth extra execution when callers bump by
20-25% anyway, and for a transaction that inspects its own remaining gas it "probably
doesn't want to return the lowest possible gas limit for these cases anyway". Those are
precisely the transactions that reach the fallback, so it bisects and stops within the ratio
rather than converging.

Also pins `eth_createAccessList` returning an empty list for an access that touches an
account but no storage slot. Under EIP-8038 an entry costs the cold charge minus
`WARM_ACCESS`, so prepaying is gas-neutral for a single access while the entry's floor
tokens still raise the EIP-7623 floor — the minimal list is the empty one, and the same
testing found four of six clients returning a costlier list. ethrex already returns the
empty list, but incidentally: `Substate::make_access_list` derives entries from
`accessed_storage_slots`, so an address with no storage access cannot appear, and no
profitability heuristic tracks the pricing. The test is what keeps that true if the pricing
moves again.

A third finding from the same testing is not addressed here: `eth_simulateV1` with
`traceTransfers` double-counts EIP-7708 transfer logs across clients. ethrex answers
`-32601` because the method is unimplemented (#6212), so there is nothing to fix yet, but it
is a design requirement for #6951 — and the reporter is right that EIP-7708 and the
`traceTransfers` flag need an explicit rule about which log wins.

**L2: estimating against the fees the transaction will pay**

Making the estimate exact surfaced an older bug, as `test_fee_token: Deploy transaction
failed` across the L2 integration jobs. It took two goes to find, and the first answer was
only half of it.

`EthClient::estimate_gas` hand-builds its call object and sent only
`to`/`input`/`from`/`value` (plus blobs and nonce). With no fee field the server backfills
`env.gas_price` to zero — and on an L2 a zero gas price makes `adjust_disabled_l2_fees` drop
the fee configs outright, so the estimate is computed with **no L1 data fee gas at all**.
`build_generic_tx` submits the estimate verbatim, so the transaction ran out of gas at
exactly its own estimate. The call object now carries `maxFeePerGas`,
`maxPriorityFeePerGas`, `maxFeePerBlobGas` and a non-zero `gasPrice`; a zero `gasPrice` is
still omitted rather than sent as `0x0`, so a genuinely fee-less call keeps reaching the
relaxed path that exists for it.

The second half is the size that fee is computed from. The L2 prices its L1 data fee from
`Transaction::length()`, but `generic_tx_to_transaction` built the simulated transaction with
`..Default::default()` for everything except `to`/`value`/`data`/`access_list`, and a zero
`U256` is one RLP byte where a real signature component is 33 — a plain deploy encoded **15
bytes against the signed transaction's 93**. That only becomes load-bearing once the fee
configs are enabled at all, which is why fixing it first changed nothing. The envelope is
now carried over and the signature stamped at full width, deliberately at the maximum: a
real component can be shorter after leading-zero trimming, and over-reserving the L1 fee is
safe where under-reserving is not.

Populating `gas_limit` regressed `eth_call` before a test caught it, which is worth naming:
the hooks read `vm.tx.gas_limit()` for the EIP-7825 per-transaction cap, so a call passing
more than 16 777 216 gas — tools routinely pass the block gas limit — began failing with
`TxMaxGasLimitExceeded` where it used to simulate. That cap gates a transaction's admission,
not its execution, so it now honours the same `disable_gas_allowance_check` as the
block-level allowance, with the flag's documentation covering both. Real transactions are
unaffected: only the simulation entry points set the flag, and the 18 EIP-7825 fixtures in
the blockchain suite still pass.

**Tests**

`estimate_gas_returns_the_exact_minimum_for_a_transfer` and `..._for_a_zero_value_call` pin
the reported case; both fail before this change with `left: 21165, right: 21000`.

`estimate_gas_for_a_gas_observing_call_is_executable_and_within_the_tolerance` covers the
fallback, so it is not untested. A predeploy running `GAS; PUSH2 0x2710; GT; JUMPI` into
`INVALID` fails at its own `gas_used`, forcing the search, and the test pins the one-sided
contract the search owes: the estimate is executable, never sits below the true minimum —
found by bisection — and stays within the ratio above it.

`create_access_list_omits_an_account_only_access` pins the empty access list.

`simulated_tx_never_encodes_shorter_than_the_signed_one` pins the L2 invariant across an
empty, a small and a 4 KiB payload; without the fix it reports 15 bytes against 93.
`eth_call_tolerates_gas_above_the_per_tx_cap` pins the regression the cap gating avoids.
`carries_the_fees_the_transaction_will_pay` and `carries_gas_price_only_when_set` pin the
estimate's call object, which is where this went wrong unseen — the JSON construction is
split out as `estimate_gas_call_object` so the field set can be asserted on rather than
inspected by eye.

Regression sweep: 11752 blockchain ef-tests (including the 18 EIP-7825 fixtures), 449 levm
and rpc integration tests, 11 vm and 18 levm unit tests, 106 rpc unit tests.

Already on `glamsterdam-devnet-8` (`da0d87c30`).


