### PR TITLE
chore(l1,l2): bump version to 25.0.0

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -504,11 +504,16 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - name: Download artifacts
+      # Only the guest artifacts are signed, so only those are needed here. An
+      # unanchored `*ethrex*` would also pull the docker jobs' `.dockerbuild`
+      # build records, which download-artifact cannot extract. This job does not
+      # wait on the docker jobs, so it usually runs before those records exist —
+      # which is exactly why the rehearsal passed while finalize-release failed.
+      - name: Download stateless-validator artifacts
         uses: actions/download-artifact@v6
         with:
           path: ./bin
-          pattern: "*ethrex*"
+          pattern: "stateless-validator-ethrex-*"
 
       - name: Skip notice
         if: env.HAS_MINISIGN_SECRET_KEY != 'true'
@@ -596,14 +601,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download artifacts
+      # Two anchored patterns, not one `*ethrex*`. The release needs `ethrex-*`
+      # (binaries, contracts tarball) and `stateless-validator-ethrex-*` (guest
+      # ELF/VK), but an unanchored pattern also matches the build records the
+      # docker jobs upload as `<org>~ethrex~<id>.dockerbuild`. Those are not zip
+      # archives, so download-artifact cannot extract them and fails the job —
+      # taking the whole release down before anything is published.
+      - name: Download release binaries
         uses: actions/download-artifact@v6
         with:
           path: ./bin
-          # `*ethrex*`, not `ethrex*`: the stateless-validator artifacts are named
-          # stateless-validator-ethrex-<zkvm>-<version>, so a leading-anchor
-          # pattern would silently omit them from the release.
-          pattern: "*ethrex*"
+          pattern: "ethrex*"
+
+      - name: Download stateless-validator artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: ./bin
+          pattern: "stateless-validator-ethrex-*"
 
       # The zkEVM guest handbook requires the stateless-validator ELF and
       # verification key to ship as signed release assets:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-benches"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors)",
  "bytes",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "clap",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.9",
  "ethrex-common",
@@ -4127,7 +4127,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-monitor"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-repl"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "clap",
  "colored",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4363,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-test"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "history-validator"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "clap",
  "ethrex-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ resolver = "2"
 default-members = ["cmd/ethrex"]
 
 [workspace.package]
-version = "24.0.0"
+version = "25.0.0"
 edition = "2024"
 authors = ["LambdaClass"]
 documentation = "https://docs.ethrex.xyz"
@@ -75,27 +75,27 @@ debug = "line-tables-only"
 incremental = true
 
 [workspace.dependencies]
-ethrex-blockchain = { path = "./crates/blockchain", version = "24.0.0", default-features = false }
-ethrex-common = { path = "./crates/common", version = "24.0.0", default-features = false }
+ethrex-blockchain = { path = "./crates/blockchain", version = "25.0.0", default-features = false }
+ethrex-common = { path = "./crates/common", version = "25.0.0", default-features = false }
 ethrex-config = { path = "./crates/common/config" }
-ethrex-p2p = { path = "./crates/networking/p2p", version = "24.0.0" }
-ethrex-rpc = { path = "./crates/networking/rpc", version = "24.0.0" }
-ethrex-storage = { path = "./crates/storage", version = "24.0.0" }
-ethrex-vm = { path = "./crates/vm", version = "24.0.0", default-features = false }
-ethrex-levm = { path = "./crates/vm/levm", version = "24.0.0" }
-ethrex-trie = { path = "./crates/common/trie", version = "24.0.0" }
-ethrex-rlp = { path = "./crates/common/rlp", version = "24.0.0" }
-ethrex-crypto = { path = "./crates/common/crypto", version = "24.0.0", default-features = false }
-ethrex-metrics = { path = "./crates/blockchain/metrics", version = "24.0.0" }
+ethrex-p2p = { path = "./crates/networking/p2p", version = "25.0.0" }
+ethrex-rpc = { path = "./crates/networking/rpc", version = "25.0.0" }
+ethrex-storage = { path = "./crates/storage", version = "25.0.0" }
+ethrex-vm = { path = "./crates/vm", version = "25.0.0", default-features = false }
+ethrex-levm = { path = "./crates/vm/levm", version = "25.0.0" }
+ethrex-trie = { path = "./crates/common/trie", version = "25.0.0" }
+ethrex-rlp = { path = "./crates/common/rlp", version = "25.0.0" }
+ethrex-crypto = { path = "./crates/common/crypto", version = "25.0.0", default-features = false }
+ethrex-metrics = { path = "./crates/blockchain/metrics", version = "25.0.0" }
 ethrex-l2 = { path = "./crates/l2" }
-ethrex-l2-common = { path = "./crates/l2/common", version = "24.0.0" }
-ethrex-sdk = { path = "./crates/l2/sdk", version = "24.0.0" }
+ethrex-l2-common = { path = "./crates/l2/common", version = "25.0.0" }
+ethrex-sdk = { path = "./crates/l2/sdk", version = "25.0.0" }
 ethrex-l2-prover = { path = "./crates/l2/prover" }
 ethrex-prover = { path = "./crates/prover", default-features = false }
 ethrex-guest-program = { path = "./crates/guest-program", default-features = false }
-ethrex-storage-rollup = { path = "./crates/l2/storage", version = "24.0.0" }
+ethrex-storage-rollup = { path = "./crates/l2/storage", version = "25.0.0" }
 ethrex = { path = "./cmd/ethrex" }
-ethrex-l2-rpc = { path = "./crates/l2/networking/rpc", version = "24.0.0" }
+ethrex-l2-rpc = { path = "./crates/l2/networking/rpc", version = "25.0.0" }
 ethrex-monitor = { path = "./tooling/monitor" }
 ethrex-repl = { path = "./tooling/repl" }
 

--- a/crates/blockchain/Cargo.toml
+++ b/crates/blockchain/Cargo.toml
@@ -17,7 +17,7 @@ ethrex-crypto.workspace = true
 ethrex-storage.workspace = true
 ethrex-trie.workspace = true
 ethrex-vm.workspace = true
-ethrex-metrics = { path = "./metrics", version = "24.0.0", default-features = false }
+ethrex-metrics = { path = "./metrics", version = "25.0.0", default-features = false }
 
 ethrex-guest-program = { workspace = true, default-features = false }
 libssz = { workspace = true }

--- a/crates/guest-program/bin/openvm/Cargo.lock
+++ b/crates/guest-program/bin/openvm/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-openvm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bls12_381 0.8.0 (git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors)",
  "bytes",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/openvm/Cargo.toml
+++ b/crates/guest-program/bin/openvm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "24.0.0"
+version = "25.0.0"
 name = "ethrex-guest-openvm"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/guest-program/bin/risc0/Cargo.toml
+++ b/crates/guest-program/bin/risc0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-risc0"
-version = "24.0.0"
+version = "25.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/sp1/Cargo.lock
+++ b/crates/guest-program/bin/sp1/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bls12_381",
  "bytes",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-sp1"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ethrex-guest-program",
  "ethrex-vm",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/sp1/Cargo.toml
+++ b/crates/guest-program/bin/sp1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethrex-guest-sp1"
-version = "24.0.0"
+version = "25.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/guest-program/bin/zisk/Cargo.lock
+++ b/crates/guest-program/bin/zisk/Cargo.lock
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-zisk"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-guest-program",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/bin/zisk/Cargo.toml
+++ b/crates/guest-program/bin/zisk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "24.0.0"
+version = "25.0.0"
 name = "ethrex-guest-zisk"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/guest-program/stateless-validator/Cargo.lock
+++ b/crates/guest-program/stateless-validator/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/stateless-validator/bin/openvm/Cargo.lock
+++ b/crates/guest-program/stateless-validator/bin/openvm/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/stateless-validator/bin/sp1/Cargo.lock
+++ b/crates/guest-program/stateless-validator/bin/sp1/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/guest-program/stateless-validator/bin/zisk/Cargo.lock
+++ b/crates/guest-program/stateless-validator/bin/zisk/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/crates/l2/sdk/Cargo.toml
+++ b/crates/l2/sdk/Cargo.toml
@@ -14,7 +14,7 @@ ethrex-blockchain.workspace = true
 ethrex-rpc.workspace = true
 ethrex-l2-common.workspace = true
 ethrex-l2-rpc.workspace = true
-ethrex-sdk-contract-utils = { path = "contract_utils", version = "24.0.0" }
+ethrex-sdk-contract-utils = { path = "contract_utils", version = "25.0.0" }
 
 ethereum-types.workspace = true
 tokio.workspace = true
@@ -34,7 +34,7 @@ name = "ethrex_l2_sdk"
 path = "src/sdk.rs"
 
 [build-dependencies]
-ethrex-sdk-contract-utils = { path = "contract_utils", version = "24.0.0" }
+ethrex-sdk-contract-utils = { path = "contract_utils", version = "25.0.0" }
 hex.workspace = true
 
 [lints.clippy]

--- a/crates/l2/tee/quote-gen/Cargo.lock
+++ b/crates/l2/tee/quote-gen/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "quote-gen"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "configfs-tsm",
  "ethrex-blockchain",

--- a/crates/l2/tee/quote-gen/Cargo.toml
+++ b/crates/l2/tee/quote-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quote-gen"
-version = "24.0.0"
+version = "25.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [dependencies]
 ethrex-common = { workspace = true, default-features = false }
 ethrex-crypto.workspace = true
-ethrex-levm = { path = "./levm", version = "24.0.0", default-features = false }
+ethrex-levm = { path = "./levm", version = "25.0.0", default-features = false }
 ethrex-rlp.workspace = true
 
 derive_more = { version = "1.0.0", features = ["full"] }

--- a/crates/vm/levm/bench/revm_comparison/Cargo.lock
+++ b/crates/vm/levm/bench/revm_comparison/Cargo.lock
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -301,7 +301,7 @@ Block building options:
           Block extra data message.
           
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 24.0.0"]
+          [default: "ethrex 25.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.
@@ -515,7 +515,7 @@ Block building options:
           Block extra data message.
 
           [env: ETHREX_BUILDER_EXTRA_DATA=]
-          [default: "ethrex 24.0.0"]
+          [default: "ethrex 25.0.0"]
 
       --builder.gas-limit <GAS_LIMIT>
           Target block gas limit.

--- a/tooling/Cargo.lock
+++ b/tooling/Cargo.lock
@@ -836,11 +836,11 @@ dependencies = [
  "clap 4.6.0",
  "clap_complete",
  "ethrex",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "eyre",
  "hex",
  "lazy_static",
@@ -2901,11 +2901,11 @@ dependencies = [
  "bytes",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-guest-program",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-vm",
  "hex",
  "lazy_static",
@@ -2925,12 +2925,12 @@ dependencies = [
  "ctor",
  "datatest-stable",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-p2p",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "hex",
  "rayon",
  "regex",
@@ -2950,11 +2950,11 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-vm",
  "hex",
  "itertools 0.13.0",
@@ -2979,12 +2979,12 @@ dependencies = [
  "clap_complete",
  "colored",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-l2-rpc",
  "ethrex-levm",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-vm",
  "hex",
  "prettytable-rs",
@@ -3216,14 +3216,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "clap 4.6.0",
  "directories",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-config",
  "ethrex-crypto",
  "ethrex-dev",
@@ -3234,10 +3234,10 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-p2p",
  "ethrex-repl",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-storage-rollup",
  "ethrex-vm",
  "eyre",
@@ -3267,17 +3267,17 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-metrics",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
- "ethrex-trie 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
+ "ethrex-trie 25.0.0",
  "ethrex-vm",
  "libssz",
  "libssz-merkle",
@@ -3318,14 +3318,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 24.0.0",
- "ethrex-trie 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-trie 25.0.0",
  "hex",
  "hex-literal",
  "hex-simd",
@@ -3351,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-p2p",
  "hex",
  "serde",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-dev"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3408,11 +3408,11 @@ dependencies = [
  "bytes",
  "clap 4.6.0",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-vm",
  "hex",
  "serde",
@@ -3423,14 +3423,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-vm",
  "hex",
  "libssz",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3455,7 +3455,7 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-config",
  "ethrex-crypto",
  "ethrex-guest-program",
@@ -3465,12 +3465,12 @@ dependencies = [
  "ethrex-metrics",
  "ethrex-monitor",
  "ethrex-p2p",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 24.0.0",
+ "ethrex-trie 25.0.0",
  "ethrex-vm",
  "futures",
  "hex",
@@ -3498,11 +3498,11 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lambdaworks-crypto 0.13.0",
@@ -3515,20 +3515,20 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-prover"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-guest-program",
  "ethrex-l2",
  "ethrex-l2-common",
  "ethrex-prover",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-sdk",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-vm",
  "hex",
  "rkyv",
@@ -3543,19 +3543,19 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.8",
  "bytes",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-p2p",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-storage-rollup",
  "hex",
  "reqwest 0.12.28",
@@ -3574,13 +3574,13 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "libssz",
  "malachite",
  "rayon",
@@ -3592,10 +3592,10 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.8",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "prometheus",
  "serde",
  "serde_json",
@@ -3612,13 +3612,13 @@ dependencies = [
  "bytes",
  "chrono",
  "crossterm 0.29.0",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-config",
  "ethrex-l2-common",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
  "ethrex-sdk",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-storage-rollup",
  "futures",
  "hex",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3646,14 +3646,14 @@ dependencies = [
  "ctr",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-metrics",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
  "ethrex-storage-rollup",
- "ethrex-trie 24.0.0",
+ "ethrex-trie 25.0.0",
  "futures",
  "hex",
  "hkdf",
@@ -3681,14 +3681,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bincode",
  "bytes",
  "clap 4.6.0",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-guest-program",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-vm",
  "libssz",
  "rkyv",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -3752,13 +3752,13 @@ dependencies = [
  "envy",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-metrics",
  "ethrex-p2p",
- "ethrex-rlp 24.0.0",
- "ethrex-storage 24.0.0",
- "ethrex-trie 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-storage 25.0.0",
+ "ethrex-trie 25.0.0",
  "ethrex-vm",
  "hex",
  "hex-literal",
@@ -3783,15 +3783,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "ethrex-rpc",
  "ethrex-sdk-contract-utils",
  "hex",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -3838,14 +3838,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
- "ethrex-rlp 24.0.0",
- "ethrex-trie 24.0.0",
+ "ethrex-rlp 25.0.0",
+ "ethrex-trie 25.0.0",
  "fastbloom",
  "lru 0.16.3",
  "rayon",
@@ -3860,12 +3860,12 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "async-trait",
  "bincode",
  "ethereum-types",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-l2-common",
  "futures",
  "rkyv",
@@ -3896,14 +3896,14 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
  "ethereum-types",
  "ethrex-crypto",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "hashbrown 0.15.5",
  "rayon",
  "rkyv",
@@ -3915,15 +3915,15 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "dyn-clone",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-crypto",
  "ethrex-levm",
- "ethrex-rlp 24.0.0",
+ "ethrex-rlp 25.0.0",
  "rayon",
  "rustc-hash 2.1.2",
  "serde",
@@ -5608,7 +5608,7 @@ dependencies = [
  "clap 4.6.0",
  "ethereum-types",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-l2-common",
  "ethrex-l2-rpc",
  "ethrex-rpc",
@@ -5812,9 +5812,9 @@ dependencies = [
  "clap 4.6.0",
  "ethrex-blockchain",
  "ethrex-common 1.0.0",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-storage 1.0.0",
- "ethrex-storage 24.0.0",
+ "ethrex-storage 25.0.0",
  "libc",
  "rocksdb",
  "tokio",
@@ -7657,7 +7657,7 @@ version = "4.0.0"
 dependencies = [
  "ethrex",
  "ethrex-blockchain",
- "ethrex-common 24.0.0",
+ "ethrex-common 25.0.0",
  "ethrex-config",
  "ethrex-l2-common",
  "ethrex-l2-rpc",

--- a/tooling/zkevm_bench/Cargo.lock
+++ b/tooling/zkevm_bench/Cargo.lock
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-config"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.9",
  "bytes",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.9",
  "ethrex-common",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-prover"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "axum 0.8.9",
  "axum-extra",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-sdk-contract-utils"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage-rollup"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "24.0.0"
+version = "25.0.0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",


### PR DESCRIPTION
**Motivation**

Merges the `release/v25.0.0` branch back into `main` now that [v25.0.0](https://github.com/lambdaclass/ethrex/releases/tag/v25.0.0) is published, per the last step of the [release process](https://github.com/lambdaclass/ethrex/blob/main/docs/developers/release-process.md).

The second commit matters on its own: **`main`'s release workflow is currently broken**, and this is what fixes it. Any tag cut from `main` before this merges would build every artifact and then fail to publish a release.

**Description**

Two commits, no conflicts with `main`:

- `chore(l1,l2): bump version to 25.0.0` — the 25 internal version pins across 9 `Cargo.toml` files, the regenerated lockfiles, and both `--builder.extra-data` defaults in `docs/CLI.md`.

  Includes the four `crates/guest-program/stateless-validator/**/Cargo.lock` files, which are each their own workspace and reach the ethrex crates through path dependencies, so they pin the workspace version and go stale on a bump. `make update-cargo-lock` does not cover them while `check-cargo-lock` does, so they were refreshed by hand — worth closing that asymmetry in a follow-up, since every future bump hits it.

- `ci(l1,l2): stop the release asset download from matching docker build records` — `finalize-release` downloaded artifacts with `pattern: "*ethrex*"`, which also matches the build records the docker jobs upload as `<org>~ethrex~<id>.dockerbuild`. Those are not zip archives, so `download-artifact` exhausted its retries trying to extract them and the job died before publishing anything.

  This is a regression from #7115, which widened the pattern to pick up the new `stateless-validator-ethrex-*` artifacts; the previous anchored pattern never matched the docker records. v25.0.0-rc.1 hit it — all 13 build jobs green, no release created. The dry-run rehearsal could not have caught it either: that job only waits on the guest builds, so it runs before any docker record exists.

  Fixed with two anchored patterns, `ethrex*` and `stateless-validator-ethrex-*`, verified against the run's real 17 artifacts to select exactly the 12 release assets. rc.2 published all 22 assets correctly.

**Validation**

v25.0.0 went through the full release checklist: three mainnet canaries paired with Prysm/Teku/Grandine, an eth-docker mainnet node, 13 consecutive successful multisync runs across hoodi/sepolia/mainnet, the SP1 GPU integration suite, and the L2 upgrade test — the last of which ran with a real SP1 GPU prover for the first time (see #7203).

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.