### PR TITLE
ci: fold the runner image family into the shared cache key, not `key`

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -22,9 +22,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Extract Rust version and runner image family
+    - name: Extract Rust version and compose the cache key
       id: rustver
       shell: bash
+      env:
+        CACHE_POOL: ${{ inputs.cache-pool }}
       run: |
         rust_version=$(grep -E '^[[:space:]]*channel[[:space:]]*=' rust-toolchain.toml \
                  | sed -E 's/.*"([^"]+)".*/\1/')
@@ -34,8 +36,19 @@ runs:
         # revisions in one job and runs this action from each, and a differing
         # step list between them trips the runner's post-step bookkeeping with
         # "Index was out of range".
-        echo "image_family=${ImageOS:-unknown}" >>"$GITHUB_OUTPUT"
-        echo "Runner image family: ${ImageOS:-unknown}"
+        image_family="${ImageOS:-unknown}"
+        echo "image_family=${image_family}" >>"$GITHUB_OUTPUT"
+        echo "Runner image family: ${image_family}"
+        # rust-cache appends its `key` input only on the branch that builds a
+        # per-job key; when `shared-key` is set it takes that branch instead and
+        # `key` is dropped entirely. So a pooled job has to carry the image
+        # family inside the shared key itself. Empty when no pool is configured,
+        # which leaves rust-cache on the per-job key where `key` does apply.
+        if [ -n "${CACHE_POOL}" ]; then
+          echo "shared_key=${CACHE_POOL}-${image_family}" >>"$GITHUB_OUTPUT"
+        else
+          echo "shared_key=" >>"$GITHUB_OUTPUT"
+        fi
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
@@ -55,6 +68,9 @@ runs:
     # `ImageOS` (ubuntu22 / ubuntu24 / macos15) is the image family, so it
     # separates the glibc floors without keying on `ImageVersion`, which
     # changes with every runner image release and would evict the pool weekly.
+    # It goes into `shared-key`, not `key`: rust-cache ignores `key` whenever
+    # `shared-key` is set, so keying the image family there alone left every
+    # pooled job on the shared, image-blind key it was meant to split.
     # Read via `$GITHUB_OUTPUT` rather than `env.ImageOS` directly: the `env`
     # context is not reliably available to `with:` on a `uses:` step inside a
     # composite action. Self-hosted runners may not set it; they then share one
@@ -80,7 +96,7 @@ runs:
     - name: Add Rust Cache
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ inputs.cache-pool }}
+        shared-key: ${{ steps.rustver.outputs.shared_key }}
         key: ${{ steps.rustver.outputs.image_family }}
         save-if: ${{ inputs.save-cache == 'true' && github.ref == 'refs/heads/main' }}
         workspaces: |


### PR DESCRIPTION
**Motivation**

`Ethrex Release` is still red on `main` after #7154, failing in `build-ethrex (ubuntu-22.04, l2)` with the same error that PR set out to fix ([run 32302415108](https://github.com/lambdaclass/ethrex/actions/runs/32302415108/job/96227727106), on `7277c63ee`, which already contains it):

```
error: …/libparity_scale_codec_derive-….so: /lib/x86_64-linux-gnu/libc.so.6:
       version `GLIBC_2.39' not found
```

The diagnosis in #7154 holds: a proc-macro `.so` built on ubuntu-24.04 is restored into an ubuntu-22.04 job, `rustc` cannot dlopen it, and `parity-scale-codec` collapses into eighteen `E0432`s that name the dependency rather than the cache. The fix is what did not work.

#7154 passed the image family to `Swatinem/rust-cache` through its `key` input. `key` is only honoured on the branch that builds a per-job key:

```ts
// rust-cache src/config.ts
const sharedKey = core.getInput("shared-key");
if (sharedKey) {
  key += `-${sharedKey}`;
} else {
  const inputKey = core.getInput("key");
  if (inputKey) key += `-${inputKey}`;
  // …job id…
}
```

Every job that sets `cache-pool` sets `shared-key`, so it takes the first branch and `key` is dropped. The failing run shows the input arriving and the key ignoring it:

```
with:
  shared-key: l2
  key: ubuntu22
…
Runner image family: ubuntu22
Restore Key:  v0-rust-l2-Linux-x64-73d6c353
Cache Key:    v0-rust-l2-Linux-x64-73d6c353-18b5747f
Restored from cache key "v0-rust-l2-Linux-x64-73d6c353-18b5747f" full match: true.
```

Same pool, same key, both images. The 24.04 writer (`pr-main_l2.yaml:integration-test`, `runs-on: ubuntu-latest`) and the 22.04 reader (`tag_release.yaml:build-ethrex`) still share one entry.

**Description**

Fold the image family into the shared key itself: `shared-key: <pool>-<image family>`, so it lands on the branch rust-cache actually uses.

| | before | after |
| --- | --- | --- |
| pooled job on 22.04 | `v0-rust-l2-Linux-x64-…` | `v0-rust-l2-ubuntu22-Linux-x64-…` |
| pooled job on 24.04 | `v0-rust-l2-Linux-x64-…` | `v0-rust-l2-ubuntu24-Linux-x64-…` |

The shared key is left empty when `cache-pool` is unset, which keeps those jobs (e.g. `pr_nostd.yaml`) on rust-cache's per-job key. `key: ${{ image_family }}` stays on the step for exactly that case, where it is honoured. `inputs.cache-pool` reaches the script through `env:` rather than direct `${{ }}` interpolation.

**Consequences**

`l2` has no 22.04 writer: the pool is written by `integration-test` on `ubuntu-latest`. So `build-ethrex (ubuntu-22.04, l2)` gets a cold build rather than a poisoned warm one. That is the correct outcome and the only one available without a 22.04 writer for that pool; giving the release job its own writable pool would warm it, but each entry runs 1.2-2.75GB against a 10GB LRU budget, so it is a separate call and left out here.

As in #7154, changing the key invalidates existing entries once. Pools refill on the next `main` build.

**How to test**

`tag_release.yaml` has no `pull_request` trigger, so the real check is that `build-ethrex (ubuntu-22.04, l2)` goes green on the next push to `main`. Before then, any job's log shows the key now carrying the image family:

```
v0-rust-l2-ubuntu22-Linux-x64-…
```

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
