### PR TITLE
refactor(l1): reuse get_account_state in Store account getters

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2275,18 +2275,13 @@ impl Store {
         let Some(state_trie) = self.state_trie(block_hash)? else {
             return Ok(None);
         };
-        let hashed_address = hash_address_fixed(&address);
-
-        let Some(encoded_state) = state_trie.get(hashed_address.as_bytes())? else {
-            return Ok(None);
-        };
-
-        let account_state = AccountState::decode(&encoded_state)?;
-        Ok(Some(AccountInfo {
-            code_hash: account_state.code_hash,
-            balance: account_state.balance,
-            nonce: account_state.nonce,
-        }))
+        Ok(self
+            .get_account_state_from_trie(&state_trie, address)?
+            .map(|account_state| AccountInfo {
+                code_hash: account_state.code_hash,
+                balance: account_state.balance,
+                nonce: account_state.nonce,
+            }))
     }
 
     pub fn get_account_state_by_acc_hash(
@@ -2324,18 +2319,10 @@ impl Store {
         block_number: BlockNumber,
         address: Address,
     ) -> Result<Option<Code>, StoreError> {
-        let Some(block_hash) = self.get_canonical_block_hash(block_number).await? else {
-            return Ok(None);
-        };
-        let Some(state_trie) = self.state_trie(block_hash)? else {
-            return Ok(None);
-        };
-        let hashed_address = hash_address_fixed(&address);
-        let Some(encoded_state) = state_trie.get(hashed_address.as_bytes())? else {
-            return Ok(None);
-        };
-        let account_state = AccountState::decode(&encoded_state)?;
-        self.get_account_code(account_state.code_hash)
+        match self.get_account_state(block_number, address).await? {
+            Some(account_state) => self.get_account_code(account_state.code_hash),
+            None => Ok(None),
+        }
     }
 
     pub async fn get_nonce_by_account_address(
@@ -2343,18 +2330,10 @@ impl Store {
         block_number: BlockNumber,
         address: Address,
     ) -> Result<Option<u64>, StoreError> {
-        let Some(block_hash) = self.get_canonical_block_hash(block_number).await? else {
-            return Ok(None);
-        };
-        let Some(state_trie) = self.state_trie(block_hash)? else {
-            return Ok(None);
-        };
-        let hashed_address = hash_address_fixed(&address);
-        let Some(encoded_state) = state_trie.get(hashed_address.as_bytes())? else {
-            return Ok(None);
-        };
-        let account_state = AccountState::decode(&encoded_state)?;
-        Ok(Some(account_state.nonce))
+        Ok(self
+            .get_account_state(block_number, address)
+            .await?
+            .map(|account_state| account_state.nonce))
     }
 
     /// Applies account updates based on the block's latest storage state


### PR DESCRIPTION
**Motivation**

`Store::get_code_by_account_address` and `Store::get_nonce_by_account_address` each inlined the full account-lookup sequence (canonical block hash → state trie → `hash_address_fixed` → `trie.get` → `AccountState::decode`) that the public `Store::get_account_state` already implements, and `Store::get_account_info_by_hash` inlined the get+decode half that `get_account_state_from_trie` provides.

Three hand-rolled copies of the same walk are a liability: any future change to account lookup (key derivation, decode handling, the missing-trie tri-state) has to be replicated in four places, and a copy that drifts silently diverges in behavior. Deduplicating to the canonical helpers removes 19 net lines of code and leaves the tri-state logic spelled exactly once.

**Description**

Only the three function bodies in `crates/storage/store.rs` change; every signature (async-ness included) is byte-identical, so no caller changes.

- `get_nonce_by_account_address` now delegates to `get_account_state(block_number, address)` and maps the nonce out.
- `get_code_by_account_address` now delegates to `get_account_state(block_number, address)` and, when the account exists, still resolves the code through `get_account_code(code_hash)` — preserving the `account_code_cache` fast path and the account-exists-but-code-missing ⇒ `Ok(None)` (not error) semantics.
- `get_account_info_by_hash` stays sync: it keeps its own `state_trie(block_hash)?` call and delegates only to the sync `get_account_state_from_trie`, mapping the `AccountState` into `AccountInfo` (its sync caller `get_account_info` is untouched).

Invariants preserved and how: the tri-state `Ok(None)` semantics (missing canonical hash, missing state trie, absent account) come from the same let-else guards now living solely in `get_account_state` / `get_account_state_from_trie`, while trie/DB/decode errors still propagate via `?` as `StoreError`; key derivation remains `hash_address_fixed` because that is what `get_account_state_from_trie` already uses; `get_account_state_by_acc_hash` (pre-hashed key, a different helper) is deliberately untouched.

If this change were wrong, one of these would have to be true: `get_account_state`'s lookup sequence differs from the inlined copies (it is verbatim the same five steps), some caller depended on a signature or sync-ness change (workspace clippy compiles all callers unchanged), missing code for an existing account now errors (the `get_account_code` call is preserved verbatim), or a `None` case now errors (all three `None` sources still short-circuit to `Ok(None)`).

**How to test**

- `cargo fmt` — clean (diff is +15/−36 in one file).
- `cargo clippy -p ethrex-storage --all-targets -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, proving all RPC/l2 callers compile against the unchanged signatures.
- `cargo test -p ethrex-storage` — 91 passed, 0 failed (plus doctests).

**Checklist**

- [x] No `Store` schema, on-disk format, or RLP change — pure in-memory dedup of function bodies — so `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) is untouched.
