### PR TITLE
refactor(l1): factor the repeated RocksDB column-family lookups into one helper

### DIFF
--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -54,6 +54,16 @@ impl std::fmt::Debug for RocksDBBackend {
     }
 }
 
+/// Resolves a table's column family handle, erroring if the CF is missing.
+/// The handle borrows `db`, so the caller's borrow decides its lifetime.
+fn cf_handle<'a>(
+    db: &'a DBWithThreadMode<MultiThreaded>,
+    table: &str,
+) -> Result<Arc<rocksdb::BoundColumnFamily<'a>>, StoreError> {
+    db.cf_handle(table)
+        .ok_or_else(|| StoreError::Custom(format!("Table {table} not found")))
+}
+
 /// Extracts a RocksDB statistics ticker value from a `get_statistics()` dump.
 /// Ticker lines look like `rocksdb.block.cache.hit COUNT : 12345`.
 fn parse_stats_ticker(stats: &str, ticker: &str) -> u64 {
@@ -354,10 +364,7 @@ impl Drop for RocksDBBackend {
 
 impl StorageBackend for RocksDBBackend {
     fn clear_table(&self, table: &'static str) -> Result<(), StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom("Column family not found".to_string()))?;
+        let cf = cf_handle(&self.db, table)?;
 
         let mut iter = self.db.iterator_cf(&cf, rocksdb::IteratorMode::Start);
         let mut batch = WriteBatch::default();
@@ -451,9 +458,7 @@ impl StorageBackend for RocksDBBackend {
     ) -> Result<Box<dyn StorageLockedView>, StoreError> {
         let db = Box::leak(Box::new(self.db.clone()));
         let lock = db.snapshot();
-        let cf = db
-            .cf_handle(table_name)
-            .ok_or_else(|| StoreError::Custom(format!("Table {} not found", table_name)))?;
+        let cf = cf_handle(db, table_name)?;
 
         Ok(Box::new(RocksDBLocked { db, lock, cf }))
     }
@@ -496,10 +501,7 @@ pub struct RocksDBReadTx {
 
 impl StorageReadView for RocksDBReadTx {
     fn get(&self, table: &'static str, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {} not found", table)))?;
+        let cf = cf_handle(&self.db, table)?;
 
         self.db
             .get_cf(&cf, key)
@@ -533,10 +535,7 @@ impl StorageReadView for RocksDBReadTx {
         table: &'static str,
         prefix: &[u8],
     ) -> Result<Box<dyn Iterator<Item = PrefixResult> + '_>, StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {} not found", table)))?;
+        let cf = cf_handle(&self.db, table)?;
 
         let iter = self.db.prefix_iterator_cf(&cf, prefix).map(|result| {
             result.map_err(|e| StoreError::Custom(format!("Failed to iterate: {e}")))
@@ -545,10 +544,7 @@ impl StorageReadView for RocksDBReadTx {
     }
 
     fn first_key(&self, table: &'static str) -> Result<Option<Vec<u8>>, StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {table} not found")))?;
+        let cf = cf_handle(&self.db, table)?;
         let mut iter = self.db.iterator_cf(&cf, rocksdb::IteratorMode::Start);
         match iter.next() {
             Some(Ok((k, _))) => Ok(Some(k.to_vec())),
@@ -558,10 +554,7 @@ impl StorageReadView for RocksDBReadTx {
     }
 
     fn last_key(&self, table: &'static str) -> Result<Option<Vec<u8>>, StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {table} not found")))?;
+        let cf = cf_handle(&self.db, table)?;
         let mut iter = self.db.iterator_cf(&cf, rocksdb::IteratorMode::End);
         match iter.next() {
             Some(Ok((k, _))) => Ok(Some(k.to_vec())),
@@ -581,10 +574,7 @@ pub struct RocksDBWriteTx {
 
 impl StorageWriteBatch for RocksDBWriteTx {
     fn put(&mut self, table: &'static str, key: &[u8], value: &[u8]) -> Result<(), StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {table:?} not found")))?;
+        let cf = cf_handle(&self.db, table)?;
         self.batch.put_cf(&cf, key, value);
         Ok(())
     }
@@ -596,10 +586,7 @@ impl StorageWriteBatch for RocksDBWriteTx {
         table: &'static str,
         batch: Vec<(Vec<u8>, Vec<u8>)>,
     ) -> Result<(), StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {table:?} not found")))?;
+        let cf = cf_handle(&self.db, table)?;
 
         for (key, value) in batch {
             self.batch.put_cf(&cf, key, value);
@@ -608,10 +595,7 @@ impl StorageWriteBatch for RocksDBWriteTx {
     }
 
     fn delete(&mut self, table: &'static str, key: &[u8]) -> Result<(), StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {} not found", table)))?;
+        let cf = cf_handle(&self.db, table)?;
 
         self.batch.delete_cf(&cf, key);
         Ok(())
@@ -623,10 +607,7 @@ impl StorageWriteBatch for RocksDBWriteTx {
         start: &[u8],
         end: &[u8],
     ) -> Result<(), StoreError> {
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {table:?} not found")))?;
+        let cf = cf_handle(&self.db, table)?;
         self.batch.delete_range_cf(&cf, start, end);
         Ok(())
     }
@@ -641,10 +622,7 @@ impl StorageWriteBatch for RocksDBWriteTx {
                 "merge not supported for table {table} (no merge operator registered)"
             )));
         }
-        let cf = self
-            .db
-            .cf_handle(table)
-            .ok_or_else(|| StoreError::Custom(format!("Table {} not found", table)))?;
+        let cf = cf_handle(&self.db, table)?;
 
         self.batch.merge_cf(&cf, key, operand);
         Ok(())


### PR DESCRIPTION
**Motivation**

`crates/storage/backend/rocksdb.rs` resolved a table's column family with the same four-line incantation in eleven different places — `self.db.cf_handle(table).ok_or_else(|| StoreError::Custom(format!(...)))?` — and the eleven copies had already drifted into four different error strings for the identical failure: `"Column family not found"` (no table name at all, in `clear_table`), `format!("Table {} not found", table)`, `format!("Table {table} not found")`, and `format!("Table {table:?} not found")`. That is 43 lines saying one thing, and the drift is the liability: every new backend method copies whichever neighbour it was pasted from, so the next reader cannot tell whether the phrasing differences are meaningful (they are not), and a caller trying to diagnose a missing CF gets a different message depending on which entry point it came through — including one with no table name in it.

**Description**

Added one private module-level free function next to the file's other helpers, and replaced all eleven copies with a one-line call:

```rust
fn cf_handle<'a>(
    db: &'a DBWithThreadMode<MultiThreaded>,
    table: &str,
) -> Result<Arc<rocksdb::BoundColumnFamily<'a>>, StoreError> {
    db.cf_handle(table)
        .ok_or_else(|| StoreError::Custom(format!("Table {table} not found")))
}
```

Call sites converted: `clear_table`, `begin_locked`, `RocksDBReadTx::{get, prefix_iterator, first_key, last_key}`, `RocksDBWriteTx::{put, put_batch, delete, delete_range, merge}`. Net −25 lines of code in one file (21 insertions / 43 deletions; blank and comment-only lines excluded from the count), no other file touched.

Three `cf_handle` uses were deliberately left alone because they are not this pattern: `db_stats` (`let Some(cf) = ... else { continue }` — missing CFs are skipped on purpose, not an error), `flush` (`if let Some(cf)` — same, best-effort per-CF flush), and `multi_get`, which has to fan a single lookup failure out into one `Err` per key and therefore needs the message string rather than a `Result` (`StoreError` is not `Clone`).

Invariants preserved, and how:

- The helper takes an explicit lifetime `'a` tying the returned handle to the `db` borrow. The elided `'_` form does not compile here (E0106: a return type needs a named lifetime when the signature has more than one candidate input).
- `begin_locked` passes the *leaked* `db`, not `&self.db`. `RocksDBLocked.cf` is declared `Arc<BoundColumnFamily<'static>>`, which only the `&'static mut Arc<DB>` from `Box::leak` can satisfy; borrowing `&self.db` there would tie the handle to `&self` and fail to compile.
- The `Box::leak` / `impl Drop for RocksDBLocked` pairing is untouched. The helper only *borrows* `db` — it never takes ownership and never clones the `Arc` — so the pointer stored in `RocksDBLocked.db` is still exactly the leaked allocation that `Drop` reconstructs with `Box::from_raw`, and the `Arc` strong count is unchanged.
- Error phrasing is unified on `format!("Table {table} not found")`, which keeps the table name in every message (it strictly *adds* information to `clear_table`, which previously omitted it) and drops the `{:?}` debug quoting. This changes only the `Display` text of `StoreError::Custom` on the missing-CF path; nothing in the workspace matches on that text — a grep for the old strings and for string-comparison patterns (`contains` / `starts_with` / `==` / `matches!`) over `.rs` outside `target/` returns no consumers, only producers. The observable effect is log output.
- `STORE_SCHEMA_VERSION` and every on-disk/RLP shape are untouched: no key, value, CF name, or encoding changed.

If this change were wrong, one of these would have to be true:

- Some caller distinguishes the four old messages from each other — but no code in the workspace reads `StoreError::Custom`'s string at all, only constructs it.
- One of the eleven sites needed a *different* fallback than "error out" — but each one was already `?`-propagating the same `StoreError::Custom`; the three sites with a genuinely different policy (skip, best-effort, per-key error) were left as they were.
- The helper widened or narrowed a lifetime — but the returned handle is tied to the passed `&'a DBWithThreadMode`, exactly what `db.cf_handle(...)` returned before, and the one site that needs `'static` (`begin_locked`) gets it from the leaked reference, which the compiler checks.
- The helper changed the `Arc<DB>` refcount seen by `RocksDBLocked::drop` — but it takes `&DBWithThreadMode`, reached by deref coercion, so no `Arc` is cloned.

**How to test**

```
cargo fmt -p ethrex-storage -- --check                                        # clean
cargo check -p ethrex-storage --features rocksdb --all-targets                # Finished, no warnings
cargo check -p ethrex-storage                                                 # (feature off) Finished, no warnings
cargo clippy -p ethrex-storage --features rocksdb --all-targets -- -D warnings # exit 0, no warnings
cargo clippy --all-targets -- -D warnings                                     # workspace, exit 0, no warnings
cargo test -p ethrex-storage --features rocksdb                               # 93 passed; 0 failed (+ doc-tests 1 passed; 1 ignored)
```

Building with `--features rocksdb` is required to compile this module at all, since it sits behind `#[cfg(feature = "rocksdb")]` — a default build type-checks none of it.

The two RocksDB-backend integration tests that drive a real on-disk DB — `backend::rocksdb::tests::merge_operator_survives_flush_and_compaction` and `merge_operator_dedupes_across_compaction` — both pass. They run `begin_write` → `tx.merge(...)` → `tx.commit()` → `begin_read` → `read.get(...)`, which covers two of the eleven converted call sites, `RocksDBWriteTx::merge` and `RocksDBReadTx::get`; `commit` does no CF lookup and neither test calls `put`. For the other nine sites the guarantee is the shape of the transformation rather than a test: each is the same `db.cf_handle(table)` call behind the same `?`, with only the message string unified.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) is untouched: this only reshapes an in-memory column-family lookup and its error string, with zero effect on keys, values, CF names, or encodings, so no re-sync is required.
