### PR TITLE
docs(l2): fix stale zkevm_bench README commands and gitignore ZisK run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,13 @@ openspec/
 dev_ethrex_l1/
 dev_ethrex_l2/
 
+# ZisK backend run artifacts: the backend writes the guest ELF and its proof
+# output next to the crate manifest (see crates/prover/src/backend/zisk.rs),
+# so any zisk execute/prove/bench run dirties the tree. Its zisk_input.bin
+# sibling is already covered by *.bin above.
+crates/prover/zkvm-zisk-program
+crates/prover/zisk_output/
+
 # Logs
 logs/
 

--- a/tooling/zkevm_bench/README.md
+++ b/tooling/zkevm_bench/README.md
@@ -42,10 +42,14 @@ any invocation directory (see [Running](#running) below).
    make zkevm-bench-setup
    ```
 
-   This installs ZisK's apt build dependencies and runs `ziskup -v 1.1.0-alpha`
-   with `--nokey`, which skips downloading the (large) proving key —
-   emulation via `ziskemu` doesn't need it. Afterwards, add `~/.zisk/bin` to
-   `PATH` (it provides `ziskemu`):
+   This installs ZisK's apt build dependencies, runs `ziskup -v 1.1.0-alpha`
+   with `--nokey` (skipping the large proving key, which emulation via
+   `ziskemu` doesn't need), and pins the zisk Rust toolchain to the same
+   release CI uses (`zisk-3.0.0` at the time of writing; the root `Makefile`
+   is the source of truth) so a locally built guest links the same way as
+   CI's. Afterwards, add
+   `~/.zisk/bin` to `PATH` (it provides both `ziskemu` and the `cargo-zisk`
+   the build needs):
 
    ```bash
    export PATH="$HOME/.zisk/bin:$PATH"
@@ -64,17 +68,33 @@ any invocation directory (see [Running](#running) below).
 
 ## Build
 
-Build from the repo root:
+Select the crate by manifest path, which works from any cwd (e.g. the repo
+root):
 
 ```bash
-cargo build -p ethrex-zkevm-bench --features zisk-elf
+cargo build --manifest-path tooling/zkevm_bench/Cargo.toml --features zisk-elf
 ```
 
-`tooling/zkevm_bench` is a member of the root workspace, but `tooling/`
-itself also has its own nested workspace (`tooling/Cargo.toml`, used by
-`ef_tests`, `load_test`, etc.) that does *not* include this crate. Running
-cargo from inside `tooling/` picks up that nested workspace instead and
-won't find `ethrex-zkevm-bench` — always invoke cargo from the repo root.
+`tooling/zkevm_bench` is a **standalone workspace** with its own
+`Cargo.lock`. It sits in the root workspace's `exclude` list (see the comment
+in the root `Cargo.toml`) because it hard-depends on zisk's x86-64-only
+`lib-c`, and `tooling/`'s own nested workspace (`tooling/Cargo.toml`, used by
+`ef_tests`, `load_test`, etc.) doesn't include it either. So no plain
+workspace invocation finds it: `-p ethrex-zkevm-bench` from the repo root
+fails with `error: cannot specify features for packages outside of
+workspace`, and a bare `cargo build` inside `tooling/` picks up the nested
+workspace instead. Always point cargo at the manifest (as the root
+`Makefile` does), or `cd tooling/zkevm_bench` and build there.
+
+Being its own workspace, it also has its own target directory: the binary
+lands at `tooling/zkevm_bench/target/debug/ethrex-zkevm-bench`, not under
+the root `target/`.
+
+The ZisK toolchain has to be on `PATH` at **build** time, not just at run
+time: the `zisk-build-elf` build script shells out to `cargo-zisk`
+(`crates/guest-program/build.rs`), and without it the build panics with
+`Failed to execute zisk build command: ... NotFound`. Export
+`PATH="$HOME/.zisk/bin:$PATH"` as in [Setup](#setup) above before building.
 
 The `zisk-elf` feature enables `ethrex-guest-program/{zisk-build-elf,ci}`:
 `zisk-build-elf` compiles the guest program to the zisk RISC-V target and
@@ -88,7 +108,7 @@ Workload `source` paths in the manifest resolve relative to the manifest
 file itself, so `run` can be invoked from any cwd — e.g. from the repo root:
 
 ```bash
-cargo run -p ethrex-zkevm-bench --features zisk-elf -- run \
+cargo run --manifest-path tooling/zkevm_bench/Cargo.toml --features zisk-elf -- run \
   --mode quick \
   --workloads tooling/zkevm_bench/fixtures/manifest.toml \
   --out r.json
@@ -96,7 +116,12 @@ cargo run -p ethrex-zkevm-bench --features zisk-elf -- run \
 
 No `cd` into `tooling/zkevm_bench` needed. The examples below assume the
 binary has already been built (see [Build](#build)) and invoke it directly
-from the repo root as `./target/debug/ethrex-zkevm-bench`.
+from the repo root as `./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench`.
+
+`run` also accepts `--filter <substring>`, which keeps only workloads whose
+name matches, and `--strict-elf`, which fails immediately when the embedded
+guest ELF is empty (the binary was built without `--features zisk-elf`)
+instead of writing a report with every workload `guest_output_ok: false`.
 
 ### Tiered modes (`--mode`)
 
@@ -118,11 +143,11 @@ Each workload in the manifest declares an optional `tier` (`quick` or
 the narrower ones.
 
 ```bash
-./target/debug/ethrex-zkevm-bench run \
+./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench run \
   --workloads tooling/zkevm_bench/fixtures/manifest.toml \
   --mode quick --out quick.json
 
-./target/debug/ethrex-zkevm-bench run \
+./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench run \
   --workloads tooling/zkevm_bench/fixtures/manifest.toml \
   --mode slow --stress-dir /path/to/generated-stress --out slow.json
 ```
@@ -130,7 +155,7 @@ the narrower ones.
 ### Compare two reports (regression gate)
 
 ```bash
-./target/debug/ethrex-zkevm-bench compare baseline.json report.json
+./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench compare baseline.json report.json
 ```
 
 Matches workloads by name, diffs `air_cost.total`, and exits `1` if any
@@ -140,7 +165,7 @@ diff.json` to also write the per-workload deltas as JSON.
 ### Curate real-block fixtures
 
 ```bash
-./target/debug/ethrex-zkevm-bench curate --cache-dir <dir-of-cache_mainnet_*.json> --out curation.json [--ziskemu]
+./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench curate --cache-dir <dir-of-cache_mainnet_*.json> --out curation.json [--ziskemu]
 ```
 
 Scans a directory of ethrex-replay `cache_mainnet_*.json` files, records
@@ -179,6 +204,11 @@ AIR-cost breakdown. Used to select which blocks to commit as fixtures (see
   ]
 }
 ```
+
+`meta.zisk_version` is read from `ziskemu --version` at run time; when
+`ziskemu` isn't on `PATH` (or its output can't be parsed) the run warns and
+records the `v1.0.0-alpha` fallback, so that value in a report can also mean
+"detection failed" rather than "that toolchain produced it".
 
 `air_cost.total` equals the sum of `base + main + opcodes + precompiles +
 memory`. The example above is a real, verified `mainnet_25087668_light` run.
@@ -245,7 +275,7 @@ is generated on demand rather than committed:
    tool, no zisk toolchain):
 
    ```bash
-   ./target/debug/ethrex-zkevm-bench generate-stress \
+   ./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench generate-stress \
      --input-dir <extracted>/blockchain_tests \
      --out-dir <stress-dir>
    ```


### PR DESCRIPTION
**Motivation**

`tooling/zkevm_bench` became a standalone workspace (it's in the root workspace's `exclude` list, since it hard-depends on x86-64-only zisk), but its README still documents the old root-workspace invocations. Following the README top to bottom currently fails at the very first build step:

```
$ cargo build -p ethrex-zkevm-bench --features zisk-elf
error: cannot specify features for packages outside of workspace
```

and every subsequent example points at `./target/debug/ethrex-zkevm-bench`, while a standalone workspace builds into `tooling/zkevm_bench/target/debug/` instead. The root `Makefile` already uses `--manifest-path` for this crate (`cargo tree` / `cargo metadata` targets); the README just never caught up.

Walking those steps also surfaced that a zisk run dirties the working tree, so the two artifact paths it writes are now gitignored.

**Description**

README (`tooling/zkevm_bench/README.md`):

- Build/run examples now select the crate with `--manifest-path tooling/zkevm_bench/Cargo.toml` and reference the binary at `tooling/zkevm_bench/target/debug/ethrex-zkevm-bench` (5 call sites).
- Rewrote the workspace explanation: it's excluded from the root workspace with its own `Cargo.lock`, so neither `-p` from the root nor a bare build inside `tooling/` resolves it, and it has its own target directory.
- Added the build-time `PATH` requirement: `zisk-build-elf` shells out to `cargo-zisk` from `crates/guest-program/build.rs`, so without `~/.zisk/bin` on `PATH` the build panics with `Failed to execute zisk build command: ... NotFound` rather than anything mentioning zisk.
- Documented `run`'s `--filter` and `--strict-elf` flags (`--strict-elf` is the guard against silently producing an all-`guest_output_ok: false` report from a binary built without `--features zisk-elf`).
- Noted that `meta.zisk_version` comes from `ziskemu --version` at run time and falls back to `v1.0.0-alpha` with a warning when `ziskemu` isn't on `PATH`, so that value alone doesn't attribute a report to that toolchain.
- Mentioned that `make zkevm-bench-setup` also pins the zisk Rust toolchain, since that's what keeps a local guest linking like CI's.

`.gitignore`:

- Ignore `crates/prover/zkvm-zisk-program` and `crates/prover/zisk_output/`. `ZiskBackend` writes the guest ELF and its proof output next to the crate manifest (`CARGO_MANIFEST_DIR` consts in `crates/prover/src/backend/zisk.rs`), so a benchmark run or any zisk execute/prove leaves the tree dirty and invites committing a build artifact. The `zisk_input.bin` sibling was already covered by the existing `*.bin` rule; these two weren't.

No code changes.

**Verification**

Walked the corrected commands on the branch. The fixed build command gets all the way through the dependency graph and the `--manifest-path` form is confirmed correct; on a machine without the ZisK toolchain it stops exactly where the new note says it will:

```
error: failed to run custom build command for `ethrex-guest-program`
  panicked at crates/guest-program/build.rs:168:
  Failed to execute zisk build command: Os { code: 2, kind: NotFound }
```

Building without `--features zisk-elf` succeeds, and the resulting binary loads the manifest, resolves fixtures and writes a report from the repo root, so the corrected paths and flags are exercised end to end:

```
$ ./tooling/zkevm_bench/target/debug/ethrex-zkevm-bench run \
    --workloads tooling/zkevm_bench/fixtures/manifest.toml \
    --mode quick --filter light --strict-elf --out strict.json
Error: guest ELF is empty — build with `--features zisk-elf` or every workload will fail (guest_output_ok=false)
```

That run is also what produced the stray `crates/prover/zkvm-zisk-program`; both new ignore rules were checked with `git check-ignore -v` against the real paths.

Real AIR-cost numbers still need a Linux x86-64 box with the ZisK toolchain installed; this was run on macOS/arm64, so no benchmark figures are claimed here.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.