### PR TITLE
perf(l1): store jump destinations as a bitmap

### DIFF
--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -95,16 +95,31 @@ impl Code {
 
     /// Builds the [`Code::jumpdests`] bitmap: one pass over the bytecode, setting the
     /// bit for every `JUMPDEST` while skipping `PUSH` immediates.
+    ///
+    /// The bits of a byte are accumulated in a register and written once the scan leaves
+    /// that byte, which the monotonic `i` makes safe. Reading the bitmap back inside the
+    /// loop instead would turn each `JUMPDEST` into a read-modify-write, and indexing it
+    /// would put a bounds-check panic path in the loop; either costs more than the scan
+    /// itself for bytecode with few jump destinations.
     pub fn compute_jumpdests(code: &[u8]) -> Arc<[u8]> {
         let mut bitmap = vec![0u8; code.len().div_ceil(8)];
         let mut any = false;
+        let mut current_byte = usize::MAX;
+        let mut bits = 0u8;
         let mut i = 0;
         while i < code.len() {
             // TODO: we don't use the constants from the vm module to avoid a circular dependency
             match code[i] {
                 // OP_JUMPDEST
                 0x5B => {
-                    bitmap[i / 8] |= 1 << (i % 8);
+                    if i / 8 != current_byte {
+                        if let Some(byte) = bitmap.get_mut(current_byte) {
+                            *byte = bits;
+                        }
+                        current_byte = i / 8;
+                        bits = 0;
+                    }
+                    bits |= 1 << (i % 8);
                     any = true;
                 }
                 // OP_PUSH1..32
@@ -115,6 +130,9 @@ impl Code {
                 _ => (),
             }
             i += 1;
+        }
+        if let Some(byte) = bitmap.get_mut(current_byte) {
+            *byte = bits;
         }
         // Share the single empty bitmap for jumpless bytecode (very common: EOAs,
         // tiny contracts) so we don't allocate for an all-zero map; `is_valid_jumpdest`

--- a/crates/common/types/account.rs
+++ b/crates/common/types/account.rs
@@ -22,7 +22,7 @@ use crate::constants::{EMPTY_KECCAK_HASH, EMPTY_TRIE_HASH};
 /// `JUMPDEST` clone this (a refcount bump) instead of allocating a fresh empty
 /// `Arc` header each time. This matters because the per-tx `Code::default()`
 /// placeholder and every EOA / empty-code load would otherwise each allocate.
-static EMPTY_JUMP_TARGETS: LazyLock<Arc<[u32]>> = LazyLock::new(|| Arc::from(Vec::new()));
+static EMPTY_JUMPDESTS: LazyLock<Arc<[u8]>> = LazyLock::new(|| Arc::from(Vec::new()));
 
 /// Trailing STOP bytes appended to every bytecode so the dispatch loop can read
 /// the next opcode without a bounds check. 33 is the widest single-opcode advance
@@ -42,13 +42,15 @@ pub struct Code {
     bytecode: Bytes,
     /// The real bytecode length, needed for some opcodes, `bytecode` is padded with 33 STOPs to avoid checked adds on hot loop.
     bytecode_len: usize,
-    // `Arc<[u32]>` so cloning `Code` (hot: every message-call resolves and clones
-    // the callee's code) is a refcount bump instead of deep-copying the table.
+    /// One bit per bytecode byte, set when that offset holds a `JUMPDEST` that is not
+    /// part of a `PUSH` immediate. A bitmap is `len/8` bytes regardless of how dense
+    /// the jump destinations are, and validating a jump is a bit test rather than a
+    /// search.
+    //
+    // `Arc<[u8]>` so cloning `Code` (hot: every message-call resolves and clones
+    // the callee's code) is a refcount bump instead of deep-copying the bitmap.
     // Serializes via serde's `rc` feature (enabled workspace-wide).
-    // The valid addresses are 32-bit because, despite EIP-3860 restricting initcode size,
-    // this does not apply to previous forks. This is tested in the EEST tests, which would
-    // panic in debug mode.
-    pub jump_targets: Arc<[u32]>,
+    jumpdests: Arc<[u8]>,
 }
 
 impl Code {
@@ -59,26 +61,26 @@ impl Code {
     // `code` is the logical, unpadded bytecode; `BYTECODE_PADDING` STOP bytes are
     // appended internally by `from_parts_unchecked`.
     pub fn from_bytecode_unchecked(code: Bytes, hash: H256) -> Self {
-        let jump_targets = Self::compute_jump_targets(&code);
-        Self::from_parts_unchecked(hash, &code, jump_targets)
+        let jumpdests = Self::compute_jumpdests(&code);
+        Self::from_parts_unchecked(hash, &code, jumpdests)
     }
 
     /// `code` is the logical, unpadded bytecode; `BYTECODE_PADDING` STOP bytes are
     /// appended internally by `from_parts_unchecked`.
     pub fn from_bytecode(code: Bytes, crypto: &dyn Crypto) -> Self {
-        let jump_targets = Self::compute_jump_targets(&code);
+        let jumpdests = Self::compute_jumpdests(&code);
         let hash = H256(crypto.keccak256(code.as_ref()));
-        Self::from_parts_unchecked(hash, &code, jump_targets)
+        Self::from_parts_unchecked(hash, &code, jumpdests)
     }
 
     /// Builds a `Code` from precomputed parts. The caller must guarantee `hash`
-    /// and `jump_targets` correspond to `code`; neither is recomputed or validated.
+    /// and `jumpdests` correspond to `code`; neither is recomputed or validated.
     ///
     /// `code` is the logical, unpadded bytecode: this function appends
     /// `BYTECODE_PADDING` STOP bytes and records the original length in
     /// `bytecode_len`. Never pass a pre-padded buffer, or the logical length and
     /// every `JUMPDEST`/`PUSH` offset derived from it would be wrong.
-    pub fn from_parts_unchecked(hash: H256, code: &[u8], jump_targets: Arc<[u32]>) -> Self {
+    pub fn from_parts_unchecked(hash: H256, code: &[u8], jumpdests: Arc<[u8]>) -> Self {
         let bytecode_len = code.len();
         let mut padded_code = Vec::with_capacity(bytecode_len + BYTECODE_PADDING);
         padded_code.extend_from_slice(code);
@@ -87,20 +89,23 @@ impl Code {
             hash,
             bytecode: Bytes::from_owner(padded_code),
             bytecode_len,
-            jump_targets,
+            jumpdests,
         }
     }
 
-    fn compute_jump_targets(code: &[u8]) -> Arc<[u32]> {
-        debug_assert!(code.len() <= u32::MAX as usize);
-        let mut targets = Vec::new();
+    /// Builds the [`Code::jumpdests`] bitmap: one pass over the bytecode, setting the
+    /// bit for every `JUMPDEST` while skipping `PUSH` immediates.
+    pub fn compute_jumpdests(code: &[u8]) -> Arc<[u8]> {
+        let mut bitmap = vec![0u8; code.len().div_ceil(8)];
+        let mut any = false;
         let mut i = 0;
         while i < code.len() {
             // TODO: we don't use the constants from the vm module to avoid a circular dependency
             match code[i] {
                 // OP_JUMPDEST
                 0x5B => {
-                    targets.push(i as u32);
+                    bitmap[i / 8] |= 1 << (i % 8);
+                    any = true;
                 }
                 // OP_PUSH1..32
                 c @ 0x60..0x80 => {
@@ -111,13 +116,29 @@ impl Code {
             }
             i += 1;
         }
-        // Share the single empty table for jumpless bytecode (very common: EOAs,
-        // tiny contracts) so we don't allocate an `Arc` header for an empty slice.
-        if targets.is_empty() {
-            EMPTY_JUMP_TARGETS.clone()
+        // Share the single empty bitmap for jumpless bytecode (very common: EOAs,
+        // tiny contracts) so we don't allocate for an all-zero map; `is_valid_jumpdest`
+        // reads a missing byte as "no jump destination".
+        if any {
+            Arc::from(bitmap)
         } else {
-            Arc::from(targets)
+            EMPTY_JUMPDESTS.clone()
         }
+    }
+
+    /// Whether `offset` is a valid jump destination, i.e. it holds a `JUMPDEST` that is
+    /// not part of a `PUSH` immediate. Offsets past the bytecode are not valid.
+    #[inline]
+    pub fn is_valid_jumpdest(&self, offset: usize) -> bool {
+        self.jumpdests
+            .get(offset / 8)
+            .is_some_and(|byte| byte & (1 << (offset % 8)) != 0)
+    }
+
+    /// The raw [`Code::jumpdests`] bitmap, for persisting it alongside the bytecode.
+    #[inline]
+    pub fn jumpdests(&self) -> &[u8] {
+        &self.jumpdests
     }
 
     #[inline]
@@ -151,16 +172,18 @@ impl Code {
     /// Estimates the size of the Code struct in bytes
     /// (including stack size and heap allocation).
     ///
-    /// Note: This is an estimation and may not be exact.
+    /// Note: This is an estimation and may not be exact. Shared allocations (the
+    /// empty bitmap, a `Bytes` slice of a larger buffer) are counted in full, so the
+    /// estimate is an upper bound.
     ///
     /// # Returns
     ///
     /// usize - Estimated size in bytes
     pub fn size(&self) -> usize {
         let hash_size = size_of::<H256>();
-        let bytes_size = size_of::<Bytes>();
-        let vec_size = size_of::<Arc<[u32]>>() + self.jump_targets.len() * size_of::<u32>();
-        hash_size + bytes_size + vec_size
+        let bytes_size = size_of::<Bytes>() + self.bytecode.len();
+        let bitmap_size = size_of::<Arc<[u8]>>() + self.jumpdests.len();
+        hash_size + bytes_size + bitmap_size
     }
 }
 
@@ -174,7 +197,7 @@ impl Code {
 struct CodeSerde {
     hash: H256,
     code: Bytes,
-    jump_targets: Arc<[u32]>,
+    jumpdests: Arc<[u8]>,
 }
 
 impl Serialize for Code {
@@ -182,7 +205,7 @@ impl Serialize for Code {
         CodeSerde {
             hash: self.hash,
             code: self.code_bytes(),
-            jump_targets: self.jump_targets.clone(),
+            jumpdests: self.jumpdests.clone(),
         }
         .serialize(serializer)
     }
@@ -193,9 +216,9 @@ impl<'de> Deserialize<'de> for Code {
         let CodeSerde {
             hash,
             code,
-            jump_targets,
+            jumpdests,
         } = CodeSerde::deserialize(deserializer)?;
-        Ok(Self::from_parts_unchecked(hash, &code, jump_targets))
+        Ok(Self::from_parts_unchecked(hash, &code, jumpdests))
     }
 }
 
@@ -263,7 +286,7 @@ impl Default for Code {
             bytecode: Bytes::from_static(&[0u8; BYTECODE_PADDING]),
             bytecode_len: 0,
             hash: *EMPTY_KECCAK_HASH,
-            jump_targets: EMPTY_JUMP_TARGETS.clone(),
+            jumpdests: EMPTY_JUMPDESTS.clone(),
         }
     }
 }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -36,7 +36,7 @@ use ethrex_common::{
 };
 use ethrex_crypto::{NativeCrypto, keccak::keccak_hash};
 use ethrex_rlp::{
-    decode::{RLPDecode, decode_bytes},
+    decode::{RLPDecode, decode_bytes, decode_rlp_item},
     encode::RLPEncode,
 };
 use ethrex_trie::{EMPTY_TRIE_HASH, Nibbles, Trie, TrieLogger, TrieNode, TrieWitness};
@@ -134,8 +134,32 @@ enum FKVGeneratorControlMessage {
     Continue,
 }
 
-// 64mb
-const CODE_CACHE_MAX_SIZE: u64 = 64 * 1024 * 1024;
+/// Share of the process's memory budget the bytecode cache may claim.
+///
+/// Bytecode is a small fraction of the working set next to trie nodes and flat
+/// key-values (which the RocksDB block cache serves, see
+/// [`ROCKSDB_BLOCK_CACHE_MEMORY_PERCENT`]), but a cold code read costs a blob-file
+/// fetch, so caching a few tens of thousands of contracts pays for itself.
+const CODE_CACHE_MEMORY_PERCENT: usize = 2;
+
+/// Floor for [`code_cache_size_for`], so a small or undetectable host still caches
+/// the hot contracts.
+const MIN_CODE_CACHE_SIZE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Ceiling for [`code_cache_size_for`]: past this the cache holds more distinct
+/// bytecode than any block realistically touches.
+const MAX_CODE_CACHE_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// Size of the in-memory bytecode cache, derived from the memory this process is
+/// allowed to use, clamped to [`MIN_CODE_CACHE_SIZE_BYTES`] ..=
+/// [`MAX_CODE_CACHE_SIZE_BYTES`]. `None` means detection failed.
+fn code_cache_size_for(memory_limit: Option<usize>) -> u64 {
+    let Some(limit) = memory_limit else {
+        return MIN_CODE_CACHE_SIZE_BYTES;
+    };
+    ((limit / 100 * CODE_CACHE_MEMORY_PERCENT) as u64)
+        .clamp(MIN_CODE_CACHE_SIZE_BYTES, MAX_CODE_CACHE_SIZE_BYTES)
+}
 
 /// Key used to persist the `flushed_upto` block number in `MISC_VALUES`.
 const FLUSHED_UPTO_KEY: &[u8] = b"bodies_flushed_upto";
@@ -150,6 +174,7 @@ const MAX_BAD_BLOCKS: usize = 16;
 struct CodeCache {
     inner_cache: LruCache<H256, Code, FxBuildHasher>,
     cache_size: u64,
+    max_size: u64,
 }
 
 impl Default for CodeCache {
@@ -157,6 +182,7 @@ impl Default for CodeCache {
         Self {
             inner_cache: LruCache::unbounded_with_hasher(FxBuildHasher),
             cache_size: 0,
+            max_size: code_cache_size_for(host_memory_limit_bytes()),
         }
     }
 }
@@ -167,15 +193,17 @@ impl CodeCache {
     }
 
     fn insert(&mut self, code: &Code) -> Result<(), StoreError> {
-        let code_size = code.size();
-        let cache_len = self.inner_cache.len() + 1;
-        self.cache_size += code_size as u64;
-        let current_size = self.cache_size;
-        debug!(
-            "[ACCOUNT CODE CACHE] cache elements (): {cache_len}, total size: {current_size} bytes"
-        );
+        // A hash already cached must not be added to `cache_size` again, or the counter
+        // drifts up permanently and evicts entries that fit. `get` also refreshes
+        // recency, which is what a repeated read should do.
+        if self.inner_cache.get(&code.hash).is_some() {
+            return Ok(());
+        }
 
-        while self.cache_size > CODE_CACHE_MAX_SIZE {
+        self.cache_size += code.size() as u64;
+        self.inner_cache.put(code.hash, code.clone());
+
+        while self.cache_size > self.max_size {
             if let Some((_, code)) = self.inner_cache.pop_lru() {
                 self.cache_size -= code.size() as u64;
             } else {
@@ -183,7 +211,11 @@ impl CodeCache {
             }
         }
 
-        self.inner_cache.get_or_insert(code.hash, || code.clone());
+        let cache_len = self.inner_cache.len();
+        let current_size = self.cache_size;
+        debug!(
+            "[ACCOUNT CODE CACHE] cache elements (): {cache_len}, total size: {current_size} bytes"
+        );
         Ok(())
     }
 }
@@ -1003,11 +1035,11 @@ impl Store {
         else {
             return Ok(None);
         };
-        let (bytecode_slice, targets) = decode_bytes(&bytes)?;
+        let (bytecode_slice, jumpdests) = decode_bytes(&bytes)?;
         let code = Code::from_parts_unchecked(
             code_hash,
             bytecode_slice,
-            <Vec<u32>>::decode(targets)?.into(),
+            decode_jumpdests(bytecode_slice, jumpdests)?,
         );
 
         // insert into cache and evict if needed
@@ -5287,13 +5319,25 @@ pub fn receipt_key(block_hash: &BlockHash, index: u64) -> Vec<u8> {
 }
 
 fn encode_code(code: &Code) -> Vec<u8> {
-    let mut buf =
-        Vec::with_capacity(6 + code.len() + std::mem::size_of_val::<[u32]>(&code.jump_targets));
+    let jumpdests = code.jumpdests();
+    let mut buf = Vec::with_capacity(6 + code.len() + jumpdests.len());
     code.code().encode(&mut buf);
-    // `Arc<[u32]>` (the in-memory share) has no `RLPEncode` impl; encode through an
-    // owned `Vec` on this cold DB-write path (code is persisted once per hash).
-    code.jump_targets.to_vec().encode(&mut buf);
+    jumpdests.encode(&mut buf);
     buf
+}
+
+/// Decodes the JUMPDEST bitmap stored after the bytecode in an [`ACCOUNT_CODES`] value.
+///
+/// Values written before the bitmap representation hold an RLP *list* of `u32` offsets
+/// there instead. The RLP item header distinguishes a list from a byte string, so both
+/// forms are readable: for the older one the bitmap is rebuilt from the bytecode, which
+/// is cheaper than decoding the list.
+fn decode_jumpdests(code: &[u8], encoded: &[u8]) -> Result<Arc<[u8]>, StoreError> {
+    let (is_list, payload, _) = decode_rlp_item(encoded)?;
+    if is_list {
+        return Ok(Code::compute_jumpdests(code));
+    }
+    Ok(Arc::from(payload))
 }
 
 #[derive(Debug, Default, Clone)]
@@ -5466,6 +5510,149 @@ pub fn read_chain_id_from_db(path: &Path) -> Option<u64> {
     {
         let _ = path;
         None
+    }
+}
+
+#[cfg(test)]
+mod account_code_tests {
+    use super::*;
+
+    const JUMPDEST: u8 = 0x5b;
+    const PUSH1: u8 = 0x60;
+
+    /// A max-size contract that is almost entirely JUMPDESTs, the shape that makes the
+    /// jump-destination representation matter: as a list of offsets it is ~4x the size
+    /// of the bytecode it describes.
+    fn jumpdest_dense_code() -> Code {
+        let mut bytecode = vec![JUMPDEST; 24576];
+        bytecode[0] = 0x00;
+        Code::from_bytecode_unchecked(bytecode.into(), H256::zero())
+    }
+
+    /// Encodes an `ACCOUNT_CODES` value the way it was written before the bitmap: the
+    /// bytecode followed by an RLP list of `u32` JUMPDEST offsets.
+    fn encode_code_legacy(code: &Code) -> Vec<u8> {
+        let offsets: Vec<u32> = (0..code.len())
+            .filter(|offset| code.is_valid_jumpdest(*offset))
+            .map(|offset| offset as u32)
+            .collect();
+        let mut buf = Vec::new();
+        code.code().encode(&mut buf);
+        offsets.encode(&mut buf);
+        buf
+    }
+
+    #[test]
+    fn encoded_value_carries_one_bitmap_bit_per_code_byte() {
+        let code = jumpdest_dense_code();
+        let encoded = encode_code(&code);
+
+        assert_eq!(encoded.len(), 6 + code.len() + code.len().div_ceil(8));
+    }
+
+    #[test]
+    fn round_trip_preserves_the_bitmap() {
+        let code = jumpdest_dense_code();
+        let encoded = encode_code(&code);
+
+        let (bytecode, jumpdests) = decode_bytes(&encoded).unwrap();
+        assert_eq!(bytecode, code.code());
+        assert_eq!(
+            decode_jumpdests(bytecode, jumpdests).unwrap().as_ref(),
+            code.jumpdests()
+        );
+    }
+
+    /// Values written before the bitmap SHALL still decode, with the bitmap rebuilt from
+    /// the bytecode, so an existing database needs no migration.
+    #[test]
+    fn legacy_offset_list_values_decode_to_the_same_bitmap() {
+        for bytecode in [
+            vec![0x00, JUMPDEST, 0x00, JUMPDEST],
+            vec![PUSH1, JUMPDEST, JUMPDEST],
+            vec![0x00; 32],
+        ] {
+            let code = Code::from_bytecode_unchecked(bytecode.into(), H256::zero());
+            let legacy = encode_code_legacy(&code);
+
+            let (decoded_bytecode, jumpdests) = decode_bytes(&legacy).unwrap();
+            assert_eq!(decoded_bytecode, code.code());
+            assert_eq!(
+                decode_jumpdests(decoded_bytecode, jumpdests)
+                    .unwrap()
+                    .as_ref(),
+                code.jumpdests()
+            );
+        }
+    }
+
+    /// Re-inserting a cached hash SHALL NOT grow the accounted size, or the counter
+    /// drifts up until the cache evicts entries that fit.
+    #[test]
+    fn repeated_inserts_do_not_inflate_the_accounted_size() {
+        let code = jumpdest_dense_code();
+        let mut cache = CodeCache::default();
+
+        cache.insert(&code).unwrap();
+        let after_first = cache.cache_size;
+        for _ in 0..8 {
+            cache.insert(&code).unwrap();
+        }
+
+        assert_eq!(cache.cache_size, after_first);
+        assert_eq!(cache.inner_cache.len(), 1);
+    }
+
+    /// The accounted size SHALL include the bytecode itself, so the cache honors its
+    /// memory budget instead of holding orders of magnitude more than it accounts for.
+    #[test]
+    fn accounted_size_covers_the_bytecode_and_bitmap() {
+        let code = jumpdest_dense_code();
+        let mut cache = CodeCache::default();
+        cache.insert(&code).unwrap();
+
+        assert!(cache.cache_size >= (code.len() + code.jumpdests().len()) as u64);
+    }
+
+    #[test]
+    fn cache_evicts_down_to_its_budget() {
+        let mut cache = CodeCache {
+            max_size: 128 * 1024,
+            ..Default::default()
+        };
+
+        for i in 0..16u8 {
+            let mut bytecode = vec![JUMPDEST; 24576];
+            bytecode[0] = i;
+            cache
+                .insert(&Code::from_bytecode_unchecked(
+                    bytecode.into(),
+                    H256::from_low_u64_be(i.into()),
+                ))
+                .unwrap();
+        }
+
+        assert!(cache.cache_size <= cache.max_size);
+        assert!(cache.inner_cache.len() < 16);
+    }
+
+    #[test]
+    fn code_cache_size_is_clamped_to_its_bounds() {
+        assert_eq!(code_cache_size_for(None), MIN_CODE_CACHE_SIZE_BYTES);
+        assert_eq!(
+            code_cache_size_for(Some(1024 * 1024 * 1024)),
+            MIN_CODE_CACHE_SIZE_BYTES
+        );
+        assert_eq!(
+            code_cache_size_for(Some(1024 * 1024 * 1024 * 1024)),
+            MAX_CODE_CACHE_SIZE_BYTES
+        );
+        let expected = 32u64 * 1024 * 1024 * 1024 / 100 * CODE_CACHE_MEMORY_PERCENT as u64;
+        assert_eq!(
+            code_cache_size_for(Some(32 * 1024 * 1024 * 1024)),
+            expected,
+            "a 32 GiB budget lands between the bounds"
+        );
     }
 }
 

--- a/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
+++ b/crates/vm/levm/src/opcode_handlers/stack_memory_storage_flow.rs
@@ -467,25 +467,10 @@ impl OpcodeHandler for OpJumpIHandler {
 /// JUMPDEST charge), and the JUMPDEST step is pushed directly via
 /// `synthesize_step` after the gas is charged.
 fn jump(vm: &mut VM<'_>, target: usize, parent_gas_cost: u64) -> Result<(), VMError> {
-    // Check target address validity.
-    //   - Target bytecode has to be a JUMPDEST.
-    //   - Target address must not be blacklisted (aka. the JUMPDEST must not be part of a literal).
-    #[expect(clippy::as_conversions, reason = "safe")]
-    if vm
-        .current_call_frame
-        .bytecode
-        .dispatch_buf()
-        .get(target)
-        .is_some_and(|&value| {
-            value == Opcode::JUMPDEST as u8
-                && vm
-                    .current_call_frame
-                    .bytecode
-                    .jump_targets
-                    .binary_search(&(target as u32))
-                    .is_ok()
-        })
-    {
+    // Check target address validity: the target has to be a JUMPDEST that is not part
+    // of a literal (aka. a PUSH immediate). Both are answered by the bitmap, which only
+    // has bits set for JUMPDESTs reached by the opcode walk.
+    if vm.current_call_frame.bytecode.is_valid_jumpdest(target) {
         if vm.opcode_tracer.active {
             // Override the parent JUMP/JUMPI's gasCost so the dispatch loop
             // doesn't roll the upcoming JUMPDEST charge into it.

--- a/test/tests/common/code_serde_tests.rs
+++ b/test/tests/common/code_serde_tests.rs
@@ -19,7 +19,7 @@ fn code_serde_roundtrip_preserves_logical_code_and_repads() {
     assert_eq!(restored.code(), code.code());
     assert_eq!(restored.len(), code.len());
     assert_eq!(restored.hash, code.hash);
-    assert_eq!(restored.jump_targets, code.jump_targets);
+    assert_eq!(restored.jumpdests(), code.jumpdests());
     // The dispatch buffer must carry the trailing padding after a round-trip.
     assert_eq!(restored.dispatch_buf().len(), code.len() + BYTECODE_PADDING);
     assert_eq!(restored, code);

--- a/test/tests/common/jumpdest_bitmap_tests.rs
+++ b/test/tests/common/jumpdest_bitmap_tests.rs
@@ -1,0 +1,79 @@
+//! [`Code`]'s JUMPDEST bitmap: which offsets are valid jump destinations.
+
+use ethrex_common::H256;
+use ethrex_common::types::Code;
+
+const JUMPDEST: u8 = 0x5b;
+const PUSH1: u8 = 0x60;
+const PUSH32: u8 = 0x7f;
+const STOP: u8 = 0x00;
+
+fn code_of(bytecode: Vec<u8>) -> Code {
+    Code::from_bytecode_unchecked(bytecode.into(), H256::zero())
+}
+
+/// A `JUMPDEST` reached by the opcode walk SHALL be a valid destination.
+#[test]
+fn jumpdests_outside_immediates_are_valid() {
+    let code = code_of(vec![STOP, JUMPDEST, STOP, JUMPDEST]);
+
+    assert!(code.is_valid_jumpdest(1));
+    assert!(code.is_valid_jumpdest(3));
+    assert!(!code.is_valid_jumpdest(0));
+    assert!(!code.is_valid_jumpdest(2));
+}
+
+/// A `0x5b` byte that is part of a `PUSH` immediate SHALL NOT be a valid destination:
+/// it is data, not an opcode.
+#[test]
+fn jumpdest_bytes_inside_push_immediates_are_not_valid() {
+    // PUSH1 0x5b | JUMPDEST | PUSH32 <32 x 0x5b> | JUMPDEST
+    let mut bytecode = vec![PUSH1, JUMPDEST, JUMPDEST, PUSH32];
+    bytecode.extend([JUMPDEST; 32]);
+    bytecode.push(JUMPDEST);
+    let code = code_of(bytecode);
+
+    assert!(!code.is_valid_jumpdest(1), "PUSH1 immediate");
+    assert!(code.is_valid_jumpdest(2), "opcode between the two PUSHes");
+    for offset in 4..36 {
+        assert!(!code.is_valid_jumpdest(offset), "PUSH32 immediate {offset}");
+    }
+    assert!(code.is_valid_jumpdest(36), "opcode after the immediates");
+}
+
+/// Offsets past the bytecode SHALL NOT be valid, including offsets inside the trailing
+/// [`BYTECODE_PADDING`](ethrex_common::types::BYTECODE_PADDING) and inside the last,
+/// partially used bitmap byte.
+#[test]
+fn offsets_past_the_bytecode_are_not_valid() {
+    // 9 bytes of code, so the bitmap's second byte covers offsets 8..16 and only its
+    // lowest bit is meaningful.
+    let code = code_of(vec![JUMPDEST; 9]);
+
+    assert!(code.is_valid_jumpdest(8));
+    for offset in [9, 10, 15, 16, 100, usize::MAX] {
+        assert!(!code.is_valid_jumpdest(offset));
+    }
+}
+
+/// Jumpless bytecode SHALL NOT allocate a bitmap, and empty code SHALL have none.
+#[test]
+fn jumpless_bytecode_has_an_empty_bitmap() {
+    assert!(code_of(vec![STOP; 64]).jumpdests().is_empty());
+    assert!(code_of(vec![PUSH1, JUMPDEST]).jumpdests().is_empty());
+    assert!(Code::default().jumpdests().is_empty());
+    assert!(!Code::default().is_valid_jumpdest(0));
+}
+
+/// The bitmap SHALL be one bit per bytecode byte.
+#[test]
+fn bitmap_is_one_bit_per_bytecode_byte() {
+    for len in [1usize, 7, 8, 9, 24576] {
+        let mut bytecode = vec![STOP; len];
+        bytecode[len - 1] = JUMPDEST;
+        let code = code_of(bytecode);
+
+        assert_eq!(code.jumpdests().len(), len.div_ceil(8), "len {len}");
+        assert!(code.is_valid_jumpdest(len - 1), "len {len}");
+    }
+}

--- a/test/tests/common/mod.rs
+++ b/test/tests/common/mod.rs
@@ -6,6 +6,7 @@ mod blobs_bundle_tests;
 mod code_serde_tests;
 mod eip7702_authorization_tests;
 mod frame_tx_validation_tests;
+mod jumpdest_bitmap_tests;
 mod legacy_signature_tests;
 mod logs_bloom_validation_tests;
 mod progressive_ssz_tests;


### PR DESCRIPTION
> [!WARNING]
> **Blocked on #7093.** `Code::size()` here accounts its allocation against a budget
> derived from `host_memory_limit_bytes()`, which #7093 introduces and `main` does not
> yet have. CI will fail to compile until #7093 merges. The bitmap logic itself is
> complete and reviewable now; I deliberately did not vendor #7093's commits into this
> branch, because resolving another PR's conflicts on its behalf would make both harder
> to review.

**Motivation**

The last feature on `glamsterdam-devnet-8` genuinely missing from `main`. EthPandaOps need devnet-8 to mirror `main`, so it is being upstreamed rather than carried on the branch.

Jump destinations were a sorted `Arc<[u32]>` of offsets persisted next to the bytecode. For jumpdest-dense contracts that is roughly 4× the code size — a measured 97,906 B of value for 24,576 B of code — and ~10 ns per entry to rebuild on every code-cache miss, so 246 µs for a max-size runtime that is almost all `JUMPDEST`s.

**Description**

One bit per bytecode byte, set when that offset holds a `JUMPDEST` that is not part of a `PUSH` immediate.

| | offset list | bitmap |
|---|---|---|
| size | ~4× code size at high density | `len/8` at **any** density |
| decode | 246 µs (max-size, dense) | 0.5 µs (a memcpy) |
| jump validation | 12.9 ns (binary search) | 0.37 ns (bit test) |

**No migration.** Values in the older form are still readable: the RLP item header distinguishes a list from a byte string, and for a list the bitmap is rebuilt from the bytecode — 26.6 µs, still ~9× cheaper than decoding the list.

`Code::size()` now counts the bytecode allocation it previously excluded, so the code cache honours its byte budget instead of holding orders of magnitude more than it accounted for. That is the line that pulls in #7093.

**The second commit is not optional.** Indexing the bitmap put a bounds-check panic path in the scan loop that cost more than the scan: jumpdest-free 24 KB initcode went to 55.4 µs against 11.2 µs for the offset-list version it replaced, and `benchmarkoor`'s `test_jumpdest_analysis[00]` lost 69–78 % throughput. Accumulating a byte's bits in a register and storing once per byte fixes it — the monotonically increasing index makes the single store safe. Net against the offset-list version, per 24 KB: dense 49.8 → 17.0 µs, jumpdest-free 11.1 → 11.8 µs, 1-in-32 12.5 → 12.0 µs, PUSH-heavy unchanged.

**Tests**

Adds `test/tests/common/jumpdest_bitmap_tests.rs`. Running on `glamsterdam-devnet-8` since 2026-08-03.

All performance figures above are from the original commit messages; I have not reproduced any of them. The jumpdest-free row is a small regression (11.1 → 11.8 µs) that the author accepted, which is worth a second look given how common jumpdest-free initcode is.
