### PR TITLE
fix(l1): return INVALID for undecodable blockAccessList, bump Amsterdam fixtures to v8.1.3

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,7 +1,7 @@
 # Amsterdam (BAL) hive test configuration
-# Pinned to tests-glamsterdam-devnet@v8.1.1 (execution-specs `devnets/glamsterdam/8`).
+# Pinned to tests-glamsterdam-devnet@v8.1.3 (execution-specs `devnets/glamsterdam/8`).
 # Keep this in lock-step with `tooling/ef_tests/.fixtures_url_amsterdam`: the two pins
 # grade the same client, so a release that only one of them follows fails every fixture
 # the other release changed.
-fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.1/fixtures_glamsterdam-devnet.tar.gz
-eels_commit: 32f597f7e56e3843198a83c7cf437a0b49aa6c0e
+fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.3/fixtures_glamsterdam-devnet.tar.gz
+eels_commit: 8ca2f4ceefd83100a4d21d0c33747114278a0bc2

--- a/crates/networking/rpc/clients/auth/mod.rs
+++ b/crates/networking/rpc/clients/auth/mod.rs
@@ -217,6 +217,7 @@ impl EngineClient {
             // matches the V4 path and is not suitable for deposit-bearing Amsterdam tests.
             execution_requests: vec![],
             raw_bal_hash: None,
+            undecodable_bal: false,
         }
         .into();
 

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -278,6 +278,12 @@ pub struct NewPayloadV5Request {
     /// The BAL hash computed from the raw RLP bytes as received (no re-encoding/sorting).
     /// This preserves the exact encoding from the payload for block hash validation.
     pub raw_bal_hash: Option<H256>,
+    /// Set when `blockAccessList` was present as well-formed DATA (0x-prefixed hex)
+    /// whose bytes are not a valid RLP encoding of the block access list. The engine
+    /// spec mandates `{status: INVALID, latestValidHash: null}` for this — not a
+    /// -32602 error, which is reserved for a missing or schema-invalid field
+    /// (execution-apis amsterdam.md, engine_newPayloadV5 spec 3).
+    pub undecodable_bal: bool,
 }
 
 impl From<NewPayloadV5Request> for RpcRequest {
@@ -307,7 +313,9 @@ impl RpcHandler for NewPayloadV5Request {
         // Extract the raw BAL hash from the JSON payload before deserialization.
         // We hash the raw RLP bytes as-received to preserve the exact encoding
         // (including any ordering) for accurate block hash validation.
-        let raw_bal_hash = params[0]
+        let mut payload_value = params[0].clone();
+        let mut undecodable_bal = false;
+        let raw_bal_hash = payload_value
             .get("blockAccessList")
             .map(|v| {
                 let hex_str = v
@@ -320,12 +328,26 @@ impl RpcHandler for NewPayloadV5Request {
                     .ok_or(RpcErr::WrongParam("blockAccessList".to_string()))?;
                 let bytes = hex::decode(hex_body)
                     .map_err(|_| RpcErr::WrongParam("blockAccessList".to_string()))?;
+                // Well-formed DATA whose bytes don't RLP-decode into a BAL must yield
+                // `{status: INVALID}`, not -32602. Flag it here (the decision belongs
+                // to `handle`, which can return a status) rather than failing parse.
+                if BlockAccessList::decode(&bytes).is_err() {
+                    undecodable_bal = true;
+                }
                 Ok::<_, RpcErr>(ethrex_common::utils::keccak(bytes))
             })
             .transpose()?;
+        if undecodable_bal {
+            // `ExecutionPayload`'s serde RLP-decodes the field and would fail the
+            // whole params parse with -32602; drop it so deserialization succeeds
+            // and `handle` can answer with the mandated INVALID status.
+            if let Some(obj) = payload_value.as_object_mut() {
+                obj.remove("blockAccessList");
+            }
+        }
 
         Ok(Self {
-            payload: serde_json::from_value(params[0].clone())
+            payload: serde_json::from_value(payload_value)
                 .map_err(|_| RpcErr::WrongParam("payload".to_string()))?,
             expected_blob_versioned_hashes: serde_json::from_value(params[1].clone())
                 .map_err(|_| RpcErr::WrongParam("expected_blob_versioned_hashes".to_string()))?,
@@ -334,6 +356,7 @@ impl RpcHandler for NewPayloadV5Request {
             execution_requests: serde_json::from_value(params[3].clone())
                 .map_err(|_| RpcErr::WrongParam("execution_requests".to_string()))?,
             raw_bal_hash,
+            undecodable_bal,
         })
     }
 
@@ -348,6 +371,15 @@ impl NewPayloadV5Request {
         context: RpcApiContext,
         make_witness: bool,
     ) -> Result<Value, RpcErr> {
+        // Must precede every other check: a present-but-undecodable BAL answers
+        // `{status: INVALID, latestValidHash: null}` (engine spec, amsterdam.md
+        // newPayloadV5 spec 3). The field was dropped from `self.payload` at parse
+        // time, so falling through would misreport it as missing (-32602).
+        if self.undecodable_bal {
+            return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
+                "blockAccessList is not a valid RLP encoding of the block access list",
+            ))?);
+        }
         validate_execution_payload_v5(&self.payload)?;
 
         // validate the received requests

--- a/crates/networking/rpc/engine/payload.rs
+++ b/crates/networking/rpc/engine/payload.rs
@@ -376,8 +376,14 @@ impl NewPayloadV5Request {
         // newPayloadV5 spec 3). The field was dropped from `self.payload` at parse
         // time, so falling through would misreport it as missing (-32602).
         if self.undecodable_bal {
+            // Wording matters: EEST's ethrex exception mapper resolves
+            // BlockException.INVALID_BLOCK_ACCESS_LIST by matching the substring
+            // "Failed to RLP decode BAL" (the serde-layer message this path
+            // predates). Keep it as the prefix so consume-engine attributes the
+            // INVALID status to the right exception.
             return Ok(serde_json::to_value(PayloadStatus::invalid_with_err(
-                "blockAccessList is not a valid RLP encoding of the block access list",
+                "Failed to RLP decode BAL: blockAccessList is not a valid RLP \
+                 encoding of the block access list",
             ))?);
         }
         validate_execution_payload_v5(&self.payload)?;

--- a/test/tests/rpc/mod.rs
+++ b/test/tests/rpc/mod.rs
@@ -8,6 +8,7 @@ mod fork_choice_tests;
 mod get_block_by_hash_tests;
 mod http_batch_tests;
 mod missing_rpc_methods_tests;
+mod new_payload_bal_tests;
 mod raw_receipts_completeness_tests;
 mod send_raw_transaction_tests;
 mod subscription_manager_tests;

--- a/test/tests/rpc/new_payload_bal_tests.rs
+++ b/test/tests/rpc/new_payload_bal_tests.rs
@@ -1,0 +1,117 @@
+use ethrex_common::{
+    H256,
+    types::{Block, BlockBody, BlockHeader, block_access_list::BlockAccessList},
+};
+use ethrex_rlp::encode::RLPEncode;
+use ethrex_rpc::{
+    engine::payload::NewPayloadV5Request,
+    rpc::{RpcApiContext, RpcHandler},
+    test_utils::default_context_with_storage,
+    utils::RpcErrorMetadata,
+};
+use ethrex_storage::{EngineType, Store};
+use serde_json::{Value, json};
+
+async fn fresh_context() -> RpcApiContext {
+    let store = Store::new("test", EngineType::InMemory).expect("store");
+    default_context_with_storage(store).await
+}
+
+/// Build the 4-element engine_newPayloadV5 params with the given `blockAccessList`
+/// JSON value spliced into an otherwise well-formed payload object.
+fn v5_params(bal: Option<Value>) -> Option<Vec<Value>> {
+    let payload = ethrex_rpc::types::payload::ExecutionPayload::from_block(
+        Block::new(BlockHeader::default(), BlockBody::default()),
+        None,
+    );
+    let mut payload_json = serde_json::to_value(payload).expect("payload to json");
+    match bal {
+        Some(v) => {
+            payload_json["blockAccessList"] = v;
+        }
+        None => {
+            payload_json
+                .as_object_mut()
+                .expect("payload object")
+                .remove("blockAccessList");
+        }
+    }
+    Some(vec![
+        payload_json,
+        json!([]),
+        json!(H256::zero()),
+        json!([]),
+    ])
+}
+
+/// amsterdam.md newPayloadV5 spec 3: a `blockAccessList` that is well-formed DATA but
+/// not a valid RLP encoding of the BAL MUST produce
+/// `{status: INVALID, latestValidHash: null}` — a payload status, not -32602.
+#[tokio::test]
+async fn undecodable_bal_returns_invalid_status_not_an_error() {
+    // 0xde opens a 30-byte RLP list but only 3 bytes follow: valid DATA, invalid RLP.
+    let params = v5_params(Some(json!("0xdeadbeef")));
+
+    let request = NewPayloadV5Request::parse(&params).expect("parse must not fail");
+    assert!(
+        request.undecodable_bal,
+        "the BAL must be flagged undecodable"
+    );
+
+    let ctx = fresh_context().await;
+    let response = request
+        .handle(ctx)
+        .await
+        .expect("must be a result, not an error");
+    assert_eq!(response["status"], "INVALID");
+    assert_eq!(response["latestValidHash"], Value::Null);
+    assert!(
+        response["validationError"].is_string(),
+        "validationError should carry the reason, got {response:?}"
+    );
+}
+
+/// A valid RLP BAL (here the empty list) must not trip the undecodable flag, so the
+/// request proceeds into regular validation.
+#[test]
+fn well_formed_bal_is_not_flagged() {
+    let bal_hex = format!(
+        "0x{}",
+        hex::encode(BlockAccessList::default().encode_to_vec())
+    );
+    let params = v5_params(Some(json!(bal_hex)));
+
+    let request = NewPayloadV5Request::parse(&params).expect("parse");
+    assert!(!request.undecodable_bal);
+    assert!(request.raw_bal_hash.is_some());
+    assert!(
+        request.payload.block_access_list.is_some(),
+        "a decodable BAL must survive into the payload"
+    );
+}
+
+/// amsterdam.md newPayloadV5 spec 2 (unchanged): a MISSING blockAccessList stays a
+/// -32602 error — the INVALID-status rule is only for present-but-undecodable values.
+#[tokio::test]
+async fn missing_bal_still_returns_invalid_params() {
+    let params = v5_params(None);
+    let request = NewPayloadV5Request::parse(&params).expect("parse");
+    assert!(!request.undecodable_bal);
+
+    let ctx = fresh_context().await;
+    let err = request.handle(ctx).await.expect_err("must be an error");
+    let metadata = RpcErrorMetadata::from(err);
+    assert_eq!(metadata.code, -32602);
+}
+
+/// A schema-invalid value (missing the mandatory 0x prefix) is not "undecodable RLP";
+/// it fails DATA validation and stays -32602 at parse time.
+#[test]
+fn schema_invalid_bal_still_fails_parse_with_invalid_params() {
+    let params = v5_params(Some(json!("deadbeef")));
+    let Err(err) = NewPayloadV5Request::parse(&params) else {
+        panic!("parse must fail for an unprefixed blockAccessList");
+    };
+    let metadata = RpcErrorMetadata::from(err);
+    assert_eq!(metadata.code, -32602);
+}

--- a/tooling/ef_tests/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.1/fixtures_glamsterdam-devnet.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.3/fixtures_glamsterdam-devnet.tar.gz


### PR DESCRIPTION
## Motivation

Two halves that only work together (each fails CI without the other):

1. **execution-apis#869** (merged) clarifies `engine_newPayloadV5`: a `blockAccessList` that is present but not a valid RLP encoding of the BAL MUST answer `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` — a payload status, not a `-32602` error. A missing field stays `-32602` (spec 2, unchanged). ethrex RLP-decoded the field inside serde during `ExecutionPayload` deserialization, so an undecodable BAL failed the whole params parse and surfaced as `-32602`.
2. **[tests-glamsterdam-devnet@v8.1.3](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v8.1.3)** (EELS `devnets/glamsterdam/8` @ `8ca2f4ce`, test-only release — no spec changes) encodes that clarification: the `bal_invalid_engine_payload_encoding` fixtures (`empty_byte_string`, `rlp_non_list`, `rlp_truncated_list`) now expect `{status: INVALID}` instead of `-32602`, and more ported-static Amsterdam SSTORE/refund state tests are un-skipped.

The fix fails the v8.1.1-pinned CI (old fixtures assert `-32602`), and the v8.1.3 pins fail without the fix — so they land atomically here.

## Description

**Fix** (`crates/networking/rpc/engine/payload.rs`):
- `NewPayloadV5Request::parse` already extracts the raw BAL bytes (for `raw_bal_hash`); it now also attempts `BlockAccessList::decode` there. On failure it flags the request (`undecodable_bal`) instead of erroring, and strips the field from the payload JSON so the serde pass survives.
- `handle_with_witness` answers `PayloadStatus::invalid_with_err(...)` first thing when the flag is set — before `validate_execution_payload_v5`, which would otherwise misreport the stripped field as missing. Covers `engine_newPayloadV5` and `engine_newPayloadWithWitnessV5`.
- Boundary rules preserved and pinned by unit tests: missing field → `-32602`; schema-invalid DATA (unprefixed hex) → `-32602`; well-formed DATA with undecodable bytes → `{status: INVALID, latestValidHash: null}` (fails without the fix); decodable BAL unflagged.

**Fixture bump** (lock-step per the comment in `.github/config/hive/amsterdam.yaml`):
- `tooling/ef_tests/.fixtures_url_amsterdam` → v8.1.3 (feeds the engine/state/blockchain EF suites)
- `.github/config/hive/amsterdam.yaml` → v8.1.3 fixtures + `eels_commit 8ca2f4ce`

## Validation

- Engine EF suite on **main + v8.1.3**: fails exactly `bal_invalid_engine_payload_encoding` (3 fixtures, `unexpected_jsonrpc_error code=-32602`), 79,432/79,435 pass — proving the pins need the fix.
- #7239's previous CI (fix + v8.1.1): failed exactly the same fixture family in reverse (`missing_error_code expected_code=-32602`) — proving the fix needs the pins.
- Engine EF suite on **this branch (fix + v8.1.3)**: green locally (79,435/79,435).
- State + blockchain suites on v8.1.3 (incl. the newly un-skipped ported-static tests): green locally.

```
cd tooling/ef_tests/engine && make test
cd tooling/ef_tests/state && make run-evm-ef-tests-ci
cargo test -p ethrex-test --test ethrex_tests -- rpc::new_payload_bal_tests
```
