### PR TITLE
test(l1): bump zkevm tests to v0.8.4

### DIFF
--- a/crates/common/types/stateless_ssz.rs
+++ b/crates/common/types/stateless_ssz.rs
@@ -415,9 +415,11 @@ const PUBLIC_KEY_BYTES: usize = 65;
 /// does **not** identify the encoding. Three dialects have shipped under it:
 /// `tests-zkevm@v0.6.2`, then #3248 + #3278, then #3356 (which moved `state`,
 /// `codes` and `public_keys` to `ProgressiveList`). ethrex speaks the last one,
-/// matching `tests-zkevm@v0.8.0` and unchanged in `v0.8.2` (upstream #3372 only
-/// renamed the Python classes; SSZ encoding is positional, so the wire is
-/// identical). A bundle from an older dialect will not be caught by this
+/// matching `tests-zkevm@v0.8.0` and unchanged through `v0.8.3`. Both later
+/// releases only moved Python around: #3372 renamed the classes, and v0.8.3
+/// deleted `stateless_ssz.py` by folding those definitions into annotations on
+/// the dataclasses in `stateless.py`. SSZ encoding is positional, so neither
+/// touched the wire. A bundle from an older dialect will not be caught by this
 /// prefix — it fails later, in decode or on a mismatched root.
 pub const STATELESS_INPUT_SCHEMA_ID: u16 = 0x1501;
 

--- a/crates/common/types/stateless_ssz.rs
+++ b/crates/common/types/stateless_ssz.rs
@@ -414,13 +414,12 @@ const PUBLIC_KEY_BYTES: usize = 65;
 /// Note that upstream keeps `0x1501` across incompatible body changes, so the id
 /// does **not** identify the encoding. Three dialects have shipped under it:
 /// `tests-zkevm@v0.6.2`, then #3248 + #3278, then #3356 (which moved `state`,
-/// `codes` and `public_keys` to `ProgressiveList`). ethrex speaks the last one,
-/// matching `tests-zkevm@v0.8.0` and unchanged through `v0.8.3`. Both later
-/// releases only moved Python around: #3372 renamed the classes, and v0.8.3
-/// deleted `stateless_ssz.py` by folding those definitions into annotations on
-/// the dataclasses in `stateless.py`. SSZ encoding is positional, so neither
-/// touched the wire. A bundle from an older dialect will not be caught by this
-/// prefix — it fails later, in decode or on a mismatched root.
+/// `codes` and `public_keys` to `ProgressiveList`). ethrex speaks the last one.
+/// Releases since have only rearranged the Python that declares it, and SSZ
+/// encoding is positional, so renames and module moves leave the wire alone;
+/// which bundle is actually pinned lives in `tooling/ef_tests/.fixtures_url_zkevm`.
+/// A bundle from an older dialect will not be caught by this prefix — it fails
+/// later, in decode or on a mismatched root.
 pub const STATELESS_INPUT_SCHEMA_ID: u16 = 0x1501;
 
 /// Byte length of the big-endian [`STATELESS_INPUT_SCHEMA_ID`] prefix.

--- a/docs/eip-8025.md
+++ b/docs/eip-8025.md
@@ -15,13 +15,11 @@ rather than building its own ethrex guest (issue
 
 ### Target schema
 
-The wire format is the one shipped in `tests-zkevm@v0.8.0` and unchanged through
-`v0.8.3`, the release the vectors are pinned to. Both later releases only moved
-Python around: `v0.8.2` renamed `Ssz*` → `SSZ*`
-([#3372](https://github.com/ethereum/execution-specs/pull/3372)), and `v0.8.3`
-deleted `stateless_ssz.py`, folding the container definitions into annotations on
-the dataclasses in `stateless.py`. SSZ encoding is positional and the schema id
-stayed `0x1501`, so nothing on the wire moved. It is the sum of three merged PRs:
+The wire format is the one shipped in `tests-zkevm@v0.8.0` and unchanged since.
+Later releases have only rearranged the Python that declares it — class renames,
+and folding the SSZ containers into annotations on the dataclasses — but SSZ
+encoding is positional and the schema id stayed `0x1501`, so nothing on the wire
+moved. It is the sum of three merged PRs:
 
 | PR | merged | change |
 |---|---|---|
@@ -45,7 +43,7 @@ Conformance vectors come from the released bundle pinned by
 | Resource | Link |
 |----------|------|
 | EIP-8025 | [eips.ethereum.org/EIPS/eip-8025](https://eips.ethereum.org/EIPS/eip-8025) |
-| Stateless spec | [`stateless.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless.py) (carried the SSZ containers in `stateless_ssz.py` up to `v0.8.2`) |
+| Stateless spec | [`stateless.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless.py) |
 | Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless_guest.py) |
 | EIP-7916 (progressive lists) | [eips.ethereum.org/EIPS/eip-7916](https://eips.ethereum.org/EIPS/eip-7916) |
 | libssz | [github.com/lambdaclass/libssz](https://github.com/lambdaclass/libssz) |

--- a/docs/eip-8025.md
+++ b/docs/eip-8025.md
@@ -43,8 +43,8 @@ Conformance vectors come from the released bundle pinned by
 | Resource | Link |
 |----------|------|
 | EIP-8025 | [eips.ethereum.org/EIPS/eip-8025](https://eips.ethereum.org/EIPS/eip-8025) |
-| Stateless spec | [`stateless.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless.py) |
-| Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless_guest.py) |
+| Stateless spec | [`stateless.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.4/src/ethereum/forks/amsterdam/stateless.py) |
+| Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.4/src/ethereum/forks/amsterdam/stateless_guest.py) |
 | EIP-7916 (progressive lists) | [eips.ethereum.org/EIPS/eip-7916](https://eips.ethereum.org/EIPS/eip-7916) |
 | libssz | [github.com/lambdaclass/libssz](https://github.com/lambdaclass/libssz) |
 | Ere / ere-guests | [eth-act/ere](https://github.com/eth-act/ere), [eth-act/ere-guests](https://github.com/eth-act/ere-guests) |
@@ -327,8 +327,8 @@ cargo test --manifest-path crates/guest-program/stateless-validator/Cargo.toml -
 ```
 
 The bundle is pinned by `tooling/ef_tests/.fixtures_url_zkevm`, currently
-`tests-zkevm@v0.8.3`, which is filled against the same
-`tests-glamsterdam-devnet@v8.1.3` content as the Amsterdam bundle. `v0.8.0` was the first zkEVM release carrying both this
+`tests-zkevm@v0.8.4`, which is filled against the same
+`tests-glamsterdam-devnet@v8.1.4` content as the Amsterdam bundle. `v0.8.0` was the first zkEVM release carrying both this
 schema (#3248, #3278, #3356) and the glamsterdam-devnet-8 gas schedule; earlier
 releases had at most one of the two, which is why the vectors were briefly
 generated from a pinned execution-specs commit instead.
@@ -344,7 +344,7 @@ vectors. The ere-platform path needs no separate parity test: it runs the same
 
 ### Measured baseline
 
-The `tests-zkevm@v0.8.3` bundle passes in full: 3240/3240 fixture files via
+The `tests-zkevm@v0.8.4` bundle passes in full: 3259/3259 fixture files via
 `make test-stateless`, with no zkEVM-specific skips (`EXTRA_SKIPS` in
 `tooling/ef_tests/blockchain/tests/all.rs` is empty).
 

--- a/docs/eip-8025.md
+++ b/docs/eip-8025.md
@@ -15,11 +15,13 @@ rather than building its own ethrex guest (issue
 
 ### Target schema
 
-The wire format is the one shipped in `tests-zkevm@v0.8.0` and unchanged in
-`v0.8.2`, the release the vectors are pinned to (the v0.8.0 → v0.8.2 upstream
-delta is release automation plus `Ssz*` → `SSZ*` Python renames,
-[#3372](https://github.com/ethereum/execution-specs/pull/3372) — SSZ encoding
-is positional, so nothing on the wire moved). It is the sum of three merged PRs:
+The wire format is the one shipped in `tests-zkevm@v0.8.0` and unchanged through
+`v0.8.3`, the release the vectors are pinned to. Both later releases only moved
+Python around: `v0.8.2` renamed `Ssz*` → `SSZ*`
+([#3372](https://github.com/ethereum/execution-specs/pull/3372)), and `v0.8.3`
+deleted `stateless_ssz.py`, folding the container definitions into annotations on
+the dataclasses in `stateless.py`. SSZ encoding is positional and the schema id
+stayed `0x1501`, so nothing on the wire moved. It is the sum of three merged PRs:
 
 | PR | merged | change |
 |---|---|---|
@@ -43,8 +45,8 @@ Conformance vectors come from the released bundle pinned by
 | Resource | Link |
 |----------|------|
 | EIP-8025 | [eips.ethereum.org/EIPS/eip-8025](https://eips.ethereum.org/EIPS/eip-8025) |
-| Stateless spec | [`stateless_ssz.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.2/src/ethereum/forks/amsterdam/stateless_ssz.py) |
-| Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.2/src/ethereum/forks/amsterdam/stateless_guest.py) |
+| Stateless spec | [`stateless.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless.py) (carried the SSZ containers in `stateless_ssz.py` up to `v0.8.2`) |
+| Guest entrypoint | [`stateless_guest.py`](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.3/src/ethereum/forks/amsterdam/stateless_guest.py) |
 | EIP-7916 (progressive lists) | [eips.ethereum.org/EIPS/eip-7916](https://eips.ethereum.org/EIPS/eip-7916) |
 | libssz | [github.com/lambdaclass/libssz](https://github.com/lambdaclass/libssz) |
 | Ere / ere-guests | [eth-act/ere](https://github.com/eth-act/ere), [eth-act/ere-guests](https://github.com/eth-act/ere-guests) |
@@ -327,7 +329,8 @@ cargo test --manifest-path crates/guest-program/stateless-validator/Cargo.toml -
 ```
 
 The bundle is pinned by `tooling/ef_tests/.fixtures_url_zkevm`, currently
-`tests-zkevm@v0.8.2`. `v0.8.0` was the first zkEVM release carrying both this
+`tests-zkevm@v0.8.3`, which is filled against the same
+`tests-glamsterdam-devnet@v8.1.3` content as the Amsterdam bundle. `v0.8.0` was the first zkEVM release carrying both this
 schema (#3248, #3278, #3356) and the glamsterdam-devnet-8 gas schedule; earlier
 releases had at most one of the two, which is why the vectors were briefly
 generated from a pinned execution-specs commit instead.
@@ -343,7 +346,7 @@ vectors. The ere-platform path needs no separate parity test: it runs the same
 
 ### Measured baseline
 
-The `tests-zkevm@v0.8.2` bundle passes in full: 3218/3218 fixture files via
+The `tests-zkevm@v0.8.3` bundle passes in full: 3240/3240 fixture files via
 `make test-stateless`, with no zkEVM-specific skips (`EXTRA_SKIPS` in
 `tooling/ef_tests/blockchain/tests/all.rs` is empty).
 

--- a/tooling/ef_tests/.fixtures_url_zkevm
+++ b/tooling/ef_tests/.fixtures_url_zkevm
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.8.3/fixtures_zkevm.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.8.4/fixtures_zkevm.tar.gz

--- a/tooling/ef_tests/.fixtures_url_zkevm
+++ b/tooling/ef_tests/.fixtures_url_zkevm
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.8.2/fixtures_zkevm.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-zkevm%40v0.8.3/fixtures_zkevm.tar.gz

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -28,14 +28,11 @@ AMSTERDAM_URL := $(shell cat $(AMSTERDAM_FIXTURES_FILE))
 AMSTERDAM_SUBTREES := for_amsterdam for_bpo2toamsterdamattime15k
 AMSTERDAM_STAMP := $(SPECTEST_VECTORS_DIR)/.amsterdam_overlay
 
-# zkevm@v0.8.3 is filled against tests-glamsterdam-devnet@v8.1.3, the same content
-# the Amsterdam bundle above is pinned to; v0.8.2 trailed it at v8.1.0. It carries
-# the EIP-8025 stateless witness fields on top (executionWitness /
-# statelessInputBytes / statelessOutputBytes). The v0.8.2 → v0.8.3 upstream delta
-# leaves the guest contract alone: the schema id is still 0x1501, and `state`,
-# `codes` and `public_keys` stay progressive lists with `headers` bounded. What
-# moved is where the spec declares those types — a separate SSZ mirror module was
-# folded into annotations on the dataclasses themselves.
+# The zkevm bundle is the Amsterdam fixtures plus the EIP-8025 stateless witness
+# fields (executionWitness / statelessInputBytes / statelessOutputBytes). Bump it
+# to a release filled against the same tests-glamsterdam-devnet content the
+# Amsterdam pin above names: when the two drift, the bundles describe slightly
+# different chains.
 # Both bundles extract a `for_amsterdam/` subtree, so we keep the zkevm bundle in
 # a separate root that only the stateless harness reads, to avoid overlaying the
 # regular Amsterdam fixtures.

--- a/tooling/ef_tests/blockchain/Makefile
+++ b/tooling/ef_tests/blockchain/Makefile
@@ -28,10 +28,14 @@ AMSTERDAM_URL := $(shell cat $(AMSTERDAM_FIXTURES_FILE))
 AMSTERDAM_SUBTREES := for_amsterdam for_bpo2toamsterdamattime15k
 AMSTERDAM_STAMP := $(SPECTEST_VECTORS_DIR)/.amsterdam_overlay
 
-# zkevm@v0.8.2 is filled against the same tests-glamsterdam-devnet@v8.1.0 content
-# as v0.8.0 (its upstream delta is release CI and Python renames only) — the same
-# base line as the Amsterdam bundle — and additionally carries the EIP-8025 stateless
-# witness fields (executionWitness / statelessInputBytes / statelessOutputBytes).
+# zkevm@v0.8.3 is filled against tests-glamsterdam-devnet@v8.1.3, the same content
+# the Amsterdam bundle above is pinned to; v0.8.2 trailed it at v8.1.0. It carries
+# the EIP-8025 stateless witness fields on top (executionWitness /
+# statelessInputBytes / statelessOutputBytes). The v0.8.2 → v0.8.3 upstream delta
+# leaves the guest contract alone: the schema id is still 0x1501, and `state`,
+# `codes` and `public_keys` stay progressive lists with `headers` bounded. What
+# moved is where the spec declares those types — a separate SSZ mirror module was
+# folded into annotations on the dataclasses themselves.
 # Both bundles extract a `for_amsterdam/` subtree, so we keep the zkevm bundle in
 # a separate root that only the stateless harness reads, to avoid overlaying the
 # regular Amsterdam fixtures.


### PR DESCRIPTION
> **Stacked on #7254.** Base is `fix/eip8037-repay-state-gas-spill`; GitHub retargets this to `main` automatically once that merges. Review the last commits only — the LEVM changes shown belong to #7254.

**Motivation**

`tests-zkevm@v0.8.4` is refilled on top of [`tests-glamsterdam-devnet@v8.1.4`](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v8.1.4), which is where #7254 moves `.fixtures_url_amsterdam`. The zkEVM bundle is the Amsterdam fixtures plus the EIP-8025 stateless witness fields, so the two pins should name the same upstream content; `v0.8.2` trailed at `v8.1.0`. Upstream reports no spec or test changes in the zkEVM project itself across these releases.

**Description**

- Bump `tooling/ef_tests/.fixtures_url_zkevm` to `tests-zkevm@v0.8.4`.
- Rewrite the bundle comments in `crates/common/types/stateless_ssz.rs` and the blockchain `Makefile` to state the invariant that survives a bump — the schema id does not identify the encoding, and the zkEVM pin has to track the Amsterdam pin's upstream content — rather than narrating what each release changed. Which release is pinned is stated once, in `.fixtures_url_zkevm`.
- Follow the spec links in `docs/eip-8025.md`: upstream deleted `stateless_ssz.py`, folding the SSZ containers into annotations on the dataclasses in `stateless.py`, so the old path 404s at the new tag.

**Why this is stacked rather than independent**

`v0.8.4` does not stand on its own. Without the reservoir-repay fix in #7254 it fails nine cases under `eip8037_state_creation_gas_cost_increase/state_gas_cross_frame_refund` — `cross_frame_refund_repays_spill_at_merge`, `repaid_credit_funds_execution` and friends — which are exactly the behaviour that fix implements. With it, the suite is 3259/3259, up from 3240 at `v0.8.3`.

Worth noting the dependency is new coverage, not a regression: `v0.8.3` passes both with and without #7254, because `v8.1.3` has no cross-frame case. `EXTRA_SKIPS` in `tooling/ef_tests/blockchain/tests/all.rs` stays empty.

Nothing in the guest contract moves: the schema id is still `0x1501`, `state`, `codes` and `public_keys` are still progressive lists, and `headers` is still bounded at 256.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync. — not applicable, no `Store` changes.
