### PR TITLE
refactor(l1): dedup the canonical-block-hash read onto load_canonical_block_hash

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -1209,20 +1209,10 @@ impl Store {
         if last.number == block_number {
             return Ok(Some(last.hash()));
         }
-        let backend = self.backend.clone();
-        tokio::task::spawn_blocking(move || {
-            backend
-                .begin_read()?
-                .get(
-                    CANONICAL_BLOCK_HASHES,
-                    block_number.to_le_bytes().as_slice(),
-                )?
-                .map(|bytes| H256::decode(bytes.as_slice()))
-                .transpose()
-                .map_err(StoreError::from)
-        })
-        .await
-        .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.load_canonical_block_hash(block_number))
+            .await
+            .map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?
     }
 
     /// Stores the chain configuration values, should only be called once after reading the genesis file
@@ -1604,14 +1594,7 @@ impl Store {
         if last.number == block_number {
             return Ok(Some(last.hash()));
         }
-        let txn = self.backend.begin_read()?;
-        txn.get(
-            CANONICAL_BLOCK_HASHES,
-            block_number.to_le_bytes().as_slice(),
-        )?
-        .map(|bytes| H256::decode(bytes.as_slice()))
-        .transpose()
-        .map_err(StoreError::from)
+        self.load_canonical_block_hash(block_number)
     }
 
     /// CAUTION: This method writes directly to the underlying database, bypassing any caching layer.


### PR DESCRIPTION
**Motivation**

The exact `CANONICAL_BLOCK_HASHES` read — `begin_read()? → get(CANONICAL_BLOCK_HASHES, block_number.to_le_bytes())? → H256::decode → transpose → map_err(StoreError::from)` — was written out three times in `crates/storage/store.rs`: inside `get_canonical_block_hash`'s `spawn_blocking` closure, in `get_canonical_block_hash_sync`, and in the private `load_canonical_block_hash`.

Triplicated read logic is a liability: a future change to the key encoding, the value decoding, or the error mapping has to be applied in three places, and the sync variant's post-fast-path body being byte-identical to `load_canonical_block_hash` invites the copies to drift apart silently.

**Description**

Both public variants now keep their `latest_block_header` fast path and delegate the actual DB read to the existing private `load_canonical_block_hash`, mirroring the `get_block_header_by_hash` → `load_block_header_by_hash` split already used elsewhere in this file. Net −17 lines, one concern, no behavior change.

- `get_canonical_block_hash` (async): the `spawn_blocking` closure now captures a `Store` clone and calls `store.load_canonical_block_hash(block_number)`. `Store` is `Clone` (Arcs plus plain data), and the clone happens once per call, not in any loop. The JoinError mapping `.map_err(|e| StoreError::Custom(format!("Task panicked: {}", e)))?` is unchanged.
- `get_canonical_block_hash_sync`: after the fast path, the body is now `self.load_canonical_block_hash(block_number)`.
- `load_canonical_block_hash` itself is untouched: no fast path was added to it, because the `load_*` family deliberately bypasses the `latest_block_header` cache to serve init/genesis paths. The fast paths stay in the two public functions, so hot callers (`is_canonical_sync`, the BLOCKHASH-opcode path in `blockchain/vm.rs`) keep their cache hit.
- The fourth inline occurrence of this read pattern, in `get_block_bodies`, is intentionally left alone: it amortizes a single read transaction across a loop, which delegating per-iteration would undo.

If this change were wrong, one of these would have to be true:

- `load_canonical_block_hash` reads a different table, key encoding, or decoding than the inlined copies did — it is byte-identical to the removed code.
- The async variant's error surface changed — the closure still returns `Result<Option<BlockHash>, StoreError>` through `spawn_blocking`, and the JoinError arm is character-for-character the same.
- `Store` could not be moved into `spawn_blocking` — it is `Clone` and all fields are `Send + Sync`; the crate compiles under `clippy --all-targets -D warnings`.
- A caller depended on the removed fast-path behavior differing between the variants — both fast paths are preserved verbatim.

**How to test**

- `cargo fmt -p ethrex-storage` — no diff after the change.
- `cargo clippy -p ethrex-storage --all-targets -- -D warnings` — clean.
- `cargo test -p ethrex-storage` — 91 passed, 0 failed; doctests 1 passed, 1 ignored.

Public signatures are unchanged, so no dependent crate is affected.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — No `Store` schema change (pure read-path dedup), so `STORE_SCHEMA_VERSION` is untouched.
