### PR TITLE
refactor(l1): drop the unused discovery lookup interval config

### DIFF
--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -592,7 +592,7 @@ impl Default for Options {
             mempool_max_queued_txs_per_account: DEFAULT_MAX_QUEUED_TXS_PER_ACCOUNT,
             tx_broadcasting_time_interval: Default::default(),
             target_peers: Default::default(),
-            lookup_interval: Default::default(),
+            lookup_interval: INITIAL_LOOKUP_INTERVAL_MS,
             extra_data: get_minimal_client_version(),
             gas_limit: DEFAULT_BUILDER_GAS_CEIL,
             max_blobs_per_block: None,

--- a/cmd/ethrex/cli.rs
+++ b/cmd/ethrex/cli.rs
@@ -456,7 +456,7 @@ pub struct Options {
         long = "p2p.lookup-interval",
         default_value_t = INITIAL_LOOKUP_INTERVAL_MS,
         value_name = "INITIAL_LOOKUP_INTERVAL",
-        help = "Initial Lookup Time Interval (ms) to trigger each Discovery lookup message and RLPx connection attempt.",
+        help = "Initial time interval (ms) between RLPx connection attempts. Widens towards 600ms as the target peer count is approached.",
         help_heading = "P2P options",
         env = "ETHREX_P2P_LOOKUP_INTERVAL"
     )]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -382,7 +382,6 @@ pub async fn init_network(
     let discovery_config = DiscoveryConfig {
         discv4_enabled: opts.discv4_enabled,
         discv5_enabled: opts.discv5_enabled,
-        ..Default::default()
     };
 
     ethrex_p2p::start_network(context, bootnodes, discovery_config)

--- a/crates/networking/p2p/discovery/mod.rs
+++ b/crates/networking/p2p/discovery/mod.rs
@@ -25,26 +25,17 @@ use std::time::Duration;
 pub struct DiscoveryConfig {
     pub discv4_enabled: bool,
     pub discv5_enabled: bool,
-    pub initial_lookup_interval: f64,
 }
 
-impl Default for DiscoveryConfig {
-    fn default() -> Self {
-        Self {
-            discv4_enabled: true,
-            discv5_enabled: true,
-            initial_lookup_interval: INITIAL_LOOKUP_INTERVAL_MS,
-        }
-    }
-}
-
-/// Lookup interval constants shared by discv4, discv5, and RLPx initiator.
+/// Lookup interval bounds for the RLPx initiator's connection attempts. The
+/// discovery server has its own bounds, since each of its iterative lookups
+/// emits far more traffic than a single connection attempt.
 pub const INITIAL_LOOKUP_INTERVAL_MS: f64 = 100.0; // 10 per second
 pub const LOOKUP_INTERVAL_MS: f64 = 600.0; // 100 per minute
 
-/// Smooth easing curve for discovery lookup intervals based on peer completion progress.
+/// Smooth easing curve for lookup intervals based on peer completion progress.
 ///
-/// Shared by discv4, discv5, and RLPx initiator.
+/// Shared by the discovery server and the RLPx initiator.
 pub fn lookup_interval_function(progress: f64, lower_limit: f64, upper_limit: f64) -> Duration {
     // Smooth progression curve
     // See https://easings.net/#easeInOutCubic

--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -457,7 +457,6 @@ impl DiscoveryServer {
             config: DiscoveryConfig {
                 discv4_enabled: false,
                 discv5_enabled: true,
-                initial_lookup_interval: 1000.0,
             },
             discv4: None,
             discv5: Some(Discv5State::default()),

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -137,10 +137,7 @@ pub async fn start_network(
         udp_socket,
         context.table.clone(),
         bootnodes,
-        DiscoveryConfig {
-            initial_lookup_interval: context.initial_lookup_interval,
-            ..config
-        },
+        config,
     )
     .await
     .inspect_err(|e| {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -216,7 +216,7 @@ P2P options:
           [default: 100]
 
       --p2p.lookup-interval <INITIAL_LOOKUP_INTERVAL>
-          Initial Lookup Time Interval (ms) to trigger each Discovery lookup message and RLPx connection attempt.
+          Initial time interval (ms) between RLPx connection attempts. Widens towards 600ms as the target peer count is approached.
           
           [env: ETHREX_P2P_LOOKUP_INTERVAL=]
           [default: 100]


### PR DESCRIPTION
**Motivation**

`DiscoveryConfig::initial_lookup_interval` is dead data. #6511 (kademlia
k-bucket routing table v2) replaced the configurable bound in
`DiscoveryServer::get_lookup_interval` with its own constants, because
each iterative lookup emits ~16 FindNode messages instead of 1 and
needed a rescaled schedule:

```diff
         lookup_interval_function(
             peer_completion,
-            self.config.initial_lookup_interval,
-            super::LOOKUP_INTERVAL_MS,
+            ITERATIVE_LOOKUP_INITIAL_MS,   // 500.0
+            ITERATIVE_LOOKUP_INTERVAL_MS,  // 10_000.0
         )
```

The field itself survived, still threaded from `--p2p.lookup-interval`
through `P2PContext` and `start_network` into a `DiscoveryServer` that
never reads it. The only live consumer of the flag is the RLPx
initiator, so the help text was also misleading.

While tracing it, a second problem turned up: `impl Default for Options`
sets `lookup_interval: Default::default()`, which is `0.0` for `f64`
rather than the `INITIAL_LOOKUP_INTERVAL_MS` that clap uses for the
flag. `default_l1()`, `default_l2()` and the L2 node options all build
on that impl, so they hand the RLPx initiator a 0ms lower bound. With no
peers connected the easing curve returns `Duration::ZERO`, and
`handle_look_for_peer` re-arms its timer with no delay at all. Present
since #5518 added the flag.

**Description**

- Remove `initial_lookup_interval` from `DiscoveryConfig` and stop
  overriding it in `start_network`. `DiscoveryConfig`'s `Default` impl
  goes with it: both remaining fields are set explicitly at the single
  construction site, and clap already defaults them to `true`.
- Reword `--p2p.lookup-interval`'s help to describe what it actually
  controls, and refresh the now-stale doc comments on
  `INITIAL_LOOKUP_INTERVAL_MS` / `LOOKUP_INTERVAL_MS` /
  `lookup_interval_function`.
- Default `Options::lookup_interval` to `INITIAL_LOOKUP_INTERVAL_MS`.

No behavior change for the discovery server, which was already running
on its own constants. The second commit does change behavior for the
dev/L2 paths that go through `Options::default()`, restoring the 100ms
floor they were meant to have.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
