### PR TITLE
perf(l1): bloom filter and 4KB blocks for the account-code CFs [post-Glamsterdam only]

### DIFF
--- a/crates/storage/backend/rocksdb.rs
+++ b/crates/storage/backend/rocksdb.rs
@@ -1,6 +1,6 @@
 use crate::api::tables::{
-    ACCOUNT_CODES, ACCOUNT_FLATKEYVALUE, ACCOUNT_TRIE_NODES, BLOCK_NUMBERS, BODIES,
-    CANONICAL_BLOCK_HASHES, FULLSYNC_HEADERS, HEADERS, RECEIPTS_V2, STORAGE_FLATKEYVALUE,
+    ACCOUNT_CODE_METADATA, ACCOUNT_CODES, ACCOUNT_FLATKEYVALUE, ACCOUNT_TRIE_NODES, BLOCK_NUMBERS,
+    BODIES, CANONICAL_BLOCK_HASHES, FULLSYNC_HEADERS, HEADERS, RECEIPTS_V2, STORAGE_FLATKEYVALUE,
     STORAGE_TRIE_NODES, TRANSACTION_LOCATIONS,
 };
 use crate::api::{
@@ -265,18 +265,28 @@ impl RocksDBBackend {
                     configure_block_cache(&mut block_opts);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }
-                ACCOUNT_CODES => {
+                ACCOUNT_CODES | ACCOUNT_CODE_METADATA => {
                     cf_opts.set_write_buffer_size(128 * 1024 * 1024); // 128MB
                     cf_opts.set_max_write_buffer_number(3);
                     cf_opts.set_target_file_size_base(256 * 1024 * 1024); // 256MB
 
-                    cf_opts.set_enable_blob_files(true);
-                    // Small bytecodes should go inline (mainly for delegation indicators)
-                    cf_opts.set_min_blob_size(32);
-                    cf_opts.set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+                    if cf_name == ACCOUNT_CODES {
+                        cf_opts.set_enable_blob_files(true);
+                        // Small bytecodes should go inline (mainly for delegation indicators)
+                        cf_opts.set_min_blob_size(32);
+                        cf_opts.set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+                    }
 
                     let mut block_opts = BlockBasedOptions::default();
-                    block_opts.set_block_size(32 * 1024); // 32KB
+                    // Exact-key point lookups on the execution read path, same shape as the
+                    // trie-node and flat-KV CFs above: EXT*/CALL* resolve a code hash to its
+                    // bytecode or length. A 4KB (page-sized) block keeps per-get read
+                    // amplification down — with blob files the SST value is just a blob
+                    // reference, so a large block buys nothing — and the filter prunes the
+                    // levels that cannot hold the hash instead of reading a data block per
+                    // level to find out.
+                    block_opts.set_block_size(4 * 1024); // 4KB
+                    block_opts.set_bloom_filter(10.0, false); // 10 bits per key
                     configure_block_cache(&mut block_opts);
                     cf_opts.set_block_based_table_factory(&block_opts);
                 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until Glamsterdam activates on mainnet.** This is an improvement
> under Glamsterdam but a **regression on current mainnet**, so it is correct on
> `glamsterdam-devnet-8` and premature on `main`. Opened as a draft to record the
> feature and its constraint, not to land now.

**Motivation**

One of the features that exists on `glamsterdam-devnet-8` but never had a PR to `main`. EthPandaOps need devnet-8 to be a mirror of `main`, so each such feature is being surfaced as its own PR — including the ones that turn out to be deliberate, fork-gated divergences rather than oversights. This is one of those.

`ACCOUNT_CODES` and `ACCOUNT_CODE_METADATA` are read by exact-key point lookup on the execution read path — `EXTCODESIZE`, `EXTCODECOPY` and the `CALL` family resolve a code hash to its bytecode or its length. They were configured with 32 KB blocks and no bloom filter, which is the wrong shape for that pattern:

- with blob files enabled the SST value is only a blob *reference*, so a large block reads more bytes for nothing
- without a filter, a point lookup reads a data block at every candidate level to discover the key is absent

**Description**

Treats these two CFs like the trie-node and flat-KV CFs already are: 32 KB → **4 KB** blocks, plus a **bloom filter at 10 bits per key**. Blob files stay enabled for `ACCOUNT_CODES` only — `ACCOUNT_CODE_METADATA` holds small fixed-size values, so inlining is correct there and blob indirection would be overhead. That is why the shared match arm now branches on CF name.

These are write-time options: they apply to newly flushed and compacted SSTs, and existing SSTs are read as-is.

**Why it must wait**

Under Glamsterdam the state-access repricing changes how hot these lookups are relative to everything else, and the smaller block plus filter wins. On today's mainnet workload the same change costs more than it saves. The commit message does not record this, which is worth fixing on the branch — the constraint is currently tribal knowledge, and nothing in the code or history would stop someone merging it.

**Tests**

`cargo clippy -p ethrex-storage --all-targets -- -D warnings` clean; 91 storage tests pass. Being a tuning change, the tests only prove no regression in behaviour. It has run on `glamsterdam-devnet-8` since 2026-08-03.

I have not benchmarked either side of the claim myself — neither the Glamsterdam gain nor the mainnet regression. Both are carried over from whoever measured them originally, and the mainnet regression in particular deserves a recorded number somewhere before this is revisited.
