### PR TITLE
fix(l1): skip elided blob txs in pre-eth/72 announcements

### DIFF
--- a/crates/networking/p2p/rlpx/eth/transactions.rs
+++ b/crates/networking/p2p/rlpx/eth/transactions.rs
@@ -91,8 +91,8 @@ impl RLPxMessage for Transactions {
 // Broadcast message
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NewPooledTransactionHashes {
-    pub(crate) transaction_types: Bytes,
-    pub(crate) transaction_sizes: Vec<usize>,
+    pub transaction_types: Bytes,
+    pub transaction_sizes: Vec<usize>,
     pub transaction_hashes: Vec<H256>,
 }
 
@@ -143,6 +143,18 @@ impl NewPooledTransactionHashes {
                     else {
                         continue;
                     };
+                    // A tx ingested over eth/72 may hold an elided bundle (commitments
+                    // and proofs, no blobs; cells travel separately). This pre-72
+                    // announcement promises a full-blob delivery, but the serve path
+                    // drops elided txs from pre-72 responses (`GetPooledTransactions`
+                    // arm in `connection/server.rs`), so we would announce a hash we
+                    // never deliver — and with a size no full-blob delivery can match.
+                    // geth's tx fetcher checks a delivered tx against every peer that
+                    // announced its hash, so when another peer delivers the full tx the
+                    // mismatch is charged to us. Skip it, mirroring the serve path.
+                    if tx_blobs_bundle.blobs.len() != tx_blobs_bundle.commitments.len() {
+                        continue;
+                    }
                     let p2p_tx =
                         P2PTransaction::EIP4844TransactionWithBlobs(WrappedEIP4844Transaction {
                             tx: eip4844_tx,

--- a/test/tests/p2p/rlpx/eth72_tests.rs
+++ b/test/tests/p2p/rlpx/eth72_tests.rs
@@ -364,3 +364,89 @@ fn an_all_zero_mask_on_a_non_blob_announcement_is_not_an_availability_claim() {
     let with_blob = npth(Some(0xFF));
     assert!(with_blob.announces_blob_tx());
 }
+
+// ── NewPooledTransactionHashes72::new pool-state tests ───────────────────────
+
+fn test_blockchain() -> ethrex_blockchain::Blockchain {
+    let store = ethrex_storage::Store::new("", ethrex_storage::EngineType::InMemory)
+        .expect("in-memory store");
+    ethrex_blockchain::Blockchain::default_with_store(store)
+}
+
+/// Adds a 1-blob EIP-4844 tx to the mempool with the given bundle (or none, mimicking the
+/// state after the bundle was dropped by eviction or payload building) and returns the tx.
+fn add_blob_tx_with_bundle(
+    bc: &ethrex_blockchain::Blockchain,
+    nonce: u64,
+    bundle: Option<BlobsBundle>,
+) -> Transaction {
+    let tx = Transaction::EIP4844Transaction(EIP4844Transaction {
+        nonce,
+        gas: 21_000,
+        to: Address::from_low_u64_be(2),
+        ..Default::default()
+    });
+    let sender = Address::from_low_u64_be(3);
+    let mtx = MempoolTransaction::new(tx.clone(), sender);
+    let hash = mtx.hash(&ethrex_crypto::NativeCrypto);
+    if let Some(bundle) = bundle {
+        bc.mempool
+            .add_blobs_bundle(hash, bundle)
+            .expect("add bundle");
+    }
+    bc.mempool
+        .add_transaction(hash, sender, mtx, None, None)
+        .expect("add to mempool");
+    tx
+}
+
+/// eth/72 serves blob txs elided (cells travel separately), so a sparse-held tx —
+/// elided bundle stored, blobs absent — is announceable on eth/72. The skip that
+/// protects pre-72 links from elided bundles must not leak into this variant.
+#[test]
+fn eth72_announcement_keeps_a_sparse_held_blob_tx() {
+    let bc = test_blockchain();
+    let elided = BlobsBundle {
+        blobs: vec![],
+        commitments: vec![[0u8; 48]],
+        proofs: vec![[0u8; 48]; CELLS_PER_EXT_BLOB],
+        version: 1,
+    };
+    let tx = add_blob_tx_with_bundle(&bc, 0, Some(elided));
+    let hash = tx.hash(&ethrex_crypto::NativeCrypto);
+
+    let announcement = NewPooledTransactionHashes72::new(vec![tx], &bc).expect("announce");
+
+    assert_eq!(
+        announcement.transaction_hashes,
+        vec![hash],
+        "a sparse-held blob tx must still be announced on eth/72"
+    );
+    assert_eq!(announcement.transaction_types.as_ref(), &[3u8]);
+    assert!(
+        announcement.cell_mask.is_some(),
+        "a type-3 announcement must carry a cell mask"
+    );
+}
+
+/// A blob tx whose bundle left the pool entirely can't be served on any protocol
+/// version, so eth/72 must skip it too — and when the skip removes the only type-3
+/// tx, the announcement must carry a nil cell mask (EIP-8070: cell_mask MUST be nil
+/// when no type-3 tx is announced).
+#[test]
+fn eth72_announcement_skips_a_gone_bundle_blob_tx_and_keeps_cell_mask_nil() {
+    let bc = test_blockchain();
+    let gone_blob_tx = add_blob_tx_with_bundle(&bc, 0, None);
+
+    let announcement =
+        NewPooledTransactionHashes72::new(vec![gone_blob_tx], &bc).expect("announce");
+
+    assert!(
+        announcement.transaction_hashes.is_empty(),
+        "a bundle-less blob tx must not be announced"
+    );
+    assert_eq!(
+        announcement.cell_mask, None,
+        "cell_mask must be nil when no type-3 tx is announced"
+    );
+}

--- a/test/tests/p2p/rlpx/transactions_tests.rs
+++ b/test/tests/p2p/rlpx/transactions_tests.rs
@@ -2,11 +2,14 @@ use bytes::Bytes;
 use ethrex_blockchain::Blockchain;
 use ethrex_common::{
     Address, H256,
-    types::{EIP1559Transaction, MempoolTransaction, P2PTransaction, Transaction},
+    types::{
+        BYTES_PER_BLOB, BlobsBundle, EIP1559Transaction, EIP4844Transaction, MempoolTransaction,
+        P2PTransaction, Transaction,
+    },
 };
 use ethrex_crypto::NativeCrypto;
 use ethrex_p2p::rlpx::{
-    eth::transactions::{GetPooledTransactions, PooledTransactions},
+    eth::transactions::{GetPooledTransactions, NewPooledTransactionHashes, PooledTransactions},
     message::RLPxMessage,
 };
 use ethrex_storage::{EngineType, Store};
@@ -114,5 +117,108 @@ fn get_pooled_transactions_handle_caps_response_bytes() {
         "the byte budget must stop the response short of the full {}-tx request, got {}",
         hashes.len(),
         resp.pooled_transactions.len()
+    );
+}
+
+/// Adds a 1-blob EIP-4844 tx to the mempool with the given bundle (or none, mimicking the
+/// state after the bundle was dropped by eviction or payload building) and returns the tx.
+fn add_blob_tx_with_bundle(
+    bc: &Blockchain,
+    nonce: u64,
+    bundle: Option<BlobsBundle>,
+) -> Transaction {
+    let tx = Transaction::EIP4844Transaction(EIP4844Transaction {
+        nonce,
+        gas: 21_000,
+        to: Address::from_low_u64_be(1),
+        ..Default::default()
+    });
+    let sender = Address::from_low_u64_be(2);
+    let mtx = MempoolTransaction::new(tx.clone(), sender);
+    let hash = mtx.hash(&NativeCrypto);
+    if let Some(bundle) = bundle {
+        bc.mempool
+            .add_blobs_bundle(hash, bundle)
+            .expect("add bundle");
+    }
+    bc.mempool
+        .add_transaction(hash, sender, mtx, None, None)
+        .expect("add to mempool");
+    tx
+}
+
+fn full_bundle() -> BlobsBundle {
+    BlobsBundle {
+        blobs: vec![[0u8; BYTES_PER_BLOB]],
+        commitments: vec![[0u8; 48]],
+        proofs: vec![[0u8; 48]],
+        version: 0,
+    }
+}
+
+/// An eth/72 elided bundle: commitments and proofs present, blobs absent (cells are stored
+/// and fetched separately).
+fn elided_bundle() -> BlobsBundle {
+    BlobsBundle {
+        blobs: vec![],
+        commitments: vec![[0u8; 48]],
+        proofs: vec![[0u8; 48]; 128],
+        version: 1,
+    }
+}
+
+/// A blob tx whose bundle left the pool (pulled into a payload or evicted after the
+/// broadcaster snapshot) can't be served, so it must not be announced — substituting an
+/// empty bundle would announce a size no delivery can match, and peers checking announced
+/// vs delivered size (geth's fetcher, our own `validate_requested`) disconnect over it.
+/// The parallel type/size/hash arrays must stay in lockstep across the skip.
+#[test]
+fn pre72_announcement_skips_a_blob_tx_whose_bundle_is_gone() {
+    let bc = test_blockchain();
+    let normal_hash = add_mempool_tx(&bc, 0, 0);
+    let normal_tx = bc
+        .mempool
+        .get_transaction_by_hash(normal_hash)
+        .expect("mempool read")
+        .expect("tx present");
+    let gone_blob_tx = add_blob_tx_with_bundle(&bc, 0, None);
+
+    let announcement =
+        NewPooledTransactionHashes::new(vec![gone_blob_tx, normal_tx], &bc).expect("announce");
+
+    assert_eq!(
+        announcement.transaction_hashes,
+        vec![normal_hash],
+        "the bundle-less blob tx must not be announced"
+    );
+    assert_eq!(announcement.transaction_types.as_ref(), &[2u8]);
+    assert_eq!(announcement.transaction_sizes.len(), 1);
+}
+
+/// A blob tx held elided (eth/72 ingest: commitments + proofs, no blobs) is dropped from
+/// pre-72 `PooledTransactions` responses by the serve path, so a pre-72 announcement of it
+/// advertises a hash we never deliver — with a size no full-blob delivery can match, which
+/// geth charges to every announcer of the hash once someone else delivers the full tx.
+/// A fully-held blob tx in the same batch must still be announced, at its full wrapped size.
+#[test]
+fn pre72_announcement_skips_an_elided_blob_tx_but_keeps_a_full_one() {
+    let bc = test_blockchain();
+    let elided_tx = add_blob_tx_with_bundle(&bc, 0, Some(elided_bundle()));
+    let full_tx = add_blob_tx_with_bundle(&bc, 1, Some(full_bundle()));
+    let full_hash = full_tx.hash(&NativeCrypto);
+
+    let announcement =
+        NewPooledTransactionHashes::new(vec![elided_tx, full_tx], &bc).expect("announce");
+
+    assert_eq!(
+        announcement.transaction_hashes,
+        vec![full_hash],
+        "the elided blob tx must not be announced on a pre-72 link"
+    );
+    assert_eq!(announcement.transaction_types.as_ref(), &[3u8]);
+    assert!(
+        announcement.transaction_sizes[0] > BYTES_PER_BLOB,
+        "the announced size must be the full wrapped encoding (blobs included), got {}",
+        announcement.transaction_sizes[0]
     );
 }


### PR DESCRIPTION
## Motivation

#7235 stopped announcing blob txs whose bundle is **gone**. The same announce/serve contradiction survives through a second pool state: a tx ingested over eth/72 holds an **elided** bundle — commitments and proofs, no blobs, cells stored and fetched separately — so `get_blobs_bundle` returns `Some` and the pre-72 announcement path still announces it.

But the pre-72 serve path drops elided txs from `PooledTransactions` responses (the `GetPooledTransactions` arm in `connection/server.rs` retains only wrappers with `blobs.len() == commitments.len()`). So on a pre-72 link we announce a hash we never deliver, with the elided size — a size no full-blob delivery can match. geth's fetcher cleanup (`eth/fetcher/tx_fetcher.go`) checks a delivered transaction against **every** peer that announced its hash, so when any other peer delivers the full tx, the mismatch is charged to us: the same penalty mechanism #7235 measured (~15k drops on glamsterdam-devnet-8), reached through the sparse-held state.

Triggers when blob sampling (eth/72) is enabled and a peer negotiates < eth/72.

## Description

- `NewPooledTransactionHashes::new` skips blob txs whose bundle is elided (`blobs.len() != commitments.len()`), mirroring the serve-side retain, and rides on #7235's push-after-size ordering so the three parallel arrays stay in lockstep.
- The eth/72 variant is intentionally unchanged: eth/72 serves elided encodings, so sparse-held txs remain announceable there — now pinned by a test.
- `NewPooledTransactionHashes`' fields align with the eth/72 variant's visibility (`pub`) so integration tests can assert the announcement shape.
- Regression tests:
  - pre-72 skips a gone-bundle tx and keeps the arrays in lockstep (pins #7235 itself, which merged without tests of its own);
  - pre-72 skips an elided tx while keeping a fully-held one at its full wrapped size (fails without this fix);
  - eth/72 keeps announcing a sparse-held tx;
  - eth/72 skips a gone-bundle tx and keeps `cell_mask` nil when the skip removes the only type-3 tx (EIP-8070's MUST-nil rule).

## How to test

```
cargo test -p ethrex-test --test ethrex_tests -- rlpx::transactions_tests rlpx::eth72_tests
```

