### PR TITLE
fix(l1): stop eth_feeHistory aborting when the window is below retained history

### DIFF
--- a/crates/networking/rpc/eth/fee_market.rs
+++ b/crates/networking/rpc/eth/fee_market.rs
@@ -100,6 +100,16 @@ impl RpcHandler for FeeHistoryRequest {
 
         let (start_block, end_block) =
             get_range(storage, self.block_count, &self.newest_block).await?;
+        // `get_range` clamps its two bounds independently: the finish is capped by the
+        // latest block, the start is raised to the earliest block we still hold. On a
+        // snap-synced node (earliest = pivot) a request whose window lies entirely
+        // below the pivot therefore yields start > end. The subtraction below would
+        // wrap, and `vec![0; huge]` aborts the process, so answer the empty history
+        // the caller is entitled to instead.
+        if start_block > end_block {
+            return serde_json::to_value(FeeHistoryResponse::default())
+                .map_err(|error| RpcErr::Internal(error.to_string()));
+        }
         let oldest_block = start_block;
         let block_count = (end_block - start_block + 1) as usize;
         let mut base_fee_per_gas = vec![0_u64; block_count + 1];

--- a/test/tests/rpc/fee_history_range_tests.rs
+++ b/test/tests/rpc/fee_history_range_tests.rs
@@ -1,0 +1,71 @@
+//! `eth_feeHistory` must not abort when the requested window sits below the
+//! earliest block the node still holds.
+//!
+//! `get_range` clamps its bounds independently — the finish by the latest block,
+//! the start up to the earliest retained block — so on a snap-synced node
+//! (earliest = pivot) a window entirely below the pivot produces start > end.
+//! The block count is then computed as `end - start + 1` on u64, which wraps in
+//! release and turns into a `vec![0; ~1.8e19]` allocation abort: a one-request
+//! process kill from an unauthenticated RPC.
+
+use ethrex_rpc::test_utils::{
+    add_legacy_tx_blocks, call_http, default_context_with_storage, setup_store,
+};
+
+#[tokio::test]
+async fn fee_history_below_the_earliest_retained_block_is_empty_not_a_crash() {
+    let store = setup_store().await;
+    add_legacy_tx_blocks(&store, 6, 1).await;
+    // Simulate a snap-synced datadir: history below the pivot is not retained.
+    store.update_earliest_block_number(5).await.unwrap();
+    let context = default_context_with_storage(store).await;
+
+    // newestBlock (0x1) is below earliest (5), so the whole window is unavailable.
+    let response = call_http(
+        context,
+        r#"{"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x1","0x1",[]],"id":1}"#
+            .to_string(),
+    )
+    .await;
+
+    assert!(
+        response.get("error").is_none(),
+        "a window below retained history must not error: {response}"
+    );
+    let result = &response["result"];
+    assert_eq!(
+        result["baseFeePerGas"].as_array().map(|a| a.len()),
+        Some(0),
+        "expected an empty fee history, got {response}"
+    );
+    assert_eq!(
+        result["gasUsedRatio"].as_array().map(|a| a.len()),
+        Some(0),
+        "expected an empty fee history, got {response}"
+    );
+}
+
+#[tokio::test]
+async fn fee_history_partially_below_earliest_still_serves_the_retained_part() {
+    let store = setup_store().await;
+    add_legacy_tx_blocks(&store, 6, 1).await;
+    store.update_earliest_block_number(4).await.unwrap();
+    let context = default_context_with_storage(store).await;
+
+    // Ask for 10 blocks ending at 6; only 4..=6 are retained.
+    let response = call_http(
+        context,
+        r#"{"jsonrpc":"2.0","method":"eth_feeHistory","params":["0xa","0x6",[]],"id":1}"#
+            .to_string(),
+    )
+    .await;
+
+    assert!(
+        response.get("error").is_none(),
+        "a partially-available window must still be served: {response}"
+    );
+    assert_eq!(
+        response["result"]["oldestBlock"], "0x4",
+        "oldestBlock must be clamped to the earliest retained block, got {response}"
+    );
+}

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -3,6 +3,7 @@ mod block_access_list_tests;
 mod client_version_tests;
 mod create_access_list_tests;
 mod estimate_gas_tests;
+mod fee_history_range_tests;
 mod fork_choice_tests;
 mod http_batch_tests;
 mod missing_rpc_methods_tests;


### PR DESCRIPTION
**Motivation**

`get_range` clamps its two bounds independently — the finish is capped by the latest block, the start is raised to the earliest block we still hold (`crates/networking/rpc/eth/fee_market.rs:231-234`):

```rust
let finish_block_num = expected_finish_block_num.min(latest_block_num);
let expected_start_block_num = (finish_block_num + 1).saturating_sub(block_count);
let start_block_num = earliest_block_num.max(expected_start_block_num);
```

On a snap-synced node the earliest block is the pivot, so a request whose window lies entirely below the pivot yields `start > end`. The caller then computes (`:104-105`):

```rust
let block_count = (end_block - start_block + 1) as usize;
let mut base_fee_per_gas = vec![0_u64; block_count + 1];
```

With overflow checks that panics. In release it wraps, and the allocation asks for roughly 1.8e19 elements, which aborts the process. A single unauthenticated `eth_feeHistory` call is therefore a remote kill on any snap-synced node — that is, on the standard mainnet deployment.

Reproduced against a store whose earliest block is 5:

```
eth_feeHistory("0x1", "0x1", [])
  → panicked at crates/networking/rpc/eth/fee_market.rs:110:28:
    attempt to subtract with overflow
```

This will get easier to hit, not harder: history pruning (#6673) makes a non-zero earliest block the normal steady state rather than a snap-sync artifact.

**Description**

Return the empty fee history the caller is entitled to when the requested window lies entirely below retained history, matching the existing `block_count == 0` path immediately above. Partially-available windows are unaffected and still serve the retained part with `oldestBlock` clamped up.

**Tests**

Two tests in `test/tests/rpc/fee_history_range_tests.rs`, against a store with `earliest = 5` and `earliest = 4` respectively:
- a window entirely below the earliest retained block returns an empty history rather than crashing — this test panics with `attempt to subtract with overflow` without the fix
- a window partially below it still serves the retained part, with `oldestBlock` clamped to the earliest retained block, so the fix does not turn a servable request into an empty one
