### PR TITLE
refactor(l1): remove dead `From<u8>` impls for `ChainDataIndex` and `SnapStateIndex`

### DIFF
--- a/crates/storage/utils.rs
+++ b/crates/storage/utils.rs
@@ -10,26 +10,6 @@ pub enum ChainDataIndex {
     PendingBlockNumber = 5,
 }
 
-impl From<u8> for ChainDataIndex {
-    fn from(value: u8) -> Self {
-        match value {
-            x if x == ChainDataIndex::ChainConfig as u8 => ChainDataIndex::ChainConfig,
-            x if x == ChainDataIndex::EarliestBlockNumber as u8 => {
-                ChainDataIndex::EarliestBlockNumber
-            }
-            x if x == ChainDataIndex::FinalizedBlockNumber as u8 => {
-                ChainDataIndex::FinalizedBlockNumber
-            }
-            x if x == ChainDataIndex::SafeBlockNumber as u8 => ChainDataIndex::SafeBlockNumber,
-            x if x == ChainDataIndex::LatestBlockNumber as u8 => ChainDataIndex::LatestBlockNumber,
-            x if x == ChainDataIndex::PendingBlockNumber as u8 => {
-                ChainDataIndex::PendingBlockNumber
-            }
-            _ => panic!("Invalid value when casting to ChainDataIndex: {value}"),
-        }
-    }
-}
-
 /// Represents the key for each unique value of the snap state stored in the db
 //  Stores the snap state from previous sync cycles. Currently stores the header & state trie download checkpoint
 //, but will later on also include the body download checkpoint and the last pivot used
@@ -45,17 +25,4 @@ pub enum SnapStateIndex {
     StateTrieRebuildCheckpoint = 3,
     // Storage tries awaiting rebuild (AccountHash, ExpectedRoot)
     StorageTrieRebuildPending = 4,
-}
-
-impl From<u8> for SnapStateIndex {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => SnapStateIndex::HeaderDownloadCheckpoint,
-            1 => SnapStateIndex::StateTrieKeyCheckpoint,
-            2 => SnapStateIndex::StateHealPaths,
-            3 => SnapStateIndex::StateTrieRebuildCheckpoint,
-            4 => SnapStateIndex::StorageTrieRebuildPending,
-            _ => panic!("Invalid value when casting to SnapDataIndex: {value}"),
-        }
-    }
 }


### PR DESCRIPTION
**Motivation**

`impl From<u8> for ChainDataIndex` and `impl From<u8> for SnapStateIndex` in `crates/storage/utils.rs` are dead code: nothing in the workspace ever converts a `u8` back into either enum.
The enums are only used in the value-to-key direction — `chain_data_key`/`snap_state_key` in `crates/storage/store.rs` take the enum and cast it with `as u8` to build the DB key; the reverse mapping these impls provide has no caller in `crates/`, `cmd/`, or `tooling/`.
Beyond being unused, both impls carry a `panic!` arm for unknown bytes, and the `SnapStateIndex` panic message even names the wrong type ("SnapDataIndex") — unexercised, unreviewed-in-use code that only adds maintenance surface: every future variant added to these enums would have to keep a match arm in sync for no consumer.

**Description**

Deletes the two `impl From<u8>` blocks (plus their separating blank lines) from `crates/storage/utils.rs`. The diff is deletion-only: 31 lines of code (plus their 2 separating blank lines) removed, 0 added, one file touched.
Invariants preserved, and how: the enum definitions, their doc comments, and their explicit discriminants (`ChainDataIndex` 0..=5, `SnapStateIndex` 0..=4) are untouched — those discriminants define the on-disk DB key bytes via `(index as u8).encode_to_vec()` in `chain_data_key`/`snap_state_key`, so key encoding is byte-identical and no schema migration is needed. All call sites in `store.rs` and the doc references in `crates/storage/api/tables.rs` are untouched.
The impls were technically public via `pub mod utils`, so this is a small API-surface reduction of the internal `ethrex-storage` crate; no workspace code consumes them (a hypothetical external tool decoding raw DB key bytes back into these enums would need its own conversion, and none exists in this repo).
If this change were wrong, one of these would have to be true: (1) some workspace code calls `ChainDataIndex::from(u8)`/`SnapStateIndex::from(u8)` or an inferred `u8 -> enum` `.into()` — then `cargo clippy --all-targets -- -D warnings` over the workspace would fail to compile, and it passes; (2) grep for `ChainDataIndex::from`, `SnapStateIndex::from`, and `From<u8>` would show a call site or a still-needed impl — it shows zero call sites and only unrelated types; (3) the DB key bytes would have to change — impossible with a deletion-only diff that never touches the enums or `chain_data_key`/`snap_state_key`.

**How to test**

- `cargo fmt` — no changes (diff stays 33 deletions, 0 insertions, `crates/storage/utils.rs` only).
- `cargo clippy -p ethrex-storage --all-targets --all-features -- -D warnings` — clean, exit 0.
- `cargo test -p ethrex-storage --all-features` — 93 passed, 0 failed (doc-tests: 1 passed, 1 ignored), exit 0.
- `cargo clippy --all-targets -- -D warnings` (workspace, all bins/tests/examples) — clean, exit 0; this also proves no in-workspace caller of the removed impls exists, since removing a used impl is a compile error.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. Not applicable: deletion-only removal of unused impls, enum discriminants and DB key bytes are unchanged, so `STORE_SCHEMA_VERSION` is untouched.
