### PR TITLE
fix(l1): recap `eth_estimateGas` by the fee the balance check uses

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -547,33 +547,29 @@ impl RpcHandler for EstimateGasRequest {
         };
 
         // The cap has to be computed against the same fee the balance check will be
-        // measured against. `default_hook` requires `tx_max_fee_per_gas * gas_limit`,
-        // falling back to `gas_price` only when the former is absent, so recapping by
-        // `gas_price` alone leaves a 1559 request — where the legacy field is absent and
-        // deserializes to zero — uncapped at the block gas limit, and the simulation then
-        // fails `InsufficientAccountFunds` for any sender that cannot afford the whole
-        // block's gas at its fee cap.
-        let fee_cap = if transaction.gas_price.is_zero() {
-            transaction
-                .max_fee_per_gas
-                .map(U256::from)
-                .unwrap_or_default()
-        } else {
-            transaction.gas_price
-        };
+        // measured against, and by the same rule: `default_hook` requires
+        // `tx_max_fee_per_gas * gas_limit`, falling back to `gas_price` only when the
+        // former is absent. Recapping by `gas_price` alone left a 1559 request — where the
+        // legacy field is absent and deserializes to zero — uncapped at the block gas
+        // limit, and the simulation then failed `InsufficientAccountFunds` for any sender
+        // that could not afford the whole block's gas at its fee cap. Written as the same
+        // expression rather than an equivalent one, so the two sites cannot drift: a call
+        // object setting both fields (which `GenericTransaction` accepts, and which
+        // `calculate_gas_price_for_generic` resolves legacy-first) would otherwise cap
+        // against one fee and be checked against the other.
+        let fee_cap = transaction
+            .max_fee_per_gas
+            .map(U256::from)
+            .unwrap_or(transaction.gas_price);
 
-        // Zero means no fee was specified at all, which is the caller asking not to be
-        // capped; it also guards the division below.
-        if !fee_cap.is_zero() {
-            highest_gas_limit = recap_with_account_balances(
-                highest_gas_limit,
-                &transaction,
-                fee_cap,
-                storage,
-                block_header.number,
-            )
-            .await?;
-        }
+        highest_gas_limit = recap_with_account_balances(
+            highest_gas_limit,
+            &transaction,
+            fee_cap,
+            storage,
+            block_header.number,
+        )
+        .await?;
 
         // Check whether the execution is possible
         let mut transaction = transaction.clone();
@@ -649,8 +645,13 @@ impl RpcHandler for EstimateGasRequest {
 
 /// Caps the estimation ceiling at the gas the sender can actually pay for.
 ///
-/// `fee_cap` must be the per-gas price the transaction's balance check uses: the legacy
-/// `gas_price` when it is set, otherwise `max_fee_per_gas`. It must be non-zero.
+/// `fee_cap` is the per-gas price the transaction's balance check uses: `max_fee_per_gas`
+/// when the call object carries one, otherwise the legacy `gas_price`.
+///
+/// A zero `fee_cap` is a request that names no fee at all, or names a fee of zero, and in
+/// both cases no balance bounds the gas: the ceiling is returned unchanged. Checked here
+/// rather than at the call site so no caller can reach the division with a zero divisor,
+/// which is the same split this function's `fee_cap` argument exists to close.
 async fn recap_with_account_balances(
     highest_gas_limit: u64,
     transaction: &GenericTransaction,
@@ -658,6 +659,9 @@ async fn recap_with_account_balances(
     storage: &Store,
     block_number: BlockNumber,
 ) -> Result<u64, RpcErr> {
+    if fee_cap.is_zero() {
+        return Ok(highest_gas_limit);
+    }
     let account_balance = storage
         .get_account_info(block_number, transaction.from)
         .await?
@@ -876,12 +880,35 @@ mod estimate_gas_fee_cap_tests {
     /// block's worth of gas at its own fee cap.
     #[tokio::test]
     async fn estimate_gas_recaps_a_1559_request_by_its_max_fee_per_gas() {
+        // Calldata so the plain-transfer short circuit above the recap cannot answer this
+        // request: it returns TRANSACTION_GAS without ever reaching the cap, which would
+        // make the test pass for a reason unrelated to what it is asserting.
         let result = run_estimate_gas(json!({
             "from": SENDER,
             "to": SENDER,
             "value": "0x1",
+            "input": "0x0102030405060708",
             "maxFeePerGas": ONE_GWEI,
             "maxPriorityFeePerGas": "0x0",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5348".to_string()));
+    }
+
+    /// A call object may carry both fee fields — `GenericTransaction` has no conflict
+    /// check, and `calculate_gas_price_for_generic` resolves `env.gas_price` legacy-first
+    /// while `env.tx_max_fee_per_gas` comes straight from `maxFeePerGas`, so the two can
+    /// hold different numbers. The balance check reads the max fee, so the recap must too:
+    /// capping against 2 gwei while the check demands 3 gwei would leave a ceiling the
+    /// sender cannot afford, which is this PR's bug in a second guise.
+    #[tokio::test]
+    async fn estimate_gas_recaps_by_the_max_fee_when_both_fees_are_set() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "gasPrice": "0x77359400",      // 2 gwei
+            "maxFeePerGas": "0xb2d05e00",  // 3 gwei
         }))
         .await;
         assert_eq!(result, Value::String("0x5208".to_string()));

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ethrex_blockchain::{Blockchain, vm::StoreVmDatabase};
 use ethrex_common::{
-    H256,
+    H256, U256,
     types::{AccessListEntry, BlockHash, BlockHeader, BlockNumber, GenericTransaction, TxKind},
 };
 
@@ -546,10 +546,29 @@ impl RpcHandler for EstimateGasRequest {
             None => highest_gas_limit,
         };
 
-        if !transaction.gas_price.is_zero() {
+        // The cap has to be computed against the same fee the balance check will be
+        // measured against. `default_hook` requires `tx_max_fee_per_gas * gas_limit`,
+        // falling back to `gas_price` only when the former is absent, so recapping by
+        // `gas_price` alone leaves a 1559 request — where the legacy field is absent and
+        // deserializes to zero — uncapped at the block gas limit, and the simulation then
+        // fails `InsufficientAccountFunds` for any sender that cannot afford the whole
+        // block's gas at its fee cap.
+        let fee_cap = if transaction.gas_price.is_zero() {
+            transaction
+                .max_fee_per_gas
+                .map(U256::from)
+                .unwrap_or_default()
+        } else {
+            transaction.gas_price
+        };
+
+        // Zero means no fee was specified at all, which is the caller asking not to be
+        // capped; it also guards the division below.
+        if !fee_cap.is_zero() {
             highest_gas_limit = recap_with_account_balances(
                 highest_gas_limit,
                 &transaction,
+                fee_cap,
                 storage,
                 block_header.number,
             )
@@ -628,9 +647,14 @@ impl RpcHandler for EstimateGasRequest {
     }
 }
 
+/// Caps the estimation ceiling at the gas the sender can actually pay for.
+///
+/// `fee_cap` must be the per-gas price the transaction's balance check uses: the legacy
+/// `gas_price` when it is set, otherwise `max_fee_per_gas`. It must be non-zero.
 async fn recap_with_account_balances(
     highest_gas_limit: u64,
     transaction: &GenericTransaction,
+    fee_cap: U256,
     storage: &Store,
     block_number: BlockNumber,
 ) -> Result<u64, RpcErr> {
@@ -639,7 +663,7 @@ async fn recap_with_account_balances(
         .await?
         .map(|acc| acc.balance)
         .unwrap_or_default();
-    let account_gas = account_balance.saturating_sub(transaction.value) / transaction.gas_price;
+    let account_gas = account_balance.saturating_sub(transaction.value) / fee_cap;
     // If account_gas exceeds u64, the account can afford any gas limit.
     let account_gas = u64::try_from(account_gas).unwrap_or(highest_gas_limit);
     Ok(highest_gas_limit.min(account_gas))
@@ -794,5 +818,99 @@ mod call_nonce_tests {
         }))
         .await;
         assert_eq!(result, Value::String("0x".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod estimate_gas_fee_cap_tests {
+    use std::str::FromStr;
+
+    use crate::rpc::map_http_requests;
+    use crate::test_utils::default_context_with_storage;
+    use crate::utils::RpcRequest;
+    use ethrex_common::types::Genesis;
+    use ethrex_common::{Address, U256};
+    use ethrex_storage::{EngineType, Store};
+    use serde_json::{Value, json};
+
+    /// Funded EOA from fixtures/genesis/l1.json.
+    const SENDER: &str = "0x00000a8d3f37af8def18832962ee008d8dca4f7b";
+    /// 0.01 ETH: enough for any real fill, far short of the fee cap times the
+    /// genesis block gas limit (1 gwei * 25M = 0.025 ETH).
+    const SENDER_BALANCE: u64 = 10_000_000_000_000_000;
+    const ONE_GWEI: &str = "0x3b9aca00";
+
+    async fn setup_store_with_poor_sender() -> Store {
+        let genesis: &str = include_str!("../../../../fixtures/genesis/l1.json");
+        let mut genesis: Genesis =
+            serde_json::from_str(genesis).expect("Fatal: test config is invalid");
+        genesis
+            .alloc
+            .get_mut(&Address::from_str(SENDER).unwrap())
+            .expect("test sender missing from genesis")
+            .balance = U256::from(SENDER_BALANCE);
+        let mut store =
+            Store::new("test-store", EngineType::InMemory).expect("Fail to create in-memory db");
+        store.add_initial_state(genesis).await.unwrap();
+        store
+    }
+
+    async fn run_estimate_gas(call_object: Value) -> Value {
+        let storage = setup_store_with_poor_sender().await;
+        let context = default_context_with_storage(storage).await;
+        let request: RpcRequest = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_estimateGas",
+            "params": [call_object, "latest"],
+        }))
+        .unwrap();
+        map_http_requests(&request, context).await.unwrap()
+    }
+
+    /// A 1559 call object carries its fee cap in `maxFeePerGas`, leaving the legacy
+    /// `gasPrice` to deserialize to zero. The estimation ceiling used to be recapped by
+    /// `gasPrice` alone, so such a request kept the whole block's gas limit as its
+    /// ceiling while the balance check measured that ceiling against `maxFeePerGas` —
+    /// failing `InsufficientAccountFunds` for every sender holding less than a full
+    /// block's worth of gas at its own fee cap.
+    #[tokio::test]
+    async fn estimate_gas_recaps_a_1559_request_by_its_max_fee_per_gas() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "maxFeePerGas": ONE_GWEI,
+            "maxPriorityFeePerGas": "0x0",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5208".to_string()));
+    }
+
+    /// The legacy path keeps recapping by `gasPrice`, which is the only fee such a
+    /// request states.
+    #[tokio::test]
+    async fn estimate_gas_recaps_a_legacy_request_by_its_gas_price() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "gasPrice": ONE_GWEI,
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5208".to_string()));
+    }
+
+    /// A request that states no fee at all asks not to be capped, and must not divide
+    /// by a zero fee cap on the way there.
+    #[tokio::test]
+    async fn estimate_gas_without_any_fee_is_not_recapped() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5208".to_string()));
     }
 }


### PR DESCRIPTION
## Motivation

`eth_estimateGas` fails with `Insufficient account funds` for an EIP-1559 call object whenever the sender's balance is below `maxFeePerGas * block_gas_limit`, even when the transaction it is estimating costs a few tens of thousands of gas and the sender can pay for it many times over. The same call succeeds against other clients.

The estimation ceiling is recapped against the sender's balance only when the legacy `gasPrice` field is set:

```rust
if !transaction.gas_price.is_zero() {
    highest_gas_limit = recap_with_account_balances(...)
}
```

A 1559 call object states its fee cap in `maxFeePerGas` and does not carry `gasPrice`, and `GenericTransaction::gas_price` is `#[serde(default)]`, so it deserializes to zero. The guard is false, the recap is skipped, and `highest_gas_limit` stays at the whole block's gas limit.

The balance check that the simulation then runs reads a *different* field. `default_hook::validate_sufficient_balance` requires:

```rust
vm.env.tx_max_fee_per_gas.unwrap_or(vm.env.gas_price).checked_mul(gas_limit.into())
```

and `tx_max_fee_per_gas` *is* populated from `maxFeePerGas`. So with the ceiling left at the block gas limit, the check demands a full block's worth of gas at the caller's fee cap: at a 60M block limit and a 10 gwei cap, 0.6 ETH, before the transaction has been simulated at all.

That asymmetry is the bug. The recap reads `gas_price`; the check reads `max_fee_per_gas`. geth caps by `GasFeeCap` first and falls back to `GasPrice`, so it computes a real allowance and estimates fine.

## Description

Pick the fee cap the balance check will actually be measured against, and recap by that:

- `maxFeePerGas` when the call object carries one, otherwise the legacy `gasPrice`. Written as the same expression the check uses rather than an equivalent one, so the two sites cannot drift: a call object setting *both* fields, which `GenericTransaction` accepts with no conflict check, would otherwise be capped against one fee and checked against the other.
- A request stating no fee at all, or an explicit fee of zero, is left uncapped: no balance bounds the gas. That check now lives inside `recap_with_account_balances`, which returns the ceiling unchanged, so no caller can reach the division with a zero divisor.
- `recap_with_account_balances` takes the fee cap explicitly rather than reaching for `transaction.gas_price`.

Four regression tests over an in-memory store whose sender holds 0.01 ETH, against a 25M genesis gas limit and a 1 gwei fee cap (1 gwei * 25M = 0.025 ETH, so an uncapped ceiling cannot be afforded):

- a 1559 request estimates `0x5348` instead of failing (fails on `main`),
- a request setting both fees is capped by the max fee (fails against a `gasPrice`-first recap),
- a legacy request still estimates `0x5208`,
- a request with no fee at all is not recapped and does not divide by zero.

The 1559 tests carry calldata deliberately. The plain-transfer short circuit above the recap answers `TRANSACTION_GAS` without reaching the cap, and a test that asserts on the recap should not depend on missing it.

Two things mask the bug, which is why it is not more visible: a sender holding more than a full block's gas at its own fee cap, and a recipient absent from state entirely, which takes the short circuit above the recap and never reaches it.

`maxFeePerBlobGas` is the one term of the balance check still missing from the recap; that is #7209, stacked on this.
