### PR TITLE
refactor(l1): deduplicate LE block-number decoding in the store

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -845,12 +845,7 @@ impl Store {
         }
         self.read_async(BLOCK_NUMBERS, block_hash.encode_to_vec())
             .await?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
+            .map(decode_block_number)
             .transpose()
     }
 
@@ -1246,46 +1241,34 @@ impl Store {
         self.write_async(CHAIN_DATA, key, value).await
     }
 
+    /// Reads a block number stored under the given chain-data index.
+    async fn read_chain_data_block_number(
+        &self,
+        index: ChainDataIndex,
+    ) -> Result<Option<BlockNumber>, StoreError> {
+        self.read_async(CHAIN_DATA, chain_data_key(index))
+            .await?
+            .map(decode_block_number)
+            .transpose()
+    }
+
     /// Obtain earliest block number
     pub async fn get_earliest_block_number(&self) -> Result<BlockNumber, StoreError> {
-        let key = chain_data_key(ChainDataIndex::EarliestBlockNumber);
-        self.read_async(CHAIN_DATA, key)
+        self.read_chain_data_block_number(ChainDataIndex::EarliestBlockNumber)
             .await?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
-            .ok_or(StoreError::MissingEarliestBlockNumber)?
+            .ok_or(StoreError::MissingEarliestBlockNumber)
     }
 
     /// Obtain finalized block number
     pub async fn get_finalized_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        let key = chain_data_key(ChainDataIndex::FinalizedBlockNumber);
-        self.read_async(CHAIN_DATA, key)
-            .await?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
-            .transpose()
+        self.read_chain_data_block_number(ChainDataIndex::FinalizedBlockNumber)
+            .await
     }
 
     /// Obtain safe block number
     pub async fn get_safe_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        let key = chain_data_key(ChainDataIndex::SafeBlockNumber);
-        self.read_async(CHAIN_DATA, key)
-            .await?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
-            .transpose()
+        self.read_chain_data_block_number(ChainDataIndex::SafeBlockNumber)
+            .await
     }
 
     /// Obtain latest block number
@@ -1305,16 +1288,8 @@ impl Store {
 
     /// Obtain pending block number
     pub async fn get_pending_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        let key = chain_data_key(ChainDataIndex::PendingBlockNumber);
-        self.read_async(CHAIN_DATA, key)
-            .await?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
-            .transpose()
+        self.read_chain_data_block_number(ChainDataIndex::PendingBlockNumber)
+            .await
     }
 
     /// DB mutation step of `forkchoice_update`.
@@ -1586,12 +1561,7 @@ impl Store {
         }
         let txn = self.backend.begin_read()?;
         txn.get(BLOCK_NUMBERS, &block_hash.encode_to_vec())?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
+            .map(decode_block_number)
             .transpose()
     }
 
@@ -4203,16 +4173,8 @@ impl Store {
 
     /// Loads the latest block number stored in the database, bypassing the latest block number cache
     async fn load_latest_block_number(&self) -> Result<Option<BlockNumber>, StoreError> {
-        let key = chain_data_key(ChainDataIndex::LatestBlockNumber);
-        self.read_async(CHAIN_DATA, key)
-            .await?
-            .map(|bytes| -> Result<BlockNumber, StoreError> {
-                let array: [u8; 8] = bytes
-                    .try_into()
-                    .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
-                Ok(BlockNumber::from_le_bytes(array))
-            })
-            .transpose()
+        self.read_chain_data_block_number(ChainDataIndex::LatestBlockNumber)
+            .await
     }
 
     fn load_canonical_block_hash(
@@ -5302,6 +5264,14 @@ pub fn hash_key_fixed(key: &H256) -> [u8; 32] {
 
 fn chain_data_key(index: ChainDataIndex) -> Vec<u8> {
     (index as u8).encode_to_vec()
+}
+
+/// Decodes a block number stored as little-endian bytes.
+fn decode_block_number(bytes: Vec<u8>) -> Result<BlockNumber, StoreError> {
+    let array: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| StoreError::Custom("Invalid BlockNumber bytes".to_string()))?;
+    Ok(BlockNumber::from_le_bytes(array))
 }
 
 fn snap_state_key(index: SnapStateIndex) -> Vec<u8> {


### PR DESCRIPTION
**Motivation**

`crates/storage/store.rs` repeated the same 6-line closure — decode a `BlockNumber` from little-endian DB bytes, mapping bad lengths to `StoreError::Custom("Invalid BlockNumber bytes")` — verbatim in seven read paths. On top of that, four chain-data getters (`get_finalized_block_number`, `get_safe_block_number`, `get_pending_block_number`, `load_latest_block_number`) had byte-identical bodies except for the `ChainDataIndex` variant they key on.

**Description**

Read-path-only deduplication, one file, net −30 lines (+31/−61):

- New private free fn `decode_block_number(bytes: Vec<u8>) -> Result<BlockNumber, StoreError>` holding the one copy of the decode + error string, placed next to `chain_data_key`. It serves both the async paths (`read_async`) and the sync path (`txn.get`), which both yield `Option<Vec<u8>>`.
- New private method `read_chain_data_block_number(&self, index: ChainDataIndex) -> Result<Option<BlockNumber>, StoreError>` = `read_async(CHAIN_DATA, chain_data_key(index)) → map(decode) → transpose`.
- `get_finalized_block_number`, `get_safe_block_number`, `get_pending_block_number`, and `load_latest_block_number` become one-call delegations to it; `get_earliest_block_number` is the delegation plus its existing `.ok_or(StoreError::MissingEarliestBlockNumber)`; `get_block_number` and `get_block_number_sync` replace their inline closures with `.map(decode_block_number)`.

Behavior is preserved exactly:

- The write path (`to_le_bytes`) and on-disk format are untouched; `STORE_SCHEMA_VERSION` is unaffected.
- The `"Invalid BlockNumber bytes"` error string is unchanged (and grep shows nothing in the workspace matches on it).
- `get_earliest_block_number` error ordering is preserved: a missing key still yields `MissingEarliestBlockNumber`, while present-but-malformed bytes still yield the decode error — the `?` after the delegated read propagates decode failures before `ok_or` runs, same as the old `Option<Result<_,_>>.ok_or(...)?` construction.
- `load_latest_block_number` stays private and still reads `CHAIN_DATA` directly, deliberately bypassing the `latest_block_header` cache (its doc comment is kept); `get_latest_block_number` (the cache read) is untouched.
- `get_block_number_sync` remains sync — the helper is a plain fn, no `.await` introduced.
- `get_oldest_witness_number` is intentionally NOT folded in: same decode shape but a different error string ("Invalid oldest witness block number bytes"), so unifying it would change behavior.
- Both helpers are private — no public API surface change. External callers (`crates/blockchain/fork_choice.rs`, `crates/networking/rpc/...`) see identical signatures.

**How to test**

```bash
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p ethrex-storage
make -C tooling/ef_tests/blockchain test-levm
make -C tooling/ef_tests/engine test
```

Results on this branch:

- `cargo fmt` — clean (diff is post-fmt)
- `cargo clippy -p ethrex-storage --all-targets -- -D warnings` — clean
- `cargo test -p ethrex-storage` — 91 passed, 0 failed (plus doctests)
- `cargo check -p ethrex-blockchain` — passes (direct dependent of the getters)

No tests were deleted or modified.

**What would have to be true for this change to be wrong**

- Some call site would need to depend on the *closure* being monomorphized inline rather than calling a free fn — not observable in Rust semantics.
- The sync path (`txn.get`) would need to yield a type other than `Option<Vec<u8>>` — it doesn't; `Store::read` returns `txn.get(...)` with type `Result<Option<Vec<u8>>, StoreError>` and the crate compiles under `-D warnings`.
- `get_earliest_block_number` callers would need malformed-bytes to surface as `MissingEarliestBlockNumber` — the old code surfaced the decode error in that case too (the `ok_or` wrapped the `Result` inside the `Option`, it never swallowed it), so the new code is bit-for-bit the same mapping.
- `load_latest_block_number` would need to be reading through the header cache after this change — it isn't; the helper goes straight to `read_async` on `CHAIN_DATA`.

- ef-tests: the blockchain and engine suites run green, with their fixture counts unchanged.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched (read-path helper extraction only; the LE write path and DB layout are identical).
