### PR TITLE
test(l1): bump zkevm tests to v0.8.2

### DIFF
--- a/crates/common/types/stateless_ssz.rs
+++ b/crates/common/types/stateless_ssz.rs
@@ -415,8 +415,10 @@ const PUBLIC_KEY_BYTES: usize = 65;
 /// does **not** identify the encoding. Three dialects have shipped under it:
 /// `tests-zkevm@v0.6.2`, then #3248 + #3278, then #3356 (which moved `state`,
 /// `codes` and `public_keys` to `ProgressiveList`). ethrex speaks the last one,
-/// matching `tests-zkevm@v0.8.0`. A bundle from an older dialect will not be
-/// caught by this prefix — it fails later, in decode or on a mismatched root.
+/// matching `tests-zkevm@v0.8.0` and unchanged in `v0.8.2` (upstream #3372 only
+/// renamed the Python classes; SSZ encoding is positional, so the wire is
+/// identical). A bundle from an older dialect will not be caught by this
+/// prefix — it fails later, in decode or on a mismatched root.
 pub const STATELESS_INPUT_SCHEMA_ID: u16 = 0x1501;
 
 /// Byte length of the big-endian [`STATELESS_INPUT_SCHEMA_ID`] prefix.

--- a/docs/eip-8025.md
+++ b/docs/eip-8025.md
@@ -15,22 +15,26 @@ rather than building its own ethrex guest (issue
 
 ### Target schema
 
-The wire format tracks **execution-specs master at commit
-`3c3b6f4af315b268a61e20d5a4da8aa4f24c91f0`**, which is two merged PRs:
+The wire format is the one shipped in `tests-zkevm@v0.8.0` and unchanged in
+`v0.8.2`, the release the vectors are pinned to (the v0.8.0 → v0.8.2 upstream
+delta is release automation plus `Ssz*` → `SSZ*` Python renames,
+[#3372](https://github.com/ethereum/execution-specs/pull/3372) — SSZ encoding
+is positional, so nothing on the wire moved). It is the sum of three merged PRs:
 
 | PR | merged | change |
 |---|---|---|
 | [#3248](https://github.com/ethereum/execution-specs/pull/3248) | 2026-07-29 | "change StatelessInput SSZ serialization to be EIP-7688 aligned" — introduces `ProgressiveContainer` / `ProgressiveList` |
 | [#3278](https://github.com/ethereum/execution-specs/pull/3278) | 2026-08-03 | deletes `ChainConfig` from the wire, adds `schema_id` to the output |
+| [#3356](https://github.com/ethereum/execution-specs/pull/3356) | 2026-08-11 | moves `state`, `codes` and `public_keys` from bounded `SszList` to `ProgressiveList` |
 
-Neither has shipped in a `tests-zkevm` release — the newest is `v0.6.2`
-(2026-07-13), which predates both. Conformance vectors are therefore **generated**
-from the pinned spec commit; see [Testing](#testing).
+Conformance vectors come from the released bundle pinned by
+`tooling/ef_tests/.fixtures_url_zkevm`; see [Testing](#testing).
 
-> **Schema id `0x1501` is overloaded.** Upstream changed the wire across those two
-> PRs without bumping the revision byte, so `0x1501` means the pre-#3248 body in
-> `v0.6.2` fixtures and the current body on master. A consumer cannot tell them
-> apart from the id alone. ethrex speaks the newer dialect; anything still on the
+> **Schema id `0x1501` is overloaded.** Upstream changed the wire across these
+> PRs without bumping the revision byte, so three incompatible bodies have
+> shipped as `0x1501`: the pre-#3248 body in `v0.6.2` fixtures, the #3248+#3278
+> body, and the post-#3356 body in `v0.8.0`+. A consumer cannot tell them
+> apart from the id alone. ethrex speaks the newest dialect; anything still on an
 > older one — including `ere-guests`' `stateless-validator-common` as of
 > 2026-08-05 — will misparse our artifacts until it moves.
 
@@ -39,8 +43,8 @@ from the pinned spec commit; see [Testing](#testing).
 | Resource | Link |
 |----------|------|
 | EIP-8025 | [eips.ethereum.org/EIPS/eip-8025](https://eips.ethereum.org/EIPS/eip-8025) |
-| Stateless spec | [`stateless_ssz.py`](https://github.com/ethereum/execution-specs/blob/3c3b6f4af315b268a61e20d5a4da8aa4f24c91f0/src/ethereum/forks/amsterdam/stateless_ssz.py) |
-| Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/3c3b6f4af315b268a61e20d5a4da8aa4f24c91f0/src/ethereum/forks/amsterdam/stateless_guest.py) |
+| Stateless spec | [`stateless_ssz.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.2/src/ethereum/forks/amsterdam/stateless_ssz.py) |
+| Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.2/src/ethereum/forks/amsterdam/stateless_guest.py) |
 | EIP-7916 (progressive lists) | [eips.ethereum.org/EIPS/eip-7916](https://eips.ethereum.org/EIPS/eip-7916) |
 | libssz | [github.com/lambdaclass/libssz](https://github.com/lambdaclass/libssz) |
 | Ere / ere-guests | [eth-act/ere](https://github.com/eth-act/ere), [eth-act/ere-guests](https://github.com/eth-act/ere-guests) |
@@ -323,10 +327,10 @@ cargo test --manifest-path crates/guest-program/stateless-validator/Cargo.toml -
 ```
 
 The bundle is pinned by `tooling/ef_tests/.fixtures_url_zkevm`, currently
-`tests-zkevm@v0.8.0`. That is the first zkEVM release carrying both this schema
-(#3248, #3278, #3356) and the glamsterdam-devnet-8 gas schedule; earlier releases
-had at most one of the two, which is why the vectors were briefly generated from a
-pinned execution-specs commit instead.
+`tests-zkevm@v0.8.2`. `v0.8.0` was the first zkEVM release carrying both this
+schema (#3248, #3278, #3356) and the glamsterdam-devnet-8 gas schedule; earlier
+releases had at most one of the two, which is why the vectors were briefly
+generated from a pinned execution-specs commit instead.
 
 Note that the 2-byte schema-id prefix does not identify the encoding — upstream has
 shipped three incompatible bodies under `0x1501`. A stale bundle therefore fails in
@@ -339,9 +343,9 @@ vectors. The ere-platform path needs no separate parity test: it runs the same
 
 ### Measured baseline
 
-The generated `3c3b6f4af` conformance set passes in full: 100/100 fixture files
-via `make test-stateless`, with five fixtures skipped for spec-base skew (see
-`docs/known_issues.md`).
+The `tests-zkevm@v0.8.2` bundle passes in full: 3218/3218 fixture files via
+`make test-stateless`, with no zkEVM-specific skips (`EXTRA_SKIPS` in
+`tooling/ef_tests/blockchain/tests/all.rs` is empty).
 
 Two stateless divergences found when the suite was first pointed at this set are
 fixed:

--- a/docs/eip-8025.md
+++ b/docs/eip-8025.md
@@ -347,8 +347,8 @@ The `tests-zkevm@v0.8.2` bundle passes in full: 3218/3218 fixture files via
 `make test-stateless`, with no zkEVM-specific skips (`EXTRA_SKIPS` in
 `tooling/ef_tests/blockchain/tests/all.rs` is empty).
 
-Two stateless divergences found when the suite was first pointed at this set are
-fixed:
+Two stateless divergences found when the suite was first pointed at conformance
+vectors are fixed:
 
 - **Undecodable witness entries are tolerated.** `rebuild_state_and_storage_tries`
   hard-failed on any witness entry that did not RLP-decode as a trie node, so a

--- a/docs/roadmaps/forks-roadmap.md
+++ b/docs/roadmaps/forks-roadmap.md
@@ -42,7 +42,6 @@ matched, since `calc_excess_blob_gas` reads the parent unconditionally.
 |------|----------------|
 | **EIP-8070 (eth/72)** | Mandatory for all ELs on devnet-8. In review at [#6776]. Ships no fixtures and hive covers it execute-only ([hive#1365]), so the bundle gives it zero coverage either way — needs an `execute` sim wired up. |
 | **`debug_getRawBlockAccessList`** | Protocol-side requirement per [execution-apis#794](https://github.com/ethereum/execution-apis/pull/794), along with `-32001` for the BAL getters. In review at [#7069]. |
-| **devnet-8 zkEVM bundle** | `tests-zkevm` is still filled against devnet-7, so the stateless run skips every Amsterdam+ fixture (see [known issues](../known_issues.md)). No devnet-8 stateless coverage until a new bundle ships. |
 | **EIP-8038 spec text** | The v8.0.0 access-list repricing landed in the tests ahead of its EIPs PR. Confirm the EIP matches once that merges. |
 | **`eth_simulateV1`** | Still unimplemented. Tracked at [#6212]. |
 | **EIP-8189 (snap/2)** | BAL-based state healing, newly listed in [EIP-7773]. Not evaluated. |

--- a/tooling/ef_tests/.fixtures_url_zkevm
+++ b/tooling/ef_tests/.fixtures_url_zkevm
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.8.0/fixtures_zkevm.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.8.2/fixtures_zkevm.tar.gz

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -28,8 +28,9 @@ AMSTERDAM_URL := $(shell cat $(AMSTERDAM_FIXTURES_FILE))
 AMSTERDAM_SUBTREES := for_amsterdam for_bpo2toamsterdamattime15k
 AMSTERDAM_STAMP := $(SPECTEST_VECTORS_DIR)/.amsterdam_overlay
 
-# zkevm@v0.8.0 is filled against tests-glamsterdam-devnet@v8.1.0 — the same base
-# as the Amsterdam bundle — and additionally carries the EIP-8025 stateless
+# zkevm@v0.8.2 is filled against the same tests-glamsterdam-devnet@v8.1.0 content
+# as v0.8.0 (its upstream delta is release CI and Python renames only) — the same
+# base line as the Amsterdam bundle — and additionally carries the EIP-8025 stateless
 # witness fields (executionWitness / statelessInputBytes / statelessOutputBytes).
 # Both bundles extract a `for_amsterdam/` subtree, so we keep the zkevm bundle in
 # a separate root that only the stateless harness reads, to avoid overlaying the


### PR DESCRIPTION
**Motivation**

Move the zkEVM EF-test pin to [`tests-zkevm@v0.8.2`](https://github.com/ethereum/execution-specs/releases/tag/tests-zkevm%40v0.8.2), the current release of the stream. Its release notes list three PRs and make no spec-change claims; the tag-to-tag diff confirms them (verified, not assumed — see below). No `v0.8.1` was ever published, so `v0.8.2` is the direct successor to `v0.8.0`.

**Description**

**What the release actually changes.** From the `tests-zkevm@v0.8.0...tests-zkevm@v0.8.2` diff (9 commits, 22 files), read hunk-by-hunk rather than taken from the notes:

- [#3372](https://github.com/ethereum/execution-specs/pull/3372) — renames the Python SSZ classes `Ssz*` → `SSZ*` (`SszStatelessInput` → `SSZStatelessInput`, the `SszList` import alias, etc.) in `stateless_{ssz,guest,host}.py`, the consume-simulator RPC types, and one docstring. SSZ encoding is positional and structural, so class names never reach the wire: no container shape, bound, field order, or schema-id change. The schema stays `0x1501` in the same post-#3356 dialect ethrex already speaks.
- [#3366](https://github.com/ethereum/execution-specs/pull/3366) — CI only (geth branch used for bench-fill comparison).
- [#3389](https://github.com/ethereum/execution-specs/pull/3389) — release automation that introduces a separate `tests-zkevm-benchmark@` release stream. ethrex consumes nothing from that stream; the zkevm_bench micro workloads read the same `vectors_zkevm/` tree this pin populates, so they move together.

Nothing in the diff touches test logic, gas schedules, or fork configuration, which is why this PR contains **no client-code changes** — only the pin and the version-bearing comments/docs around it.

**Fixture-content verification.** Extracting the `for_amsterdam` subtree (the one the stateless harness runs) from both release tarballs and comparing: identical file lists, 3218 JSON files each, and a key-by-key comparison of every fixture finds differences only in `_info.url` — the fill-commit hash in each fixture's source link (`0695c34c1` → `117dd1cf9`, matching each tarball's `.meta/fixtures.ini`). Zero differences outside `_info`; per-fixture hashes match. v0.8.2 ships the same test content as v0.8.0, which is what a CI-and-renames-only diff should produce.

**Base compatibility.** `v0.8.2`'s notes don't name a base; `v0.8.0`'s notes name `tests-glamsterdam-devnet@v8.1.0`, and the 9 commits between the tags merge nothing from the base branch, so the fill content is still the v8.1.0 line. `.fixtures_url_amsterdam` points at `v8.1.1` (#7159), which satisfies the matching-or-newer constraint from #7153.

**Doc corrections riding along.** The v0.8.0 transition (#7153) left three spots stating the pre-v0.8.0 world; this bump would have made them staler, so they now state what is true (per the review principle from #7153: the tree states what is true now rather than how it got here):

- `docs/eip-8025.md` "Target schema" still said the newest release was `v0.6.2` and that conformance vectors are *generated* from a pinned spec commit — the generator was removed in #7153. The section now describes the released wire format (#3248 + #3278 + #3356), the three-dialects-under-`0x1501` note covers all three bodies, and the spec links are anchored to the `tests-zkevm@v0.8.2` tag instead of a pre-#3356 commit.
- `docs/eip-8025.md` "Measured baseline" still reported the generated 100-file set with five skips; it now reports the released bundle: 3218/3218 with `EXTRA_SKIPS` empty. The follow-up sentence about the two historical stateless divergences is re-anchored to "conformance vectors" so its referent stays true across pin bumps.
- `docs/roadmaps/forks-roadmap.md` still listed "devnet-8 zkEVM bundle" as a pending item claiming the stateless run skips every Amsterdam+ fixture — resolved by #7153, row removed.

`crates/common/types/stateless_ssz.rs`'s dialect history comment and the Makefile's bundle comment now name `v0.8.2` (comment-only changes).

**Results**

| Suite | Command | Result |
|---|---|---|
| blockchain (LEVM) | `make -C tooling/ef_tests/blockchain test-levm` | 14880 passed, 0 failed, 0 ignored (97s) |
| stateless | `make -C tooling/ef_tests/blockchain test-stateless` | 3218 passed, 0 failed, 0 filtered out (19s) |

No skips added; `EXTRA_SKIPS` stays empty and the five pre-existing `SKIPPED_BASE` name filters are untouched. The stateless count equals the extracted file count (one datatest case per JSON file), so the suite demonstrably ran the new bundle rather than an empty or stale directory — and since the release ships identical test content, "no new fixtures" is the verified expectation here, not an assumption.

**How to Test**

```bash
make -C tooling/ef_tests/blockchain test-levm        # re-downloads nothing zkevm-related
make -C tooling/ef_tests/blockchain test-stateless   # fetches the v0.8.2 bundle
```

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

Not needed: the PR changes a fixtures pin, comments, and docs; no `Store` schema or on-disk layout is touched.
