### PR TITLE
fix(l1): keep `global_asm!` blocks from leaking their section state

### DIFF
--- a/crates/common/crypto/blake2f/x86_64.s
+++ b/crates/common/crypto/blake2f/x86_64.s
@@ -35,6 +35,10 @@
 .endm
 
 
+    # Be explicit about the section: `global_asm!` blocks inherit the assembler's
+    # current section from whatever block was emitted before them in this codegen
+    # unit. See issue #7246.
+    .text
     .global _blake2b_f
     .type   _blake2b_f, @function
 _blake2b_f:

--- a/crates/common/crypto/keccak/README.md
+++ b/crates/common/crypto/keccak/README.md
@@ -37,7 +37,12 @@ $ ./keccak1600-armv8.pl linux64 keccak1600-armv8.s
 $ cd ../x86_64
 $ ./keccak1600-x86_64.pl linux64 keccak1600-x86_64.s
 ```
-- The x86 can be directly imported by the Rust compiler with the current options, but the ARM code requires a few changes, commented at the top of the `keccak1600-armv8.s` file.
+- Both the x86 and the ARM code need a few changes before the Rust compiler can import them. Each file lists its
+  own changes in a `Modified:` comment at the top; the ARM code needs the most of them.
+- One change applies to every file: each `global_asm!` block must both start in `.text` and leave `.text`
+  current when it ends. Blocks in the same codegen unit share the assembler's section state, so a block that
+  finishes in some other section makes the *next* block emit its functions there instead of in `.text`.
+  This is why the trailing `.note.gnu.property` block uses `.pushsection`/`.popsection` rather than `.section`.
 
 ## Copyright Notice
 

--- a/crates/common/crypto/keccak/keccak1600-armv8-elf.s
+++ b/crates/common/crypto/keccak/keccak1600-armv8-elf.s
@@ -6,9 +6,14 @@
 //     Reason: `.L` local labels are ELF-specific.
 //   - Replaced instance of `adr x??,label` by `adrp x??,label` followed by
 //     `add x??,x??,:lo12:label`.
+//   - Added an explicit `.text`.
+//     Reason: `global_asm!` blocks inherit the assembler's current section from
+//     whatever block was emitted before them in the same codegen unit.
 //
 // TODO: this is probably a matter of selecting the right parameter
 // for the translator.
+
+.text
 
 .align	8	// strategic alignment and padding that allows to use
 		// address value as loop termination condition...

--- a/crates/common/crypto/keccak/keccak1600-armv8-macho.s
+++ b/crates/common/crypto/keccak/keccak1600-armv8-macho.s
@@ -6,9 +6,14 @@
 //     Reason: `.L` local labels are ELF-specific.
 //   - Replaced instance of `adr x??,label` by `adrp x??,label@PAGE` followed by
 //     `add x??,x??,label@PAGEOFF`.
+//   - Added an explicit `.text`.
+//     Reason: `global_asm!` blocks inherit the assembler's current section from
+//     whatever block was emitted before them in the same codegen unit.
 //
 // TODO: this is probably a matter of selecting the right parameter
 // for the translator.
+
+.text
 
 .align	8	// strategic alignment and padding that allows to use
 		// address value as loop termination condition...

--- a/crates/common/crypto/keccak/keccak1600-x86_64.s
+++ b/crates/common/crypto/keccak/keccak1600-x86_64.s
@@ -1,3 +1,9 @@
+# Modified:
+#   - Wrapped the trailing `.note.gnu.property` block in `.pushsection`/`.popsection`.
+#     Reason: `global_asm!` blocks share the assembler's section state within a codegen
+#     unit, so leaving the note section current made a *following* `global_asm!` emit its
+#     functions into `.note.gnu.property` instead of `.text`. See issue #7246.
+
 .text	
 
 .type	__KeccakF1600,@function
@@ -528,9 +534,10 @@ iotas:
 .size	iotas,.-iotas
 .byte	75,101,99,99,97,107,45,49,54,48,48,32,97,98,115,111,114,98,32,97,110,100,32,115,113,117,101,101,122,101,32,102,111,114,32,120,56,54,95,54,52,44,32,67,82,89,80,84,79,71,65,77,83,32,98,121,32,60,97,112,112,114,111,64,111,112,101,110,115,115,108,46,111,114,103,62,0
 
-.section	.note.gnu.property,"a",@note
+.pushsection	.note.gnu.property,"a",@note
 	.long	4,2f-1f,5
 	.byte	0x47,0x4E,0x55,0
 1:	.long	0xc0000002,4,3
 .align	8
 2:
+.popsection


### PR DESCRIPTION
**Motivation**

`keccak1600-x86_64.s` ends with a `.section .note.gnu.property` block carrying the CET
feature flags, and never switches back to `.text`. Blocks emitted by `global_asm!` share the
assembler's section state within a codegen unit, so whichever block rustc places after it keeps
emitting into that note section.

On Rust 1.99-beta that next block is the blake2f AVX2 implementation, so `_blake2b_f` is
defined inside a non-executable `NOTE` section. The link then fails:

```
rust-lld: error: ethrex_crypto-<hash>.ethrex_crypto.<hash>-cgu.0.rcgu.o:(.note.gnu.property+0x20): data is too short
```

(lld parses `.note.gnu.property` to compute the output's GNU property bits, and walks off the
end of what it thinks is a note once ~5 KiB of blake2f code is sitting in there.)

As @cuviper points out in #7246, this is not really a compiler regression: nothing guarantees
an ordering between `global_asm!` blocks, and the old ordering working was luck. Confirmed:
on stable rustc emits the blake2f block *first*, which is the only reason the stray section
state never reached it.

This affects **release** builds specifically. `[profile.release]` sets `codegen-units = 1`,
which is what puts both blocks in the same codegen unit; the default multi-CGU split used by
debug and `cargo test` builds happens to separate them, and those are unaffected on either
toolchain.

**Description**

- `keccak1600-x86_64.s`: wrap the trailing note block in `.pushsection`/`.popsection` so it
  restores the previous section instead of leaking it. This is the fix for #7246, and is what
  the issue suggests.
- Make each `global_asm!` block declare `.text` up front rather than inheriting whatever
  section it happens to start in, so the pairing is robust in both directions:
  `blake2f/x86_64.s`, `keccak1600-armv8-elf.s`, `keccak1600-armv8-macho.s`. (The x86_64 keccak
  file already opened with `.text`.) These three are defensive, not required to close the issue.
- Record the change in each file's `Modified:` header, and update the keccak `README.md`, which
  claimed the x86 file was imported unmodified.

No functional change to any of the assembly itself.

**Verification**

Reproduced and fixed on an x86_64 Linux host (`stable` 1.92.0 vs `beta` 1.99.0-beta.3, linking
through the host `cc` with `-fuse-ld=lld`), building the real `ethrex-crypto` crate:

```
CARGO_PROFILE_DEV_CODEGEN_UNITS=1 CARGO_PROFILE_DEV_INCREMENTAL=false \
  cargo +beta test --no-run -p ethrex-crypto
```

| rev | toolchain | `_blake2b_f` lands in | `.note.gnu.property` size | result |
| --- | --- | --- | --- | --- |
| base | stable 1.92.0 | `.text` | `0x20` | ok (by luck: blake2f block emitted first) |
| base | beta 1.99.0-beta.3 | `.note.gnu.property` | `0x13c0` | **link error** |
| this PR | stable 1.92.0 | `.text` | `0x20` | ok |
| this PR | beta 1.99.0-beta.3 | `.text` | `0x20` | ok |

The failure:

```
rust-lld: error: ethrex_crypto-<hash>.ethrex_crypto.<hash>-cgu.0.rcgu.o:(.note.gnu.property+0x20): data is too short
error: could not compile `ethrex-crypto` (lib test) due to 1 previous error
```

The section column above comes from unpacking the rlib and reading the symbol table, which is
worth doing on the base commit even where the link succeeds, since it shows the note section
ballooning from its correct `0x20` bytes to `0x13c0`:

```
ar x "$CARGO_TARGET_DIR"/debug/deps/libethrex_crypto-*.rlib
readelf -sW *cgu.0.rcgu.o | grep _blake2b_f   # field 7 is the section index
readelf -SW *cgu.0.rcgu.o | grep -E 'note\.gnu\.property|\.text'
```

**`codegen-units = 1` is required to reproduce.** Plain `cargo test` uses the `test` profile
(inheriting `[profile.dev]`), where rustc's default multi-CGU split places the keccak and
blake2f `global_asm!` blocks in different codegen units, so the leaked section state never
reaches blake2f. For the record, on the same host `cargo +stable test --no-run` and
`cargo +beta test --no-run` over the whole workspace both exit 0 on the pre-fix base as well as
on this PR — those commands alone do **not** exercise the bug.

aarch64 cannot hit this at all: neither ARMv8 file contains a `.note.gnu.property` block, so
the `.text` added to them is purely defensive. Checked regardless on aarch64-apple-darwin —
full-workspace `cargo test --no-run` on both stable and beta, plus the keccak suite
(`crypto::keccak_tests`, 11 tests) — all green.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.

  Not applicable: assembly and documentation only, no `Store` changes.

Closes #7246
