### PR TITLE
feat(l1): add eth_getHeaderByHash and eth_getHeaderByNumber

### DIFF
--- a/crates/common/types/block.rs
+++ b/crates/common/types/block.rs
@@ -124,8 +124,13 @@ pub struct BlockHeader {
     pub prev_randao: H256,
     #[serde(with = "crate::serde_utils::u64::hex_str_padding")]
     pub nonce: u64,
-    #[serde(default, with = "crate::serde_utils::u64::hex_str_opt")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "crate::serde_utils::u64::hex_str_opt",
+        default = "Option::default"
+    )]
     pub base_fee_per_gas: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none", default = "Option::default")]
     #[rkyv(with=crate::rkyv_utils::OptionH256Wrapper)]
     pub withdrawals_root: Option<H256>,
     #[serde(
@@ -140,6 +145,7 @@ pub struct BlockHeader {
         default = "Option::default"
     )]
     pub excess_blob_gas: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none", default = "Option::default")]
     #[rkyv(with=crate::rkyv_utils::OptionH256Wrapper)]
     pub parent_beacon_block_root: Option<H256>,
     #[serde(skip_serializing_if = "Option::is_none", default = "Option::default")]

--- a/crates/networking/rpc/eth/block.rs
+++ b/crates/networking/rpc/eth/block.rs
@@ -5,8 +5,8 @@ use tracing::debug;
 use crate::{
     rpc::{RpcApiContext, RpcHandler},
     types::{
-        block::RpcBlock,
-        block_identifier::{BlockIdentifier, BlockIdentifierOrHash},
+        block::{RpcBlock, RpcHeader},
+        block_identifier::{BlockIdentifier, BlockIdentifierOrHash, BlockTag},
         receipt::{RpcReceipt, RpcReceiptBlockInfo, RpcReceiptTxInfo},
     },
     utils::RpcErr,
@@ -24,6 +24,14 @@ pub struct GetBlockByNumberRequest {
 pub struct GetBlockByHashRequest {
     pub block: BlockHash,
     pub hydrated: bool,
+}
+
+pub struct GetHeaderByNumberRequest {
+    pub block: BlockIdentifier,
+}
+
+pub struct GetHeaderByHashRequest {
+    pub block: BlockHash,
 }
 
 pub struct GetBlockTransactionCountRequest {
@@ -110,6 +118,65 @@ impl RpcHandler for GetBlockByHashRequest {
         };
         let block = RpcBlock::build(block.header, block.body, self.block, self.hydrated)?;
         serde_json::to_value(&block).map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+impl RpcHandler for GetHeaderByNumberRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<GetHeaderByNumberRequest, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
+        };
+        Ok(GetHeaderByNumberRequest {
+            block: BlockIdentifier::parse(params[0].clone(), 0)?,
+        })
+    }
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let storage = &context.storage;
+        debug!("Requested header with number: {}", self.block);
+        // Per the spec, the pending tag returns null instead of aliasing latest.
+        if matches!(self.block, BlockIdentifier::Tag(BlockTag::Pending)) {
+            return Ok(Value::Null);
+        }
+        let block_number = match self.block.resolve_block_number(storage).await? {
+            Some(block_number) => block_number,
+            _ => return Ok(Value::Null),
+        };
+        let header = match storage.get_block_header(block_number)? {
+            Some(header) => header,
+            _ => return Ok(Value::Null),
+        };
+        let hash = header.hash();
+        serde_json::to_value(RpcHeader { hash, header })
+            .map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+impl RpcHandler for GetHeaderByHashRequest {
+    fn parse(params: &Option<Vec<Value>>) -> Result<GetHeaderByHashRequest, RpcErr> {
+        let params = params
+            .as_ref()
+            .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
+        if params.len() != 1 {
+            return Err(RpcErr::BadParams("Expected 1 param".to_owned()));
+        };
+        Ok(GetHeaderByHashRequest {
+            block: serde_json::from_value(params[0].clone())?,
+        })
+    }
+    async fn handle(&self, context: RpcApiContext) -> Result<Value, RpcErr> {
+        let storage = &context.storage;
+        debug!("Requested header with hash: {:#x}", self.block);
+        let Some(header) = storage.get_block_header_by_hash(self.block)? else {
+            return Ok(Value::Null);
+        };
+        serde_json::to_value(RpcHeader {
+            hash: self.block,
+            header,
+        })
+        .map_err(|error| RpcErr::Internal(error.to_string()))
     }
 }
 

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -31,8 +31,9 @@ use crate::eth::{
     },
     block::{
         BlockNumberRequest, GetBlobBaseFee, GetBlockByHashRequest, GetBlockByNumberRequest,
-        GetBlockReceiptsRequest, GetBlockTransactionCountRequest, GetRawBlockRequest,
-        GetRawHeaderRequest, GetRawReceipts, GetUncleCountRequest,
+        GetBlockReceiptsRequest, GetBlockTransactionCountRequest, GetHeaderByHashRequest,
+        GetHeaderByNumberRequest, GetRawBlockRequest, GetRawHeaderRequest, GetRawReceipts,
+        GetUncleCountRequest,
     },
     block_access_list::{BlockAccessListRequest, RawBlockAccessListRequest},
     client::{ChainId, Syncing},
@@ -1399,6 +1400,8 @@ pub async fn map_eth_requests(req: &RpcRequest, context: RpcApiContext) -> Resul
         "eth_syncing" => Syncing::call(req, context).await,
         "eth_getBlockByNumber" => GetBlockByNumberRequest::call(req, context).await,
         "eth_getBlockByHash" => GetBlockByHashRequest::call(req, context).await,
+        "eth_getHeaderByNumber" => GetHeaderByNumberRequest::call(req, context).await,
+        "eth_getHeaderByHash" => GetHeaderByHashRequest::call(req, context).await,
         "eth_getBalance" => GetBalanceRequest::call(req, context).await,
         "eth_getCode" => GetCodeRequest::call(req, context).await,
         "eth_getStorageAt" => GetStorageAtRequest::call(req, context).await,
@@ -1755,6 +1758,50 @@ mod tests {
                 ),
                 "default allowlist should route {method}, got {result:?}"
             );
+        }
+    }
+
+    /// eth_getHeaderBy* returns the header with its hash and no size or body
+    /// fields, and null for unknown blocks and the pending tag.
+    #[tokio::test]
+    async fn eth_get_header_by_number_and_hash() {
+        let storage = crate::test_utils::setup_store().await;
+        crate::test_utils::add_empty_blocks(&storage, 2).await;
+        let context = default_context_with_storage(storage).await;
+
+        let request: RpcRequest = serde_json::from_str(
+            r#"{"jsonrpc":"2.0","method":"eth_getHeaderByNumber","params":["latest"],"id":1}"#,
+        )
+        .unwrap();
+        let header = map_http_requests(&request, context.clone()).await.unwrap();
+        assert_eq!(header["number"], "0x2");
+        assert!(header.get("hash").is_some());
+        assert!(header.get("size").is_none());
+        assert!(header.get("transactions").is_none());
+        assert!(header.get("uncles").is_none());
+
+        let hash = header["hash"].as_str().unwrap().to_owned();
+        let request: RpcRequest = serde_json::from_str(&format!(
+            r#"{{"jsonrpc":"2.0","method":"eth_getHeaderByHash","params":["{hash}"],"id":1}}"#
+        ))
+        .unwrap();
+        let by_hash = map_http_requests(&request, context.clone()).await.unwrap();
+        assert_eq!(by_hash, header);
+
+        for (method, param) in [
+            ("eth_getHeaderByNumber", r#""0x3e8""#),
+            ("eth_getHeaderByNumber", r#""pending""#),
+            (
+                "eth_getHeaderByHash",
+                r#""0x0000000000000000000000000000000000000000000000000000000000000000""#,
+            ),
+        ] {
+            let request: RpcRequest = serde_json::from_str(&format!(
+                r#"{{"jsonrpc":"2.0","method":"{method}","params":[{param}],"id":1}}"#
+            ))
+            .unwrap();
+            let result = map_http_requests(&request, context.clone()).await.unwrap();
+            assert_eq!(result, Value::Null, "{method} {param}");
         }
     }
 

--- a/crates/networking/rpc/types/block.rs
+++ b/crates/networking/rpc/types/block.rs
@@ -21,6 +21,14 @@ pub struct RpcBlock {
     pub body: BlockBodyWrapper,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHeader {
+    pub hash: H256,
+    #[serde(flatten)]
+    pub header: BlockHeader,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockBodyWrapper {


### PR DESCRIPTION
Adds `eth_getHeaderByHash` and `eth_getHeaderByNumber`, implementing the spec proposed in ethereum/execution-apis#877 (ethereum/execution-apis#874). geth, Nethermind, and reth already serve these methods.

The result is the consensus header plus the derived `hash`, with no `size`, `totalDifficulty`, or body fields. The result is `null` for an unknown block, for the `pending` tag (the spec diverges from `resolve_block_number`'s latest fallback here), and for an unresolvable `safe` or `finalized` tag.

`BlockHeader` serialization now skips `baseFeePerGas`, `withdrawalsRoot`, and `parentBeaconBlockRoot` when absent, matching the struct's other optional fork fields. The spec requires pre-fork fields to be omitted rather than `null`, and this also aligns `eth_getBlockBy*` responses with geth, which omits them. Deserialization is unchanged.

Full workspace `cargo check` passes; `ethrex-common` and `ethrex-rpc` test suites pass, including a new test covering the header shape, the by-hash round trip, and the three null cases.
