### PR TITLE
feat(l1): add the eth_ namespace methods other clients serve

### DIFF
--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -47,6 +47,11 @@ pub struct GetRawReceipts {
     pub block: BlockIdentifier,
 }
 
+/// `eth_getUncleCountByBlockHash` / `eth_getUncleCountByBlockNumber`.
+pub struct GetUncleCountRequest {
+    pub block: BlockIdentifierOrHash,
+}
+
 pub struct BlockNumberRequest;
 pub struct GetBlobBaseFee;
 
@@ -146,6 +151,40 @@ impl RpcHandler for GetBlockTransactionCountRequest {
         let transaction_count = block_body.transactions.len();
 
         serde_json::to_value(format!("{transaction_count:#x}"))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+impl RpcHandler for GetUncleCountRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<GetUncleCountRequest, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
+        };
+        Ok(GetUncleCountRequest {
+            block: BlockIdentifierOrHash::parse(params[0].clone(), 0)?,
+        })
+    }
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        debug!("Requested uncle count for block: {}", self.block);
+        // Post-merge every canonical block has an empty ommers list, so this is
+        // always `0x0` in practice. It is still derived from the stored body
+        // rather than hardcoded, so pre-merge history read from a synced archive
+        // answers truthfully. An unknown block yields `null`, matching the
+        // transaction-count getters and the other clients.
+        let block_number = match self.block.resolve_block_number(&context.storage).await? {
+            Some(block_number) => block_number,
+            _ => return Ok(Value::Null),
+        };
+        let block_body = match context.storage.get_block_body(block_number).await? {
+            Some(block_body) => block_body,
+            _ => return Ok(Value::Null),
+        };
+        let uncle_count = block_body.ommers.len();
+
+        serde_json::to_value(format!("{uncle_count:#x}"))
             .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -45,6 +45,15 @@ pub fn clean_outdated_filters(filters: ActiveFilters, filter_duration: Duration)
 /// Maps IDs to active pollable filters and their timestamps.
 pub type ActiveFilters = Arc<Mutex<HashMap<u64, (Instant, PollableFilter)>>>;
 
+/// What a pollable filter yields on each `eth_getFilterChanges`.
+#[derive(Debug, Clone)]
+pub enum FilterKind {
+    /// `eth_newFilter`: logs matching the filter over the polled range.
+    Logs(LogsFilter),
+    /// `eth_newBlockFilter`: the hashes of blocks added since the last poll.
+    Blocks,
+}
+
 #[derive(Debug, Clone)]
 pub struct PollableFilter {
     /// Last block number from when this
@@ -53,7 +62,7 @@ pub struct PollableFilter {
     /// the log will be applied from this
     /// block number up to the latest one.
     pub last_block_number: BlockNumber,
-    pub filter_data: LogsFilter,
+    pub kind: FilterKind,
 }
 
 impl NewFilterRequest {
@@ -110,12 +119,63 @@ impl NewFilterRequest {
                 timestamp,
                 PollableFilter {
                     last_block_number,
-                    filter_data: self.request_data.clone(),
+                    kind: FilterKind::Logs(self.request_data.clone()),
                 },
             ),
         );
         let as_hex = json!(format!("0x{:x}", id));
         Ok(as_hex)
+    }
+
+    pub async fn stateful_call(
+        req: &RpcRequest,
+        storage: Store,
+        state: ActiveFilters,
+    ) -> Result<Value, RpcErr> {
+        let request = Self::parse(&req.params)?;
+        request.handle(storage, state).await
+    }
+}
+
+/// `eth_newBlockFilter`: registers a filter that yields the hash of every block
+/// appended since the previous poll. Takes no parameters.
+pub struct NewBlockFilterRequest;
+
+impl NewBlockFilterRequest {
+    pub fn parse(params: &Option<Vec<serde_json::Value>>) -> Result<Self, RpcErr> {
+        // Other clients accept both an absent and an empty params array here.
+        match params.as_deref() {
+            None | Some([]) => Ok(NewBlockFilterRequest),
+            Some(_) => Err(RpcErr::BadParams("Expected no params".to_string())),
+        }
+    }
+
+    pub async fn handle(
+        &self,
+        storage: ethrex_storage::Store,
+        filters: ActiveFilters,
+    ) -> Result<serde_json::Value, crate::utils::RpcErr> {
+        // Anchor at the current head so the first poll reports only blocks that
+        // arrive after registration, matching the log filters and other clients.
+        let last_block_number = storage.get_latest_block_number().await?;
+        let id: u64 = rand::random();
+        let mut active_filters_guard = filters.lock().unwrap_or_else(|mut poisoned_guard| {
+            error!("THREAD CRASHED WITH MUTEX TAKEN; SYSTEM MIGHT BE UNSTABLE");
+            **poisoned_guard.get_mut() = HashMap::new();
+            filters.clear_poison();
+            poisoned_guard.into_inner()
+        });
+        active_filters_guard.insert(
+            id,
+            (
+                Instant::now(),
+                PollableFilter {
+                    last_block_number,
+                    kind: FilterKind::Blocks,
+                },
+            ),
+        );
+        Ok(json!(format!("0x{:x}", id)))
     }
 
     pub async fn stateful_call(
@@ -206,9 +266,32 @@ impl FilterChangesRequest {
                 poisoned_guard.into_inner()
             }));
         if let Some((timestamp, filter)) = active_filters_guard.get_mut(&self.id) {
+            // A block filter has no range to validate: it always reports whatever
+            // blocks arrived since the last poll.
+            if matches!(filter.kind, FilterKind::Blocks) {
+                *timestamp = Instant::now();
+                let from = filter.last_block_number.saturating_add(1);
+                filter.last_block_number = latest_block_num;
+                drop(active_filters_guard);
+                let mut hashes = Vec::new();
+                for number in from..=latest_block_num {
+                    // A number with no canonical hash means the chain reorged out
+                    // from under us mid-scan; skip rather than fail the poll.
+                    if let Some(hash) = storage.get_canonical_block_hash(number).await? {
+                        hashes.push(format!("{hash:#x}"));
+                    }
+                }
+                return serde_json::to_value(hashes).map_err(|error| {
+                    tracing::error!("Block filter request failed with: {error}");
+                    RpcErr::Internal("Failed to collect block hashes".to_string())
+                });
+            }
+            let FilterKind::Logs(filter_data) = &filter.kind else {
+                unreachable!("block filters are handled above")
+            };
             // We'll only get changes for a filter that either has a block
             // range for upcoming blocks, or for the 'latest' tag.
-            let valid_block_range = match filter.filter_data.to_block {
+            let valid_block_range = match filter_data.to_block {
                 BlockIdentifier::Tag(BlockTag::Latest) => true,
                 BlockIdentifier::Number(block_num) if block_num >= latest_block_num => true,
                 _ => false,
@@ -223,14 +306,18 @@ impl FilterChangesRequest {
                 *timestamp = Instant::now();
                 // Update this filter so the current query
                 // starts from the last polled block.
-                filter.filter_data.from_block = BlockIdentifier::Number(filter.last_block_number);
+                let mut logs_filter = match &filter.kind {
+                    FilterKind::Logs(data) => data.clone(),
+                    FilterKind::Blocks => unreachable!("block filters are handled above"),
+                };
+                logs_filter.from_block = BlockIdentifier::Number(filter.last_block_number);
+                logs_filter.to_block = BlockIdentifier::Number(latest_block_num);
                 filter.last_block_number = latest_block_num;
-                let mut filter = filter.clone();
-                filter.filter_data.to_block = BlockIdentifier::Number(latest_block_num);
+                filter.kind = FilterKind::Logs(logs_filter.clone());
                 // Drop the lock early to process this filter's query
                 // and not keep the lock more than we should.
                 drop(active_filters_guard);
-                let logs = fetch_logs_with_filter(&filter.filter_data, storage).await?;
+                let logs = fetch_logs_with_filter(&logs_filter, storage).await?;
                 serde_json::to_value(logs).map_err(|error| {
                     tracing::error!("Log filtering request failed with: {error}");
                     RpcErr::Internal("Failed to filter logs".to_string())
@@ -280,6 +367,17 @@ mod tests {
 
     use serde_json::{Value, json};
 
+    /// Every filter these tests register is a log filter; unwrap the kind so the
+    /// assertions can keep reading the `LogsFilter` fields directly.
+    fn logs_filter(filter: &PollableFilter) -> &LogsFilter {
+        match &filter.kind {
+            crate::eth::filter::FilterKind::Logs(data) => data,
+            crate::eth::filter::FilterKind::Blocks => {
+                panic!("test filter should be a log filter")
+            }
+        }
+    }
+
     #[tokio::test]
     async fn filter_request_smoke_test_valid_params() {
         let filter_req_params = json!(
@@ -306,16 +404,16 @@ mod tests {
         assert!(filters.len() == 1);
         let (_, filter) = filters.clone().get(&id).unwrap().clone();
         assert!(matches!(
-            filter.filter_data.from_block,
+            logs_filter(&filter).from_block,
             BlockIdentifier::Number(1)
         ));
         assert!(matches!(
-            filter.filter_data.to_block,
+            logs_filter(&filter).to_block,
             BlockIdentifier::Number(2)
         ));
-        assert!(filter.filter_data.address_filters.is_none());
+        assert!(logs_filter(&filter).address_filters.is_none());
         assert!(matches!(
-            &filter.filter_data.topics[..],
+            &logs_filter(&filter).topics[..],
             [TopicFilter::Topic(_)]
         ));
     }
@@ -343,15 +441,15 @@ mod tests {
         assert!(filters.len() == 1);
         let (_, filter) = filters.clone().get(&id).unwrap().clone();
         assert!(matches!(
-            filter.filter_data.from_block,
+            logs_filter(&filter).from_block,
             BlockIdentifier::Number(1)
         ));
         assert!(matches!(
-            filter.filter_data.to_block,
+            logs_filter(&filter).to_block,
             BlockIdentifier::Number(255)
         ));
-        assert!(filter.filter_data.address_filters.is_none());
-        assert!(matches!(&filter.filter_data.topics[..], []));
+        assert!(logs_filter(&filter).address_filters.is_none());
+        assert!(matches!(&logs_filter(&filter).topics[..], []));
     }
 
     #[tokio::test]
@@ -377,18 +475,18 @@ mod tests {
         assert!(filters.len() == 1);
         let (_, filter) = filters.clone().get(&id).unwrap().clone();
         assert!(matches!(
-            filter.filter_data.from_block,
+            logs_filter(&filter).from_block,
             BlockIdentifier::Number(1)
         ));
         assert!(matches!(
-            filter.filter_data.to_block,
+            logs_filter(&filter).to_block,
             BlockIdentifier::Number(255)
         ));
         assert!(matches!(
-            filter.filter_data.address_filters.unwrap(),
+            logs_filter(&filter).address_filters.clone().unwrap(),
             AddressFilter::Many(_)
         ));
-        assert!(matches!(&filter.filter_data.topics[..], []));
+        assert!(matches!(&logs_filter(&filter).topics[..], []));
     }
 
     #[tokio::test]
@@ -483,13 +581,13 @@ mod tests {
                 Instant::now(),
                 PollableFilter {
                     last_block_number: 0,
-                    filter_data: LogsFilter {
+                    kind: crate::eth::filter::FilterKind::Logs(LogsFilter {
                         from_block: BlockIdentifier::Number(1),
                         to_block: BlockIdentifier::Number(2),
                         block_hash: None,
                         address_filters: None,
                         topics: vec![],
-                    },
+                    }),
                 },
             ),
         );

--- a/crates/networking/rpc/eth/filter.rs
+++ b/crates/networking/rpc/eth/filter.rs
@@ -157,7 +157,7 @@ impl NewBlockFilterRequest {
     ) -> Result<serde_json::Value, crate::utils::RpcErr> {
         // Anchor at the current head so the first poll reports only blocks that
         // arrive after registration, matching the log filters and other clients.
-        let last_block_number = storage.get_latest_block_number().await?;
+        let last_block_number = storage.get_latest_block_number()?;
         let id: u64 = rand::random();
         let mut active_filters_guard = filters.lock().unwrap_or_else(|mut poisoned_guard| {
             error!("THREAD CRASHED WITH MUTEX TAKEN; SYSTEM MIGHT BE UNSTABLE");

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -44,6 +44,13 @@ pub struct GetTransactionByBlockNumberAndIndexRequest {
     pub transaction_index: usize,
 }
 
+/// `eth_getRawTransactionByBlockHashAndIndex` / `...ByBlockNumberAndIndex`.
+/// `BlockIdentifierOrHash` covers both spellings with one handler.
+pub struct GetRawTransactionByBlockAndIndex {
+    pub block: BlockIdentifierOrHash,
+    pub transaction_index: usize,
+}
+
 pub struct GetTransactionByBlockHashAndIndexRequest {
     pub block: BlockHash,
     pub transaction_index: usize,
@@ -373,6 +380,46 @@ impl RpcHandler for CreateAccessListRequest {
         };
 
         serde_json::to_value(result).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+impl RpcHandler for GetRawTransactionByBlockAndIndex {
+    fn parse(params: &Option<Vec<Value>>) -> Result<Self, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 2 {
+            return Err(RpcErr::BadParams(format!(
+                "Expected two params and {} were provided",
+                params.len()
+            )));
+        };
+        let index_as_string: String = serde_json::from_value(params[1].clone())?;
+        Ok(GetRawTransactionByBlockAndIndex {
+            block: BlockIdentifierOrHash::parse(params[0].clone(), 0)?,
+            transaction_index: usize::from_str_radix(index_as_string.trim_start_matches("0x"), 16)
+                .map_err(|error| RpcErr::BadParams(error.to_string()))?,
+        })
+    }
+
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        debug!(
+            "Requested raw transaction at index {} of block {}",
+            self.transaction_index, self.block
+        );
+        // An unknown block, or an index past the end of a known one, both yield
+        // `null` rather than an error — same as the decoded by-index getters.
+        let Some(block_number) = self.block.resolve_block_number(&context.storage).await? else {
+            return Ok(Value::Null);
+        };
+        let Some(block_body) = context.storage.get_block_body(block_number).await? else {
+            return Ok(Value::Null);
+        };
+        let Some(tx) = block_body.transactions.get(self.transaction_index) else {
+            return Ok(Value::Null);
+        };
+        serde_json::to_value(format!("0x{}", &hex::encode(tx.encode_to_vec())))
+            .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -32,19 +32,23 @@ use crate::eth::{
     block::{
         BlockNumberRequest, GetBlobBaseFee, GetBlockByHashRequest, GetBlockByNumberRequest,
         GetBlockReceiptsRequest, GetBlockTransactionCountRequest, GetRawBlockRequest,
-        GetRawHeaderRequest, GetRawReceipts,
+        GetRawHeaderRequest, GetRawReceipts, GetUncleCountRequest,
     },
     block_access_list::BlockAccessListRequest,
     client::{ChainId, Syncing},
     fee_market::FeeHistoryRequest,
-    filter::{self, ActiveFilters, DeleteFilterRequest, FilterChangesRequest, NewFilterRequest},
+    filter::{
+        self, ActiveFilters, DeleteFilterRequest, FilterChangesRequest, NewBlockFilterRequest,
+        NewFilterRequest,
+    },
     gas_price::GasPrice,
     gas_tip_estimator::GasTipEstimator,
     logs::LogsFilter,
     transaction::{
         CallRequest, CreateAccessListRequest, EstimateGasRequest, GetRawTransaction,
-        GetTransactionByBlockHashAndIndexRequest, GetTransactionByBlockNumberAndIndexRequest,
-        GetTransactionByHashRequest, GetTransactionReceiptRequest,
+        GetRawTransactionByBlockAndIndex, GetTransactionByBlockHashAndIndexRequest,
+        GetTransactionByBlockNumberAndIndexRequest, GetTransactionByHashRequest,
+        GetTransactionReceiptRequest,
     },
 };
 use crate::subscription_manager::{SubscriptionManager, SubscriptionManagerProtocol};
@@ -1364,6 +1368,18 @@ pub async fn map_eth_requests(req: &RpcRequest, context: RpcApiContext) -> Resul
         "eth_getBlockTransactionCountByHash" => {
             GetBlockTransactionCountRequest::call(req, context).await
         }
+        "eth_getUncleCountByBlockNumber" => GetUncleCountRequest::call(req, context).await,
+        "eth_getUncleCountByBlockHash" => GetUncleCountRequest::call(req, context).await,
+        // `eth_`-namespace spellings of the raw-transaction getters. geth,
+        // nethermind, reth and erigon all serve these; only the `debug_` form
+        // existed here, so tooling probing the `eth_` names saw them as missing.
+        "eth_getRawTransactionByHash" => GetRawTransaction::call(req, context).await,
+        "eth_getRawTransactionByBlockHashAndIndex" => {
+            GetRawTransactionByBlockAndIndex::call(req, context).await
+        }
+        "eth_getRawTransactionByBlockNumberAndIndex" => {
+            GetRawTransactionByBlockAndIndex::call(req, context).await
+        }
         "eth_getTransactionByBlockNumberAndIndex" => {
             GetTransactionByBlockNumberAndIndexRequest::call(req, context).await
         }
@@ -1384,6 +1400,9 @@ pub async fn map_eth_requests(req: &RpcRequest, context: RpcApiContext) -> Resul
         "eth_getLogs" => LogsFilter::call(req, context).await,
         "eth_newFilter" => {
             NewFilterRequest::stateful_call(req, context.storage, context.active_filters).await
+        }
+        "eth_newBlockFilter" => {
+            NewBlockFilterRequest::stateful_call(req, context.storage, context.active_filters).await
         }
         "eth_uninstallFilter" => {
             DeleteFilterRequest::stateful_call(req, context.storage, context.active_filters)

--- a/test/tests/rpc/missing_rpc_methods_tests.rs
+++ b/test/tests/rpc/missing_rpc_methods_tests.rs
@@ -1,0 +1,154 @@
+//! Methods that differential testing on glamsterdam-devnet-8 found missing.
+//!
+//! Each of these returned `Method not found: …` from ethrex while geth served
+//! them, so tooling that probes the standard surface reported ethrex as lacking
+//! functionality it largely already had internally.
+
+use ethrex_rpc::test_utils::{
+    add_legacy_tx_blocks, call_http, default_context_with_storage, setup_store,
+};
+use serde_json::Value;
+
+async fn context_with_one_block() -> ethrex_rpc::RpcApiContext {
+    let store = setup_store().await;
+    add_legacy_tx_blocks(&store, 1, 1).await;
+    default_context_with_storage(store).await
+}
+
+fn call(method: &str, params: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","method":"{method}","params":{params},"id":1}}"#)
+}
+
+#[tokio::test]
+async fn uncle_count_is_zero_for_a_known_block_and_null_for_an_unknown_one() {
+    let context = context_with_one_block().await;
+
+    let by_number = call_http(
+        context.clone(),
+        call("eth_getUncleCountByBlockNumber", r#"["0x1"]"#),
+    )
+    .await;
+    assert_eq!(
+        by_number["result"], "0x0",
+        "a post-merge block has no ommers; got {by_number}"
+    );
+
+    let block_hash = call_http(
+        context.clone(),
+        call("eth_getBlockByNumber", r#"["0x1",false]"#),
+    )
+    .await["result"]["hash"]
+        .as_str()
+        .expect("block should have a hash")
+        .to_owned();
+    let by_hash = call_http(
+        context.clone(),
+        call(
+            "eth_getUncleCountByBlockHash",
+            &format!(r#"["{block_hash}"]"#),
+        ),
+    )
+    .await;
+    assert_eq!(by_hash["result"], "0x0", "got {by_hash}");
+
+    // An unknown block must be `null`, not an error — matching the
+    // transaction-count getters this mirrors.
+    let unknown = call_http(
+        context,
+        call("eth_getUncleCountByBlockNumber", r#"["0x999999"]"#),
+    )
+    .await;
+    assert_eq!(unknown["result"], Value::Null, "got {unknown}");
+}
+
+#[tokio::test]
+async fn new_block_filter_registers_and_polls() {
+    let context = context_with_one_block().await;
+
+    let created = call_http(context.clone(), call("eth_newBlockFilter", "[]")).await;
+    let id = created["result"]
+        .as_str()
+        .unwrap_or_else(|| panic!("eth_newBlockFilter must return a filter id: {created}"))
+        .to_owned();
+    assert!(id.starts_with("0x"), "filter id must be hex: {id}");
+
+    // The filter anchors at the head at registration, so an immediate poll
+    // reports nothing rather than replaying history.
+    let changes = call_http(
+        context,
+        call("eth_getFilterChanges", &format!(r#"["{id}"]"#)),
+    )
+    .await;
+    let hashes = changes["result"]
+        .as_array()
+        .unwrap_or_else(|| panic!("getFilterChanges must return an array: {changes}"));
+    assert!(
+        hashes.is_empty(),
+        "a freshly registered block filter has no new blocks yet, got {hashes:?}"
+    );
+}
+
+#[tokio::test]
+async fn raw_transaction_getters_agree_across_all_three_spellings() {
+    let context = context_with_one_block().await;
+
+    let block = call_http(
+        context.clone(),
+        call("eth_getBlockByNumber", r#"["0x1",true]"#),
+    )
+    .await;
+    let tx_hash = block["result"]["transactions"][0]["hash"]
+        .as_str()
+        .expect("block should contain a transaction")
+        .to_owned();
+    let block_hash = block["result"]["hash"].as_str().expect("hash").to_owned();
+
+    let by_hash = call_http(
+        context.clone(),
+        call("eth_getRawTransactionByHash", &format!(r#"["{tx_hash}"]"#)),
+    )
+    .await;
+    let raw = by_hash["result"]
+        .as_str()
+        .unwrap_or_else(|| panic!("eth_getRawTransactionByHash must return RLP: {by_hash}"));
+    assert!(raw.starts_with("0x") && raw.len() > 2, "got {raw}");
+
+    // The `debug_` spelling already existed; the `eth_` one must agree with it.
+    let debug_form = call_http(
+        context.clone(),
+        call("debug_getRawTransaction", &format!(r#"["{tx_hash}"]"#)),
+    )
+    .await;
+    assert_eq!(
+        by_hash["result"], debug_form["result"],
+        "eth_ and debug_ spellings must return identical bytes"
+    );
+
+    for (method, params) in [
+        (
+            "eth_getRawTransactionByBlockNumberAndIndex",
+            r#"["0x1","0x0"]"#.to_owned(),
+        ),
+        (
+            "eth_getRawTransactionByBlockHashAndIndex",
+            format!(r#"["{block_hash}","0x0"]"#),
+        ),
+    ] {
+        let response = call_http(context.clone(), call(method, &params)).await;
+        assert_eq!(
+            response["result"], by_hash["result"],
+            "{method} must return the same bytes as by-hash; got {response}"
+        );
+    }
+
+    // An index past the end is `null`, not an error.
+    let past_end = call_http(
+        context,
+        call(
+            "eth_getRawTransactionByBlockNumberAndIndex",
+            r#"["0x1","0x9"]"#,
+        ),
+    )
+    .await;
+    assert_eq!(past_end["result"], Value::Null, "got {past_end}");
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -5,6 +5,7 @@ mod create_access_list_tests;
 mod estimate_gas_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
+mod missing_rpc_methods_tests;
 mod send_raw_transaction_tests;
 mod subscription_manager_tests;
 mod trace_call_tests;


### PR DESCRIPTION
**Motivation**

Differential RPC testing against the other execution clients on glamsterdam-devnet-8 found these methods returning `Method not found` from ethrex alone. Measured live against geth on a local two-client devnet:

| Method | ethrex | geth |
|---|---|---|
| `eth_getUncleCountByBlockNumber` | `Method not found` | `0x0` |
| `eth_newBlockFilter` | `Method not found` | returns a filter id |
| `eth_getRawTransactionByHash` | `Method not found` | `0x…` |

Tooling that probes the standard surface therefore reported ethrex as lacking functionality it largely already had internally — `debug_getRawTransaction` already did the raw-transaction work, and the filter registry already backed `eth_newFilter`.

**Description**

`eth_getUncleCountByBlockHash` / `eth_getUncleCountByBlockNumber` — derived from the stored body rather than hardcoded to zero, so pre-merge history read from a synced archive answers truthfully. An unknown block yields `null`, matching the transaction-count getters this mirrors.

`eth_newBlockFilter` — `PollableFilter` carried a `LogsFilter` directly, so a filter could only ever be a log filter. It now carries a `FilterKind`, and `eth_getFilterChanges` branches on it to return the hashes of blocks appended since the last poll. A block number with no canonical hash is skipped rather than failing the poll, since that means the chain reorged mid-scan. The filter anchors at the head at registration, so the first poll reports only blocks that arrive afterwards.

`eth_getRawTransactionByHash`, `eth_getRawTransactionByBlockHashAndIndex`, `eth_getRawTransactionByBlockNumberAndIndex` — by-hash reuses the existing `debug_getRawTransaction` handler, so the two spellings cannot drift. The two by-index forms share one handler over `BlockIdentifierOrHash`.

Not included: the `trace_*` namespace. geth does not serve it either — only erigon, nethermind and reth do — so it is a much larger piece of work with a weaker parity argument, and `debug_trace*` already covers the common cases.

**Tests**

Three tests: uncle count (zero for a known block by both number and hash, `null` for an unknown one); block filter (registers, returns a hex id, and reports nothing on an immediate poll rather than replaying history); raw transaction (all three spellings return identical bytes, the `eth_` form agrees with the pre-existing `debug_` form, and an index past the end is `null` rather than an error).
