### PR TITLE
ci(l1): make the daily reports fail loudly and attribute honestly

### DIFF
--- a/.github/scripts/notify_snapsync_run.sh
+++ b/.github/scripts/notify_snapsync_run.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 #   HEAD_SHA, START_TIME, RUN_ID, RUN_ATTEMPT
 # Optional:
 #   COMMIT_MESSAGE  (falls back to `git log` of HEAD_SHA when unset)
+#   EVENT_NAME      (github.event_name; labels HEAD_SHA honestly on scheduled runs)
+#   GH_TOKEN        (needs actions:read; adds this workflow's earlier conclusions
+#                    on the same commit)
 
 REPO=${REPO:-}
 NAME=${NAME:-}
@@ -16,6 +19,8 @@ START_TIME=${START_TIME:-}
 RUN_ID=${RUN_ID:-}
 RUN_ATTEMPT=${RUN_ATTEMPT:-1}
 COMMIT_MESSAGE=${COMMIT_MESSAGE:-}
+EVENT_NAME=${EVENT_NAME:-}
+GH_TOKEN=${GH_TOKEN:-}
 
 if ! [[ "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
   RUN_ATTEMPT=1
@@ -83,18 +88,54 @@ if [[ -z "$COMMIT_TITLE" && -n "$HEAD_SHA" ]]; then
 fi
 COMMIT_TITLE=$(printf '%s' "$COMMIT_TITLE" | head -n 1)
 
+# On a scheduled run HEAD_SHA is whatever main pointed at when the run started,
+# not a change under test. Label it that way and show the commit's age: a
+# failure on a two-day-old commit that ran fine in between is a flaky run, not
+# a regression, and the alert should not read as a case for reverting it.
+COMMIT_LABEL="Commit"
+if [[ "$EVENT_NAME" == "schedule" ]]; then
+  COMMIT_LABEL="Head of main at run start"
+fi
+
+COMMIT_AGE=""
+if [[ -n "$HEAD_SHA" ]]; then
+  COMMIT_TS=$(git log -1 --format=%ct "$HEAD_SHA" 2>/dev/null || true)
+  if [[ "$COMMIT_TS" =~ ^[0-9]+$ ]] && (( EPOCHSECONDS >= COMMIT_TS )); then
+    AGE_SECS=$((EPOCHSECONDS - COMMIT_TS))
+    COMMIT_AGE=" (committed $((AGE_SECS / 86400))d $(((AGE_SECS % 86400) / 3600))h ago)"
+  fi
+fi
+
 if [[ -n "$HEAD_SHA" ]]; then
   SHORT_SHA="${HEAD_SHA:0:8}"
   COMMIT_URL="https://github.com/${REPO}/commit/${HEAD_SHA}"
-  COMMIT_LINE="*Commit:* <${COMMIT_URL}|${SHORT_SHA}>"
+  COMMIT_LINE="*${COMMIT_LABEL}:* <${COMMIT_URL}|${SHORT_SHA}>"
   if [[ -n "$COMMIT_TITLE" ]]; then
     COMMIT_LINE="${COMMIT_LINE} $(slack_escape "$COMMIT_TITLE")"
   fi
+  COMMIT_LINE="${COMMIT_LINE}${COMMIT_AGE}"
 else
-  COMMIT_LINE="*Commit:* unknown"
+  COMMIT_LINE="*${COMMIT_LABEL}:* unknown"
+fi
+
+# This workflow's earlier conclusions on the same commit. "success ×6,
+# failure ×1" is the quickest way to tell a flaky run from a broken commit.
+# Omitted when no token is provided.
+HISTORY_LINE=""
+if [[ -n "$GH_TOKEN" && -n "$HEAD_SHA" && -n "$REPO" && -n "${GITHUB_WORKFLOW:-}" ]]; then
+  prior=$(curl -sS --max-time 20 \
+      -H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" 2>/dev/null \
+    | jq -r --arg wf "$GITHUB_WORKFLOW" --arg id "$RUN_ID" '
+        [.workflow_runs[]? | select(.name == $wf and (.id|tostring) != $id and .conclusion != null) | .conclusion]
+        | group_by(.) | map("\(.[0]) ×\(length)") | join(", ")' 2>/dev/null || true)
+  HISTORY_LINE="*Earlier runs on this commit:* ${prior:-none}"
 fi
 
 DETAILS="${COMMIT_LINE}"$'\n'"*Duration:* ${DURATION}"
+if [[ -n "$HISTORY_LINE" ]]; then
+  DETAILS="${DETAILS}"$'\n'"${HISTORY_LINE}"
+fi
 
 # Construct the Slack payload using jq for safe JSON escaping
 PAYLOAD=$(jq -n \

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -224,19 +224,37 @@ jobs:
         with:
           path: hive/workspace/logs
           pattern: "*_daily-results.zip"
-          merge-multiple: true
+
+      # Each simulator's results land in a directory named after its artifact. A
+      # simulator whose job finished without uploading anything must not vanish
+      # into a 0/0 line on an otherwise green report: on 2026-09-03 the
+      # consume-engine-rest artifact was missing and 20k tests dropped out of the
+      # totals with nothing flagged.
+      - name: Check that every simulator reported
+        id: coverage
+        shell: bash
+        run: |
+          missing=()
+          # The expected set is read from this workflow's own matrix so it cannot drift from it.
+          for sim in $(grep -oE 'file_name: [a-z0-9-]+' .github/workflows/daily_hive_report.yaml | awk '{print $2}' | sort -u); do
+            if ! compgen -G "hive/workspace/logs/${sim}_daily-results.zip/*.json" > /dev/null; then
+              missing+=("$sim")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            echo "::error::No results were uploaded by: ${missing[*]}. The report counts them as 0/0."
+          fi
+          echo "missing=${missing[*]-}" >> "$GITHUB_OUTPUT"
 
       - name: Flatten hive result files
         shell: bash
         run: |
-          shopt -s globstar nullglob
+          shopt -s nullglob
           mkdir -p hive/workspace/logs
-          for json in hive/workspace/logs/**/*.json; do
-            base_name=$(basename "$json")
-            target="hive/workspace/logs/$base_name"
-            if [[ "$json" != "$target" ]]; then
-              mv "$json" "$target"
-            fi
+          # One level down: the per-artifact directories. Client logs sit deeper
+          # and are deliberately left behind.
+          for f in hive/workspace/logs/*/*.json hive/workspace/logs/*/*.log; do
+            mv "$f" "hive/workspace/logs/$(basename "$f")"
           done
           find hive/workspace/logs -mindepth 1 -type d -exec rm -rf {} +
 
@@ -262,6 +280,17 @@ jobs:
       - name: Generate the hive report
         run: cargo run --manifest-path tooling/Cargo.toml -p hive_report > results.md
 
+      - name: Flag missing simulators in the report
+        if: steps.coverage.outputs.missing != ''
+        env:
+          MISSING: ${{ steps.coverage.outputs.missing }}
+        shell: bash
+        run: |
+          note="⚠️ *No results from:* ${MISSING// /, }. Counted as 0/0 below."
+          { printf '%s\n\n' "$note"; cat results.md; } > results.tmp && mv results.tmp results.md
+          jq --arg t "$note" '.blocks |= ([.[0], {type: "section", text: {type: "mrkdwn", text: $t}}] + .[1:])' \
+            hive_slack_blocks.json > blocks.tmp && mv blocks.tmp hive_slack_blocks.json
+
       - name: Upload daily result
         uses: actions/upload-artifact@v6
         with:
@@ -276,9 +305,16 @@ jobs:
           echo "# Hive coverage report" >> $GITHUB_STEP_SUMMARY
           cat results.md >> $GITHUB_STEP_SUMMARY
 
+      # Last, so the report and its artifact still go out; the job just stops
+      # being green about it.
+      - name: Fail when a simulator did not report
+        if: steps.coverage.outputs.missing != ''
+        run: exit 1
+
   post-daily-report:
     name: Post report to slack
     needs: [hive-report]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -236,11 +236,11 @@ jobs:
         run: |
           missing=()
           # The expected set is read from this workflow's own matrix so it cannot drift from it.
-          for sim in $(grep -oE 'file_name: [a-z0-9-]+' .github/workflows/daily_hive_report.yaml | awk '{print $2}' | sort -u); do
+          while read -r sim; do
             if ! compgen -G "hive/workspace/logs/${sim}_daily-results.zip/*.json" > /dev/null; then
               missing+=("$sim")
             fi
-          done
+          done < <(grep -oE 'file_name: [a-z0-9-]+' .github/workflows/daily_hive_report.yaml | awk '{print $2}' | sort -u)
           if (( ${#missing[@]} )); then
             echo "::error::No results were uploaded by: ${missing[*]}. The report counts them as 0/0."
           fi

--- a/.github/workflows/daily_snapsync.yaml
+++ b/.github/workflows/daily_snapsync.yaml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  actions: read # notify_snapsync_run.sh lists earlier runs on the same commit
 
 concurrency:
   group: ethrex-sync-server
@@ -130,6 +131,8 @@ jobs:
           START_TIME: ${{ steps.start.outputs.timestamp }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           bash .github/scripts/notify_snapsync_run.sh
 
@@ -182,5 +185,7 @@ jobs:
           START_TIME: ${{ steps.start.outputs.timestamp }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           bash .github/scripts/notify_snapsync_run.sh


### PR DESCRIPTION
**Motivation**

The 2026-09-03 daily report looked like a regression on the head of main and led to a revert evaluation. It was not one: the same commit had passed the previous seven snapsync runs and a 100% P2P day, the P2P collapse came from an unpinned go-ethereum checkout inside hive's devp2p simulator, and 20k tests had silently dropped out of the totals. Two reporting defects made that harder to see than it needed to be.

**Description**

- Daily hive report: each simulator's artifact is downloaded into its own directory and checked against the workflow's own matrix. When one is missing, a warning is prepended to the report and the Slack blocks, and the job fails last so the report still goes out. Previously a missing artifact became a `0/0` line on a green job.
- Snapsync alerts: on scheduled runs the SHA is labelled as the head of main at run start (not "Commit:"), the commit's age is shown, and this workflow's earlier conclusions on the same commit are listed (`success ×6, failure ×1`). The history lookup needs `actions: read` on the token.

The geth pin for the devp2p simulator is handled separately: it needs a hive fork or an upstream change, since the simulator's Dockerfile clones geth master at build time.

**Checklist**

- [x] No `Store` changes.

**Testing**

- The modified hive-report job ran on this branch (run 33769918540): the coverage check passed with every simulator present, and the flag/fail steps were skipped as intended. The missing-artifact path is exercised only by a missing artifact, so it is verified by reading.
- The two red checks are `Hive - Devp2p tests` and its aggregator. They fail identically on `main`: hive's devp2p simulator clones go-ethereum master at build time and geth moved on 2026-09-02. Pinning geth is a separate change (needs a hive repo we control).
- The snapsync workflow's run for this branch was displaced from the `ethrex-sync-server` concurrency queue by the scheduled run before it started, so the new alert text has not run in CI yet.
