### PR TITLE
fix(levm): repay spilled state gas from the reservoir when a child merges (EIP-8037, v8.1.4)

### DIFF
--- a/.github/config/hive/amsterdam.yaml
+++ b/.github/config/hive/amsterdam.yaml
@@ -1,7 +1,7 @@
 # Amsterdam (BAL) hive test configuration
-# Pinned to tests-glamsterdam-devnet@v8.1.3 (execution-specs `devnets/glamsterdam/8`).
+# Pinned to tests-glamsterdam-devnet@v8.1.4 (execution-specs `devnets/glamsterdam/8`).
 # Keep this in lock-step with `tooling/ef_tests/.fixtures_url_amsterdam`: the two pins
 # grade the same client, so a release that only one of them follows fails every fixture
 # the other release changed.
-fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.3/fixtures_glamsterdam-devnet.tar.gz
-eels_commit: 8ca2f4ceefd83100a4d21d0c33747114278a0bc2
+fixtures: https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.4/fixtures_glamsterdam-devnet.tar.gz
+eels_commit: 7341820b5b394b1934dfe7bb6f621fcdab7baf7f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Perf
 
+### 2026-09-03
+
+- EIP-8037 (execution-specs#3478, consensus-breaking): when a successful child frame merges, the state-gas reservoir now repays the spill still outstanding in the merged frame back into `gas_remaining`, debiting the reservoir by the same amount. A cross-frame refund can credit the reservoir while the `gas_remaining` that funded the charge stays reduced; the merge is the first point where the claim and the credit share a frame. Billing-neutral by construction — the user total (`gas_limit - gas_remaining - reservoir`) and the EIP-7778 dimensions are unchanged — but it changes how much execution gas a parent frame has after a child returns, so it is consensus-visible. Fixtures move to `tests-glamsterdam-devnet@v8.1.4` [#7250](https://github.com/lambdaclass/ethrex/pull/7250)
+
 ### 2026-08-24
 
 - Make `eth_estimateGas`'s plain-transfer short circuit fire. Its condition tested whether the recipient account existed rather than whether it had code, so every transfer to an ordinary funded wallet ran the full binary search instead of returning `TRANSACTION_GAS` at once [#7211](https://github.com/lambdaclass/ethrex/pull/7211)

--- a/crates/vm/levm/src/opcode_handlers/system.rs
+++ b/crates/vm/levm/src/opcode_handlers/system.rs
@@ -1436,6 +1436,12 @@ impl<'a> VM<'a> {
                     .frame_state_gas_spilled
                     .checked_add(child_frame_state_gas_spilled)
                     .ok_or(InternalError::Overflow)?;
+                // EIP-8037 (execution-specs#3478): with the child's gas merged in, the
+                // reservoir repays whatever spill is still outstanding in this frame —
+                // EELS calls `repay_state_gas_spill` here, on the success arm only.
+                if self.env.config.fork >= Fork::Amsterdam {
+                    self.repay_state_gas_spill()?;
+                }
             }
             TxResult::Revert(_) => {
                 // EIP-8037: the child already self-refilled its execution state gas via
@@ -1505,6 +1511,12 @@ impl<'a> VM<'a> {
                     .frame_state_gas_spilled
                     .checked_add(child_frame_state_gas_spilled)
                     .ok_or(InternalError::Overflow)?;
+                // EIP-8037 (execution-specs#3478): with the child's gas merged in, the
+                // reservoir repays whatever spill is still outstanding in this frame —
+                // EELS calls `repay_state_gas_spill` here, on the success arm only.
+                if self.env.config.fork >= Fork::Amsterdam {
+                    self.repay_state_gas_spill()?;
+                }
                 // EIP-8037 (#3002): the parent charged the NEW_ACCOUNT state gas only
                 // when the target was NOT alive (`new_account_charged = !target_alive`),
                 // exactly as EELS `generic_create`. On child success EELS does not

--- a/crates/vm/levm/src/vm.rs
+++ b/crates/vm/levm/src/vm.rs
@@ -1237,6 +1237,63 @@ impl<'a> VM<'a> {
         Ok(())
     }
 
+    /// EIP-8037 `repay_state_gas_spill` (EELS `incorporate_child`, success arm): once a
+    /// successful child's gas has merged into this frame, the reservoir repays the spill
+    /// still outstanding, up to what the reservoir holds.
+    ///
+    /// A refund can land in a different frame than the charge it undoes: the refunding
+    /// frame's spill may be smaller than the refund, so the excess credits the reservoir
+    /// even though the charge drew from `gas_remaining`. The merge is where the claim
+    /// (this frame's spill) and the credit (the reservoir) first share a frame, so that
+    /// is where the two pools settle between themselves.
+    ///
+    /// No state creation is undone, so `state_gas_used` does not move: the gas only
+    /// crosses back between the pools it drifted across. Both settlements stay
+    /// unchanged, which is what makes this repayment billing-neutral:
+    /// - user gas (`gas_limit - gas_remaining - state_gas_reservoir`) is unchanged
+    ///   because `gas_remaining` rises by exactly what the reservoir loses;
+    /// - the EIP-7778 regular dimension subtracts the cumulative `state_gas_spill`, so
+    ///   that counter drops by the repayment too — the reservoir (the state dimension)
+    ///   covered the charge after all, so it must stop being billed as regular gas.
+    ///
+    /// A failed child repays nothing: its rollback already restored the state whose
+    /// removal any refund credited.
+    #[expect(
+        clippy::arithmetic_side_effects,
+        reason = "subtractions proven safe by min()"
+    )]
+    pub fn repay_state_gas_spill(&mut self) -> Result<(), VMError> {
+        debug_assert!(
+            self.env.config.fork >= Fork::Amsterdam,
+            "repay_state_gas_spill called pre-Amsterdam"
+        );
+        let repayment = self
+            .state_gas_reservoir
+            .min(self.current_call_frame.frame_state_gas_spilled);
+        if repayment == 0 {
+            return Ok(());
+        }
+        self.current_call_frame.gas_remaining = self
+            .current_call_frame
+            .gas_remaining
+            .checked_add(i64::try_from(repayment).map_err(|_| InternalError::Overflow)?)
+            .ok_or(InternalError::Overflow)?;
+        // Safe: repayment = min(reservoir, frame spill) <= both.
+        self.state_gas_reservoir -= repayment;
+        self.current_call_frame.frame_state_gas_spilled -= repayment;
+        // Block accounting: every frame spill is mirrored in the cumulative counter, so
+        // it covers this repayment (`checked_sub` guards the invariant regardless).
+        self.state_gas_spill = self
+            .state_gas_spill
+            .checked_sub(repayment)
+            .ok_or(InternalError::Underflow)?;
+        // EELS asserts the claim and the credit cannot both survive a repayment.
+        debug_assert!(
+            self.state_gas_reservoir == 0 || self.current_call_frame.frame_state_gas_spilled == 0
+        );
+        Ok(())
+    }
+
     /// EIP-8037 `refill_frame_state_gas`: roll back this frame's state gas in LIFO
     /// order on revert or exceptional halt, mirroring EELS `refill_frame_state_gas`.
     ///

--- a/tooling/ef_tests/.fixtures_url_amsterdam
+++ b/tooling/ef_tests/.fixtures_url_amsterdam
@@ -1,1 +1,1 @@
-https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.3/fixtures_glamsterdam-devnet.tar.gz
+https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet%40v8.1.4/fixtures_glamsterdam-devnet.tar.gz


### PR DESCRIPTION
## Motivation

[tests-glamsterdam-devnet@v8.1.4](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v8.1.4) (EELS `devnets/glamsterdam/8` @ `7341820b`) carries a **consensus-breaking EIP-8037 change** — [execution-specs#3478](https://github.com/ethereum/execution-specs/pull/3478): when a successful child frame merges, the state-gas reservoir repays the parent's outstanding spill into `gas_left`, debiting the reservoir by the same amount.

The case it fixes: a refund can land in a different frame than the charge it undoes. The refunding frame's spill may be smaller than the refund, so the excess credits the reservoir even though the charge drew from `gas_left`. The merge is the first point where the claim (the frame's spill) and the credit (the reservoir) share one meter, so that is where the two pools settle between themselves. A failed child repays nothing — its rollback already restored the state whose removal any refund credited.

## Description

`VM::repay_state_gas_spill` mirrors EELS `repay_state_gas_spill`, called from both merge paths (`handle_return_call` and `handle_return_create`, success arms only, Amsterdam-gated) right after the child's per-frame spill is propagated — matching EELS, which merges both pools in `incorporate_child` and only then repays.

`repayment = min(state_gas_reservoir, frame_state_gas_spilled)`, then `gas_remaining += repayment`, `reservoir -= repayment`, `frame spill -= repayment`. ethrex's reservoir is already VM-global, so EELS's `state_gas_left` merge is implicit; the frame-spill propagation is the other half and already existed.

**The non-obvious part — and the reason this isn't a one-liner.** The repayment must stay billing-neutral, exactly as in EELS where `gas_used_before_refund = tx_gas - gas_left - state_gas_left` (the sum is invariant) and the used counters do not move:

- User total: ethrex computes `gas_limit - gas_remaining - state_gas_reservoir`, so it is unchanged — `gas_remaining` rises by exactly what the reservoir loses.
- EIP-7778 regular dimension: ethrex derives it as `raw_consumed - intrinsic_state - reservoir_initial - state_gas_spill`. The repayment lowers `raw_consumed`, so the cumulative `state_gas_spill` must drop by the repayment too, or **the block's regular dimension would silently shrink by every repayment**. Conceptually right as well: the reservoir (the state dimension) covered that charge after all, so it must stop being billed as regular gas. This mirrors what `credit_state_gas_refund` already does for its `gas_remaining`-credited portion.

What *does* change, and is consensus-visible, is how much execution gas a parent frame holds after a child returns — which is the point of the spec change.

Fixture pins move to v8.1.4 in lock-step (`tooling/ef_tests/.fixtures_url_amsterdam` + `.github/config/hive/amsterdam.yaml` with `eels_commit 7341820b`), as that file's comment requires.

## Validation

On v8.1.4 fixtures:
- engine: **79,508 / 79,508** fixtures (11,067 tests)
- state: **8,993 groups, all 100%** (includes the expanded cross-frame/nested/delegation/reuse coverage)
- blockchain: **3,218** tests
- `make lint`, `cargo test --workspace --no-run`, `cargo fmt --check`: clean

**Negative control** (the check that this isn't fixture-chasing): reverting only the `repay_state_gas_spill()` call and re-running the engine suite fails **13 fixtures, every one in `test_state_gas_cross_frame_refund`** — the suite the spec change added. Restored: back to 79,508/79,508.

## How to test

```
cd tooling/ef_tests/engine && make amsterdam-vectors && make test
cd tooling/ef_tests/state && make amsterdam-vectors && make run-evm-ef-tests-ci
```
