### PR TITLE
docs(l2): add the multiprover (SP1 GPU + TDX) release test

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -122,6 +122,7 @@
   - [Integration tests](./developers/l2/integration-tests.md)
   - [Upgrade test](./developers/l2/upgrade-test.md)
   - [L2 integration tests with a SP1 GPU prover](./developers/l2/sp1-gpu-integration-test.md)
+  - [Multiprover test (SP1 GPU + TDX)](./developers/l2/multiprover-test.md)
   - [Running the Prover](./developers/l2/prover.md)
   - [Generate blobs for the state reconstruction test](./developers/l2/state-reconstruction-blobs.md)
 - [Prover](./prover/prover.md)

--- a/docs/developers/l2/multiprover-test.md
+++ b/docs/developers/l2/multiprover-test.md
@@ -161,6 +161,8 @@ Each response is `{"<object>": {...}, "signature": "<hex>"}`; the DAO wants the 
 
 The proof coordinator must bind `0.0.0.0` so the SP1 prover on the other host can reach it, and the qpl tool path must be passed even in dev mode.
 
+`--committer.commit-time` must not outpace proof generation. Both proofs are required per batch, so the pipeline advances at the slower prover's rate: an SP1 proof on `l2-gpu` measured a steady 106s, which is why 120s is used here. At 15s the committer outruns proving by about 7x, and the gap never closes — a 63-hour run reached batch 10983 committed against 2127 verified. Step 9 cannot pass in that state, however long it is left running.
+
 ```bash
 set -a; . ~/multiprover/$TAG/.env; set +a
 ~/multiprover/$TAG/ethrex-l2-linux-x86_64 l2 --no-monitor \
@@ -170,7 +172,7 @@ set -a; . ~/multiprover/$TAG/.env; set +a
   --l1.bridge-address "$ETHREX_WATCHER_BRIDGE_ADDRESS" \
   --l1.on-chain-proposer-address "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" \
   --l1.timelock-address "$ETHREX_TIMELOCK_ADDRESS" \
-  --eth.rpc-url http://localhost:8545 --committer.commit-time 15000 \
+  --eth.rpc-url http://localhost:8545 --committer.commit-time 120000 \
   --block-producer.coinbase-address 0x0007a881CD95B1484fca47615B64803dad620C8d \
   --committer.l1-private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924 \
   --proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
@@ -209,6 +211,8 @@ done
 
 ### 9. Run the integration suite
 
+The withdrawal tests block in `wait_for_verified_proof` until `lastVerifiedBatch` reaches the batch holding the withdrawal, so verification has to be keeping pace before this starts. Confirm `lastVerifiedBatch` is climbing and within a few batches of `lastCommittedBatch` rather than thousands behind; if it is falling behind, fix the commit time in step 5 and restart from a fresh L1 and L2.
+
 ```bash
 cd src
 INTEGRATION_TEST_L1_RPC=http://localhost:8545 \
@@ -231,5 +235,6 @@ cargo test -p ethrex-test l2_integration_test --release --features l2 -- --nocap
 | `Incorrect_Enclave_Id_Version` (`0x4e0f5696`) | TD_QE needs version 4 or 5, not the `version` inside the JSON |
 | `Unsupported chain_id: 9` | `automata-dcap-qpl-tool` cannot serve a dev chain; load the collateral directly (step 4) |
 | `verifyBatch` reverts `0x62013a95` | `InvalidTdxProof()` — a real quote was registered while dev mode was on, so the signer is quote-header bytes; deploy with `ETHREX_TDX_DEV_MODE=false` |
+| Suite hangs in a withdrawal test and later fails on an unreachable L2 RPC | verification is thousands of batches behind commits; `--committer.commit-time` is below the SP1 proof time (step 5) |
 | VM sits on `No blocks to prove` while batches are committed | the prover is asking for a batch whose input was pruned; restart from a fresh L1 **and** L2 with both provers attached before the first batch |
 | VM sits on `No blocks to prove` with nothing committed | normal; if it persists, the committer is failing — check the sequencer log |

--- a/docs/developers/l2/multiprover-test.md
+++ b/docs/developers/l2/multiprover-test.md
@@ -2,34 +2,43 @@
 
 A per-release acceptance test for the configuration a real rollup runs: an `OnChainProposer` that requires **both** an SP1 proof and a TDX proof before it will verify a batch.
 
-The other L2 checks each exercise one prover. This one is the only place where a batch has to satisfy two independent provers, running on two machines, before `lastVerifiedBatch` moves.
+The other L2 checks each exercise one prover. This one is the only place where a batch has to satisfy two independent provers, running on two machines, before `lastVerifiedBatch` moves — and the only place a TDX quote is verified on chain, against real TDX hardware, rather than trusted.
 
-## Attestation runs in dev mode, and the TDX guest is a plain VM
+## Real attestation, and what it needs
 
-Deploy with `ETHREX_TDX_DEV_MODE=true`, and boot the prover VM as an **ordinary QEMU guest** — no `confidential-guest-support=tdx`, no `tdx-guest` object. This is CI's configuration, and the two settings go together.
+Deploy with `ETHREX_TDX_DEV_MODE=false` and boot the prover VM as a **real TDX guest**. `TDXVerifier.register()` then calls `verifyAndAttestOnChain`, so the quote is checked against the on-chain PCCS collateral and its measurements compared to the ones the verifier was deployed with.
 
-In dev mode `TDXVerifier.register()` sets
+Dev mode (`ETHREX_TDX_DEV_MODE=true`) is what CI uses, and it is not equivalent: `register()` short-circuits, taking the signing address from the quote's first 20 bytes and skipping verification entirely. That only works with a *plain* QEMU guest, whose dev quote begins with that address. Booting a real TDX guest in dev mode registers quote-header bytes as the signer and every `verifyBatch` then reverts with `InvalidTdxProof()` (`0x62013a95`) while registration appears to have succeeded. Dev mode is the fallback when no TDX host is available; it does not exercise the verifier.
 
-```solidity
-authorizedSignature = _getAddress(quote, 0);   // first 20 bytes of the quote
-```
+Three things must be on chain before a real quote will verify. The deploy handles none of them, and `ethrex` normally loads the collateral by shelling out to `automata-dcap-qpl-tool` — which cannot work here, because it resolves contract addresses from a registry keyed by chain id and rejects the dev L1 with `Unsupported chain_id: 9`. Its failure is silent: `prepare_quote_prerequisites` discards the tool's exit status, so the first symptom is an unrelated revert later. Load the collateral directly instead, as [step 3](#3-load-this-platforms-tdx-collateral) does.
 
-and returns, skipping `verifyAndAttestOnChain`. A plain guest emits a dev quote whose leading bytes *are* the prover's address, so that assignment is correct. Boot the same image as a real TDX guest and `quote-gen` produces a genuine quote beginning `0400 0200 81…` — a quote header, not an address — so the contract registers nonsense as the authorized signer, and every `verifyBatch` reverts with `InvalidTdxProof()` (`0x62013a95`) while registration itself appears to succeed.
+### The verifier's expected measurements
 
-Running the real TDX path instead would need `ETHREX_TDX_DEV_MODE=false`, which requires the quote's collateral (PCK certs, TCB info) in the PCCS contracts. The sequencer loads it by shelling out to `automata-dcap-qpl-tool`, which resolves addresses from a registry keyed by chain id and knows only public networks: on the dev L1 (chain id 9) it exits `Unsupported chain_id: 9`. That failure is silent, because `prepare_quote_prerequisites` discards the tool's exit status, so the first symptom is a later revert.
+`_validateReport` requires MRTD and RTMR0-2 in the quote to equal the values compiled into `TDXVerifier.sol`. Those constants pin one specific image build, so they will not match the image of the release under test — a mismatch reverts with `MRTD mismatch`. Since the contracts are compiled at deploy time, pin them to the image being released, which is what this test should be asserting.
 
-**So this test covers the two-prover verification path with a real SP1 GPU proof, and does not exercise TDX hardware or on-chain DCAP verification** — the same coverage CI has. Because the guest is plain, the test needs no TDX-capable CPU; it needs a GPU. Extending it to real attestation is future work and needs a chain the DCAP registry recognises.
+### The TCB Signing CA
+
+The deploy upserts the root CA (`CA.ROOT`) and platform CA (`CA.PLATFORM`), but not `CA.SIGNING` — the Intel SGX TCB Signing certificate that signs the TCB info and QE identity. Without it the DAO has nothing to validate signatures against and rejects the upsert with `TCB_Cert_Expired` (`0xea8cd522`), which is misleading: nothing has expired.
+
+### This platform's TCB info and QE identity
+
+Fetched from the host's PCCS service and upserted into `AutomataFmspcTcbDao` and `AutomataEnclaveIdentityDao`.
 
 ## Where to run it
 
 Two hosts, with the SP1 prover reaching the proof coordinator over the tailnet:
 
-| Host | Runs |
-| --- | --- |
-| `ethrex-tdx-baremetal` | L1, contract deploy, sequencer + proof coordinator, TDX prover VM |
-| `l2-gpu` | SP1 prover |
+| Host | Runs | Requires |
+| --- | --- | --- |
+| `ethrex-tdx-baremetal` | L1, contract deploy, sequencer + proof coordinator, TDX prover VM | TDX-capable CPU, `qgsd` and `pccs` services, the nix-built TDX QEMU |
+| `l2-gpu` | SP1 prover | CUDA GPU |
 
-`ethrex-tdx-baremetal` is the designated host for the TDX side, and is where extending this test to real attestation would happen — though as described above, the dev-mode configuration this test uses does not depend on its TDX hardware.
+The TDX host really is required: a quote signed by real hardware is what `verifyAndAttestOnChain` checks. Confirm it before starting, because the VM boots on a non-TDX machine and only fails later, at quote generation:
+
+```bash
+cat /sys/module/kvm_intel/parameters/tdx     # must print Y
+systemctl is-active qgsd pccs                # both active; pccs serves the collateral
+```
 
 Both are shared machines running other people's work, so keep the footprint small: check that ports 8545, 1729 and 3900 are free before starting, and tear the stack down afterwards. On `l2-gpu`, this test and the [SP1 GPU integration test](sp1-gpu-integration-test.md) contend for the same GPU, ports and datadirs — run them one after the other, never concurrently.
 
@@ -73,14 +82,44 @@ chmod +x bin/solc && export PATH=$PWD/bin:$PATH
 
 The TDX deploy also needs `automata-dcap-qpl-tool` built from `crates/l2/tee/contracts`. If the host has no Rust toolchain, build it elsewhere and copy the binary into `src/crates/l2/tee/contracts/automata-dcap-qpl/automata-dcap-qpl-tool/target/release/`.
 
-### 2. Start L1 and deploy with both provers required
+### 2. Measure the image and pin the verifier to it
+
+Boot the real TDX guest once, take a quote, and write its measurements into `TDXVerifier.sol` before the contracts are compiled. `run-qemu` from `hypervisor.nix` hardcodes `-serial mon:stdio`, so it dies when detached; the invocation below is the same TDX configuration with a file sink.
+
+```bash
+QEMU=$(nix-build --no-out-link crates/l2/tee/quote-gen/hypervisor.nix)/bin/run-qemu   # for reference
+# daemonized equivalent:
+qemu-system-x86_64 -daemonize -serial file:$PWD/tdx.log -name guest=ethrex_tdx_prover \
+  -machine q35,kernel_irqchip=split,confidential-guest-support=tdx,hpet=off -smp 2 -m 2G \
+  -accel kvm -cpu host -nographic -nodefaults -bios <OVMF from the nix store> -no-user-config \
+  -netdev user,id=net0,net=192.168.76.0/24 -device e1000,netdev=net0 \
+  -device ide-hd,bus=ide.0,drive=main,bootindex=0 \
+  -drive "if=none,media=disk,id=main,file.filename=$PWD/image.raw,discard=unmap,detect-zeroes=unmap" \
+  -object '{"qom-type":"tdx-guest","id":"tdx","quote-generation-socket":{"type":"vsock","cid":"2","port":"4050"}}'
+```
+
+The VM cannot reach a coordinator yet, so it logs `Error sending quote` — that is expected, and the quote it prints is what we need. Take it from the serial log and read the measurements out of it. In a v4 TDX quote the report body starts at byte 48; MRTD is at body offset 136 and RTMR0-2 follow at 328, 376 and 424, 48 bytes each.
+
+```bash
+QUOTE=$(grep -ao 'Sending quote [0-9a-f]*' tdx.log | head -1 | sed 's/Sending quote //')
+python3 - "$QUOTE" <<'PYEOF'
+import sys
+b = bytes.fromhex(sys.argv[1])[48:]
+for name, off in (("MRTD",136), ("RTMR0",328), ("RTMR1",376), ("RTMR2",424)):
+    print(name, b[off:off+48].hex())
+PYEOF
+```
+
+Replace the four `bytes public MRTD/RTMR0/RTMR1/RTMR2` initialisers in `crates/l2/tee/contracts/src/TDXVerifier.sol` with those values, then shut the VM down (`pkill -f 'guest=ethrex_tdx_prover'`) — it is started again in step 5, once the coordinator exists.
+
+### 3. Start L1 and deploy with both provers required
 
 ```bash
 ./ethrex-linux-x86_64 --network src/fixtures/genesis/l1.json \
   --http.addr 0.0.0.0 --http.port 8545 --authrpc.port 8551 --dev --datadir dev_l1 &
 
 cd src/crates/l2          # the deployer resolves tee/contracts relative to cwd
-COMPILE_CONTRACTS=true ETHREX_TDX_DEV_MODE=true \
+COMPILE_CONTRACTS=true ETHREX_TDX_DEV_MODE=false \
   ~/multiprover/$TAG/ethrex-l2-linux-x86_64 l2 deploy \
     --eth-rpc-url http://localhost:8545 \
     --private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924 \
@@ -98,7 +137,27 @@ COMPILE_CONTRACTS=true ETHREX_TDX_DEV_MODE=true \
 
 `--sp1 true --tdx true` together are what make this a multiprover test: the `OnChainProposer` then requires a proof of each kind per batch.
 
-### 3. Start the sequencer
+### 4. Load this platform's TDX collateral
+
+The DAOs take `(string json, bytes signature)`. `cast` cannot pass these on the command line — its tuple parser splits on the commas inside the JSON — so encode the calldata and send it raw. Addresses come from `crates/l2/tee/contracts/deploydeps/automata-on-chain-pccs/deployment/`.
+
+First the TCB Signing CA, which the deploy does not load. It is the leaf of the issuer chain the PCCS returns alongside the TCB info (`TCB-Info-Issuer-Chain` header, URL-encoded PEM):
+
+```bash
+cast send "$PCS_DAO" 'upsertPcsCertificates(uint8,bytes)' 3 "0x<signing cert DER>" \
+  --private-key "$PK" --rpc-url http://localhost:8545
+```
+
+Then the TCB info and QE identity for this platform. The FMSPC is in the PCK certificate embedded in the quote, under OID `1.2.840.113741.1.13.1.4`:
+
+```bash
+curl -sk "https://localhost:8081/tdx/certification/v4/tcb?fmspc=$FMSPC" -o tcb.json
+curl -sk "https://localhost:8081/tdx/certification/v4/qe/identity"      -o qeid.json
+```
+
+Each response is `{"<object>": {...}, "signature": "<hex>"}`; the DAO wants the inner object as a compact JSON string and the signature as bytes. Encode `upsertFmspcTcb((string,bytes))` and `upsertEnclaveIdentity(uint256,uint256,(string,bytes))` and send the calldata directly. For the identity, pass id `2` (`EnclaveId.TD_QE`) and version **4** — the DAO requires 4 or 5 for TD_QE and rejects the `version: 2` carried inside the JSON with `Incorrect_Enclave_Id_Version` (`0x4e0f5696`).
+
+### 5. Start the sequencer
 
 The proof coordinator must bind `0.0.0.0` so the SP1 prover on the other host can reach it, and the qpl tool path must be passed even in dev mode.
 
@@ -120,24 +179,13 @@ set -a; . ~/multiprover/$TAG/.env; set +a
   --proof-coordinator.qpl-tool-path <path to automata-dcap-qpl-tool> &
 ```
 
-### 4. Start the TDX prover VM
+### 6. Start the TDX prover VM
 
-A plain guest — see [above](#attestation-runs-in-dev-mode-and-the-tdx-guest-is-a-plain-vm) for why this must not be the real-TDX launcher in `hypervisor.nix`:
+Boot the real TDX guest again, exactly as in [step 2](#2-measure-the-image-and-pin-the-verifier-to-it) — the coordinator now exists, so the quote it sends is registered instead of erroring.
 
-```bash
-qemu-system-x86_64 -daemonize \
-  -serial file:$PWD/tdx_prover.log -name guest=ethrex_tdx_prover \
-  -machine q35,kernel_irqchip=split,hpet=off -smp 2 -m 2G \
-  -accel kvm -cpu host -nographic -nodefaults \
-  -bios /usr/share/ovmf/OVMF.fd -no-user-config \
-  -netdev user,id=net0,net=192.168.76.0/24 -device e1000,netdev=net0 \
-  -device ide-hd,bus=ide.0,drive=main,bootindex=0 \
-  -drive "if=none,media=disk,id=main,file.filename=$PWD/image.raw,discard=unmap,detect-zeroes=unmap"
-```
+Registration has succeeded when the sequencer logs `ProverSetup received for TDX` followed by `ProverSetupACK sent`, with no `Failed to handle ProverSetup` between them. That ACK is the real result: with dev mode off, it means the quote passed `verifyAndAttestOnChain` against the collateral loaded in step 4 and its measurements matched the ones pinned in step 2.
 
-The VM has registered once the sequencer logs `ProverSetup received for TDX` without a following error, and the VM's serial console moves from `Error sending quote` to `No blocks to prove`.
-
-### 5. Start the SP1 prover on `l2-gpu`
+### 7. Start the SP1 prover on `l2-gpu`
 
 ```bash
 ssh l2-gpu
@@ -145,7 +193,7 @@ ssh l2-gpu
   --proof-coordinators tcp://<tdx-host-tailscale-ip>:3900 --log.level info
 ```
 
-### 6. Wait for a batch verified by both proofs
+### 8. Wait for a batch verified by both proofs
 
 This is the assertion the test exists for. `lastVerifiedBatch` only advances once both an SP1 and a TDX proof have been submitted for the same batch.
 
@@ -159,7 +207,7 @@ while :; do
 done
 ```
 
-### 7. Run the integration suite
+### 9. Run the integration suite
 
 ```bash
 cd src
@@ -178,6 +226,10 @@ cargo test -p ethrex-test l2_integration_test --release --features l2 -- --nocap
 | `execution reverted` in `deploy-p256` | deploying onto a chain that already has the CREATE2 contracts; start from a fresh L1 datadir |
 | `Source file requires different compiler version` | solc is not exactly 0.8.31 |
 | VM loops on `Error sending quote: Failed to get ProverSetupAck` | the coordinator rejected registration; check the sequencer log for the error behind `Failed to handle ProverSetup` |
-| `verifyBatch` reverts `0x62013a95` | `InvalidTdxProof()` — the VM was booted as a real TDX guest, so dev-mode `register()` stored quote-header bytes as the signer; use the plain-guest invocation |
+| `MRTD mismatch` on registration | the verifier was deployed with the committed measurements; pin them to the image under test (step 2) |
+| `TCB_Cert_Expired` (`0xea8cd522`) on upsert | nothing has expired: `CA.SIGNING` was never loaded, so signatures cannot be checked (step 4) |
+| `Incorrect_Enclave_Id_Version` (`0x4e0f5696`) | TD_QE needs version 4 or 5, not the `version` inside the JSON |
+| `Unsupported chain_id: 9` | `automata-dcap-qpl-tool` cannot serve a dev chain; load the collateral directly (step 4) |
+| `verifyBatch` reverts `0x62013a95` | `InvalidTdxProof()` — a real quote was registered while dev mode was on, so the signer is quote-header bytes; deploy with `ETHREX_TDX_DEV_MODE=false` |
 | VM sits on `No blocks to prove` while batches are committed | the prover is asking for a batch whose input was pruned; restart from a fresh L1 **and** L2 with both provers attached before the first batch |
 | VM sits on `No blocks to prove` with nothing committed | normal; if it persists, the committer is failing — check the sequencer log |

--- a/docs/developers/l2/multiprover-test.md
+++ b/docs/developers/l2/multiprover-test.md
@@ -22,14 +22,16 @@ Running the real TDX path instead would need `ETHREX_TDX_DEV_MODE=false`, which 
 
 ## Where to run it
 
-Everything except SP1 proving is host-agnostic. The simplest layout is to run the whole thing on the GPU host; the split below is what was used first and still works, with the proof coordinator reached over the tailnet.
+Two hosts, with the SP1 prover reaching the proof coordinator over the tailnet:
 
 | Host | Runs |
 | --- | --- |
-| any Linux host with QEMU/KVM | L1, contract deploy, sequencer + proof coordinator, TDX prover VM |
+| `ethrex-tdx-baremetal` | L1, contract deploy, sequencer + proof coordinator, TDX prover VM |
 | `l2-gpu` | SP1 prover |
 
-If you do use a shared box, keep the footprint small and check ports 8545, 1729 and 3900 are free first.
+`ethrex-tdx-baremetal` is the designated host for the TDX side, and is where extending this test to real attestation would happen — though as described above, the dev-mode configuration this test uses does not depend on its TDX hardware.
+
+Both are shared machines running other people's work, so keep the footprint small: check that ports 8545, 1729 and 3900 are free before starting, and tear the stack down afterwards. On `l2-gpu`, this test and the [SP1 GPU integration test](sp1-gpu-integration-test.md) contend for the same GPU, ports and datadirs — run them one after the other, never concurrently.
 
 ## Environment pins
 
@@ -50,7 +52,7 @@ Set the release under test once:
 export TAG=vX.Y.Z-rc.W
 ```
 
-### 1. Prepare the host
+### 1. Prepare `ethrex-tdx-baremetal`
 
 ```bash
 # release binaries and contracts (the vk the deployer registers)
@@ -135,7 +137,7 @@ qemu-system-x86_64 -daemonize \
 
 The VM has registered once the sequencer logs `ProverSetup received for TDX` without a following error, and the VM's serial console moves from `Error sending quote` to `No blocks to prove`.
 
-### 5. Start the SP1 prover on the GPU host
+### 5. Start the SP1 prover on `l2-gpu`
 
 ```bash
 ssh l2-gpu
@@ -179,5 +181,3 @@ cargo test -p ethrex-test l2_integration_test --release --features l2 -- --nocap
 | `verifyBatch` reverts `0x62013a95` | `InvalidTdxProof()` — the VM was booted as a real TDX guest, so dev-mode `register()` stored quote-header bytes as the signer; use the plain-guest invocation |
 | VM sits on `No blocks to prove` while batches are committed | the prover is asking for a batch whose input was pruned; restart from a fresh L1 **and** L2 with both provers attached before the first batch |
 | VM sits on `No blocks to prove` with nothing committed | normal; if it persists, the committer is failing — check the sequencer log |
-
-Both L2 GPU checks share ports and datadirs on their hosts, so run this and the [SP1 GPU integration test](sp1-gpu-integration-test.md) one after the other, not concurrently.

--- a/docs/developers/l2/multiprover-test.md
+++ b/docs/developers/l2/multiprover-test.md
@@ -1,0 +1,240 @@
+# Multiprover test (SP1 GPU + TDX)
+
+A per-release acceptance test for the configuration a real rollup runs: an
+`OnChainProposer` that requires **both** an SP1 proof and a TDX proof before it
+will verify a batch.
+
+The other L2 checks each exercise one prover. This one is the only place where
+a batch has to satisfy two independent provers, running on two machines, before
+`lastVerifiedBatch` moves.
+
+## Attestation runs in dev mode, and the TDX guest is a plain VM
+
+Deploy with `ETHREX_TDX_DEV_MODE=true`, and boot the prover VM as an **ordinary
+QEMU guest** — no `confidential-guest-support=tdx`, no `tdx-guest` object. This
+is CI's configuration, and the two settings go together.
+
+In dev mode `TDXVerifier.register()` sets
+
+```solidity
+authorizedSignature = _getAddress(quote, 0);   // first 20 bytes of the quote
+```
+
+and returns, skipping `verifyAndAttestOnChain`. A plain guest emits a dev quote
+whose leading bytes *are* the prover's address, so that assignment is correct.
+Boot the same image as a real TDX guest and `quote-gen` produces a genuine
+quote beginning `0400 0200 81…` — a quote header, not an address — so the
+contract registers nonsense as the authorized signer, and every `verifyBatch`
+reverts with `InvalidTdxProof()` (`0x62013a95`) while registration itself
+appears to succeed.
+
+Running the real TDX path instead would need `ETHREX_TDX_DEV_MODE=false`, which
+requires the quote's collateral (PCK certs, TCB info) in the PCCS contracts.
+The sequencer loads it by shelling out to `automata-dcap-qpl-tool`, which
+resolves addresses from a registry keyed by chain id and knows only public
+networks: on the dev L1 (chain id 9) it exits `Unsupported chain_id: 9`. That
+failure is silent, because `prepare_quote_prerequisites` discards the tool's
+exit status, so the first symptom is a later revert.
+
+**So this test covers the two-prover verification path with a real SP1 GPU
+proof, and does not exercise TDX hardware or on-chain DCAP verification** — the
+same coverage CI has. Because the guest is plain, the test needs no TDX-capable
+CPU; it needs a GPU. Extending it to real attestation is future work and needs
+a chain the DCAP registry recognises.
+
+## Where to run it
+
+Everything except SP1 proving is host-agnostic. The simplest layout is to run
+the whole thing on the GPU host; the split below is what was used first and
+still works, with the proof coordinator reached over the tailnet.
+
+| Host | Runs |
+| --- | --- |
+| any Linux host with QEMU/KVM | L1, contract deploy, sequencer + proof coordinator, TDX prover VM |
+| `l2-gpu` | SP1 prover |
+
+If you do use a shared box, keep the footprint small and check ports 8545,
+1729 and 3900 are free first.
+
+## Environment pins
+
+Three things must be right or the deploy fails in ways that do not point at
+their cause:
+
+- **solc must be exactly 0.8.31.** `TDXVerifier.sol` declares
+  `pragma solidity =0.8.31`, so 0.8.30 fails with "Source file requires
+  different compiler version". Install it locally rather than changing the
+  system compiler on a shared host.
+- **Deploy onto a fresh chain.** The deploy is not idempotent: CREATE2 puts the
+  dependency contracts at fixed addresses, so re-running against a chain that
+  already has them reverts in `deploy-p256` with no reason string. Wipe the L1
+  datadir between attempts.
+- **Set `--watcher.watch-interval 1000`.** At the 12000 ms default, on a `--dev`
+  L1 that mines instantly, the deposits the sequencer has processed drift out of
+  step with the bridge's pending queue, and every commit reverts with
+  `InvalidPrivilegedTransactionLogs()` (`0x9e6e5638`). CI sets 1000 ms for the
+  same reason.
+- **Attach both provers before the first batch is committed, and reset the L1
+  and L2 datadirs together.** The coordinator hands out work starting at
+  `1 + lastVerifiedBatch`, and prover inputs for old batches are eventually
+  pruned. A prover that joins after batches have accumulated — or a sequencer
+  restarted against an L1 that already has committed batches — asks forever for
+  a batch whose input no longer exists, reports `No blocks to prove`, and
+  nothing advances: verification needs both proofs, so `lastVerifiedBatch`
+  never moves and the request never changes. Wiping only one of the two
+  datadirs reproduces this reliably.
+
+The TDX prover image (`image.raw`) is built with nix from
+`crates/l2/tee/quote-gen`. If the host has no nix, build it on another host and
+copy it over — it is ~700 MB and depends only on the release, not the host.
+
+## Procedure
+
+Set the release under test once:
+
+```bash
+export TAG=vX.Y.Z-rc.W
+```
+
+### 1. Prepare the TDX host
+
+```bash
+# release binaries and contracts (the vk the deployer registers)
+mkdir -p ~/multiprover/$TAG && cd ~/multiprover/$TAG
+for a in ethrex-linux-x86_64 ethrex-l2-linux-x86_64; do
+  curl -fsSL -o $a "https://github.com/lambdaclass/ethrex/releases/download/$TAG/$a" && chmod +x $a
+done
+mkdir -p contracts && curl -fsSL \
+  "https://github.com/lambdaclass/ethrex/releases/download/$TAG/ethrex-contracts.tar.gz" | tar xz -C contracts
+
+# source at the tag, for genesis, keys and the contract build
+git clone --depth 1 --branch $TAG https://github.com/lambdaclass/ethrex.git src
+
+# pinned solc, local to the test
+curl -fsSL -o bin/solc https://github.com/ethereum/solidity/releases/download/v0.8.31/solc-static-linux
+chmod +x bin/solc && export PATH=$PWD/bin:$PATH
+```
+
+The TDX deploy also needs `automata-dcap-qpl-tool` built from
+`crates/l2/tee/contracts`. If the host has no Rust toolchain, build it elsewhere
+and copy the binary into
+`src/crates/l2/tee/contracts/automata-dcap-qpl/automata-dcap-qpl-tool/target/release/`.
+
+### 2. Start L1 and deploy with both provers required
+
+```bash
+./ethrex-linux-x86_64 --network src/fixtures/genesis/l1.json \
+  --http.addr 0.0.0.0 --http.port 8545 --authrpc.port 8551 --dev --datadir dev_l1 &
+
+cd src/crates/l2          # the deployer resolves tee/contracts relative to cwd
+COMPILE_CONTRACTS=true ETHREX_TDX_DEV_MODE=true \
+  ~/multiprover/$TAG/ethrex-l2-linux-x86_64 l2 deploy \
+    --eth-rpc-url http://localhost:8545 \
+    --private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924 \
+    --sp1 true --sp1-vk-path ~/multiprover/$TAG/contracts/ethrex-riscv32im-succinct-zkvm-vk-bn254 \
+    --tdx true \
+    --on-chain-proposer-owner 0x4417092b70a3e5f10dc504d0947dd256b965fc62 \
+    --bridge-owner 0x4417092b70a3e5f10dc504d0947dd256b965fc62 \
+    --bridge-owner-pk 0x941e103320615d394a55708be13e45994c7d93b932b064dbcb2b511fe3254e2e \
+    --deposit-rich --private-keys-file-path ../../fixtures/keys/private_keys_l1.txt \
+    --genesis-l1-path ../../fixtures/genesis/l1.json \
+    --genesis-l2-path ../../fixtures/genesis/l2.json \
+    --inclusion-max-wait 86400 \
+    --env-file-path ~/multiprover/$TAG/.env
+```
+
+`--sp1 true --tdx true` together are what make this a multiprover test: the
+`OnChainProposer` then requires a proof of each kind per batch.
+
+### 3. Start the sequencer
+
+The proof coordinator must bind `0.0.0.0` so the SP1 prover on the other host
+can reach it, and the qpl tool path must be passed even in dev mode.
+
+```bash
+set -a; . ~/multiprover/$TAG/.env; set +a
+~/multiprover/$TAG/ethrex-l2-linux-x86_64 l2 --no-monitor \
+  --watcher.block-delay 0 --watcher.watch-interval 1000 \
+  --network ../../fixtures/genesis/l2.json \
+  --http.addr 0.0.0.0 --http.port 1729 --datadir ~/multiprover/$TAG/dev_l2 \
+  --l1.bridge-address "$ETHREX_WATCHER_BRIDGE_ADDRESS" \
+  --l1.on-chain-proposer-address "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" \
+  --l1.timelock-address "$ETHREX_TIMELOCK_ADDRESS" \
+  --eth.rpc-url http://localhost:8545 --committer.commit-time 15000 \
+  --block-producer.coinbase-address 0x0007a881CD95B1484fca47615B64803dad620C8d \
+  --committer.l1-private-key 0x385c546456b6a603a1cfcaa9ec9494ba4832da08dd6bcf4de9a71e4a01b74924 \
+  --proof-coordinator.l1-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
+  --proof-coordinator.tdx-private-key 0x39725efee3fb28614de3bacaffe4cc4bd8c436257e2c8bb887c4b5c4be45e76d \
+  --proof-coordinator.addr 0.0.0.0 \
+  --proof-coordinator.qpl-tool-path <path to automata-dcap-qpl-tool> &
+```
+
+### 4. Start the TDX prover VM
+
+A plain guest — see [above](#attestation-runs-in-dev-mode-and-the-tdx-guest-is-a-plain-vm)
+for why this must not be the real-TDX launcher in `hypervisor.nix`:
+
+```bash
+qemu-system-x86_64 -daemonize \
+  -serial file:$PWD/tdx_prover.log -name guest=ethrex_tdx_prover \
+  -machine q35,kernel_irqchip=split,hpet=off -smp 2 -m 2G \
+  -accel kvm -cpu host -nographic -nodefaults \
+  -bios /usr/share/ovmf/OVMF.fd -no-user-config \
+  -netdev user,id=net0,net=192.168.76.0/24 -device e1000,netdev=net0 \
+  -device ide-hd,bus=ide.0,drive=main,bootindex=0 \
+  -drive "if=none,media=disk,id=main,file.filename=$PWD/image.raw,discard=unmap,detect-zeroes=unmap"
+```
+
+The VM has registered once the sequencer logs `ProverSetup received for TDX`
+without a following error, and the VM's serial console moves from
+`Error sending quote` to `No blocks to prove`.
+
+### 5. Start the SP1 prover on the GPU host
+
+```bash
+ssh l2-gpu
+./ethrex-l2 l2 prover --backend sp1 \
+  --proof-coordinators tcp://<tdx-host-tailscale-ip>:3900 --log.level info
+```
+
+### 6. Wait for a batch verified by both proofs
+
+This is the assertion the test exists for. `lastVerifiedBatch` only advances
+once both an SP1 and a TDX proof have been submitted for the same batch.
+
+```bash
+while :; do
+  C=$(rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'lastCommittedBatch()' http://localhost:8545)
+  V=$(rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'lastVerifiedBatch()'  http://localhost:8545)
+  echo "committed=$((C)) verified=$((V))"
+  [ "$((V))" -ge 1 ] && break
+  sleep 30
+done
+```
+
+### 7. Run the integration suite
+
+```bash
+cd src
+INTEGRATION_TEST_L1_RPC=http://localhost:8545 \
+INTEGRATION_TEST_L2_RPC=http://localhost:1729 \
+INTEGRATION_TEST_PRIVATE_KEYS_FILE_PATH=$PWD/fixtures/keys/private_keys_l1.txt \
+INTEGRATION_TEST_BRIDGE_OWNER_PRIVATE_KEY=0x941e103320615d394a55708be13e45994c7d93b932b064dbcb2b511fe3254e2e \
+cargo test -p ethrex-test l2_integration_test --release --features l2 -- --nocapture --test-threads=1
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `execution reverted: 0x9e6e5638` on commit | `InvalidPrivilegedTransactionLogs()` — watcher interval left at the default; set `--watcher.watch-interval 1000` |
+| `execution reverted` in `deploy-p256` | deploying onto a chain that already has the CREATE2 contracts; start from a fresh L1 datadir |
+| `Source file requires different compiler version` | solc is not exactly 0.8.31 |
+| VM loops on `Error sending quote: Failed to get ProverSetupAck` | the coordinator rejected registration; check the sequencer log for the error behind `Failed to handle ProverSetup` |
+| `verifyBatch` reverts `0x62013a95` | `InvalidTdxProof()` — the VM was booted as a real TDX guest, so dev-mode `register()` stored quote-header bytes as the signer; use the plain-guest invocation |
+| VM sits on `No blocks to prove` while batches are committed | the prover is asking for a batch whose input was pruned; restart from a fresh L1 **and** L2 with both provers attached before the first batch |
+| VM sits on `No blocks to prove` with nothing committed | normal; if it persists, the committer is failing — check the sequencer log |
+
+Both L2 GPU checks share ports and datadirs on their hosts, so run this and the
+[SP1 GPU integration test](sp1-gpu-integration-test.md) one after the other,
+not concurrently.

--- a/docs/developers/l2/multiprover-test.md
+++ b/docs/developers/l2/multiprover-test.md
@@ -1,18 +1,12 @@
 # Multiprover test (SP1 GPU + TDX)
 
-A per-release acceptance test for the configuration a real rollup runs: an
-`OnChainProposer` that requires **both** an SP1 proof and a TDX proof before it
-will verify a batch.
+A per-release acceptance test for the configuration a real rollup runs: an `OnChainProposer` that requires **both** an SP1 proof and a TDX proof before it will verify a batch.
 
-The other L2 checks each exercise one prover. This one is the only place where
-a batch has to satisfy two independent provers, running on two machines, before
-`lastVerifiedBatch` moves.
+The other L2 checks each exercise one prover. This one is the only place where a batch has to satisfy two independent provers, running on two machines, before `lastVerifiedBatch` moves.
 
 ## Attestation runs in dev mode, and the TDX guest is a plain VM
 
-Deploy with `ETHREX_TDX_DEV_MODE=true`, and boot the prover VM as an **ordinary
-QEMU guest** — no `confidential-guest-support=tdx`, no `tdx-guest` object. This
-is CI's configuration, and the two settings go together.
+Deploy with `ETHREX_TDX_DEV_MODE=true`, and boot the prover VM as an **ordinary QEMU guest** — no `confidential-guest-support=tdx`, no `tdx-guest` object. This is CI's configuration, and the two settings go together.
 
 In dev mode `TDXVerifier.register()` sets
 
@@ -20,73 +14,33 @@ In dev mode `TDXVerifier.register()` sets
 authorizedSignature = _getAddress(quote, 0);   // first 20 bytes of the quote
 ```
 
-and returns, skipping `verifyAndAttestOnChain`. A plain guest emits a dev quote
-whose leading bytes *are* the prover's address, so that assignment is correct.
-Boot the same image as a real TDX guest and `quote-gen` produces a genuine
-quote beginning `0400 0200 81…` — a quote header, not an address — so the
-contract registers nonsense as the authorized signer, and every `verifyBatch`
-reverts with `InvalidTdxProof()` (`0x62013a95`) while registration itself
-appears to succeed.
+and returns, skipping `verifyAndAttestOnChain`. A plain guest emits a dev quote whose leading bytes *are* the prover's address, so that assignment is correct. Boot the same image as a real TDX guest and `quote-gen` produces a genuine quote beginning `0400 0200 81…` — a quote header, not an address — so the contract registers nonsense as the authorized signer, and every `verifyBatch` reverts with `InvalidTdxProof()` (`0x62013a95`) while registration itself appears to succeed.
 
-Running the real TDX path instead would need `ETHREX_TDX_DEV_MODE=false`, which
-requires the quote's collateral (PCK certs, TCB info) in the PCCS contracts.
-The sequencer loads it by shelling out to `automata-dcap-qpl-tool`, which
-resolves addresses from a registry keyed by chain id and knows only public
-networks: on the dev L1 (chain id 9) it exits `Unsupported chain_id: 9`. That
-failure is silent, because `prepare_quote_prerequisites` discards the tool's
-exit status, so the first symptom is a later revert.
+Running the real TDX path instead would need `ETHREX_TDX_DEV_MODE=false`, which requires the quote's collateral (PCK certs, TCB info) in the PCCS contracts. The sequencer loads it by shelling out to `automata-dcap-qpl-tool`, which resolves addresses from a registry keyed by chain id and knows only public networks: on the dev L1 (chain id 9) it exits `Unsupported chain_id: 9`. That failure is silent, because `prepare_quote_prerequisites` discards the tool's exit status, so the first symptom is a later revert.
 
-**So this test covers the two-prover verification path with a real SP1 GPU
-proof, and does not exercise TDX hardware or on-chain DCAP verification** — the
-same coverage CI has. Because the guest is plain, the test needs no TDX-capable
-CPU; it needs a GPU. Extending it to real attestation is future work and needs
-a chain the DCAP registry recognises.
+**So this test covers the two-prover verification path with a real SP1 GPU proof, and does not exercise TDX hardware or on-chain DCAP verification** — the same coverage CI has. Because the guest is plain, the test needs no TDX-capable CPU; it needs a GPU. Extending it to real attestation is future work and needs a chain the DCAP registry recognises.
 
 ## Where to run it
 
-Everything except SP1 proving is host-agnostic. The simplest layout is to run
-the whole thing on the GPU host; the split below is what was used first and
-still works, with the proof coordinator reached over the tailnet.
+Everything except SP1 proving is host-agnostic. The simplest layout is to run the whole thing on the GPU host; the split below is what was used first and still works, with the proof coordinator reached over the tailnet.
 
 | Host | Runs |
 | --- | --- |
 | any Linux host with QEMU/KVM | L1, contract deploy, sequencer + proof coordinator, TDX prover VM |
 | `l2-gpu` | SP1 prover |
 
-If you do use a shared box, keep the footprint small and check ports 8545,
-1729 and 3900 are free first.
+If you do use a shared box, keep the footprint small and check ports 8545, 1729 and 3900 are free first.
 
 ## Environment pins
 
-Three things must be right or the deploy fails in ways that do not point at
-their cause:
+Four things must be right, and each fails in a way that does not point at its cause:
 
-- **solc must be exactly 0.8.31.** `TDXVerifier.sol` declares
-  `pragma solidity =0.8.31`, so 0.8.30 fails with "Source file requires
-  different compiler version". Install it locally rather than changing the
-  system compiler on a shared host.
-- **Deploy onto a fresh chain.** The deploy is not idempotent: CREATE2 puts the
-  dependency contracts at fixed addresses, so re-running against a chain that
-  already has them reverts in `deploy-p256` with no reason string. Wipe the L1
-  datadir between attempts.
-- **Set `--watcher.watch-interval 1000`.** At the 12000 ms default, on a `--dev`
-  L1 that mines instantly, the deposits the sequencer has processed drift out of
-  step with the bridge's pending queue, and every commit reverts with
-  `InvalidPrivilegedTransactionLogs()` (`0x9e6e5638`). CI sets 1000 ms for the
-  same reason.
-- **Attach both provers before the first batch is committed, and reset the L1
-  and L2 datadirs together.** The coordinator hands out work starting at
-  `1 + lastVerifiedBatch`, and prover inputs for old batches are eventually
-  pruned. A prover that joins after batches have accumulated — or a sequencer
-  restarted against an L1 that already has committed batches — asks forever for
-  a batch whose input no longer exists, reports `No blocks to prove`, and
-  nothing advances: verification needs both proofs, so `lastVerifiedBatch`
-  never moves and the request never changes. Wiping only one of the two
-  datadirs reproduces this reliably.
+- **solc must be exactly 0.8.31.** `TDXVerifier.sol` declares `pragma solidity =0.8.31`, so 0.8.30 fails with "Source file requires different compiler version". Install it locally rather than changing the system compiler on a shared host.
+- **Deploy onto a fresh chain.** The deploy is not idempotent: CREATE2 puts the dependency contracts at fixed addresses, so re-running against a chain that already has them reverts in `deploy-p256` with no reason string. Wipe the L1 datadir between attempts.
+- **Set `--watcher.watch-interval 1000`.** At the 12000 ms default, on a `--dev` L1 that mines instantly, the deposits the sequencer has processed drift out of step with the bridge's pending queue, and every commit reverts with `InvalidPrivilegedTransactionLogs()` (`0x9e6e5638`). CI sets 1000 ms for the same reason.
+- **Attach both provers before the first batch is committed, and reset the L1 and L2 datadirs together.** The coordinator hands out work starting at `1 + lastVerifiedBatch`, and prover inputs for old batches are eventually pruned. A prover that joins after batches have accumulated — or a sequencer restarted against an L1 that already has committed batches — asks forever for a batch whose input no longer exists, reports `No blocks to prove`, and nothing advances: verification needs both proofs, so `lastVerifiedBatch` never moves and the request never changes. Wiping only one of the two datadirs reproduces this reliably.
 
-The TDX prover image (`image.raw`) is built with nix from
-`crates/l2/tee/quote-gen`. If the host has no nix, build it on another host and
-copy it over — it is ~700 MB and depends only on the release, not the host.
+The TDX prover image (`image.raw`) is built with nix from `crates/l2/tee/quote-gen`. If the host has no nix, build it on another host and copy it over — it is ~700 MB and depends only on the release, not the host.
 
 ## Procedure
 
@@ -96,7 +50,7 @@ Set the release under test once:
 export TAG=vX.Y.Z-rc.W
 ```
 
-### 1. Prepare the TDX host
+### 1. Prepare the host
 
 ```bash
 # release binaries and contracts (the vk the deployer registers)
@@ -115,10 +69,7 @@ curl -fsSL -o bin/solc https://github.com/ethereum/solidity/releases/download/v0
 chmod +x bin/solc && export PATH=$PWD/bin:$PATH
 ```
 
-The TDX deploy also needs `automata-dcap-qpl-tool` built from
-`crates/l2/tee/contracts`. If the host has no Rust toolchain, build it elsewhere
-and copy the binary into
-`src/crates/l2/tee/contracts/automata-dcap-qpl/automata-dcap-qpl-tool/target/release/`.
+The TDX deploy also needs `automata-dcap-qpl-tool` built from `crates/l2/tee/contracts`. If the host has no Rust toolchain, build it elsewhere and copy the binary into `src/crates/l2/tee/contracts/automata-dcap-qpl/automata-dcap-qpl-tool/target/release/`.
 
 ### 2. Start L1 and deploy with both provers required
 
@@ -143,13 +94,11 @@ COMPILE_CONTRACTS=true ETHREX_TDX_DEV_MODE=true \
     --env-file-path ~/multiprover/$TAG/.env
 ```
 
-`--sp1 true --tdx true` together are what make this a multiprover test: the
-`OnChainProposer` then requires a proof of each kind per batch.
+`--sp1 true --tdx true` together are what make this a multiprover test: the `OnChainProposer` then requires a proof of each kind per batch.
 
 ### 3. Start the sequencer
 
-The proof coordinator must bind `0.0.0.0` so the SP1 prover on the other host
-can reach it, and the qpl tool path must be passed even in dev mode.
+The proof coordinator must bind `0.0.0.0` so the SP1 prover on the other host can reach it, and the qpl tool path must be passed even in dev mode.
 
 ```bash
 set -a; . ~/multiprover/$TAG/.env; set +a
@@ -171,8 +120,7 @@ set -a; . ~/multiprover/$TAG/.env; set +a
 
 ### 4. Start the TDX prover VM
 
-A plain guest — see [above](#attestation-runs-in-dev-mode-and-the-tdx-guest-is-a-plain-vm)
-for why this must not be the real-TDX launcher in `hypervisor.nix`:
+A plain guest — see [above](#attestation-runs-in-dev-mode-and-the-tdx-guest-is-a-plain-vm) for why this must not be the real-TDX launcher in `hypervisor.nix`:
 
 ```bash
 qemu-system-x86_64 -daemonize \
@@ -185,9 +133,7 @@ qemu-system-x86_64 -daemonize \
   -drive "if=none,media=disk,id=main,file.filename=$PWD/image.raw,discard=unmap,detect-zeroes=unmap"
 ```
 
-The VM has registered once the sequencer logs `ProverSetup received for TDX`
-without a following error, and the VM's serial console moves from
-`Error sending quote` to `No blocks to prove`.
+The VM has registered once the sequencer logs `ProverSetup received for TDX` without a following error, and the VM's serial console moves from `Error sending quote` to `No blocks to prove`.
 
 ### 5. Start the SP1 prover on the GPU host
 
@@ -199,8 +145,7 @@ ssh l2-gpu
 
 ### 6. Wait for a batch verified by both proofs
 
-This is the assertion the test exists for. `lastVerifiedBatch` only advances
-once both an SP1 and a TDX proof have been submitted for the same batch.
+This is the assertion the test exists for. `lastVerifiedBatch` only advances once both an SP1 and a TDX proof have been submitted for the same batch.
 
 ```bash
 while :; do
@@ -235,6 +180,4 @@ cargo test -p ethrex-test l2_integration_test --release --features l2 -- --nocap
 | VM sits on `No blocks to prove` while batches are committed | the prover is asking for a batch whose input was pruned; restart from a fresh L1 **and** L2 with both provers attached before the first batch |
 | VM sits on `No blocks to prove` with nothing committed | normal; if it persists, the committer is failing — check the sequencer log |
 
-Both L2 GPU checks share ports and datadirs on their hosts, so run this and the
-[SP1 GPU integration test](sp1-gpu-integration-test.md) one after the other,
-not concurrently.
+Both L2 GPU checks share ports and datadirs on their hosts, so run this and the [SP1 GPU integration test](sp1-gpu-integration-test.md) one after the other, not concurrently.

--- a/docs/developers/release-process.md
+++ b/docs/developers/release-process.md
@@ -177,7 +177,9 @@ rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'REQUIRE_SP1_PROOF()' "$L
 rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'REQUIRE_TDX_PROOF()' "$L1_RPC"   # 0x..01
 ```
 
-The check passes when `lastVerifiedBatch` advances past zero with both flags set. Note the TDX side runs in dev mode against a plain QEMU guest, as it does in CI, so it does not exercise TDX hardware or on-chain DCAP verification.
+The check passes when `lastVerifiedBatch` advances past zero with both flags set.
+
+Run it with `ETHREX_TDX_DEV_MODE=false`, so the TDX quote is verified on chain by `verifyAndAttestOnChain` rather than trusted. That is the point of running on TDX hardware, and it is what CI cannot do — CI uses dev mode, where registration skips verification entirely. It needs two extra steps the runbook covers: pinning the verifier's expected measurements to the image being released, and loading this platform's TCB collateral, since the tool `ethrex` normally shells out to cannot serve a dev chain.
 
 ### Publish
 

--- a/docs/developers/release-process.md
+++ b/docs/developers/release-process.md
@@ -168,23 +168,16 @@ See [L2 integration tests with a SP1 GPU prover](l2/sp1-gpu-integration-test.md)
 
 See [Multiprover test](l2/multiprover-test.md) for the full procedure.
 
-The single-prover checks above each exercise one prover against an
-`OnChainProposer` that requires only that one. This is the only check where a
-batch must satisfy **two** provers before `lastVerifiedBatch` moves, which is
-the configuration a production rollup runs.
+The single-prover checks above each exercise one prover against an `OnChainProposer` that requires only that one. This is the only check where a batch must satisfy **two** provers before `lastVerifiedBatch` moves, which is the configuration a production rollup runs.
 
-Confirm on-chain that the deployment really requires both, rather than trusting
-the deploy flags — a batch verifying under a single-prover deployment would
-prove nothing:
+Confirm on-chain that the deployment really requires both, rather than trusting the deploy flags — a batch verifying under a single-prover deployment would prove nothing:
 
 ```bash
 rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'REQUIRE_SP1_PROOF()' "$L1_RPC"   # 0x..01
 rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'REQUIRE_TDX_PROOF()' "$L1_RPC"   # 0x..01
 ```
 
-The check passes when `lastVerifiedBatch` advances past zero with both flags
-set. Note the TDX side runs in dev mode against a plain QEMU guest, as it does
-in CI, so it does not exercise TDX hardware or on-chain DCAP verification.
+The check passes when `lastVerifiedBatch` advances past zero with both flags set. Note the TDX side runs in dev mode against a plain QEMU guest, as it does in CI, so it does not exercise TDX hardware or on-chain DCAP verification.
 
 ### Publish
 

--- a/docs/developers/release-process.md
+++ b/docs/developers/release-process.md
@@ -98,7 +98,7 @@ Before publishing the release, run through the following checks using the pre-re
 - [ ] Launch multisync on `ethrex-multisync-main`
 - [ ] Upgrade a local L2 created with the previous version and run the integration tests
 - [ ] Run the L2 integration tests with a SP1 prover on the GPU server (`l2-gpu`)
-- [ ] Run the multiprover test (SP1 GPU + TDX)
+- [ ] Run the multiprover test: SP1 prover on the GPU server (`l2-gpu`), TDX prover and the rest of the stack on `ethrex-tdx-baremetal`
 
 The commands for each target follow. The host roster changes between releases — fill in the ones you run and leave the placeholders for the rest. Replace `vX.Y.Z-rc.W` / `release/vX.Y.Z` with the version under test.
 
@@ -166,7 +166,7 @@ See [L2 integration tests with a SP1 GPU prover](l2/sp1-gpu-integration-test.md)
 
 #### Multiprover test (SP1 GPU + TDX)
 
-See [Multiprover test](l2/multiprover-test.md) for the full procedure.
+See [Multiprover test](l2/multiprover-test.md) for the full procedure. It runs across two hosts: the SP1 prover on `l2-gpu`, and the L1, deploy, sequencer and TDX prover VM on `ethrex-tdx-baremetal`, with the SP1 prover reaching the proof coordinator over the tailnet.
 
 The single-prover checks above each exercise one prover against an `OnChainProposer` that requires only that one. This is the only check where a batch must satisfy **two** provers before `lastVerifiedBatch` moves, which is the configuration a production rollup runs.
 

--- a/docs/developers/release-process.md
+++ b/docs/developers/release-process.md
@@ -98,6 +98,7 @@ Before publishing the release, run through the following checks using the pre-re
 - [ ] Launch multisync on `ethrex-multisync-main`
 - [ ] Upgrade a local L2 created with the previous version and run the integration tests
 - [ ] Run the L2 integration tests with a SP1 prover on the GPU server (`l2-gpu`)
+- [ ] Run the multiprover test (SP1 GPU + TDX)
 
 The commands for each target follow. The host roster changes between releases — fill in the ones you run and leave the placeholders for the rest. Replace `vX.Y.Z-rc.W` / `release/vX.Y.Z` with the version under test.
 
@@ -162,6 +163,28 @@ See [Upgrade test](l2/upgrade-test.md) for the full procedure.
 #### L2 integration tests with a SP1 prover (`l2-gpu`)
 
 See [L2 integration tests with a SP1 GPU prover](l2/sp1-gpu-integration-test.md) for the full procedure.
+
+#### Multiprover test (SP1 GPU + TDX)
+
+See [Multiprover test](l2/multiprover-test.md) for the full procedure.
+
+The single-prover checks above each exercise one prover against an
+`OnChainProposer` that requires only that one. This is the only check where a
+batch must satisfy **two** provers before `lastVerifiedBatch` moves, which is
+the configuration a production rollup runs.
+
+Confirm on-chain that the deployment really requires both, rather than trusting
+the deploy flags — a batch verifying under a single-prover deployment would
+prove nothing:
+
+```bash
+rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'REQUIRE_SP1_PROOF()' "$L1_RPC"   # 0x..01
+rex call "$ETHREX_COMMITTER_ON_CHAIN_PROPOSER_ADDRESS" 'REQUIRE_TDX_PROOF()' "$L1_RPC"   # 0x..01
+```
+
+The check passes when `lastVerifiedBatch` advances past zero with both flags
+set. Note the TDX side runs in dev mode against a plain QEMU guest, as it does
+in CI, so it does not exercise TDX hardware or on-chain DCAP verification.
 
 ### Publish
 


### PR DESCRIPTION
**Motivation**

Every L2 check in the release process exercises a single prover against an `OnChainProposer` configured to require only that one. A production rollup runs with two, and nothing verified that a batch can satisfy both — so a regression in the two-prover verification path would ship unnoticed.

**Description**

Adds `docs/developers/l2/multiprover-test.md` and a release-process checklist entry for a deployment where `REQUIRE_SP1_PROOF` and `REQUIRE_TDX_PROOF` are both set, so `lastVerifiedBatch` only advances once a batch has satisfied both.

The TDX side runs with `ETHREX_TDX_DEV_MODE=false` on real TDX hardware, so the quote is checked on chain by `verifyAndAttestOnChain`. This is deliberately stronger than CI, which uses dev mode — there `TDXVerifier.register()` short-circuits, taking the signing address from the quote's first 20 bytes and never verifying anything. Dev mode is documented as the fallback when no TDX host is available.

**Validation**

Run against `v25.0.0-rc.2`, SP1 prover on `l2-gpu`, everything else on `ethrex-tdx-baremetal`:

| Check | Result |
| --- | --- |
| `TDX_VERIFIER_ADDRESS.isDevMode()` | `false` — real verification, not the dev short-circuit |
| `REQUIRE_SP1_PROOF()` / `REQUIRE_TDX_PROOF()` | both `true` |
| `lastVerifiedBatch` | advanced past zero with both flags set |
| `InvalidTdxProof()` reverts | none |
| `MRTD()` on chain | `0x4e2d467d…`, the measurement of the image under test |
| `authorizedSignature()` | set from the verified report, not from raw quote bytes |

`ProverSetup received for TDX` → `ProverSetupACK sent` with dev mode off is the verifier accepting a quote signed by that machine's silicon.

**Prerequisites the deploy does not handle**

Real attestation needed three things, each of which fails opaquely and none of which were documented:

| Blocker | What is actually wrong |
| --- | --- |
| `MRTD mismatch` | `_validateReport` compares MRTD/RTMR0-2 against constants compiled into `TDXVerifier.sol` that pin one historical image build; they must be pinned to the image being released |
| `TCB_Cert_Expired` (`0xea8cd522`) | nothing has expired — the deploy loads `CA.ROOT` and `CA.PLATFORM` but never `CA.SIGNING`, so the DAO cannot check collateral signatures |
| `Unsupported chain_id: 9` | `automata-dcap-qpl-tool` resolves addresses from a chain-id-keyed registry and cannot serve a dev chain; its exit status is discarded by `prepare_quote_prerequisites`, so the first symptom is an unrelated revert later |

Also recorded: TD_QE identity needs version 4 or 5, not the `version` inside the JSON (`Incorrect_Enclave_Id_Version`); these upserts must be sent as raw calldata because cast's tuple parser splits on the commas in the JSON payload; and `run-qemu` from `hypervisor.nix` cannot be detached because it hardcodes `-serial mon:stdio`.

**Environment pins**

Four more, each hit while bringing the test up:

| Pin | Symptom when wrong |
| --- | --- |
| solc exactly 0.8.31 | `Source file requires different compiler version` — `TDXVerifier.sol` pins the pragma |
| fresh chain per deploy | `deploy-p256` reverts with no reason string (CREATE2 addresses already populated) |
| `--watcher.watch-interval 1000` | every commit reverts `InvalidPrivilegedTransactionLogs()` (`0x9e6e5638`) on an instantly-mining dev L1 |
| both provers attached before the first batch; L1 and L2 reset together | a prover deadlocks on `No blocks to prove`, asking forever for a batch whose input was pruned, while `lastVerifiedBatch` cannot advance without it |

**Follow-ups this surfaced** (not in this PR)

- `prepare_quote_prerequisites` discards the qpl tool's exit status, so a failed collateral load only surfaces as an unrelated revert much later.
- The late-joining-prover deadlock is a coordinator robustness gap, not just a test-setup quirk: a prover that restarts after batches accumulate can never catch up.
- `TDXVerifier`'s measurements are storage variables with no setter, so authorising a new prover image means redeploying the verifier.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
