### PR TITLE
fix(l1): spend blob cost out of the balance `eth_estimateGas` recaps against

### DIFF
--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -547,33 +547,29 @@ impl RpcHandler for EstimateGasRequest {
         };
 
         // The cap has to be computed against the same fee the balance check will be
-        // measured against. `default_hook` requires `tx_max_fee_per_gas * gas_limit`,
-        // falling back to `gas_price` only when the former is absent, so recapping by
-        // `gas_price` alone leaves a 1559 request — where the legacy field is absent and
-        // deserializes to zero — uncapped at the block gas limit, and the simulation then
-        // fails `InsufficientAccountFunds` for any sender that cannot afford the whole
-        // block's gas at its fee cap.
-        let fee_cap = if transaction.gas_price.is_zero() {
-            transaction
-                .max_fee_per_gas
-                .map(U256::from)
-                .unwrap_or_default()
-        } else {
-            transaction.gas_price
-        };
+        // measured against, and by the same rule: `default_hook` requires
+        // `tx_max_fee_per_gas * gas_limit`, falling back to `gas_price` only when the
+        // former is absent. Recapping by `gas_price` alone left a 1559 request — where the
+        // legacy field is absent and deserializes to zero — uncapped at the block gas
+        // limit, and the simulation then failed `InsufficientAccountFunds` for any sender
+        // that could not afford the whole block's gas at its fee cap. Written as the same
+        // expression rather than an equivalent one, so the two sites cannot drift: a call
+        // object setting both fields (which `GenericTransaction` accepts, and which
+        // `calculate_gas_price_for_generic` resolves legacy-first) would otherwise cap
+        // against one fee and be checked against the other.
+        let fee_cap = transaction
+            .max_fee_per_gas
+            .map(U256::from)
+            .unwrap_or(transaction.gas_price);
 
-        // Zero means no fee was specified at all, which is the caller asking not to be
-        // capped; it also guards the division below.
-        if !fee_cap.is_zero() {
-            highest_gas_limit = recap_with_account_balances(
-                highest_gas_limit,
-                &transaction,
-                fee_cap,
-                storage,
-                block_header.number,
-            )
-            .await?;
-        }
+        highest_gas_limit = recap_with_account_balances(
+            highest_gas_limit,
+            &transaction,
+            fee_cap,
+            storage,
+            block_header.number,
+        )
+        .await?;
 
         // Check whether the execution is possible
         let mut transaction = transaction.clone();
@@ -649,8 +645,13 @@ impl RpcHandler for EstimateGasRequest {
 
 /// Caps the estimation ceiling at the gas the sender can actually pay for.
 ///
-/// `fee_cap` must be the per-gas price the transaction's balance check uses: the legacy
-/// `gas_price` when it is set, otherwise `max_fee_per_gas`. It must be non-zero.
+/// `fee_cap` is the per-gas price the transaction's balance check uses: `max_fee_per_gas`
+/// when the call object carries one, otherwise the legacy `gas_price`.
+///
+/// A zero `fee_cap` is a request that names no fee at all, or names a fee of zero, and in
+/// both cases no balance bounds the gas: the ceiling is returned unchanged. Checked here
+/// rather than at the call site so no caller can reach the division with a zero divisor,
+/// which is the same split this function's `fee_cap` argument exists to close.
 async fn recap_with_account_balances(
     highest_gas_limit: u64,
     transaction: &GenericTransaction,
@@ -658,6 +659,9 @@ async fn recap_with_account_balances(
     storage: &Store,
     block_number: BlockNumber,
 ) -> Result<u64, RpcErr> {
+    if fee_cap.is_zero() {
+        return Ok(highest_gas_limit);
+    }
     let account_balance = storage
         .get_account_info(block_number, transaction.from)
         .await?
@@ -876,12 +880,35 @@ mod estimate_gas_fee_cap_tests {
     /// block's worth of gas at its own fee cap.
     #[tokio::test]
     async fn estimate_gas_recaps_a_1559_request_by_its_max_fee_per_gas() {
+        // Calldata so the plain-transfer short circuit above the recap cannot answer this
+        // request: it returns TRANSACTION_GAS without ever reaching the cap, which would
+        // make the test pass for a reason unrelated to what it is asserting.
         let result = run_estimate_gas(json!({
             "from": SENDER,
             "to": SENDER,
             "value": "0x1",
+            "input": "0x0102030405060708",
             "maxFeePerGas": ONE_GWEI,
             "maxPriorityFeePerGas": "0x0",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5348".to_string()));
+    }
+
+    /// A call object may carry both fee fields — `GenericTransaction` has no conflict
+    /// check, and `calculate_gas_price_for_generic` resolves `env.gas_price` legacy-first
+    /// while `env.tx_max_fee_per_gas` comes straight from `maxFeePerGas`, so the two can
+    /// hold different numbers. The balance check reads the max fee, so the recap must too:
+    /// capping against 2 gwei while the check demands 3 gwei would leave a ceiling the
+    /// sender cannot afford, which is this PR's bug in a second guise.
+    #[tokio::test]
+    async fn estimate_gas_recaps_by_the_max_fee_when_both_fees_are_set() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "gasPrice": "0x77359400",      // 2 gwei
+            "maxFeePerGas": "0xb2d05e00",  // 3 gwei
         }))
         .await;
         assert_eq!(result, Value::String("0x5208".to_string()));

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ethrex_blockchain::{Blockchain, vm::StoreVmDatabase};
 use ethrex_common::{
-    H256,
+    H256, U256,
     types::{AccessListEntry, BlockHash, BlockHeader, BlockNumber, GenericTransaction, TxKind},
 };
 
@@ -546,10 +546,29 @@ impl RpcHandler for EstimateGasRequest {
             None => highest_gas_limit,
         };
 
-        if !transaction.gas_price.is_zero() {
+        // The cap has to be computed against the same fee the balance check will be
+        // measured against. `default_hook` requires `tx_max_fee_per_gas * gas_limit`,
+        // falling back to `gas_price` only when the former is absent, so recapping by
+        // `gas_price` alone leaves a 1559 request — where the legacy field is absent and
+        // deserializes to zero — uncapped at the block gas limit, and the simulation then
+        // fails `InsufficientAccountFunds` for any sender that cannot afford the whole
+        // block's gas at its fee cap.
+        let fee_cap = if transaction.gas_price.is_zero() {
+            transaction
+                .max_fee_per_gas
+                .map(U256::from)
+                .unwrap_or_default()
+        } else {
+            transaction.gas_price
+        };
+
+        // Zero means no fee was specified at all, which is the caller asking not to be
+        // capped; it also guards the division below.
+        if !fee_cap.is_zero() {
             highest_gas_limit = recap_with_account_balances(
                 highest_gas_limit,
                 &transaction,
+                fee_cap,
                 storage,
                 block_header.number,
             )
@@ -628,9 +647,14 @@ impl RpcHandler for EstimateGasRequest {
     }
 }
 
+/// Caps the estimation ceiling at the gas the sender can actually pay for.
+///
+/// `fee_cap` must be the per-gas price the transaction's balance check uses: the legacy
+/// `gas_price` when it is set, otherwise `max_fee_per_gas`. It must be non-zero.
 async fn recap_with_account_balances(
     highest_gas_limit: u64,
     transaction: &GenericTransaction,
+    fee_cap: U256,
     storage: &Store,
     block_number: BlockNumber,
 ) -> Result<u64, RpcErr> {
@@ -639,7 +663,7 @@ async fn recap_with_account_balances(
         .await?
         .map(|acc| acc.balance)
         .unwrap_or_default();
-    let account_gas = account_balance.saturating_sub(transaction.value) / transaction.gas_price;
+    let account_gas = account_balance.saturating_sub(transaction.value) / fee_cap;
     // If account_gas exceeds u64, the account can afford any gas limit.
     let account_gas = u64::try_from(account_gas).unwrap_or(highest_gas_limit);
     Ok(highest_gas_limit.min(account_gas))
@@ -794,5 +818,99 @@ mod call_nonce_tests {
         }))
         .await;
         assert_eq!(result, Value::String("0x".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod estimate_gas_fee_cap_tests {
+    use std::str::FromStr;
+
+    use crate::rpc::map_http_requests;
+    use crate::test_utils::default_context_with_storage;
+    use crate::utils::RpcRequest;
+    use ethrex_common::types::Genesis;
+    use ethrex_common::{Address, U256};
+    use ethrex_storage::{EngineType, Store};
+    use serde_json::{Value, json};
+
+    /// Funded EOA from fixtures/genesis/l1.json.
+    const SENDER: &str = "0x00000a8d3f37af8def18832962ee008d8dca4f7b";
+    /// 0.01 ETH: enough for any real fill, far short of the fee cap times the
+    /// genesis block gas limit (1 gwei * 25M = 0.025 ETH).
+    const SENDER_BALANCE: u64 = 10_000_000_000_000_000;
+    const ONE_GWEI: &str = "0x3b9aca00";
+
+    async fn setup_store_with_poor_sender() -> Store {
+        let genesis: &str = include_str!("../../../../fixtures/genesis/l1.json");
+        let mut genesis: Genesis =
+            serde_json::from_str(genesis).expect("Fatal: test config is invalid");
+        genesis
+            .alloc
+            .get_mut(&Address::from_str(SENDER).unwrap())
+            .expect("test sender missing from genesis")
+            .balance = U256::from(SENDER_BALANCE);
+        let mut store =
+            Store::new("test-store", EngineType::InMemory).expect("Fail to create in-memory db");
+        store.add_initial_state(genesis).await.unwrap();
+        store
+    }
+
+    async fn run_estimate_gas(call_object: Value) -> Value {
+        let storage = setup_store_with_poor_sender().await;
+        let context = default_context_with_storage(storage).await;
+        let request: RpcRequest = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_estimateGas",
+            "params": [call_object, "latest"],
+        }))
+        .unwrap();
+        map_http_requests(&request, context).await.unwrap()
+    }
+
+    /// A 1559 call object carries its fee cap in `maxFeePerGas`, leaving the legacy
+    /// `gasPrice` to deserialize to zero. The estimation ceiling used to be recapped by
+    /// `gasPrice` alone, so such a request kept the whole block's gas limit as its
+    /// ceiling while the balance check measured that ceiling against `maxFeePerGas` —
+    /// failing `InsufficientAccountFunds` for every sender holding less than a full
+    /// block's worth of gas at its own fee cap.
+    #[tokio::test]
+    async fn estimate_gas_recaps_a_1559_request_by_its_max_fee_per_gas() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "maxFeePerGas": ONE_GWEI,
+            "maxPriorityFeePerGas": "0x0",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5208".to_string()));
+    }
+
+    /// The legacy path keeps recapping by `gasPrice`, which is the only fee such a
+    /// request states.
+    #[tokio::test]
+    async fn estimate_gas_recaps_a_legacy_request_by_its_gas_price() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "gasPrice": ONE_GWEI,
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5208".to_string()));
+    }
+
+    /// A request that states no fee at all asks not to be capped, and must not divide
+    /// by a zero fee cap on the way there.
+    #[tokio::test]
+    async fn estimate_gas_without_any_fee_is_not_recapped() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5208".to_string()));
     }
 }

--- a/crates/networking/rpc/eth/transaction.rs
+++ b/crates/networking/rpc/eth/transaction.rs
@@ -12,6 +12,7 @@ use crate::{
 use ethrex_blockchain::{Blockchain, vm::StoreVmDatabase};
 use ethrex_common::{
     H256, U256,
+    constants::GAS_PER_BLOB,
     types::{AccessListEntry, BlockHash, BlockHeader, BlockNumber, GenericTransaction, TxKind},
 };
 
@@ -643,6 +644,22 @@ impl RpcHandler for EstimateGasRequest {
     }
 }
 
+/// The most a call object's blobs can cost, mirroring levm's `get_max_blob_gas_price`:
+/// `max_fee_per_blob_gas * GAS_PER_BLOB * blobs`.
+///
+/// Saturates rather than erroring on overflow. A product that cannot fit a `U256` is one no
+/// balance could cover, so `U256::MAX` leaves nothing available and caps the ceiling at
+/// zero, which is the arithmetically correct answer rather than a fallback.
+fn max_blob_gas_cost(blob_versioned_hashes: &[H256], max_fee_per_blob_gas: Option<U256>) -> U256 {
+    let Some(max_fee) = max_fee_per_blob_gas else {
+        return U256::zero();
+    };
+    U256::from(GAS_PER_BLOB)
+        .checked_mul(blob_versioned_hashes.len().into())
+        .and_then(|blob_gas| max_fee.checked_mul(blob_gas))
+        .unwrap_or(U256::MAX)
+}
+
 /// Caps the estimation ceiling at the gas the sender can actually pay for.
 ///
 /// `fee_cap` is the per-gas price the transaction's balance check uses: `max_fee_per_gas`
@@ -667,7 +684,21 @@ async fn recap_with_account_balances(
         .await?
         .map(|acc| acc.balance)
         .unwrap_or_default();
-    let account_gas = account_balance.saturating_sub(transaction.value) / fee_cap;
+    // Blob gas is a separate market with its own fee, and `validate_sufficient_balance`
+    // adds `max_fee_per_blob_gas * GAS_PER_BLOB * blobs` to what the sender must hold.
+    // Balance spent there cannot also pay for execution gas, so it comes off before the
+    // division — the same subtraction geth makes — or the ceiling this returns is one the
+    // check will reject. `validate_sender_balance` runs ahead of `validate_4844_tx` in
+    // `prepare_execution`, so a call object carrying blob fields reaches the check even
+    // when it is not a well-formed blob transaction.
+    let blob_cost = max_blob_gas_cost(
+        &transaction.blob_versioned_hashes,
+        transaction.max_fee_per_blob_gas,
+    );
+    let available = account_balance
+        .saturating_sub(transaction.value)
+        .saturating_sub(blob_cost);
+    let account_gas = available / fee_cap;
     // If account_gas exceeds u64, the account can afford any gas limit.
     let account_gas = u64::try_from(account_gas).unwrap_or(highest_gas_limit);
     Ok(highest_gas_limit.min(account_gas))
@@ -926,6 +957,45 @@ mod estimate_gas_fee_cap_tests {
         }))
         .await;
         assert_eq!(result, Value::String("0x5208".to_string()));
+    }
+
+    /// Blob gas is priced in its own market, and `validate_sufficient_balance` adds
+    /// `max_fee_per_blob_gas * GAS_PER_BLOB * blobs` to what the sender must hold. Balance
+    /// committed there cannot also pay for execution gas, so the recap has to spend it
+    /// too: one blob at 45 gwei is ~0.0059 ETH against this sender's 0.01, so a ceiling
+    /// computed from the full balance is one the check then rejects.
+    #[tokio::test]
+    async fn estimate_gas_recaps_blob_cost_out_of_the_available_balance() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "input": "0x0102030405060708",
+            "maxFeePerGas": ONE_GWEI,
+            "maxPriorityFeePerGas": "0x0",
+            "maxFeePerBlobGas": "0xa7a358200",  // 45 gwei
+            "blobVersionedHashes": [
+                "0x0100000000000000000000000000000000000000000000000000000000000001"
+            ],
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5348".to_string()));
+    }
+
+    /// A call object with no blob fields must be unaffected: nothing is subtracted, so the
+    /// whole balance still backs the ceiling.
+    #[tokio::test]
+    async fn a_request_without_blobs_loses_no_balance_to_them() {
+        let result = run_estimate_gas(json!({
+            "from": SENDER,
+            "to": SENDER,
+            "value": "0x1",
+            "input": "0x0102030405060708",
+            "maxFeePerGas": ONE_GWEI,
+            "maxPriorityFeePerGas": "0x0",
+        }))
+        .await;
+        assert_eq!(result, Value::String("0x5348".to_string()));
     }
 
     /// A request that states no fee at all asks not to be capped, and must not divide


### PR DESCRIPTION
Stacked on #7206; merge that first. Follow-up raised in its review.

## Motivation

#7206 made `eth_estimateGas` recap its ceiling against the same fee the balance check uses. One term of that check is still missing from the recap.

`validate_sufficient_balance` requires:

```
max_fee_per_gas * gas_limit + value + max_fee_per_blob_gas * GAS_PER_BLOB * blobs
```

`recap_with_account_balances` subtracted only `value`. Balance committed to blob gas cannot also pay for execution gas, so a call object carrying `blobVersionedHashes` and `maxFeePerBlobGas` was capped at a ceiling the check then rejected, and estimation failed `Insufficient account funds` for a sender that could comfortably afford the transaction.

This is not a rounding term: one blob at 45 gwei is `45e9 * 131072` = ~0.0059 ETH, most of a small sender's balance.

A call object reaches the check with blob fields even when it is not a well-formed blob transaction, because `validate_sender_balance` runs ahead of `validate_4844_tx` in `prepare_execution`.

## Description

Subtract the blob cost from the balance before dividing, the same subtraction geth makes.

The cost is computed the way levm's `get_max_blob_gas_price` computes it, and saturates on overflow rather than erroring: a product that cannot fit a `U256` is one no balance could cover, so leaving nothing available caps the ceiling at zero, which is the arithmetically correct answer rather than a fallback.

Two tests, against the same 0.01 ETH sender and 25M genesis gas limit #7206 uses:

- a request with one blob at 45 gwei estimates `0x5348` instead of failing (fails without the subtraction),
- a request with no blob fields is unaffected, so nothing is subtracted from an ordinary call.

`cargo test -p ethrex-rpc`: 114 passed. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.