### PR TITLE
fix(l1): advertise the earliest block we can actually serve

### DIFF
--- a/crates/networking/p2p/rlpx/connection/server.rs
+++ b/crates/networking/p2p/rlpx/connection/server.rs
@@ -937,7 +937,7 @@ async fn send_block_range_update(state: &mut Established) -> Result<(), PeerConn
         .is_some_and(|eth| eth.version >= 69)
     {
         trace!(peer=%state.node, "Sending BlockRangeUpdate");
-        let update = BlockRangeUpdate::new(&state.storage)?;
+        let update = BlockRangeUpdate::new(&state.storage).await?;
         let latest_block = update.latest_block;
         send(state, Message::BlockRangeUpdate(update)).await?;
         state.last_block_range_update_block = latest_block - (latest_block % 32);
@@ -966,9 +966,9 @@ where
     if let Some(eth) = state.negotiated_eth_capability.clone() {
         let status = match eth.version {
             68 => Message::Status68(StatusMessage68::new(&state.storage)?),
-            69 => Message::Status69(StatusMessage69::new(&state.storage)?),
-            70 => Message::Status70(StatusMessage70::new(&state.storage)?),
-            71 => Message::Status71(StatusMessage71::new(&state.storage)?),
+            69 => Message::Status69(StatusMessage69::new(&state.storage).await?),
+            70 => Message::Status70(StatusMessage70::new(&state.storage).await?),
+            71 => Message::Status71(StatusMessage71::new(&state.storage).await?),
             ver => {
                 return Err(PeerConnectionError::HandshakeError(format!(
                     "Invalid eth version {ver}"

--- a/crates/networking/p2p/rlpx/eth/eth69/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth69/status.rs
@@ -24,8 +24,8 @@ impl RLPxMessage for StatusMessage69 {
 }
 
 impl StatusMessage69 {
-    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
-        StatusDataPost68::new(69, storage).map(Self)
+    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+        StatusDataPost68::new(69, storage).await.map(Self)
     }
 }
 

--- a/crates/networking/p2p/rlpx/eth/eth70/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth70/status.rs
@@ -76,7 +76,7 @@ impl RLPxMessage for StatusMessage70 {
 }
 
 impl StatusMessage70 {
-    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
         let chain_config = storage.get_chain_config();
         let network_id = chain_config.chain_id;
 
@@ -105,7 +105,7 @@ impl StatusMessage70 {
             network_id,
             genesis,
             fork_id,
-            earliest_block: 0,
+            earliest_block: storage.get_earliest_block_number().await?,
             latest_block,
             latest_block_hash,
         })

--- a/crates/networking/p2p/rlpx/eth/eth71/status.rs
+++ b/crates/networking/p2p/rlpx/eth/eth71/status.rs
@@ -24,8 +24,8 @@ impl RLPxMessage for StatusMessage71 {
 }
 
 impl StatusMessage71 {
-    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
-        StatusDataPost68::new(71, storage).map(Self)
+    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+        StatusDataPost68::new(71, storage).await.map(Self)
     }
 }
 

--- a/crates/networking/p2p/rlpx/eth/status.rs
+++ b/crates/networking/p2p/rlpx/eth/status.rs
@@ -38,7 +38,7 @@ pub struct StatusDataPost68 {
 }
 
 impl StatusDataPost68 {
-    pub fn new(eth_version: u8, storage: &Store) -> Result<Self, PeerConnectionError> {
+    pub async fn new(eth_version: u8, storage: &Store) -> Result<Self, PeerConnectionError> {
         let chain_config = storage.get_chain_config();
         let network_id = chain_config.chain_id;
 
@@ -52,6 +52,12 @@ impl StatusDataPost68 {
                 .ok_or(PeerConnectionError::NotFound(format!(
                     "Block {latest_block}"
                 )))?;
+
+        // The earliest block we can actually serve. Advertising 0 unconditionally
+        // claims history from genesis, which is already untrue on any snap-synced
+        // node (earliest is the pivot) and becomes materially wrong once history
+        // pruning lands: peers select us for ranges we cannot answer.
+        let earliest_block = storage.get_earliest_block_number().await?;
 
         let genesis = genesis_header.hash();
         let latest_block_hash = block_header.hash();
@@ -67,7 +73,7 @@ impl StatusDataPost68 {
             network_id,
             genesis,
             fork_id,
-            earliest_block: 0,
+            earliest_block,
             latest_block,
             latest_block_hash,
         })
@@ -119,5 +125,65 @@ impl StatusDataPost68 {
             latest_block,
             latest_block_hash,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rlpx::eth::update::BlockRangeUpdate;
+    use ethrex_storage::EngineType;
+
+    /// An in-memory store whose earliest retained block has been moved off zero,
+    /// which is the shape a snap-synced (and, later, a pruned) node presents.
+    async fn store_with_earliest(earliest: u64) -> Store {
+        let mut store = Store::new("", EngineType::InMemory).expect("in-memory store");
+        store
+            .add_initial_state(ethrex_common::types::Genesis::default())
+            .await
+            .expect("load genesis");
+        store
+            .update_earliest_block_number(earliest)
+            .await
+            .expect("set earliest");
+        store
+    }
+
+    /// Advertising 0 unconditionally tells peers we hold history from genesis. That
+    /// is already false on a snap-synced node, and peers use the advertised range to
+    /// decide what to ask us for.
+    #[tokio::test]
+    async fn status_advertises_the_real_earliest_block() {
+        let store = store_with_earliest(12_345).await;
+        for eth_version in [69, 70, 71] {
+            let status = StatusDataPost68::new(eth_version, &store)
+                .await
+                .expect("build status");
+            assert_eq!(
+                status.earliest_block, 12_345,
+                "eth/{eth_version} status must advertise the earliest retained block"
+            );
+        }
+    }
+
+    /// The ongoing half of the same advertisement: the handshake value goes stale as
+    /// the barrier moves, so BlockRangeUpdate has to track it too. Only genesis is
+    /// stored here, so the only earliest consistent with `validate`'s
+    /// `earliest <= latest` invariant is 0 — this pins that the field is read from
+    /// the store rather than hardcoded, without manufacturing an impossible range.
+    #[tokio::test]
+    async fn block_range_update_reads_earliest_from_the_store() {
+        let store = store_with_earliest(0).await;
+        let update = BlockRangeUpdate::new(&store).await.expect("build update");
+        assert_eq!(update.earliest_block, 0);
+        update.validate().expect("a consistent range must validate");
+    }
+
+    /// Genesis-synced nodes must keep advertising 0, so the change is a no-op for them.
+    #[tokio::test]
+    async fn a_full_history_node_still_advertises_zero() {
+        let store = store_with_earliest(0).await;
+        let status = StatusDataPost68::new(69, &store).await.expect("status");
+        assert_eq!(status.earliest_block, 0);
     }
 }

--- a/crates/networking/p2p/rlpx/eth/update.rs
+++ b/crates/networking/p2p/rlpx/eth/update.rs
@@ -19,7 +19,10 @@ pub struct BlockRangeUpdate {
 }
 
 impl BlockRangeUpdate {
-    pub fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+    pub async fn new(storage: &Store) -> Result<Self, PeerConnectionError> {
+        // See StatusDataPost68::new — this is the ongoing half of the same
+        // advertisement, so it must track the earliest block as it moves.
+        let earliest_block = storage.get_earliest_block_number().await?;
         let latest_block = storage.get_latest_block_number()?;
         let block_header =
             storage
@@ -30,7 +33,7 @@ impl BlockRangeUpdate {
         let latest_block_hash = block_header.hash();
 
         Ok(Self {
-            earliest_block: 0,
+            earliest_block,
             latest_block,
             latest_block_hash,
         })


### PR DESCRIPTION
**Motivation**

Three places hardcoded the advertised earliest block to `0`:

| Site | What it feeds |
|---|---|
| `crates/networking/p2p/rlpx/eth/status.rs:69` | shared eth/69+ handshake status (eth/69, eth/71) |
| `crates/networking/p2p/rlpx/eth/eth70/status.rs:108` | eth/70's own status struct |
| `crates/networking/p2p/rlpx/eth/update.rs:33` | `BlockRangeUpdate` — the ongoing half of the same advertisement |

So every eth/69+ peer was told we hold history from genesis. That is already untrue on any snap-synced node, where the earliest retained block is the pivot, and peers use the advertised range to decide what to request from us — meaning we invite requests we then answer with empty replies.

It gets materially worse with history pruning (#6673): the earliest block moves continuously, so a hardcoded handshake value is wrong within hours of starting, and `BlockRangeUpdate` exists precisely to keep peers current as the range moves.

**Description**

Reads the value from the store in all three places.

`get_earliest_block_number` is async (`crates/storage/store.rs:1256`) while these constructors were sync — there is no cached sync accessor for it the way `get_latest_block_number` has one (`:1275`, backed by `latest_block_header`). So the constructors and their four handshake call sites in `rlpx/connection/server.rs` become async. The alternative, caching earliest in memory alongside latest, is a larger change for no benefit on a path that runs once per handshake.

**Tests**

Three tests in `crates/networking/p2p/rlpx/eth/status.rs`:
- the eth/69, eth/70 and eth/71 handshake statuses all advertise a non-zero earliest block set on the store
- `BlockRangeUpdate` reads the field from the store rather than hardcoding it, and the result still satisfies `validate`'s `earliest <= latest` invariant
- a genesis-synced node still advertises `0`, so this is a no-op for full-history nodes

Note the second test deliberately uses `earliest = 0` on a genesis-only store: setting a non-zero earliest above the latest block manufactures a range that `validate` correctly rejects, which is a state a real node cannot reach.
