### PR TITLE
perf(l1): answer EXTCODESIZE from the code-length table

### DIFF
--- a/crates/vm/backends/levm/db.rs
+++ b/crates/vm/backends/levm/db.rs
@@ -80,6 +80,15 @@ impl LevmDatabase for DatabaseLogger {
     }
 
     fn get_code_metadata(&self, code_hash: CoreH256) -> Result<CodeMetadata, DatabaseError> {
+        // A size-only read still observes the bytecode, so the witness must carry it:
+        // EIP-8025 stateless validation recomputes the length from the code itself, and
+        // that is also how `ExecutionWitness::get_code_metadata` answers.
+        if code_hash != *EMPTY_KECCAK_HASH {
+            self.code_accessed
+                .lock()
+                .map_err(|_| DatabaseError::Custom("Could not lock mutex".to_string()))?
+                .push(code_hash);
+        }
         self.store.get_code_metadata(code_hash)
     }
 }

--- a/crates/vm/levm/src/db/gen_db.rs
+++ b/crates/vm/levm/src/db/gen_db.rs
@@ -492,29 +492,18 @@ impl GeneralizedDatabase {
         match self.code_metadata.entry(code_hash) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
             Entry::Vacant(entry) => {
-                // First ensure code is loaded into cache by calling get_code
-                // This handles witness fallbacks and other code loading logic correctly
+                // Answer from the size-only store lookup rather than the bytecode: a
+                // contract's code is up to 24KB and lives out-of-line, so materializing it
+                // to return a length is the dominant cost of EXTCODESIZE. Code already
+                // loaded for another reason answers for free.
                 #[expect(clippy::as_conversions, reason = "same sized types (on 64bit)")]
-                let code_length = {
-                    // Note: `self.get_code(code_hash)` has been inlined due to mutability borrow issues.
-                    //   To avoid this inlinement, self.get_code has to be moved into `self.codes` so that it's called
-                    //   like this: `self.codes.get(code_hash)`.
-                    let code = match self.codes.entry(code_hash) {
-                        Entry::Occupied(entry) => entry.into_mut(),
-                        Entry::Vacant(entry) => {
-                            entry.insert(self.store.get_account_code(code_hash)?)
-                        }
-                    };
-
-                    code.len() as u64
-                };
-
-                let metadata = CodeMetadata {
-                    length: code_length,
+                let length = match self.codes.get(&code_hash) {
+                    Some(code) => code.len() as u64,
+                    None => self.store.get_code_metadata(code_hash)?.length,
                 };
 
                 // Insert into cache and return reference
-                Ok(entry.insert(metadata))
+                Ok(entry.insert(CodeMetadata { length }))
             }
         }
     }


### PR DESCRIPTION
**Motivation**

One of the features on `glamsterdam-devnet-8` that never had a PR to `main`. EthPandaOps need devnet-8 to mirror `main`, so each is being upstreamed individually.

`get_code_metadata` loaded the entire bytecode just to return `.len()`. For a max-size contract that materialises up to 24 KB out of the blob store to answer a size query. Meanwhile the size-only `ACCOUNT_CODE_METADATA` table was already plumbed through every storage layer but was only ever read from a mempool check.

**Description**

Read the metadata table instead, falling back to bytecode that is already loaded for another reason.

Witness generation stays complete: a metadata read still observes the bytecode, so the trie logger records the code hash and the witness continues to carry the code — which is what stateless validation recomputes the length from. That is the part worth checking in review, since it is the only place where reading less could have changed what a witness contains.

**Relationship to the other upstreamed perf commits**

This comes from the same 2026-08-03 cluster as #7218, which is fork-gated (an improvement under Glamsterdam, a regression on current mainnet) and therefore a draft. This one reads a length instead of a whole blob, which should win on any workload, so I believe it is unconditional — but I did not measure either commit and #7218's own message did not record its constraint, so that belief is inference rather than fact. Worth a second opinion from whoever benchmarked the cluster.

**Tests**

`cargo clippy --workspace --all-targets -- -D warnings` clean; ethrex-vm unit tests and the full 967-test integration suite pass. Running on `glamsterdam-devnet-8` since 2026-08-03.
