### PR TITLE
fix(l2): pin the TDX qpl tool's crate resolution to the repo's lockfile

### DIFF
--- a/crates/l2/tee/contracts/Makefile
+++ b/crates/l2/tee/contracts/Makefile
@@ -121,6 +121,16 @@ automata-dcap-qpl:
 	cd automata-dcap-qpl/automata-dcap-qpl-tool; git clone https://github.com/automata-network/pccs-reader-rs
 	git -C automata-dcap-qpl/automata-dcap-qpl-tool/pccs-reader-rs checkout --detach $(PCCS_READER_REV)
 	rm automata-dcap-qpl/Cargo.toml
+# Removing the workspace manifest above orphans the repo's root Cargo.lock, so
+# the build below would re-resolve every crates.io dependency at its latest
+# version — the git revs are pinned but the resolution floats. Carry the lock
+# into the tool's new workspace so the versions the repo built against are kept
+# (cargo prunes entries for the members that are gone, and only re-resolves on a
+# requirement mismatch). alloy-sol-types 1.7.0 is the incident this guards
+# against: it added required trait methods that the pinned attestation rev's
+# generated bindings do not implement, breaking this build for anyone resolving
+# fresh after its release.
+	cp automata-dcap-qpl/Cargo.lock automata-dcap-qpl/automata-dcap-qpl-tool/Cargo.lock
 	echo "" >> automata-dcap-qpl/automata-dcap-qpl-tool/Cargo.toml
 	echo "[workspace]" >> automata-dcap-qpl/automata-dcap-qpl-tool/Cargo.toml
 	cd automata-dcap-qpl/automata-dcap-qpl-tool; cargo build --release


### PR DESCRIPTION
**Motivation**

Every `Integration Test - TDX` run after 2026-08-25 15:29 UTC fails during "Start L1 & Deploy contracts", killing 56 E0046 errors deep in a third-party crate — including on the v25.0.0 merge-back (#7215). Runs that look green after that time merely skipped the job through the paths filter. The TDX prover itself is never reached.

`alloy-sol-types 1.7.0` (published at that timestamp) added required trait methods (`abi_decode_returns_with_config` and friends) that the generated bindings in the pinned `automata-dcap-attestation` rev do not implement, so compiling `automata-dcap-evm-bindings` fails for anyone resolving fresh.

Resolution floats because of our own recipe: the `automata-dcap-qpl` target deletes the cloned repo's workspace `Cargo.toml` to build the collateral CLI standalone, which **orphans the repo's root `Cargo.lock`** — every git rev in the Makefile is pinned (#7102), but the tool's crates.io dependencies re-resolved at latest on every build.

**Description**

Copy the repo's root `Cargo.lock` into the tool's new workspace before building. Cargo prunes the entries for the removed members and keeps the locked versions for everything else, so the build compiles the dependency set the pinned rev was developed against (`alloy-sol-types 1.6.1`).

Verified both directions:

- without the lock: fresh resolution picks `alloy-sol-types 1.7.1` → the bindings fail to compile with the same E0046 errors as CI
- with the carried lock: resolves `1.6.1`, and `cargo check` of the tool (including `automata-dcap-evm-bindings`) passes

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.