### PR TITLE
feat(l1): add net_listening RPC method

### DIFF
--- a/crates/networking/rpc/net/mod.rs
+++ b/crates/networking/rpc/net/mod.rs
@@ -12,6 +12,10 @@ pub fn version(_req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcEr
     Ok(value)
 }
 
+pub fn listening(_req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
+    Ok(json!(context.peer_handler.is_some()))
+}
+
 pub async fn peer_count(_req: &RpcRequest, mut context: RpcApiContext) -> Result<Value, RpcErr> {
     let Some(peer_handler) = &mut context.peer_handler else {
         return Err(RpcErr::Internal("Peer handler not initialized".to_string()));

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1534,6 +1534,7 @@ pub fn map_web3_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Val
 pub async fn map_net_requests(req: &RpcRequest, contex: RpcApiContext) -> Result<Value, RpcErr> {
     match req.method.as_str() {
         "net_version" => net::version(req, contex),
+        "net_listening" => net::listening(req, contex),
         "net_peerCount" => net::peer_count(req, contex).await,
         unknown_net_method => Err(RpcErr::MethodNotFound(unknown_net_method.to_owned())),
     }
@@ -1940,6 +1941,24 @@ mod tests {
         let expected_response_string =
             format!(r#"{{"id":67,"jsonrpc": "2.0","result": "{chain_id}"}}"#);
         let expected_response = to_rpc_response_success_value(&expected_response_string);
+        assert_eq!(response.to_string(), expected_response.to_string());
+    }
+
+    #[tokio::test]
+    async fn net_listening_test() {
+        let body = r#"{"jsonrpc":"2.0","method":"net_listening","params":[],"id":67}"#;
+        let request: RpcRequest = serde_json::from_str(body).expect("serde serialization failed");
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let context = default_context_with_storage(storage).await;
+        let result = map_http_requests(&request, context).await;
+        let response = rpc_response(request.id, result).unwrap();
+        let expected_response =
+            to_rpc_response_success_value(r#"{"id":67,"jsonrpc": "2.0","result": true}"#);
         assert_eq!(response.to_string(), expected_response.to_string());
     }
 


### PR DESCRIPTION
**Motivation**

ethereum/execution-apis#843 adds `net_listening` to the JSON-RPC spec, with hive `rpc-compat` fixtures. ethrex does not implement the method and answers `-32601`. It is the only client in the hive matrix that fails the new test.

**Description**

Add `net_listening` to the `net` namespace. The method returns `true` when the RPC context holds a peer handler. This is the same presence check `net_peerCount` uses.

One known limit. The L1 initializer creates the peer handler before it reads `--p2p.disabled`, so the method also returns `true` in that mode. geth returns a hardcoded `true` in every mode, so this matches the reference client. A stricter answer requires the initializer to pass `None`, which also changes what `net_peerCount` reports on a p2p-disabled node. That change is out of scope here.

Verified with `cargo test -p ethrex-rpc --lib` (109 passed) and with the hive `rpc-compat` fixtures from execution-apis#843. All `net_` tests pass against this commit: `net_listening`, `net_peerCount`, `net_version`.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
