### PR TITLE
fix(l1): skip blob tx whose bundle is gone instead of announcing an empty-bundle size

### DIFF
--- a/crates/networking/p2p/rlpx/eth/eth72/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/eth72/transactions.rs
@@ -91,18 +91,17 @@ impl NewPooledTransactionHashes72 {
 
         for transaction in transactions {
             let tx_type = transaction.tx_type();
-            if tx_type as u8 == 3 {
-                has_blob_tx = true;
-            }
-            transaction_types.push(tx_type as u8);
             let transaction_hash = transaction.hash(&NativeCrypto);
-            transaction_hashes.push(transaction_hash);
             let transaction_size = match transaction {
                 Transaction::EIP4844Transaction(eip4844_tx) => {
-                    let tx_blobs_bundle = blockchain
-                        .mempool
-                        .get_blobs_bundle(transaction_hash)?
-                        .unwrap_or_default();
+                    // See `NewPooledTransactionHashes::new`: a blob tx whose bundle is no
+                    // longer in the pool cannot be served, so it must not be announced.
+                    // An empty bundle would announce ~162 bytes for a ~137 KB transaction.
+                    let Some(tx_blobs_bundle) =
+                        blockchain.mempool.get_blobs_bundle(transaction_hash)?
+                    else {
+                        continue;
+                    };
                     let p2p_tx =
                         P2PTransaction::EIP4844TransactionWithBlobs(WrappedEIP4844Transaction {
                             tx: eip4844_tx,
@@ -114,6 +113,11 @@ impl NewPooledTransactionHashes72 {
                 }
                 _ => transaction.encode_canonical_len(),
             };
+            if tx_type as u8 == 3 {
+                has_blob_tx = true;
+            }
+            transaction_types.push(tx_type as u8);
+            transaction_hashes.push(transaction_hash);
             transaction_sizes.push(transaction_size);
         }
 

--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -120,9 +120,7 @@ impl NewPooledTransactionHashes {
         let mut transaction_hashes = Vec::with_capacity(transactions_len);
         for transaction in transactions {
             let transaction_type = transaction.tx_type();
-            transaction_types.push(transaction_type as u8);
             let transaction_hash = transaction.hash(&NativeCrypto);
-            transaction_hashes.push(transaction_hash);
             // size is defined as the len of the canonical encoding of the transaction
             // as it would appear in a PooledTransactions response.
             // https://eips.ethereum.org/EIPS/eip-2718
@@ -131,10 +129,20 @@ impl NewPooledTransactionHashes {
                 // which includes the blobs bundle.
                 // https://eips.ethereum.org/EIPS/eip-4844#networking
                 Transaction::EIP4844Transaction(eip4844_tx) => {
-                    let tx_blobs_bundle = blockchain
-                        .mempool
-                        .get_blobs_bundle(transaction_hash)?
-                        .unwrap_or_default();
+                    // If the bundle is gone (the tx was evicted or pulled into a payload
+                    // between the broadcaster's snapshot and now) we cannot serve this tx
+                    // either: `Blockchain::get_p2p_transaction_by_hash` errors out on a
+                    // blob tx with no bundle, so `GetPooledTransactions` skips it. Skip it
+                    // here too. Substituting an empty bundle would announce ~162 bytes for
+                    // a ~137 KB transaction, and peers that check the announced size
+                    // against the delivered one (geth's tx fetcher, and our own
+                    // `validate_requested` below, both with an 8-byte tolerance) will
+                    // disconnect us for the mismatch.
+                    let Some(tx_blobs_bundle) =
+                        blockchain.mempool.get_blobs_bundle(transaction_hash)?
+                    else {
+                        continue;
+                    };
                     let p2p_tx =
                         P2PTransaction::EIP4844TransactionWithBlobs(WrappedEIP4844Transaction {
                             tx: eip4844_tx,
@@ -146,6 +154,8 @@ impl NewPooledTransactionHashes {
                 }
                 _ => transaction.encode_canonical_len(),
             };
+            transaction_types.push(transaction_type as u8);
+            transaction_hashes.push(transaction_hash);
             transaction_sizes.push(transaction_size);
         }
         Ok(Self {


### PR DESCRIPTION
## Problem

On the `glamsterdam-devnet-8` devnet, geth dropped ethrex peers **~14,970 times** between 2026-08-27 and 08-31 with:

```
Announced transaction size mismatch  size=137,567  ann=162
```

`NewPooledTransactionHashes::new` computes the announced size for a type-3 transaction as:

```rust
let tx_blobs_bundle = blockchain.mempool.get_blobs_bundle(transaction_hash)?.unwrap_or_default();
```

(`crates/networking/p2p/rlpx/eth/transactions.rs:136-137`, and identically `eth72/transactions.rs:104-105`)

When the bundle is no longer in the pool — the transaction was pulled into a payload or evicted between the broadcaster's snapshot and the announcement — `unwrap_or_default()` yields an **empty** bundle, and we announce the size of a blobless wrapper.

The window is real: `TxBroadcaster` announces from a snapshot (`tx_broadcaster.rs:309`), while `remove_transaction_with_lock` (`mempool.rs:290-296`) atomically drops the transaction *and* its bundle when it is pulled into a payload or evicted — exactly the race our own serve-path comment describes.

### Byte arithmetic

For a single-blob v1 transaction with `L = 156` = `len(rlp(EIP-4844 body list))`:

| | bytes |
|---|---:|
| announced: `1` (type) + `2` (list header) + `L` + `3` (three empty lists `0xc0`, version omitted) | **162** |
| actually served: `L` + `ListSize(sidecar 137,406)` + `1` | **137,567** |

Both figures reproduce the observed log line exactly.

## Why this is a bug rather than a tolerable approximation

**It contradicts our own serve path.** `Blockchain::get_p2p_transaction_by_hash` (`crates/blockchain/blockchain.rs:3743-3747`) treats the very same condition as a hard error — *"Blob transaction present without its bundle"* — so `GetPooledTransactions` skips the transaction. We announce a transaction we then refuse to serve, with a size that matches neither outcome.

**It contradicts our own receive-side validation.** `PooledTransactions::validate_requested` (`transactions.rs:372`, `eth72/transactions.rs:377`) rejects any peer whose delivered size differs from the announced size by more than `POOLED_TX_SIZE_TOLERANCE = 8`. **ethrex would disconnect a peer doing what ethrex does here.**

**The penalty lands even though we never serve the transaction.** geth's cleanup loop (`eth/fetcher/tx_fetcher.go:793-826`) checks the one delivered transaction against *every* peer that announced that hash — so we are dropped for the announcement alone.

This is the same class as #6255 (*"ethrex-to-ethrex peers stuck in connect/disconnect loop — Invalid pooled transaction size"*, fixed by #6256, which is in the build I measured) reached via a different route.

## Fix

Skip the transaction rather than substituting an empty bundle, so an announcement can never describe something we cannot serve. `transaction_types` and `transaction_hashes` move below the size computation so that `continue` keeps the three parallel arrays in lockstep — they were previously pushed first, so an early `continue` would have desynced them.

Applied to both `eth/transactions.rs` and `eth72/transactions.rs`.

`cargo check -p ethrex-p2p` — clean.

## Context

Four clients were dropped by geth for announced-size mismatches on the same devnet, for four different reasons. ethrex accounted for 16.7% of them. The others:

- **nethermind** announces the bare consensus size on eth/72 — NethermindEth/nethermind#13049
- **besu** announces the pre-upgrade v0 size while serving v1 — besu-eth/besu#11203
- **reth** announces the un-elided size on eth/72 — already being fixed upstream in paradigmxyz/reth#26574, no action needed
- the underlying **spec ambiguity** (`txsize` is specified as the "consensus encoding", which no client announces) — ethereum/devp2p#281, ethereum/EIPs#12275

Full write-up with the per-client breakdown: https://panda-uploads-production.devops-539.workers.dev/panda/uploads/a7974b/teardown.html
