### PR TITLE
revert(l1): drop blockTimestamp from RPC log objects (#7142)

### DIFF
--- a/.github/scripts/check-hive-results.sh
+++ b/.github/scripts/check-hive-results.sh
@@ -59,23 +59,7 @@ mkdir -p "${failed_logs_root}"
 
 # Tests excluded from the failure count (substring match against test case
 # name).
-#
-# The rpc-compat cases below are the ones whose recorded response contains at
-# least one log object. That corpus is pinned to execution-apis d08382ae, which
-# predates `blockTimestamp` on log objects, and rpc-compat compares byte-exactly,
-# so emitting the field (as every other client does) cannot match. The pin cannot
-# move: the field only reaches those fixtures in revisions that also carry a
-# pre-merge test chain, which ethrex does not support by design. See
-# docs/known_issues.md.
 KNOWN_EXCLUDED_TESTS=(
-  "eth_getLogs/contract-addr"
-  "eth_getLogs/no-topics"
-  "eth_getLogs/topic-exact-match"
-  "eth_getLogs/topic-wildcard"
-  "eth_getBlockReceipts/get-block-receipts-latest"
-  "eth_getTransactionReceipt/get-access-list"
-  "eth_getTransactionReceipt/get-blob-tx"
-  "eth_getTransactionReceipt/get-dynamic-fee"
 )
 
 # Build a jq filter that excludes the known-excluded tests.

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -395,7 +395,6 @@ pub async fn get_all_block_rpc_receipts(
         .map_err(|_| RpcErr::Internal("blob_base_fee does not fit in u64".to_owned()))?;
     // Fetch receipt info from block
     let block_hash = header.hash();
-    let block_timestamp = header.timestamp;
     let block_info = RpcReceiptBlockInfo::from_block_header(header);
     // Fetch receipts: only up to target_index+1 when set, otherwise all
     let fetch_count = target_index
@@ -435,7 +434,6 @@ pub async fn get_all_block_rpc_receipts(
             tx_info,
             block_info.clone(),
             current_log_index,
-            block_timestamp,
         );
         last_cumulative_gas_used += gas_used;
         current_log_index += receipt.logs.len() as u64;

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -316,7 +316,6 @@ async fn collect_block_logs(
                         transaction_index: tx_index as u64,
                         block_number: block_num,
                         block_hash,
-                        block_timestamp: block_header.timestamp,
                         removed: false,
                     });
                 }

--- a/crates/networking/rpc/types/receipt.rs
+++ b/crates/networking/rpc/types/receipt.rs
@@ -58,18 +58,11 @@ impl RpcReceipt {
         tx_info: RpcReceiptTxInfo,
         block_info: RpcReceiptBlockInfo,
         init_log_index: u64,
-        block_timestamp: u64,
     ) -> Self {
         let mut logs = vec![];
         let mut log_index = init_log_index;
         for log in receipt.logs.clone() {
-            logs.push(RpcLog::new(
-                log,
-                log_index,
-                &tx_info,
-                &block_info,
-                block_timestamp,
-            ));
+            logs.push(RpcLog::new(log, log_index, &tx_info, &block_info));
             log_index += 1;
         }
         let payer = receipt.payer;
@@ -125,18 +118,6 @@ pub struct RpcLog {
     pub block_hash: BlockHash,
     #[serde(with = "serde_utils::u64::hex_str")]
     pub block_number: BlockNumber,
-    /// Timestamp of the block this log was emitted in. Optional in the
-    /// execution-apis `Log` schema, but every other client populates it, and
-    /// indexers that read it off the log would otherwise need a separate block
-    /// lookup per receipt. Passed in rather than taken from
-    /// `RpcReceiptBlockInfo`, which is flattened into `RpcReceipt` and so must
-    /// not gain a serialized field: `blockTimestamp` belongs on the log object
-    /// only, not alongside the receipt's own keys.
-    ///
-    /// Defaulted on the way in: the schema marks it optional, so a peer that
-    /// omits it must still decode rather than fail the whole response.
-    #[serde(with = "serde_utils::u64::hex_str", default)]
-    pub block_timestamp: u64,
 }
 
 impl RpcLog {
@@ -145,7 +126,6 @@ impl RpcLog {
         log_index: u64,
         tx_info: &RpcReceiptTxInfo,
         block_info: &RpcReceiptBlockInfo,
-        block_timestamp: u64,
     ) -> RpcLog {
         Self {
             log: log.into(),
@@ -155,7 +135,6 @@ impl RpcLog {
             transaction_index: tx_info.transaction_index,
             block_hash: block_info.block_hash,
             block_number: block_info.block_number,
-            block_timestamp,
         }
     }
 }
@@ -306,63 +285,8 @@ mod tests {
                 block_number: 3,
             },
             0,
-            1786901200,
         );
-        let expected = r#"{"type":"0x3","status":"0x1","cumulativeGasUsed":"0x93","logsBloom":"0x00000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","logs":[{"address":"0x0000000000000000000000000000000000000000","topics":[],"data":"0x73747261776265727279","logIndex":"0x0","removed":false,"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3","blockTimestamp":"0x6a81f2d0"}],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","from":"0x0000000000000000000000000000000000000000","to":"0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f","contractAddress":null,"gasUsed":"0x93","effectiveGasPrice":"0x9d","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3"}"#;
+        let expected = r#"{"type":"0x3","status":"0x1","cumulativeGasUsed":"0x93","logsBloom":"0x00000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","logs":[{"address":"0x0000000000000000000000000000000000000000","topics":[],"data":"0x73747261776265727279","logIndex":"0x0","removed":false,"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3"}],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x1","from":"0x0000000000000000000000000000000000000000","to":"0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f","contractAddress":null,"gasUsed":"0x93","effectiveGasPrice":"0x9d","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x3"}"#;
         assert_eq!(serde_json::to_string(&receipt).unwrap(), expected);
-    }
-
-    /// `blockTimestamp` belongs on the log object and nowhere else. Every other
-    /// client populates it there, and indexers reading it off a receipt's logs
-    /// otherwise need a separate block lookup per receipt. The placement half
-    /// matters just as much: `RpcReceiptBlockInfo` is `#[serde(flatten)]`-ed into
-    /// `RpcReceipt`, so sourcing the timestamp from it would also emit a
-    /// receipt-level `blockTimestamp` that no other client sends.
-    #[test]
-    fn block_timestamp_is_on_the_log_and_not_on_the_receipt() {
-        let receipt = RpcReceipt::new(
-            Receipt {
-                tx_type: TxType::EIP1559,
-                succeeded: true,
-                cumulative_gas_used: 21_000,
-                logs: vec![Log {
-                    address: Address::zero(),
-                    topics: vec![],
-                    data: Bytes::new(),
-                }],
-                payer: None,
-                frame_receipts: None,
-            },
-            RpcReceiptTxInfo {
-                transaction_hash: H256::zero(),
-                transaction_index: 0,
-                from: Address::zero(),
-                to: None,
-                contract_address: None,
-                gas_used: 21_000,
-                effective_gas_price: 1,
-                blob_gas_price: None,
-                blob_gas_used: None,
-            },
-            RpcReceiptBlockInfo {
-                block_hash: BlockHash::zero(),
-                block_number: 3,
-            },
-            0,
-            1786901200,
-        );
-
-        let json = serde_json::to_value(&receipt).expect("serialize");
-        let obj = json.as_object().expect("receipt is an object");
-        assert!(
-            !obj.contains_key("blockTimestamp"),
-            "receipt-level keys must stay byte-for-byte what they were"
-        );
-        let log = json["logs"][0].as_object().expect("log is an object");
-        assert_eq!(
-            log.get("blockTimestamp").and_then(|v| v.as_str()),
-            Some("0x6a81f2d0"),
-            "each log must carry the block's timestamp"
-        );
     }
 }

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -1,38 +1,3 @@
-### rpc-compat log-bearing cases excluded
-
-**Where:** `KNOWN_EXCLUDED_TESTS` in `.github/scripts/check-hive-results.sh` counts out
-eight hive `rpc-compat` cases — the four `eth_getLogs` cases, `eth_getBlockReceipts/get-block-receipts-latest`,
-and three `eth_getTransactionReceipt` cases. They are exactly the cases whose recorded
-response contains at least one log object; every case with an empty log array still runs.
-Note this leaves `eth_getLogs` with no rpc-compat coverage at all, since all four of its
-cases are in the set.
-
-**Why:** ethrex populates `blockTimestamp` on log objects, as geth, besu, nethermind, reth
-and erigon all do. hive's rpc-compat compares responses byte-exactly (`jsondiff.FullMatch`;
-the lenient `checkJSONStructure` path applies only to cases upstream marks `speconly`), and
-the corpus is pinned to execution-apis `d08382ae` (2025-02-10), whose recordings predate the
-field — it entered the schema in execution-apis#639 and the fixtures in #846 (2026-07-22).
-So the extra key cannot match, and this is a property of the pin rather than of the response.
-
-**The pin cannot move, and this is not temporary.** The pin sits one commit before
-execution-apis#627, which moved the test chain to a pre-merge genesis: the current corpus has
-~36 proof-of-work blocks before its terminal total difficulty. ethrex does not support
-pre-merge chains and will not, so importing that `chain.rlp` fails at block 1 —
-`validate_block_header` has no pre-London base-fee path. Every revision carrying
-`blockTimestamp` in its fixtures also carries that chain, so there is no revision that
-satisfies both. Nor can the corpus be patched locally: rpc-compat's Dockerfile clones
-`ethereum/execution-apis` by hard-coded URL, so the `branch` buildarg cannot point at a fork.
-
-**Coverage:** the field itself is pinned by
-`block_timestamp_is_on_the_log_and_not_on_the_receipt` in
-`crates/networking/rpc/types/receipt.rs`, which asserts it is present on each log and absent
-from the receipt level.
-
-**Removal:** delete the entries if ethrex ever gains pre-merge chain import, or if upstream
-marks these cases `speconly` so they are type-checked instead of compared byte-for-byte.
-
----
-
 ### The stateless schema id does not identify the encoding
 
 **Where:** `STATELESS_INPUT_SCHEMA_ID` in `crates/common/types/stateless_ssz.rs`.


### PR DESCRIPTION
**Motivation**

Reverts #7142.

The `blockTimestamp` key that #7142 added to RPC log objects makes eight hive `rpc-compat` cases fail: the simulation compares responses byte-exactly against a corpus pinned to execution-apis `d08382ae`, which predates the field. The pin cannot move forward (every revision whose fixtures carry `blockTimestamp` also carries a pre-merge test chain, which ethrex does not support), so the daily hive report has been stuck at `RPC API Compatibility: 88/96 (91.67%)` since the change landed. #7142 anticipated this and excluded the eight cases in `KNOWN_EXCLUDED_TESTS`, but the coverage loss is real — all four `eth_getLogs` cases are in the excluded set, leaving that method with no rpc-compat coverage at all.

**Description**

Removes `block_timestamp` from `RpcLog` (one struct change covers `eth_getLogs`, `eth_getTransactionReceipt` and `eth_getBlockReceipts`, which all build the same type), and drops the eight `KNOWN_EXCLUDED_TESTS` entries plus the `docs/known_issues.md` section that #7142 introduced.

Trade-off, kept explicit: log objects no longer carry `blockTimestamp`, diverging from the other clients that populate it. Hive conformance and full `eth_getLogs` rpc-compat coverage win over the convenience field.

**How to test**

```
cargo test -p ethrex-rpc --lib
```

End to end, validated locally with hive at the CI-pinned commit (`7c4c99e`) against a locally built image of this branch:

```
./hive --client-file ../fixtures/hive/clients.yaml --client ethrex \
  --sim ethereum/rpc-compat --sim.parallelism 4 --sim.loglevel 1 \
  --sim.buildarg "branch=d08382ae5c808680e976fce4b73f4ba91647199b"
```

Result: `tests=96 failed=0` — including all eight previously excluded cases (fixture diff analysis of the failing daily run showed the extra `blockTimestamp` key was the only difference in every case).

**Checklist**

- [x] No `Store` schema change, so `STORE_SCHEMA_VERSION` is untouched.