### PR TITLE
refactor(l1): unify the storage-trie `BackendTrieDB` constructors on an `Option<H256>` prefix

### DIFF
--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -3823,6 +3823,7 @@ impl Store {
             self.gated_snapshot(state_root)?,
             Box::new(BackendTrieDB::new_for_storages(
                 self.backend.clone(),
+                None,
                 self.last_written()?,
             )?),
             Some(account_hash),
@@ -3869,6 +3870,7 @@ impl Store {
             Box::new(BackendTrieDB::new_for_storages_with_view(
                 self.backend.clone(),
                 read_view,
+                None,
                 last_written,
             )?),
             Some(account_hash),
@@ -3884,9 +3886,9 @@ impl Store {
         storage_root: H256,
     ) -> Result<Trie, StoreError> {
         Ok(Trie::open(
-            Box::new(BackendTrieDB::new_for_account_storage(
+            Box::new(BackendTrieDB::new_for_storages(
                 self.backend.clone(),
-                account_hash,
+                Some(account_hash),
                 self.last_written()?,
             )?),
             storage_root,
@@ -5121,10 +5123,10 @@ fn flatkeyvalue_generator(
             }
 
             let mut iter_inner = Trie::open(
-                Box::new(BackendTrieDB::new_for_account_storage_with_view(
+                Box::new(BackendTrieDB::new_for_storages_with_view(
                     backend.clone(),
                     read_tx.clone(),
-                    account_hash,
+                    Some(account_hash),
                     path.as_ref().to_vec(),
                 )?),
                 account_state.storage_root,

--- a/crates/storage/trie.rs
+++ b/crates/storage/trie.rs
@@ -22,7 +22,7 @@ pub struct BackendTrieDB {
     nodes_table: &'static str,
     fkv_table: &'static str,
     /// Storage trie address prefix (for storage tries)
-    /// None for state tries, Some(address) for storage tries
+    /// None for state tries, or when the caller prefixes the paths itself
     address_prefix: Option<H256>,
 }
 
@@ -54,18 +54,24 @@ impl BackendTrieDB {
     }
 
     /// Create a new BackendTrieDB for the storage tries
+    /// `address_prefix` is `Some(account_hash)` to scope reads and writes to a single
+    /// account's storage trie, or `None` when the caller already prefixes the paths
+    /// (e.g. a `TrieWrapper` built with `Some(account_hash)`) - passing the hash twice
+    /// would double-prefix every key
     pub fn new_for_storages(
         db: Arc<dyn StorageBackend>,
+        address_prefix: Option<H256>,
         last_written: Vec<u8>,
     ) -> Result<Self, StoreError> {
         let read_view = db.begin_read()?;
-        Self::new_for_storages_with_view(db, read_view, last_written)
+        Self::new_for_storages_with_view(db, read_view, address_prefix, last_written)
     }
 
     /// Create a new BackendTrieDB for the storage tries with a shared read view
     pub fn new_for_storages_with_view(
         db: Arc<dyn StorageBackend>,
         read_view: Arc<dyn StorageReadView>,
+        address_prefix: Option<H256>,
         last_written: Vec<u8>,
     ) -> Result<Self, StoreError> {
         let last_computed_flatkeyvalue = Nibbles::from_hex(last_written);
@@ -75,35 +81,7 @@ impl BackendTrieDB {
             last_computed_flatkeyvalue,
             nodes_table: STORAGE_TRIE_NODES,
             fkv_table: STORAGE_FLATKEYVALUE,
-            address_prefix: None,
-        })
-    }
-
-    /// Create a new BackendTrieDB for a specific storage trie
-    pub fn new_for_account_storage(
-        db: Arc<dyn StorageBackend>,
-        address_prefix: H256,
-        last_written: Vec<u8>,
-    ) -> Result<Self, StoreError> {
-        let read_view = db.begin_read()?;
-        Self::new_for_account_storage_with_view(db, read_view, address_prefix, last_written)
-    }
-
-    /// Create a new BackendTrieDB for a specific storage trie with a shared read view
-    pub fn new_for_account_storage_with_view(
-        db: Arc<dyn StorageBackend>,
-        read_view: Arc<dyn StorageReadView>,
-        address_prefix: H256,
-        last_written: Vec<u8>,
-    ) -> Result<Self, StoreError> {
-        let last_computed_flatkeyvalue = Nibbles::from_hex(last_written);
-        Ok(Self {
-            db,
-            read_view,
-            last_computed_flatkeyvalue,
-            nodes_table: STORAGE_TRIE_NODES,
-            fkv_table: STORAGE_FLATKEYVALUE,
-            address_prefix: Some(address_prefix),
+            address_prefix,
         })
     }
 

--- a/test/tests/storage/trie_db_tests.rs
+++ b/test/tests/storage/trie_db_tests.rs
@@ -35,7 +35,7 @@ fn test_trie_db_with_address_prefix() {
 
     // Create TrieDB with address prefix and write data
     let address = H256::from([0xaa; 32]);
-    let trie_db = BackendTrieDB::new_for_account_storage(backend.clone(), address, vec![]).unwrap();
+    let trie_db = BackendTrieDB::new_for_storages(backend.clone(), Some(address), vec![]).unwrap();
 
     let node_hash = Nibbles::from_hex(vec![1]);
     let node_data = vec![1, 2, 3, 4, 5];
@@ -45,7 +45,7 @@ fn test_trie_db_with_address_prefix() {
         .unwrap();
 
     // Create a fresh TrieDB to read back
-    let trie_db = BackendTrieDB::new_for_account_storage(backend, address, vec![]).unwrap();
+    let trie_db = BackendTrieDB::new_for_storages(backend, Some(address), vec![]).unwrap();
 
     let retrieved_data = trie_db.get(node_hash).unwrap().unwrap();
     assert_eq!(retrieved_data, node_data);


### PR DESCRIPTION
**Motivation**

`BackendTrieDB` had four constructors for the storage tables and they came in two copies of the same code. `new_for_storages` / `new_for_storages_with_view` and `new_for_account_storage` / `new_for_account_storage_with_view` set the identical `STORAGE_TRIE_NODES` / `STORAGE_FLATKEYVALUE` tables, derive `last_computed_flatkeyvalue` the identical way, and differ in exactly one expression: `address_prefix: None` versus `address_prefix: Some(address_prefix)`.

That duplication is a liability precisely because the one differing field is the dangerous one. `address_prefix` feeds `apply_prefix` on every key path (`make_key`, behind `get` and `put_batch`, plus `flatkeyvalue_computed` directly), so picking the wrong constructor silently changes every key written to and read from the storage tables. Encoding the choice in the function *name* means the compiler cannot help: `new_for_storages` and `new_for_account_storage` are both in scope, both compile at every call site, and only one of them is correct at each. Any future edit to one copy also has to be mirrored into the other, and a copy that drifts is a data-corruption bug, not a style problem.

**Description**

The prefix is now a parameter instead of a name. `new_for_storages` and `new_for_storages_with_view` take `address_prefix: Option<H256>` and assign it straight to the field; `new_for_account_storage` and `new_for_account_storage_with_view` are deleted. Net 20 non-comment, non-blank lines removed from `crates/storage`. The surviving name is the neutral one - `new_for_account_storage(db, None, ..)` would have read as a contradiction.

Which value each call site passes is load-bearing, and each was derived from whether the caller already applies the prefix:

| call site | prefix | why |
| --- | --- | --- |
| `Store::open_storage_trie` | `None` | the `BackendTrieDB` is wrapped in `TrieWrapper::new(.., Some(account_hash))`, and `TrieWrapper` prepends the prefix itself (`layering.rs`, `prefix_nibbles` built in `new` and concatenated in `get`/`flatkeyvalue_computed`). Passing the hash here too would prefix every key twice. |
| `Store::open_storage_trie_shared` | `None` | same shape, same `TrieWrapper` prefix. |
| `Store::open_direct_storage_trie` | `Some(account_hash)` | no wrapper - `Trie::open` sits directly on the `BackendTrieDB`, so the prefix has to come from here. |
| `flatkeyvalue_generator`'s inner storage loop | `Some(account_hash)` | no wrapper either; this is the loop that writes `STORAGE_FLATKEYVALUE` entries. |

Both `None` sites are the ones that previously called a `new_for_storages*` constructor, and both `Some` sites are the ones that previously called a `new_for_account_storage*` constructor, so the value reaching `address_prefix` is unchanged at all four. `new_for_accounts` / `new_for_accounts_with_view` (the `ACCOUNT_*` tables) and `LockedTrieDB` are untouched.

The doc comment on `new_for_storages` now spells out the `None` case, because that is the invariant a future caller can get wrong and the type system will not catch.

If this change were wrong, one of these would have to be true:

- `TrieWrapper` does not apply the account prefix itself, so the two `None` sites now under-prefix their keys. It does apply it: the prefix nibbles are built in `TrieWrapper::new` and concatenated onto the key on every read path in `crates/storage/layering.rs`.
- The two constructor families differed in something other than the prefix - a different table, a different `last_written` handling. The deleted bodies are in this diff; every other field is character-for-character identical.
- A caller outside this workspace depends on the removed names. `BackendTrieDB` is public, but `grep -rn 'new_for_account_storage'` over the repo now returns nothing, and before this change the only callers were the four in `crates/storage/store.rs` and two in `test/tests/storage/trie_db_tests.rs`.
- The on-disk key layout moved. `address_prefix` is read only where keys are derived (`make_key` for `get`/`put_batch`, and `flatkeyvalue_computed`), and the value it receives at each of the four sites is the same as before, so the bytes written to `STORAGE_TRIE_NODES` / `STORAGE_FLATKEYVALUE` are identical.

No test was deleted. `test_trie_db_with_address_prefix` still covers the `Some` path; it just calls the merged constructor.

**How to test**

```
cargo fmt --all -- --check
cargo clippy --all-targets --workspace -- -D warnings
cargo clippy -p ethrex-storage --all-targets --features rocksdb -- -D warnings
cargo test -p ethrex-storage
cargo test -p ethrex-test --test ethrex_tests
```

Results on this branch:

- `cargo fmt --all -- --check` - clean.
- `cargo clippy --all-targets --workspace -- -D warnings` - clean (exit 0).
- `cargo clippy -p ethrex-storage --all-targets --features rocksdb -- -D warnings` - clean; the RocksDB-gated code compiles against the new signature too, since the default gate does not build it.
- `cargo test -p ethrex-storage` - 91 passed, 0 failed; doc-tests 1 passed, 1 ignored.
- `cargo test -p ethrex-test --test ethrex_tests` - 964 passed, 0 failed, 1 ignored.

The targeted coverage inside that suite, for reviewers who want to run less:

- `cargo test -p ethrex-test --test ethrex_tests storage::` - 24 passed, including `storage::trie_db_tests::test_trie_db_with_address_prefix` (write-then-read round trip through the `Some(address)` path) and `storage::storage_batch_tests::*` (parity between the sharded and serial storage writers).
- `cargo test -p ethrex-test --test ethrex_tests blockchain::storage_sharding` - 11 passed; these build storage tries through `open_direct_storage_trie` (the `Some` path) and compare sharded against serial roots, so a double-prefixed or unprefixed key shows up as a root mismatch.
- `cargo test -p ethrex-test --test ethrex_tests p2p::snap_server` - 18 passed; `storage_ranges_*` serves storage slots back out of the same tables that were written through the changed constructors.

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) is untouched: the only field affected is `BackendTrieDB::address_prefix`, every call site passes the same value it passed before, and the key bytes written to `STORAGE_TRIE_NODES` / `STORAGE_FLATKEYVALUE` are byte-identical - no re-sync is required.
