### PR TITLE
refactor(l1): remove the dead `Default` impl for `TrieLayerCache`

### DIFF
--- a/crates/storage/layering.rs
+++ b/crates/storage/layering.rs
@@ -159,20 +159,6 @@ impl fmt::Debug for TrieLayerCache {
     }
 }
 
-impl Default for TrieLayerCache {
-    fn default() -> Self {
-        Self {
-            bloom: Self::create_filter(BLOOM_SIZE),
-            last_id: 0,
-            layers: Default::default(),
-            // TODO (issue #6345): this is coupled with DB_COMMIT_THRESHOLD in store.rs — unify them.
-            commit_threshold: 128,
-            overlay: None,
-            safe_commit_root: Arc::new(RwLock::new(H256::zero())),
-        }
-    }
-}
-
 impl TrieLayerCache {
     /// Creates a new cache with the given commit threshold and a shared safe-commit-root cell.
     ///


### PR DESCRIPTION
**Motivation**

`impl Default for TrieLayerCache` in `crates/storage/layering.rs` is dead code, and it is the more dangerous kind of dead code: it hardcodes a second, independent definition of the layer-commit threshold.

Nothing can reach it. `layering` is a private module (`mod layering;`, `crates/storage/lib.rs:72`) and only `apply_prefix` is re-exported (`crates/storage/lib.rs:80`), so `TrieLayerCache` cannot even be named outside the `ethrex-storage` crate. Inside the crate, every single construction site — three in `crates/storage/store.rs` (lines 2026, 4048, 4132) and six in the `layering.rs` test modules — calls `TrieLayerCache::new_with_safe_commit(commit_threshold, safe_commit_root)`. There is no `TrieLayerCache::default()`, no `Default::default()` inferred to that type, and no `#[derive(Default)]` struct in the crate that holds a `TrieLayerCache` field (the five deriving structs are `ThreadList`, `PendingTrieRoots`, `LatestBlockHeaderCache`, `CfStats`, and `RocksDbStats`, none of which do), so nothing can invoke it indirectly either.

The liability is the duplication. The impl re-spelled the whole `new_with_safe_commit` body with `commit_threshold: 128` baked in, and it carried its own TODO admitting the problem: `TODO (issue #6345): this is coupled with DB_COMMIT_THRESHOLD in store.rs — unify them.` The real production default already lives in exactly one place, `DB_COMMIT_THRESHOLD` (`crates/storage/store.rs:68`), which the live constructors thread through. Leaving a second hardcoded `128` behind an unreachable constructor means that any future code reaching for `Default` — an `Arc::default()`, a `mem::take` on the cache — would silently get 128 layers instead of the configured threshold, with no compile error to catch it. Deleting the impl is the unification the TODO asked for.

**Description**

Deletes the 13-line `impl Default for TrieLayerCache` block plus its trailing blank separator from `crates/storage/layering.rs`. Deletion-only: 14 lines removed (12 of them code — one is the TODO comment, one is the blank separator), 0 added, one file touched. `new_with_safe_commit` becomes the single constructor.

Invariants preserved, and how. `create_filter` is shared with `new_with_safe_commit` and is untouched, as is its `expected_items(expected_items.max(BLOOM_SIZE))` sizing — the surviving constructor still calls `Self::create_filter(BLOOM_SIZE)` exactly as before. The `bloom` field, the `overlay: Option<Arc<Overlay>>` three-state read semantics, `safe_commit_root`, and `commit_threshold` are all untouched, since the deleted block only ever *initialized* them on a path with no callers. `TrieLayerCache` is a purely in-memory cache: no on-disk format, no RLP encode/decode impl, and no `STORE_SCHEMA_VERSION` involvement. `BLOOM_SIZE`, `H256::zero()`, and `RwLock` all remain in use elsewhere in the file, so no imports or constants are orphaned by the deletion.

If a future caller genuinely needs `Default` on `TrieLayerCache`, it must be reintroduced deliberately with the configured `commit_threshold` plumbed through — not the old hardcoded 128, which is precisely what diverges from `DB_COMMIT_THRESHOLD`.

If this change were wrong, one of these would have to be true: (1) some code constructs a `TrieLayerCache` via `Default` — then `cargo clippy --workspace --all-targets -- -D warnings` would fail to compile, because removing a used trait impl is a hard error, and it passes clean; (2) a generic bound `T: Default` is instantiated with `TrieLayerCache` somewhere — same compile error, same green gate; (3) a `..Default::default()` struct-update expression targets `TrieLayerCache` — all three such expressions in `layering.rs` (lines 795, 1172, 1222) target `Overlay`, not `TrieLayerCache`; (4) the impl were reachable from outside the crate — impossible, `mod layering` is private and only `apply_prefix` is re-exported; (5) runtime behavior would change — impossible, since no execution path ever entered the deleted function.

No tests were deleted: the deleted code had no test of its own, and all 93 existing `ethrex-storage` tests (six of which construct a `TrieLayerCache` through `new_with_safe_commit`) still pass unchanged.

**How to test**

- `cargo fmt --all --check` — clean, exit 0; the diff stays at 14 deletions / 0 insertions in `crates/storage/layering.rs` only.
- `cargo clippy -p ethrex-storage --all-targets --all-features -- -D warnings` — clean, exit 0. `--all-features` matters here: it covers the `rocksdb`-gated code in `store.rs` that the default feature set skips.
- `cargo test -p ethrex-storage --all-features` — 93 passed, 0 failed, 0 ignored; doc-tests 1 passed, 1 ignored. Exit 0.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, exit 0. This is the CI L1 tooling lint gate, and it doubles as the completeness proof for the dead-code claim: any in-workspace consumer of the removed impl, direct or via a generic `Default` bound, would be a compile error here.

**Checklist**

- [x] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. Not applicable: `TrieLayerCache` is an in-memory cache with no on-disk representation, and this is a deletion-only change to an unreachable constructor, so no `Store` schema change and `STORE_SCHEMA_VERSION` is untouched.
