### PR TITLE
fix(l1): reject unsolicited discv5 NODES responses

### DIFF
--- a/crates/networking/p2p/discovery/discv5_handlers.rs
+++ b/crates/networking/p2p/discovery/discv5_handlers.rs
@@ -540,7 +540,26 @@ impl DiscoveryServer {
     async fn discv5_handle_nodes_message(
         &mut self,
         nodes_message: NodesMessage,
+        sender_id: H256,
     ) -> Result<(), DiscoveryServerError> {
+        // Only accept a NODES that answers a FINDNODE we actually sent to this
+        // peer. Without the check, any peer that has completed a handshake can
+        // push ENRs of its choosing into our peer table with an unsolicited
+        // NODES, and we then hand them back out in our own FINDNODE responses.
+        let solicited = self.discv5.as_ref().is_some_and(|discv5| {
+            discv5
+                .pending_findnodes
+                .contains_key(&(sender_id, nodes_message.req_id.clone()))
+        });
+        if !solicited {
+            trace!(
+                protocol = "discv5",
+                from = %sender_id,
+                "Dropping unsolicited NODES response"
+            );
+            return Ok(());
+        }
+
         self.peer_table
             .new_contact_records(nodes_message.nodes.clone())?;
 
@@ -604,6 +623,13 @@ impl DiscoveryServer {
         };
 
         let discv5 = self.discv5.as_mut().expect("discv5 state must exist");
+        // Remember the request id so the matching NODES response is accepted.
+        // Done in every send path so none can issue a FINDNODE unregistered.
+        if let Message::FindNode(find_node) = &message {
+            discv5
+                .pending_findnodes
+                .insert((node.node_id(), find_node.req_id.clone()), Instant::now());
+        }
         let mut rng = OsRng;
         let masking_iv: u128 = rng.r#gen();
         let nonce = discv5.next_nonce(&mut rng);
@@ -652,12 +678,19 @@ impl DiscoveryServer {
             use ethrex_metrics::p2p::METRICS_P2P;
             METRICS_P2P.inc_discv5_outgoing(message.metric_label());
         }
+        let discv5 = self.discv5.as_mut().expect("discv5 state must exist");
+        // Remember the request id so the matching NODES response is accepted.
+        // Done in every send path so none can issue a FINDNODE unregistered.
+        if let Message::FindNode(find_node) = &message {
+            discv5
+                .pending_findnodes
+                .insert((*dest_id, find_node.req_id.clone()), Instant::now());
+        }
         let ordinary = Ordinary {
             src_id: self.local_node.node_id(),
             message,
         };
 
-        let discv5 = self.discv5.as_mut().expect("discv5 state must exist");
         let mut rng = OsRng;
         let masking_iv: u128 = rng.r#gen();
         let nonce = discv5.next_nonce(&mut rng);
@@ -701,6 +734,13 @@ impl DiscoveryServer {
         };
 
         let discv5 = self.discv5.as_mut().expect("discv5 state must exist");
+        // Remember the request id so the matching NODES response is accepted.
+        // Done in every send path so none can issue a FINDNODE unregistered.
+        if let Message::FindNode(find_node) = &message {
+            discv5
+                .pending_findnodes
+                .insert((node.node_id(), find_node.req_id.clone()), Instant::now());
+        }
         let mut rng = OsRng;
         let masking_iv: u128 = rng.r#gen();
         let nonce = discv5.next_nonce(&mut rng);
@@ -868,7 +908,8 @@ impl DiscoveryServer {
                 .await?;
             }
             Message::Nodes(nodes_message) => {
-                self.discv5_handle_nodes_message(nodes_message).await?;
+                self.discv5_handle_nodes_message(nodes_message, sender_id)
+                    .await?;
             }
             Message::TalkReq(talk_req_message) => {
                 if talk_req_message.req_id.len() > 8 {

--- a/crates/networking/p2p/discv5/server.rs
+++ b/crates/networking/p2p/discv5/server.rs
@@ -4,6 +4,7 @@ use crate::{
     discv5::messages::Packet,
     types::{Node, NodeRecord},
 };
+use bytes::Bytes;
 use ethrex_common::H256;
 use lru::LruCache;
 use rand::RngCore;
@@ -26,6 +27,10 @@ const MESSAGE_CACHE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Max age of a `session_ips` entry before it is evicted. Bounds the map: it is inserted
 /// per discv5 handshake and (absent this) was never removed for nodes we don't keep as peers.
 const SESSION_TTL: Duration = Duration::from_secs(3600);
+/// How long an outstanding FINDNODE stays eligible to be answered. Generous
+/// enough for a multi-packet NODES response over a slow link, short enough that
+/// a request id cannot be replayed against us much later.
+const PENDING_FINDNODE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Source IP a discv5 session was established from, paired with when it was recorded so stale
 /// entries can be evicted (see `SESSION_TTL`).
@@ -62,6 +67,15 @@ pub struct Discv5State {
     pub first_ip_vote_round_completed: bool,
     /// Currently active iterative lookups.
     pub active_lookups: Vec<IterativeLookup>,
+    /// FINDNODE requests we sent and have not yet timed out, keyed by
+    /// (peer node id, request id). A NODES response is only accepted if it
+    /// matches one of these: without the check, any peer with a session can
+    /// push arbitrary ENRs into the peer table by sending an unsolicited
+    /// NODES, and we then serve them back from our own FINDNODE responses.
+    /// Entries are not removed on first use, because a single response may be
+    /// split across up to `total` packets sharing one request id; they expire
+    /// via `PENDING_FINDNODE_TIMEOUT` instead.
+    pub pending_findnodes: FxHashMap<(H256, Bytes), Instant>,
 }
 
 impl Default for Discv5State {
@@ -70,6 +84,7 @@ impl Default for Discv5State {
             counter: 0,
             pending_by_nonce: Default::default(),
             pending_challenges: Default::default(),
+            pending_findnodes: Default::default(),
             whoareyou_rate_limit: LruCache::new(
                 NonZero::new(MAX_WHOAREYOU_RATE_LIMIT_ENTRIES)
                     .expect("MAX_WHOAREYOU_RATE_LIMIT_ENTRIES must be non-zero"),
@@ -110,6 +125,9 @@ impl Discv5State {
                 now.duration_since(*timestamp) < MESSAGE_CACHE_TIMEOUT
             });
         let removed_messages = before_messages - self.pending_by_nonce.len();
+
+        self.pending_findnodes
+            .retain(|_key, timestamp| now.duration_since(*timestamp) < PENDING_FINDNODE_TIMEOUT);
 
         let before_challenges = self.pending_challenges.len();
         self.pending_challenges


### PR DESCRIPTION
**Motivation**

`discv5_handle_nodes_message` inserted every record from a NODES response into the peer table without checking that we had asked for it — the handler never even read `req_id`:

```rust
async fn discv5_handle_nodes_message(&mut self, nodes_message: NodesMessage) -> ... {
    self.peer_table.new_contact_records(nodes_message.nodes.clone())?;
```

So any peer that completes a handshake can push ENRs of its own choosing into our routing table by sending an unsolicited NODES, and we then hand those nodes back out in our own FINDNODE responses — seeding other peers from an attacker's list. PING already tracked its request id (`record_ping_sent`); NODES had no equivalent.

Hive's devp2p `discv5/UnsolicitedNodes` case covers exactly this. From the failure artifact:

```
-- UnsolicitedNodes (ethrex)
 This test sends an unsolicited NODES response advertising a fake node.
 The remote node should neither contact the injected node nor return it from
 later FINDNODE queries.
 sending unsolicited NODES response with injected node
 (fb338a06782919fa) >> NODES/v5
 (338a10a83459346f) >> FINDNODE/v5
 (338a10a83459346f) << NODES/v5
 attempt 1: FINDNODE result contains node from unsolicited NODES response
```

It surfaces intermittently — whether an injected node comes back from any particular FINDNODE depends on bucket placement — which is why the suite passes on most runs and this went unnoticed.

**Description**

Tracks the `(peer node id, request id)` of every FINDNODE we send in `Discv5State::pending_findnodes`, and drops a NODES whose `(sender, req_id)` does not match one.

- Recording happens in **every** send path, so no path can issue a FINDNODE without registering it.
- Entries are **not** consumed on first use: one logical response may be split across up to `total` packets sharing a single request id.
- They expire after `PENDING_FINDNODE_TIMEOUT` (10s) via the existing `cleanup_stale_entries` sweep, which also prevents a request id being replayed against us much later.

**Tests**

`cargo clippy -p ethrex-p2p --all-targets -- -D warnings` is clean and the 103 existing `ethrex-p2p` unit tests pass. The behaviour this changes is exercised by Hive `devp2p` `discv5/UnsolicitedNodes`, which runs in CI on this PR — that job failing before and passing after is the real verification, and I have not been able to run Hive locally to confirm it ahead of CI.
