### PR TITLE
test(trie): fix nonexistent edge keys test name

### DIFF
--- a/test/tests/trie/verify_range_tests.rs
+++ b/test/tests/trie/verify_range_tests.rs
@@ -175,8 +175,8 @@ proptest! {
     }
 
     #[test]
-    // Two Edge Proofs, first and last keys dont exist
-    fn proptest_verify_range_nonexistant_edge_keys(data in btree_set(vec(1..u8::MAX-1, 32), 200), start in 1_usize..=100_usize, end in 101..199_usize) {
+    // Two edge proofs where the first and last keys do not exist
+    fn proptest_verify_range_nonexistent_edge_keys(data in btree_set(vec(1..u8::MAX-1, 32), 200), start in 1_usize..=100_usize, end in 101..199_usize) {
         let data = data.into_iter().collect::<Vec<_>>();
         // Build trie
         let mut trie = Trie::new_temp();


### PR DESCRIPTION
**Motivation**

The range-proof property test misspells “nonexistent” in its function name and uses an ambiguous sentence in the adjacent comment. Accurate test names make failures and filtered test runs easier to interpret.

**Description**

Rename `proptest_verify_range_nonexistant_edge_keys` to `proptest_verify_range_nonexistent_edge_keys` and clarify that both boundary keys are absent. The generated cases and assertions are unchanged. `cargo fmt --all -- --check` passes.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` — not applicable; storage and schemas are unchanged.

Closes N/A