### PR TITLE
chore(l1): bump mainnet ef-test fixtures to execution-specs tests@v20.0.1

### DIFF
--- a/.github/config/hive/mainnet.yaml
+++ b/.github/config/hive/mainnet.yaml
@@ -1,6 +1,10 @@
 # Mainnet hive test configuration
-# Pinned to tests@v20.0.0 (execution-specs first mainnet fixture release:
+# Pinned to tests@v20.0.1 (execution-specs mainnet fixture release:
 # Osaka + BPO1 + BPO2). Replaces the archived
 # ethereum/execution-spec-tests `fixtures_develop` bundle.
-fixtures: https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0/fixtures.tar.gz
-eels_commit: 376414e07c4642574b38c4bb97eab2f2f719436b
+fixtures: https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.1/fixtures.tar.gz
+# The tests@v20.0.1 tag commit. Any future pin must still descend from
+# execution-specs ecd94a47 (PR #3104), which carries the ethrex
+# INVALID_SIGNATURE_VRS exception mappings; older commits silently fail
+# 80 consume-engine bad_v_r_s cases.
+eels_commit: 87aba1a38a476b31f819a2390eb481527e6dc683

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -64,12 +64,17 @@ jobs:
               simulation: ethereum/eels/consume-engine,
               limit: ".*fork_Prague.*",
             }
+          # Lower parallelism for the same OOM as consume-rlp Amsterdam below:
+          # with parallelism 4 the runner gets SIGTERM'd (exit 143) mid-run on
+          # the glamsterdam-devnet-8 fixture set; no run has completed since
+          # that bump (2026-08-13).
           - {
               name: "Consume Engine tests (Amsterdam)",
               file_name: consume-engine-amsterdam,
               simulation: ethereum/eels/consume-engine,
               limit: ".*fork_.*Amsterdam.*",
               amsterdam: true,
+              parallelism: 2,
             }
           - {
               name: "Consume RLP tests (Rest)",

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -150,8 +150,8 @@ jobs:
               FLAGS+=" --sim.buildarg branch=$AMSTERDAM_EELS_COMMIT"
             else
               # All other forks (Prague, Osaka, Cancun, Shanghai, Paris) use the
-              # mainnet bundle (execution-specs tests@v20.0.0), which includes
-              # comprehensive coverage including ported static tests.
+              # mainnet bundle, which includes comprehensive coverage including
+              # ported static tests.
               # Config loaded from .github/config/hive/mainnet.yaml
               FLAGS+=" --sim.buildarg fixtures=$MAINNET_FIXTURES"
               FLAGS+=" --sim.buildarg branch=$MAINNET_EELS_COMMIT"

--- a/docs/developers/l1/testing/hive.md
+++ b/docs/developers/l1/testing/hive.md
@@ -9,7 +9,7 @@ This project uses three key repositories for Hive testing:
 1. **[ethereum/hive](https://github.com/ethereum/hive)** - The main Hive testing framework
    - Current commit: `0921fb7833e3de180eacdc9f26de6e51dcab0dba`
 2. **[ethereum/execution-specs](https://github.com/ethereum/execution-specs)** - Test fixtures and vectors (the former `ethereum/execution-spec-tests` repo is archived)
-   - Mainnet: `tests@v20.0.0` (Osaka + BPO1 + BPO2); Amsterdam: `tests-glamsterdam-devnet@v8.0.0`
+   - Mainnet: `tests@v20.0.1` (Osaka + BPO1 + BPO2); Amsterdam: `tests-glamsterdam-devnet@v8.0.0`
 3. **[ethereum/execution-specs](https://github.com/ethereum/execution-specs)** - Fork specifications
    - Current branch: `forks/amsterdam`
 
@@ -311,7 +311,7 @@ Contents:
 
 ```
 # .fixtures_url
-https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0/fixtures.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.1/fixtures.tar.gz
 
 # .fixtures_url_amsterdam
 https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.0.0/fixtures_glamsterdam-devnet.tar.gz

--- a/tooling/ef_tests/.fixtures_url
+++ b/tooling/ef_tests/.fixtures_url
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.0/fixtures.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests%40v20.0.1/fixtures.tar.gz


### PR DESCRIPTION
**Motivation**

`tests@v20.0.1` is out — the patch release for the `tests@v20.0.0` mainnet stream (Osaka + BPO1 + BPO2), [announced as having no consensus-impacting changes](https://github.com/ethereum/execution-specs/releases/tag/tests%40v20.0.1): test additions and fixture modifications only.

**Description**

Moves `tooling/ef_tests/.fixtures_url` and `.github/config/hive/mainnet.yaml` (`fixtures` + `eels_commit`) to v20.0.1. Both, together: grading one release's client against another release's bundle fails every fixture the two disagree on (the amsterdam stream learned this at a cost of 2168 hive failures).

`eels_commit` is `87aba1a3`, the `tests@v20.0.1` tag commit. It descends from `ecd94a47` (specs#3104), so the `INVALID_SIGNATURE_VRS` exception mappings that #6978 pinned past are retained — the yaml now carries a comment documenting that ancestry constraint so a future bump can't silently regress the 80 `bad_v_r_s` consume-engine cases. Also refreshes the two version mentions in `docs/developers/l1/testing/hive.md` and drops the version literal from a `daily_hive_report.yaml` comment (the `mainnet.yaml` pointer on the next line is the source of truth).

No client change was needed.

**Verified the release's claims rather than assuming them.** The tag-to-tag spec diff (`b6956dbe...87aba1a3`) touches exactly one thing in the deployed mainnet forks: specs#3036 reorders `validate_transaction` so the `nonce >= 2**64-1` check runs after the init-code-size and gas-limit-cap checks (shanghai → bpo5). Order-only — every path still rejects the transaction, so state-transition results are unchanged; the only observable surface is which exception class fires for multiply-invalid transactions, and our runners assert rejection rather than exception class (hive's eels mapper moves in lockstep via `eels_commit`). The remaining spec-source changes are a coincurve → spec256k1 backend swap in the reference implementation's secp256k1 recovery (same semantics) and Amsterdam-fork work that isn't in this bundle.

The new coverage runs and passes without client changes:

- specs#3165 nonce boundary: `tx_max_nonce` state tests (nonce = 2^64−1, `NONCE_IS_MAX`) from Frontier onwards — LEVM already rejects via its checked nonce handling, and the exception is already mapped. The true overflow case (nonce = 2^64) landed as a `transaction_tests` fixture, a format these suites don't consume.
- specs#3086 access-list slot warmth surviving a failed `CREATE2` — ran on every applicable fork.
- specs#3154 restored `sstore_combinations` (Istanbul EIP-2200, 774 cases/fork).
- specs#3125 state fixtures now emit `chainId` in the transaction: value is `0x01` on typed txs, matching the chain id the state runner already assumes; the deserializer tolerates the new field.
- specs#3122 repacks `blockchain_tests_engine_x` pre-alloc groups (5458 → 3279): hive `consume-enginex` runtime win; the local engine suite consumes `blockchain_tests_engine`, which is unaffected.

Per-format fixture files in the bundle, confirming the suites picked up the new coverage:

| format | v20.0.0 | v20.0.1 | Δ |
|---|---|---|---|
| blockchain_tests | 8577 | 8618 | +41 |
| blockchain_tests_engine | 7842 | 7862 | +20 |
| blockchain_tests_engine_x | 11835 | 10214 | −1621 (packing) |
| state_tests | 8117 | 8172 | +55 |
| transaction_tests | 24 | 38 | +14 (not consumed) |

**How to test**

```
make -C tooling/ef_tests/blockchain test-levm
make -C tooling/ef_tests/engine test
make -C tooling/ef_tests/state run-evm-ef-tests-ci
```

Results on this branch:

| suite | result |
|---|---|
| blockchain | **14921 passed, 0 failed** (all 8618 bundle files ran: 11793 eest = 8618 mainnet + 3175 Amsterdam overlay, + 3128 legacy) |
| engine | **11040 passed, 0 failed** (all 7862 bundle files ran, + 3178 Amsterdam overlay) |
| state | **68629 passed, 0 failed** (8988 groups, 213459/213459 vectors, none below 100%) |

The `test-levm-nostd-crypto` state variant that LEVM PR CI runs also passes against the new vectors: **68629 passed, 0 failed**, no group below 100%.

A same-branch baseline run against the v20.0.0 bundle gives blockchain **14880 passed, 0 failed** — the +41 delta is exactly the release's new fixture files, so the new coverage demonstrably ran. The new `frontier/validation/transaction` state groups (nonce boundary) pass on every fork dir (e.g. 25/25 on for_prague/for_osaka).

One benign observable: the blockchain runner logs two new exception-class *warnings* (tests pass — rejection is what's asserted). specs#3052's EIP-2780 preparation manually re-derived the `low_gas_limit` `-g3` boundary as `intrinsic − 1`; at Prague/Osaka that value (21009, one zero calldata byte) clears the regular intrinsic (21004) but sits below the EIP-7623 floor (21010), so ethrex rejects with its calldata-floor message where the fixture's label is `INTRINSIC_GAS_TOO_LOW`. EELS raises a single error class for both (`max(regular, floor) > gas`), and the `EthrexExceptionMapper` at the pinned `eels_commit` maps ethrex's floor message to both exceptions, so hive grades these as pass. No mapping change was made — the local warning is reporting granularity, not a conformance gap.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched.
