### PR TITLE
ci(l1,l2): stop the merge queue satisfying the required integration checks with a skipped job

### DIFF
--- a/.github/scripts/check-queued-pr-checks.sh
+++ b/.github/scripts/check-queued-pr-checks.sh
@@ -1,27 +1,55 @@
 #!/usr/bin/env bash
 #
-# Assert that every check run matching one of the given name prefixes concluded
-# successfully on the head commit of each pull request in the current merge group.
+# Assert that this workflow's required integration gate was genuinely green on
+# the head of every pull request in the current merge group.
 #
-# Usage: check-queued-pr-checks.sh "Hive - " "Assertoor - " ...
+# Usage: check-queued-pr-checks.sh "<gate job name>"
 #
-# Why this exists: the expensive suites (hive, assertoor) are deliberately not
-# re-run inside the merge queue, so the required gate job has nothing of its own
-# to inspect there. Skipping the gate instead is not a safe substitute — GitHub
-# counts a skipped check run as satisfying a required status check, so the queue
-# would merge a pull request whose suites were red or still running. Reading the
-# pull request's own results here keeps the queue cheap while making the
-# requirement real, and because it runs at merge time it also catches a result
-# that turned red (or was re-triggered) after the pull request was queued.
+# Why this exists: the expensive suites (hive, assertoor, the L2 integration
+# tests) are deliberately not re-run inside the merge queue, so the required
+# gate job has nothing of its own to inspect there. Skipping the gate instead is
+# not a safe substitute — GitHub counts a skipped check run as satisfying a
+# required status check, so a gate that skips is a gate that always passes, and
+# the queue would merge a pull request whose suites were red or still running.
+# GitHub also decides queue eligibility when the pull request is enqueued and
+# never re-evaluates it afterwards, so a result that turns red later cannot
+# evict it.
+#
+# What it reads: the latest `pull_request` run of *this* workflow on each queued
+# pull request's head, and within that run the verdict of this same gate job.
+# Reading the gate's own verdict rather than matching suite check-run names
+# keeps one definition of what is required — the workflow's own
+# `Check if any job failed` step — and cannot be confused by an unrelated
+# workflow that happens to name a job the same way.
+#
+# How the three outcomes are read:
+#   - `success` passes, obviously.
+#   - `skipped` passes. That is what the gate looks like on a pull request whose
+#     changes did not require these suites at all, for example the L2 gate on an
+#     L1-only pull request. It is not the same as the suites being skipped for
+#     the wrong reason: when a dependency such as the docker build fails, the
+#     suites skip but the gate itself runs and fails.
+#   - A run that is not yet `completed` fails. That is the case this exists for:
+#     re-running a suite bumps the run attempt, so a re-run in flight blocks the
+#     merge group instead of being bypassed.
 set -euo pipefail
 
-if [[ $# -eq 0 ]]; then
-  echo "usage: $0 <check-name-prefix> [<check-name-prefix> ...]" >&2
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <gate-job-name>" >&2
   exit 2
 fi
 
+gate_name=$1
+
 : "${GITHUB_REPOSITORY:?}"
 : "${GITHUB_EVENT_PATH:?}"
+: "${GITHUB_WORKFLOW_REF:?}"
+
+# "owner/repo/.github/workflows/pr-main_l1.yaml@refs/heads/..." — the middle is
+# what the runs API reports as `.path`. Derived from the environment rather than
+# passed in so it cannot drift if the workflow file is renamed.
+workflow_path=${GITHUB_WORKFLOW_REF#"${GITHUB_REPOSITORY}/"}
+workflow_path=${workflow_path%%@*}
 
 base_sha=$(jq -r '.merge_group.base_sha' "$GITHUB_EVENT_PATH")
 head_sha=$(jq -r '.merge_group.head_sha' "$GITHUB_EVENT_PATH")
@@ -32,7 +60,9 @@ if [[ -z "$base_sha" || "$base_sha" == "null" || -z "$head_sha" || "$head_sha" =
 fi
 
 # One squashed commit per queued pull request, each titled "... (#1234)". Read
-# them over the API rather than from a checkout so the job needs no clone.
+# them over the API rather than from a checkout so the job needs no deep clone,
+# and from the commit subjects rather than the queue branch name because a
+# batched group's ref names only its last pull request.
 mapfile -t pr_numbers < <(
   gh api "repos/${GITHUB_REPOSITORY}/compare/${base_sha}...${head_sha}" \
     --jq '.commits[].commit.message | split("\n")[0]' |
@@ -48,58 +78,82 @@ if [[ ${#pr_numbers[@]} -eq 0 ]]; then
 fi
 
 echo "Merge group covers pull request(s): ${pr_numbers[*]}"
+echo "Gate: '${gate_name}' in ${workflow_path}"
 
 failed=0
 for pr in "${pr_numbers[@]}"; do
+  # The pull request's live head, deliberately, rather than the commit that was
+  # squashed into the merge group: the merge_group payload carries no pull
+  # request head to compare against, and reading the newest head is what lets
+  # this catch a result that turned red after the pull request was queued. Every
+  # way the two can disagree is fail-closed — a head that moved after queueing
+  # has either no run at all or one still in flight, and both fail below.
   pr_head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq '.head.sha')
   echo "::group::PR #${pr} (head ${pr_head})"
 
-  # One row per check name, tab separated, keeping only the most recently started
-  # run of that name. A single commit can carry several check suites (a re-trigger
-  # creates a new suite rather than updating the old one), and without this a
-  # superseded red run would keep blocking a head that is now green.
-  all_checks=$(
+  run=$(
     gh api --paginate --slurp \
-      "repos/${GITHUB_REPOSITORY}/commits/${pr_head}/check-runs?per_page=100" |
-      jq -r '[.[].check_runs[]]
-             | group_by(.name)
-             | map(max_by(.started_at // ""))
-             | .[]
-             | [.name, .status, (.conclusion // "")]
-             | @tsv'
+      "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${pr_head}&event=pull_request&per_page=100" |
+      jq -r --arg path "$workflow_path" \
+        '[.[].workflow_runs[] | select(.path == $path)]
+         | if length == 0 then empty
+           else max_by([.run_number, .id]) | [.id, .status, .html_url] | @tsv
+           end'
+  )
+
+  if [[ -z "$run" ]]; then
+    echo "No ${workflow_path} pull_request run on head ${pr_head}."
+    echo "Refusing to pass: a gate that cannot see what it is verifying must not report success."
+    failed=1
+    echo "::endgroup::"
+    continue
+  fi
+
+  IFS=$'\t' read -r run_id run_status run_url <<<"$run"
+
+  if [[ "$run_status" != "completed" ]]; then
+    echo "PENDING  the run is still '${run_status}', so this cannot be merged yet: ${run_url}"
+    failed=1
+    echo "::endgroup::"
+    continue
+  fi
+
+  # `/jobs` defaults to the latest run attempt, which is the one whose verdict
+  # counts. Every job carrying the gate's name is read, so a duplicate cannot
+  # hide behind a green sibling.
+  gate_jobs=$(
+    gh api --paginate --slurp \
+      "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100" |
+      jq -r --arg name "$gate_name" \
+        '.[].jobs[] | select(.name == $name) | [.name, .status, (.conclusion // "")] | @tsv'
   )
 
   matched=0
   while IFS=$'\t' read -r name status conclusion; do
     [[ -z "$name" ]] && continue
-    for prefix in "$@"; do
-      if [[ "$name" == "$prefix"* ]]; then
-        matched=$((matched + 1))
-        if [[ "$status" != "completed" ]]; then
-          echo "PENDING  ${name} (status=${status}) is still running, so it cannot be merged yet"
-          failed=1
-        elif [[ "$conclusion" != "success" && "$conclusion" != "skipped" && "$conclusion" != "neutral" ]]; then
-          echo "FAILED   ${name} (conclusion=${conclusion})"
-          failed=1
-        else
-          echo "ok       ${name} (${conclusion})"
-        fi
-        break
-      fi
-    done
-  done <<<"$all_checks"
+    matched=$((matched + 1))
+    if [[ "$status" != "completed" ]]; then
+      echo "PENDING  ${name} is '${status}', so this cannot be merged yet: ${run_url}"
+      failed=1
+    elif [[ "$conclusion" == "success" || "$conclusion" == "skipped" ]]; then
+      echo "ok       ${name} (${conclusion}): ${run_url}"
+    else
+      echo "FAILED   ${name} concluded '${conclusion}': ${run_url}"
+      failed=1
+    fi
+  done <<<"$gate_jobs"
 
   if [[ $matched -eq 0 ]]; then
-    echo "No check runs matching [$*] on PR #${pr}."
-    echo "Refusing to pass: the suites this gate exists to enforce never reported."
+    echo "No job named '${gate_name}' in ${run_url}."
+    echo "Refusing to pass: a gate that cannot see what it is verifying must not report success."
     failed=1
   fi
   echo "::endgroup::"
 done
 
 if [[ $failed -ne 0 ]]; then
-  echo "Required suites did not pass on the queued pull request head(s)." >&2
+  echo "The required gate was not green on the queued pull request head(s)." >&2
   exit 1
 fi
 
-echo "All required suites passed on every queued pull request head."
+echo "'${gate_name}' was green on every queued pull request head."

--- a/.github/scripts/check-queued-pr-checks.sh
+++ b/.github/scripts/check-queued-pr-checks.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Assert that every check run matching one of the given name prefixes concluded
+# successfully on the head commit of each pull request in the current merge group.
+#
+# Usage: check-queued-pr-checks.sh "Hive - " "Assertoor - " ...
+#
+# Why this exists: the expensive suites (hive, assertoor) are deliberately not
+# re-run inside the merge queue, so the required gate job has nothing of its own
+# to inspect there. Skipping the gate instead is not a safe substitute — GitHub
+# counts a skipped check run as satisfying a required status check, so the queue
+# would merge a pull request whose suites were red or still running. Reading the
+# pull request's own results here keeps the queue cheap while making the
+# requirement real, and because it runs at merge time it also catches a result
+# that turned red (or was re-triggered) after the pull request was queued.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <check-name-prefix> [<check-name-prefix> ...]" >&2
+  exit 2
+fi
+
+: "${GITHUB_REPOSITORY:?}"
+: "${GITHUB_EVENT_PATH:?}"
+
+base_sha=$(jq -r '.merge_group.base_sha' "$GITHUB_EVENT_PATH")
+head_sha=$(jq -r '.merge_group.head_sha' "$GITHUB_EVENT_PATH")
+
+if [[ -z "$base_sha" || "$base_sha" == "null" || -z "$head_sha" || "$head_sha" == "null" ]]; then
+  echo "No merge_group payload found; this script only runs on merge_group events." >&2
+  exit 2
+fi
+
+# One squashed commit per queued pull request, each titled "... (#1234)". Read
+# them over the API rather than from a checkout so the job needs no clone.
+mapfile -t pr_numbers < <(
+  gh api "repos/${GITHUB_REPOSITORY}/compare/${base_sha}...${head_sha}" \
+    --jq '.commits[].commit.message | split("\n")[0]' |
+    grep -oE '\(#[0-9]+\)$' |
+    tr -d '(#)' |
+    sort -u
+)
+
+if [[ ${#pr_numbers[@]} -eq 0 ]]; then
+  echo "Could not identify any pull request in merge group ${base_sha}..${head_sha}." >&2
+  echo "Refusing to pass: a gate that cannot find what to verify must not report success." >&2
+  exit 1
+fi
+
+echo "Merge group covers pull request(s): ${pr_numbers[*]}"
+
+failed=0
+for pr in "${pr_numbers[@]}"; do
+  pr_head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq '.head.sha')
+  echo "::group::PR #${pr} (head ${pr_head})"
+
+  # One row per check name, tab separated, keeping only the most recently started
+  # run of that name. A single commit can carry several check suites (a re-trigger
+  # creates a new suite rather than updating the old one), and without this a
+  # superseded red run would keep blocking a head that is now green.
+  all_checks=$(
+    gh api --paginate --slurp \
+      "repos/${GITHUB_REPOSITORY}/commits/${pr_head}/check-runs?per_page=100" |
+      jq -r '[.[].check_runs[]]
+             | group_by(.name)
+             | map(max_by(.started_at // ""))
+             | .[]
+             | [.name, .status, (.conclusion // "")]
+             | @tsv'
+  )
+
+  matched=0
+  while IFS=$'\t' read -r name status conclusion; do
+    [[ -z "$name" ]] && continue
+    for prefix in "$@"; do
+      if [[ "$name" == "$prefix"* ]]; then
+        matched=$((matched + 1))
+        if [[ "$status" != "completed" ]]; then
+          echo "PENDING  ${name} (status=${status}) is still running, so it cannot be merged yet"
+          failed=1
+        elif [[ "$conclusion" != "success" && "$conclusion" != "skipped" && "$conclusion" != "neutral" ]]; then
+          echo "FAILED   ${name} (conclusion=${conclusion})"
+          failed=1
+        else
+          echo "ok       ${name} (${conclusion})"
+        fi
+        break
+      fi
+    done
+  done <<<"$all_checks"
+
+  if [[ $matched -eq 0 ]]; then
+    echo "No check runs matching [$*] on PR #${pr}."
+    echo "Refusing to pass: the suites this gate exists to enforce never reported."
+    failed=1
+  fi
+  echo "::endgroup::"
+done
+
+if [[ $failed -ne 0 ]]; then
+  echo "Required suites did not pass on the queued pull request head(s)." >&2
+  exit 1
+fi
+
+echo "All required suites passed on every queued pull request head."

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -473,12 +473,20 @@ jobs:
     # status check, so a gate that skips is a gate that always passes: inside the
     # merge queue, where assertoor and hive do not run, that let a pull request
     # whose suites were red merge on a vacuous green.
-    if: ${{ always() && needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ always() && (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
     permissions:
       contents: read
       checks: read
       pull-requests: read
     steps:
+      - name: Fail if change detection did not conclude
+        if: ${{ needs.detect-changes.result != 'success' }}
+        run: |
+          # Without a run_tests answer there is no way to tell whether the suites
+          # below were required, and an unanswerable gate must not report success.
+          echo "detect-changes concluded '${{ needs.detect-changes.result }}'"
+          exit 1
+
       - name: Checkout sources
         uses: actions/checkout@v6
 

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -476,7 +476,7 @@ jobs:
     if: ${{ always() && (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
     permissions:
       contents: read
-      checks: read
+      actions: read
       pull-requests: read
     steps:
       - name: Fail if change detection did not conclude
@@ -491,14 +491,14 @@ jobs:
         uses: actions/checkout@v6
 
       # Assertoor and hive are skipped in the merge queue to keep it cheap, so
-      # there is no local result to inspect. Read the queued pull request's own
-      # results instead, which also catches a suite that turned red or was
-      # re-triggered after the pull request was added to the queue.
-      - name: Check the queued pull request's suites
+      # there is no local result to inspect. Read this gate's own verdict on the
+      # queued pull request's head instead, which also catches a suite that
+      # turned red or was re-triggered after the pull request was queued.
+      - name: Check the queued pull request's gate
         if: ${{ github.event_name == 'merge_group' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./.github/scripts/check-queued-pr-checks.sh "Hive - " "Assertoor - "
+        run: ./.github/scripts/check-queued-pr-checks.sh "Integration Test"
 
       - name: Check if any job failed
         if: ${{ github.event_name != 'merge_group' }}

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -468,10 +468,32 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
     needs: [detect-changes, run-assertoor, run-hive, check-cargo-locks, engine-ef-tests]
-    # Make sure this job runs even if the previous jobs failed or were skipped
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
+    # Runs even when a dependency failed, and deliberately does not bail out on a
+    # skipped one. GitHub counts a skipped check run as satisfying a required
+    # status check, so a gate that skips is a gate that always passes: inside the
+    # merge queue, where assertoor and hive do not run, that let a pull request
+    # whose suites were red merge on a vacuous green.
+    if: ${{ always() && needs.detect-changes.outputs.run_tests == 'true' }}
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      # Assertoor and hive are skipped in the merge queue to keep it cheap, so
+      # there is no local result to inspect. Read the queued pull request's own
+      # results instead, which also catches a suite that turned red or was
+      # re-triggered after the pull request was added to the queue.
+      - name: Check the queued pull request's suites
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.github/scripts/check-queued-pr-checks.sh "Hive - " "Assertoor - "
+
       - name: Check if any job failed
+        if: ${{ github.event_name != 'merge_group' }}
         run: |
           if [ "${{ needs.run-assertoor.result }}" != "success" ]; then
             echo "Job Assertoor Tx Check failed"
@@ -483,7 +505,9 @@ jobs:
             exit 1
           fi
 
-          # engine-ef-tests is skipped in the merge queue (merge_group), which is OK.
+          # Tolerating a skipped engine-ef-tests is defensive rather than load
+          # bearing: outside the merge queue it only skips when run_tests is
+          # false, and then this job does not run either.
           if [ "${{ needs.engine-ef-tests.result }}" != "success" ] && [ "${{ needs.engine-ef-tests.result }}" != "skipped" ]; then
             echo "Job Engine EF tests failed"
             exit 1

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -472,8 +472,13 @@ jobs:
     # skipped one. GitHub counts a skipped check run as satisfying a required
     # status check, so a gate that skips is a gate that always passes: inside the
     # merge queue, where assertoor and hive do not run, that let a pull request
-    # whose suites were red merge on a vacuous green.
-    if: ${{ always() && (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
+    # whose suites were red merge on a vacuous green. In the queue it therefore
+    # runs unconditionally, because `run_tests` there tracks only Rust changes
+    # and a pull request touching just workflows, scripts or fixtures would keep
+    # skipping the gate. `!cancelled()` rather than `always()` so a
+    # concurrency-cancelled run does not stamp a red required check on a
+    # superseded commit.
+    if: ${{ !cancelled() && (github.event_name == 'merge_group' || needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -492,7 +492,10 @@ jobs:
           echo "detect-changes concluded '${{ needs.detect-changes.result }}'"
           exit 1
 
+      # Only the merge_group step below needs the tree; the pull_request and push
+      # paths read the `needs` context and nothing else.
       - name: Checkout sources
+        if: ${{ github.event_name == 'merge_group' }}
         uses: actions/checkout@v6
 
       # Assertoor and hive are skipped in the merge queue to keep it cheap, so

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -996,7 +996,10 @@ jobs:
           echo "detect-changes concluded '${{ needs.detect-changes.result }}'"
           exit 1
 
+      # Only the merge_group step below needs the tree; the pull_request and push
+      # paths read the `needs` context and nothing else.
       - name: Checkout sources
+        if: ${{ github.event_name == 'merge_group' }}
         uses: actions/checkout@v6
 
       # These suites are skipped in the merge queue to keep it cheap, so there is

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -972,10 +972,37 @@ jobs:
         uniswap-swap,
         integration-test-shared-bridge,
       ]
-    # Make sure this job runs even if the previous jobs failed or were skipped
-    if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() && needs.integration-test.result != 'skipped' && needs.state-diff-test.result != 'skipped' && needs.integration-test-tdx.result != 'skipped' && needs.uniswap-swap.result != 'skipped' && needs.integration-test-shared-bridge.result != 'skipped' }}
+    # Runs even when a dependency failed, and deliberately does not bail out on a
+    # skipped one. GitHub counts a skipped check run as satisfying a required
+    # status check, so a gate that skips is a gate that always passes: inside the
+    # merge queue, where none of these suites run, that let a pull request whose
+    # suites were red merge on a vacuous green.
+    if: ${{ always() && needs.detect-changes.outputs.run_tests == 'true' }}
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      # These suites are skipped in the merge queue to keep it cheap, so there is
+      # no local result to inspect. Read the queued pull request's own results
+      # instead, which also catches a suite that turned red or was re-triggered
+      # after the pull request was added to the queue.
+      - name: Check the queued pull request's suites
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./.github/scripts/check-queued-pr-checks.sh \
+            "Integration Test - " \
+            "State Reconstruction Tests" \
+            "Uniswap Swap Token Flow" \
+            "Integration Test Shared Bridge - "
+
       - name: Check if any job failed
+        if: ${{ github.event_name != 'merge_group' }}
         run: |
           if [ "${{ needs.integration-test.result }}" != "success" ]; then
             echo "Job Integration Tests failed"

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -976,8 +976,13 @@ jobs:
     # skipped one. GitHub counts a skipped check run as satisfying a required
     # status check, so a gate that skips is a gate that always passes: inside the
     # merge queue, where none of these suites run, that let a pull request whose
-    # suites were red merge on a vacuous green.
-    if: ${{ always() && (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
+    # suites were red merge on a vacuous green. In the queue it therefore runs
+    # unconditionally, because `run_tests` there tracks only Rust changes and a
+    # pull request touching just workflows, scripts or fixtures would keep
+    # skipping the gate. `!cancelled()` rather than `always()` so a
+    # concurrency-cancelled run does not stamp a red required check on a
+    # superseded commit.
+    if: ${{ !cancelled() && (github.event_name == 'merge_group' || needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -977,12 +977,20 @@ jobs:
     # status check, so a gate that skips is a gate that always passes: inside the
     # merge queue, where none of these suites run, that let a pull request whose
     # suites were red merge on a vacuous green.
-    if: ${{ always() && needs.detect-changes.outputs.run_tests == 'true' }}
+    if: ${{ always() && (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
     permissions:
       contents: read
       checks: read
       pull-requests: read
     steps:
+      - name: Fail if change detection did not conclude
+        if: ${{ needs.detect-changes.result != 'success' }}
+        run: |
+          # Without a run_tests answer there is no way to tell whether the suites
+          # below were required, and an unanswerable gate must not report success.
+          echo "detect-changes concluded '${{ needs.detect-changes.result }}'"
+          exit 1
+
       - name: Checkout sources
         uses: actions/checkout@v6
 

--- a/.github/workflows/pr-main_l2.yaml
+++ b/.github/workflows/pr-main_l2.yaml
@@ -980,7 +980,7 @@ jobs:
     if: ${{ always() && (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.run_tests == 'true') }}
     permissions:
       contents: read
-      checks: read
+      actions: read
       pull-requests: read
     steps:
       - name: Fail if change detection did not conclude
@@ -995,19 +995,14 @@ jobs:
         uses: actions/checkout@v6
 
       # These suites are skipped in the merge queue to keep it cheap, so there is
-      # no local result to inspect. Read the queued pull request's own results
-      # instead, which also catches a suite that turned red or was re-triggered
-      # after the pull request was added to the queue.
-      - name: Check the queued pull request's suites
+      # no local result to inspect. Read this gate's own verdict on the queued
+      # pull request's head instead, which also catches a suite that turned red
+      # or was re-triggered after the pull request was queued.
+      - name: Check the queued pull request's gate
         if: ${{ github.event_name == 'merge_group' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          ./.github/scripts/check-queued-pr-checks.sh \
-            "Integration Test - " \
-            "State Reconstruction Tests" \
-            "Uniswap Swap Token Flow" \
-            "Integration Test Shared Bridge - "
+        run: ./.github/scripts/check-queued-pr-checks.sh "Integration Test L2"
 
       - name: Check if any job failed
         if: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
**Motivation**

A pull request whose `Hive` run was red, or whose re-run was still in flight, could merge
through the merge queue without that result ever being consulted.

`Integration Test` and `Integration Test L2` are required status checks on `main`, and both
gate jobs bailed out whenever a dependency was skipped:

```yaml
if: ${{ ... && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
```

Hive, assertoor and the L2 suites are all excluded from `merge_group` to keep the queue
cheap, so inside the queue that condition was always false and the gate job was **skipped**.
GitHub counts a skipped check run as *satisfying* a required status check, so every merge
group satisfied both requirements without running or even consulting the suites they exist to
enforce.

`Merge when ready` compounds it: GitHub decides queue eligibility when the pull request is
enqueued and does not re-evaluate the head afterwards. A stale green `Integration Test` is
enough to get in, a later red result cannot evict it, and the merge group's own gate was
vacuous. So re-running a failed Hive job did not protect `main` — the merge went ahead while
the re-run was still going, and the re-run's failure landed after the merge.

Observed on three merges the same day:

| pull request | `Integration Test` on its head | outcome |
| --- | --- | --- |
| #7200 | `failure` at 16:49:47 | merge group started 16:50:00, merged |
| #7201 | `failure` at 17:03:50 | merged at 17:52 |

Both had a red `Hive - Devp2p tests`, and `main` went red on devp2p immediately afterwards
until #7204 fixed the underlying discv5 bug.

**Description**

No suite is added to the merge queue. All fourteen `github.event_name != 'merge_group'`
exclusions are untouched, so hive, assertoor, reorg, engine-EF and the L2 suites still do not
run there, and the queue's cost profile is unchanged. What changes is what the gate does.

On the pull request side, three things stop the gate from passing vacuously:

- It no longer bails out on a skipped dependency, because a gate that skips is a gate that
  always passes. This is also what makes a broken docker build — which turns every hive and
  assertoor job into a skip — produce a red `Integration Test` rather than no verdict at all.
- A failed `detect-changes` publishes no outputs, so `'' == 'true'` skipped the gate and
  turned both required checks green with nothing evaluated. The gate now runs and fails.
- `!cancelled()` replaces `always()`, so a concurrency-cancelled run does not stamp a red
  required check on a commit that has already been superseded.

On `merge_group` the gate runs `.github/scripts/check-queued-pr-checks.sh`, which asserts
that **this same gate was green on each queued pull request's own head**. Per queued pull
request:

1. Resolve the pull request from the merge group's commit subjects via the `compare` API, not
   from the queue branch name, because a batched group's ref names only its last pull request.
2. Find the latest `pull_request` run of *this* workflow on that pull request's head. The
   workflow path comes from `GITHUB_WORKFLOW_REF` rather than an argument, so it cannot drift
   if the file is renamed.
3. Require that run to be `completed`. Re-running a suite bumps the run attempt, so a Hive
   re-run in flight now blocks the merge group instead of being bypassed — the case this pull
   request is really about. Because this runs at merge time rather than at enqueue time, it
   also catches a result that turned red after the pull request was queued.
4. Require this gate job's verdict inside that run to be `success` or `skipped`.

Reading the gate's own verdict rather than matching suite check-run names is what keeps the
gate honest, and it is the part of this pull request worth reviewing closely:

- It leaves **one** definition of what is required — the workflow's own `Check if any job
  failed` step. A prefix list is a second definition that can disagree with it, which is
  exactly how `Integration Test - TDX` ended up matched by the merge-group side while the
  pull_request side does not require it, and how `Engine EF tests` ended up in the gate's
  `needs` but in no prefix list. Neither is expressible now, and a suite added later is
  covered without touching the script.
- It cannot be confused by a job another workflow happens to name the same way. Jobs are read
  from one workflow run resolved by `.path`, so `daily_hive_report.yaml` — which publishes
  `Hive - <name>` with `continue-on-error: true` on any pull request touching its trigger
  paths — is out of scope by construction rather than by a tie-break on `started_at`.
- `skipped` remains a pass, but now means something checkable: *this gate* was not required,
  which is what an L1-only pull request looks like to the L2 workflow and a docs-only one to
  both. A suite skipped for the wrong reason no longer produces it, because a failed
  dependency makes the gate run and fail.
- Finding no run, or no job carrying the gate's name, fails. A gate that cannot see what it
  is verifying must not report success.

One more hole closed on the same dependency: on `merge_group`, `run_tests` is `code_changed`,
which matches only `**/*.rs`, `**/*.toml` and `**/*.lock`. Any pull request touching just
workflows, scripts, fixtures or configs therefore skipped the gate in the queue anyway — this
branch included. PR #7193 is the worked example: its merge group skipped every job,
`Integration Test` among them, and it merged, while its head carried seven green `Hive - *`
results the queue never read. The gate now runs on `merge_group` regardless of `run_tests`; a
pull request that genuinely required nothing still passes, because the verdict it then reads
on the head is `skipped`.

The gate's `checkout` is also limited to the `merge_group` path, the only one that reads the
tree.

**Verification**

The gate's decision logic is not something CI can exercise, so it was driven directly against
live repository data, with only the merge group's `compare` response stubbed so the case under
test could name any pull request. Fifteen cases, all as expected:

| case | data | expected |
| --- | --- | --- |
| green L1 gate | #7204's merge group | pass |
| gate `skipped` | #7194 (L1-only) through the L2 gate | pass |
| CI-only pull request | #7193's merge group | pass |
| red gate | #7200 (`Integration Test` = failure, red `Hive - Rpc Compat tests`) | block |
| run in flight | #7239 (L1 run `in_progress`) | block |
| no run on the head | #6760 | block |
| workflow never approved | #7059 (run `action_required`, zero jobs) | block |
| batch, one red | #7200 + #7217 | block |
| batch, both green | #7217 + #7180 | pass |
| gate name matches nothing | #7217, bogus name | block |
| workflow path never ran | #7217, bogus path | block |
| no `(#N)` in any subject | empty commit list | block |
| no arguments | — | usage, exit 2 |
| not a `merge_group` event | pull_request payload | exit 2 |
| `GITHUB_WORKFLOW_REF` unset | — | non-zero |

Head `e104cdbc` — the docker-build failure that produced `Build Docker` = failure with hive
and assertoor `skipped` — is the case the old prefix loop reported green. It is not in the
table because its recorded gate verdict predates this branch: with the `!= 'skipped'` guards
dropped, that head's `Check if any job failed` step sees `needs.run-assertoor.result` =
`skipped` and exits 1, so the gate is `failure` and the merge group blocks.

**Known limitations**

If the merge group's gate has already reported green and a Hive job is re-run after that, the
merge can still complete. Closing that would need the suites to run in the queue, which is the
trade this pull request deliberately does not make: it would add roughly twenty minutes per
queued pull request and let a hive flake evict pull requests from the queue.

**Not addressed here**

- `Integration Test` is declared by three workflows: `pr-main_l1.yaml`,
  `pr-main_l1_l2_dev.yaml` (which also runs on `merge_group`) and `pr-main_levm.yaml`. A
  required check name shared by several workflows is ambiguous to branch protection — on PR
  #7209's head the L1 one was `failure` while the L2-Dev one was `success`, and it merged.
  This pull request makes `pr-main_l1.yaml`'s own verdict real in the queue, but resolving the
  collision needs one of the jobs renamed *and* the required-check settings updated together,
  which cannot be done from a pull request alone.
- `check-cargo-locks` is in the L1 gate's `needs` but its result is still never inspected, so
  `Check Cargo.lock` remains unenforced by the required check. That is a separate policy call.
- `Integration Test - TDX` stays not required. It is in the L2 gate's `needs` with no
  `continue-on-error`, and concluded failure or cancelled in 5 of 12 sampled `pull_request`
  runs; promoting it to a merge blocker is a policy change, not a fix to this hole. Both sides
  now agree that it does not gate.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
