### PR TITLE
fix(l1): require the generated witness to be sufficient, not identical to the fixture's

### DIFF
--- a/tooling/ef_tests/blockchain/test_runner.rs
+++ b/tooling/ef_tests/blockchain/test_runner.rs
@@ -796,15 +796,10 @@ async fn check_witness_generation_against_fixture(
 
     const MAX_REPORTED_ITEMS: usize = 8;
 
-    // EEST leniency fixtures (`*_extra_unused_*`) deliberately pad the witness
-    // with unused items (ancestor headers, bytecodes, trie nodes) to prove
-    // consumers accept them. Their `executionWitness` is intentionally NOT the
-    // canonical generation target, so the comparison is skipped.
-    if test_key.contains("extra_unused") {
-        return Ok(());
-    }
-
+    // `errors` fail the test; `differences` are reported only. See the note at
+    // the comparison below for why a witness need not equal the fixture's.
     let mut errors: Vec<String> = Vec::new();
+    let mut differences: Vec<String> = Vec::new();
     for block_fixture in test.blocks.iter() {
         if block_fixture.expect_exception.is_some() {
             continue;
@@ -874,7 +869,7 @@ async fn check_witness_generation_against_fixture(
             let missing: Vec<&&[u8]> = exp_set.difference(&got_set).collect();
             let extra: Vec<&&[u8]> = got_set.difference(&exp_set).collect();
             if missing.is_empty() && extra.is_empty() {
-                errors.push(format!(
+                differences.push(format!(
                     "{test_key} block {block_number} {section}: same item set but \
                      different multiplicity (generated {}, fixture {})",
                     got.len(),
@@ -909,15 +904,32 @@ async fn check_witness_generation_against_fixture(
             if !extra.is_empty() {
                 msg.push_str(&format!(" extra in generated: [{}]", fmt_items(&extra)));
             }
-            errors.push(msg);
+            // Reported, not failed. A witness only has to be *sufficient*, which
+            // is asserted above by re-executing with it; it does not have to
+            // equal the fixture's. EEST ships `validation_codes_extra_unused_bytecode`
+            // (and the `state`/`headers` equivalents) precisely to pin that a
+            // witness carrying extra unused items is valid, so neither direction
+            // of this difference is a defect. Upstream bundles differ in policy
+            // too: the zkevm conformance set excludes bytecode created inside the
+            // block, while the zkevm-benchmark set includes it, so requiring
+            // equality fails whichever one the client does not happen to mirror.
+            differences.push(msg);
         }
+    }
+
+    if !differences.is_empty() {
+        eprintln!(
+            "note: {test_key} witness differs from the fixture's (both valid; the \
+             generated one is proven sufficient above):\n{}",
+            differences.join("\n")
+        );
     }
 
     if errors.is_empty() {
         Ok(())
     } else {
         Err(format!(
-            "witness generation mismatch:\n{}",
+            "generated witness is not usable for stateless execution:\n{}",
             errors.join("\n")
         ))
     }


### PR DESCRIPTION
**Motivation**

`check_witness_generation_against_fixture` asserts two different things, and only one of them is a real requirement:

1. the witness ethrex generates must support stateless re-execution of the block — checked by actually re-executing with it;
2. that witness must equal the fixture's, item for item.

The second is stricter than the spec. EEST ships `validation_codes_extra_unused_bytecode`, `validation_state_extra_unused_trie_node` and `witness_headers_extra_unused_older_ancestor`, all expecting `successful_validation = 1`. A witness carrying extra unused items is valid, so two clients can emit different witnesses for the same block and both be correct. Equality was never the rule; sufficiency is.

Upstream's own bundles already disagree on this. The zkevm conformance set *excludes* bytecode created inside the block — `witness_excludes_bytecode_created_in_same_block` is precisely that case — while [`tests-zkevm-benchmark@v0.8.2`](https://github.com/ethereum/execution-specs/releases/tag/tests-zkevm-benchmark%40v0.8.2) *includes* it. Requiring equality means failing against whichever policy the client does not happen to mirror.

Running that benchmark bundle through the harness produced 9 failures across 3 fixtures, in all three gas tiers. Every one was a single in-block-created code entry that ethrex omits and the fixture carries:

| missing entry | count | what it is |
| --- | --- | --- |
| `0xef0100ca136acfd7…` (23 B) | 21 | EIP-7702 delegation designator |
| `0x60016000525b6020…` (38 B) | 18 | contract deployed in-block |
| `0x33ff` (2 B) | 6 | `CALLER SELFDESTRUCT`, created then destroyed |

Meanwhile the stateless wire path passed all 3464 tests in that bundle, and the generated witnesses passed the sufficiency check. Nothing was actually wrong.

**Description**

The set comparison is now reported instead of failed; only insufficiency fails the test. Drift stays visible in the output without turning a legal difference into a red test.

This also drops the `extra_unused` name-based skip. It existed because those fixtures cannot satisfy equality by construction — but it returned early, skipping the sufficiency check too. With equality no longer required, they are checked like every other fixture, so the change adds coverage rather than removing it.

**How to test**

```bash
make -C tooling/ef_tests/blockchain test-stateless
```

Conformance suite is unchanged at 3218 passed / 0 failed. Against the `tests-zkevm-benchmark@v0.8.2` bundle the same harness goes from 330/9 to 339/0, with the remaining differences printed as notes.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
