### PR TITLE
perf(l1): give the RLP encoder's scratch buffer an initial capacity

### DIFF
--- a/crates/common/rlp/structs.rs
+++ b/crates/common/rlp/structs.rs
@@ -181,14 +181,25 @@ impl core::fmt::Debug for Encoder<'_> {
     }
 }
 
+/// Initial capacity of the payload scratch buffer.
+///
+/// Fields are staged in `temp_buf` so the list header can be written once the
+/// payload length is known. Starting that buffer empty makes every encode pay a
+/// chain of doubling reallocations — an RLP list of a few hundred bytes grows
+/// 8 → 16 → … → 512, so seven allocations and six copies for one node.
+///
+/// 512 covers a trie node (the hashing path already sizes its own buffers at
+/// 512 as the maximum encoded node size) and the common transaction and receipt
+/// shapes, which is where the encoder is hottest. Larger payloads still grow
+/// from here; the point is to skip the small doublings, not to bound the size.
+const ENCODER_SCRATCH_CAPACITY: usize = 512;
+
 impl<'a> Encoder<'a> {
     /// Creates a new encoder that writes to the given buffer.
     pub fn new(buf: &'a mut dyn BufMut) -> Self {
-        // PERF: we could pre-allocate the buffer or switch to `ArrayVec`` if we could
-        // bound the size of the encoded data.
         Self {
             buf,
-            temp_buf: Default::default(),
+            temp_buf: Vec::with_capacity(ENCODER_SCRATCH_CAPACITY),
         }
     }
 


### PR DESCRIPTION
**Motivation**

`Encoder` stages a struct's fields in `temp_buf` so the list header can be written once the payload length is known. That buffer starts empty, so every encode pays a chain of doubling reallocations: an RLP list of a few hundred bytes grows 8 → 16 → … → 512, which is seven allocations and six copies to encode one node.

The `PERF` note already in `Encoder::new` asks for exactly this.

**Description**

Start `temp_buf` at 512 bytes. That covers a trie node — the hashing path already sizes its own buffers at 512 as the maximum encoded node size — and the common transaction and receipt shapes, which is where the encoder is hottest. Larger payloads still grow from there; the point is to skip the small doublings, not to bound the size.

Encoding output is unchanged: capacity only affects how many times the buffer is reallocated on the way there.

**Measurements**

Taken on the LambdaVM zkVM guest, which runs ethrex's block execution as a RISC-V program, so every allocation is executed work rather than something a host allocator can hide:

| block | before | after | delta |
|---|---:|---:|---:|
| empty | 609,404 | 586,983 | −3.68% |
| 1 transfer | 1,097,816 | 1,059,997 | −3.44% |
| 10 transfers | 3,702,726 | 3,604,757 | −2.65% |

A guest profile attributes it: `Encoder::encode_bytes`, previously 7–10% of all allocator cycles, disappears from the profile entirely, and total allocator cycles fall 23%.

The capacity was picked by sweeping it — 64 gave −1.0%/−1.8%, 128 −1.7%/−2.7%, 512 −2.3%/−3.0%, 1024 −2.3%/−3.4%. Returns flatten after 512, which is also the bound the trie code already assumes.

**Validation**

`cargo test -p ethrex-rlp` and `cargo test -p ethrex-common` (171 tests, which exercise RLP round-trips) pass; `cargo clippy` clean.