### PR TITLE
fix(l1): refuse a newer-schema database with a version error instead of a fake migration failure

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -867,6 +867,18 @@ pub async fn init_l1(
     };
     let store = match store_result {
         Ok(store) => store,
+        // Written by a newer ethrex. The data is intact and needs no resync; the
+        // fix is the binary, not the database. `removedb` is only mentioned as the
+        // deliberate way to abandon it.
+        Err(StoreError::IncompatibleDBVersion { found, expected }) if found > expected => {
+            return Err(eyre::eyre!(
+                "The database at {} was written by a newer ethrex (schema v{found}) than this binary supports (schema v{expected}). \
+                 Downgrading a database is not supported and it has not been modified. \
+                 Start an ethrex build that supports schema v{found} or later and the node will resume without resyncing. \
+                 Only if you intend to abandon this database, erase it with `ethrex removedb` and resync from scratch.",
+                datadir.display()
+            ));
+        }
         Err(err @ StoreError::IncompatibleDBVersion { .. })
         | Err(err @ StoreError::NotFoundDBVersion) => {
             return Err(eyre::eyre!(

--- a/crates/storage/migrations.rs
+++ b/crates/storage/migrations.rs
@@ -50,9 +50,9 @@ fn migration_for_version(version: u64) -> MigrationFn {
 /// list of `u32` offsets. Both forms are readable, so a v3 database needs no rewriting
 /// and this migration only moves the version marker.
 ///
-/// The bump exists for the other direction: a v3 binary cannot decode a bitmap, and
-/// `run_pending_migrations` warns that the database is ahead of the binary instead of
-/// letting it fail on the first code read.
+/// The bump exists for the other direction: a v3 binary cannot decode a bitmap, so the
+/// store refuses to open a v4 database (`IncompatibleDBVersion`) instead of letting it
+/// fail on the first code read.
 fn migrate_3_to_4(_backend: &dyn StorageBackend) -> Result<(), StoreError> {
     Ok(())
 }
@@ -74,20 +74,22 @@ fn entries_per_second(count: u64, elapsed: Duration) -> f64 {
 ///
 /// Returns `Ok(())` if `current_version == STORE_SCHEMA_VERSION` (no-op).
 /// If `current_version > STORE_SCHEMA_VERSION` (older binary against a newer
-/// database), it warns and returns `Ok(())` without migrating.
+/// database), it returns `IncompatibleDBVersion` without touching the database:
+/// there is no downgrade path, and continuing would fail on the first read of a
+/// format this binary cannot decode.
 pub fn run_pending_migrations(
     backend: &dyn StorageBackend,
     db_path: &Path,
     current_version: u64,
 ) -> Result<(), StoreError> {
     if current_version > STORE_SCHEMA_VERSION {
-        tracing::warn!(
-            "Database schema is at v{current_version}, ahead of this binary's v{STORE_SCHEMA_VERSION}; \
-             running an older binary against a newer database is unsupported. Upgrade the binary"
-        );
+        return Err(StoreError::IncompatibleDBVersion {
+            found: current_version,
+            expected: STORE_SCHEMA_VERSION,
+        });
     }
 
-    let pending = STORE_SCHEMA_VERSION.saturating_sub(current_version);
+    let pending = STORE_SCHEMA_VERSION - current_version;
     if pending == 0 {
         return Ok(());
     }
@@ -361,6 +363,34 @@ mod tests {
 
         let result = run_pending_migrations(&backend, temp_dir.path(), STORE_SCHEMA_VERSION);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn run_pending_migrations_rejects_a_database_ahead_of_the_binary() {
+        // A database stamped by a newer ethrex must be refused, not "migrated"
+        // downwards or silently opened: this binary cannot decode formats
+        // introduced after its schema version.
+        let backend = crate::backend::in_memory::InMemoryBackend::open().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let newer = STORE_SCHEMA_VERSION + 1;
+        write_metadata_version(temp_dir.path(), newer).unwrap();
+
+        let result = run_pending_migrations(&backend, temp_dir.path(), newer);
+
+        assert!(
+            matches!(
+                result,
+                Err(StoreError::IncompatibleDBVersion { found, expected })
+                    if found == newer && expected == STORE_SCHEMA_VERSION
+            ),
+            "expected IncompatibleDBVersion, got {result:?}"
+        );
+        // The marker is left as the newer binary wrote it, so that binary can
+        // still open the database.
+        let contents =
+            std::fs::read_to_string(temp_dir.path().join(STORE_METADATA_FILENAME)).unwrap();
+        let metadata: StoreMetadata = serde_json::from_str(&contents).unwrap();
+        assert_eq!(metadata.schema_version, newer);
     }
 
     #[test]

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -2284,20 +2284,22 @@ impl Store {
                     // of erroring out.
                     init_metadata_file(&db_path)?;
                 }
+                // Neither arm below runs a migration, so neither is a
+                // `MigrationFailed`: that variant tells the operator the data may be
+                // half-converted, which is false here — the database is untouched.
                 Some(v) if v < 1 => {
-                    return Err(StoreError::MigrationFailed {
-                        from: v,
-                        to: STORE_SCHEMA_VERSION,
-                        reason: format!("DB version v{v} is invalid (predates migrations)"),
+                    // No ethrex ever wrote a v0 marker; the file is corrupt or hand-edited.
+                    return Err(StoreError::IncompatibleDBVersion {
+                        found: v,
+                        expected: STORE_SCHEMA_VERSION,
                     });
                 }
                 Some(v) if v > STORE_SCHEMA_VERSION => {
-                    return Err(StoreError::MigrationFailed {
-                        from: v,
-                        to: STORE_SCHEMA_VERSION,
-                        reason: format!(
-                            "DB version v{v} is more recent than the client expects (v{STORE_SCHEMA_VERSION}). Rolling back is not supported"
-                        ),
+                    // Written by a newer ethrex. Downgrading is unsupported, but the
+                    // database is intact: a binary that speaks v{v} opens it as is.
+                    return Err(StoreError::IncompatibleDBVersion {
+                        found: v,
+                        expected: STORE_SCHEMA_VERSION,
                     });
                 }
                 #[cfg(feature = "rocksdb")]
@@ -7523,6 +7525,74 @@ mod backfill_write_tests {
                 "block {n} must have a body (no gap left by resume)"
             );
         }
+    }
+}
+
+/// The schema-version guard runs before any backend is opened, so these tests need
+/// a persistent `EngineType` but never touch RocksDB itself.
+#[cfg(test)]
+#[cfg(feature = "rocksdb")]
+mod schema_version_guard_tests {
+    use super::*;
+
+    fn write_marker(dir: &Path, schema_version: u64) {
+        let metadata = StoreMetadata::new(schema_version);
+        std::fs::write(
+            dir.join(STORE_METADATA_FILENAME),
+            serde_json::to_string_pretty(&metadata).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn read_marker(dir: &Path) -> u64 {
+        read_store_schema_version(dir).unwrap().unwrap()
+    }
+
+    #[test]
+    fn a_database_ahead_of_the_binary_is_refused_and_left_untouched() {
+        // The scenario behind this test: a datadir opened once by a newer build
+        // (which stamps its own schema version) and then handed back to an older
+        // one. The older build must refuse with a version error — not a
+        // "migration failed" — and must not rewrite the marker, so the newer
+        // build can still open the database.
+        let dir = tempfile::tempdir().unwrap();
+        let newer = STORE_SCHEMA_VERSION + 1;
+        write_marker(dir.path(), newer);
+
+        let result =
+            Store::new_with_config(dir.path(), EngineType::RocksDB, StoreConfig::default());
+
+        assert!(
+            matches!(
+                result,
+                Err(StoreError::IncompatibleDBVersion { found, expected })
+                    if found == newer && expected == STORE_SCHEMA_VERSION
+            ),
+            "expected IncompatibleDBVersion, got {:?}",
+            result.err()
+        );
+        assert_eq!(read_marker(dir.path()), newer);
+    }
+
+    #[test]
+    fn a_zero_schema_version_is_incompatible_not_a_failed_migration() {
+        // No ethrex ever writes v0; the marker is corrupt. Nothing was migrated,
+        // so the error must not claim a migration failed.
+        let dir = tempfile::tempdir().unwrap();
+        write_marker(dir.path(), 0);
+
+        let result =
+            Store::new_with_config(dir.path(), EngineType::RocksDB, StoreConfig::default());
+
+        assert!(
+            matches!(
+                result,
+                Err(StoreError::IncompatibleDBVersion { found: 0, expected })
+                    if expected == STORE_SCHEMA_VERSION
+            ),
+            "expected IncompatibleDBVersion, got {:?}",
+            result.err()
+        );
     }
 }
 

--- a/docs/l1/fundamentals/databases.md
+++ b/docs/l1/fundamentals/databases.md
@@ -1,3 +1,14 @@
 # Databases
 
 Ethrex uses a versioning system to ensure we don't run on invalid data if we restart the node after a breaking change to the DB structure. This system consists of a `STORE_SCHEMA_VERSION` constant, defined in `crates/storage/lib.rs` that must be increased after any breaking change and that is checked every time we start the node.
+
+## Schema version checks at startup
+
+The version is stored in `metadata.json` inside the datadir and compared with the binary's `STORE_SCHEMA_VERSION` before the database is opened:
+
+- **Same version**: the node starts normally.
+- **Database older than the binary**: the pending migrations run automatically, one version at a time, and `metadata.json` is updated after each step. Migrations are forward-only.
+- **Database newer than the binary**: the node refuses to start with an `Incompatible DB Version` error and leaves the database untouched. There is no downgrade path, but nothing needs to be erased: start an ethrex build that supports the database's schema version (the one that wrote it, or newer) and the node resumes where it left off. `ethrex removedb` is only needed if you intend to abandon the database and resync from scratch.
+- **No version file next to an existing database**: the database predates versioning and cannot be migrated; a resync (`ethrex removedb`) is required.
+
+The newer-database case is easy to reach when the same datadir is shared by binaries built from different branches (for example, an image built from `main` and one built from a devnet branch): the first newer binary that opens the datadir stamps its own version, and the older one then refuses to open it.


### PR DESCRIPTION
**Motivation**

When a datadir carries a schema version above the binary's, the store returned `MigrationFailed { from: v, to: STORE_SCHEMA_VERSION }` even though no migration ran. Its Display reads `Migration from v4 to v3 failed: DB version v4 is more recent than the client expects (v3)`, and the node wrapped it with "The database may be in an inconsistent state. Please erase your DB by running `ethrex removedb`". Both statements are false: the database is intact, and a binary that speaks the newer schema opens it as is.

This is not hypothetical. On a devnet-8 node the same datadir was opened by an image built from `main` (schema v4, which stamps the marker via the no-op `migrate_3_to_4`) and then handed back to the devnet-branch image (v3). The v3 binary crash-looped for ~9 hours with the message above, and the operator followed the advice and wiped a healthy 70 GB database — twice in one night — when switching images back would have resumed the node without a resync.

Related dead code made the situation worse: `IncompatibleDBVersion { found, expected }` existed with a dedicated startup message but was never constructed, and the "Database schema is at v{n}, ahead of this binary's… Upgrade the binary" warning in `run_pending_migrations` was unreachable because the store guard returns first.

**Description**

- `Store::new_with_config` guard: the "database ahead" and "v0 marker" arms return `IncompatibleDBVersion` instead of a fabricated `MigrationFailed`. `MigrationFailed` is now only produced by a migration step that actually failed, so its "may be in an inconsistent state" advice is accurate whenever it appears.
- `run_pending_migrations`: the unreachable warn-and-continue branch for `current_version > STORE_SCHEMA_VERSION` now returns `IncompatibleDBVersion`, so no caller can proceed into a format the binary cannot decode. The function's and `migrate_3_to_4`'s doc comments described the old (never-executed) behaviour and are corrected.
- Node startup (`cmd/ethrex/initializers.rs`): a newer-schema database gets its own message, naming the datadir and both versions, stating that the database has not been modified, that starting a build which supports that schema resumes without resyncing, and presenting `ethrex removedb` only as the way to deliberately abandon it. The pre-existing `removedb` advice is kept for `NotFoundDBVersion` and for a corrupt v0 marker, where it is correct.
- `docs/l1/fundamentals/databases.md`: documents the startup outcomes (same / older / newer / unversioned database) and the mixed-branch scenario that produces the newer case.
- Tests: `schema_version_guard_tests` (store guard: ahead → `IncompatibleDBVersion` with the marker left untouched; v0 → `IncompatibleDBVersion`) and `run_pending_migrations_rejects_a_database_ahead_of_the_binary` (migration runner).

Before / after, running a v4 binary against a datadir stamped v99:

```
Error: Migration from v99 to v4 failed: DB version v99 is more recent than the client expects (v4). Rolling back is not supported. The database may be in an inconsistent state. Please erase your DB by running `ethrex removedb` and restart node to resync.
```

```
Error: The database at <datadir> was written by a newer ethrex (schema v99) than this binary supports (schema v4). Downgrading a database is not supported and it has not been modified. Start an ethrex build that supports schema v99 or later and the node will resume without resyncing. Only if you intend to abandon this database, erase it with `ethrex removedb` and resync from scratch.
```

No schema or data-format change; `STORE_SCHEMA_VERSION` is unchanged.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
