### PR TITLE
ci(l1,l2): widen the docs-only CI gate to all documentation and repo metadata

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,59 @@
+name: Detect changes
+description: >
+  Classify the files a push or pull request touches so callers can skip build
+  and test jobs when nothing they compile or execute changed.
+
+outputs:
+  inert_only:
+    description: >
+      'true' when every changed file is documentation or repository metadata.
+    value: ${{ steps.classify.outputs.inert_only }}
+  code_changed:
+    description: >
+      'true' when a Rust source file, a Cargo manifest or a lockfile changed.
+    value: ${{ steps.filter.outputs.code_changed }}
+
+runs:
+  using: composite
+  steps:
+    - uses: dorny/paths-filter@v4
+      id: filter
+      with:
+        # `inert` is a positive list, compared against `all_files` in the next
+        # step, rather than a list of `!` negations. paths-filter ORs a filter's
+        # patterns together, so `['!docs/**', '!**/*.md']` still matches
+        # `README.md`: that file is not under `docs/`, the first negation
+        # accepts it, and the gate never closes.
+        filters: |
+          all_files:
+            - '**'
+          inert:
+            - 'docs/**'
+            - '**/*.md'
+            - '.gitignore'
+            - '**/.gitignore'
+            - 'audits/**'
+            - 'LICENSE-*'
+            - '.github/ISSUE_TEMPLATE/**'
+          code_changed:
+            - '**/*.rs'
+            - '**/*.toml'
+            - '**/*.lock'
+
+    - name: Classify changed files
+      id: classify
+      shell: bash
+      env:
+        ALL_FILES: ${{ steps.filter.outputs.all_files_count }}
+        INERT: ${{ steps.filter.outputs.inert_count }}
+      run: |
+        set -euo pipefail
+        # Equality, not `inert_count > 0`: a commit that touches a README *and*
+        # a source file still has to build.
+        if [[ "$INERT" == "$ALL_FILES" ]]; then
+          inert_only=true
+        else
+          inert_only=false
+        fi
+        echo "inert_only=${inert_only}" >> "$GITHUB_OUTPUT"
+        echo "inert_only=${inert_only} (changed=${ALL_FILES}, inert=${INERT})"

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -28,26 +28,23 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/detect-changes
+        id: changes
       - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
             run_tests:
               - '!crates/l2/**'
-            non_docs:
-              - "!docs/**"
-            code_changed:
-              - "**/*.rs"
-              - "**/*.toml"
-              - "**/*.lock"
       - name: finish
         id: finish
         run: |
-          if [[ "${{ steps.filter.outputs.non_docs_count }}" == 0 ]]; then
+          if [[ "${{ steps.changes.outputs.inert_only }}" == "true" ]]; then
+            # Documentation and repository metadata only: no job here builds it.
             echo "run_tests=false" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
               # In merge queue, only run lint if code files changed
-              echo "run_tests=${{ steps.filter.outputs.code_changed }}" >> "$GITHUB_OUTPUT"
+              echo "run_tests=${{ steps.changes.outputs.code_changed }}" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
               echo "run_tests=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/pr-main_l1_l2_dev.yaml
+++ b/.github/workflows/pr-main_l1_l2_dev.yaml
@@ -28,15 +28,12 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            run_tests:
-              - '!docs/**'
+      - uses: ./.github/actions/detect-changes
+        id: changes
       - name: finish
         id: finish
-        run: echo "run_tests=${{ steps.filter.outputs.run_tests }}" >> "$GITHUB_OUTPUT"
+        # Documentation and repository metadata only: no job here builds it.
+        run: echo "run_tests=${{ steps.changes.outputs.inert_only == 'false' }}" >> "$GITHUB_OUTPUT"
       - name: Print result
         run: echo "run_tests=${{ steps.finish.outputs.run_tests }}"
 

--- a/.github/workflows/pr-main_l2_prover.yaml
+++ b/.github/workflows/pr-main_l2_prover.yaml
@@ -26,15 +26,12 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            run_tests:
-              - '!docs/**'
+      - uses: ./.github/actions/detect-changes
+        id: changes
       - name: finish
         id: finish
-        run: echo "run_tests=${{ steps.filter.outputs.run_tests }}" >> "$GITHUB_OUTPUT"
+        # Documentation and repository metadata only: no job here builds it.
+        run: echo "run_tests=${{ steps.changes.outputs.inert_only == 'false' }}" >> "$GITHUB_OUTPUT"
       - name: Print result
         run: echo "run_tests=${{ steps.finish.outputs.run_tests }}"
 

--- a/.github/workflows/pr-main_l2_tdx_build.yaml
+++ b/.github/workflows/pr-main_l2_tdx_build.yaml
@@ -25,15 +25,12 @@ jobs:
       run_tests: ${{ steps.finish.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            run_tests:
-              - '!docs/**'
+      - uses: ./.github/actions/detect-changes
+        id: changes
       - name: finish
         id: finish
-        run: echo "run_tests=${{ steps.filter.outputs.run_tests }}" >> "$GITHUB_OUTPUT"
+        # Documentation and repository metadata only: no job here builds it.
+        run: echo "run_tests=${{ steps.changes.outputs.inert_only == 'false' }}" >> "$GITHUB_OUTPUT"
       - name: Print result
         run: echo "run_tests=${{ steps.finish.outputs.run_tests }}"
 


### PR DESCRIPTION
**Motivation**

The docs-only gate added in #5766 only recognizes `docs/**`. Any other Markdown file, `.gitignore`, an audit report or a license falls through to the full suite. #7191 (`.gitignore` plus one README) spent ~310 runner-minutes and over 50 minutes of wall clock on jobs with nothing new to compile — including `Test - macos-15`, billed at 10x.

Its own `detect-changes` log shows the gate had the answer and didn't use it:

```
[modified] .gitignore
[modified] tooling/zkevm_bench/README.md
Detected 2 changed files
##[group]Filter run_tests = true
##[group]Filter non_docs = true          <- both files counted
##[group]Filter code_changed = false     <- nothing compiled changed
run_tests=true
```

`code_changed = false` means the same change in the merge queue already skips everything; only the `pull_request` path is affected.

**Description**

Extracts the gate into a `detect-changes` composite action and widens it to cover documentation and repository metadata outside `docs/`:

```yaml
all_files:    ['**']
inert:        ['docs/**', '**/*.md', '.gitignore', '**/.gitignore',
               'audits/**', 'LICENSE-*', '.github/ISSUE_TEMPLATE/**']
code_changed: ['**/*.rs', '**/*.toml', '**/*.lock']
```

The list cannot be widened by adding more `!` negations. paths-filter ORs a filter's patterns together (`src/filter.ts`: "Multiple patterns are OR-ed together"), so `['!docs/**', '!**/*.md']` still matches `README.md` — that file is not under `docs/`, the first negation accepts it, and the gate never closes. The action matches a positive `inert` list against a catch-all `all_files` filter instead, closing the gate only when *every* changed file is inert. Equality rather than a non-zero test keeps a commit that touches a README *and* a source file building.

Wired into `pr-main_l1.yaml`, `pr-main_l1_l2_dev.yaml`, `pr-main_l2_prover.yaml` and `pr-main_l2_tdx_build.yaml`. Only the inert list moves into the action — each workflow keeps its own `run_tests` logic, including the L1 scope filter (`!crates/l2/**`) and the merge-queue branch. `pr-main_l2.yaml` is untouched: its explicit path allowlist already skipped this class of change.

Deliberately left outside the inert list, so they keep running the suite: `Makefile`, Dockerfiles, workflow YAML, `.sol` sources, `package.json`, `rust-toolchain.toml` and everything under `fixtures/`.

**Verification**

`actionlint -ignore SC2086 -ignore SC2006 -ignore SC2046` is clean. Since this PR touches `.github/actions/**`, the repo's own `Github Actions` lint runs it here too.

Confirmed from `dorny/paths-filter@v4`'s `src/filter.ts` that it compiles patterns with `dot: true`, which is why `**` counts `.gitignore` and the count comparison is sound.

The classifier was replayed offline against the file lists of the last 150 merged PRs, using picomatch with the same options:

```
sampled merged PRs:                            150
already skipped (docs-only):                     6
newly skipped:                                   4   (#7116, #6962, #6890, #6885)
inert-classified PRs containing .rs/.toml/.lock:  0
files not matched by '**':                        0
```

Direct checks: #7191's own file list classifies `inert_only=true`; a mixed `README.md` + `crates/vm/levm/src/lib.rs` change classifies `inert_only=false`. Spot-checked that `Makefile`, `fixtures/genesis/l1.json`, `Dockerfile`, `.github/workflows/pr-main_l1.yaml`, `crates/l2/contracts/src/A.sol`, `package.json` and `rust-toolchain.toml` all stay classified as code.

What only CI can show is that every required check (`Test`, `Lint`, `Integration Test`, `Integration Test L2`, `Lint L2`) reports skipped-as-success on an inert change. That is the mechanism #5766 was built on, and this PR is not itself an inert change — it edits workflow YAML — so a follow-up commit here will exercise both directions.

**Scope note**

This is a latency fix for documentation authors (roughly 50 minutes to 1 minute per push), not a cost reduction: inert-only changes are about 3% of merged PRs, so the aggregate CI saving is small.

Separately and not addressed here: `pr-main_l1_l2_dev.yaml`, `pr-main_l2_prover.yaml` and `pr-main_l2_tdx_build.yaml` still have no path scope beyond the inert gate, so roughly 55 runner-minutes of L2 dev integration, backend lints and the Nix TDX build fire on every non-docs PR, including pure-L1 ones. Giving those three the kind of allowlist `pr-main_l2.yaml` already has is worth far more than this change, but it needs a per-job dependency analysis.

One caveat worth stating: `.gitignore` is the least strictly inert entry, since a new ignore rule can change what `cargo package` includes. `publish.yml` runs on release rather than on pull requests, so no PR-time coverage is lost either way.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
