### PR TITLE
fix(l2): stop the sequencer builder listing a recipient a failed authorization never reached

### DIFF
--- a/crates/l2/sequencer/block_producer/payload_builder.rs
+++ b/crates/l2/sequencer/block_producer/payload_builder.rs
@@ -10,7 +10,7 @@ use ethrex_blockchain::{
 use ethrex_common::NativeCrypto;
 use ethrex_common::{
     U256,
-    types::{Block, EIP1559_DEFAULT_SERIALIZED_LENGTH, SAFE_BYTES_PER_BLOB, Transaction, TxKind},
+    types::{Block, EIP1559_DEFAULT_SERIALIZED_LENGTH, SAFE_BYTES_PER_BLOB, Transaction},
 };
 use ethrex_l2_common::{
     messages::get_block_l2_out_messages, privileged_transactions::PRIVILEGED_TX_BUDGET,
@@ -262,12 +262,14 @@ pub async fn fill_transactions(
             .as_ref()
             .map(|r| r.tx_checkpoint());
 
-        // Record tx sender and recipient for BAL
+        // Record the tx sender for BAL. The recipient is NOT recorded here:
+        // it is recorded when the prepare region loads it (default_hook), per
+        // the EIP-7928 v7.1.0 update — an EIP-7702 auth halt before the
+        // recipient load must exclude it. Pre-recording it here produced a BAL
+        // this sequencer's own validation rejects, discarding its own payloads.
+        // Mirrors the L1 block builder in `crates/blockchain/payload.rs`.
         if let Some(recorder) = context.vm.db.bal_recorder_mut() {
             recorder.record_touched_address(head_tx.tx.sender());
-            if let TxKind::Call(to) = head_tx.to() {
-                recorder.record_touched_address(to);
-            }
         }
 
         // Execute tx. Snapshot every PayloadBuildContext counter that


### PR DESCRIPTION
**Motivation**

The L1 block builder used to pre-record a transaction's recipient in the Block Access List before executing it. That is wrong for a type-4 transaction that runs out of gas while applying its authorization: since `tests-glamsterdam-devnet@v7.1.0` the spec loads the recipient only in the top-frame `prepare_dispatch`, which an EIP-7702 authorization halt precedes, so the recipient is never accessed and must be absent from the BAL. `main` has already been corrected on the L1 side.

The L2 sequencer builder still carries the original code, comment included, so it still emits a BAL its own validation rejects and discards its own payloads. On L1 this cost roughly six in ten blocks on a devnet for one 30,000-gas transaction shape while every other client built normally.

The trigger: a type-4 transaction with one authorization and `gas_limit = 30000`. Intrinsic cost is 22,816, leaving 7,184 — short of the 9,000-gas `ACCOUNT_WRITE` the authorization then needs. It ends `gasUsed = 30000, status = 0x0`.

**Description**

Drops the recipient pre-record in `crates/l2/sequencer/block_producer/payload_builder.rs` and keeps the sender's, whose nonce bump and fee deduction happen before the atomic prepare region and are never rolled back — so the sender is touched however the transaction ends. The VM records the recipient at its real load point, gated on `pending_prep_oog` (`default_hook.rs`), which is the only place with the information needed to get this right.

The tx-level checkpoint immediately above the pre-record does not help: it is restored only when a transaction is *rejected*, and an out-of-gas transaction is a legitimately included one, so the spurious entry survives.

This brings the sequencer in line with the L1 builder on `main`.

**Tests**

The equivalent L1 defect is covered by a PoC that builds a block containing exactly this transaction shape and asserts the recipient is absent from the produced BAL, checking first that the transaction was included, failed, and burned its whole gas limit — so a drift in the trigger shape fails loudly rather than passing vacuously. That test exercises the L1 builder; an L2 equivalent needs a sequencer payload-build harness that does not exist yet, so this change is covered by `cargo clippy --all-targets` and the existing L2 suite only. Worth following up.
