### PR TITLE
fix(l1): distinguish a disabled RPC namespace from an unimplemented method

### DIFF
--- a/crates/l2/networking/rpc/rpc.rs
+++ b/crates/l2/networking/rpc/rpc.rs
@@ -348,17 +348,23 @@ pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Resu
                 .allowed_namespaces
                 .contains(&L1RpcNamespace::Eth)
             {
-                return Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotFound(
-                    req.method.clone(),
-                )));
+                return Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotServedHere {
+                    method: req.method.clone(),
+                    reason: "the 'eth' namespace is not enabled on this endpoint; add it to \
+                             --http.api"
+                        .to_string(),
+                }));
             }
             map_eth_requests(req, context).await
         }
         Ok(RpcNamespace::EthrexL2) => {
             if !context.ethrex_namespace_allowed {
-                return Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotFound(
-                    req.method.clone(),
-                )));
+                return Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotServedHere {
+                    method: req.method.clone(),
+                    reason: "the 'ethrex' namespace is disabled on this endpoint; enable it with \
+                             --http.api.ethrex"
+                        .to_string(),
+                }));
             }
             map_l2_requests(req, context).await
         }
@@ -442,7 +448,8 @@ mod tests {
     }
 
     /// With `--http.api.ethrex=false`, L2-specific `ethrex_*` methods must be
-    /// rejected at the dispatcher with MethodNotFound and never reach handlers.
+    /// rejected at the dispatcher and never reach handlers — while still saying
+    /// the namespace is disabled rather than unimplemented.
     #[tokio::test]
     async fn ethrex_namespace_blocked_when_disabled() {
         let body = r#"{"jsonrpc":"2.0","method":"ethrex_batchNumber","params":[],"id":1}"#;
@@ -451,10 +458,14 @@ mod tests {
 
         let result = map_http_requests(&request, context).await;
         match result {
-            Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotFound(method))) => {
+            Err(RpcErr::L1RpcErr(ethrex_rpc::RpcErr::MethodNotServedHere { method, reason })) => {
                 assert_eq!(method, "ethrex_batchNumber");
+                assert!(
+                    reason.contains("--http.api.ethrex"),
+                    "names the flag: {reason}"
+                );
             }
-            other => panic!("expected MethodNotFound, got {other:?}"),
+            other => panic!("expected MethodNotServedHere, got {other:?}"),
         }
     }
 }

--- a/crates/networking/rpc/debug/execution_witness.rs
+++ b/crates/networking/rpc/debug/execution_witness.rs
@@ -14,7 +14,10 @@ impl RpcHandler for ExecutionWitnessRequest {
         let params = params
             .as_ref()
             .ok_or(RpcErr::BadParams("No params provided".to_owned()))?;
-        if params.len() > 2 {
+        // The lower bound matters as much as the upper one: `params[0]` below
+        // panics on an empty array, which drops the connection with no
+        // JSON-RPC response at all instead of reporting a bad request.
+        if params.is_empty() || params.len() > 2 {
             return Err(RpcErr::BadParams(format!(
                 "Expected one or two params and {} were provided",
                 params.len()
@@ -102,5 +105,59 @@ impl RpcHandler for ExecutionWitnessRequest {
 
         serde_json::to_value(rpc_execution_witness)
             .map_err(|error| RpcErr::Internal(error.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// `debug_executionWitness` with `params: []` used to index `params[0]` past
+    /// the end of an empty vector. The panic unwound through the connection task,
+    /// so the caller got a dropped connection and no JSON-RPC response at all.
+    #[test]
+    fn empty_params_are_rejected_instead_of_panicking() {
+        let err = ExecutionWitnessRequest::parse(&Some(vec![]))
+            .err()
+            .expect("empty params must not parse");
+        assert!(
+            matches!(err, RpcErr::BadParams(_)),
+            "expected BadParams, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_params_are_rejected() {
+        let err = ExecutionWitnessRequest::parse(&None)
+            .err()
+            .expect("absent params must not parse");
+        assert!(
+            matches!(err, RpcErr::BadParams(_)),
+            "expected BadParams, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn one_or_two_block_identifiers_parse() {
+        let single = ExecutionWitnessRequest::parse(&Some(vec![json!("latest")]))
+            .expect("a single block identifier is a valid request");
+        assert!(single.to.is_none());
+
+        let range = ExecutionWitnessRequest::parse(&Some(vec![json!("0x1"), json!("0x2")]))
+            .expect("a block range is a valid request");
+        assert!(range.to.is_some());
+    }
+
+    #[test]
+    fn more_than_two_params_are_rejected() {
+        let err =
+            ExecutionWitnessRequest::parse(&Some(vec![json!("0x1"), json!("0x2"), json!("0x3")]))
+                .err()
+                .expect("three params must not parse");
+        assert!(
+            matches!(err, RpcErr::BadParams(_)),
+            "expected BadParams, got {err:?}"
+        );
     }
 }

--- a/crates/networking/rpc/rpc.rs
+++ b/crates/networking/rpc/rpc.rs
@@ -403,6 +403,7 @@ pub trait RpcHandler: Sized {
 fn get_error_kind(err: &RpcErr) -> &'static str {
     match err {
         RpcErr::MethodNotFound(_) => "MethodNotFound",
+        RpcErr::MethodNotServedHere { .. } => "MethodNotServedHere",
         RpcErr::WrongParam(_) => "WrongParam",
         RpcErr::BadParams(_) => "BadParams",
         RpcErr::InvalidParams(_) => "InvalidParams",
@@ -1186,7 +1187,8 @@ where
             // a node started with e.g. `--http.api web3` would still expose
             // `eth_subscribe("newHeads")` over WS.
             if !context.allowed_namespaces.contains(&RpcNamespace::Eth) {
-                let err: Result<Value, RpcErr> = Err(RpcErr::MethodNotFound(req.method.clone()));
+                let err: Result<Value, RpcErr> =
+                    Err(namespace_not_enabled(&req.method, RpcNamespace::Eth));
                 return rpc_response(req.id, err).ok();
             }
             let result = if req.method == "eth_subscribe" {
@@ -1304,14 +1306,49 @@ pub async fn handle_eth_unsubscribe(
     Ok(Value::Bool(removed))
 }
 
+/// `-32601` for a method whose namespace ethrex implements but this endpoint is
+/// not configured to serve. Naming the namespace and the flag keeps a disabled
+/// allowlist from reading like an unimplemented method.
+fn namespace_not_enabled(method: &str, namespace: RpcNamespace) -> RpcErr {
+    RpcErr::MethodNotServedHere {
+        method: method.to_string(),
+        reason: format!(
+            "the '{}' namespace is not enabled on this endpoint; add it to --http.api",
+            namespace.as_prefix()
+        ),
+    }
+}
+
+/// `-32601` for `engine_*` reaching the public HTTP port. Distinct from
+/// [`namespace_not_enabled`]: `--http.api` refuses `engine` outright, so telling
+/// the caller to add it there would send them down a dead end.
+fn engine_not_on_http(method: &str) -> RpcErr {
+    RpcErr::MethodNotServedHere {
+        method: method.to_string(),
+        reason: "the 'engine' namespace is served on the authenticated RPC port \
+                 (--authrpc.port), not on the public HTTP port"
+            .to_string(),
+    }
+}
+
 /// Handle requests that can come from either clients or other users
 pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Result<Value, RpcErr> {
     let namespace = match req.namespace() {
         Ok(ns) => ns,
         Err(rpc_err) => return Err(rpc_err),
     };
+    // Engine is served on the authenticated port only. The CLI parser already
+    // rejects `--http.api engine`, but `allowed_namespaces` can also be built
+    // programmatically (e.g. in tests or future call sites), so HTTP dispatch
+    // must refuse Engine even if it ends up in the set. This runs *before* the
+    // allowlist check because `engine` is never in the allowlist on a real node:
+    // otherwise every `engine_*` call over HTTP would be told to add `engine` to
+    // a flag that rejects it.
+    if namespace == RpcNamespace::Engine {
+        return Err(engine_not_on_http(&req.method));
+    }
     if !context.allowed_namespaces.contains(&namespace) {
-        return Err(RpcErr::MethodNotFound(req.method.clone()));
+        return Err(namespace_not_enabled(&req.method, namespace));
     }
     match namespace {
         RpcNamespace::Eth => map_eth_requests(req, context).await,
@@ -1321,11 +1358,10 @@ pub async fn map_http_requests(req: &RpcRequest, context: RpcApiContext) -> Resu
         RpcNamespace::Net => map_net_requests(req, context).await,
         RpcNamespace::Mempool => map_mempool_requests(req, context),
         RpcNamespace::Testing => map_testing_requests(req, context).await,
-        // Engine is served on the authenticated port only. The CLI parser
-        // already rejects `--http.api engine`, but `allowed_namespaces` can
-        // also be built programmatically (e.g. in tests or future call sites),
-        // so HTTP dispatch must refuse Engine even if it ends up in the set.
-        RpcNamespace::Engine => Err(RpcErr::MethodNotFound(req.method.clone())),
+        // Unreachable: the guard above already returned. Kept so the match stays
+        // exhaustive without a catch-all arm that would silently route a
+        // namespace added later.
+        RpcNamespace::Engine => Err(engine_not_on_http(&req.method)),
     }
 }
 
@@ -1337,7 +1373,14 @@ pub async fn map_authrpc_requests(
     match req.namespace() {
         Ok(RpcNamespace::Engine) => map_engine_requests(req, context).await,
         Ok(RpcNamespace::Eth) => map_eth_requests(req, context).await,
-        _ => Err(RpcErr::MethodNotFound(req.method.clone())),
+        // A known namespace that this port does not serve is not the same as an
+        // unparseable method name, which `namespace()` already rejects.
+        Ok(_) => Err(RpcErr::MethodNotServedHere {
+            method: req.method.clone(),
+            reason: "the authenticated RPC port only serves the 'engine' and 'eth' namespaces"
+                .to_string(),
+        }),
+        Err(rpc_err) => Err(rpc_err),
     }
 }
 
@@ -1615,8 +1658,10 @@ mod tests {
     use std::{fs::File, path::Path};
 
     /// With the default `--http.api` allowlist (`eth,net,web3`), requests for
-    /// disabled namespaces like `debug_*` must return MethodNotFound and never
-    /// reach the handler.
+    /// disabled namespaces like `debug_*` must be refused before the handler and
+    /// must say *why*: a bare "Method not found" reads as "ethrex does not
+    /// implement `debug_traceTransaction`", which is what operators kept
+    /// concluding.
     #[tokio::test]
     async fn http_api_allowlist_blocks_debug_namespace_by_default() {
         let body = r#"{"jsonrpc":"2.0","method":"debug_traceTransaction","params":["0x0"],"id":1}"#;
@@ -1632,11 +1677,39 @@ mod tests {
 
         let result = map_http_requests(&request, context).await;
         match result {
-            Err(RpcErr::MethodNotFound(method)) => {
+            Err(RpcErr::MethodNotServedHere { method, reason }) => {
                 assert_eq!(method, "debug_traceTransaction");
+                assert!(reason.contains("'debug'"), "names the namespace: {reason}");
+                assert!(reason.contains("--http.api"), "names the flag: {reason}");
             }
-            other => panic!("expected MethodNotFound, got {other:?}"),
+            other => panic!("expected MethodNotServedHere, got {other:?}"),
         }
+    }
+
+    /// The reason must reach the wire under the spec's `-32601`, so a client that
+    /// keys on the code is unaffected while a human (or an agent) reading the
+    /// message learns the method exists.
+    #[test]
+    fn namespace_not_enabled_serializes_as_method_not_found() {
+        let meta: RpcErrorMetadata =
+            namespace_not_enabled("txpool_content", RpcNamespace::Mempool).into();
+        assert_eq!(meta.code, -32601);
+        assert!(
+            meta.message.contains("txpool_content"),
+            "names the method: {}",
+            meta.message
+        );
+        // The CLI spelling, not the enum variant name: `--http.api txpool`.
+        assert!(
+            meta.message.contains("'txpool'"),
+            "names the CLI namespace: {}",
+            meta.message
+        );
+        assert!(
+            meta.message.contains("--http.api"),
+            "names the flag: {}",
+            meta.message
+        );
     }
 
     /// A bind conflict must surface as a typed `RpcStartupError` naming the role and the
@@ -1676,7 +1749,10 @@ mod tests {
             let request: RpcRequest = serde_json::from_str(&body).unwrap();
             let result = map_http_requests(&request, context.clone()).await;
             assert!(
-                !matches!(result, Err(RpcErr::MethodNotFound(_))),
+                !matches!(
+                    result,
+                    Err(RpcErr::MethodNotFound(_) | RpcErr::MethodNotServedHere { .. })
+                ),
                 "default allowlist should route {method}, got {result:?}"
             );
         }
@@ -1733,6 +1809,40 @@ mod tests {
         );
     }
 
+    /// On a normally-configured node `engine` is simply absent from the
+    /// allowlist, so this is the path every real `engine_*` call over HTTP takes.
+    /// It must point at the authenticated port rather than at `--http.api`, which
+    /// refuses `engine`.
+    #[tokio::test]
+    async fn engine_namespace_on_http_points_at_the_authenticated_port() {
+        let body = r#"{"jsonrpc":"2.0","method":"engine_forkchoiceUpdatedV3","params":[],"id":1}"#;
+        let request: RpcRequest = serde_json::from_str(body).unwrap();
+        let mut storage =
+            Store::new("temp.db", EngineType::InMemory).expect("Failed to create test DB");
+        storage
+            .set_chain_config(&example_chain_config())
+            .await
+            .unwrap();
+        let mut context = default_context_with_storage(storage).await;
+        context.allowed_namespaces = Arc::new(crate::DEFAULT_HTTP_API.iter().copied().collect());
+
+        let result = map_http_requests(&request, context).await;
+        match result {
+            Err(RpcErr::MethodNotServedHere { method, reason }) => {
+                assert_eq!(method, "engine_forkchoiceUpdatedV3");
+                assert!(
+                    reason.contains("--authrpc.port"),
+                    "points at the authenticated port: {reason}"
+                );
+                assert!(
+                    !reason.contains("--http.api"),
+                    "must not send the caller to a flag that rejects `engine`: {reason}"
+                );
+            }
+            other => panic!("expected MethodNotServedHere, got {other:?}"),
+        }
+    }
+
     /// The Engine namespace must never be served over the public HTTP endpoint,
     /// even if an operator passes `engine` to `--http.api` (the CLI rejects it,
     /// but defense-in-depth: the dispatcher still refuses).
@@ -1753,7 +1863,16 @@ mod tests {
         context.allowed_namespaces = Arc::new(all_with_engine);
 
         let result = map_http_requests(&request, context).await;
-        assert!(matches!(result, Err(RpcErr::MethodNotFound(_))));
+        match result {
+            Err(RpcErr::MethodNotServedHere { method, reason }) => {
+                assert_eq!(method, "engine_forkchoiceUpdatedV3");
+                assert!(
+                    reason.contains("--authrpc.port"),
+                    "points at the authenticated port: {reason}"
+                );
+            }
+            other => panic!("expected MethodNotServedHere, got {other:?}"),
+        }
     }
 
     // Maps string rpc response to RpcSuccessResponse as serde Value

--- a/crates/networking/rpc/utils.rs
+++ b/crates/networking/rpc/utils.rs
@@ -28,6 +28,13 @@ use ethrex_blockchain::error::MempoolError;
 pub enum RpcErr {
     #[error("Method not found: {0}")]
     MethodNotFound(String),
+    /// Also `-32601`, but for a method this build *does* implement and this
+    /// endpoint does not serve: its namespace is off the `--http.api` allowlist,
+    /// or it belongs to the other RPC port. The reason travels in the message so
+    /// callers stop reading a bare "Method not found" as "ethrex has not
+    /// implemented this method".
+    #[error("Method not found: {method} ({reason})")]
+    MethodNotServedHere { method: String, reason: String },
     #[error("Wrong parameter: {0}")]
     WrongParam(String),
     #[error("Invalid params: {0}")]
@@ -98,6 +105,11 @@ impl From<RpcErr> for RpcErrorMetadata {
                 code: -32601,
                 data: None,
                 message: format!("Method not found: {bad_method}"),
+            },
+            RpcErr::MethodNotServedHere { method, reason } => RpcErrorMetadata {
+                code: -32601,
+                data: None,
+                message: format!("Method not found: {method} ({reason})"),
             },
             RpcErr::WrongParam(field) => RpcErrorMetadata {
                 code: -32602,
@@ -289,6 +301,23 @@ pub enum RpcNamespace {
 }
 
 impl RpcNamespace {
+    /// Renders the namespace back to its CLI/method-prefix form, the inverse of
+    /// [`RpcNamespace::from_prefix`]. Error messages use this so operators see
+    /// the exact string they would pass to `--http.api` (`txpool`, not
+    /// `Mempool`).
+    pub fn as_prefix(self) -> &'static str {
+        match self {
+            RpcNamespace::Engine => "engine",
+            RpcNamespace::Eth => "eth",
+            RpcNamespace::Admin => "admin",
+            RpcNamespace::Debug => "debug",
+            RpcNamespace::Web3 => "web3",
+            RpcNamespace::Net => "net",
+            RpcNamespace::Mempool => "txpool",
+            RpcNamespace::Testing => "testing",
+        }
+    }
+
     /// Parses a namespace name from its CLI/method-prefix form.
     pub fn from_prefix(s: &str) -> Option<Self> {
         match s {
@@ -482,5 +511,41 @@ pub fn parse_json_hex(hex: &serde_json::Value) -> Result<u64, String> {
         maybe_parsed.map_err(|_| format!("Could not parse given hex {maybe_hex}"))
     } else {
         Err(format!("Could not parse given hex {hex}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `as_prefix` feeds `--http.api` advice in error messages, so it must stay
+    /// the exact inverse of the parser operators' input goes through. Drift would
+    /// tell someone to enable a namespace under a name the CLI rejects.
+    #[test]
+    fn namespace_prefix_round_trips() {
+        for namespace in [
+            RpcNamespace::Engine,
+            RpcNamespace::Eth,
+            RpcNamespace::Admin,
+            RpcNamespace::Debug,
+            RpcNamespace::Web3,
+            RpcNamespace::Net,
+            RpcNamespace::Mempool,
+            RpcNamespace::Testing,
+        ] {
+            let prefix = namespace.as_prefix();
+            assert_eq!(
+                RpcNamespace::from_prefix(prefix),
+                Some(namespace),
+                "{namespace:?} renders as {prefix:?}, which does not parse back"
+            );
+        }
+    }
+
+    /// The `txpool_*` methods live under the `Mempool` variant, so the CLI name
+    /// and the variant name genuinely differ. Error messages must use the former.
+    #[test]
+    fn mempool_renders_as_its_cli_name() {
+        assert_eq!(RpcNamespace::Mempool.as_prefix(), "txpool");
     }
 }


### PR DESCRIPTION
**Motivation**

A `debug_*` call against a stock node returns a bare `Method not found`, which reads as "ethrex does not implement this method". Tooling that probes the standard RPC surface keeps drawing that conclusion — the same failure shape already documented at the top of `test/tests/rpc/missing_rpc_methods_tests.rs`, where differential testing reported ethrex as lacking functionality it largely already had.

The cause is not the request: `--http.api` defaults to `eth,net,web3`, so on a stock node every `debug_*` request is refused by the namespace allowlist before the handler ever sees its params. Reproduced against a running node — the response is identical with valid params, with empty params, and with no `params` field at all:

| request | response |
|---|---|
| `debug_traceBlockByNumber` `["latest"]` | `-32601 Method not found` |
| `debug_traceBlockByNumber` `[]` | `-32601 Method not found` |
| `debug_chainConfig` (no `params` field) | `-32601 Method not found` |

Investigating it surfaced a second, unrelated defect: one handler panics on empty params and drops the connection.

**Description**

*Distinguish "not served here" from "not implemented".* Adds `RpcErr::MethodNotServedHere { method, reason }` for a method this build implements but this endpoint does not serve. The code stays `-32601`, which is correct per JSON-RPC 2.0 and matches geth's behaviour for a disabled module, so any client keying on the code is unaffected; only the message gains the reason. A genuinely unknown method still returns the bare `MethodNotFound`, so the two cases are now distinguishable.

```
debug_traceCall             -32601  Method not found: debug_traceCall (the 'debug' namespace is not
                                    enabled on this endpoint; add it to --http.api)
txpool_content              -32601  Method not found: txpool_content (the 'txpool' namespace is not
                                    enabled on this endpoint; add it to --http.api)
engine_forkchoiceUpdatedV3  -32601  Method not found: engine_forkchoiceUpdatedV3 (the 'engine'
                                    namespace is served on the authenticated RPC port
                                    (--authrpc.port), not on the public HTTP port)
bogus_method                -32601  Method not found: bogus_method
```

Applied to every sibling refusal, not just the HTTP allowlist: the authenticated port's non-`engine`/`eth` rejection, the WebSocket `eth_subscribe` allowlist guard, and the L2 dispatcher's `eth` and `ethrex` guards — the last naming `--http.api.ethrex`, which is the flag that actually controls it.

`engine_*` over HTTP is now checked *before* the allowlist. It previously fell through to the allowlist branch and was told to add `engine` to `--http.api`, a flag whose parser rejects `engine` outright; it now points at `--authrpc.port`.

`RpcNamespace::as_prefix` renders the CLI spelling (`txpool`, not `Mempool`) and has a round-trip test against `from_prefix`, so the advice cannot drift into naming something the CLI would refuse.

*Fix the panic.* `debug_executionWitness` bounded its params only from above (`params.len() > 2`) and then indexed `params[0]`, so `"params": []` panicked with an index-out-of-bounds inside the connection task — the caller got a dropped connection and no JSON-RPC response at all, and the node logged:

```
thread 'tokio-rt-worker' panicked at crates/networking/rpc/debug/execution_witness.rs:24:49:
index out of bounds: the len is 0 but the index is 0
```

Every sibling handler (`eth_call`, `eth_estimateGas`, `eth_createAccessList`, `debug_traceCall`, `engine_forkchoiceUpdated*`) already had the `is_empty()` guard; this one was missing it. Sweeping all 68 dispatched non-`engine` methods against `[]`, `[null]`, `[null,null]` and `[null,null,null]` confirms it was the only method in the whole surface that could be made to drop a connection, and that none can after the fix.

**How to Test**

```bash
# Panic regression — was an empty reply (curl exit 52), now a param error.
cargo run --bin ethrex -- --dev --http.api eth,net,web3,debug --datadir memory
curl -s -X POST -H 'content-type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"debug_executionWitness","params":[]}' \
  http://localhost:8545

# Namespace message — run without --http.api to get the default allowlist.
cargo run --bin ethrex -- --dev --datadir memory
curl -s -X POST -H 'content-type: application/json' \
  --data '{"jsonrpc":"2.0","id":1,"method":"debug_traceCall","params":[]}' \
  http://localhost:8545
```

Unit coverage: `cargo test -p ethrex-rpc -p ethrex-l2-rpc --lib` and `cargo test -p ethrex-test --test ethrex_tests`.

**Out of scope**

Param errors return `-32000` (`RpcErr::BadParams`) across the entire RPC surface where JSON-RPC 2.0 specifies `-32602`. The crate already has an `InvalidParams` variant at `-32602` and the migration is happening spot by spot (#7236 did `eth_getLogs`); a blanket change touches every namespace and its test expectations, so it is left for its own PR. Related, also untouched: `"params": {}` returns `-32000 "Invalid request body"` with `"id": ""`, where the spec wants `-32600` with the request's id.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
