### PR TITLE
feat(l1): track the EEST zkEVM benchmark suite as bench workloads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,7 @@ hive/
 ethereum-package/
 tooling/ef_tests/blockchain/vectors
 tooling/ef_tests/blockchain/vectors_zkevm
+tooling/ef_tests/blockchain/vectors_zkevm_benchmark
 tooling/ef_tests/state/vectors
 tooling/sync/multisync_logs/
 dev_ethrex_l1/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 tooling/ef_tests/blockchain/vectors
 tooling/ef_tests/blockchain/vectors_zkevm
+tooling/ef_tests/blockchain/vectors_zkevm_benchmark
 
 tooling/ef_tests/state/vectors
 

--- a/tooling/ef_tests/.fixtures_url_zkevm_benchmark
+++ b/tooling/ef_tests/.fixtures_url_zkevm_benchmark
@@ -1,0 +1,1 @@
+https://github.com/ethereum/execution-specs/releases/download/tests-zkevm-benchmark%40v0.8.2/fixtures_zkevm-benchmark.tar.gz

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -40,11 +40,14 @@ ZKEVM_FIXTURES_FILE := ../.fixtures_url_zkevm
 ZKEVM_ARTIFACT := zkevm-tests.tar.gz
 ZKEVM_URL := $(shell cat $(ZKEVM_FIXTURES_FILE))
 
-# tests-zkevm-benchmark@v0.8.2 — Amsterdam compute benchmarks at 10M/30M/60M gas,
-# filled by the EEST pipeline on the same tests-zkevm@v0.8.0 base, so the schema
-# matches what the stateless harness already reads. Kept in its own root and NOT
-# a `download-test-vectors` prerequisite: it is ~500MB and only the zkevm bench
-# reads it. Fetch on demand with `make zkevm-benchmark-vectors`.
+# tests-zkevm-benchmark@v0.8.2 — Amsterdam compute benchmarks at 10M/30M/60M gas.
+# Filled by the EEST pipeline at execution-specs 117dd1cf with go-ethereum's
+# `evm` as t8n, not the EELS t8n that produced tests-zkevm@v0.8.0 (0695c34c);
+# the two pins move independently despite the shared "zkevm" name.
+#
+# Kept in its own root and NOT a `download-test-vectors` prerequisite: 519MB
+# compressed and ~3.9GB extracted, and only the zkevm bench reads it. Fetch on
+# demand with `make zkevm-benchmark-vectors`.
 ZKEVM_BENCH_VECTORS_ROOT := vectors_zkevm_benchmark
 ZKEVM_BENCH_VECTORS_DIR := $(ZKEVM_BENCH_VECTORS_ROOT)/eest
 ZKEVM_BENCH_FIXTURES_FILE := ../.fixtures_url_zkevm_benchmark
@@ -106,13 +109,41 @@ $(ZKEVM_VECTORS_DIR): $(ZKEVM_ARTIFACT)
 $(ZKEVM_BENCH_ARTIFACT): $(ZKEVM_BENCH_FIXTURES_FILE)
 	$(DOWNLOAD) $(ZKEVM_BENCH_URL) $(ZKEVM_BENCH_ARTIFACT)
 
-# Extracts all three gas tiers (for_amsterdam_at_{0010,0030,0060}M).
-$(ZKEVM_BENCH_VECTORS_DIR): $(ZKEVM_BENCH_ARTIFACT)
-	rm -rf $(ZKEVM_BENCH_VECTORS_DIR)
-	mkdir -p $(ZKEVM_BENCH_VECTORS_DIR)
-	tar -xzf $(ZKEVM_BENCH_ARTIFACT) --strip-components=2 -C $(ZKEVM_BENCH_VECTORS_DIR) fixtures/blockchain_tests
+# Only the subtrees the manifest references, not all 339 fixture files: the
+# whole tree unpacks to ~3.9GB for the 15 workloads actually run.
+ZKEVM_BENCH_SUBTREES := \
+  compute/instruction/keccak \
+  compute/precompile/alt_bn128 \
+  compute/precompile/p256verify \
+  compute/eip7928_block_level_access_lists/block_access_list \
+  compute/scenario/mix_operations
+ZKEVM_BENCH_TIERS := for_amsterdam_at_0010M for_amsterdam_at_0030M for_amsterdam_at_0060M
 
-zkevm-benchmark-vectors: $(ZKEVM_BENCH_VECTORS_DIR) ## 📥 Download the zkEVM benchmark fixtures (~500MB)
+# Keyed on the release URL, like `amsterdam-vectors`, and written only after a
+# successful untar. Two things this buys: `clean-vectors` runs from the
+# `$(SPECTEST_ARTIFACT)` rule on any `.fixtures_url` bump, which would otherwise
+# silently discard this opt-in multi-GB download; and an interrupted extraction
+# leaves no stamp, so the next run redoes it instead of reporting "nothing to be
+# done" while workloads fail on missing files.
+ZKEVM_BENCH_STAMP := $(ZKEVM_BENCH_VECTORS_DIR)/.zkevm_benchmark_url
+
+zkevm-benchmark-vectors: ## 📥 Download the zkEVM benchmark fixtures (519MB compressed, ~3.9GB extracted)
+	@have=$$(cat $(ZKEVM_BENCH_STAMP) 2>/dev/null); \
+	if [ "$$have" = "$(ZKEVM_BENCH_URL)" ]; then \
+		echo "zkEVM benchmark fixtures already extracted from $(ZKEVM_BENCH_URL)"; \
+	else \
+		$(MAKE) $(ZKEVM_BENCH_ARTIFACT) && \
+		rm -rf $(ZKEVM_BENCH_VECTORS_DIR) && \
+		mkdir -p $(ZKEVM_BENCH_VECTORS_DIR) && \
+		members=""; \
+		for tier in $(ZKEVM_BENCH_TIERS); do \
+			for sub in $(ZKEVM_BENCH_SUBTREES); do \
+				members="$$members fixtures/blockchain_tests/$$tier/$$sub"; \
+			done; \
+		done; \
+		tar -xzf $(ZKEVM_BENCH_ARTIFACT) --strip-components=2 -C $(ZKEVM_BENCH_VECTORS_DIR) $$members && \
+		echo "$(ZKEVM_BENCH_URL)" > $(ZKEVM_BENCH_STAMP); \
+	fi
 
 zkevm-vectors: $(ZKEVM_VECTORS_DIR)
 

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -1,4 +1,4 @@
-.PHONY: download-test-vectors clean-vectors test test-levm test-stateless amsterdam-vectors zkevm-vectors
+.PHONY: download-test-vectors clean-vectors test test-levm test-stateless amsterdam-vectors zkevm-vectors zkevm-benchmark-vectors
 
 VECTORS_ROOT := vectors
 FIXTURES_FILE := ../.fixtures_url
@@ -39,6 +39,17 @@ ZKEVM_VECTORS_DIR := $(ZKEVM_VECTORS_ROOT)/eest
 ZKEVM_FIXTURES_FILE := ../.fixtures_url_zkevm
 ZKEVM_ARTIFACT := zkevm-tests.tar.gz
 ZKEVM_URL := $(shell cat $(ZKEVM_FIXTURES_FILE))
+
+# tests-zkevm-benchmark@v0.8.2 — Amsterdam compute benchmarks at 10M/30M/60M gas,
+# filled by the EEST pipeline on the same tests-zkevm@v0.8.0 base, so the schema
+# matches what the stateless harness already reads. Kept in its own root and NOT
+# a `download-test-vectors` prerequisite: it is ~500MB and only the zkevm bench
+# reads it. Fetch on demand with `make zkevm-benchmark-vectors`.
+ZKEVM_BENCH_VECTORS_ROOT := vectors_zkevm_benchmark
+ZKEVM_BENCH_VECTORS_DIR := $(ZKEVM_BENCH_VECTORS_ROOT)/eest
+ZKEVM_BENCH_FIXTURES_FILE := ../.fixtures_url_zkevm_benchmark
+ZKEVM_BENCH_ARTIFACT := zkevm-benchmark-tests.tar.gz
+ZKEVM_BENCH_URL := $(shell cat $(ZKEVM_BENCH_FIXTURES_FILE))
 
 VECTORS_TARGETS := $(SPECTEST_VECTORS_DIR) $(LEGACYTEST_VECTORS_DIR)
 
@@ -92,6 +103,17 @@ $(ZKEVM_VECTORS_DIR): $(ZKEVM_ARTIFACT)
 	mkdir -p $(ZKEVM_VECTORS_DIR)
 	tar -xzf $(ZKEVM_ARTIFACT) --strip-components=2 -C $(ZKEVM_VECTORS_DIR) fixtures/blockchain_tests/for_amsterdam
 
+$(ZKEVM_BENCH_ARTIFACT): $(ZKEVM_BENCH_FIXTURES_FILE)
+	$(DOWNLOAD) $(ZKEVM_BENCH_URL) $(ZKEVM_BENCH_ARTIFACT)
+
+# Extracts all three gas tiers (for_amsterdam_at_{0010,0030,0060}M).
+$(ZKEVM_BENCH_VECTORS_DIR): $(ZKEVM_BENCH_ARTIFACT)
+	rm -rf $(ZKEVM_BENCH_VECTORS_DIR)
+	mkdir -p $(ZKEVM_BENCH_VECTORS_DIR)
+	tar -xzf $(ZKEVM_BENCH_ARTIFACT) --strip-components=2 -C $(ZKEVM_BENCH_VECTORS_DIR) fixtures/blockchain_tests
+
+zkevm-benchmark-vectors: $(ZKEVM_BENCH_VECTORS_DIR) ## 📥 Download the zkEVM benchmark fixtures (~500MB)
+
 zkevm-vectors: $(ZKEVM_VECTORS_DIR)
 
 help: ## 📚 Show help for each of the Makefile recipes
@@ -100,8 +122,8 @@ help: ## 📚 Show help for each of the Makefile recipes
 download-test-vectors: $(VECTORS_TARGETS) amsterdam-vectors zkevm-vectors ## 📥 Download test vectors
 
 clean-vectors: ## 🗑️  Clean test vectors
-	rm -rf $(VECTORS_ROOT) $(ZKEVM_VECTORS_ROOT)
-	rm -f $(SPECTEST_ARTIFACT) $(LEGACYTEST_ARTIFACT) $(AMSTERDAM_ARTIFACT) $(AMSTERDAM_ARTIFACT).part $(ZKEVM_ARTIFACT)
+	rm -rf $(VECTORS_ROOT) $(ZKEVM_VECTORS_ROOT) $(ZKEVM_BENCH_VECTORS_ROOT)
+	rm -f $(SPECTEST_ARTIFACT) $(LEGACYTEST_ARTIFACT) $(AMSTERDAM_ARTIFACT) $(AMSTERDAM_ARTIFACT).part $(ZKEVM_ARTIFACT) $(ZKEVM_BENCH_ARTIFACT)
 
 test-levm: $(VECTORS_TARGETS) amsterdam-vectors ## 🧪 Run blockchain tests with LEVM
 	cargo test --profile release-fast

--- a/tooling/zkevm_bench/README.md
+++ b/tooling/zkevm_bench/README.md
@@ -28,13 +28,21 @@ Every entry in `fixtures/manifest.toml` has a `type`:
   below).
 
 Benchmark-suite workloads also use the `micro` type. `tests-zkevm-benchmark@v0.8.2`
-is upstream's own Amsterdam compute benchmark set at fixed 10M/30M/60M gas
-targets, pinned by `tooling/ef_tests/.fixtures_url_zkevm_benchmark` and fetched
-with `make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors` (~500MB,
-gitignored). It differs from `stress` in where the witnesses come from: `stress`
-uses ethrex's own witness generation, so those numbers are self-referential,
-while these are filled by the EEST pipeline and are therefore comparable against
-other zkEVM clients. The 10M tier runs in `medium`, 30M and 60M in `slow`.
+is upstream's Amsterdam compute benchmark set at fixed 10M/30M/60M gas targets,
+pinned by `tooling/ef_tests/.fixtures_url_zkevm_benchmark` and fetched with
+`make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors` (519MB compressed;
+the target unpacks only the referenced subtrees, ~370MB, rather than the full
+~3.9GB tree). It differs from `stress` in where the witnesses come from:
+`stress` uses ethrex's own witness generation, so those numbers are
+self-referential, while these are filled upstream and are therefore comparable
+against other zkEVM clients. Note the provenance is not identical to the
+`.fixtures_url_zkevm` pin — the benchmark bundle was filled at execution-specs
+`117dd1cf` with go-ethereum's `evm` as t8n, the zkevm bundle at `0695c34c` with
+the EELS t8n 2.19.0 — and the two pins move independently.
+
+All benchmark workloads are `tier = "slow"`. The download is opt-in and is not a
+`download-test-vectors` prerequisite, so putting any of them in the default
+`medium` mode would report a missing download as an AIR-cost regression.
 
 `real-block` and `stress` both load through the same `Cache` loader
 (`src/cache.rs`); `micro` goes through a separate loader for raw EEST test
@@ -66,6 +74,14 @@ any invocation directory (see [Running](#running) below).
 
    ```bash
    make -C tooling/ef_tests/blockchain zkevm-vectors
+   ```
+
+   The benchmark-suite workloads (`eest_bench_*`, all `tier = "slow"`) come from
+   a second, larger bundle and need their own fetch — only required for
+   `--mode slow`:
+
+   ```bash
+   make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors
    ```
 
    Real-block and stress workloads need no download — their fixtures are
@@ -110,8 +126,8 @@ from the repo root as `./target/debug/ethrex-zkevm-bench`.
 ### Tiered modes (`--mode`)
 
 `run` takes a `--mode quick|medium|slow` tier ceiling (default `medium`).
-Each workload in the manifest declares an optional `tier` (`quick` or
-`medium`; absent means `medium`); `--mode` selects which tiers run:
+Each workload in the manifest declares an optional `tier` (`quick`, `medium`
+or `slow`; absent means `medium`); `--mode` selects which tiers run:
 
 - **`quick`** — only `tier = "quick"` workloads: a fast, **committed-only**
   sanity subset (~5–10 min) of real blocks + a few stress categories, so it
@@ -119,9 +135,11 @@ Each workload in the manifest declares an optional `tier` (`quick` or
   it requires `make zkevm-vectors`).
 - **`medium`** (default) — `quick` plus untagged/`medium`-tagged
   workloads, i.e. the full committed manifest (~1–2 h).
-- **`slow`** — everything `medium` runs, plus (if given) `--stress-dir
-  <dir>`, which adds every generated Cache-format fixture found in `<dir>`
-  as additional `stress` workloads. This is the exhaustive sweep.
+- **`slow`** — everything `medium` runs, plus `tier = "slow"` workloads (the
+  `eest_bench_*` benchmark suite, which needs `make zkevm-benchmark-vectors`),
+  plus (if given) `--stress-dir <dir>`, which adds every generated Cache-format
+  fixture found in `<dir>` as additional `stress` workloads. This is the
+  exhaustive sweep.
 
 `quick ⊆ medium ⊆ slow` by construction — each wider mode is a superset of
 the narrower ones.

--- a/tooling/zkevm_bench/README.md
+++ b/tooling/zkevm_bench/README.md
@@ -27,6 +27,15 @@ Every entry in `fixtures/manifest.toml` has a `type`:
   [Generating the exhaustive stress set](#generating-the-exhaustive-stress-set-for-slow)
   below).
 
+Benchmark-suite workloads also use the `micro` type. `tests-zkevm-benchmark@v0.8.2`
+is upstream's own Amsterdam compute benchmark set at fixed 10M/30M/60M gas
+targets, pinned by `tooling/ef_tests/.fixtures_url_zkevm_benchmark` and fetched
+with `make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors` (~500MB,
+gitignored). It differs from `stress` in where the witnesses come from: `stress`
+uses ethrex's own witness generation, so those numbers are self-referential,
+while these are filled by the EEST pipeline and are therefore comparable against
+other zkEVM clients. The 10M tier runs in `medium`, 30M and 60M in `slow`.
+
 `real-block` and `stress` both load through the same `Cache` loader
 (`src/cache.rs`); `micro` goes through a separate loader for raw EEST test
 vectors (`src/micro.rs`). All three types declare their `source` relative to

--- a/tooling/zkevm_bench/fixtures/manifest.toml
+++ b/tooling/zkevm_bench/fixtures/manifest.toml
@@ -152,3 +152,121 @@ source = "stress/stress_ecrecover_150M.json.gz"
 # NOTE: bls12_381 stress fixture is omitted — ethrex host witness generation
 # needs the `blst` feature for the BLS12-381 precompile; add it and regenerate
 # to include a worst-precompile-bls entry.
+
+# ---- EEST zkEVM benchmark suite (tests-zkevm-benchmark@v0.8.2) ----
+#
+# Amsterdam compute benchmarks at fixed gas targets, filled by the EEST pipeline
+# on the tests-zkevm@v0.8.0 base. Unlike `stress`, these witnesses come from
+# upstream's own t8n rather than ethrex's witness generation, so the numbers are
+# comparable against other zkEVM clients instead of being self-referential.
+#
+# Gitignored downloaded data: run
+#   make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors
+# The three gas tiers map onto run modes so a mode's cost stays proportional:
+# 10M in medium, 30M and 60M in slow.
+
+[[workload]]
+name = "eest_bench_keccak_10M"
+type = "micro"
+category = "bench-10M"
+tier = "medium"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/instruction/keccak/keccak.json"
+
+[[workload]]
+name = "eest_bench_bn128_pairing_10M"
+type = "micro"
+category = "bench-10M"
+tier = "medium"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/precompile/alt_bn128/bn128_pairings_amortized.json"
+
+[[workload]]
+name = "eest_bench_p256verify_10M"
+type = "micro"
+category = "bench-10M"
+tier = "medium"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/precompile/p256verify/p256verify.json"
+
+[[workload]]
+name = "eest_bench_bal_mixed_10M"
+type = "micro"
+category = "bench-10M"
+tier = "medium"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/eip7928_block_level_access_lists/block_access_list/mixed_dependency_graph.json"
+
+[[workload]]
+name = "eest_bench_jumpdest_10M"
+type = "micro"
+category = "bench-10M"
+tier = "medium"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/scenario/mix_operations/jumpdest_analysis.json"
+
+[[workload]]
+name = "eest_bench_keccak_30M"
+type = "micro"
+category = "bench-30M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/instruction/keccak/keccak.json"
+
+[[workload]]
+name = "eest_bench_bn128_pairing_30M"
+type = "micro"
+category = "bench-30M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/precompile/alt_bn128/bn128_pairings_amortized.json"
+
+[[workload]]
+name = "eest_bench_p256verify_30M"
+type = "micro"
+category = "bench-30M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/precompile/p256verify/p256verify.json"
+
+[[workload]]
+name = "eest_bench_bal_mixed_30M"
+type = "micro"
+category = "bench-30M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/eip7928_block_level_access_lists/block_access_list/mixed_dependency_graph.json"
+
+[[workload]]
+name = "eest_bench_jumpdest_30M"
+type = "micro"
+category = "bench-30M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/scenario/mix_operations/jumpdest_analysis.json"
+
+[[workload]]
+name = "eest_bench_keccak_60M"
+type = "micro"
+category = "bench-60M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/instruction/keccak/keccak.json"
+
+[[workload]]
+name = "eest_bench_bn128_pairing_60M"
+type = "micro"
+category = "bench-60M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/precompile/alt_bn128/bn128_pairings_amortized.json"
+
+[[workload]]
+name = "eest_bench_p256verify_60M"
+type = "micro"
+category = "bench-60M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/precompile/p256verify/p256verify.json"
+
+[[workload]]
+name = "eest_bench_bal_mixed_60M"
+type = "micro"
+category = "bench-60M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/eip7928_block_level_access_lists/block_access_list/mixed_dependency_graph.json"
+
+[[workload]]
+name = "eest_bench_jumpdest_60M"
+type = "micro"
+category = "bench-60M"
+tier = "slow"
+source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/scenario/mix_operations/jumpdest_analysis.json"
+

--- a/tooling/zkevm_bench/fixtures/manifest.toml
+++ b/tooling/zkevm_bench/fixtures/manifest.toml
@@ -155,118 +155,160 @@ source = "stress/stress_ecrecover_150M.json.gz"
 
 # ---- EEST zkEVM benchmark suite (tests-zkevm-benchmark@v0.8.2) ----
 #
-# Amsterdam compute benchmarks at fixed gas targets, filled by the EEST pipeline
-# on the tests-zkevm@v0.8.0 base. Unlike `stress`, these witnesses come from
-# upstream's own t8n rather than ethrex's witness generation, so the numbers are
-# comparable against other zkEVM clients instead of being self-referential.
+# Amsterdam compute benchmarks at fixed 10M/30M/60M gas targets. Filled by the
+# EEST pipeline at execution-specs commit 117dd1cf using go-ethereum's `evm` as
+# t8n (`fixtures/.meta/fixtures.ini`), whereas `tests-zkevm@v0.8.0` — what
+# `.fixtures_url_zkevm` pins — was filled at 0695c34c with the EELS t8n 2.19.0.
+# Different commit and different t8n, and the two pins move independently, so
+# treat schema compatibility as something to re-check on each bump rather than
+# something the shared "zkevm" name guarantees.
 #
-# Gitignored downloaded data: run
+# Value over the `stress` tier: those witnesses come from ethrex's own witness
+# generation, which makes their AIR costs self-referential. These come from
+# upstream, so they are comparable against other zkEVM clients.
+#
+# Gitignored downloaded data (~519MB compressed, ~3.9GB extracted):
 #   make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors
-# The three gas tiers map onto run modes so a mode's cost stays proportional:
-# 10M in medium, 30M and 60M in slow.
+# All tiers are `slow`: the download is opt-in and deliberately not a
+# `download-test-vectors` prerequisite, so putting any of them in the default
+# `medium` mode would report a missing 500MB download as an AIR-cost regression.
+#
+# `case` pins the pytest id. These files hold up to 18 parametrisations and
+# `compare` matches on workload name alone, so without it an upstream rename
+# that sorts earlier silently changes what the name means.
 
 [[workload]]
 name = "eest_bench_keccak_10M"
 type = "micro"
-category = "bench-10M"
-tier = "medium"
+category = "keccak"
+tier = "slow"
+gas = 10000000
+case = "mem_update_False-offset_0-mem_alloc_b''-benchmark-gas-value_10M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/instruction/keccak/keccak.json"
 
 [[workload]]
-name = "eest_bench_bn128_pairing_10M"
+name = "eest_bench_bn128_pair_10M"
 type = "micro"
-category = "bench-10M"
-tier = "medium"
+category = "precompile"
+tier = "slow"
+gas = 10000000
+case = "blockchain_test-benchmark-gas-value_10M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/precompile/alt_bn128/bn128_pairings_amortized.json"
 
 [[workload]]
 name = "eest_bench_p256verify_10M"
 type = "micro"
-category = "bench-10M"
-tier = "medium"
+category = "precompile"
+tier = "slow"
+gas = 10000000
+case = "blockchain_test-p256verify-benchmark-gas-value_10M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/precompile/p256verify/p256verify.json"
 
 [[workload]]
 name = "eest_bench_bal_mixed_10M"
 type = "micro"
-category = "bench-10M"
-tier = "medium"
+category = "block-access-list"
+tier = "slow"
+gas = 10000000
+case = "greedy_fill-group_size_1-benchmark-gas-value_10M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/eip7928_block_level_access_lists/block_access_list/mixed_dependency_graph.json"
 
 [[workload]]
 name = "eest_bench_jumpdest_10M"
 type = "micro"
-category = "bench-10M"
-tier = "medium"
+category = "control-flow"
+tier = "slow"
+gas = 10000000
+case = "blockchain_test-5b-benchmark-gas-value_10M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0010M/compute/scenario/mix_operations/jumpdest_analysis.json"
 
 [[workload]]
 name = "eest_bench_keccak_30M"
 type = "micro"
-category = "bench-30M"
+category = "keccak"
 tier = "slow"
+gas = 30000000
+case = "mem_update_False-offset_0-mem_alloc_b''-benchmark-gas-value_30M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/instruction/keccak/keccak.json"
 
 [[workload]]
-name = "eest_bench_bn128_pairing_30M"
+name = "eest_bench_bn128_pair_30M"
 type = "micro"
-category = "bench-30M"
+category = "precompile"
 tier = "slow"
+gas = 30000000
+case = "blockchain_test-benchmark-gas-value_30M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/precompile/alt_bn128/bn128_pairings_amortized.json"
 
 [[workload]]
 name = "eest_bench_p256verify_30M"
 type = "micro"
-category = "bench-30M"
+category = "precompile"
 tier = "slow"
+gas = 30000000
+case = "blockchain_test-p256verify-benchmark-gas-value_30M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/precompile/p256verify/p256verify.json"
 
 [[workload]]
 name = "eest_bench_bal_mixed_30M"
 type = "micro"
-category = "bench-30M"
+category = "block-access-list"
 tier = "slow"
+gas = 30000000
+case = "greedy_fill-group_size_1-benchmark-gas-value_30M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/eip7928_block_level_access_lists/block_access_list/mixed_dependency_graph.json"
 
 [[workload]]
 name = "eest_bench_jumpdest_30M"
 type = "micro"
-category = "bench-30M"
+category = "control-flow"
 tier = "slow"
+gas = 30000000
+case = "blockchain_test-5b-benchmark-gas-value_30M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0030M/compute/scenario/mix_operations/jumpdest_analysis.json"
 
 [[workload]]
 name = "eest_bench_keccak_60M"
 type = "micro"
-category = "bench-60M"
+category = "keccak"
 tier = "slow"
+gas = 60000000
+case = "mem_update_False-offset_0-mem_alloc_b''-benchmark-gas-value_60M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/instruction/keccak/keccak.json"
 
 [[workload]]
-name = "eest_bench_bn128_pairing_60M"
+name = "eest_bench_bn128_pair_60M"
 type = "micro"
-category = "bench-60M"
+category = "precompile"
 tier = "slow"
+gas = 60000000
+case = "blockchain_test-benchmark-gas-value_60M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/precompile/alt_bn128/bn128_pairings_amortized.json"
 
 [[workload]]
 name = "eest_bench_p256verify_60M"
 type = "micro"
-category = "bench-60M"
+category = "precompile"
 tier = "slow"
+gas = 60000000
+case = "blockchain_test-p256verify-benchmark-gas-value_60M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/precompile/p256verify/p256verify.json"
 
 [[workload]]
 name = "eest_bench_bal_mixed_60M"
 type = "micro"
-category = "bench-60M"
+category = "block-access-list"
 tier = "slow"
+gas = 60000000
+case = "greedy_fill-group_size_1-benchmark-gas-value_60M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/eip7928_block_level_access_lists/block_access_list/mixed_dependency_graph.json"
 
 [[workload]]
 name = "eest_bench_jumpdest_60M"
 type = "micro"
-category = "bench-60M"
+category = "control-flow"
 tier = "slow"
+gas = 60000000
+case = "blockchain_test-5b-benchmark-gas-value_60M"
 source = "../../ef_tests/blockchain/vectors_zkevm_benchmark/eest/for_amsterdam_at_0060M/compute/scenario/mix_operations/jumpdest_analysis.json"
 

--- a/tooling/zkevm_bench/src/manifest.rs
+++ b/tooling/zkevm_bench/src/manifest.rs
@@ -17,7 +17,14 @@ pub struct WorkloadSpec {
     pub source: String,
     #[serde(default)]
     pub gas: Option<u64>,
-    /// Run-tier ceiling ("quick"|"medium"); `None` is treated as "medium".
+    /// For `micro` workloads: substring of the pytest id to measure. EEST
+    /// fixture files hold up to 18 parametrisations, so leaving the choice to
+    /// map ordering means an upstream rename can silently change what a
+    /// workload measures while its name — the only thing `compare` matches
+    /// on — stays put.
+    #[serde(default)]
+    pub case: Option<String>,
+    /// Run-tier ceiling ("quick"|"medium"|"slow"); `None` is treated as "medium".
     /// Kept as a raw string here (rather than `Option<Tier>`) so
     /// `load_manifest` can validate it itself and produce an error that
     /// names both the offending workload and the bad value; see
@@ -38,17 +45,19 @@ pub struct Manifest {
 pub enum Tier {
     Quick,
     Medium,
+    Slow,
 }
 
 impl Tier {
     /// Parses a manifest `tier` string. Returns `None` for anything other
-    /// than `"quick"`/`"medium"` — callers turn that into a hard manifest
-    /// load error rather than silently falling back to a default, so a
+    /// than `"quick"`/`"medium"`/`"slow"` — callers turn that into a hard
+    /// manifest load error rather than silently falling back to a default, so a
     /// typo (e.g. `"quik"`) can't be silently dropped from quick/medium.
     fn parse(s: &str) -> Option<Self> {
         match s {
             "quick" => Some(Self::Quick),
             "medium" => Some(Self::Medium),
+            "slow" => Some(Self::Slow),
             _ => None,
         }
     }
@@ -62,7 +71,7 @@ pub fn load_manifest(path: &str) -> eyre::Result<Manifest> {
             && Tier::parse(tier).is_none()
         {
             eyre::bail!(
-                "workload {:?} has unknown tier {:?} (expected \"quick\" or \"medium\")",
+                "workload {:?} has unknown tier {:?} (expected \"quick\", \"medium\" or \"slow\")",
                 w.name,
                 tier
             );

--- a/tooling/zkevm_bench/src/micro.rs
+++ b/tooling/zkevm_bench/src/micro.rs
@@ -1,98 +1,150 @@
 use std::collections::BTreeMap;
 
-use bytes::Bytes;
-use ef_tests_blockchain::fork::Fork;
-use ethrex_common::NativeCrypto;
-use ethrex_common::types::Block;
-use ethrex_common::types::block_execution_witness::{RpcExecutionWitness, decode_witness_headers};
 use ethrex_guest_program::input::ProgramInput;
-use ethrex_l2::sequencer::native_rollup::l1_advancer::build_ssz_stateless_input;
-use ethrex_rlp::decode::RLPDecode;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct MicroTest {
-    network: Fork,
     blocks: Vec<MicroBlock>,
 }
 
 #[derive(Deserialize)]
 struct MicroBlock {
-    #[serde(with = "ethrex_common::serde_utils::bytes")]
-    rlp: Bytes,
-    #[serde(rename = "executionWitness", default)]
-    execution_witness: Option<RpcExecutionWitness>,
+    /// The spec's schema-prefixed stateless input — exactly the bytes another
+    /// client's guest would consume for this block.
+    #[serde(rename = "statelessInputBytes", default)]
+    stateless_input_bytes: Option<String>,
+    /// Committed result the guest must reproduce; byte 32 is
+    /// `successful_validation`.
+    #[serde(rename = "statelessOutputBytes", default)]
+    stateless_output_bytes: Option<String>,
     #[serde(rename = "expectException", default)]
     expect_exception: Option<serde_json::Value>,
 }
 
-/// Reads an EEST zkevm fixture (keyed by test name), takes the first test's
-/// first executable block (no `expectException`, present `executionWitness`),
-/// RLP-decodes it, converts the witness into the guest-consumable
-/// `ExecutionWitness`, and returns a single-block `ProgramInput`.
+fn decode_hex(label: &str, s: &str) -> eyre::Result<Vec<u8>> {
+    hex::decode(s.trim_start_matches("0x")).map_err(|e| eyre::eyre!("{label} hex decode: {e}"))
+}
+
+/// Reads an EEST zkevm fixture and returns the block's `statelessInputBytes`
+/// verbatim as the guest input.
 ///
-/// `gas` is workload metadata only (the gas limit is already baked into the
-/// fixture); it is recorded in the report, not applied here.
-pub fn micro_to_program_input(source: &str, _gas: Option<u64>) -> eyre::Result<ProgramInput> {
+/// The bytes are taken from the fixture rather than rebuilt from `rlp` plus
+/// `executionWitness`. Re-deriving them host side means re-deriving every field
+/// the wire format carries, and missing one is silent: an earlier version
+/// passed no block access list, so on Amsterdam the header's
+/// `block_access_list_hash` was absent and `validate_block_pre_execution`
+/// rejected the block before the EVM ran. `run_stateless_guest` never returns
+/// an error — it commits `successful_validation = 0` — and the emulator still
+/// exits 0, so the run was recorded as a success whose AIR cost measured
+/// witness loading and header validation instead of the workload. Consuming the
+/// fixture's own bytes removes that whole class of divergence.
+///
+/// `case` picks the pytest id to measure. These files hold up to 18
+/// parametrisations and the choice must not depend on map ordering: on an
+/// experimental tag an upstream rename that sorts earlier would silently change
+/// what a workload measures, and `compare` matches on workload name alone, so
+/// the swap would read as a client regression. A substring is enough to be
+/// stable against unrelated suffixes; ambiguity is an error rather than a
+/// coin flip.
+///
+/// `gas` is workload metadata only (the target is baked into the fixture); it
+/// is recorded in the report, not applied here.
+pub fn micro_to_program_input(
+    source: &str,
+    case: Option<&str>,
+    _gas: Option<u64>,
+) -> eyre::Result<ProgramInput> {
     let raw = std::fs::read_to_string(source)?;
     let fixture: BTreeMap<String, MicroTest> = serde_json::from_str(&raw)?;
-    let (_name, test) = fixture
-        .into_iter()
-        .next()
-        .ok_or_else(|| eyre::eyre!("empty fixture {source}"))?;
-    let chain_config = *test.network.chain_config();
 
-    for block in test.blocks {
+    let matches: Vec<(&String, &MicroTest)> = match case {
+        Some(c) => fixture.iter().filter(|(k, _)| k.contains(c)).collect(),
+        None => fixture.iter().collect(),
+    };
+    let (name, test) = match matches.as_slice() {
+        [] => eyre::bail!(
+            "no test in {source} matches {:?} (file holds {} case(s))",
+            case.unwrap_or("<any>"),
+            fixture.len()
+        ),
+        [one] => *one,
+        many => eyre::bail!(
+            "{:?} matches {} cases in {source}; narrow it (first: {})",
+            case.unwrap_or("<any>"),
+            many.len(),
+            many[0].0
+        ),
+    };
+
+    for block in &test.blocks {
         if block.expect_exception.is_some() {
             continue;
         }
-        let Some(rpc_witness) = block.execution_witness else {
+        let Some(input_hex) = block.stateless_input_bytes.as_deref() else {
             continue;
         };
-        let core_block =
-            Block::decode(&block.rlp).map_err(|e| eyre::eyre!("decode block rlp: {e:?}"))?;
-        let block_number = core_block.header.number;
-        let decoded_headers = decode_witness_headers(&rpc_witness.headers)
-            .map_err(|e| eyre::eyre!("decode witness headers: {e:?}"))?;
-        let execution_witness = rpc_witness
-            .into_execution_witness(chain_config, block_number, &decoded_headers, &NativeCrypto)
-            .map_err(|e| eyre::eyre!("into_execution_witness: {e:?}"))?;
-        // The L1 `ProgramInput` is the spec's schema-prefixed
-        // `statelessInputBytes`; see `cache::cache_to_program_input`.
-        return build_ssz_stateless_input(
-            &core_block.header,
-            &core_block.body,
-            &execution_witness,
-            None,
-        )
-        .map_err(|e| eyre::eyre!("build stateless input: {e}"));
+        let input = decode_hex("statelessInputBytes", input_hex)?;
+        if input.is_empty() {
+            continue;
+        }
+        // A fixture whose own expected result is a failure would benchmark the
+        // rejection path, not the workload.
+        if let Some(out_hex) = block.stateless_output_bytes.as_deref() {
+            let out = decode_hex("statelessOutputBytes", out_hex)?;
+            match out.get(32) {
+                Some(1) => {}
+                Some(_) => continue,
+                None => eyre::bail!(
+                    "statelessOutputBytes for {name} is {} bytes, too short to carry \
+                     successful_validation at index 32",
+                    out.len()
+                ),
+            }
+        }
+        return Ok(input);
     }
-    eyre::bail!("no executable block with executionWitness in {source}")
+    eyre::bail!("no executable block with statelessInputBytes in {source} ({name})")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Verified to exist: network Amsterdam, 1 block, has executionWitness, no expectException.
     const FIXTURE: &str = "../ef_tests/blockchain/vectors_zkevm/eest/for_amsterdam/amsterdam/eip8025_optional_proofs/witness_7702/witness_codes_delegation_chain.json";
 
     #[test]
     fn builds_program_input_from_eest_fixture() {
         // `vectors_zkevm` is gitignored (downloaded via `make zkevm-vectors`).
-        // CI's L1 unit-test step runs this crate before any vector download, so
-        // skip gracefully when the fixture is absent (mirrors the ziskemu-skip
-        // pattern in tests/smoke.rs). When present, the test runs and asserts.
         if !std::path::Path::new(FIXTURE).exists() {
-            eprintln!(
-                "skipping: EEST fixture absent (run `make zkevm-vectors` in tooling/ef_tests/blockchain)"
-            );
+            eprintln!("skipping: EEST fixture absent (run `make zkevm-vectors`)");
             return;
         }
-        // If this path moves in a future fixture bump, pick any file under
-        // vectors_zkevm whose first block has no expectException and has an
-        // executionWitness; the schema is uniform across the set.
-        let input = micro_to_program_input(FIXTURE, Some(100_000_000)).expect("convert");
+        let input = micro_to_program_input(FIXTURE, None, Some(100_000_000)).expect("convert");
         assert!(!input.is_empty(), "stateless input bytes must not be empty");
+        let schema_id = u16::from_be_bytes([input[0], input[1]]);
+        assert_eq!(
+            schema_id,
+            ethrex_common::types::stateless_ssz::STATELESS_INPUT_SCHEMA_ID
+        );
+    }
+
+    #[test]
+    fn ambiguous_case_selector_is_an_error() {
+        if !std::path::Path::new(FIXTURE).exists() {
+            return;
+        }
+        // "test_" prefixes every pytest id, so it can only be unambiguous when
+        // the file holds exactly one case.
+        let raw = std::fs::read_to_string(FIXTURE).unwrap();
+        let n = serde_json::from_str::<BTreeMap<String, serde_json::Value>>(&raw)
+            .unwrap()
+            .len();
+        let got = micro_to_program_input(FIXTURE, Some("test_"), None);
+        assert_eq!(
+            got.is_err(),
+            n > 1,
+            "ambiguity must not be resolved silently"
+        );
     }
 }

--- a/tooling/zkevm_bench/src/run.rs
+++ b/tooling/zkevm_bench/src/run.rs
@@ -99,6 +99,9 @@ fn discover_stress_workloads(dir: &str) -> eyre::Result<Vec<WorkloadSpec>> {
             category: None,
             source: entry.path().to_string_lossy().to_string(),
             gas: None,
+            // Discovered stress caches are whole-file inputs, not EEST fixtures
+            // with multiple pytest ids, so there is nothing to select.
+            case: None,
             tier: None,
         });
     }
@@ -155,9 +158,11 @@ pub fn run_bench(
         let result: eyre::Result<ZiskAirCost> = (|| {
             let input = match spec.r#type {
                 WorkloadType::RealBlock => cache_to_program_input(load_cache(&spec.source)?)?,
-                WorkloadType::Micro => {
-                    crate::micro::micro_to_program_input(&spec.source, spec.gas)?
-                }
+                WorkloadType::Micro => crate::micro::micro_to_program_input(
+                    &spec.source,
+                    spec.case.as_deref(),
+                    spec.gas,
+                )?,
                 WorkloadType::Stress => cache_to_program_input(load_cache(&spec.source)?)?,
             };
             backend


### PR DESCRIPTION
**Motivation**

[`tests-zkevm-benchmark@v0.8.2`](https://github.com/ethereum/execution-specs/releases/tag/tests-zkevm-benchmark%40v0.8.2) is upstream's first benchmark fixture release — Amsterdam compute benchmarks at 10M, 30M and 60M gas, produced entirely in the EEST pipeline on the same `tests-zkevm@v0.8.0` base the stateless harness already reads.

The reason to take it is where the witnesses come from. `tooling/zkevm_bench`'s `stress` tier is generated locally using **ethrex's own witness generation**, which makes those numbers self-referential: a witness-generation bug would be baked into the baseline it is measured against. These fixtures carry upstream's witnesses, so the AIR costs are comparable against other zkEVM clients rather than only against ourselves.

**Description**

Pinned by `tooling/ef_tests/.fixtures_url_zkevm_benchmark`, fetched on demand:

```bash
make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors
```

Deliberately **not** a `download-test-vectors` prerequisite — the bundle is ~500MB and only the bench reads it. The extracted root is gitignored, same treatment as `vectors_zkevm`.

Fifteen workloads are wired into `fixtures/manifest.toml`: five areas (keccak, bn128 pairings, p256verify, EIP-7928 block access lists, jumpdest analysis) across the three gas tiers. They reuse the existing `micro` loader, which already reads EEST fixtures, so there is no new loading path. Tiers map onto run modes so a mode's cost stays proportional — 10M in `medium`, 30M and 60M in `slow`.

No client changes were needed. The bundle's schema matches what we already consume: `0x1501` prefix, 43-byte outputs, and all 7390 blocks carrying both `statelessInputBytes` and `executionWitness`.

**Validation**

Ran the release against ethrex before wiring it in:

- **all 3464 tests pass the stateless wire path** — decode `statelessInputBytes`, run the guest, compare the 43-byte `statelessOutputBytes`
- the full 339-file set runs **339 passed / 0 failed** through the EF harness (needs #7164, which stops the harness demanding our generated witness equal the fixture's; without it 9 files fail on a difference the spec explicitly permits)
- tier medians land exactly on 10M / 30M / 60M gas

Two observations reported upstream rather than worked around: some blocks run well above their tier (largest is 613,958,400 gas in the 10M tier, ~61×, all cold-access benchmarks that look like state-priming setup blocks), and `gasLimit` is `1e12` on every header, which leaves gas-limit-derived logic such as EIP-7928's BAL size cap unexercised.

Upstream flagged the release as experimental, so the tag is pinned exactly and churn is expected.

**How to test**

```bash
make -C tooling/ef_tests/blockchain zkevm-benchmark-vectors
cargo run --manifest-path tooling/zkevm_bench/Cargo.toml -- run --mode medium
```

AIR-cost figures need `ziskemu` on x86-64; the validation above was native execution.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
