### PR TITLE
refactor(l1): return the collected vector directly from the in-memory prefix iterator

### DIFF
--- a/crates/storage/backend/in_memory.rs
+++ b/crates/storage/backend/in_memory.rs
@@ -81,18 +81,6 @@ pub struct InMemoryLocked {
     table_name: &'static str,
 }
 
-pub struct InMemoryPrefixIter {
-    results: std::vec::IntoIter<PrefixResult>,
-}
-
-impl Iterator for InMemoryPrefixIter {
-    type Item = PrefixResult;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.results.next()
-    }
-}
-
 impl StorageLockedView for InMemoryLocked {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
         Ok(self
@@ -122,11 +110,10 @@ impl StorageReadView for InMemoryReadTx {
         prefix: &[u8],
     ) -> Result<Box<dyn Iterator<Item = PrefixResult> + '_>, StoreError> {
         let table_data = self.snapshot.get(table).cloned().unwrap_or_default();
-        let prefix_vec = prefix.to_vec();
 
         let mut entries: Vec<(Vec<u8>, Vec<u8>)> = table_data
             .into_iter()
-            .filter(|(key, _)| key.starts_with(&prefix_vec))
+            .filter(|(key, _)| key.starts_with(prefix))
             .collect();
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
 
@@ -135,10 +122,7 @@ impl StorageReadView for InMemoryReadTx {
             .map(|(k, v)| Ok((k.into_boxed_slice(), v.into_boxed_slice())))
             .collect();
 
-        let iter = InMemoryPrefixIter {
-            results: results.into_iter(),
-        };
-        Ok(Box::new(iter))
+        Ok(Box::new(results.into_iter()))
     }
 
     fn first_key(&self, table: &'static str) -> Result<Option<Vec<u8>>, StoreError> {


### PR DESCRIPTION
**Motivation**

`InMemoryBackend::prefix_iterator` already collects every matching entry into a `Vec<PrefixResult>` before returning. It then wrapped that vector's `IntoIter` in a `pub struct InMemoryPrefixIter` whose entire `Iterator` impl was `fn next(&mut self) -> Option<Self::Item> { self.results.next() }` — a hand-written newtype that delegates to the iterator it holds and adds nothing. `std::vec::IntoIter<PrefixResult>` already satisfies the trait's return type on its own.

That kind of pass-through wrapper is a small but real liability: it is a `pub` item in `ethrex-storage`'s API surface that nobody constructs or names, it makes the reader open a second definition to confirm there is no hidden filtering or state, and it hides the fact that this backend's `prefix_iterator` is fully eager. The same function also copied the prefix into a `Vec` (`let prefix_vec = prefix.to_vec()`) to satisfy a borrow that never needed satisfying, since the filter runs inside `collect()` while the `&[u8]` parameter is still live.

**Description**

One file, `crates/storage/backend/in_memory.rs`, net −16 lines (`-18/+2`):

- Deleted `pub struct InMemoryPrefixIter` and its `impl Iterator for InMemoryPrefixIter`.
- In `prefix_iterator`, dropped `let prefix_vec = prefix.to_vec();` and filter with `key.starts_with(prefix)` against the parameter directly.
- Replaced the four-line wrapper construction with `Ok(Box::new(results.into_iter()))`.

Invariants preserved, and how:

- **Collection stays eager.** The `.collect()` into `Vec<PrefixResult>` is untouched, so all work still finishes before the function returns; only the already-materialized vector escapes. This is what lets the closure borrow the `prefix` parameter and what keeps the local `table_data` clone from having to outlive the call. No lazy rewrite was attempted.
- **Key ordering is untouched.** `entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right))` is the sole source of ordering here (the table is an `FxHashMap`, so the explicit sort does all the work) and it was not modified. Ordering is load-bearing: `migrate_2_to_3` in `crates/storage/migrations.rs` documents that "Both backends yield keys in sorted order, which the same-prefix grouping below relies on", and both production callers (`Store` receipts-by-block-range and execution-witness pruning) `break` on the first key outside their range, so a regression here would silently truncate results rather than error. Five existing tests drive that path on the in-memory backend and all pass.
- **Item type is unchanged.** Still `PrefixResult = Result<(Box<[u8]>, Box<[u8]>), StoreError>`, still produced by the same `.map(|(k, v)| Ok((k.into_boxed_slice(), v.into_boxed_slice())))`. `std::vec::IntoIter<PrefixResult>` is `'static`, which coerces into the trait's `Box<dyn Iterator<Item = PrefixResult> + '_>`.
- **No trait or caller changes.** The `StorageReadView::prefix_iterator` signature in `crates/storage/api/mod.rs`, the RocksDB backend, and every call site are all untouched. The returned iterator's `size_hint` becomes exact instead of `(0, None)`; no test asserts on it and no caller was adjusted to exploit it.

If this change were wrong, one of these would have to be true:

- `std::vec::IntoIter<PrefixResult>` does not implement `Iterator<Item = PrefixResult>` — it does, and `cargo clippy --workspace --all-targets -- -D warnings` compiles the coercion.
- Something outside this file named or constructed `InMemoryPrefixIter` — `grep -rn "InMemoryPrefixIter"` over the repo returns zero hits, and its only field was private, so no external code could ever have built one.
- The removed `Iterator` impl did something besides delegate — it was exactly `self.results.next()`, no filtering, no state, no error mapping.
- `key.starts_with(prefix)` differs from `key.starts_with(&prefix_vec)` — both resolve to `<[u8]>::starts_with(&[u8])` over identical bytes; the copy only ever existed to extend a lifetime that eager collection makes unnecessary.
- Ordering came from the wrapper rather than the explicit sort — the wrapper had no ordering logic, and the sort it depended on is still there and still covered by the migration tests.

One consequence worth naming explicitly: `InMemoryPrefixIter` was `pub`, so this removes a public item from `ethrex-storage`. There are no in-workspace consumers, but a downstream fork that named the type would need to stop doing so.

No tests were deleted or modified — the removed code had no dedicated tests, and the behavior it participated in is covered by the existing migration tests listed below.

**How to test**

```
cargo fmt --all                                              # no diff introduced
cargo clippy -p ethrex-storage --all-targets -- -D warnings   # clean
cargo clippy --workspace --all-targets -- -D warnings         # clean (exit 0) — matches CI's pr-main_l1 job
cargo test -p ethrex-storage                                  # 91 passed, 0 failed; doctests 1 passed, 1 ignored
```

Results: all four pass. The clippy run on `ethrex-storage` was repeated after `touch crates/storage/backend/in_memory.rs` to make sure it was a real recheck and not a cache hit.

The tests that actually exercise this code path are the in-memory-backend migration tests, which call `prefix_iterator` and depend on its ordering:

```
cargo test -p ethrex-storage migrations::tests::migrate_2_to_3
```

covering `migrate_2_to_3_empty_table`, `migrate_2_to_3_single_entry_per_hash`, `migrate_2_to_3_multi_block_per_hash`, `migrate_2_to_3_is_idempotent_on_partial_state`, and `migrate_2_to_3_unions_same_hash_mixed_state` — all passing. Two of them additionally iterate the whole table through `prefix_iterator` with an empty prefix and assert on every key returned.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` (crates/storage/lib.rs, still `3`) is untouched: this only changes the concrete iterator type returned by one backend method, not any key layout, encoding, or table.
