### PR TITLE
refactor(l1): deduplicate the account-update loop in `Store`

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2451,6 +2451,7 @@ impl Store {
                                     state_root,
                                     account_state.storage_root,
                                 )?;
+
                                 vacant.insert(TrieLogger::open_trie(trie))
                             }
                         };
@@ -2462,24 +2463,31 @@ impl Store {
                             state_root,
                             account_state.storage_root,
                         )?;
+
                         &mut local_trie
                     }
                 };
                 for (storage_key, storage_value) in &update.added_storage {
                     let hashed_key = hash_key(storage_key);
                     if storage_value.is_zero() {
+
                         storage_trie.remove(&hashed_key)?;
                     } else {
                         storage_trie.insert(hashed_key, storage_value.encode_to_vec())?;
+
                     }
                 }
+
                 let (storage_hash, storage_updates) =
+
                     storage_trie.collect_changes_since_last_hash(&NativeCrypto);
+
                 account_state.storage_root = storage_hash;
                 ret_storage_updates.push((hashed_address, storage_updates));
             }
             state_trie.insert(
                 hashed_address.as_bytes().to_vec(),
+
                 account_state.encode_to_vec(),
             )?;
         }
@@ -2494,21 +2502,26 @@ impl Store {
         })
     }
 
+
     /// Adds all genesis accounts and returns the genesis block's state_root
+
     pub async fn setup_genesis_state_trie(
         &self,
         genesis_accounts: BTreeMap<Address, GenesisAccount>,
     ) -> Result<H256, StoreError> {
         let mut storage_trie_nodes = vec![];
         let mut genesis_state_trie = self.open_direct_state_trie(EMPTY_TRIE_HASH)?;
+
         for (address, account) in genesis_accounts {
             let hashed_address = hash_address(&address);
+
             let h256_hashed_address = H256::from_slice(&hashed_address);
 
             // Store account code (as this won't be stored in the trie)
             let code = Code::from_bytecode(account.code, &NativeCrypto);
             let code_hash = code.hash;
             self.add_account_code(code).await?;
+
 
             // Store the account's storage in a clean storage trie and compute its root
             let mut storage_trie =

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2379,6 +2379,37 @@ impl Store {
         state_trie: &mut Trie,
         account_updates: impl IntoIterator<Item = &'a AccountUpdate>,
     ) -> Result<AccountUpdatesList, StoreError> {
+        self.apply_account_updates_from_trie_inner(state_trie, account_updates, None)
+    }
+
+    /// Performs the same actions as apply_account_updates_from_trie
+    ///  but also returns the used storage tries with witness recorded
+    pub fn apply_account_updates_from_trie_with_witness(
+        &self,
+        mut state_trie: Trie,
+        account_updates: &[AccountUpdate],
+        mut storage_tries: StorageTries,
+    ) -> Result<(StorageTries, AccountUpdatesList), StoreError> {
+        let account_updates_list = self.apply_account_updates_from_trie_inner(
+            &mut state_trie,
+            account_updates,
+            Some(&mut storage_tries),
+        )?;
+        Ok((storage_tries, account_updates_list))
+    }
+
+    /// Applies account updates to the given state trie.
+    ///
+    /// With `storage_tries`, storage tries are opened through [`TrieLogger`] and
+    /// cached in the map (keyed by unhashed address) so witness recording spans
+    /// updates; without it, a fresh storage trie is opened per account at its
+    /// current storage root.
+    fn apply_account_updates_from_trie_inner<'a>(
+        &self,
+        state_trie: &mut Trie,
+        account_updates: impl IntoIterator<Item = &'a AccountUpdate>,
+        mut storage_tries: Option<&mut StorageTries>,
+    ) -> Result<AccountUpdatesList, StoreError> {
         let mut ret_storage_updates = Vec::new();
         let mut code_updates = Vec::new();
         let state_root = state_trie.hash_no_commit(&NativeCrypto);
@@ -2409,8 +2440,31 @@ impl Store {
             }
             // Store the added storage in the account's storage trie and compute its new root
             if !update.added_storage.is_empty() {
-                let mut storage_trie =
-                    self.open_storage_trie(hashed_address, state_root, account_state.storage_root)?;
+                let mut local_trie;
+                let storage_trie = match storage_tries.as_deref_mut() {
+                    Some(tries) => {
+                        let (_witness, storage_trie) = match tries.entry(update.address) {
+                            Entry::Occupied(value) => value.into_mut(),
+                            Entry::Vacant(vacant) => {
+                                let trie = self.open_storage_trie(
+                                    hashed_address,
+                                    state_root,
+                                    account_state.storage_root,
+                                )?;
+                                vacant.insert(TrieLogger::open_trie(trie))
+                            }
+                        };
+                        storage_trie
+                    }
+                    None => {
+                        local_trie = self.open_storage_trie(
+                            hashed_address,
+                            state_root,
+                            account_state.storage_root,
+                        )?;
+                        &mut local_trie
+                    }
+                };
                 for (storage_key, storage_value) in &update.added_storage {
                     let hashed_key = hash_key(storage_key);
                     if storage_value.is_zero() {
@@ -2438,102 +2492,6 @@ impl Store {
             storage_updates: ret_storage_updates,
             code_updates,
         })
-    }
-
-    /// Performs the same actions as apply_account_updates_from_trie
-    ///  but also returns the used storage tries with witness recorded
-    pub fn apply_account_updates_from_trie_with_witness(
-        &self,
-        mut state_trie: Trie,
-        account_updates: &[AccountUpdate],
-        mut storage_tries: StorageTries,
-    ) -> Result<(StorageTries, AccountUpdatesList), StoreError> {
-        let mut ret_storage_updates = Vec::new();
-
-        let mut code_updates = Vec::new();
-
-        let state_root = state_trie.hash_no_commit(&NativeCrypto);
-
-        for update in account_updates.iter() {
-            let hashed_address = hash_address(&update.address);
-
-            if update.removed {
-                // Remove account from trie
-                state_trie.remove(&hashed_address)?;
-
-                continue;
-            }
-
-            // Add or update AccountState in the trie
-            // Fetch current state or create a new state to be inserted
-            let mut account_state = match state_trie.get(&hashed_address)? {
-                Some(encoded_state) => AccountState::decode(&encoded_state)?,
-                None => AccountState::default(),
-            };
-
-            if update.removed_storage {
-                account_state.storage_root = EMPTY_TRIE_HASH;
-            }
-
-            if let Some(info) = &update.info {
-                account_state.nonce = info.nonce;
-
-                account_state.balance = info.balance;
-
-                account_state.code_hash = info.code_hash;
-
-                // Store updated code in DB
-                if let Some(code) = &update.code {
-                    code_updates.push((info.code_hash, code.clone()));
-                }
-            }
-
-            // Store the added storage in the account's storage trie and compute its new root
-            if !update.added_storage.is_empty() {
-                let (_witness, storage_trie) = match storage_tries.entry(update.address) {
-                    Entry::Occupied(value) => value.into_mut(),
-                    Entry::Vacant(vacant) => {
-                        let trie = self.open_storage_trie(
-                            H256::from_slice(&hashed_address),
-                            state_root,
-                            account_state.storage_root,
-                        )?;
-                        vacant.insert(TrieLogger::open_trie(trie))
-                    }
-                };
-
-                for (storage_key, storage_value) in &update.added_storage {
-                    let hashed_key = hash_key(storage_key);
-
-                    if storage_value.is_zero() {
-                        storage_trie.remove(&hashed_key)?;
-                    } else {
-                        storage_trie.insert(hashed_key, storage_value.encode_to_vec())?;
-                    }
-                }
-
-                let (storage_hash, storage_updates) =
-                    storage_trie.collect_changes_since_last_hash(&NativeCrypto);
-
-                account_state.storage_root = storage_hash;
-
-                ret_storage_updates.push((H256::from_slice(&hashed_address), storage_updates));
-            }
-
-            state_trie.insert(hashed_address, account_state.encode_to_vec())?;
-        }
-
-        let (state_trie_hash, state_updates) =
-            state_trie.collect_changes_since_last_hash(&NativeCrypto);
-
-        let account_updates_list = AccountUpdatesList {
-            state_trie_hash,
-            state_updates,
-            storage_updates: ret_storage_updates,
-            code_updates,
-        };
-
-        Ok((storage_tries, account_updates_list))
     }
 
     /// Adds all genesis accounts and returns the genesis block's state_root

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2452,30 +2452,20 @@ impl Store {
 
             // Store the added storage in the account's storage trie and compute its new root
             if !update.added_storage.is_empty() {
-                let mut local_trie;
+                let open_fresh_trie = || {
+                    self.open_storage_trie(hashed_address, state_root, account_state.storage_root)
+                };
+
+                let mut local_trie = None;
+
                 let storage_trie = match storage_tries.as_deref_mut() {
-                    Some(tries) => {
-                        let (_witness, storage_trie) = match tries.entry(update.address) {
-                            Entry::Occupied(value) => value.into_mut(),
-                            Entry::Vacant(vacant) => {
-                                let trie = self.open_storage_trie(
-                                    hashed_address,
-                                    state_root,
-                                    account_state.storage_root,
-                                )?;
-                                vacant.insert(TrieLogger::open_trie(trie))
-                            }
-                        };
-                        storage_trie
-                    }
-                    None => {
-                        local_trie = self.open_storage_trie(
-                            hashed_address,
-                            state_root,
-                            account_state.storage_root,
-                        )?;
-                        &mut local_trie
-                    }
+                    Some(tries) => match tries.entry(update.address) {
+                        Entry::Occupied(cached) => &mut cached.into_mut().1,
+                        Entry::Vacant(vacant) => {
+                            &mut vacant.insert(TrieLogger::open_trie(open_fresh_trie()?)).1
+                        }
+                    },
+                    None => local_trie.insert(open_fresh_trie()?),
                 };
 
                 for (storage_key, storage_value) in &update.added_storage {

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2411,33 +2411,45 @@ impl Store {
         mut storage_tries: Option<&mut StorageTries>,
     ) -> Result<AccountUpdatesList, StoreError> {
         let mut ret_storage_updates = Vec::new();
+
         let mut code_updates = Vec::new();
+
         let state_root = state_trie.hash_no_commit(&NativeCrypto);
+
         for update in account_updates {
             let hashed_address = hash_address_fixed(&update.address);
+
             if update.removed {
                 // Remove account from trie
                 state_trie.remove(hashed_address.as_bytes())?;
+
                 continue;
             }
+
             // Add or update AccountState in the trie
             // Fetch current state or create a new state to be inserted
             let mut account_state = match state_trie.get(hashed_address.as_bytes())? {
                 Some(encoded_state) => AccountState::decode(&encoded_state)?,
                 None => AccountState::default(),
             };
+
             if update.removed_storage {
                 account_state.storage_root = EMPTY_TRIE_HASH;
             }
+
             if let Some(info) = &update.info {
                 account_state.nonce = info.nonce;
+
                 account_state.balance = info.balance;
+
                 account_state.code_hash = info.code_hash;
+
                 // Store updated code in DB
                 if let Some(code) = &update.code {
                     code_updates.push((info.code_hash, code.clone()));
                 }
             }
+
             // Store the added storage in the account's storage trie and compute its new root
             if !update.added_storage.is_empty() {
                 let mut local_trie;
@@ -2451,7 +2463,6 @@ impl Store {
                                     state_root,
                                     account_state.storage_root,
                                 )?;
-
                                 vacant.insert(TrieLogger::open_trie(trie))
                             }
                         };
@@ -2463,34 +2474,34 @@ impl Store {
                             state_root,
                             account_state.storage_root,
                         )?;
-
                         &mut local_trie
                     }
                 };
+
                 for (storage_key, storage_value) in &update.added_storage {
                     let hashed_key = hash_key(storage_key);
-                    if storage_value.is_zero() {
 
+                    if storage_value.is_zero() {
                         storage_trie.remove(&hashed_key)?;
                     } else {
                         storage_trie.insert(hashed_key, storage_value.encode_to_vec())?;
-
                     }
                 }
 
                 let (storage_hash, storage_updates) =
-
                     storage_trie.collect_changes_since_last_hash(&NativeCrypto);
 
                 account_state.storage_root = storage_hash;
+
                 ret_storage_updates.push((hashed_address, storage_updates));
             }
+
             state_trie.insert(
                 hashed_address.as_bytes().to_vec(),
-
                 account_state.encode_to_vec(),
             )?;
         }
+
         let (state_trie_hash, state_updates) =
             state_trie.collect_changes_since_last_hash(&NativeCrypto);
 
@@ -2502,26 +2513,21 @@ impl Store {
         })
     }
 
-
     /// Adds all genesis accounts and returns the genesis block's state_root
-
     pub async fn setup_genesis_state_trie(
         &self,
         genesis_accounts: BTreeMap<Address, GenesisAccount>,
     ) -> Result<H256, StoreError> {
         let mut storage_trie_nodes = vec![];
         let mut genesis_state_trie = self.open_direct_state_trie(EMPTY_TRIE_HASH)?;
-
         for (address, account) in genesis_accounts {
             let hashed_address = hash_address(&address);
-
             let h256_hashed_address = H256::from_slice(&hashed_address);
 
             // Store account code (as this won't be stored in the trie)
             let code = Code::from_bytecode(account.code, &NativeCrypto);
             let code_hash = code.hash;
             self.add_account_code(code).await?;
-
 
             // Store the account's storage in a clean storage trie and compute its root
             let mut storage_trie =


### PR DESCRIPTION
**Motivation**

`Store::apply_account_updates_from_trie_batch` and `Store::apply_account_updates_from_trie_with_witness` were two hand-maintained copies of the same per-update algorithm: remove the account if `update.removed`; decode-or-default the `AccountState`; reset `storage_root` on `removed_storage`; copy nonce/balance/code_hash and collect `code_updates`; apply `added_storage` to a storage trie and `collect_changes_since_last_hash`; insert the account; finally collect state changes into an `AccountUpdatesList`. Any future change to the update semantics had to be made twice, and the copies had already drifted cosmetically (hashed-address type, blank-line style), which obscured that the only real difference is how the storage trie is acquired.

**Description**

Extracts the loop into a private `apply_account_updates_from_trie_inner(&self, state_trie, account_updates, storage_tries: Option<&mut StorageTries>)` and turns both public functions into thin wrappers with their exact original signatures. `crates/storage/store.rs` is the only file touched: `+46/−79`, a net **−35 lines of code**.

Line accounting (code lines only — blank and comment-only lines counted as zero, the way `tokei` counts):

| | before | after |
|---|---|---|
| `apply_account_updates_from_trie_batch` | 59 | 7 (wrapper) |
| `apply_account_updates_from_trie_with_witness` | 67 | 13 (wrapper) |
| `apply_account_updates_from_trie_inner` | — | 71 |
| **total** | **126** | **91** |

Of that, the duplicated loop bodies go 113 → 64 code lines; the three signatures plus their delegating calls cost 27 where the two originals cost 13. Blank lines were not touched to move the number: the diff's blank-line count is +1 and its comment count +1, and the surviving loop keeps the blank-line structure of `apply_account_updates_from_trie_with_witness`, the function it was extracted from.

The merged body is byte-identical (modulo blank lines) to main's *batch* loop body everywhere except the storage-trie acquisition block, and identical to main's *witness* body except for that block, the hashed-address type, and the return shape. Both diffs are small enough to read line by line, which is how each invariant below was checked.

The two variants' only genuine differences are preserved verbatim behind the `Option`:

- **Storage-trie acquisition** (the load-bearing difference): `None` (batch) opens a **fresh** trie per account via `open_storage_trie` at that account's current `storage_root`, exactly as before. `Some(map)` (witness) uses the entry API on the map keyed by **unhashed** `update.address`: `Occupied` reuses the cached `(TrieWitness, Trie)` — the cached trie's in-memory state intentionally wins over `account_state.storage_root`, including ignoring an `EMPTY_TRIE_HASH` reset from `removed_storage` — and `Vacant` opens the trie **after** the `removed_storage` reset, wraps it in `TrieLogger::open_trie`, and inserts it into the map so witness nodes for storage tries first touched during update application are recorded; the mutated map is returned to the caller as before.
- The shared `open_storage_trie` call lives in a closure so it stays **lazy**: an `Occupied` hit never opens a trie, just as it never did before.
- **Hashed address**: unified on `hash_address_fixed` (`H256`). The witness copy used `hash_address` (`Vec<u8>`) and converted back with `H256::from_slice`; both are the same keccak digest of the address, so trie keys and `storage_updates` keys are byte-identical. This also drops the `H256::from_slice` length-panic path.
- `state_root` passed to `open_storage_trie` remains the single pre-loop `hash_no_commit` snapshot, not recomputed per iteration.
- Borrow checking: the `Option<&mut StorageTries>` is reborrowed per iteration with `as_deref_mut()`, and the batch arm parks its fresh trie in a per-iteration `Option` local so both arms unify as `&mut Trie`.

Public API, RLP encoding, DB schema, and `STORE_SCHEMA_VERSION` are untouched. No tests were deleted or modified.

If this change were wrong, one of these would have to be true:

- `hash_address` and `hash_address_fixed` would have to produce different bytes for some address — they are both `keccak(address.to_fixed_bytes())` (`store.rs`), one returning `Vec<u8>`, the other `H256`.
- The witness variant would have to depend on re-opening a cached storage trie at the post-`removed_storage` root — it cannot: the `Occupied` arm never consulted `account_state.storage_root` before this change either, and the closure that would do the opening is not called on that arm.
- A caller would have to key `StorageTries` by hashed address — callers in `blockchain.rs` populate and drain it keyed by unhashed `Address`, which this change keeps.
- The batch variant would have to rely on storage-trie state carrying across accounts — it opened a fresh trie per account before and still does, and its body is otherwise byte-identical to what it replaced.

**How to test**

```bash
cargo fmt --all --check
cargo clippy -- -D warnings                  # what CI's L1 Lint job runs
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p ethrex-storage
cargo test -p ethrex-blockchain              # covers the batch and witness call sites
cargo test -p ethrex-test --test ethrex_tests batch
```

Results on this branch:

- `cargo fmt --all --check` — clean.
- `cargo clippy -- -D warnings` — clean, exit 0. This is the exact command the L1 Lint job runs, and it is the gate that previously failed on this branch with `clippy::empty_line_after_doc_comments`.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p ethrex-storage` — 91 passed, 0 failed (plus doctests: 1 passed, 1 ignored).
- `cargo test -p ethrex-blockchain` — 58 passed, 0 failed.
- `cargo test -p ethrex-test --test ethrex_tests batch` — 30 passed, 0 failed. Includes `batch_selfdestruct_created_account_no_spurious_state`, which exercises exactly the default-`AccountState` + `removed_storage` + state-root-parity semantics of this loop end to end, plus `account_batch_parity_in_memory` and `storage_batch_parity_in_memory`.
- ef-tests: the blockchain and engine suites run green on this branch. Nothing in this diff touches serialization or API surface.
- Not covered by any local test, before or after: witness *completeness* for storage tries first touched during update application. There is no fast fixture for it — the stateless harness needs the separate `vectors_zkevm` bundle — so that invariant was checked by reading the `Vacant` arm against the original line by line: it still wraps in `TrieLogger::open_trie`, still inserts into the map, and the wrapper still returns the mutated map.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) is untouched — this is a private helper extraction; public API, RLP encoding and DB layout are identical, so no re-sync is required.
