### PR TITLE
fix(l1): return -32602 for eth_getLogs block ranges beyond head

### DIFF
--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -201,8 +201,16 @@ pub(crate) async fn fetch_logs_with_filter(
                 .resolve_block_number(&storage)
                 .await?
                 .ok_or(RpcErr::WrongParam("toBlock".to_string()))?;
-            if (from..=to).is_empty() {
-                return Err(RpcErr::BadParams("Empty range".to_string()));
+            let latest = storage.get_latest_block_number()?;
+            if to > latest {
+                return Err(RpcErr::InvalidParams(
+                    "block range extends beyond current head block".to_string(),
+                ));
+            }
+            if from > to {
+                return Err(RpcErr::InvalidParams(
+                    "invalid block range params".to_string(),
+                ));
             }
             // The idea here is to fetch every log and filter by address, if given.
             // For that, we'll need each block in range, and its transactions,
@@ -500,6 +508,72 @@ mod tests {
     /// canonical number index would instead return the logs of whatever block
     /// replaced it at the same height after a reorg, silently, which is the
     /// substitution EIP-234 exists to prevent.
+    #[tokio::test]
+    async fn test_get_logs_rejects_out_of_range_blocks() {
+        use ethrex_common::types::{Block, BlockBody};
+        use ethrex_storage::EngineType;
+
+        let storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        let block = Block::new(
+            BlockHeader {
+                number: 1,
+                ..Default::default()
+            },
+            BlockBody::default(),
+        );
+        let hash = block.hash();
+        storage.add_block(block).await.unwrap();
+        storage
+            .forkchoice_update(vec![(1, hash)], 1, hash, None, None)
+            .await
+            .unwrap();
+
+        let filter_for = |from_block, to_block| LogsFilter {
+            from_block,
+            to_block,
+            block_hash: None,
+            address_filters: None,
+            topics: vec![],
+        };
+
+        let err = fetch_logs_with_filter(
+            &filter_for(BlockIdentifier::Number(1), BlockIdentifier::Number(3)),
+            storage.clone(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, RpcErr::InvalidParams(ref m) if m == "block range extends beyond current head block"),
+            "{err:?}"
+        );
+
+        let err = fetch_logs_with_filter(
+            &filter_for(
+                BlockIdentifier::Number(2),
+                BlockIdentifier::Tag(BlockTag::Latest),
+            ),
+            storage.clone(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, RpcErr::InvalidParams(ref m) if m == "invalid block range params"),
+            "{err:?}"
+        );
+
+        let err = fetch_logs_with_filter(
+            &filter_for(BlockIdentifier::Number(1), BlockIdentifier::Number(0)),
+            storage,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, RpcErr::InvalidParams(ref m) if m == "invalid block range params"),
+            "{err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_get_logs_by_block_hash_survives_reorg() {
         use ethrex_common::types::{Block, BlockBody, LegacyTransaction, Log, Receipt, TxType};

--- a/crates/networking/rpc/eth/logs.rs
+++ b/crates/networking/rpc/eth/logs.rs
@@ -202,14 +202,14 @@ pub(crate) async fn fetch_logs_with_filter(
                 .await?
                 .ok_or(RpcErr::WrongParam("toBlock".to_string()))?;
             let latest = storage.get_latest_block_number()?;
-            if to > latest {
-                return Err(RpcErr::InvalidParams(
-                    "block range extends beyond current head block".to_string(),
-                ));
-            }
             if from > to {
                 return Err(RpcErr::InvalidParams(
                     "invalid block range params".to_string(),
+                ));
+            }
+            if to > latest {
+                return Err(RpcErr::InvalidParams(
+                    "block range extends beyond current head block".to_string(),
                 ));
             }
             // The idea here is to fetch every log and filter by address, if given.

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -405,6 +405,7 @@ fn get_error_kind(err: &RpcErr) -> &'static str {
         RpcErr::MethodNotFound(_) => "MethodNotFound",
         RpcErr::WrongParam(_) => "WrongParam",
         RpcErr::BadParams(_) => "BadParams",
+        RpcErr::InvalidParams(_) => "InvalidParams",
         RpcErr::InvalidRequest(_) => "InvalidRequest",
         RpcErr::MissingParam(_) => "MissingParam",
         RpcErr::TooLargeRequest => "TooLargeRequest",

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -32,6 +32,8 @@ pub enum RpcErr {
     WrongParam(String),
     #[error("Invalid params: {0}")]
     BadParams(String),
+    #[error("{0}")]
+    InvalidParams(String),
     #[error("Missing parameter: {0}")]
     MissingParam(String),
     #[error("Too large request")]
@@ -103,6 +105,11 @@ impl From<RpcErr> for RpcErrorMetadata {
                 code: -32000,
                 data: None,
                 message: format!("Invalid params: {context}"),
+            },
+            RpcErr::InvalidParams(context) => RpcErrorMetadata {
+                code: -32602,
+                data: None,
+                message: context,
             },
             RpcErr::InvalidRequest(context) => RpcErrorMetadata {
                 code: -32600,

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -32,6 +32,9 @@ pub enum RpcErr {
     WrongParam(String),
     #[error("Invalid params: {0}")]
     BadParams(String),
+    /// Spec-compliant invalid params error (-32602). The message is used
+    /// verbatim, with no "Invalid params: " prefix, so error strings can
+    /// match other clients exactly. `BadParams`/`WrongParam` map to -32000.
     #[error("{0}")]
     InvalidParams(String),
     #[error("Missing parameter: {0}")]


### PR DESCRIPTION
**Motivation**

A cross-client survey in hive rpc-compat (ethereum/execution-apis#875) found ethrex diverges from the other five execution clients on eth_getLogs range validation. geth, Nethermind, Besu, Erigon, and reth return `-32602` for these requests. ethrex returns:

- `-32000 "Invalid params: Empty range"` when the resolved range is empty (reversed range, or fromBlock past the head with toBlock `latest`)
- `-32603 "Internal Error: Could not get header for block N"` when toBlock is a number past the head, because the per-block loop only fails when the header lookup misses

**Description**

- Add an `RpcErr::InvalidParams` variant that maps to code `-32602` with the given message.
- Validate the range up front in `fetch_logs_with_filter`: toBlock past the head returns `-32602 "block range extends beyond current head block"`, and fromBlock above toBlock returns `-32602 "invalid block range params"`. Both messages match go-ethereum.
- Add a test that covers the three shapes.

ethereum/execution-apis#875 also adds rpc-compat fixtures for these cases.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.