### PR TITLE
build(l1,l2): resolve Cargo.lock updates under a 14-day publish-age cooldown

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,16 @@ rustflags = [
     "-Ctarget-cpu=x86-64-v3",
     "-Ctarget-feature=+avx2,+sse2,+ssse3,+sse4.1,+sse4.2,+bmi1,+lzcnt,+pclmulqdq",
 ]
+
+# Supply-chain cooldown for dependency resolution (unstable min-publish-age,
+# tracking issue rust-lang/cargo#17009): crate versions published less than
+# 14 days ago are excluded when the resolver runs on a nightly cargo.
+# Stable cargo ignores these tables silently, so builds from the committed
+# Cargo.lock files are unaffected; `make update-cargo-lock` resolves under the
+# policy. When the feature stabilizes, drop the [unstable] table and the
+# nightly resolver pin in the Makefile: the policy then binds all resolution.
+[unstable]
+min-publish-age = true
+
+[registry]
+global-min-publish-age = "14 days"

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -466,12 +466,28 @@ jobs:
         run: |
           make check-cargo-lock
 
+  cooldown-check:
+    name: Check dependency cooldown
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.run_tests == 'true' }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      # Stable cargo ignores the publish-age cooldown in .cargo/config.toml, so a
+      # lockfile can pin too-young crates. If this fails, re-resolve the offending
+      # lockfile with `make update-cargo-lock` or wait for the crate to age out.
+      - name: Check Cargo.lock files against the publish-age cooldown
+        run: |
+          make cooldown-check
+
   # The purpose of this job is to add it as a required check in GitHub so that we don't have to add every individual job as a required check
   all-tests:
     # "Integration Test" is a required check, don't change the name
     name: Integration Test
     runs-on: ubuntu-latest
-    needs: [detect-changes, run-assertoor, run-hive, check-cargo-locks, engine-ef-tests]
+    needs: [detect-changes, run-assertoor, run-hive, check-cargo-locks, cooldown-check, engine-ef-tests]
     # Make sure this job runs even if the previous jobs failed or were skipped
     if: ${{ needs.detect-changes.outputs.run_tests == 'true' && always() && needs.run-assertoor.result != 'skipped' && needs.run-hive.result != 'skipped' }}
     steps:
@@ -484,6 +500,11 @@ jobs:
 
           if [ "${{ needs.run-hive.result }}" != "success" ]; then
             echo "Job Hive failed"
+            exit 1
+          fi
+
+          if [ "${{ needs.cooldown-check.result }}" != "success" ]; then
+            echo "Job Check dependency cooldown failed"
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ Thank you for your interest in contributing to ethrex! Please read the following
 1. Fork the repository and create your branch from `main`.
 2. Make your changes, following the code style guidelines below.
 3. Run tests locally to ensure nothing is broken.
+   If you changed a dependency in any `Cargo.toml`, refresh the lockfiles with `make update-cargo-lock`
+   rather than a plain `cargo update`: it resolves under a 14-day publish-age cooldown
+   (`.cargo/config.toml`) that skips freshly published crate versions as a supply-chain precaution.
+   For an urgent bump to a version younger than that, prefix the command with
+   `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` and review the whole lockfile diff.
 4. Open a pull request with a descriptive title (see PR naming rules below).
 5. Fill in the PR template if available, and link related issues.
 

--- a/Makefile
+++ b/Makefile
@@ -261,18 +261,14 @@ docs-serve: mermaid-init.js mermaid.min.js ## 📚 Generate and serve the docume
 
 # Used ONLY to resolve lockfile updates: the publish-age cooldown in
 # .cargo/config.toml (versions published less than 14 days ago are excluded) is
-# nightly-only; everything else runs on the stable toolchain in rust-toolchain.toml.
-# Resolution done on stable (`cargo add`, plain `cargo update`, an unlocked build
-# after a manifest edit) is NOT covered; this target is the intended path. Git
+# nightly-only; everything else runs on the stable toolchain in rust-toolchain.toml. Git
 # dependencies have no publish age and are refreshed WITHOUT any cooldown: review
-# their lockfile rev changes manually. Escape hatch for an urgent bump to a
-# version younger than the cooldown, applied to the WHOLE resolution:
-#   CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow make update-cargo-lock
+# their lockfile rev changes manually.
 RESOLVER_TOOLCHAIN := nightly-2026-06-21
 CARGO_RESOLVE := cargo +$(RESOLVER_TOOLCHAIN) -Z min-publish-age tree
 
 update-cargo-lock: ## 📦 Update Cargo.lock files under the publish-age cooldown
-	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1
+	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal --no-self-update > /dev/null
 	$(CARGO_RESOLVE)
 	$(CARGO_RESOLVE) --manifest-path crates/guest-program/bin/sp1/Cargo.toml
 	# risc0 temporarily skipped: c-kzg 2.1.8 floor exceeds the highest risc0 c-kzg fork tag
@@ -288,6 +284,41 @@ update-cargo-lock: ## 📦 Update Cargo.lock files under the publish-age cooldow
 	$(CARGO_RESOLVE) --manifest-path tooling/zkevm_bench/Cargo.toml
 	$(CARGO_RESOLVE) --manifest-path tooling/Cargo.toml
 	$(CARGO_RESOLVE) --manifest-path tooling/ef_tests/state/Cargo.toml
+
+# One entry per committed Cargo.lock (tooling/ef_tests/state shares tooling's;
+# risc0 is skipped for the reason above).
+COOLDOWN_MANIFESTS := Cargo.toml \
+	crates/guest-program/bin/sp1/Cargo.toml \
+	crates/guest-program/bin/zisk/Cargo.toml \
+	crates/guest-program/bin/openvm/Cargo.toml \
+	crates/guest-program/stateless-validator/Cargo.toml \
+	crates/guest-program/stateless-validator/bin/sp1/Cargo.toml \
+	crates/guest-program/stateless-validator/bin/zisk/Cargo.toml \
+	crates/guest-program/stateless-validator/bin/openvm/Cargo.toml \
+	crates/l2/tee/quote-gen/Cargo.toml \
+	crates/vm/levm/bench/revm_comparison/Cargo.toml \
+	tooling/zkevm_bench/Cargo.toml \
+	tooling/Cargo.toml
+
+# Stable cargo ignores the cooldown, so a lockfile can pin too-young crates
+# (`cargo update` on stable, or the CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow
+# escape hatch). Re-resolve each lockfile under the cooldown without touching
+# it: a pin younger than the window shows up as a downgrade annotated with the
+# too-young version's publish date (downgrades for other reasons carry no such
+# note and are not flagged). A resolution that fails for reasons unrelated to
+# age only warns; the root workspace does today, since openvm's git deps pin
+# conflicting p3-baby-bear versions and only `cargo tree` can refresh its lock.
+cooldown-check: ## 🔍 Fail if a Cargo.lock pins crates younger than the publish-age cooldown
+	@rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal --no-self-update > /dev/null && \
+	status=0; \
+	for manifest in $(COOLDOWN_MANIFESTS); do \
+		if ! out=$$(cargo +$(RESOLVER_TOOLCHAIN) update --dry-run -Z min-publish-age --manifest-path $$manifest 2>&1); then \
+			echo "WARNING: publish-age cooldown probe failed for $$manifest:"; echo "$$out" | grep -v "^ *Updating " | head -20; continue; \
+		fi; \
+		hits=$$(echo "$$out" | grep -E "^ *Downgrading .*published" || true); \
+		if [ -n "$$hits" ]; then echo "ERROR: $$manifest pins crates younger than the publish-age cooldown:"; echo "$$hits"; status=1; fi; \
+	done; \
+	exit $$status
 
 check-cargo-lock: ## 🔍 Check Cargo.lock files are up to date
 	cargo metadata --locked > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -259,22 +259,35 @@ docs: mermaid-init.js mermaid.min.js ## 📚 Generate the documentation
 docs-serve: mermaid-init.js mermaid.min.js ## 📚 Generate and serve the documentation
 	mdbook serve --open
 
-update-cargo-lock: ## 📦 Update Cargo.lock files
-	cargo tree
-	cargo tree --manifest-path crates/guest-program/bin/sp1/Cargo.toml
+# Used ONLY to resolve lockfile updates: the publish-age cooldown in
+# .cargo/config.toml (versions published less than 14 days ago are excluded) is
+# nightly-only; everything else runs on the stable toolchain in rust-toolchain.toml.
+# Resolution done on stable (`cargo add`, plain `cargo update`, an unlocked build
+# after a manifest edit) is NOT covered; this target is the intended path. Git
+# dependencies have no publish age and are refreshed WITHOUT any cooldown: review
+# their lockfile rev changes manually. Escape hatch for an urgent bump to a
+# version younger than the cooldown, applied to the WHOLE resolution:
+#   CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow make update-cargo-lock
+RESOLVER_TOOLCHAIN := nightly-2026-06-21
+CARGO_RESOLVE := cargo +$(RESOLVER_TOOLCHAIN) -Z min-publish-age tree
+
+update-cargo-lock: ## 📦 Update Cargo.lock files under the publish-age cooldown
+	rustup toolchain install $(RESOLVER_TOOLCHAIN) --profile minimal > /dev/null 2>&1
+	$(CARGO_RESOLVE)
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/bin/sp1/Cargo.toml
 	# risc0 temporarily skipped: c-kzg 2.1.8 floor exceeds the highest risc0 c-kzg fork tag
 	# (v2.1.7-risczero.0), so its lockfile can't resolve. Re-add once a >=2.1.8 tag exists.
-	cargo tree --manifest-path crates/guest-program/bin/zisk/Cargo.toml
-	cargo tree --manifest-path crates/guest-program/bin/openvm/Cargo.toml
-	cargo tree --manifest-path crates/guest-program/stateless-validator/Cargo.toml
-	cargo tree --manifest-path crates/guest-program/stateless-validator/bin/sp1/Cargo.toml
-	cargo tree --manifest-path crates/guest-program/stateless-validator/bin/zisk/Cargo.toml
-	cargo tree --manifest-path crates/guest-program/stateless-validator/bin/openvm/Cargo.toml
-	cargo tree --manifest-path crates/l2/tee/quote-gen/Cargo.toml
-	cargo tree --manifest-path crates/vm/levm/bench/revm_comparison/Cargo.toml
-	cargo tree --manifest-path tooling/zkevm_bench/Cargo.toml
-	cargo tree --manifest-path tooling/Cargo.toml
-	cargo tree --manifest-path tooling/ef_tests/state/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/bin/zisk/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/bin/openvm/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/stateless-validator/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/stateless-validator/bin/sp1/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/stateless-validator/bin/zisk/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/guest-program/stateless-validator/bin/openvm/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/l2/tee/quote-gen/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path crates/vm/levm/bench/revm_comparison/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path tooling/zkevm_bench/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path tooling/Cargo.toml
+	$(CARGO_RESOLVE) --manifest-path tooling/ef_tests/state/Cargo.toml
 
 check-cargo-lock: ## 🔍 Check Cargo.lock files are up to date
 	cargo metadata --locked > /dev/null

--- a/crates/guest-program/stateless-validator/Cargo.lock
+++ b/crates/guest-program/stateless-validator/Cargo.lock
@@ -408,7 +408,7 @@ checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -837,7 +837,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1185,7 +1185,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2531,7 +2531,7 @@ checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2625,7 +2625,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2712,7 +2712,7 @@ checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2885,7 +2885,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3224,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3256,7 +3256,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3432,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/guest-program/stateless-validator/bin/openvm/Cargo.lock
+++ b/crates/guest-program/stateless-validator/bin/openvm/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -686,7 +686,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1468,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2056,7 +2056,7 @@ checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2091,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2156,7 +2156,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2214,7 +2214,7 @@ checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2343,7 +2343,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2556,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2588,7 +2588,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/guest-program/stateless-validator/bin/sp1/Cargo.lock
+++ b/crates/guest-program/stateless-validator/bin/sp1/Cargo.lock
@@ -341,7 +341,7 @@ checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -361,7 +361,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -821,7 +821,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1164,7 +1164,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1711,9 +1711,9 @@ checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2225,7 +2225,7 @@ checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2325,7 +2325,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2421,7 +2421,7 @@ checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2568,7 +2568,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2917,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2949,7 +2949,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3116,9 +3116,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/guest-program/stateless-validator/bin/zisk/Cargo.lock
+++ b/crates/guest-program/stateless-validator/bin/zisk/Cargo.lock
@@ -199,7 +199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.8",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -394,7 +394,7 @@ checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -802,7 +802,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.8",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1465,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
 dependencies = [
  "lambdaworks-math",
- "rand 0.8.8",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
@@ -1481,7 +1481,7 @@ dependencies = [
  "getrandom 0.2.17",
  "num-bigint",
  "num-traits",
- "rand 0.8.8",
+ "rand 0.8.7",
  "serde",
  "serde_json",
 ]
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.34"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -1958,7 +1958,7 @@ checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1993,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2087,7 +2087,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2174,7 +2174,7 @@ checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2305,7 +2305,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2491,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2523,7 +2523,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2695,9 +2695,9 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2984,7 +2984,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "proofman-fields",
- "rand 0.8.8",
+ "rand 0.8.7",
  "ripemd",
  "secp256k1",
  "serde",


### PR DESCRIPTION
## Motivation

Ports Commit-Boost/commit-boost-client#492 (also done for ethlambda in lambdaclass/ethlambda#607). Cargo's unstable `min-publish-age` (rust-lang/cargo#17009) lets the resolver skip crate versions published less than N days ago, a cooldown against freshly compromised releases. This enables it at 14 days, routes `make update-cargo-lock` through a pinned nightly so every lockfile in the repo is resolved under the policy, and adds a CI check that fails when a lockfile pins a crate younger than the window.

## Description

- `.cargo/config.toml`: `[unstable] min-publish-age = true`, `[registry] global-min-publish-age = "14 days"`. Stable 1.93 ignores both tables silently, so locked builds and `make check-cargo-lock` are unaffected. Run from the repo root, the same file governs the 12 nested workspaces.
- `Makefile`: `update-cargo-lock` runs `cargo +nightly-2026-06-21 -Z min-publish-age tree` for each manifest via a `CARGO_RESOLVE` variable; the target installs the toolchain on first use. New `cooldown-check` re-resolves each committed lockfile under the cooldown with `cargo update --dry-run` and fails if any pin is younger than the window. Only downgrades annotated with a publish date count: downgrades for other reasons (MSRV, tightened requirements) carry no such note and would otherwise be false positives.
- `.github/workflows/pr-main_l1.yaml`: new `cooldown-check` job running `make cooldown-check`, gated like `check-cargo-locks` and folded into the required Integration Test aggregate.
- `CONTRIBUTING.md`: tells contributors to refresh lockfiles with `make update-cargo-lock` rather than a plain `cargo update`, which resolves on stable and bypasses the cooldown.

**Root workspace limitation.** A full `cargo update` of the root workspace fails independently of this change (openvm git deps pin `p3-baby-bear =0.4.1` and `=0.4.3`), which is why lockfiles are refreshed with `cargo tree`. The check therefore only warns for the root lockfile and gates the eleven nested workspaces. Git dependencies have no publish age and are not covered.

**Lockfile changes.** The four stateless-validator lockfiles pinned crc32fast 1.5.1, log 0.4.34, rand 0.8.8, syn 3.0.4 and uuid 1.25.0, all published less than 14 days before the ERE v0.16.2 upgrade locked them, so the new job failed on each. They are moved to the highest version the cooldown allows (1.5.0, 0.4.33, 0.8.7, 3.0.3, 1.24.1) with a targeted `cargo update -p` on the pinned nightly; nothing else in those lockfiles changes, and all five are transitive patch-level dependencies of the guest programs. Guest lockfiles pin the published ELF/VK bytes, so this changes them for the next stateless-validator release.

## How to test

```
make cooldown-check         # root warns (see above), the 11 nested workspaces pass
make update-cargo-lock      # all 13 manifests resolve; git status shows no Cargo.lock change
make check-cargo-lock       # stable, passes
```

Verified in a scratch crate depending on `smallvec = "1"`: the nightly resolver picks 1.15.2 and prints `available: v1.16.0, published 3 days ago`; stable picks 1.16.0; a `--precise 1.16.0` is refused.
