### PR TITLE
fix(l1): decouple EIP-8141 activation from the Hegotá fork time

### DIFF
--- a/crates/blockchain/blockchain.rs
+++ b/crates/blockchain/blockchain.rs
@@ -3554,10 +3554,10 @@ impl Blockchain {
             .ok_or(MempoolError::NoBlockHeaderError)?;
         let config = self.storage.get_chain_config();
 
-        // EIP-8141 fork gating: reject frame transactions before Hegota activates.
+        // EIP-8141 fork gating: reject frame transactions before EIP-8141 activates.
         // Prevents FrameTransaction (type 0x06) from entering the mempool or being
         // forwarded over P2P on chains where EIP-8141 has not yet activated.
-        if is_frame_tx && !config.is_hegota_activated(header.timestamp) {
+        if is_frame_tx && !config.is_eip8141_activated(header.timestamp) {
             return Err(MempoolError::FrameTxPreFork);
         }
 

--- a/crates/blockchain/payload.rs
+++ b/crates/blockchain/payload.rs
@@ -959,12 +959,15 @@ impl Blockchain {
             }
 
             // EIP-8141 fork gating: drop frame transactions that reached the payload
-            // builder before Hegota has activated. These must never be included in a
-            // block until the fork is live.
+            // builder before EIP-8141 has activated. These must never be included in a
+            // block until it is live.
             if head_tx.tx_type() == TxType::Frame
-                && !chain_config.is_hegota_activated(context.payload.header.timestamp)
+                && !chain_config.is_eip8141_activated(context.payload.header.timestamp)
             {
-                debug!("Skipping frame transaction before Hegota fork: {}", tx_hash);
+                debug!(
+                    "Skipping frame transaction before EIP-8141 activation: {}",
+                    tx_hash
+                );
                 txs.pop();
                 self.remove_transaction_from_pool(&tx_hash)?;
                 continue;

--- a/crates/common/genesis_utils.rs
+++ b/crates/common/genesis_utils.rs
@@ -34,6 +34,7 @@ fn sort_config(genesis_map: &Map<String, Value>) -> Result<Map<String, Value>, S
         "bpo5Time",
         "amsterdamTime",
         "hegotaTime",
+        "eip8141Time",
         "lstarTime",
         "verkleTime",
         "ethash",

--- a/crates/common/types/genesis.rs
+++ b/crates/common/types/genesis.rs
@@ -281,6 +281,10 @@ pub struct ChainConfig {
         alias = "bogota_time"
     )]
     pub hegota_time: Option<u64>,
+    /// EIP-8141 (frame transactions) activation. Independent of `hegota_time` so a network can
+    /// schedule Hegotá for FOCIL without enabling frame transactions.
+    #[serde(alias = "eip8141Time", alias = "framesTime", alias = "frames_time")]
+    pub eip8141_time: Option<u64>,
     pub lstar_time: Option<u64>,
 
     /// Amount of total difficulty reached by the network that triggers the consensus upgrade.
@@ -383,6 +387,11 @@ impl From<Fork> for &str {
 impl ChainConfig {
     pub fn is_hegota_activated(&self, block_timestamp: u64) -> bool {
         self.hegota_time.is_some_and(|time| time <= block_timestamp)
+    }
+
+    pub fn is_eip8141_activated(&self, block_timestamp: u64) -> bool {
+        self.eip8141_time
+            .is_some_and(|time| time <= block_timestamp)
     }
 
     pub fn is_lstar_activated(&self, block_timestamp: u64) -> bool {

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -1879,6 +1879,7 @@ mod tests {
                             "bpo5Time": null,
                             "amsterdamTime": null,
                             "hegotaTime": null,
+                            "eip8141Time": null,
                             "lstarTime": null,
                             "terminalTotalDifficulty": "0x0",
                             "terminalTotalDifficultyPassed": true,

--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -3375,10 +3375,10 @@ impl LEVM {
     }
 
     /// Install the canonical EIP-8141 expiry verifier runtime code at
-    /// EXPIRY_VERIFIER on Hegota activation (EIP-8141: "At
+    /// EXPIRY_VERIFIER on EIP-8141 activation (EIP-8141: "At
     /// activation, clients must install..."). Idempotent: writes only when
     /// the existing code differs, so exactly one account update is produced
-    /// (at the first Hegota block) and none afterwards.
+    /// (at the first EIP-8141 block) and none afterwards.
     pub fn install_expiry_verifier_code(
         db: &mut GeneralizedDatabase,
         crypto: &dyn Crypto,
@@ -3582,10 +3582,10 @@ impl LEVM {
             return Ok(());
         }
 
-        // EIP-8141: the expiry verifier predeploy must exist from Hegota
+        // EIP-8141: the expiry verifier predeploy must exist from EIP-8141
         // activation onward. Idempotent install; also
         // hooked in apply_system_calls for the payload-build path.
-        if fork >= Fork::Hegota {
+        if chain_config.is_eip8141_activated(block_header.timestamp) {
             Self::install_expiry_verifier_code(db, crypto)?;
         }
 

--- a/crates/vm/backends/mod.rs
+++ b/crates/vm/backends/mod.rs
@@ -201,10 +201,12 @@ impl Evm {
         let chain_config = self.db.store.get_chain_config()?;
         let fork = chain_config.fork(block_header.timestamp);
 
-        // EIP-8141: the expiry verifier predeploy must exist from Hegota
+        // EIP-8141: the expiry verifier predeploy must exist from EIP-8141
         // activation onward. Idempotent install for the
         // payload-build path; the block-import path is hooked in prepare_block.
-        if fork >= Fork::Hegota && matches!(self.vm_type, VMType::L1) {
+        if chain_config.is_eip8141_activated(block_header.timestamp)
+            && matches!(self.vm_type, VMType::L1)
+        {
             LEVM::install_expiry_verifier_code(&mut self.db, self.crypto.as_ref())?;
         }
 

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -76,6 +76,8 @@ pub struct Environment {
 pub struct EVMConfig {
     pub fork: Fork,
     pub blob_schedule: ForkBlobSchedule,
+    /// EIP-8141 frame transactions and opcodes are enabled
+    pub eip8141: bool,
 }
 
 impl EVMConfig {
@@ -83,7 +85,13 @@ impl EVMConfig {
         EVMConfig {
             fork,
             blob_schedule,
+            eip8141: false,
         }
+    }
+
+    pub fn with_eip8141(mut self, eip8141: bool) -> EVMConfig {
+        self.eip8141 = eip8141;
+        self
     }
 
     pub fn new_from_chain_config(chain_config: &ChainConfig, block_header: &BlockHeader) -> Self {
@@ -93,7 +101,9 @@ impl EVMConfig {
             .get_fork_blob_schedule(block_header.timestamp)
             .unwrap_or_else(|| EVMConfig::canonical_values(fork));
 
-        EVMConfig::new(fork, blob_schedule)
+        let mut config = EVMConfig::new(fork, blob_schedule);
+        config.eip8141 = chain_config.is_eip8141_activated(block_header.timestamp);
+        config
     }
 
     /// This function is used for running the EF tests. If you don't
@@ -146,6 +156,7 @@ impl Default for EVMConfig {
         EVMConfig {
             fork,
             blob_schedule: Self::canonical_values(fork),
+            eip8141: false,
         }
     }
 }

--- a/crates/vm/levm/src/errors.rs
+++ b/crates/vm/levm/src/errors.rs
@@ -150,7 +150,7 @@ pub enum TxValidationError {
     Type4TxAuthorizationListIsEmpty,
     #[error("Contract creation in type 4 transaction")]
     Type4TxContractCreation,
-    #[error("Frame transactions (EIP-8141) are not supported before the Hegota fork")]
+    #[error("Frame transactions (EIP-8141) are not supported before EIP-8141 activates")]
     FrameTxPreFork,
     #[error("Gas limit price product overflow")]
     GasLimitPriceProductOverflow,

--- a/crates/vm/levm/src/opcodes.rs
+++ b/crates/vm/levm/src/opcodes.rs
@@ -421,7 +421,7 @@ impl<'a> VM<'a> {
     /// per-tx rebuild or 2 KB copy into the VM. `fork` is constant within a block, so every tx
     /// in a block resolves to the same table. This is faster than a conventional match.
     #[allow(clippy::as_conversions, clippy::indexing_slicing)]
-    pub(crate) fn build_opcode_table(fork: Fork) -> &'static [OpCodeFn; 256] {
+    pub(crate) fn build_opcode_table(fork: Fork, eip8141: bool) -> &'static [OpCodeFn; 256] {
         // Built once at compile time; immutable, so sharing across all VMs is trivially safe.
         // Instantiated with `'static` so the initializers don't reference the impl's `'a`.
         static HEGOTA: [OpCodeFn; 256] = VM::<'static>::build_opcode_table_hegota();
@@ -431,7 +431,7 @@ impl<'a> VM<'a> {
         static PRE_CANCUN: [OpCodeFn; 256] = VM::<'static>::build_opcode_table_pre_cancun();
         static PRE_SHANGHAI: [OpCodeFn; 256] = VM::<'static>::build_opcode_table_pre_shanghai();
 
-        if fork >= Fork::Hegota {
+        if eip8141 && fork >= Fork::Hegota {
             &HEGOTA
         } else if fork >= Fork::Amsterdam {
             &AMSTERDAM
@@ -686,7 +686,7 @@ mod tests {
         }
         // 0xEF is never assigned in any table -> it holds the invalid handler.
         for fork in [Fork::Osaka, Fork::Amsterdam] {
-            let table = VM::build_opcode_table(fork);
+            let table = VM::build_opcode_table(fork, false);
             for byte in [0xAAusize, 0xB0, 0xB1, 0xB2, 0xB3, 0xB4] {
                 assert!(
                     same_handler(table[byte], table[0xEF]),
@@ -694,7 +694,12 @@ mod tests {
                 );
             }
         }
-        let hegota = VM::build_opcode_table(Fork::Hegota);
+        let hegota_without_eip8141 = VM::build_opcode_table(Fork::Hegota, false);
+        assert!(same_handler(
+            hegota_without_eip8141[0xAA],
+            hegota_without_eip8141[0xEF]
+        ));
+        let hegota = VM::build_opcode_table(Fork::Hegota, true);
         assert!(!same_handler(hegota[0xAA], hegota[0xEF]));
     }
 }

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1092,9 +1092,9 @@ impl<'a> VM<'a> {
                 root_stack,
                 root_memory,
             ),
+            opcode_table: VM::build_opcode_table(fork, env.config.eip8141),
             env,
             frame_tx_context: None,
-            opcode_table: VM::build_opcode_table(fork),
             crypto,
             stateless_validator,
         };
@@ -1532,8 +1532,8 @@ impl<'a> VM<'a> {
         use crate::errors::TxResult;
 
         // EIP-8141 fork gating: reject frame transactions observed in a block or
-        // submitted to any non-mempool entry point before Hegota activates.
-        if self.env.config.fork < Fork::Hegota {
+        // submitted to any non-mempool entry point before EIP-8141 activates.
+        if !self.env.config.eip8141 {
             return Err(VMError::TxValidation(
                 crate::errors::TxValidationError::FrameTxPreFork,
             ));
@@ -2349,7 +2349,7 @@ impl<'a> VM<'a> {
     ) -> Result<PrefixSimResult, VMError> {
         use crate::validation_observer::ValidationObserver;
 
-        if self.env.config.fork < Fork::Hegota {
+        if !self.env.config.eip8141 {
             return Err(VMError::TxValidation(
                 crate::errors::TxValidationError::FrameTxPreFork,
             ));
@@ -3468,7 +3468,7 @@ impl<'a> VM<'a> {
             prep_baseline_state_gas_spill: 0,
             prep_region_backup_marker: PrepareRegionBackupMarker::default(),
             pending_prep_oog: false,
-            opcode_table: VM::build_opcode_table(fork),
+            opcode_table: VM::build_opcode_table(fork, false),
             crypto,
             stateless_validator: None,
             validation_observer: ValidationObserver::disabled(),

--- a/docs/eip-8141.md
+++ b/docs/eip-8141.md
@@ -546,7 +546,7 @@ Frame transactions receive special treatment in mempool validation (`blockchain.
 2. **EOA check skipped**: For the same reason — a non-existent sender is valid if a payer will fund the execution. Nonce sanity is still applied to such senders against their implied nonce of 0 (see point 7), rather than skipped.
 3. **Static + signature validation up front**: `validate_static_constraints` runs at admission, the outer `signatures` are verified, and the combined frame `data` size is bounded.
 4. **`MAX_VERIFY_GAS` signature cap**: the signature-verification cost (spec rule #6, `MAX_VERIFY_GAS = 100_000`) is checked before any per-signature crypto runs; a tx whose signatures alone exceed the budget is rejected. This is a sound subset of the full validation-prefix budget check (see Known Limitations).
-5. **Hegota fork gating**: frame txs are rejected before the Hegota fork activates.
+5. **EIP-8141 activation gating**: frame txs are rejected before `eip8141_time` (`eip8141Time` in the genesis JSON) activates. The activation is independent of `hegota_time`, so a Hegotá network without `eip8141Time` (e.g. a FOCIL devnet) never enables frame transactions, the frame opcodes or the expiry verifier predeploy.
 6. **Expiry drop**: a frame tx whose expiry-verifier deadline has passed is dropped.
 7. **Blob frame txs rejected**: a frame tx carrying `blob_versioned_hashes` is rejected at admission — there is no sidecar transport for frame-tx blobs yet (consensus still accounts for blob cost if another builder includes one).
 8. **Standard checks still apply**: Nonce ordering (including for not-yet-existent senders, whose implied nonce is 0), fee validation, gas limit vs block limit, intrinsic gas coverage, chain ID.

--- a/fixtures/networks/eip8141-devnet.yaml
+++ b/fixtures/networks/eip8141-devnet.yaml
@@ -20,15 +20,15 @@ network_params:
   seconds_per_slot: 6
   # Activate Osaka from genesis.
   fulu_fork_epoch: 0
-  # Schedule Hegota (heze) so the EIP-8141 frame-tx opcodes are enabled.
+  # Schedule Hegota (heze) so the EIP-8141 frame-tx opcodes can be enabled.
   # The EIP-8141 opcodes (APPROVE 0xAA, TXPARAM 0xB0, FRAMEDATALOAD 0xB1,
-  # FRAMEDATACOPY 0xB2, FRAMEPARAM 0xB3, SIGPARAM 0xB4) are gated on Hegota,
-  # not Osaka. The ethereum-genesis-generator emits `bogotaTime`/`hezeTime`
-  # into the EL genesis JSON, which ethrex parses into
-  # `ChainConfig.hegota_time` via its serde aliases. Without this, every
-  # frame tx is rejected with FrameTxPreFork. Ordering mirrors the proven
-  # focil.yaml (gloas at 0, heze at 1): frame transactions become valid from
-  # epoch 1 onward.
+  # FRAMEDATACOPY 0xB2, FRAMEPARAM 0xB3, SIGPARAM 0xB4) require Hegota AND
+  # `eip8141Time` in the EL genesis JSON (`ChainConfig.eip8141_time`); the
+  # activation is deliberately separate from `bogotaTime`/`hezeTime` so a
+  # FOCIL-only Hegota network never enables frame transactions. Without
+  # `eip8141Time`, every frame tx is rejected with FrameTxPreFork. Ordering
+  # mirrors the proven focil.yaml (gloas at 0, heze at 1): frame transactions
+  # become valid from epoch 1 onward once `eip8141Time` is set.
   gloas_fork_epoch: 0
   heze_fork_epoch: 1
 

--- a/test/tests/blockchain/mempool_tests.rs
+++ b/test/tests/blockchain/mempool_tests.rs
@@ -508,6 +508,7 @@ async fn setup_hegota_store() -> Store {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,
@@ -863,6 +864,7 @@ async fn setup_hegota_store_ts1000() -> Store {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,
@@ -1335,6 +1337,7 @@ async fn setup_hegota_store_funded() -> Store {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,
@@ -1432,6 +1435,7 @@ async fn mempool_rejects_underfunded_paymaster() {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,
@@ -1772,6 +1776,7 @@ async fn setup_hegota_store_with_balance(balance: U256) -> Store {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,
@@ -1959,6 +1964,7 @@ async fn mempool_rejects_frame_tx_with_banned_opcode() {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,
@@ -2015,6 +2021,7 @@ async fn mempool_revalidation_evicts_invalid_frame_tx() {
             chain_id: 0,
             shanghai_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         },
         gas_limit: 100_000_000,

--- a/test/tests/levm/eip8141_tests.rs
+++ b/test/tests/levm/eip8141_tests.rs
@@ -112,7 +112,8 @@ fn frame_tx_env(tx: &FrameTransaction) -> Environment {
         origin: tx.sender,
         gas_limit: tx.total_gas_limit(),
         block_gas_limit: (i64::MAX - 1) as u64,
-        config: EVMConfig::new(Fork::Hegota, EVMConfig::canonical_values(Fork::Hegota)),
+        config: EVMConfig::new(Fork::Hegota, EVMConfig::canonical_values(Fork::Hegota))
+            .with_eip8141(true),
         chain_id: U256::from(HARNESS_CHAIN_ID),
         base_fee_per_gas: U256::from(HARNESS_BASE_FEE),
         // NOTE: gas_price here is max_fee_per_gas, NOT the effective price.
@@ -2026,7 +2027,8 @@ mod validation_observer_tests {
     }
 
     fn hegota_env(sender: Address) -> Environment {
-        let config = EVMConfig::new(Fork::Hegota, EVMConfig::canonical_values(Fork::Hegota));
+        let config = EVMConfig::new(Fork::Hegota, EVMConfig::canonical_values(Fork::Hegota))
+            .with_eip8141(true);
         Environment {
             origin: sender,
             gas_limit: 30_000_000,
@@ -2466,6 +2468,7 @@ mod frame_validation_prefix_tests {
             osaka_time: Some(0),
             amsterdam_time: Some(0),
             hegota_time: Some(0),
+            eip8141_time: Some(0),
             ..Default::default()
         }
     }


### PR DESCRIPTION
**Motivation**

On `focil-devnet-0` (ethereum-package, ethrex/besu × lodestar/teku) the genesis generator emits `bogotaTime` for the CL `heze` fork, which ethrex parses as `hegota_time`. ethrex also gated all of EIP-8141 (frame transactions) on `hegota_time`, so at the first Hegotá block `install_expiry_verifier_code` wrote the expiry-verifier predeploy at `0x…8141`. That account write lands in the block access list; Besu (which executes that block under Amsterdam rules — its `focil-devnet-0` branch has no Bogota milestone) computes a different BAL and rejects every ethrex payload from EL block 16 onward:

```
EngineNewPayloadV6 | Invalid new payload: number: 16 … validationError: Block access list hash mismatch, calculated: 0x655546fa… header: 0xf48c7800…
```

Both Besu-backed nodes drop off the chain at the heze fork. Per the devnet plan, `focil-devnet-0` branches are FOCIL-only and EIP-8141 lives on a separate `frames-devnet-0` branch, so ethrex must not enable frame transactions on `bogotaTime`.

**Description**

- `ChainConfig.eip8141_time` (`eip8141Time` / `framesTime` in the genesis JSON) + `is_eip8141_activated`, independent of `hegota_time`.
- `EVMConfig.eip8141`, set from the chain config in `new_from_chain_config` (`with_eip8141` for direct construction).
- Gated on it instead of `Fork::Hegota` / `is_hegota_activated`: expiry verifier install (`prepare_block`, `apply_system_calls`), frame tx execution and prefix simulation in LEVM, the Hegotá opcode table (frame opcodes), mempool admission and the payload builder.
- FOCIL gating (`is_hegota_activated` for engine V5/V6, IL satisfaction) is unchanged.
- Tests: the EIP-8141 / mempool tests set `eip8141_time` / `with_eip8141(true)`; `frame_opcodes_not_installed_before_hegota` also asserts Hegotá without the flag has no frame opcodes. Docs and the `eip8141-devnet.yaml` comment updated — that devnet now needs `eip8141Time` in the EL genesis.

`cargo fmt --check` clean; `cargo test -p ethrex-test -- eip8141 mempool frame inclusion_list`: 250 passed; `cargo test -p ethrex-levm frame_opcodes_not_installed_before_hegota` passes. (`cargo clippy` on this branch currently fails on a pre-existing `needless_return` in `crates/common/crypto/kzg.rs`, unrelated.)

https://claude.ai/code/session_01YHCg1Q6QaZn8rPjB7za3UB