### PR TITLE
feat(l1): add Platåberget to the multisync matrix

### DIFF
--- a/tooling/sync/README.md
+++ b/tooling/sync/README.md
@@ -147,7 +147,7 @@ Host port mapping:
 
 [Platåberget](https://plataberget.dev/) is the public Glamsterdam testnet, run on the glamsterdam-devnet-8 spec. Its services differ from the named networks in two ways:
 
-- The consensus client is `ethpandaops/prysm-beacon-chain:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config, and Lodestar intermittently wedges in `verifyPayloadsDataAvailability` on some custody-column draws (each cycle redraws them with a fresh node identity), which would fail cycles as ethrex block stalls. Prysm is also the pairing the EF runs with ethrex on this network.
+- The consensus client is `ethpandaops/prysm-beacon-chain:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config, and Lodestar range sync wedges whenever its first finalized batch contains an ePBS empty-payload slot ([ChainSafe/lodestar#9937](https://github.com/ChainSafe/lodestar/pull/9937)), which would fail cycles as ethrex block stalls. Prysm is also the pairing the EF runs with ethrex on this network; revisit once the fix ships in the glamsterdam image.
 - The network is addressed by config files, not a `--network` name on the CL side: a `setup-config-plataberget` service downloads `config.yaml`, `genesis.ssz`, bootstrap ENRs, and the deposit-contract metadata from [ethpandaops/glamsterdam-devnets](https://github.com/ethpandaops/glamsterdam-devnets/tree/master/network-configs/devnet-8/metadata) into a shared volume once (re-fetched after `multisync-clean`).
 
 The instance snap-syncs like the rest of the matrix (multisync validates snap sync; full-sync coverage belongs to the fullsync-bench tooling). It is not in the default network set; opt in explicitly:

--- a/tooling/sync/README.md
+++ b/tooling/sync/README.md
@@ -147,7 +147,7 @@ Host port mapping:
 
 [Platåberget](https://plataberget.dev/) is the public Glamsterdam testnet, run on the glamsterdam-devnet-8 spec. Its services differ from the named networks in two ways:
 
-- The consensus client is `ethpandaops/lodestar:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config.
+- The consensus client is `ethpandaops/prysm-beacon-chain:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config, and Lodestar intermittently wedges in `verifyPayloadsDataAvailability` on some custody-column draws (each cycle redraws them with a fresh node identity), which would fail cycles as ethrex block stalls. Prysm is also the pairing the EF runs with ethrex on this network.
 - The network is addressed by config files, not a `--network` name on the CL side: a `setup-config-plataberget` service downloads `config.yaml`, `genesis.ssz`, bootstrap ENRs, and the deposit-contract metadata from [ethpandaops/glamsterdam-devnets](https://github.com/ethpandaops/glamsterdam-devnets/tree/master/network-configs/devnet-8/metadata) into a shared volume once (re-fetched after `multisync-clean`).
 
 The instance snap-syncs like the rest of the matrix (multisync validates snap sync; full-sync coverage belongs to the fullsync-bench tooling). It is not in the default network set; opt in explicitly:

--- a/tooling/sync/README.md
+++ b/tooling/sync/README.md
@@ -134,13 +134,30 @@ make multisync-run
 
 ### Docker Compose Setup
 
-The `docker-compose.multisync.yaml` file defines services for each network with isolated volumes. Each network uses Lighthouse as the consensus client with checkpoint sync.
+The `docker-compose.multisync.yaml` file defines services for each network with isolated volumes. The named networks use Lighthouse as the consensus client with checkpoint sync; plataberget uses a Glamsterdam-capable Lodestar (see below).
 
 Host port mapping:
 - **hoodi**: `localhost:8545`
 - **sepolia**: `localhost:8546`
 - **mainnet**: `localhost:8547`
 - **hoodi-2**: `localhost:8548` (for additional testing)
+- **plataberget**: `localhost:8549` (snap sync)
+- **plataberget-full**: `localhost:8550` (full sync)
+
+#### Platåberget
+
+[Platåberget](https://plataberget.dev/) is the public Glamsterdam testnet, run on the glamsterdam-devnet-8 spec. Its services differ from the named networks in two ways:
+
+- The consensus client is `ethpandaops/lodestar:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config.
+- The network is addressed by config files, not a `--network` name on the CL side: a `setup-config-plataberget` service downloads `config.yaml`, `genesis.ssz`, bootstrap ENRs, and the deposit-contract metadata from [ethpandaops/glamsterdam-devnets](https://github.com/ethpandaops/glamsterdam-devnets/tree/master/network-configs/devnet-8/metadata) into a shared volume once (re-fetched after `multisync-clean`).
+
+Two instances are defined: `plataberget` snap-syncs like the rest of the matrix, and `plataberget-full` full-syncs — executing every block including the Amsterdam fork transition, which is the strongest Glamsterdam regression signal this testnet offers. Neither is in the default network set; opt in explicitly:
+
+```bash
+make multisync-loop MULTISYNC_NETWORKS=plataberget,plataberget-full
+```
+
+Note the CL image tag is rebuilt by ethPandaOps as the devnet spec evolves; a failing plataberget matrix entry can mean the image moved, not that ethrex regressed.
 
 ### Environment Variables
 

--- a/tooling/sync/README.md
+++ b/tooling/sync/README.md
@@ -141,8 +141,7 @@ Host port mapping:
 - **sepolia**: `localhost:8546`
 - **mainnet**: `localhost:8547`
 - **hoodi-2**: `localhost:8548` (for additional testing)
-- **plataberget**: `localhost:8549` (snap sync)
-- **plataberget-full**: `localhost:8550` (full sync)
+- **plataberget**: `localhost:8549`
 
 #### Platåberget
 
@@ -151,10 +150,10 @@ Host port mapping:
 - The consensus client is `ethpandaops/lodestar:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config.
 - The network is addressed by config files, not a `--network` name on the CL side: a `setup-config-plataberget` service downloads `config.yaml`, `genesis.ssz`, bootstrap ENRs, and the deposit-contract metadata from [ethpandaops/glamsterdam-devnets](https://github.com/ethpandaops/glamsterdam-devnets/tree/master/network-configs/devnet-8/metadata) into a shared volume once (re-fetched after `multisync-clean`).
 
-Two instances are defined: `plataberget` snap-syncs like the rest of the matrix, and `plataberget-full` full-syncs — executing every block including the Amsterdam fork transition, which is the strongest Glamsterdam regression signal this testnet offers. Neither is in the default network set; opt in explicitly:
+The instance snap-syncs like the rest of the matrix (multisync validates snap sync; full-sync coverage belongs to the fullsync-bench tooling). It is not in the default network set; opt in explicitly:
 
 ```bash
-make multisync-loop MULTISYNC_NETWORKS=plataberget,plataberget-full
+make multisync-loop MULTISYNC_NETWORKS=plataberget
 ```
 
 Note the CL image tag is rebuilt by ethPandaOps as the devnet spec evolves; a failing plataberget matrix entry can mean the image moved, not that ethrex regressed.

--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -2,9 +2,8 @@
 #
 # For full documentation, see: tooling/sync/README.md (section "Multi-Network Parallel Snapsync")
 #
-# This file defines 6 networks: hoodi, sepolia, mainnet, hoodi-2, plataberget,
-# and plataberget-full (same testnet, full sync instead of snap).
-# By default, the Makefile starts only hoodi, sepolia, and mainnet.
+# This file defines 5 networks: hoodi, sepolia, mainnet, hoodi-2, and
+# plataberget. By default, the Makefile starts only hoodi, sepolia, and mainnet.
 #
 # Usage via Makefile (recommended):
 #   make multisync-loop                    # Start default networks and monitor continuously
@@ -21,12 +20,11 @@
 #
 # Each network runs in isolation with its own volumes.
 # Host ports are mapped for external RPC access:
-#   hoodi:            localhost:8545
-#   sepolia:          localhost:8546
-#   mainnet:          localhost:8547
-#   hoodi-2:          localhost:8548
-#   plataberget:      localhost:8549
-#   plataberget-full: localhost:8550
+#   hoodi:       localhost:8545
+#   sepolia:     localhost:8546
+#   mainnet:     localhost:8547
+#   hoodi-2:     localhost:8548
+#   plataberget: localhost:8549
 
 x-ethrex-common: &ethrex-common
   image: "${ETHREX_IMAGE:-ghcr.io/lambdaclass/ethrex:main}"
@@ -255,10 +253,6 @@ services:
   # ethpandaops/glamsterdam-devnets, the source plataberget.dev names as the
   # network's configuration.
   #
-  # Two instances: `plataberget` snap-syncs (matrix parity with the other
-  # networks); `plataberget-full` full-syncs, executing every block including
-  # the Amsterdam fork transition — the strongest regression signal this
-  # testnet offers.
   # =============================================================================
   setup-config-plataberget:
     image: alpine
@@ -324,60 +318,6 @@ services:
       setup-jwt-plataberget:
         condition: service_completed_successfully
 
-  # =============================================================================
-  # PLATABERGET-FULL (same network, --syncmode full)
-  # =============================================================================
-  setup-jwt-plataberget-full:
-    image: alpine
-    volumes:
-      - secrets-plataberget-full:/secrets
-    command: sh -c 'apk add openssl && openssl rand -hex 32 | tr -d "\n" | tee /secrets/jwt.hex'
-
-  consensus-plataberget-full:
-    image: ethpandaops/lodestar:glamsterdam-devnet-8
-    restart: unless-stopped
-    container_name: consensus-plataberget-full
-    volumes:
-      - secrets-plataberget-full:/secrets
-      - config-plataberget:/config:ro
-      - consensus-plataberget-full:/data
-    command: >
-      beacon
-      --dataDir /data
-      --paramsFile /config/config.yaml
-      --genesisStateFile /config/genesis.ssz
-      --bootnodesFile /config/bootstrap_nodes.yaml
-      --checkpointSyncUrl https://checkpoint-sync.plataberget.ethpandaops.io
-      --execution.urls http://ethrex-plataberget-full:8551
-      --jwtSecret /secrets/jwt.hex
-      --rest --rest.address 0.0.0.0
-    depends_on:
-      setup-jwt-plataberget-full:
-        condition: service_completed_successfully
-      setup-config-plataberget:
-        condition: service_completed_successfully
-
-  ethrex-plataberget-full:
-    <<: *ethrex-common
-    container_name: ethrex-plataberget-full
-    ports:
-      - "8550:8545"  # RPC
-    volumes:
-      - secrets-plataberget-full:/secrets
-      - ethrex-plataberget-full:/data
-    command: >
-      --http.addr 0.0.0.0
-      --http.api eth,net,web3,admin
-      --network plataberget
-      --authrpc.addr 0.0.0.0
-      --authrpc.jwtsecret /secrets/jwt.hex
-      --syncmode full
-      --datadir /data
-      --metrics --metrics.addr 0.0.0.0 --metrics.port 3701
-    depends_on:
-      setup-jwt-plataberget-full:
-        condition: service_completed_successfully
-
 volumes:
   secrets-hoodi:
   secrets-sepolia:
@@ -395,6 +335,3 @@ volumes:
   secrets-plataberget:
   consensus-plataberget:
   ethrex-plataberget:
-  secrets-plataberget-full:
-  consensus-plataberget-full:
-  ethrex-plataberget-full:

--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -274,7 +274,14 @@ services:
     command: sh -c 'apk add openssl && openssl rand -hex 32 | tr -d "\n" | tee /secrets/jwt.hex'
 
   consensus-plataberget:
-    image: ethpandaops/lodestar:glamsterdam-devnet-8
+    # Prysm rather than Lighthouse (which cannot load the gloas fork config) or
+    # Lodestar: each cycle wipes volumes, giving the CL a fresh node identity —
+    # a fresh PeerDAS custody-column draw — and Lodestar intermittently wedges
+    # in verifyPayloadsDataAvailability on some draws, looping the first
+    # finalized batch forever. A wedged CL fails the cycle as a block stall
+    # blamed on ethrex. Prysm is also the pairing the EF runs with ethrex on
+    # this network.
+    image: ethpandaops/prysm-beacon-chain:glamsterdam-devnet-8
     restart: unless-stopped
     container_name: consensus-plataberget
     volumes:
@@ -282,15 +289,15 @@ services:
       - config-plataberget:/config:ro
       - consensus-plataberget:/data
     command: >
-      beacon
-      --dataDir /data
-      --paramsFile /config/config.yaml
-      --genesisStateFile /config/genesis.ssz
-      --bootnodesFile /config/bootstrap_nodes.yaml
-      --checkpointSyncUrl https://checkpoint-sync.plataberget.ethpandaops.io
-      --execution.urls http://ethrex-plataberget:8551
-      --jwtSecret /secrets/jwt.hex
-      --rest --rest.address 0.0.0.0
+      --accept-terms-of-use
+      --datadir=/data
+      --chain-config-file=/config/config.yaml
+      --genesis-state=/config/genesis.ssz
+      --bootstrap-node=/config/bootstrap_nodes.yaml
+      --checkpoint-sync-url=https://checkpoint-sync.plataberget.ethpandaops.io
+      --genesis-beacon-api-url=https://checkpoint-sync.plataberget.ethpandaops.io
+      --execution-endpoint=http://ethrex-plataberget:8551
+      --jwt-secret=/secrets/jwt.hex
     depends_on:
       setup-jwt-plataberget:
         condition: service_completed_successfully

--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -275,12 +275,13 @@ services:
 
   consensus-plataberget:
     # Prysm rather than Lighthouse (which cannot load the gloas fork config) or
-    # Lodestar: each cycle wipes volumes, giving the CL a fresh node identity —
-    # a fresh PeerDAS custody-column draw — and Lodestar intermittently wedges
-    # in verifyPayloadsDataAvailability on some draws, looping the first
-    # finalized batch forever. A wedged CL fails the cycle as a block stall
-    # blamed on ethrex. Prysm is also the pairing the EF runs with ethrex on
-    # this network.
+    # Lodestar: Lodestar range sync wedges whenever its first finalized batch
+    # contains an ePBS empty-payload slot — DA verification waits on payload
+    # envelopes that never exist and loops the batch forever
+    # (ChainSafe/lodestar#9937; unreleased at the time of writing). A wedged
+    # CL fails the cycle as a block stall blamed on ethrex. Prysm is also the
+    # pairing the EF runs with ethrex on this network. Revisit once #9937
+    # ships in the glamsterdam image.
     image: ethpandaops/prysm-beacon-chain:glamsterdam-devnet-8
     restart: unless-stopped
     container_name: consensus-plataberget

--- a/tooling/sync/docker-compose.multisync.yaml
+++ b/tooling/sync/docker-compose.multisync.yaml
@@ -2,7 +2,8 @@
 #
 # For full documentation, see: tooling/sync/README.md (section "Multi-Network Parallel Snapsync")
 #
-# This file defines 4 networks: hoodi, sepolia, mainnet, and hoodi-2.
+# This file defines 6 networks: hoodi, sepolia, mainnet, hoodi-2, plataberget,
+# and plataberget-full (same testnet, full sync instead of snap).
 # By default, the Makefile starts only hoodi, sepolia, and mainnet.
 #
 # Usage via Makefile (recommended):
@@ -20,10 +21,12 @@
 #
 # Each network runs in isolation with its own volumes.
 # Host ports are mapped for external RPC access:
-#   hoodi:   localhost:8545
-#   sepolia: localhost:8546
-#   mainnet: localhost:8547
-#   hoodi-2: localhost:8548
+#   hoodi:            localhost:8545
+#   sepolia:          localhost:8546
+#   mainnet:          localhost:8547
+#   hoodi-2:          localhost:8548
+#   plataberget:      localhost:8549
+#   plataberget-full: localhost:8550
 
 x-ethrex-common: &ethrex-common
   image: "${ETHREX_IMAGE:-ghcr.io/lambdaclass/ethrex:main}"
@@ -242,6 +245,139 @@ services:
       setup-jwt-hoodi-2:
         condition: service_completed_successfully
 
+  # =============================================================================
+  # PLATABERGET (Glamsterdam public testnet, glamsterdam-devnet-8 spec)
+  #
+  # Differs from the named networks above: the consensus client must be a
+  # Glamsterdam-capable build (stock lighthouse cannot load the gloas fork
+  # config), and the network is addressed by config files rather than a
+  # `--network` name. The files are fetched once into a shared volume from
+  # ethpandaops/glamsterdam-devnets, the source plataberget.dev names as the
+  # network's configuration.
+  #
+  # Two instances: `plataberget` snap-syncs (matrix parity with the other
+  # networks); `plataberget-full` full-syncs, executing every block including
+  # the Amsterdam fork transition — the strongest regression signal this
+  # testnet offers.
+  # =============================================================================
+  setup-config-plataberget:
+    image: alpine
+    volumes:
+      - config-plataberget:/config
+    command: >
+      sh -c 'set -e;
+      if [ -f /config/genesis.ssz ]; then echo "plataberget config present"; exit 0; fi;
+      apk add --no-cache curl;
+      BASE=https://raw.githubusercontent.com/ethpandaops/glamsterdam-devnets/master/network-configs/devnet-8/metadata;
+      for f in config.yaml genesis.ssz bootstrap_nodes.yaml deposit_contract_block.txt genesis_validators_root.txt;
+      do curl -fsSL -o /config/$$f $$BASE/$$f; done;
+      echo "plataberget config downloaded"'
+
+  setup-jwt-plataberget:
+    image: alpine
+    volumes:
+      - secrets-plataberget:/secrets
+    command: sh -c 'apk add openssl && openssl rand -hex 32 | tr -d "\n" | tee /secrets/jwt.hex'
+
+  consensus-plataberget:
+    image: ethpandaops/lodestar:glamsterdam-devnet-8
+    restart: unless-stopped
+    container_name: consensus-plataberget
+    volumes:
+      - secrets-plataberget:/secrets
+      - config-plataberget:/config:ro
+      - consensus-plataberget:/data
+    command: >
+      beacon
+      --dataDir /data
+      --paramsFile /config/config.yaml
+      --genesisStateFile /config/genesis.ssz
+      --bootnodesFile /config/bootstrap_nodes.yaml
+      --checkpointSyncUrl https://checkpoint-sync.plataberget.ethpandaops.io
+      --execution.urls http://ethrex-plataberget:8551
+      --jwtSecret /secrets/jwt.hex
+      --rest --rest.address 0.0.0.0
+    depends_on:
+      setup-jwt-plataberget:
+        condition: service_completed_successfully
+      setup-config-plataberget:
+        condition: service_completed_successfully
+
+  ethrex-plataberget:
+    <<: *ethrex-common
+    container_name: ethrex-plataberget
+    ports:
+      - "8549:8545"  # RPC
+    volumes:
+      - secrets-plataberget:/secrets
+      - ethrex-plataberget:/data
+    command: >
+      --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
+      --network plataberget
+      --authrpc.addr 0.0.0.0
+      --authrpc.jwtsecret /secrets/jwt.hex
+      --syncmode snap
+      --datadir /data
+      --metrics --metrics.addr 0.0.0.0 --metrics.port 3701
+    depends_on:
+      setup-jwt-plataberget:
+        condition: service_completed_successfully
+
+  # =============================================================================
+  # PLATABERGET-FULL (same network, --syncmode full)
+  # =============================================================================
+  setup-jwt-plataberget-full:
+    image: alpine
+    volumes:
+      - secrets-plataberget-full:/secrets
+    command: sh -c 'apk add openssl && openssl rand -hex 32 | tr -d "\n" | tee /secrets/jwt.hex'
+
+  consensus-plataberget-full:
+    image: ethpandaops/lodestar:glamsterdam-devnet-8
+    restart: unless-stopped
+    container_name: consensus-plataberget-full
+    volumes:
+      - secrets-plataberget-full:/secrets
+      - config-plataberget:/config:ro
+      - consensus-plataberget-full:/data
+    command: >
+      beacon
+      --dataDir /data
+      --paramsFile /config/config.yaml
+      --genesisStateFile /config/genesis.ssz
+      --bootnodesFile /config/bootstrap_nodes.yaml
+      --checkpointSyncUrl https://checkpoint-sync.plataberget.ethpandaops.io
+      --execution.urls http://ethrex-plataberget-full:8551
+      --jwtSecret /secrets/jwt.hex
+      --rest --rest.address 0.0.0.0
+    depends_on:
+      setup-jwt-plataberget-full:
+        condition: service_completed_successfully
+      setup-config-plataberget:
+        condition: service_completed_successfully
+
+  ethrex-plataberget-full:
+    <<: *ethrex-common
+    container_name: ethrex-plataberget-full
+    ports:
+      - "8550:8545"  # RPC
+    volumes:
+      - secrets-plataberget-full:/secrets
+      - ethrex-plataberget-full:/data
+    command: >
+      --http.addr 0.0.0.0
+      --http.api eth,net,web3,admin
+      --network plataberget
+      --authrpc.addr 0.0.0.0
+      --authrpc.jwtsecret /secrets/jwt.hex
+      --syncmode full
+      --datadir /data
+      --metrics --metrics.addr 0.0.0.0 --metrics.port 3701
+    depends_on:
+      setup-jwt-plataberget-full:
+        condition: service_completed_successfully
+
 volumes:
   secrets-hoodi:
   secrets-sepolia:
@@ -255,3 +391,10 @@ volumes:
   secrets-hoodi-2:
   consensus-hoodi-2:
   ethrex-hoodi-2:
+  config-plataberget:
+  secrets-plataberget:
+  consensus-plataberget:
+  ethrex-plataberget:
+  secrets-plataberget-full:
+  consensus-plataberget-full:
+  ethrex-plataberget-full:

--- a/tooling/sync/docker_monitor.py
+++ b/tooling/sync/docker_monitor.py
@@ -37,6 +37,8 @@ NETWORK_PORTS = {
     "sepolia": 8546,
     "mainnet": 8547,
     "hoodi-2": 8548,
+    "plataberget": 8549,
+    "plataberget-full": 8550,
 }
 
 # Logging configuration

--- a/tooling/sync/docker_monitor.py
+++ b/tooling/sync/docker_monitor.py
@@ -38,7 +38,6 @@ NETWORK_PORTS = {
     "mainnet": 8547,
     "hoodi-2": 8548,
     "plataberget": 8549,
-    "plataberget-full": 8550,
 }
 
 # Logging configuration


### PR DESCRIPTION
**Stacked on #7240** — the base branch is `feat/plataberget-network` (the tooling here needs `--network plataberget`). Rebase to `main` once #7240 merges.

## Motivation

The multisync matrix is the release-process regression net (`ethrex-multisync-main`). With Platåberget live as the public Glamsterdam testnet, the snap-sync matrix can cover Glamsterdam continuously.

Scope note: multisync validates **snap** sync. Full-sync throughput coverage belongs to the fullsync-bench tooling proposed in #7114; once that merges, a Platåberget entry there is the follow-up.

## Description

One opt-in service trio in `docker-compose.multisync.yaml`: **`plataberget`** (host port 8549), snap sync, matrix parity with the named networks.

Structural differences from the named networks, both documented in the README:
- CL is `ethpandaops/prysm-beacon-chain:glamsterdam-devnet-8` — stock Lighthouse cannot load the gloas fork config, and Lodestar intermittently wedges in `verifyPayloadsDataAvailability` on some custody-column draws (each cycle redraws them; [debug capture](https://gist.github.com/ilitteri/97b300a3f8d5375767ce8908fe4cead0)), which would fail cycles as ethrex block stalls. Prysm is the pairing the EF runs with ethrex on this network.
- The CL is addressed by config files: a `setup-config-plataberget` service fetches `config.yaml`, `genesis.ssz`, bootstrap ENRs and deposit-contract metadata from [ethpandaops/glamsterdam-devnets](https://github.com/ethpandaops/glamsterdam-devnets/tree/master/network-configs/devnet-8/metadata) into a volume (idempotent; re-fetched after `multisync-clean`). The consensus service `depends_on` it, so the Makefile's `setup-jwt-$(n) ethrex-$(n) consensus-$(n)` service pattern keeps working unchanged.

`docker_monitor.py` only needed a port entry — success detection is RPC-driven and network-agnostic.

Not in the default `MULTISYNC_NETWORKS` set (short-lived testnet); opt in with:

```bash
make multisync-loop MULTISYNC_NETWORKS=plataberget
```

## How to test

```
docker compose -f tooling/sync/docker-compose.multisync.yaml config --quiet   # validates
cd tooling/sync && make multisync-run MULTISYNC_NETWORKS=plataberget
```
