### PR TITLE
fix(l1): bump FOCIL fixtures to tests-focil-devnet v0.2.0 and mirror its inclusion-list gates

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -2516,6 +2516,10 @@ impl Blockchain {
         // Snapshot the header for the satisfaction check (intrinsic-gas fork +
         // base fee) before `block` is moved into the inner pipeline.
         let header = block.header.clone();
+        // Withdrawals too: the satisfaction check evaluates senders at the
+        // post-transactions, PRE-withdrawals point (EELS `apply_body` order),
+        // so their credits must be discounted from the post-state balances.
+        let withdrawals = block.body.withdrawals.clone().unwrap_or_default();
 
         let (_, _, result) = self.add_block_pipeline_inner(block, bal, false, None)?;
         result?;
@@ -2558,6 +2562,7 @@ impl Blockchain {
         validator
             .refresh_all_from(&post_state, &crypto)
             .map_err(|e| ChainError::Custom(format!("IL validator refresh failed: {e}")))?;
+        validator.discount_withdrawals(&withdrawals);
 
         match validator.check(
             il,

--- a/crates/blockchain/inclusion_list_builder.rs
+++ b/crates/blockchain/inclusion_list_builder.rs
@@ -19,7 +19,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use ethrex_common::{
-    Address, U256,
+    Address, Bytes, U256,
     types::{MempoolTransaction, Transaction},
 };
 use rustc_hash::FxHashMap;
@@ -52,6 +52,14 @@ pub trait IlStateProvider {
         &self,
         address: Address,
     ) -> Result<Option<AccountStateView>, IlStateProviderError>;
+
+    /// The account's contract code; `None` when the account has none. Consumed
+    /// by the satisfaction validator's sender-is-EOA gate (EELS
+    /// `check_transaction` raises `InvalidSenderError` for a sender whose code
+    /// is set and is not a valid EIP-7702 delegation, per EIP-3607). The
+    /// builder itself never calls this: mempool admission already rejects
+    /// contract senders.
+    fn get_code(&self, address: Address) -> Result<Option<Bytes>, IlStateProviderError>;
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/blockchain/inclusion_list_validator.rs
+++ b/crates/blockchain/inclusion_list_validator.rs
@@ -33,8 +33,9 @@ use ethrex_common::{
     Address, Bytes, H256, U256,
     constants::{EMPTY_KECCAK_HASH, GAS_PER_BLOB, TX_MAX_GAS_LIMIT_AMSTERDAM},
     types::{
-        BlockHeader, ChainConfig, MAX_BLOB_COUNT, Transaction, TxType, VERSIONED_HASH_VERSION_KZG,
-        calculate_base_fee_per_blob_gas, is_eip7702_delegation,
+        BlockHeader, ChainConfig, GWEI_TO_WEI, MAX_BLOB_COUNT, Transaction, TxType,
+        VERSIONED_HASH_VERSION_KZG, Withdrawal, calculate_base_fee_per_blob_gas,
+        is_eip7702_delegation,
     },
 };
 use ethrex_crypto::Crypto;
@@ -252,6 +253,29 @@ impl InclusionListSatisfactionValidator {
             );
         }
         Ok(())
+    }
+
+    /// Roll tracked balances back to the pre-withdrawals point of the block.
+    ///
+    /// EELS `apply_body` runs `check_inclusion_list_transactions` after the
+    /// block's transactions but BEFORE `process_withdrawals`, so a sender
+    /// funded only by a same-block withdrawal is NOT includable at check time.
+    /// The tracker is refreshed from the block's final state root, which
+    /// already includes those credits; withdrawals only ever add balance
+    /// (never touching nonce or code), so subtracting the block's credits per
+    /// sender reconstructs the pre-withdrawals balance exactly. `saturating_`
+    /// arithmetic is defensive only: a final balance below the block's own
+    /// credits to that account cannot occur.
+    pub fn discount_withdrawals(&mut self, withdrawals: &[Withdrawal]) {
+        for withdrawal in withdrawals {
+            if withdrawal.amount == 0 {
+                continue;
+            }
+            if let Some(tracked) = self.il_senders.get_mut(&withdrawal.address) {
+                let credit = U256::from(withdrawal.amount).saturating_mul(U256::from(GWEI_TO_WEI));
+                tracked.balance = tracked.balance.saturating_sub(credit);
+            }
+        }
     }
 
     /// Return `Ok(())` iff every inclusion-list transaction is classified as

--- a/crates/blockchain/inclusion_list_validator.rs
+++ b/crates/blockchain/inclusion_list_validator.rs
@@ -1,10 +1,10 @@
 //! EIP-7805 (FOCIL) inclusion-list satisfaction validator. Tracks per-sender
-//! `(nonce, balance)` during block execution and, after execution, decides
-//! whether each IL transaction is `present | blob | frame | unrecoverable |
-//! intrinsic_gas_too_low | insufficient_gas | below_base_fee | invalid_nonce |
-//! invalid_balance | unsatisfied`. Returns `Err(IlUnsatisfied)` if any IL
-//! transaction is missing AND could still have been validly appended to the
-//! block (mirrors EELS `check_inclusion_list_transactions`).
+//! `(nonce, balance, code)` during block execution and, after execution,
+//! replays for each missing IL transaction the exact validity gates that block
+//! inclusion would apply. Returns `Err(IlUnsatisfied)` if any IL transaction
+//! is missing AND could still have been validly appended to the block
+//! (mirrors EELS `check_inclusion_list_transactions` + `validate_transaction`
+//! + `check_transaction`, forks/amsterdam, as of tests-focil-devnet@v0.2.0).
 //!
 //! ## State abstraction
 //!
@@ -30,13 +30,18 @@
 use std::collections::HashSet;
 
 use ethrex_common::{
-    Address, H256, U256,
-    types::{BlockHeader, ChainConfig, Transaction, TxType},
+    Address, Bytes, H256, U256,
+    constants::{EMPTY_KECCAK_HASH, GAS_PER_BLOB, TX_MAX_GAS_LIMIT_AMSTERDAM},
+    types::{
+        BlockHeader, ChainConfig, MAX_BLOB_COUNT, Transaction, TxType, VERSIONED_HASH_VERSION_KZG,
+        calculate_base_fee_per_blob_gas, is_eip7702_delegation,
+    },
 };
 use ethrex_crypto::Crypto;
 use ethrex_storage::Store;
 use rustc_hash::FxHashMap;
 
+use crate::constants::{AMSTERDAM_MAX_INITCODE_SIZE, MAX_INITCODE_SIZE};
 use crate::inclusion_list_builder::{AccountStateView, IlStateProvider, IlStateProviderError};
 use crate::mempool::transaction_intrinsic_gas;
 
@@ -62,9 +67,47 @@ impl<'a> IlStateProvider for StoreIlStateProvider<'a> {
             balance: a.balance,
         }))
     }
+
+    fn get_code(&self, address: Address) -> Result<Option<Bytes>, IlStateProviderError> {
+        let Some(acct) = self
+            .store
+            .get_account_state_by_root(self.state_root, address)
+            .map_err(|e| IlStateProviderError::Read(e.to_string()))?
+        else {
+            return Ok(None);
+        };
+        if acct.code_hash == *EMPTY_KECCAK_HASH {
+            return Ok(None);
+        }
+        let code = self
+            .store
+            .get_account_code(acct.code_hash)
+            .map_err(|e| IlStateProviderError::Read(e.to_string()))?
+            .ok_or_else(|| {
+                // The account names a code hash the store cannot resolve: a DB
+                // inconsistency, not an empty account. Surfacing it beats
+                // misclassifying the sender as code-free.
+                IlStateProviderError::Read(format!(
+                    "code missing for hash {:?} despite non-empty code_hash",
+                    acct.code_hash
+                ))
+            })?;
+        Ok(Some(code.code_bytes()))
+    }
 }
 
-/// Tracker of per-sender `(nonce, balance)` for senders appearing in the
+/// Post-state snapshot of one inclusion-list sender, as consulted by
+/// [`InclusionListSatisfactionValidator::check`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TrackedSender {
+    pub nonce: u64,
+    pub balance: U256,
+    /// The sender's contract code (`None` when it has none), for the
+    /// EIP-3607/EIP-7702 sender-is-EOA gate.
+    pub code: Option<Bytes>,
+}
+
+/// Tracker of per-sender [`TrackedSender`] state for senders appearing in the
 /// inclusion list. Built once before block execution from the parent's
 /// pre-state, refreshed incrementally during block execution as IL senders'
 /// transactions are applied, and consulted once after block execution by
@@ -74,7 +117,7 @@ impl<'a> IlStateProvider for StoreIlStateProvider<'a> {
 /// IL byte cap), NOT by block transaction count.
 #[derive(Debug, Default, Clone)]
 pub struct InclusionListSatisfactionValidator {
-    pub il_senders: FxHashMap<Address, (u64, U256)>,
+    pub il_senders: FxHashMap<Address, TrackedSender>,
 }
 
 /// Errors returned by the validator surface itself (separate from
@@ -134,11 +177,19 @@ impl InclusionListSatisfactionValidator {
             }
         }
 
-        let mut il_senders: FxHashMap<Address, (u64, U256)> =
+        let mut il_senders: FxHashMap<Address, TrackedSender> =
             FxHashMap::with_capacity_and_hasher(unique_senders.len(), Default::default());
         for sender in unique_senders {
             let view = pre_state.get_account(sender)?.unwrap_or_default();
-            il_senders.insert(sender, (view.nonce, view.balance));
+            let code = pre_state.get_code(sender)?;
+            il_senders.insert(
+                sender,
+                TrackedSender {
+                    nonce: view.nonce,
+                    balance: view.balance,
+                    code,
+                },
+            );
         }
 
         Ok(Self { il_senders })
@@ -161,7 +212,15 @@ impl InclusionListSatisfactionValidator {
             return Ok(());
         }
         let view = post_state.get_account(sender)?.unwrap_or_default();
-        self.il_senders.insert(sender, (view.nonce, view.balance));
+        let code = post_state.get_code(sender)?;
+        self.il_senders.insert(
+            sender,
+            TrackedSender {
+                nonce: view.nonce,
+                balance: view.balance,
+                code,
+            },
+        );
         Ok(())
     }
 
@@ -182,32 +241,42 @@ impl InclusionListSatisfactionValidator {
         let senders: Vec<Address> = self.il_senders.keys().copied().collect();
         for sender in senders {
             let view = state.get_account(sender)?.unwrap_or_default();
-            self.il_senders.insert(sender, (view.nonce, view.balance));
+            let code = state.get_code(sender)?;
+            self.il_senders.insert(
+                sender,
+                TrackedSender {
+                    nonce: view.nonce,
+                    balance: view.balance,
+                    code,
+                },
+            );
         }
         Ok(())
     }
 
     /// Return `Ok(())` iff every inclusion-list transaction is classified as
-    /// non-appendable (`present | blob | frame | unrecoverable |
-    /// intrinsic_gas_too_low | insufficient_gas | below_base_fee |
-    /// invalid_nonce | invalid_balance`).
-    /// Return `Err(IlUnsatisfied)` for the first IL transaction that is missing
-    /// AND could still have been validly appended to the end of the block.
+    /// non-appendable; return `Err(IlUnsatisfied)` for the first IL
+    /// transaction that is missing AND could still have been validly appended
+    /// to the end of the block.
     ///
-    /// This mirrors EELS `check_inclusion_list_transactions` +
-    /// `check_transaction` (forks/amsterdam/fork.py): for each missing IL tx it
-    /// replays exactly the validity gates that block inclusion would apply, and
-    /// reports the block as unsatisfied only when every gate passes.
+    /// This mirrors EELS `check_inclusion_list_transactions` →
+    /// `validate_transaction` → `check_transaction` (forks/amsterdam, as of
+    /// tests-focil-devnet@v0.2.0): for each missing IL tx it replays exactly
+    /// the validity gates that block inclusion would apply, and reports the
+    /// block as unsatisfied only when every gate passes. Gate order can differ
+    /// from EELS (each failing gate raises there); the satisfied/unsatisfied
+    /// verdict is order-independent.
     ///
     /// `block_txs` is the set of transaction hashes included in the block;
     /// position within the block does not matter (per the EIP rationale).
-    /// `gas_left` is `block.gas_limit - cumulative_gas_used` post-execution.
+    /// `gas_left` is `block.gas_limit - header.gas_used` post-execution.
     /// `header` and `config` describe the block under check; they supply the
-    /// fork (for the intrinsic-gas calculation) and the `base_fee_per_gas`.
+    /// fork (for the intrinsic-gas calculation), the `base_fee_per_gas`, and
+    /// the blob-gas parameters.
     ///
     /// This method MUST NOT call into the EVM. It is a pure state-comparison
     /// pass over the per-sender tracker plus stateless transaction validity
-    /// gates (intrinsic gas, base fee, signature recoverability).
+    /// gates (intrinsic gas, fees, signature recoverability).
     pub fn check(
         &self,
         il: &[Transaction],
@@ -218,6 +287,23 @@ impl InclusionListSatisfactionValidator {
         crypto: &dyn Crypto,
     ) -> Result<(), IlUnsatisfied> {
         let base_fee = U256::from(header.base_fee_per_gas.unwrap_or_default());
+        // EELS `check_block_gas_capacity`: the blob dimension has its own
+        // budget, `MAX_BLOB_GAS_PER_BLOCK - block_output.blob_gas_used`. The
+        // per-block maximum comes from the blob schedule in force at the
+        // block's timestamp; a Hegotá chain without one is a config anomaly,
+        // and 0 keeps every blob tx classified as not includable.
+        let blob_gas_left = config
+            .get_fork_blob_schedule(header.timestamp)
+            .map(|schedule| u64::from(schedule.max) * u64::from(GAS_PER_BLOB))
+            .unwrap_or_default()
+            .saturating_sub(header.blob_gas_used.unwrap_or_default());
+        // EIP-7954: Amsterdam raises the init-code cap (same selection as
+        // mempool admission).
+        let max_initcode_size = if config.is_amsterdam_activated(header.timestamp) {
+            AMSTERDAM_MAX_INITCODE_SIZE
+        } else {
+            MAX_INITCODE_SIZE
+        } as usize;
 
         for tx_il in il {
             // present in block (anywhere) → satisfied
@@ -225,17 +311,21 @@ impl InclusionListSatisfactionValidator {
                 continue;
             }
 
-            // Blob (EIP-4844) txs are excluded from the IL satisfaction check
-            // (EELS skips `BlobTransaction`) → satisfied.
-            if tx_il.tx_type() == TxType::EIP4844 {
+            // wrong chain id → satisfied. EELS `check_inclusion_list_transactions`
+            // excuses a tx whose declared chain id differs from the chain's;
+            // pre-EIP-155 legacy txs declare none and skip the gate.
+            if let Some(tx_chain_id) = tx_il.chain_id()
+                && tx_chain_id != config.chain_id
+            {
                 continue;
             }
 
             // EIP-8141 frame txs are excluded from the IL satisfaction check:
             // validity depends on executing VERIFY frames to discover `payer`,
-            // which this state-only pass cannot do. Eligibility rules for frame
-            // txs in inclusion lists are not yet specified, and an ineligible tx
-            // is excused.
+            // which this state-only pass cannot do. EELS has no frame
+            // transaction type, so eligibility rules for frame txs in
+            // inclusion lists remain unspecified, and an ineligible tx is
+            // excused.
             if tx_il.tx_type() == TxType::Frame {
                 continue;
             }
@@ -246,24 +336,103 @@ impl InclusionListSatisfactionValidator {
                 continue;
             };
 
+            // EIP-2681 nonce overflow → satisfied (EELS `validate_transaction`
+            // rejects `nonce >= 2**64 - 1`; larger values already fail the
+            // canonical decode upstream, so only the exact maximum reaches
+            // this pass).
+            if tx_il.nonce() == u64::MAX {
+                continue;
+            }
+
+            // Contract creation with oversized init code → satisfied (EELS
+            // `validate_transaction` raises `InitCodeTooLargeError`).
+            if tx_il.is_contract_creation() && tx_il.data().len() > max_initcode_size {
+                continue;
+            }
+
+            // Priority fee above the fee cap → satisfied (EELS
+            // `validate_transaction` raises `PriorityFeeGreaterThanMaxFeeError`
+            // for fee-market transactions).
+            if let (Some(max_priority), Some(max_fee)) =
+                (tx_il.max_priority_fee(), tx_il.max_fee_per_gas())
+                && max_priority > max_fee
+            {
+                continue;
+            }
+
+            // Blob (EIP-4844) txs run through the same gates as any other type
+            // since tests-focil-devnet@v0.2.0 ("Type-3 transactions were
+            // considered not-includable by default" spec fix), plus the
+            // blob-specific ones from EELS `validate_transaction`:
+            // no blob at all, more blobs than a tx may carry, or a versioned
+            // hash that is not KZG-versioned → satisfied. (A blob or set-code
+            // creation, `TransactionTypeContractCreationError` in EELS, cannot
+            // be represented here: `to` is a plain `Address`, so such a tx
+            // already failed the canonical decode and was excused.)
+            if tx_il.tx_type() == TxType::EIP4844 {
+                let blob_hashes = tx_il.blob_versioned_hashes();
+                if blob_hashes.is_empty() || blob_hashes.len() > MAX_BLOB_COUNT {
+                    continue;
+                }
+                if blob_hashes
+                    .iter()
+                    .any(|hash| hash.as_bytes()[0] != VERSIONED_HASH_VERSION_KZG)
+                {
+                    continue;
+                }
+            }
+
+            // EIP-7702 set-code tx with an empty authorization list →
+            // satisfied (EELS `validate_transaction` raises
+            // `EmptyAuthorizationListError`).
+            if tx_il
+                .authorization_list()
+                .is_some_and(|auths| auths.is_empty())
+            {
+                continue;
+            }
+
             // intrinsic_gas_too_low → satisfied. A tx whose gas limit is below
             // its intrinsic cost can never be validly included (EELS
-            // `validate_transaction`). A pricing/overflow error here likewise
-            // means the tx is not includable, so we treat it as satisfied.
+            // `validate_transaction`; `transaction_intrinsic_gas` already folds
+            // in the EIP-7623 calldata floor). A pricing/overflow error here
+            // likewise means the tx is not includable, so we treat it as
+            // satisfied. EELS also rejects an intrinsic cost above
+            // `TX_MAX_GAS_LIMIT` — unreachable for any decodable transaction
+            // (it would take megabytes of calldata), but mirrored for
+            // completeness.
             match transaction_intrinsic_gas(tx_il, sender, header, config) {
                 Ok(intrinsic) if tx_il.gas_limit() < intrinsic => continue,
+                Ok(intrinsic) if intrinsic > TX_MAX_GAS_LIMIT_AMSTERDAM => continue,
                 Err(_) => continue,
                 Ok(_) => {}
             }
 
-            // insufficient_gas → satisfied
+            // insufficient_gas → satisfied. EELS `check_block_gas_capacity`
+            // checks the execution and state gas dimensions against their own
+            // remaining budgets; the header only records their maximum
+            // (`gas_used = max(execution, state)`), so `gas_left` is the
+            // smaller of the two remaining budgets and this check matches EELS
+            // exactly whenever `tx.gas <= TX_MAX_GAS_LIMIT` (the execution
+            // dimension counts at most that much per tx).
             if tx_il.gas_limit() > gas_left {
                 continue;
+            }
+
+            // Blob gas over the block's remaining blob budget → satisfied
+            // (EELS `check_block_gas_capacity`, blob dimension).
+            if tx_il.tx_type() == TxType::EIP4844 {
+                let tx_blob_gas =
+                    tx_il.blob_versioned_hashes().len() as u64 * u64::from(GAS_PER_BLOB);
+                if tx_blob_gas > blob_gas_left {
+                    continue;
+                }
             }
 
             // below_base_fee → satisfied. Legacy/2930/privileged use
             // `gas_price`; all other types use `max_fee_per_gas`. A typed tx
             // with no recoverable max fee is unpriceable and not includable.
+            // (EELS `calculate_effective_gas_price`.)
             let max_price = match tx_il.tx_type() {
                 TxType::Legacy | TxType::EIP2930 | TxType::Privileged => tx_il.gas_price(),
                 _ => match tx_il.max_fee_per_gas() {
@@ -275,20 +444,36 @@ impl InclusionListSatisfactionValidator {
                 continue;
             }
 
+            // Blob fee cap below the block's blob gas price → satisfied (EELS
+            // `check_max_fee_per_blob_gas` against the block's own
+            // `excess_blob_gas`).
+            if tx_il.tx_type() == TxType::EIP4844 {
+                let blob_gas_price = calculate_base_fee_per_blob_gas(
+                    header.excess_blob_gas.unwrap_or_default(),
+                    config
+                        .get_fork_blob_schedule(header.timestamp)
+                        .map(|schedule| schedule.base_fee_update_fraction)
+                        .unwrap_or_default(),
+                );
+                if tx_il.max_fee_per_blob_gas().unwrap_or_default() < blob_gas_price {
+                    continue;
+                }
+            }
+
             // From here on, classify by tracked sender state.
-            let (tracker_nonce, tracker_balance) = match self.il_senders.get(&sender) {
-                Some(entry) => *entry,
+            let tracked = match self.il_senders.get(&sender) {
+                Some(entry) => entry.clone(),
                 // The sender was not registered at construction. This means
                 // the IL handed to `check` differs from the one handed to
                 // `new`, which is a caller bug. Be defensive: treat the
                 // sender as having empty state, which makes the tx unable
                 // to be included (nonce/balance mismatch) and counts as
                 // satisfied. This branch is unreachable in normal flow.
-                None => (0, U256::zero()),
+                None => TrackedSender::default(),
             };
 
             // invalid_nonce → satisfied
-            if tx_il.nonce() != tracker_nonce {
+            if tx_il.nonce() != tracked.nonce {
                 continue;
             }
 
@@ -299,7 +484,19 @@ impl InclusionListSatisfactionValidator {
             let Some(cost) = tx_il.cost_without_base_fee() else {
                 continue;
             };
-            if cost > tracker_balance {
+            if cost > tracked.balance {
+                continue;
+            }
+
+            // Sender is not an EOA → satisfied. EELS `check_transaction`
+            // raises `InvalidSenderError` when the sender's code is set and is
+            // not a valid EIP-7702 delegation (EIP-3607); such a sender's
+            // transaction can never be included. The code snapshot comes from
+            // the same post-state the nonce/balance were refreshed from.
+            if let Some(code) = &tracked.code
+                && !code.is_empty()
+                && !is_eip7702_delegation(code)
+            {
                 continue;
             }
 

--- a/crates/networking/rpc/engine/inclusion_list.rs
+++ b/crates/networking/rpc/engine/inclusion_list.rs
@@ -81,8 +81,9 @@ pub type RetainedInclusionListsHandle = Arc<Mutex<RetainedInclusionLists>>;
 ///
 /// An empty inclusion list is trivially satisfied. The algorithm is a pure
 /// state-comparison pass: the validator is seeded from the parent's pre-state,
-/// refreshed from the block's post-state, and consulted once — no transaction
-/// is re-executed.
+/// refreshed from the block's post-state (with same-block withdrawal credits
+/// discounted, since the check point precedes withdrawal processing), and
+/// consulted once — no transaction is re-executed.
 pub async fn block_satisfies_inclusion_list(
     context: &RpcApiContext,
     block_hash: H256,
@@ -127,6 +128,10 @@ pub async fn block_satisfies_inclusion_list(
         .ok_or_else(|| {
             RpcErr::Internal("block body missing for IL satisfaction check".to_string())
         })?;
+    // The satisfaction check evaluates senders at the post-transactions,
+    // PRE-withdrawals point (EELS `apply_body` order), so the withdrawals'
+    // credits must be discounted from the post-state balances.
+    validator.discount_withdrawals(body.withdrawals.as_deref().unwrap_or_default());
     let block_tx_hashes: HashSet<H256> = body
         .transactions
         .iter()

--- a/fixtures/genesis/native_l2.json
+++ b/fixtures/genesis/native_l2.json
@@ -87,6 +87,11 @@
     "amsterdamTime": 0,
     "berlinBlock": 0,
     "blobSchedule": {
+      "amsterdam": {
+        "baseFeeUpdateFraction": 11684671,
+        "max": 21,
+        "target": 14
+      },
       "bpo1": {
         "baseFeeUpdateFraction": 8346193,
         "max": 15,

--- a/test/tests/blockchain/focil_tests.rs
+++ b/test/tests/blockchain/focil_tests.rs
@@ -22,7 +22,7 @@ use ethrex_common::{
     Address, H160, H256, U256,
     types::{
         Block, BlockHeader, DEFAULT_BUILDER_GAS_CEIL, EIP1559Transaction, EIP4844Transaction,
-        ELASTICITY_MULTIPLIER, GenesisAccount, Transaction, TxKind,
+        ELASTICITY_MULTIPLIER, GenesisAccount, Transaction, TxKind, VERSIONED_HASH_VERSION_KZG,
     },
     validation::BlockValidationContext,
 };
@@ -316,8 +316,10 @@ async fn il_first_ordering_with_mempool_competition() {
 // pending IL tx (un)appendable; here we drive the same satisfaction outcomes
 // directly through the validator's per-tx appendability checks. An omitted IL
 // tx makes the block INVALID only if it is still validly appendable; otherwise
-// the block is valid. Mirrors `test_block_status_depends_on_pending_inclusion_list`
-// and `test_block_with_pending_blob_il_tx_is_valid`.
+// the block is valid. Mirrors `test_pending_il_appendability_by_nonce`,
+// `test_pending_il_appendability_by_affordability` and
+// `test_block_with_pending_blob_il_tx_is_valid` (the names the release's test
+// restructuring left them under).
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Hegotá-active chain with `senders` funded; returns store, blockchain,
@@ -396,19 +398,27 @@ async fn omitted_il_tx_unaffordable_is_valid() {
         .expect("omitted IL tx whose sender cannot afford it must be satisfied");
 }
 
-/// EELS `test_block_with_pending_blob_il_tx_is_valid`: blob (EIP-4844) txs are
-/// excluded from the EL IL-satisfaction pass, so omitting one keeps the block
-/// valid even though the sender is funded and the tx is otherwise appendable.
+/// EELS `test_block_with_pending_blob_il_tx_is_valid`: a blob (EIP-4844) tx is
+/// evaluated like any other type. Omitting an appendable one leaves the block
+/// UNSATISFIED — the blanket blob exclusion was a spec bug, removed in
+/// tests-focil-devnet@v0.2.0 ("Type-3 transactions were considered
+/// not-includable by default"), and upstream flipped this scenario's
+/// `expected_inclusion_list_satisfied` to `false` in the same release.
 #[tokio::test]
-async fn omitted_blob_il_tx_is_valid() {
+async fn omitted_blob_il_tx_is_unsatisfied() {
     let sk1 = key(TEST_PRIVATE_KEY);
     let s1 = sender_from_key(&sk1);
     let signer1: Signer = LocalSigner::new(sk1).into();
 
     let (store, blockchain, genesis, chain_id) = hegota_chain(&[s1]).await;
 
-    // A signed blob tx from a funded sender at the correct nonce: without the
-    // blob-skip it would be appendable → unsatisfied. The skip keeps it valid.
+    // A signed blob tx from a funded sender at the correct nonce, and fully
+    // includable: the versioned hash is KZG-versioned, the blob fee covers the
+    // block's blob gas price, and one blob fits the block's blob budget. So the
+    // only thing that could excuse it is a blob-type exclusion, and there is
+    // none any more.
+    let mut blob_hash = [0u8; 32];
+    blob_hash[0] = VERSIONED_HASH_VERSION_KZG;
     let mut blob_tx = Transaction::EIP4844Transaction(EIP4844Transaction {
         chain_id,
         nonce: 0,
@@ -419,17 +429,24 @@ async fn omitted_blob_il_tx_is_valid() {
         value: U256::zero(),
         data: Bytes::new(),
         max_fee_per_blob_gas: U256::from(1u64),
-        blob_versioned_hashes: vec![H256::zero()],
+        blob_versioned_hashes: vec![H256::from(blob_hash)],
         ..Default::default()
     });
     blob_tx.sign_inplace(&signer1).await.unwrap();
-    let il = vec![blob_tx];
+    let il = vec![blob_tx.clone()];
 
     let block = build_block_ignoring_il(&store, &blockchain, &genesis).await;
     let context = BlockValidationContext::with_inclusion_list(il);
-    blockchain
+    let err = blockchain
         .add_block_pipeline_with_il(block, None, &context)
-        .expect("omitted blob IL tx must be satisfied (excluded from EL IL check)");
+        .expect_err("appendable blob IL tx must count against the block");
+
+    match err {
+        ChainError::IlUnsatisfied { tx_hash } => {
+            assert_eq!(tx_hash, blob_tx.hash(&NativeCrypto));
+        }
+        other => panic!("expected ChainError::IlUnsatisfied, got {other:?}"),
+    }
 }
 
 /// EELS `unsatisfied_with_mixed_valid_and_invalid_pending_il_txs`: an IL with

--- a/test/tests/blockchain/inclusion_list_builder_tests.rs
+++ b/test/tests/blockchain/inclusion_list_builder_tests.rs
@@ -34,6 +34,15 @@ impl IlStateProvider for FakeState {
     ) -> Result<Option<AccountStateView>, IlStateProviderError> {
         Ok(self.accounts.borrow().get(&address).copied())
     }
+
+    // The builder never reads code (mempool admission already rejects
+    // contract senders); the fake models every account as code-less.
+    fn get_code(
+        &self,
+        _address: Address,
+    ) -> Result<Option<ethrex_common::Bytes>, IlStateProviderError> {
+        Ok(None)
+    }
 }
 
 fn addr(byte: u8) -> Address {

--- a/test/tests/blockchain/inclusion_list_validator_tests.rs
+++ b/test/tests/blockchain/inclusion_list_validator_tests.rs
@@ -5,10 +5,10 @@ use ethrex_blockchain::inclusion_list_builder::{
     AccountStateView, IlStateProvider, IlStateProviderError,
 };
 use ethrex_blockchain::inclusion_list_validator::{
-    IlUnsatisfied, InclusionListSatisfactionValidator,
+    IlUnsatisfied, InclusionListSatisfactionValidator, TrackedSender,
 };
 use ethrex_common::types::{BlockHeader, ChainConfig, EIP1559Transaction, Transaction, TxKind};
-use ethrex_common::{Address, H256, U256};
+use ethrex_common::{Address, Bytes, H256, U256};
 use ethrex_crypto::NativeCrypto;
 use rustc_hash::FxHashMap;
 
@@ -18,6 +18,9 @@ use rustc_hash::FxHashMap;
 #[derive(Debug, Default)]
 struct MockState {
     accounts: FxHashMap<Address, AccountStateView>,
+    /// Per-address contract code, for the sender-is-EOA gate. Addresses
+    /// absent here have no code.
+    codes: FxHashMap<Address, Bytes>,
     panic_on_read: bool,
     read_count: Cell<usize>,
 }
@@ -26,6 +29,7 @@ impl MockState {
     fn with(accounts: FxHashMap<Address, AccountStateView>) -> Self {
         Self {
             accounts,
+            codes: Default::default(),
             panic_on_read: false,
             read_count: Cell::new(0),
         }
@@ -46,11 +50,23 @@ impl IlStateProvider for MockState {
         self.read_count.set(self.read_count.get() + 1);
         Ok(self.accounts.get(&address).copied())
     }
+
+    // Deliberately does not bump `read_count`, which documents the number of
+    // ACCOUNT reads a flow performs.
+    fn get_code(&self, address: Address) -> Result<Option<Bytes>, IlStateProviderError> {
+        if self.panic_on_read {
+            panic!(
+                "MockState::get_code called during a no-EVM/no-state phase \
+                 for address {address:?} — the satisfaction check must not read state"
+            );
+        }
+        Ok(self.codes.get(&address).cloned())
+    }
 }
 
-/// `IlStateProvider` whose `get_account` panics on every call. Used to
-/// confirm that `check()` is purely state-tracker-driven and does not
-/// reach into the provider.
+/// `IlStateProvider` that panics on every call. Used to confirm that
+/// `check()` is purely state-tracker-driven and does not reach into the
+/// provider.
 #[derive(Debug, Default)]
 struct PanicState;
 
@@ -59,6 +75,10 @@ impl IlStateProvider for PanicState {
         &self,
         _address: Address,
     ) -> Result<Option<AccountStateView>, IlStateProviderError> {
+        panic!("check() must not invoke the state provider — pure tracker comparison only");
+    }
+
+    fn get_code(&self, _address: Address) -> Result<Option<Bytes>, IlStateProviderError> {
         panic!("check() must not invoke the state provider — pure tracker comparison only");
     }
 }
@@ -108,7 +128,21 @@ fn header() -> BlockHeader {
 }
 
 fn config() -> ChainConfig {
-    ChainConfig::default()
+    ChainConfig {
+        // Match `make_tx`'s declared chain id: the wrong-chain-id gate would
+        // otherwise excuse every test transaction.
+        chain_id: 1,
+        ..Default::default()
+    }
+}
+
+/// Tracker entry for a code-less sender.
+fn tracked(nonce: u64, balance: U256) -> TrackedSender {
+    TrackedSender {
+        nonce,
+        balance,
+        code: None,
+    }
 }
 
 fn account(nonce: u64, balance: U256) -> AccountStateView {
@@ -267,7 +301,7 @@ fn tracker_updates_when_executed_tx_touches_il_sender() {
     // Pre-condition: tracker has alice's pre-state nonce/balance.
     assert_eq!(
         validator.il_senders.get(&alice),
-        Some(&(5u64, rich_balance()))
+        Some(&tracked(5, rich_balance()))
     );
 
     // Executed tx by bob (NOT in IL set) should NOT update the tracker.
@@ -283,7 +317,7 @@ fn tracker_updates_when_executed_tx_touches_il_sender() {
     // alice unchanged
     assert_eq!(
         validator.il_senders.get(&alice),
-        Some(&(5u64, rich_balance()))
+        Some(&tracked(5, rich_balance()))
     );
     // bob_state was queried 0 times because bob is not tracked.
     assert_eq!(bob_state.read_count.get(), 0);
@@ -298,7 +332,7 @@ fn tracker_updates_when_executed_tx_touches_il_sender() {
         .expect("observe-alice");
     assert_eq!(
         validator.il_senders.get(&alice),
-        Some(&(6u64, U256::from(123u64)))
+        Some(&tracked(6, U256::from(123u64)))
     );
     // alice_state should have been read exactly once.
     assert_eq!(alice_state.read_count.get(), 1);
@@ -375,7 +409,7 @@ fn algorithm_is_idempotent_over_il() {
     // state level, not just the verdict level.
     assert_eq!(
         validator.il_senders.get(&alice),
-        Some(&(0u64, rich_balance()))
+        Some(&tracked(0, rich_balance()))
     );
 }
 
@@ -520,33 +554,6 @@ fn frame_il_tx_present_in_block_is_satisfied() {
     );
 }
 
-/// Build an EIP-4844 (blob) tx with a precached sender.
-fn make_blob_tx(sender: Address, nonce: u64, gas_limit: u64) -> Transaction {
-    use ethrex_common::types::EIP4844Transaction;
-    let inner = EIP4844Transaction {
-        chain_id: 1,
-        nonce,
-        max_priority_fee_per_gas: 1,
-        max_fee_per_gas: 1,
-        gas: gas_limit,
-        to: Address::repeat_byte(0xaa),
-        value: U256::zero(),
-        max_fee_per_blob_gas: U256::from(1),
-        blob_versioned_hashes: vec![H256::repeat_byte(0x01)],
-        signature_r: U256::from(1),
-        signature_s: U256::from(2),
-        ..Default::default()
-    };
-    let tx = Transaction::EIP4844Transaction(inner);
-    match &tx {
-        Transaction::EIP4844Transaction(inner) => {
-            let _ = inner.sender_cache.set(sender);
-        }
-        _ => unreachable!(),
-    }
-    tx
-}
-
 /// Build an EIP-1559 tx with a genuinely invalid signature (`r = s = 0`)
 /// and NO precached sender, so `Transaction::sender` performs real ECDSA
 /// recovery and fails.
@@ -567,27 +574,12 @@ fn make_unsigned_tx(nonce: u64, gas_limit: u64) -> Transaction {
     Transaction::EIP1559Transaction(inner)
 }
 
-/// Blob IL txs are excluded from the satisfaction check: an omitted blob
-/// tx with a funded sender must classify as satisfied (EELS skips blobs).
-#[test]
-fn omitted_blob_il_tx_is_satisfied() {
-    let crypto = NativeCrypto;
-    let alice = addr(1);
-
-    let il = vec![make_blob_tx(alice, 0, 21_000)];
-    let mut accounts: FxHashMap<Address, AccountStateView> = Default::default();
-    accounts.insert(alice, account(0, rich_balance()));
-    let state = MockState::with(accounts);
-
-    let validator =
-        InclusionListSatisfactionValidator::new(&il, &state, &crypto).expect("construct");
-
-    // Empty block, ample gas, funded sender — only the blob-skip rule keeps
-    // this satisfied.
-    let block_txs: HashSet<H256> = HashSet::new();
-    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
-    assert!(matches!(result, Ok(())), "blob IL tx must be skipped");
-}
+// NOTE: the former `omitted_blob_il_tx_is_satisfied` test pinned the
+// pre-tests-focil-devnet@v0.2.0 rule that excused every blob transaction.
+// That release's spec fix ("Type-3 transactions were considered
+// not-includable by default") evaluates blob txs like any other type; the
+// replacement coverage lives in `il_omitted_includable_blob_tx_returns_unsatisfied`
+// and `il_omitted_blob_tx_invalid_variants_return_ok` below.
 
 /// An IL tx whose gas limit is below intrinsic gas can never be validly
 /// appended → satisfied (EELS `validate_transaction` raises).
@@ -670,4 +662,461 @@ fn omitted_below_base_fee_il_tx_is_satisfied() {
     hdr_ok.base_fee_per_gas = Some(1);
     let control = validator.check(&il, &block_txs, 30_000_000, &hdr_ok, &config(), &crypto);
     assert!(matches!(control, Err(IlUnsatisfied { .. })));
+}
+
+// ─── Includability gates added for tests-focil-devnet@v0.2.0 ─────────────────
+//
+// EELS `check_inclusion_list_transactions` (forks/amsterdam) replays
+// `validate_transaction` + `check_transaction` for every missing IL tx; the
+// tests below pin the ethrex mirror of the gates that release introduced or
+// changed: wrong chain id, nonce overflow, priority fee above the cap,
+// oversized init code, empty authorization list, contract sender, and the
+// full evaluation of blob transactions (previously excused wholesale).
+
+/// EIP-1559 tx with every fee/shape knob exposed, sender pre-cached like
+/// [`make_tx`].
+#[allow(clippy::too_many_arguments)]
+fn make_tx_full(
+    sender: Address,
+    chain_id: u64,
+    nonce: u64,
+    max_priority_fee_per_gas: u64,
+    max_fee_per_gas: u64,
+    gas_limit: u64,
+    to: TxKind,
+    data: Vec<u8>,
+) -> Transaction {
+    let inner = EIP1559Transaction {
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas,
+        max_fee_per_gas,
+        gas_limit,
+        to,
+        value: U256::from(1),
+        data: data.into(),
+        access_list: vec![],
+        signature_y_parity: false,
+        signature_r: U256::from(1),
+        signature_s: U256::from(2),
+        ..Default::default()
+    };
+    let tx = Transaction::EIP1559Transaction(inner);
+    match &tx {
+        Transaction::EIP1559Transaction(inner) => {
+            let _ = inner.sender_cache.set(sender);
+        }
+        _ => unreachable!(),
+    }
+    tx
+}
+
+/// EIP-4844 tx with the given versioned hashes and blob fee cap, sender
+/// pre-cached.
+fn make_blob_tx(
+    sender: Address,
+    nonce: u64,
+    blob_versioned_hashes: Vec<H256>,
+    max_fee_per_blob_gas: U256,
+) -> Transaction {
+    let inner = ethrex_common::types::EIP4844Transaction {
+        chain_id: 1,
+        nonce,
+        max_priority_fee_per_gas: 1,
+        max_fee_per_gas: 1,
+        gas: 100_000,
+        to: Address::repeat_byte(0xaa),
+        value: U256::from(1),
+        data: Default::default(),
+        access_list: vec![],
+        max_fee_per_blob_gas,
+        blob_versioned_hashes,
+        signature_y_parity: false,
+        signature_r: U256::from(1),
+        signature_s: U256::from(2),
+        ..Default::default()
+    };
+    let tx = Transaction::EIP4844Transaction(inner);
+    match &tx {
+        Transaction::EIP4844Transaction(inner) => {
+            let _ = inner.sender_cache.set(sender);
+        }
+        _ => unreachable!(),
+    }
+    tx
+}
+
+/// A KZG-versioned (0x01-prefixed) blob versioned hash.
+fn kzg_hash() -> H256 {
+    let mut h = [0u8; 32];
+    h[0] = 0x01;
+    H256::from(h)
+}
+
+/// Config with blob parameters in force at timestamp 0 (Cancun default
+/// schedule: target 3 / max 6 / fraction 3338477).
+fn blob_config() -> ChainConfig {
+    ChainConfig {
+        cancun_time: Some(0),
+        shanghai_time: Some(0),
+        ..config()
+    }
+}
+
+fn single_sender_validator(
+    il: &[Transaction],
+    sender: Address,
+    nonce: u64,
+) -> InclusionListSatisfactionValidator {
+    let mut accounts: FxHashMap<Address, AccountStateView> = Default::default();
+    accounts.insert(sender, account(nonce, rich_balance()));
+    let state = MockState::with(accounts);
+    InclusionListSatisfactionValidator::new(il, &state, &NativeCrypto).expect("construct")
+}
+
+#[test]
+fn il_omitted_with_wrong_chain_id_returns_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    // Declared chain id 2 against config chain id 1 → never includable.
+    let il = vec![make_tx_full(
+        alice,
+        2,
+        0,
+        1,
+        1,
+        21_000,
+        TxKind::Call(Address::repeat_byte(0xaa)),
+        vec![],
+    )];
+    let validator = single_sender_validator(&il, alice, 0);
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(
+        matches!(result, Ok(())),
+        "wrong-chain-id tx must be excused"
+    );
+
+    // Control: identical tx declaring the chain's id flips to Unsatisfied.
+    let il_ok = vec![make_tx_full(
+        alice,
+        1,
+        0,
+        1,
+        1,
+        21_000,
+        TxKind::Call(Address::repeat_byte(0xaa)),
+        vec![],
+    )];
+    let validator_ok = single_sender_validator(&il_ok, alice, 0);
+    let control = validator_ok.check(
+        &il_ok,
+        &block_txs,
+        30_000_000,
+        &header(),
+        &config(),
+        &crypto,
+    );
+    assert!(matches!(control, Err(IlUnsatisfied { .. })));
+}
+
+#[test]
+fn il_omitted_with_max_nonce_returns_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    // EIP-2681: nonce == 2**64 - 1 can never be included, even when the
+    // sender's account sits at that nonce (only reachable via pre-state).
+    let il = vec![make_tx(alice, u64::MAX, 21_000, U256::from(1))];
+    let validator = single_sender_validator(&il, alice, u64::MAX);
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(
+        matches!(result, Ok(())),
+        "nonce-overflow tx must be excused"
+    );
+}
+
+#[test]
+fn il_omitted_with_priority_above_max_fee_returns_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    let il = vec![make_tx_full(
+        alice,
+        1,
+        0,
+        2, // max_priority_fee_per_gas above...
+        1, // ...max_fee_per_gas
+        21_000,
+        TxKind::Call(Address::repeat_byte(0xaa)),
+        vec![],
+    )];
+    let validator = single_sender_validator(&il, alice, 0);
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(
+        matches!(result, Ok(())),
+        "priority-above-cap tx must be excused"
+    );
+}
+
+#[test]
+fn il_omitted_with_oversized_initcode_returns_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    // Default (pre-Amsterdam) cap is MAX_INITCODE_SIZE = 49152 bytes.
+    let il = vec![make_tx_full(
+        alice,
+        1,
+        0,
+        1,
+        1,
+        1_000_000,
+        TxKind::Create,
+        vec![0u8; 49_153],
+    )];
+    let validator = single_sender_validator(&il, alice, 0);
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(
+        matches!(result, Ok(())),
+        "oversized-initcode creation must be excused"
+    );
+
+    // Control: at exactly the cap the creation is includable → Unsatisfied.
+    let il_ok = vec![make_tx_full(
+        alice,
+        1,
+        0,
+        1,
+        1,
+        1_000_000,
+        TxKind::Create,
+        vec![0u8; 49_152],
+    )];
+    let validator_ok = single_sender_validator(&il_ok, alice, 0);
+    let control = validator_ok.check(
+        &il_ok,
+        &block_txs,
+        30_000_000,
+        &header(),
+        &config(),
+        &crypto,
+    );
+    assert!(matches!(control, Err(IlUnsatisfied { .. })));
+}
+
+#[test]
+fn il_omitted_with_empty_authorization_list_returns_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    let inner = ethrex_common::types::EIP7702Transaction {
+        chain_id: 1,
+        nonce: 0,
+        max_priority_fee_per_gas: 1,
+        max_fee_per_gas: 1,
+        gas_limit: 100_000,
+        to: Address::repeat_byte(0xaa),
+        value: U256::from(1),
+        data: Default::default(),
+        access_list: vec![],
+        authorization_list: vec![],
+        signature_y_parity: false,
+        signature_r: U256::from(1),
+        signature_s: U256::from(2),
+        ..Default::default()
+    };
+    let tx = Transaction::EIP7702Transaction(inner);
+    match &tx {
+        Transaction::EIP7702Transaction(inner) => {
+            let _ = inner.sender_cache.set(alice);
+        }
+        _ => unreachable!(),
+    }
+    let il = vec![tx];
+    let validator = single_sender_validator(&il, alice, 0);
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(
+        matches!(result, Ok(())),
+        "empty-authorization-list tx must be excused"
+    );
+}
+
+#[test]
+fn il_omitted_from_contract_sender_returns_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    let il = vec![make_tx(alice, 0, 21_000, U256::from(1))];
+
+    // Alice's account carries plain contract code → EIP-3607 bars her from
+    // sending, so the omitted tx is excused.
+    let mut accounts: FxHashMap<Address, AccountStateView> = Default::default();
+    accounts.insert(alice, account(0, rich_balance()));
+    let mut codes: FxHashMap<Address, Bytes> = Default::default();
+    codes.insert(alice, Bytes::from(vec![0x60, 0x00]));
+    let state = MockState {
+        accounts: accounts.clone(),
+        codes,
+        panic_on_read: false,
+        read_count: Cell::new(0),
+    };
+    let validator =
+        InclusionListSatisfactionValidator::new(&il, &state, &crypto).expect("construct");
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(matches!(result, Ok(())), "contract sender must be excused");
+
+    // Control: an EIP-7702 delegation designation keeps the account an EOA in
+    // spirit → the omitted tx counts against the block.
+    let mut delegation = vec![0xef, 0x01, 0x00];
+    delegation.extend_from_slice(&[0x11; 20]);
+    let mut delegated_codes: FxHashMap<Address, Bytes> = Default::default();
+    delegated_codes.insert(alice, Bytes::from(delegation));
+    let delegated_state = MockState {
+        accounts,
+        codes: delegated_codes,
+        panic_on_read: false,
+        read_count: Cell::new(0),
+    };
+    let validator_ok =
+        InclusionListSatisfactionValidator::new(&il, &delegated_state, &crypto).expect("construct");
+    let control = validator_ok.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(matches!(control, Err(IlUnsatisfied { .. })));
+}
+
+#[test]
+fn il_omitted_includable_blob_tx_returns_unsatisfied() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+
+    // Fully includable blob tx (valid hash, fee covers the blob gas price,
+    // budget available): since tests-focil-devnet@v0.2.0 it counts against
+    // the block instead of being excused as a blob tx.
+    let il = vec![make_blob_tx(alice, 0, vec![kzg_hash()], U256::from(1))];
+    let validator = single_sender_validator(&il, alice, 0);
+
+    let block_txs: HashSet<H256> = HashSet::new();
+    let result = validator.check(
+        &il,
+        &block_txs,
+        30_000_000,
+        &header(),
+        &blob_config(),
+        &crypto,
+    );
+    assert!(
+        matches!(result, Err(IlUnsatisfied { .. })),
+        "includable blob tx must count against the block, got {result:?}"
+    );
+}
+
+#[test]
+fn il_omitted_blob_tx_invalid_variants_return_ok() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+    let block_txs: HashSet<H256> = HashSet::new();
+
+    // Zero blobs.
+    let il = vec![make_blob_tx(alice, 0, vec![], U256::from(1))];
+    let validator = single_sender_validator(&il, alice, 0);
+    assert!(
+        matches!(
+            validator.check(
+                &il,
+                &block_txs,
+                30_000_000,
+                &header(),
+                &blob_config(),
+                &crypto
+            ),
+            Ok(())
+        ),
+        "zero-blob tx must be excused"
+    );
+
+    // More blobs than a tx may carry (MAX_BLOB_COUNT = 6).
+    let il = vec![make_blob_tx(alice, 0, vec![kzg_hash(); 7], U256::from(1))];
+    let validator = single_sender_validator(&il, alice, 0);
+    assert!(
+        matches!(
+            validator.check(
+                &il,
+                &block_txs,
+                30_000_000,
+                &header(),
+                &blob_config(),
+                &crypto
+            ),
+            Ok(())
+        ),
+        "over-the-cap blob count must be excused"
+    );
+
+    // Versioned hash that is not KZG-versioned.
+    let il = vec![make_blob_tx(
+        alice,
+        0,
+        vec![H256::repeat_byte(0x02)],
+        U256::from(1),
+    )];
+    let validator = single_sender_validator(&il, alice, 0);
+    assert!(
+        matches!(
+            validator.check(
+                &il,
+                &block_txs,
+                30_000_000,
+                &header(),
+                &blob_config(),
+                &crypto
+            ),
+            Ok(())
+        ),
+        "non-KZG versioned hash must be excused"
+    );
+
+    // Blob fee cap below the block's blob gas price (price is 1 at zero
+    // excess blob gas).
+    let il = vec![make_blob_tx(alice, 0, vec![kzg_hash()], U256::zero())];
+    let validator = single_sender_validator(&il, alice, 0);
+    assert!(
+        matches!(
+            validator.check(
+                &il,
+                &block_txs,
+                30_000_000,
+                &header(),
+                &blob_config(),
+                &crypto
+            ),
+            Ok(())
+        ),
+        "blob fee below the blob gas price must be excused"
+    );
+
+    // Blob budget exhausted: the block already used its whole blob allowance
+    // (6 blobs × 131072 gas).
+    let il = vec![make_blob_tx(alice, 0, vec![kzg_hash()], U256::from(1))];
+    let validator = single_sender_validator(&il, alice, 0);
+    let mut hdr = header();
+    hdr.blob_gas_used = Some(6 * 131_072);
+    assert!(
+        matches!(
+            validator.check(&il, &block_txs, 30_000_000, &hdr, &blob_config(), &crypto),
+            Ok(())
+        ),
+        "blob tx beyond the remaining blob budget must be excused"
+    );
 }

--- a/test/tests/blockchain/inclusion_list_validator_tests.rs
+++ b/test/tests/blockchain/inclusion_list_validator_tests.rs
@@ -7,7 +7,9 @@ use ethrex_blockchain::inclusion_list_builder::{
 use ethrex_blockchain::inclusion_list_validator::{
     IlUnsatisfied, InclusionListSatisfactionValidator, TrackedSender,
 };
-use ethrex_common::types::{BlockHeader, ChainConfig, EIP1559Transaction, Transaction, TxKind};
+use ethrex_common::types::{
+    BlockHeader, ChainConfig, EIP1559Transaction, Transaction, TxKind, Withdrawal,
+};
 use ethrex_common::{Address, Bytes, H256, U256};
 use ethrex_crypto::NativeCrypto;
 use rustc_hash::FxHashMap;
@@ -1118,5 +1120,68 @@ fn il_omitted_blob_tx_invalid_variants_return_ok() {
             Ok(())
         ),
         "blob tx beyond the remaining blob budget must be excused"
+    );
+}
+
+/// The satisfaction check evaluates senders BEFORE same-block withdrawals are
+/// processed: EELS `apply_body` runs `check_inclusion_list_transactions`
+/// between the block's transactions and `process_withdrawals`, so a sender
+/// funded only by a withdrawal in the same block could not have had its tx
+/// appended (mirrors `test_use_value_in_tx[tx_in_withdrawals_block]`'s
+/// inclusion-list variant from tests-focil-devnet@v0.2.0).
+#[test]
+fn il_sender_funded_by_same_block_withdrawal_is_excused() {
+    let crypto = NativeCrypto;
+    let alice = addr(1);
+    let bob = addr(2);
+
+    let il = vec![make_tx(alice, 0, 21_000, U256::from(1))];
+
+    // Pre-state: penniless. Post-state: exactly the withdrawal's credit
+    // (1 gwei = 10^9 wei, comfortably above the 21_001-wei tx cost).
+    let mut pre_accounts: FxHashMap<Address, AccountStateView> = Default::default();
+    pre_accounts.insert(alice, account(0, U256::zero()));
+    let pre_state = MockState::with(pre_accounts);
+    let mut validator =
+        InclusionListSatisfactionValidator::new(&il, &pre_state, &crypto).expect("construct");
+
+    let credit_gwei = 1u64;
+    let mut post_accounts: FxHashMap<Address, AccountStateView> = Default::default();
+    post_accounts.insert(
+        alice,
+        account(0, U256::from(credit_gwei) * U256::from(1_000_000_000u64)),
+    );
+    let post_state = MockState::with(post_accounts);
+    validator
+        .refresh_all_from(&post_state, &crypto)
+        .expect("refresh");
+
+    // Control first (`check` is read-only): with the credit still in the
+    // tracker the tx is includable, so the omission counts against the block.
+    let block_txs: HashSet<H256> = HashSet::new();
+    let control = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(matches!(control, Err(IlUnsatisfied { .. })));
+
+    // Discounting the block's withdrawals (including one to an untracked
+    // address, which must be a no-op) rolls alice back to her
+    // pre-withdrawals balance: the tx is no longer payable → excused.
+    validator.discount_withdrawals(&[
+        Withdrawal {
+            index: 0,
+            validator_index: 0,
+            address: alice,
+            amount: credit_gwei,
+        },
+        Withdrawal {
+            index: 1,
+            validator_index: 1,
+            address: bob,
+            amount: 7,
+        },
+    ]);
+    let result = validator.check(&il, &block_txs, 30_000_000, &header(), &config(), &crypto);
+    assert!(
+        matches!(result, Ok(())),
+        "withdrawal-funded IL sender must be excused, got {result:?}"
     );
 }

--- a/tooling/ef_tests/engine/.fixtures_url_focil
+++ b/tooling/ef_tests/engine/.fixtures_url_focil
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-focil%40v0.1.0/fixtures_focil.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-focil-devnet%40v0.2.0/fixtures_focil-devnet.tar.gz

--- a/tooling/ef_tests/engine/Makefile
+++ b/tooling/ef_tests/engine/Makefile
@@ -32,6 +32,13 @@ AMSTERDAM_STAMP := $(SPECTEST_VECTORS_DIR)/.amsterdam_overlay
 # transaction of the last block moves into the inclusion list, expecting
 # `inclusionListSatisfied: false` when it was includable and `true` when it
 # was not (execution-specs#3337).
+#
+# 127 of those generated variants ship expected-VALID blocks that the EELS
+# spec at the same tag rejects (stale `blobGasUsed` left by the variant
+# generator; one block whose access list exceeds the EIP-7928 item cap at its
+# pinned 21k gas limit). They are enumerated -- with the full analysis and the
+# exact failure signature the harness enforces -- in
+# tests/upstream_broken_fixtures.txt.
 FOCIL_FIXTURES_FILE := .fixtures_url_focil
 FOCIL_ARTIFACT := focil-tests.tar.gz
 FOCIL_URL := $(shell cat $(FOCIL_FIXTURES_FILE))

--- a/tooling/ef_tests/engine/Makefile
+++ b/tooling/ef_tests/engine/Makefile
@@ -21,45 +21,17 @@ AMSTERDAM_STAMP := $(SPECTEST_VECTORS_DIR)/.amsterdam_overlay
 # fixtures/blockchain_tests_engine/for_bogota/. The datatest harness walks
 # vectors/eest/ recursively, so they're discovered wherever they land in the tree.
 #
-# The pinned release, tests-focil@v0.1.0, CANNOT pass on this branch, and that is
-# the spec-correct outcome rather than a FOCIL defect. It was filled 2026-06-22
-# from execution-specs `devnets/focil/0`, whose Amsterdam base predates the one
-# this branch implements, so its genesis predeploys no EIP-8282 builder
-# deposit/exit contracts -- and EIP-8282 states that if either address has no
-# code once the EIP is active, every block from activation onward MUST be
-# invalid. ethrex rejecting all 24 is exactly that rule firing.
-#
-# The FOCIL logic itself is verified against the SAME upstream test sources,
-# refilled against the Amsterdam this branch implements: **all 24 pass**, inside
-# a fully green engine suite (11014 tests / 75535 fixtures). Reproduce with
-# `focil-eest-fill.patch` in this directory, applied to execution-specs
-# `eips/bogota/eip-7805` @ e5dc8456f:
-#
-#   git clone -b eips/bogota/eip-7805 https://github.com/ethereum/execution-specs
-#   cd execution-specs && git apply /path/to/focil-eest-fill.patch && uv sync
-#   uv run fill tests/bogota/eip7805_focil --fork Bogota --output fx --clean
-#   # then overlay fx/blockchain_tests_engine/for_bogota onto vectors/eest/
-#
-# The patch carries four repairs, none of them FOCIL logic:
-#   * t8n handed `check_inclusion_list_transactions` decoded transactions where
-#     it expects `LegacyTransaction | Bytes`, so nothing filled at all;
-#   * the scenarios sized the block gas limit to their transactions alone,
-#     leaving no budget for the block's own EIP-7928 access list (fixed by
-#     raising the limit and burning the difference on ballast transactions, so
-#     `remaining_gas` -- every "fits"/"does not fit" boundary -- is unchanged);
-#   * one scenario's funding transfer predates value-carrying transfers costing
-#     extra intrinsic gas (`sends_value=True`);
-#   * that branch's Amsterdam is NEWER than glamsterdam-devnet-8 (ACCOUNT_WRITE
-#     8000 vs 9000, CREATE_ACCESS from COLD_STORAGE_ACCESS rather than
-#     COLD_ACCOUNT_ACCESS), pricing a contract creation's intrinsic at 23000
-#     against devnet-8's 24000. Aligning just that pricing is what upstream's
-#     announced EELS/EEST devnet-8 rebase will do; with it, the last scenario
-#     agrees and no client change is needed.
-#
-# So: re-pin FOCIL_URL to the devnet-8 tests-focil release when it lands, and
-# this goes green on its own. Until then the vectors here are the stale release
-# and are expected to fail; coverage comes from the refill above plus the
-# in-repo suite (test/tests/blockchain/focil_tests.rs and inclusion_list_*).
+# The pinned release, tests-focil-devnet@v0.2.0, fills every fixture on the
+# "Bogota" network whose Amsterdam base is glamsterdam-devnet-8 -- the same
+# base this branch implements. (Its predecessor tests-focil@v0.1.0 was filled
+# on an older Amsterdam whose genesis predeployed no EIP-8282 builder
+# deposit/exit contracts, so rejecting its 24 fixtures was the spec-correct
+# outcome; this re-pin aligned the fill base as that analysis predicted.)
+# Besides the eip7805_focil scenarios, the bundle carries inclusion-list
+# variants auto-generated from prior-fork blockchain/state tests: the last
+# transaction of the last block moves into the inclusion list, expecting
+# `inclusionListSatisfied: false` when it was includable and `true` when it
+# was not (execution-specs#3337).
 FOCIL_FIXTURES_FILE := .fixtures_url_focil
 FOCIL_ARTIFACT := focil-tests.tar.gz
 FOCIL_URL := $(shell cat $(FOCIL_FIXTURES_FILE))

--- a/tooling/ef_tests/engine/src/fixture.rs
+++ b/tooling/ef_tests/engine/src/fixture.rs
@@ -6,11 +6,6 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 
-/// The FOCIL fixture sentinel for an unsatisfied inclusion list. EIP-7805 reports
-/// that verdict as a `VALID` payload carrying `inclusionListSatisfied: false`;
-/// fixtures predating that structure name it as a third status value instead.
-pub const IL_UNSATISFIED_STATUS: &str = "INCLUSION_LIST_UNSATISFIED";
-
 /// One JSON file holds many fixtures keyed by test name.
 pub type EngineFixtureFile = BTreeMap<String, EngineFixture>;
 
@@ -81,20 +76,15 @@ pub struct FixturePayload {
     /// and compares the returned witness against it.
     #[serde(default, rename = "executionWitness")]
     pub execution_witness: Option<Value>,
-    /// EIP-7805 (FOCIL): the inclusion-list transactions for this payload,
-    /// carried by the fixture as a field SEPARATE from `params`. This is the
-    /// `tests-focil@v0.1.0` shape; fixtures filled against the current
-    /// Amsterdam instead pass the list as the fifth positional `params` entry,
-    /// matching the merged execution-apis `bogota.md`. Both are accepted — see
-    /// [`Self::engine_call`].
-    #[serde(default, rename = "inclusionListTransactions")]
-    pub inclusion_list_transactions: Option<Vec<Value>>,
-    /// Explicit expected payload status (e.g. `"INCLUSION_LIST_UNSATISFIED"`).
-    /// FOCIL fixtures use this third status value instead of the
-    /// `validationError`/`errorCode` VALID/INVALID model. `null` for ordinary
-    /// fixtures.
-    #[serde(default)]
-    pub status: Option<String>,
+    /// EIP-7805 (FOCIL): expected `PayloadStatusV2.inclusionListSatisfied`
+    /// value, present on every payload from Bogota on
+    /// (tests-focil-devnet@v0.2.0+; the fifth positional `params` entry
+    /// carries the inclusion list itself). Orthogonal to `validationError`:
+    /// a payload can be `VALID` while not satisfying its inclusion list.
+    /// The earlier `status: "INCLUSION_LIST_UNSATISFIED"` sixth-status shape
+    /// was removed by that release.
+    #[serde(default, rename = "inclusionListSatisfied")]
+    pub inclusion_list_satisfied: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -105,15 +95,13 @@ pub enum ValidationError {
 }
 
 impl FixturePayload {
-    /// The expected engine payload `status` string. An explicit fixture
-    /// `status` (FOCIL's `INCLUSION_LIST_UNSATISFIED`, or a literal `VALID`)
-    /// wins; otherwise it derives from the VALID/INVALID model: `INVALID` when
-    /// a `validationError` is set, else `VALID`. `errorCode` (a JSON-RPC error)
-    /// is handled separately by the response checker.
+    /// The expected engine payload `status` string, derived from the
+    /// VALID/INVALID model: `INVALID` when a `validationError` is set, else
+    /// `VALID`. `errorCode` (a JSON-RPC error) is handled separately by the
+    /// response checker. Since tests-focil-devnet@v0.2.0 this is exactly the
+    /// `PayloadStatusV1` set again — an unsatisfied inclusion list is reported
+    /// through `inclusionListSatisfied`, never through `status`.
     pub fn expected_status(&self) -> &str {
-        if let Some(s) = &self.status {
-            return s;
-        }
         if self.validation_error.is_some() {
             "INVALID"
         } else {
@@ -122,49 +110,12 @@ impl FixturePayload {
     }
 
     /// Returns `true` when the payload is expected to be accepted as the new
-    /// canonical head (status `VALID`, no JSON-RPC error). A FOCIL
-    /// `INCLUSION_LIST_UNSATISFIED` payload is NOT valid for head advancement:
-    /// the block executes but must not be attested, so the follow-up FCU is
-    /// skipped.
+    /// canonical head (status `VALID`, no JSON-RPC error). A `VALID` payload
+    /// that does not satisfy its inclusion list still advances the head — the
+    /// consensus layer merely will not attest to it — so the follow-up FCU
+    /// applies to it too, mirroring EEST's `test_via_engine.py`.
     pub fn valid(&self) -> bool {
         self.error_code.is_none() && self.expected_status() == "VALID"
-    }
-
-    /// The `engine_newPayload` version to call and the positional args for it.
-    ///
-    /// For FOCIL fixtures (`inclusionListTransactions` present) the IL is
-    /// appended as the final argument and the call is routed to ethrex's
-    /// IL-aware `engine_newPayloadV6` handler. As of tests-focil@v0.1.0 the
-    /// fixtures emit `newPayloadVersion: 6` directly (the V5→V6 bump landed in
-    /// execution-specs#3028), so forcing 6 here is idempotent; it stays as a
-    /// guard in case an IL-bearing fixture is ever tagged with a lower version.
-    pub fn engine_call(&self) -> (u8, Vec<Value>) {
-        match &self.inclusion_list_transactions {
-            // Legacy shape: the list lives outside `params`, so append it.
-            Some(il) => {
-                let mut params = self.params.clone();
-                params.push(Value::Array(il.clone()));
-                (6, params)
-            }
-            // Current shape: `params` is already the full V6 argument list.
-            None => (self.new_payload_version, self.params.clone()),
-        }
-    }
-
-    /// The inclusion list this payload carries, under either fixture shape.
-    ///
-    /// Old fixtures put it in a sibling field; current ones pass it as the
-    /// fifth `engine_newPayloadV6` parameter, per `bogota.md`.
-    pub fn inclusion_list(&self) -> Option<&Vec<Value>> {
-        if let Some(il) = &self.inclusion_list_transactions {
-            return Some(il);
-        }
-        if self.new_payload_version >= 6
-            && let Some(Value::Array(il)) = self.params.get(4)
-        {
-            return Some(il);
-        }
-        None
     }
 
     /// Extract `blockHash` from `params[0]` (the ExecutionPayload object).
@@ -206,31 +157,10 @@ impl EngineFixture {
     ///
     /// Mirrors what `hive/clients/ethrex/mapper.jq` does: assembles a Geth-style genesis
     /// JSON (alloc, config with fork activations, header fields) and deserializes it.
-    /// Whether this is an EIP-7805 (FOCIL) fixture, i.e. any payload carries an
-    /// inclusion list. ethrex gates FOCIL behind its Hegotá fork while EEST
-    /// folds it into Amsterdam, so FOCIL fixtures need Hegotá activated too.
-    pub fn is_focil(&self) -> bool {
-        self.engine_new_payloads
-            .iter()
-            .any(|p| p.inclusion_list().is_some())
-    }
-
     pub fn build_genesis(&self) -> anyhow::Result<Genesis> {
         let chain_id = parse_chain_id(&self.config)?;
         let (genesis_fork, transition) = self.schedule()?;
         let mut config_json = build_chain_config_json(genesis_fork, transition, chain_id);
-        // FOCIL bridge: EEST activates FOCIL under Amsterdam, but ethrex gates
-        // it behind Hegotá. Activate Hegotá at the same time as Amsterdam so
-        // engine_newPayloadV6's IL satisfaction check runs. Hegotá adds no
-        // genesis-header fields, so this does not change the genesis hash.
-        if self.is_focil()
-            && let Some(amsterdam_time) = config_json.get("amsterdamTime").cloned()
-        {
-            config_json
-                .as_object_mut()
-                .expect("config_json is an object")
-                .insert("hegotaTime".into(), amsterdam_time);
-        }
         // EEST fixtures carry their own per-fork blobSchedule (Cancun/Prague/Osaka/BPO*/Amsterdam)
         // with fork-name keys and hex-string values. Convert and inject; otherwise post-Cancun
         // payloads that rely on non-default blob params get rejected.
@@ -368,8 +298,9 @@ fn single_fork(s: &str) -> anyhow::Result<ethrex_common::types::Fork> {
         "BPO5" => Fork::BPO5,
         "Amsterdam" => Fork::Amsterdam,
         // EIP-7805 (FOCIL) ships as the "Bogota" fork in execution-apis /
-        // execution-specs (tests-focil@v0.1.0+); ethrex names it "Hegota"
-        // internally (genesis already aliases bogotaTime → hegota_time).
+        // execution-specs (every tests-focil-devnet@v0.2.0 fixture fills on
+        // it); ethrex names it "Hegota" internally (genesis already aliases
+        // bogotaTime → hegota_time).
         "Bogota" | "Hegota" => Fork::Hegota,
         other => anyhow::bail!("Unknown network: {other}"),
     };
@@ -424,6 +355,9 @@ fn build_chain_config_json(
         (Fork::BPO4, "bpo4Time"),
         (Fork::BPO5, "bpo5Time"),
         (Fork::Amsterdam, "amsterdamTime"),
+        // EEST's "Bogota" (EIP-7805 FOCIL) — Hegotá in ethrex. Hegotá adds no
+        // genesis-header fields, so activating it never changes a genesis hash.
+        (Fork::Hegota, "hegotaTime"),
     ];
 
     for &(fork, field) in TIME_FORKS {

--- a/tooling/ef_tests/engine/src/report.rs
+++ b/tooling/ef_tests/engine/src/report.rs
@@ -1,7 +1,10 @@
-use crate::runner::FixtureFailure;
+use std::fmt::Display;
 use std::fmt::Write as _;
 
-pub fn render_failures(failures: &[(String, FixtureFailure)]) -> String {
+/// Render one `FAIL <name>: <reason>` line per failure. Generic over the
+/// reason so callers can pass either a [`crate::runner::FixtureFailure`] or a
+/// message they synthesised themselves.
+pub fn render_failures<E: Display>(failures: &[(String, E)]) -> String {
     let mut out = String::new();
     for (name, failure) in failures {
         writeln!(out, "FAIL {name}: {failure}").expect("write to String is infallible");

--- a/tooling/ef_tests/engine/src/runner.rs
+++ b/tooling/ef_tests/engine/src/runner.rs
@@ -3,9 +3,7 @@ use std::fmt;
 use ethrex_common::H256;
 use serde_json::Value;
 
-use crate::fixture::{
-    EngineFixture, FixturePayload, IL_UNSATISFIED_STATUS, ValidationError, is_pre_paris,
-};
+use crate::fixture::{EngineFixture, FixturePayload, ValidationError, is_pre_paris};
 use crate::harness::{Backend, EngineApiHarness};
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -68,6 +66,11 @@ pub enum FixtureFailure {
         expected: String,
         got: String,
         validation_error: Option<String>,
+    },
+    IlSatisfiedMismatch {
+        index: usize,
+        expected: bool,
+        got: Option<bool>,
     },
     WrongErrorCode {
         index: usize,
@@ -143,6 +146,14 @@ impl fmt::Display for FixtureFailure {
                 ),
                 None => write!(f, "wrong_status[{index}]  expected={expected}  got={got}"),
             },
+            FixtureFailure::IlSatisfiedMismatch {
+                index,
+                expected,
+                got,
+            } => write!(
+                f,
+                "il_satisfied_mismatch[{index}]  expected={expected}  got={got:?}"
+            ),
             FixtureFailure::WrongErrorCode {
                 index,
                 want,
@@ -239,9 +250,11 @@ pub async fn run_fixture(
 
     // 5. Per-payload loop (mirrors test_via_engine.py:124–240)
     for (i, payload) in fix.engine_new_payloads.iter().enumerate() {
-        // `engine_call()` resolves the version and params, appending the
-        // FOCIL inclusion list (and remapping to V6) when present.
-        let (np_version, np_params) = payload.engine_call();
+        // `params` is the full positional argument list for
+        // `engine_newPayloadV{newPayloadVersion}`; V6 fixtures carry the
+        // EIP-7805 inclusion list as the fifth entry.
+        let np_version = payload.new_payload_version;
+        let np_params = &payload.params;
         // zkevm fixtures carry an expected witness per payload: route those
         // through `engine_newPayloadWithWitnessV5` (same params, same status
         // semantics) so the engine-side witness generation is exercised and
@@ -249,9 +262,9 @@ pub async fn run_fixture(
         // == 6) never carry a witness, so the two paths don't overlap.
         let with_witness = np_version == 5 && payload.execution_witness.is_some();
         let resp = if with_witness {
-            Box::pin(harness.new_payload_with_witness(&np_params)).await
+            Box::pin(harness.new_payload_with_witness(np_params)).await
         } else {
-            Box::pin(harness.new_payload(np_version, &np_params)).await
+            Box::pin(harness.new_payload(np_version, np_params)).await
         }
         .map_err(|e| FixtureFailure::PayloadRpc {
             index: i,
@@ -463,31 +476,9 @@ fn check_payload_response(
         })?
         .to_string();
 
-    // Expected status: VALID / INVALID, or a FOCIL `INCLUSION_LIST_UNSATISFIED`
-    // when the fixture sets an explicit `status`.
+    // Expected status: VALID / INVALID, derived from `validationError`.
     let expected = payload.expected_status();
-    if expected == IL_UNSATISFIED_STATUS {
-        // EIP-7805: `PayloadStatusV2` reports an unsatisfied inclusion list as a
-        // `VALID` payload carrying `inclusionListSatisfied: false` — the block is
-        // valid, the consensus layer just will not attest to it. The fixtures
-        // predate that structure and still name a third status value, so the
-        // fixture's sentinel is checked against the pair that now carries the
-        // same verdict.
-        let satisfied = result
-            .get("inclusionListSatisfied")
-            .and_then(|v| v.as_bool());
-        if status != "VALID" || satisfied != Some(false) {
-            return Err(FixtureFailure::WrongStatus {
-                index,
-                expected: format!("VALID + inclusionListSatisfied=false ({IL_UNSATISFIED_STATUS})"),
-                got: format!("{status} + inclusionListSatisfied={satisfied:?}"),
-                validation_error: result
-                    .get("validationError")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
-            });
-        }
-    } else if status != expected {
+    if status != expected {
         let validation_error = result
             .get("validationError")
             .and_then(|v| v.as_str())
@@ -498,6 +489,30 @@ fn check_payload_response(
             got: status,
             validation_error,
         });
+    }
+
+    // EIP-7805: the fixture's `inclusionListSatisfied` must be matched exactly
+    // by the `PayloadStatusV2` field of the same name (tests-focil-devnet@v0.2.0
+    // release notes). Checked only when the payload is deemed `VALID`:
+    // execution-apis `bogota.md` mandates `inclusionListSatisfied` MUST be
+    // `null` for any other status, yet the fill records the transition tool's
+    // internal verdict (trivially `true`: every such fixture carries an empty
+    // list) on `INVALID` payloads too. Matching those would force a client to
+    // violate the API spec the release notes themselves cite as the field's
+    // definition, so on `INVALID` payloads the artifact is ignored.
+    if status == "VALID"
+        && let Some(expected_sat) = payload.inclusion_list_satisfied
+    {
+        let got = result
+            .get("inclusionListSatisfied")
+            .and_then(|v| v.as_bool());
+        if got != Some(expected_sat) {
+            return Err(FixtureFailure::IlSatisfiedMismatch {
+                index,
+                expected: expected_sat,
+                got,
+            });
+        }
     }
 
     // Expected error code but got success response

--- a/tooling/ef_tests/engine/tests/all.rs
+++ b/tooling/ef_tests/engine/tests/all.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use ef_tests_engine::{EngineFixtureFile, FixtureFailure, RunOptions, render_summary, run_fixture};
+use ef_tests_engine::{
+    EngineFixtureFile, FixtureFailure, RunOptions, render_failures, render_summary, run_fixture,
+};
 use regex::Regex;
 
 // Aggregate fixture counters across all `engine_runner` calls. libtest reports
@@ -190,10 +192,7 @@ fn engine_runner(path: &Path) -> datatest_stable::Result<()> {
         return Ok(());
     }
 
-    let mut report = String::new();
-    for (name, failure) in &failures {
-        writeln!(report, "FAIL {name}: {failure}").expect("write to String is infallible");
-    }
+    let mut report = render_failures(&failures);
     report.push('\n');
     report.push_str(&render_summary(total, passed, skipped, failures.len()));
     if xfail_upstream > 0 {

--- a/tooling/ef_tests/engine/tests/all.rs
+++ b/tooling/ef_tests/engine/tests/all.rs
@@ -2,13 +2,13 @@
 // hundreds). We iterate fixtures serially within the test fn; datatest-stable
 // parallelises across files using libtest. Tune concurrency with RUST_TEST_THREADS.
 
+use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::path::Path;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use ef_tests_engine::{
-    EngineFixtureFile, FixtureFailure, RunOptions, render_failures, render_summary, run_fixture,
-};
+use ef_tests_engine::{EngineFixtureFile, FixtureFailure, RunOptions, render_summary, run_fixture};
 use regex::Regex;
 
 // Aggregate fixture counters across all `engine_runner` calls. libtest reports
@@ -18,6 +18,7 @@ static F_PASSED: AtomicUsize = AtomicUsize::new(0);
 static F_FAILED: AtomicUsize = AtomicUsize::new(0);
 static F_SKIPPED: AtomicUsize = AtomicUsize::new(0);
 static F_FILTERED: AtomicUsize = AtomicUsize::new(0);
+static F_XFAIL_UPSTREAM: AtomicUsize = AtomicUsize::new(0);
 
 #[ctor::dtor]
 fn print_fixture_summary() {
@@ -25,7 +26,8 @@ fn print_fixture_summary() {
     let f = F_FAILED.load(Ordering::Relaxed);
     let s = F_SKIPPED.load(Ordering::Relaxed);
     let fi = F_FILTERED.load(Ordering::Relaxed);
-    let total = p + f + s + fi;
+    let x = F_XFAIL_UPSTREAM.load(Ordering::Relaxed);
+    let total = p + f + s + fi + x;
     if total == 0 {
         return;
     }
@@ -54,13 +56,52 @@ fn print_fixture_summary() {
     };
     eprintln!(
         "\nfixture result: {verdict}. {p} {g}passed{z}; {f} {r}failed{z}; \
-         {s} {y}skipped{z}; {fi} {c}filtered{z}; {total} total",
+         {s} {y}skipped{z}; {fi} {c}filtered{z}; {x} {y}expected-fail (upstream-broken){z}; \
+         {total} total",
     );
 }
 
 // Path patterns: if any pattern is contained in the file path, the file is skipped
 // entirely. Entries are filled in once real failures are classified (Task 4.8).
 const SKIP_PATTERNS: &[&str] = &[];
+
+/// Fixtures the pinned release ships with expectations the EELS spec at the
+/// same tag rejects — see `upstream_broken_fixtures.txt` for the per-class
+/// analysis and citations. Strict on both sides: a listed fixture that passes
+/// is a stale entry and fails the suite; one that fails outside the documented
+/// signature is a real regression and fails the suite.
+static UPSTREAM_BROKEN: OnceLock<HashSet<&'static str>> = OnceLock::new();
+
+fn upstream_broken() -> &'static HashSet<&'static str> {
+    UPSTREAM_BROKEN.get_or_init(|| {
+        include_str!("upstream_broken_fixtures.txt")
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .collect()
+    })
+}
+
+/// The only failure shapes `upstream_broken_fixtures.txt` documents: an
+/// expected-`VALID` payload that ethrex rejects for the header inconsistency
+/// the broken fill baked in (stale `blobGasUsed`, or a block access list over
+/// the EIP-7928 `gas_limit / 2000` item cap).
+fn is_documented_upstream_breakage(e: &FixtureFailure) -> bool {
+    match e {
+        FixtureFailure::WrongStatus {
+            expected,
+            got,
+            validation_error: Some(ve),
+            ..
+        } => {
+            expected == "VALID"
+                && got == "INVALID"
+                && (ve.contains("Blob gas used doesn't match value in header")
+                    || ve.contains("Block access list exceeds gas limit"))
+        }
+        _ => false,
+    }
+}
 
 static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
@@ -107,7 +148,8 @@ fn engine_runner(path: &Path) -> datatest_stable::Result<()> {
     let mut passed = 0usize;
     let mut skipped = 0usize;
     let mut filtered = 0usize;
-    let mut failures: Vec<(String, FixtureFailure)> = Vec::new();
+    let mut xfail_upstream = 0usize;
+    let mut failures: Vec<(String, String)> = Vec::new();
 
     for (name, fixture) in &fixtures {
         if let Some(re) = limit
@@ -118,25 +160,45 @@ fn engine_runner(path: &Path) -> datatest_stable::Result<()> {
         }
         total += 1;
         let result = runtime().block_on(run_fixture(name, fixture, &opts));
+        let listed_broken = upstream_broken().contains(name.as_str());
         match result {
+            Ok(()) if listed_broken => failures.push((
+                name.clone(),
+                "listed in upstream_broken_fixtures.txt but passed; stale entry, remove it"
+                    .to_string(),
+            )),
             Ok(()) => passed += 1,
+            Err(e) if listed_broken && is_documented_upstream_breakage(&e) => xfail_upstream += 1,
+            Err(e) if listed_broken => failures.push((
+                name.clone(),
+                format!(
+                    "listed in upstream_broken_fixtures.txt but failed outside the documented signature: {e}"
+                ),
+            )),
             Err(e) if e.is_skip() => skipped += 1,
-            Err(e) => failures.push((name.clone(), e)),
+            Err(e) => failures.push((name.clone(), e.to_string())),
         }
     }
 
     F_PASSED.fetch_add(passed, Ordering::Relaxed);
     F_SKIPPED.fetch_add(skipped, Ordering::Relaxed);
     F_FILTERED.fetch_add(filtered, Ordering::Relaxed);
+    F_XFAIL_UPSTREAM.fetch_add(xfail_upstream, Ordering::Relaxed);
     F_FAILED.fetch_add(failures.len(), Ordering::Relaxed);
 
     if failures.is_empty() {
         return Ok(());
     }
 
-    let mut report = render_failures(&failures);
+    let mut report = String::new();
+    for (name, failure) in &failures {
+        writeln!(report, "FAIL {name}: {failure}").expect("write to String is infallible");
+    }
     report.push('\n');
     report.push_str(&render_summary(total, passed, skipped, failures.len()));
+    if xfail_upstream > 0 {
+        let _ = write!(report, " ({xfail_upstream} expected-fail upstream-broken)");
+    }
     Err(report.into())
 }
 

--- a/tooling/ef_tests/engine/tests/upstream_broken_fixtures.txt
+++ b/tooling/ef_tests/engine/tests/upstream_broken_fixtures.txt
@@ -1,0 +1,166 @@
+# tests-focil-devnet@v0.2.0 fixtures whose expected verdict contradicts the
+# EELS spec at the same tag: each expects VALID for a block that EELS's own
+# `state_transition` rejects. The harness (tests/all.rs) requires every name
+# below to fail with the documented signature and fails the suite if one
+# passes (stale entry -- remove it) or fails any other way (real regression).
+# Re-derive with: decode the payload, compare `blobGasUsed` (or the BAL item
+# count vs gasLimit/2000) against the block's transactions.
+#
+# 126 x test_blob_txs.py inclusion-list variants -- stale `blobGasUsed`.
+#   The variant generator (`make_hive_fixture`, packages/testing/src/
+#   execution_testing/specs/blockchain.py at tag commit 23b0358c) pops the
+#   last transaction into the inclusion list and clears header_verify /
+#   expected_gas_used / expected_block_access_list, but not
+#   `Block.rlp_modifier`. test_blob_txs.py's `rlp_modifier` pytest fixture
+#   pins Header(blob_gas_used=<sum over the ORIGINAL transaction list>), so
+#   the moved transaction's blob gas stays stamped on the refilled header
+#   (e.g. blobs_per_tx_(1,): zero blob txs remain, header still 0x20000).
+#   EELS raises InvalidBlock when block_output.blob_gas_used !=
+#   block.header.blob_gas_used (src/ethereum/forks/amsterdam/fork.py,
+#   state_transition), so no spec-faithful client can return VALID.
+#   Signature: wrong_status expected=VALID got=INVALID,
+#   validationError="Blob gas used doesn't match value in header".
+#
+# 1 x test_tx_gas_limit inclusion-list variant -- EIP-7928 BAL item cap.
+#   The test pins the block gas limit to 21_000. Emptying the block leaves
+#   its canonical block access list at 25 protocol-level items (six system
+#   contracts and their slots; byte-identical BAL in the original fixture),
+#   over EELS's own cap gas_limit // GasCosts.BLOCK_ACCESS_LIST_ITEM(2000)
+#   = 10 (`validate_block_access_list_gas_limit`, called from `apply_body`
+#   with block_gas_limit = header.gas_limit). No valid block exists for this
+#   variant at that gas limit; the generator should have excluded the test.
+#   Signature: wrong_status expected=VALID got=INVALID,
+#   validationError="Block access list exceeds gas limit, ...".
+#
+# Both defects are invisible to upstream's own EELS-direct consumer: the
+# inclusion-list variants exist only in the engine fixture formats
+# (blockchain_tests_engine and _x; the plain blockchain_tests tree has none),
+# which EELS never executes. Bundle provenance: fixtures/.meta/fixtures.ini ->
+# built from tag commit 23b0358c.
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(1,6,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,2,2,2,2,2,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(2,6,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,3,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,3,3,3,3,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,3,3,3,3,3,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(3,6,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,4,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,4,4,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(4,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,5,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,5,5,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(5,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,4)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,5)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,6)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,6,1)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,6,2)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_insufficient_balance_blob_tx_combinations[fork_Bogota-blobs_per_tx_(6,6,6,3)-blockchain_test_engine_inclusion_list--exact_balance_minus_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_multiple_txs[fork_Bogota-blockchain_test_engine_inclusion_list--multiple_blobs]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_multiple_txs[fork_Bogota-blockchain_test_engine_inclusion_list--multiple_blobs_single_bad_hash_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_multiple_txs[fork_Bogota-blockchain_test_engine_inclusion_list--multiple_blobs_single_bad_hash_2]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_multiple_txs[fork_Bogota-blockchain_test_engine_inclusion_list--single_blob]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_single_tx[fork_Bogota-blockchain_test_engine_inclusion_list_from_state_test--multiple_blobs]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_single_tx[fork_Bogota-blockchain_test_engine_inclusion_list_from_state_test--multiple_blobs_single_bad_hash_1]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_single_tx[fork_Bogota-blockchain_test_engine_inclusion_list_from_state_test--multiple_blobs_single_bad_hash_2]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_blob_hash_versioning_single_tx[fork_Bogota-blockchain_test_engine_inclusion_list_from_state_test--single_blob]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_block_blob_count[fork_Bogota-blobs_per_tx_(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)-blockchain_test_engine_inclusion_list-]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_block_blob_count[fork_Bogota-blobs_per_tx_(1,21)-blockchain_test_engine_inclusion_list-]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_block_blob_count[fork_Bogota-blobs_per_tx_(22,)-blockchain_test_engine_inclusion_list-]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_block_blob_count[fork_Bogota-blobs_per_tx_(6,16)-blockchain_test_engine_inclusion_list-]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_block_blob_count[fork_Bogota-blobs_per_tx_(6,6,5,5)-blockchain_test_engine_inclusion_list-]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_block_blob_count[fork_Bogota-blobs_per_tx_(6,6,6,4)-blockchain_test_engine_inclusion_list-]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_normal_gas[fork_Bogota-blockchain_test_engine_inclusion_list_from_state_test-insufficient_max_fee_per_gas]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_tx_blob_count[fork_Bogota-too_many_blobs-blockchain_test_engine_inclusion_list_from_state_test]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_tx_max_fee_per_blob_gas[fork_Bogota-insufficient_max_fee_per_blob_gas-blockchain_test_engine_inclusion_list-account_balance_modifier_1000000000]
+tests/cancun/eip4844_blobs/test_blob_txs.py::test_invalid_tx_max_fee_per_blob_gas[fork_Bogota-invalid_max_fee_per_blob_gas-blockchain_test_engine_inclusion_list-account_balance_modifier_1000000000]
+tests/frontier/validation/test_transaction.py::test_tx_gas_limit[fork_Bogota-blockchain_test_engine_inclusion_list]


### PR DESCRIPTION
**Motivation**

[`tests-focil-devnet@v0.2.0`](https://github.com/ethereum/execution-specs/releases/tag/tests-focil-devnet%40v0.2.0) is out — the third FOCIL (EIP-7805) Devnet 0 release, renaming the tag stream from `tests-focil@`. It claims three things: every fixture now fills on the `"Bogota"` network whose Amsterdam base is glamsterdam-devnet-8 (what this branch implements — the previous pin, `tests-focil@v0.1.0`, was filled on an older base whose genesis lacked the EIP-8282 predeploys, so its 24 fixtures could not pass here *by spec*); the engine fixture format drops the draft `INCLUSION_LIST_UNSATISFIED` sixth status for a per-payload `inclusionListSatisfied: Optional[bool]` mirroring `PayloadStatusV2`; and it adds auto-generated inclusion-list variants of prior-fork tests ([specs#3337](https://github.com/ethereum/execution-specs/pull/3337)) that caught three spec bugs in `check_inclusion_list_transactions` itself.

**Description**

*Pin* — `tooling/ef_tests/engine/.fixtures_url_focil` moves to the v0.2.0 tarball (the only pin on this stream; there is no hive focil config yet). The engine Makefile's long "why v0.1.0 cannot pass here" comment is replaced by a note recording that this re-pin aligned the fill base exactly as that analysis predicted; the refill patch it referenced was never committed.

*Engine runner* (`fixture.rs`, `runner.rs`) — adopts the release's fixture schema, mirroring EEST's `test_via_engine.py` at the tag:

- `status` / `INCLUSION_LIST_UNSATISFIED` handling removed; expected status is again derived purely from `validationError` (the release removed the sixth status).
- `inclusionListSatisfied` is matched **exactly** against `PayloadStatusV2` ("must be exactly equal", per the release notes) via a dedicated `IlSatisfiedMismatch` failure.
- A `VALID`-but-unsatisfied payload now gets the follow-up FCU (the old sentinel skipped it; EEST sends it for every valid payload).
- The legacy sibling `inclusionListTransactions` shape and the `engine_call` remap are gone: every v0.2.0 payload carries the IL as the fifth positional `engine_newPayloadV6` param.
- Fixtures name `Bogota` as the network, so `hegotaTime` (ethrex's name for the fork) joins the generated chain-config time forks and the `is_focil()` bridge that aliased `amsterdamTime` is deleted.

One deliberate divergence from EEST's consumer, documented inline in `check_payload_response`: the fixture records the transition tool's internal IL verdict on **`INVALID`** payloads too (always the trivially-true verdict of an empty list — 5,516 payloads in the bundle), and EEST's consumer checks it there. But execution-apis [`bogota.md`](https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md#payloadstatusv2) — the spec the release notes themselves cite as the field's definition — mandates `inclusionListSatisfied` **MUST be `null`** unless the payload is deemed `VALID`. A `bogota.md`-compliant client cannot satisfy the consumer on those payloads, so the runner matches the field only on expected-`VALID` payloads and ignores the transition-tool artifact on `INVALID` ones. ethrex stays `bogota.md`-compliant.

*Client* (`inclusion_list_validator.rs`, plus `get_code` on `IlStateProvider`) — the release rewrote EELS `check_inclusion_list_transactions` (`forks/amsterdam/fork.py`): a missing IL transaction is excused **iff** the exact gates of block inclusion (`validate_transaction` + `check_transaction`) reject it. Each ethrex change cites the mandating spec hunk:

| change | mandating spec change (v0.1.0 → v0.2.0 diff / release notes) |
|---|---|
| chain-id gate (skipped for pre-EIP-155 legacy) | new `chain_id(tx) != block_env.chain_id → excused` ("Transactions with incorrect chain-id were still considered includable" spec fix) |
| blob txs evaluated like any other type | old blanket `isinstance(tx, BlobTransaction) → continue` deleted ("Type-3 transactions were considered not-includable by default" spec fix) |
| blob gates: count ∈ [1, 6], KZG versioned-hash prefix, blob fee ≥ block blob gas price, tx blob gas ≤ remaining `BLOB_SCHEDULE_MAX × GAS_PER_BLOB − blob_gas_used` budget | `validate_transaction` blob checks + `check_max_fee_per_blob_gas` + `check_block_gas_capacity`'s blob dimension, all newly reachable once the blob skip fell |
| EIP-2681 `nonce == u64::MAX` gate | `validate_transaction`: `nonce >= 2**64−1 → NonceOverflowError` |
| oversized-initcode gate (EIP-7954 Amsterdam cap 131,072, matching EELS `MAX_INIT_CODE_SIZE = 2 × 0x10000` at the tag) | `validate_transaction`: `InitCodeTooLargeError` |
| priority-fee-above-cap gate | `validate_transaction`: `PriorityFeeGreaterThanMaxFeeError` |
| empty EIP-7702 authorization-list gate | `validate_transaction`: `EmptyAuthorizationListError` |
| intrinsic-gas ceiling at `TX_MAX_GAS_LIMIT` (16,777,216) | `validate_transaction`: intrinsic execution/floor `> TX_MAX_GAS_LIMIT → InsufficientTransactionGasError` |
| EIP-3607 sender-is-not-an-EOA gate (new `IlStateProvider::get_code`; tracker snapshots `(nonce, balance, code)`) | `check_transaction`: `code_hash != EMPTY && not is_valid_delegation → InvalidSenderError` |
| same-block withdrawal credits discounted from the refreshed balances before the check (`discount_withdrawals`, both satisfaction-check entry points) | `apply_body` runs `check_inclusion_list_transactions` **between** the block's transactions and `process_withdrawals`, so the check sees pre-withdrawals balances; a sender funded only by a same-block withdrawal is not includable (caught by `test_use_value_in_tx[tx_in_withdrawals_block]`'s inclusion-list variant) |

The RLP-decode-tolerant IL handler ethrex already had is what the release's remaining spec fix ("incorrect RLP caused an exception in the validator") converged on — no change needed there. The EIP-8141 frame-transaction skip stays: EELS has no frame type, so IL eligibility for frames is unspecified and an ineligible transaction is excused. Unit tests pin every new gate with an excused case and, where the verdict flips, an includable control.

*127 fixtures the release ships broken* — the only other engine failures are not ethrex divergences but fixtures whose expected verdict contradicts the EELS spec **at the same tag**. They are enumerated with the full analysis in `tooling/ef_tests/engine/tests/upstream_broken_fixtures.txt`, and the harness holds them to it strictly: each listed fixture must fail with exactly the documented signature — one that passes (stale entry) or fails any other way fails the suite, so a future re-pin that fixes them upstream cannot be silently absorbed.

- **126 blob-transaction inclusion-list variants** (`test_blob_txs.py`, expected `VALID`): the variant generator (`make_hive_fixture`, `packages/testing/src/execution_testing/specs/blockchain.py`) pops the last transaction into the inclusion list and clears `header_verify`/`expected_gas_used`/`expected_block_access_list` — but not `Block.rlp_modifier`. That file's `rlp_modifier` pytest fixture pins `Header(blob_gas_used=…)` computed over the *original* transaction list, so every variant ships the moved transaction's blob gas in its header (`blobs_per_tx_(1,)`: zero blob txs remain, header still `0x20000`; every `invalid_block_blob_count` variant retains `0x2c0000` whether 0, 1, 3 or 21 txs remain). EELS itself raises `InvalidBlock` when `block_output.blob_gas_used != block.header.blob_gas_used` (`state_transition`, `src/ethereum/forks/amsterdam/fork.py`), so the expected `VALID` is unsatisfiable; ethrex correctly answers `INVALID` ("Blob gas used doesn't match value in header").
- **1 `test_tx_gas_limit` inclusion-list variant** (expected `VALID`): the test pins the block gas limit to 21,000, and emptying the block still leaves its canonical block access list at 25 protocol-level items (six system contracts and their slots; byte-identical to the original fixture's BAL) — over EELS's own EIP-7928 cap `gas_limit // GasCosts.BLOCK_ACCESS_LIST_ITEM(2000) = 10` (`validate_block_access_list_gas_limit`, called from `apply_body` with the header gas limit). No valid block exists for this variant at that gas limit; ethrex correctly answers `INVALID`.

Both defects are invisible to upstream's own consumers because inclusion-list variants exist only in the engine fixture formats (`blockchain_tests_engine` and `_x`; the plain `blockchain_tests` tree has none), which EELS never executes directly — a client that fully validates blocks is the first thing to run them. Bundle provenance is pinned in the analysis (`.meta/fixtures.ini` → filled from the tag commit `23b0358c`). No upstream issue exists yet; this should be reported against ethereum/execution-specs. Accepting these blocks instead would mean disabling EIP-4844 `blobGasUsed` header validation and the EIP-7928 BAL size cap — consensus rules — to satisfy a broken fill.

*One base-branch failure fixed to get CI green* — `fixtures/genesis/native_l2.json` gains the `blobSchedule.amsterdam` entry (`max 21`, `target 14`, `baseFeeUpdateFraction 11684671`) that [#7094](https://github.com/lambdaclass/ethrex/pull/7094) already pins on `main`. This is unrelated to the bump and predates this branch — `git diff origin/focil-devnet-0..HEAD -- crates/common fixtures` was empty before this commit — but it is the whole of the red `Test` check. Since 671f2028f ("inherit the blob schedule at Amsterdam instead of pinning BPO2", on the devnet branches only) a named fork inherits the highest *activated* BPO entry rather than BPO2 unconditionally, and this genesis activates Amsterdam at timestamp 0 while scheduling no BPO and pinning no `amsterdam` entry, so its parameters resolve to Prague's 9/6 and `native_l2_genesis_activates_amsterdam` fails asserting 21. That single failing test aborts the `ubuntu-22.04` unit-test leg, fail-fast cancels the `ubuntu-22.04-arm` and `macos-15` legs, and the required-check aggregator then fails with a message that names Assertoor (a copy-paste string in `.github/workflows/pr-main_l1.yaml`, not an Assertoor failure). The entry is the only difference between `main`'s copy of the file and this branch's, so it is taken verbatim rather than by relaxing the assertion. Pinning it *restores* this genesis's parameters rather than changing them: before 671f2028f the resolution ended in `if is_bpo2_activated(ts) || is_amsterdam_activated(ts) { bpo2 }`, so the file was already running on BPO2's 21/14 — the same numbers `main` pins and the test asserts. Relaxing the assertion to 9 would have silently kept the regression.

**Verified the release's claims rather than assuming them.** `git diff tests-focil@v0.1.0..tests-focil-devnet@v0.2.0 -- src/ethereum/forks/amsterdam` is 34 files, +2506/−1440 — almost all of it the fill-base rebase onto glamsterdam-devnet-8's Amsterdam, which this branch already implements (merged earlier from `origin/glamsterdam-devnet-8`). The FOCIL-specific delta is exactly the release notes' three spec fixes plus the verdict moving from a raise to `block_output.inclusion_list_satisfied: bool` (which is what replaced the sixth status in the fixture format). Two footnotes from reading the tag: the new `check_inclusion_list_transactions` **docstring** still says "Blob transactions are excluded from this check" — stale doc, the code has no blob skip and the release notes call the old skip a bug; and a `tests-focil@v0.2.0` tag exists pointing at a *different* commit than `tests-focil-devnet@v0.2.0` — the pin follows the tag the release was published under.

**How to test**

```
make -C tooling/ef_tests/engine test
make -C tooling/ef_tests/blockchain test-levm

# what the red `Test - <runner>` legs run, in their order
cargo test --workspace --exclude 'ethrex-l2*' --exclude ethrex-prover --exclude ethrex-guest-program
make -C tooling/ef_tests/blockchain test
```

Results on this branch (every suite run locally at the head commit):

| suite | result |
|---|---|
| engine | 14,112/14,112 test files — fixtures: 102,073 passed · 0 failed · 127 expected-fail (upstream-broken) · 102,200 total (156.7 s) |
| blockchain (levm) | 14,864 passed · 0 failed (101.1 s) — unaffected by the pin (it consumes the glamsterdam bundles); guards the client-side validator and withdrawal changes against regressions |
| blockchain (stateless) | 3,138 passed · 0 failed (2.1 s) — the second half of CI's `make -C tooling/ef_tests/blockchain test`, which no CI leg reached |
| workspace unit tests | 47 test binaries · 1,964 passed · 0 failed — CI's own command, run to the end: its ubuntu leg aborts at the first failing binary, so everything after `ethrex-common` (and the blockchain EF step that follows it) was unverified upstream |

The engine count includes the release's `for_bogota` subtree (3,108 files / 26,689 fixtures / 32,776 payloads — among them 828 expected-`unsatisfied` and 1,077 expected-`satisfied` non-empty-inclusion-list payloads, all green), which previously contributed 24 expected-fail fixtures from the stale v0.1.0 fill. The 127 expected-fails are exactly the enumerated upstream-broken fixtures — the harness fails the suite if any of them passes or fails outside its documented signature.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` (3) is untouched: the validator's tracker is in-memory block-execution state, `get_code` reads the existing account-code table, and the runner/fixture changes are test tooling.
