### PR TITLE
fix(l1): refresh the eth forkid ENR entry when the chain crosses a fork

### DIFF
--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -11,6 +11,7 @@ use crate::{
     types::{Node, NodeRecord},
 };
 use bytes::BytesMut;
+use ethrex_common::types::ForkId;
 use ethrex_common::utils::keccak;
 use futures::StreamExt;
 use secp256k1::SecretKey;
@@ -27,7 +28,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::net::UdpSocket;
 use tokio_util::udp::UdpFramed;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use super::{DiscoveryConfig, codec::DiscriminatingCodec, lookup_interval_function};
 
@@ -90,6 +91,13 @@ pub struct DiscoveryServer {
     pub(crate) config: DiscoveryConfig,
     pub discv4: Option<Discv4State>,
     pub discv5: Option<Discv5State>,
+    /// Current EIP-2124 fork id, published by the network layer.
+    ///
+    /// Discovery does not read this from storage: the network layer decides what this
+    /// node announces about itself, and discovery only republishes. Without a refresh
+    /// the `eth` ENR entry goes stale the moment the chain crosses a fork, and geth's
+    /// dial-candidate filter (`NewNodeFilter`) drops us outright.
+    pub(crate) fork_id: Option<tokio::sync::watch::Receiver<ForkId>>,
 }
 
 impl std::fmt::Debug for DiscoveryServer {
@@ -106,6 +114,10 @@ impl std::fmt::Debug for DiscoveryServer {
 impl DiscoveryServer {
     /// Starts the discovery actor, advertising `local_node_record` as this
     /// node's ENR.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one more caller-supplied value; bundling them would only hide the call site"
+    )]
     pub async fn spawn(
         local_node: Node,
         local_node_record: NodeRecord,
@@ -114,6 +126,7 @@ impl DiscoveryServer {
         peer_table: PeerTable,
         bootnodes: Vec<Node>,
         config: DiscoveryConfig,
+        fork_id: Option<tokio::sync::watch::Receiver<ForkId>>,
     ) -> Result<(), DiscoveryServerError> {
         debug!("Starting discovery server");
 
@@ -150,6 +163,7 @@ impl DiscoveryServer {
             config,
             discv4,
             discv5,
+            fork_id,
         };
 
         // Ping discv4 bootnodes
@@ -382,6 +396,8 @@ impl DiscoveryServer {
             .discv5
             .as_mut()
             .and_then(|discv5| discv5.cleanup_stale_entries());
+        self.refresh_fork_id();
+
         if let Some(winning_ip) = winning_ip
             && winning_ip != self.local_node.ip
         {
@@ -412,6 +428,29 @@ impl DiscoveryServer {
             ITERATIVE_LOOKUP_INITIAL_MS,
             ITERATIVE_LOOKUP_INTERVAL_MS,
         )
+    }
+    /// Republish the ENR when the network layer reports a new fork id.
+    ///
+    /// `has_changed` is only true once per send, so a steady chain costs a flag check
+    /// per tick. A closed channel means the network layer is gone, which is shutdown,
+    /// not an error worth logging every tick.
+    fn refresh_fork_id(&mut self) {
+        let Some(rx) = self.fork_id.as_mut() else {
+            return;
+        };
+        if !rx.has_changed().unwrap_or(false) {
+            return;
+        }
+        let fork_id = rx.borrow_and_update().clone();
+        match self.local_node_record.set_fork_id(fork_id, &self.signer) {
+            Ok(()) => info!(
+                seq = self.local_node_record.seq,
+                "Chain crossed a fork; republished the local ENR with the new fork id"
+            ),
+            // A record we cannot sign is worth surfacing: peers that require an `eth`
+            // entry keep skipping us until this succeeds.
+            Err(e) => warn!(error = ?e, "Could not set the new fork id on the local ENR"),
+        }
     }
 }
 
@@ -449,6 +488,8 @@ impl DiscoveryServer {
             },
             discv4: None,
             discv5: Some(Discv5State::default()),
+            // Tests drive the ENR directly; there is no publisher to listen to.
+            fork_id: None,
         }
     }
 }

--- a/crates/networking/p2p/discovery/server.rs
+++ b/crates/networking/p2p/discovery/server.rs
@@ -27,6 +27,7 @@ use spawned_concurrency::{
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::net::UdpSocket;
+use tokio::sync::watch;
 use tokio_util::udp::UdpFramed;
 use tracing::{debug, error, info, trace, warn};
 
@@ -91,13 +92,14 @@ pub struct DiscoveryServer {
     pub(crate) config: DiscoveryConfig,
     pub discv4: Option<Discv4State>,
     pub discv5: Option<Discv5State>,
-    /// Current EIP-2124 fork id, published by the network layer.
+    /// Current EIP-2124 fork id, published by the network layer. `None` inside the
+    /// channel means the chain could not supply one yet.
     ///
     /// Discovery does not read this from storage: the network layer decides what this
     /// node announces about itself, and discovery only republishes. Without a refresh
     /// the `eth` ENR entry goes stale the moment the chain crosses a fork, and geth's
     /// dial-candidate filter (`NewNodeFilter`) drops us outright.
-    pub(crate) fork_id: Option<tokio::sync::watch::Receiver<ForkId>>,
+    pub(crate) fork_id: watch::Receiver<Option<ForkId>>,
 }
 
 impl std::fmt::Debug for DiscoveryServer {
@@ -126,7 +128,7 @@ impl DiscoveryServer {
         peer_table: PeerTable,
         bootnodes: Vec<Node>,
         config: DiscoveryConfig,
-        fork_id: Option<tokio::sync::watch::Receiver<ForkId>>,
+        fork_id: watch::Receiver<Option<ForkId>>,
     ) -> Result<(), DiscoveryServerError> {
         debug!("Starting discovery server");
 
@@ -433,15 +435,16 @@ impl DiscoveryServer {
     ///
     /// `has_changed` is only true once per send, so a steady chain costs a flag check
     /// per tick. A closed channel means the network layer is gone, which is shutdown,
-    /// not an error worth logging every tick.
+    /// not an error worth logging every tick. A `None` in the channel is the seed for
+    /// a chain that could not supply a fork id at startup; there is nothing to
+    /// republish until the publisher replaces it.
     fn refresh_fork_id(&mut self) {
-        let Some(rx) = self.fork_id.as_mut() else {
-            return;
-        };
-        if !rx.has_changed().unwrap_or(false) {
+        if !self.fork_id.has_changed().unwrap_or(false) {
             return;
         }
-        let fork_id = rx.borrow_and_update().clone();
+        let Some(fork_id) = self.fork_id.borrow_and_update().clone() else {
+            return;
+        };
         match self.local_node_record.set_fork_id(fork_id, &self.signer) {
             Ok(()) => info!(
                 seq = self.local_node_record.seq,
@@ -488,8 +491,9 @@ impl DiscoveryServer {
             },
             discv4: None,
             discv5: Some(Discv5State::default()),
-            // Tests drive the ENR directly; there is no publisher to listen to.
-            fork_id: None,
+            // Tests drive the ENR directly; there is no publisher to listen to. The
+            // sender is dropped, so `has_changed` errs and the refresh is a no-op.
+            fork_id: watch::channel(None).1,
         }
     }
 }

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use ethrex_blockchain::Blockchain;
 use ethrex_common::H256;
+use ethrex_common::types::ForkId;
 use ethrex_storage::Store;
 use secp256k1::SecretKey;
 use spawned_concurrency::tasks::ActorRef;
@@ -27,6 +28,7 @@ use std::{
     time::Duration,
 };
 use tokio::net::{TcpListener, TcpSocket, UdpSocket};
+use tokio::sync::watch;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info};
 
@@ -131,12 +133,20 @@ pub enum NetworkError {
 /// startup. The record is still usable for discovery, and a peer that requires
 /// `eth` simply passes us over until we republish with it. A record we cannot
 /// sign is different, and is reported.
-async fn build_local_node_record(context: &P2PContext) -> Result<NodeRecord, NodeError> {
+///
+/// Also returns the fork id the record was built with, so the refresh channel can
+/// be seeded with the exact value the ENR advertises: seeding from a second
+/// storage read could straddle a fork crossing, and a seed the ENR never carried
+/// is a change the refresh would never see.
+async fn build_local_node_record(
+    context: &P2PContext,
+) -> Result<(NodeRecord, Option<ForkId>), NodeError> {
     let mut record = NodeRecord::from_node(&context.local_node, INITIAL_ENR_SEQ, &context.signer)?;
-    if let Ok(fork_id) = context.storage.get_fork_id().await {
+    let fork_id = context.storage.get_fork_id().await.ok();
+    if let Some(fork_id) = fork_id.clone() {
         record.set_fork_id(fork_id, &context.signer)?;
     }
-    Ok(record)
+    Ok((record, fork_id))
 }
 
 pub async fn start_network(
@@ -150,14 +160,14 @@ pub async fn start_network(
             .map_err(NetworkError::UdpSocketError)?,
     );
 
-    let local_node_record = build_local_node_record(&context).await?;
+    let (local_node_record, initial_fork_id) = build_local_node_record(&context).await?;
 
     // The ENR's `eth` entry is only correct for the fork the chain is on. Nothing
     // recomputed it after startup, so once the chain crossed a fork we kept
     // advertising the old fork id and geth's dial-candidate filter
     // (`NewNodeFilter`) dropped us. Publish it on a channel instead: this layer
     // decides what the node announces, discovery only republishes.
-    let fork_id_rx = spawn_fork_id_publisher(&context);
+    let fork_id_rx = spawn_fork_id_publisher(&context, initial_fork_id);
 
     DiscoveryServer::spawn(
         context.local_node.clone(),
@@ -858,18 +868,22 @@ fn format_duration(duration: Duration) -> String {
 
 /// How often to re-derive the fork id. A fork boundary is a timestamp, so the ENR
 /// can lag a crossing by at most this long; cheap enough to keep tight.
-const FORK_ID_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+const FORK_ID_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Publishes the current fork id, re-deriving it periodically.
 ///
-/// Returns `None` when the chain cannot supply one at all, which keeps the existing
-/// behaviour of announcing a record without an `eth` entry rather than failing startup.
+/// `initial` is the fork id the initial ENR was built with — the channel must be
+/// seeded with what the record actually advertises, not a fresh storage read, or a
+/// fork crossed between the two reads would never register as a change. `None`
+/// (the chain could not supply one at startup) still spawns the publisher: the
+/// first successful derivation then counts as a change and gives the ENR its
+/// `eth` entry, instead of a transient startup failure disabling refresh for good.
 fn spawn_fork_id_publisher(
     context: &P2PContext,
-) -> Option<tokio::sync::watch::Receiver<ethrex_common::types::ForkId>> {
+    initial: Option<ForkId>,
+) -> watch::Receiver<Option<ForkId>> {
     let storage = context.storage.clone();
-    let initial = futures::executor::block_on(storage.get_fork_id()).ok()?;
-    let (tx, rx) = tokio::sync::watch::channel(initial);
+    let (tx, rx) = watch::channel(initial);
     context.tracker.spawn(async move {
         let mut interval = tokio::time::interval(FORK_ID_REFRESH_INTERVAL);
         loop {
@@ -879,10 +893,10 @@ fn spawn_fork_id_publisher(
                 // chain has not moved across a fork, so discovery does no work.
                 Ok(fork_id) => {
                     tx.send_if_modified(|current| {
-                        if *current == fork_id {
+                        if current.as_ref() == Some(&fork_id) {
                             false
                         } else {
-                            *current = fork_id;
+                            *current = Some(fork_id);
                             true
                         }
                     });
@@ -892,5 +906,5 @@ fn spawn_fork_id_publisher(
             }
         }
     });
-    Some(rx)
+    rx
 }

--- a/crates/networking/p2p/network.rs
+++ b/crates/networking/p2p/network.rs
@@ -28,7 +28,7 @@ use std::{
 };
 use tokio::net::{TcpListener, TcpSocket, UdpSocket};
 use tokio_util::task::TaskTracker;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 pub const MAX_MESSAGES_TO_BROADCAST: usize = 100000;
 
@@ -152,6 +152,13 @@ pub async fn start_network(
 
     let local_node_record = build_local_node_record(&context).await?;
 
+    // The ENR's `eth` entry is only correct for the fork the chain is on. Nothing
+    // recomputed it after startup, so once the chain crossed a fork we kept
+    // advertising the old fork id and geth's dial-candidate filter
+    // (`NewNodeFilter`) dropped us. Publish it on a channel instead: this layer
+    // decides what the node announces, discovery only republishes.
+    let fork_id_rx = spawn_fork_id_publisher(&context);
+
     DiscoveryServer::spawn(
         context.local_node.clone(),
         local_node_record,
@@ -160,6 +167,7 @@ pub async fn start_network(
         context.table.clone(),
         bootnodes,
         config,
+        fork_id_rx,
     )
     .await
     .inspect_err(|e| {
@@ -846,4 +854,43 @@ fn format_duration(duration: Duration) -> String {
     let minutes = (total_seconds % 3600) / 60;
     let seconds = total_seconds % 60;
     format!("{hours:02}:{minutes:02}:{seconds:02}")
+}
+
+/// How often to re-derive the fork id. A fork boundary is a timestamp, so the ENR
+/// can lag a crossing by at most this long; cheap enough to keep tight.
+const FORK_ID_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Publishes the current fork id, re-deriving it periodically.
+///
+/// Returns `None` when the chain cannot supply one at all, which keeps the existing
+/// behaviour of announcing a record without an `eth` entry rather than failing startup.
+fn spawn_fork_id_publisher(
+    context: &P2PContext,
+) -> Option<tokio::sync::watch::Receiver<ethrex_common::types::ForkId>> {
+    let storage = context.storage.clone();
+    let initial = futures::executor::block_on(storage.get_fork_id()).ok()?;
+    let (tx, rx) = tokio::sync::watch::channel(initial);
+    context.tracker.spawn(async move {
+        let mut interval = tokio::time::interval(FORK_ID_REFRESH_INTERVAL);
+        loop {
+            interval.tick().await;
+            match storage.get_fork_id().await {
+                // `send_if_modified` keeps the receiver's change flag clean when the
+                // chain has not moved across a fork, so discovery does no work.
+                Ok(fork_id) => {
+                    tx.send_if_modified(|current| {
+                        if *current == fork_id {
+                            false
+                        } else {
+                            *current = fork_id;
+                            true
+                        }
+                    });
+                }
+                // Transient: the next tick retries. Logging every 30s would be noise.
+                Err(e) => debug!(error = ?e, "Could not derive the fork id for the local ENR"),
+            }
+        }
+    });
+    Some(rx)
 }


### PR DESCRIPTION
**Motivation**

`build_local_node_record` (`crates/networking/p2p/network.rs:134`) derives the EIP-2124 fork id once at startup, and nothing recomputes it. The moment the chain crosses a fork we keep advertising the old fork id, and geth's dial-candidate filter — `NewNodeFilter` in `eth/protocols/eth/discovery.go` — returns false when the `eth` entry does not match, so we are dropped as a dial candidate.

The existing comment there already describes the consequence: a peer "passes us over until we republish with it". Nothing republished.

Supersedes #7037.

**Description**

This is a rewrite, not a rebase of #7037. That PR read `self.store` inside the discovery actor, which #6449 deliberately removed — `network.rs:127` states the record is "Built here rather than inside discovery, which has no say in what this node announces about itself." Re-adding storage to the actor would revert that decision, so the fork id is **published to** discovery instead:

- the network layer owns a `tokio::sync::watch` sender and re-derives the fork id every 30s (`FORK_ID_REFRESH_INTERVAL`), so the ENR can lag a crossing by at most that long
- discovery holds the receiver and applies changes on the prune tick it already uses to republish after an IP change, next to `update_local_ip`

`send_if_modified` keeps the receiver's change flag clean while the chain stays on one fork, so a steady chain costs one flag check per tick and no signing. A transient storage error is logged at debug and retried on the next tick rather than logged every 30s.

Three review follow-ups tightened the startup path:

- **The channel is seeded with the fork id the initial ENR was actually built with**, not a second storage read. Two reads could straddle a fork crossing, leaving the ENR permanently stale: the receiver would already hold the new fork id as its initial value, so `has_changed` would never fire for it.
- **The seed no longer uses `futures::executor::block_on`** inside the async `start_network` chain. It only worked because `get_fork_id` happens to have no real await point today; the value now arrives as a parameter from `build_local_node_record`.
- **A transient failure of the initial read no longer disables refresh for the node's lifetime.** The channel carries `Option<ForkId>`: a failed startup read seeds `None` (announcing a record without an `eth` entry, as today), and the first successful derivation counts as a change that gives the ENR its `eth` entry.

**Tests**

`cargo clippy --workspace --all-targets -- -D warnings` and `--features l2` both clean, fmt clean, 106 `ethrex-p2p` tests and the 969-test integration suite pass.

What is **not** covered: nothing here proves the ENR is actually republished across a real fork crossing. The unit tests construct the actor with a dropped publisher (`watch::channel(None).1`), which exercises the no-op path only. Verifying the live behaviour needs a devnet that crosses a fork with a geth peer, watching whether geth dials us after the transition — that is the test that would have caught the original bug, and it does not exist in either version of this change.

