### PR TITLE
fix(l1): recover a database whose head lags an interrupted full-sync batch

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1153,11 +1153,10 @@ pub async fn regenerate_head_state(
             // Nothing at or below the head. Before giving up, check whether the
             // state on disk belongs to a block *above* the head (interrupted
             // full-sync batch, see `adopt_committed_head_above`).
-            if let Some(adopted) = adopt_committed_head_above(store, head_block_number).await? {
-                info!(
-                    "Recovered from an interrupted full-sync batch: canonical head moved from \
-                     {head_block_number} to {adopted}, whose state is the one on disk"
-                );
+            if adopt_committed_head_above(store, head_block_number)
+                .await?
+                .is_some()
+            {
                 return Ok(());
             }
             return Err(eyre::eyre!(
@@ -1169,6 +1168,15 @@ pub async fn regenerate_head_state(
         debug!("Need to regenerate state for block {parent_number}");
 
         let Some(parent_header) = store.get_block_header(parent_number)? else {
+            // A snap-synced datadir has no headers below its pivot, so the walk
+            // ends here instead of at genesis; the state may still be above the
+            // head for the same reason.
+            if adopt_committed_head_above(store, head_block_number)
+                .await?
+                .is_some()
+            {
+                return Ok(());
+            }
             return Err(eyre::eyre!(
                 "Parent header for block {parent_number} not found"
             ));
@@ -1265,6 +1273,10 @@ async fn adopt_committed_head_above(
         store
             .forkchoice_update(new_canonical_blocks, number, hash, None, None)
             .await?;
+        info!(
+            "Recovered from an interrupted full-sync batch: canonical head moved from \
+             {head_number} to {number}, whose state is the one on disk"
+        );
         return Ok(Some(number));
     }
     Ok(None)

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -1224,62 +1224,102 @@ pub async fn regenerate_head_state(
 /// batch and commits trie layers by depth as it goes, but records the canonical
 /// head (`forkchoice_update`) only once, when the batch ends. A restart more than
 /// `DB_COMMIT_THRESHOLD` blocks into a batch therefore finds `LatestBlockNumber`
-/// at the previous batch end while the only state on disk belongs to a later
-/// block, and the downward walk in `regenerate_head_state` can never find it.
+/// at the previous batch end while the only state on disk (a single-version path
+/// store) belongs to a later block, and the downward walk in
+/// `regenerate_head_state` can never find it.
 ///
-/// The headers of the interrupted batch are still in `FULLSYNC_HEADERS` (written
-/// before execution starts), so walk them upward from the head, checking that
-/// they chain onto it, until one carries the state root that is on disk; make
-/// that block the canonical head. Bodies between the old and the new head may
-/// not have been flushed before the interruption, so those blocks may be
-/// unavailable over RPC; the chain resumes from the new head regardless.
+/// The persist worker journals every layer it commits into `STATE_HISTORY`, keyed
+/// by block number and carrying the block hash, and it flushes the block data up
+/// to the executing block before each commit. So the newest journal entry names
+/// the block whose post-state is on disk, and the headers from there back to the
+/// head are on disk by hash. Verify the root, walk the parent hashes down to the
+/// head, and canonicalize the range. Bodies in that range are on disk for the
+/// same reason.
 ///
-/// Returns the adopted head number, or `None` when no such block exists (the
-/// caller then reports the database as unrecoverable).
+/// Returns the adopted head number, or `None` when the journal does not describe
+/// such a block (the caller then reports the database as unrecoverable).
 async fn adopt_committed_head_above(
     store: &Store,
     head_number: BlockNumber,
 ) -> eyre::Result<Option<BlockNumber>> {
-    // A batch is at most `EXECUTE_BATCH_SIZE` (1024 by default) blocks; the bound
-    // only caps the reads on a database that is corrupt for another reason.
-    const MAX_PROBE: u64 = 4096;
-
+    let Some(committed) = store.highest_state_history_block_number()? else {
+        debug!("interrupted-batch recovery: STATE_HISTORY is empty");
+        return Ok(None);
+    };
+    if committed <= head_number {
+        debug!(
+            "interrupted-batch recovery: newest journaled block {committed} is not above head {head_number}"
+        );
+        return Ok(None);
+    }
+    let Some(committed_hash) = store.get_state_history_block_hash(committed)? else {
+        return Ok(None);
+    };
+    let Some(committed_header) = store.get_block_header_by_hash(committed_hash)? else {
+        debug!(
+            "interrupted-batch recovery: header {committed_hash:?} of journaled block {committed} is not on disk"
+        );
+        return Ok(None);
+    };
+    if !store.has_state_root(committed_header.state_root)? {
+        debug!(
+            "interrupted-batch recovery: state root of journaled block {committed} is not on disk"
+        );
+        return Ok(None);
+    }
     let Some(head_header) = store.get_block_header(head_number)? else {
         return Ok(None);
     };
-    let mut parent_hash = head_header.hash();
-    let mut new_canonical_blocks = Vec::new();
 
-    for number in (head_number + 1)..=(head_number + MAX_PROBE) {
-        let Some(header) = store.read_fullsync_batch(number, 1).await?.pop().flatten() else {
+    // Walk back from the committed block to the head through the flushed headers,
+    // collecting the range to canonicalize; every step must chain by hash.
+    let mut range = Vec::with_capacity((committed - head_number) as usize);
+    let mut header = committed_header;
+    let mut hash = committed_hash;
+    for number in ((head_number + 1)..=committed).rev() {
+        if header.number != number {
+            debug!(
+                "interrupted-batch recovery: header {hash:?} has number {} where {number} was expected",
+                header.number
+            );
+            return Ok(None);
+        }
+        range.push((number, hash));
+        let parent_hash = header.parent_hash;
+        if number == head_number + 1 {
+            if parent_hash != head_header.hash() {
+                debug!(
+                    "interrupted-batch recovery: block {number} does not extend head {head_number}"
+                );
+                return Ok(None);
+            }
+            break;
+        }
+        let Some(parent) = store.get_block_header_by_hash(parent_hash)? else {
+            debug!(
+                "interrupted-batch recovery: header {parent_hash:?} (block {}) is not on disk",
+                number - 1
+            );
             return Ok(None);
         };
-        if header.parent_hash != parent_hash {
-            // Headers from another sync cycle; they do not extend our head.
-            return Ok(None);
-        }
-        let hash = header.hash();
-        new_canonical_blocks.push((number, hash));
-        parent_hash = hash;
-
-        if !store.has_state_root(header.state_root)? {
-            continue;
-        }
-        // `forkchoice_update` loads the head header by hash; the interrupted
-        // batch may not have flushed it yet.
-        if store.get_block_header_by_hash(hash)?.is_none() {
-            store.add_block_header(hash, header).await?;
-        }
-        store
-            .forkchoice_update(new_canonical_blocks, number, hash, None, None)
-            .await?;
-        info!(
-            "Recovered from an interrupted full-sync batch: canonical head moved from \
-             {head_number} to {number}, whose state is the one on disk"
-        );
-        return Ok(Some(number));
+        header = parent;
+        hash = parent_hash;
     }
-    Ok(None)
+    range.reverse();
+
+    store
+        .forkchoice_update(range, committed, committed_hash, None, None)
+        .await?;
+    // `anchor_to_durable_head` clamps the head to the flushed-upto marker on the
+    // next start, and the failed starts before this one walked that marker down
+    // to the old head; move it to the adopted head or the recovery repeats on
+    // every boot.
+    store.set_flushed_upto(committed)?;
+    info!(
+        "Recovered from an interrupted full-sync batch: canonical head moved from \
+         {head_number} to {committed}, whose state is the one on disk"
+    );
+    Ok(Some(committed))
 }
 
 #[cfg(test)]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -15,6 +15,7 @@ use ethrex_rpc::WebSocketConfig;
 use ethrex_metrics::profiling::{FunctionProfilingLayer, initialize_block_processing_profile};
 use ethrex_metrics::rpc::initialize_rpc_metrics;
 use ethrex_p2p::rlpx::initiator::RLPxInitiator;
+use ethrex_p2p::snap::constants::EXECUTE_BATCH_SIZE_DEFAULT;
 use ethrex_p2p::{
     DiscoveryConfig,
     network::P2PContext,
@@ -1145,20 +1146,32 @@ pub async fn regenerate_head_state(
         unreachable!("Database is empty, genesis block should be present");
     };
 
+    // The persist worker journals every committed trie layer under its block
+    // number. An entry above the head means the full-sync batch that produced it
+    // was interrupted before its forkchoice update, and the walk below would
+    // descend to genesis (or to the snap pivot) without a hit: the only state on
+    // disk is above the head. Try the O(1) recovery first.
+    match store.highest_state_history_block_number() {
+        Ok(Some(journaled)) if journaled > head_block_number => {
+            match adopt_committed_head_above(store, head_block_number).await {
+                Ok(true) => return Ok(()),
+                Ok(false) => {}
+                // The walk's own diagnostic below is the one operators know; a
+                // broken journal must not replace it.
+                Err(err) => warn!(
+                    "Interrupted-batch recovery failed; continuing with the state walk: {err}"
+                ),
+            }
+        }
+        Ok(_) => {}
+        Err(err) => warn!("Could not read the trie-commit journal: {err}"),
+    }
+
     let mut current_last_header = last_header;
 
     // Find the last block with a known state root
     while !store.has_state_root(current_last_header.state_root)? {
         if current_last_header.number == 0 {
-            // Nothing at or below the head. Before giving up, check whether the
-            // state on disk belongs to a block *above* the head (interrupted
-            // full-sync batch, see `adopt_committed_head_above`).
-            if adopt_committed_head_above(store, head_block_number)
-                .await?
-                .is_some()
-            {
-                return Ok(());
-            }
             return Err(eyre::eyre!(
                 "Unknown state found in DB. Please run `ethrex removedb` and restart node"
             ));
@@ -1168,15 +1181,6 @@ pub async fn regenerate_head_state(
         debug!("Need to regenerate state for block {parent_number}");
 
         let Some(parent_header) = store.get_block_header(parent_number)? else {
-            // A snap-synced datadir has no headers below its pivot, so the walk
-            // ends here instead of at genesis; the state may still be above the
-            // head for the same reason.
-            if adopt_committed_head_above(store, head_block_number)
-                .await?
-                .is_some()
-            {
-                return Ok(());
-            }
             return Err(eyre::eyre!(
                 "Parent header for block {parent_number} not found"
             ));
@@ -1230,45 +1234,60 @@ pub async fn regenerate_head_state(
 ///
 /// The persist worker journals every layer it commits into `STATE_HISTORY`, keyed
 /// by block number and carrying the block hash, and it flushes the block data up
-/// to the executing block before each commit. So the newest journal entry names
-/// the block whose post-state is on disk, and the headers from there back to the
-/// head are on disk by hash. Verify the root, walk the parent hashes down to the
-/// head, and canonicalize the range. Bodies in that range are on disk for the
-/// same reason.
+/// to and including the block being executed before each commit. So the newest
+/// journal entry names the block whose post-state is on disk, and the headers
+/// from there back to the head are on disk by hash. Verify the root, walk the
+/// parent hashes down to the head, and canonicalize the range.
 ///
-/// Returns the adopted head number, or `None` when the journal does not describe
-/// such a block (the caller then reports the database as unrecoverable).
-async fn adopt_committed_head_above(
-    store: &Store,
-    head_number: BlockNumber,
-) -> eyre::Result<Option<BlockNumber>> {
+/// The journaled block may be at most one batch above the head; a larger gap is
+/// not an interrupted batch but a head that was moved down on purpose (for
+/// example `set_sync_block`), which must stay where it was put. Blocks above the
+/// journaled one that did not change the state root have no journal entry and are
+/// left non-canonical; the sync fetches them again.
+///
+/// Returns whether a head was adopted; `false` leaves the database untouched and
+/// the caller reports it as unrecoverable.
+async fn adopt_committed_head_above(store: &Store, head_number: BlockNumber) -> eyre::Result<bool> {
+    const MAX_INTERRUPTED_BATCH: u64 = EXECUTE_BATCH_SIZE_DEFAULT as u64;
+
     let Some(committed) = store.highest_state_history_block_number()? else {
-        debug!("interrupted-batch recovery: STATE_HISTORY is empty");
-        return Ok(None);
+        debug!("Interrupted-batch recovery: STATE_HISTORY is empty");
+        return Ok(false);
     };
     if committed <= head_number {
         debug!(
-            "interrupted-batch recovery: newest journaled block {committed} is not above head {head_number}"
+            "Interrupted-batch recovery: newest journaled block {committed} is not above head {head_number}"
         );
-        return Ok(None);
+        return Ok(false);
+    }
+    if committed - head_number > MAX_INTERRUPTED_BATCH {
+        debug!(
+            "Interrupted-batch recovery: journaled block {committed} is more than one batch \
+             ({MAX_INTERRUPTED_BATCH} blocks) above head {head_number}; treating the head as deliberate"
+        );
+        return Ok(false);
     }
     let Some(committed_hash) = store.get_state_history_block_hash(committed)? else {
-        return Ok(None);
+        debug!("Interrupted-batch recovery: journal entry {committed} vanished while reading it");
+        return Ok(false);
     };
     let Some(committed_header) = store.get_block_header_by_hash(committed_hash)? else {
         debug!(
-            "interrupted-batch recovery: header {committed_hash:?} of journaled block {committed} is not on disk"
+            "Interrupted-batch recovery: header {committed_hash:?} of journaled block {committed} is not on disk"
         );
-        return Ok(None);
+        return Ok(false);
     };
     if !store.has_state_root(committed_header.state_root)? {
         debug!(
-            "interrupted-batch recovery: state root of journaled block {committed} is not on disk"
+            "Interrupted-batch recovery: state root of journaled block {committed} is not on disk"
         );
-        return Ok(None);
+        return Ok(false);
     }
     let Some(head_header) = store.get_block_header(head_number)? else {
-        return Ok(None);
+        debug!(
+            "Interrupted-batch recovery: canonical header for head {head_number} is not on disk"
+        );
+        return Ok(false);
     };
 
     // Walk back from the committed block to the head through the flushed headers,
@@ -1279,47 +1298,177 @@ async fn adopt_committed_head_above(
     for number in ((head_number + 1)..=committed).rev() {
         if header.number != number {
             debug!(
-                "interrupted-batch recovery: header {hash:?} has number {} where {number} was expected",
+                "Interrupted-batch recovery: header {hash:?} has number {} where {number} was expected",
                 header.number
             );
-            return Ok(None);
+            return Ok(false);
         }
         range.push((number, hash));
         let parent_hash = header.parent_hash;
         if number == head_number + 1 {
             if parent_hash != head_header.hash() {
                 debug!(
-                    "interrupted-batch recovery: block {number} does not extend head {head_number}"
+                    "Interrupted-batch recovery: block {number} does not extend head {head_number}"
                 );
-                return Ok(None);
+                return Ok(false);
             }
             break;
         }
         let Some(parent) = store.get_block_header_by_hash(parent_hash)? else {
             debug!(
-                "interrupted-batch recovery: header {parent_hash:?} (block {}) is not on disk",
+                "Interrupted-batch recovery: header {parent_hash:?} (block {}) is not on disk",
                 number - 1
             );
-            return Ok(None);
+            return Ok(false);
         };
         header = parent;
         hash = parent_hash;
     }
-    range.reverse();
 
+    // Safe and finalized are left as they were: this only restores the head the
+    // interrupted batch would have recorded.
     store
         .forkchoice_update(range, committed, committed_hash, None, None)
         .await?;
     // `anchor_to_durable_head` clamps the head to the flushed-upto marker on the
     // next start, and the failed starts before this one walked that marker down
-    // to the old head; move it to the adopted head or the recovery repeats on
+    // to the old head; raise it to the adopted head or the recovery repeats on
     // every boot.
-    store.set_flushed_upto(committed)?;
+    store.advance_flushed_upto(committed)?;
     info!(
         "Recovered from an interrupted full-sync batch: canonical head moved from \
          {head_number} to {committed}, whose state is the one on disk"
     );
-    Ok(Some(committed))
+    Ok(true)
+}
+
+#[cfg(test)]
+mod interrupted_batch_recovery_tests {
+    //! `adopt_committed_head_above` against an in-memory store: genesis is the
+    //! canonical head, headers above it are on disk by hash only (as the persist
+    //! worker leaves them mid-batch), and `STATE_HISTORY` names the block whose
+    //! state is on disk.
+    use super::adopt_committed_head_above;
+    use ethrex_common::H256;
+    use ethrex_common::types::{BlockHeader, Genesis};
+    use ethrex_p2p::snap::constants::EXECUTE_BATCH_SIZE_DEFAULT;
+    use ethrex_storage::journal::JournalEntry;
+    use ethrex_storage::{EngineType, Store};
+
+    async fn store_at_genesis() -> (Store, BlockHeader) {
+        let genesis: Genesis =
+            serde_json::from_slice(include_bytes!("../../fixtures/genesis/l1.json")).unwrap();
+        let mut store = Store::new("", EngineType::InMemory).unwrap();
+        store.add_initial_state(genesis).await.unwrap();
+        let genesis_header = store.get_block_header(0).unwrap().unwrap();
+        (store, genesis_header)
+    }
+
+    /// A header chained onto `parent` with the given state root; the hash cache
+    /// starts empty so it is computed from these fields.
+    fn child(parent: &BlockHeader, state_root: H256) -> BlockHeader {
+        BlockHeader {
+            hash: Default::default(),
+            number: parent.number + 1,
+            parent_hash: parent.hash(),
+            state_root,
+            ..parent.clone()
+        }
+    }
+
+    fn journal(store: &Store, header: &BlockHeader) {
+        let entry = JournalEntry {
+            block_hash: header.hash(),
+            parent_state_root: H256::zero(),
+            account_trie_diff: vec![],
+            storage_trie_diff: vec![],
+            account_flat_diff: vec![],
+            storage_flat_diff: vec![],
+        };
+        store
+            .put_state_history_entry_for_test(header.number, &entry.encode())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn adopts_the_journaled_block_and_canonicalizes_the_range() {
+        let (store, genesis) = store_at_genesis().await;
+        // Blocks 1 and 2 changed state that is no longer on disk; block 3's state
+        // root is the one on disk (the genesis root stands in for it).
+        let b1 = child(&genesis, H256::random());
+        let b2 = child(&b1, H256::random());
+        let b3 = child(&b2, genesis.state_root);
+        for h in [&b1, &b2, &b3] {
+            store.add_block_header(h.hash(), h.clone()).await.unwrap();
+        }
+        journal(&store, &b3);
+
+        assert!(adopt_committed_head_above(&store, 0).await.unwrap());
+
+        assert_eq!(store.get_latest_block_number().unwrap(), 3);
+        for h in [&b1, &b2, &b3] {
+            assert_eq!(
+                store.get_canonical_block_hash_sync(h.number).unwrap(),
+                Some(h.hash())
+            );
+        }
+        assert_eq!(store.read_flushed_upto().unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn rejects_a_journaled_block_that_does_not_chain_onto_the_head() {
+        let (store, genesis) = store_at_genesis().await;
+        let b1 = child(&genesis, H256::random());
+        let mut b2 = child(&b1, H256::random());
+        b2.parent_hash = H256::random();
+        b2.hash = Default::default();
+        let b3 = child(&b2, genesis.state_root);
+        for h in [&b1, &b2, &b3] {
+            store.add_block_header(h.hash(), h.clone()).await.unwrap();
+        }
+        journal(&store, &b3);
+
+        assert!(!adopt_committed_head_above(&store, 0).await.unwrap());
+        assert_eq!(store.get_latest_block_number().unwrap(), 0);
+        assert_eq!(store.get_canonical_block_hash_sync(1).unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn rejects_a_journaled_block_whose_state_is_not_on_disk() {
+        let (store, genesis) = store_at_genesis().await;
+        let b1 = child(&genesis, H256::random());
+        store.add_block_header(b1.hash(), b1.clone()).await.unwrap();
+        journal(&store, &b1);
+
+        assert!(!adopt_committed_head_above(&store, 0).await.unwrap());
+        assert_eq!(store.get_latest_block_number().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn leaves_a_head_more_than_one_batch_below_the_journal_alone() {
+        let (store, genesis) = store_at_genesis().await;
+        // A head that far below the newest journaled block was moved on purpose
+        // (`set_sync_block`), not interrupted; the recovery must not undo it.
+        let mut far = child(&genesis, genesis.state_root);
+        far.number = EXECUTE_BATCH_SIZE_DEFAULT as u64 + 1;
+        far.hash = Default::default();
+        store
+            .add_block_header(far.hash(), far.clone())
+            .await
+            .unwrap();
+        journal(&store, &far);
+
+        assert!(!adopt_committed_head_above(&store, 0).await.unwrap());
+        assert_eq!(store.get_latest_block_number().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn does_nothing_when_the_journal_is_not_above_the_head() {
+        let (store, genesis) = store_at_genesis().await;
+        journal(&store, &genesis);
+        assert!(!adopt_committed_head_above(&store, 0).await.unwrap());
+        assert_eq!(store.get_latest_block_number().unwrap(), 0);
+    }
 }
 
 #[cfg(test)]

--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use ethrex_blockchain::{Blockchain, BlockchainOptions, BlockchainType};
 use ethrex_common::fd_limit::raise_fd_limit;
-use ethrex_common::types::Genesis;
+use ethrex_common::types::{BlockNumber, Genesis};
 use ethrex_config::networks::Network;
 use ethrex_rpc::WebSocketConfig;
 
@@ -1150,6 +1150,16 @@ pub async fn regenerate_head_state(
     // Find the last block with a known state root
     while !store.has_state_root(current_last_header.state_root)? {
         if current_last_header.number == 0 {
+            // Nothing at or below the head. Before giving up, check whether the
+            // state on disk belongs to a block *above* the head (interrupted
+            // full-sync batch, see `adopt_committed_head_above`).
+            if let Some(adopted) = adopt_committed_head_above(store, head_block_number).await? {
+                info!(
+                    "Recovered from an interrupted full-sync batch: canonical head moved from \
+                     {head_block_number} to {adopted}, whose state is the one on disk"
+                );
+                return Ok(());
+            }
             return Err(eyre::eyre!(
                 "Unknown state found in DB. Please run `ethrex removedb` and restart node"
             ));
@@ -1198,6 +1208,66 @@ pub async fn regenerate_head_state(
     info!("Finished regenerating state");
 
     Ok(())
+}
+
+/// Recovers a database whose canonical head lags the state on disk.
+///
+/// `add_blocks_in_batch` executes up to `EXECUTE_BATCH_SIZE` blocks per full-sync
+/// batch and commits trie layers by depth as it goes, but records the canonical
+/// head (`forkchoice_update`) only once, when the batch ends. A restart more than
+/// `DB_COMMIT_THRESHOLD` blocks into a batch therefore finds `LatestBlockNumber`
+/// at the previous batch end while the only state on disk belongs to a later
+/// block, and the downward walk in `regenerate_head_state` can never find it.
+///
+/// The headers of the interrupted batch are still in `FULLSYNC_HEADERS` (written
+/// before execution starts), so walk them upward from the head, checking that
+/// they chain onto it, until one carries the state root that is on disk; make
+/// that block the canonical head. Bodies between the old and the new head may
+/// not have been flushed before the interruption, so those blocks may be
+/// unavailable over RPC; the chain resumes from the new head regardless.
+///
+/// Returns the adopted head number, or `None` when no such block exists (the
+/// caller then reports the database as unrecoverable).
+async fn adopt_committed_head_above(
+    store: &Store,
+    head_number: BlockNumber,
+) -> eyre::Result<Option<BlockNumber>> {
+    // A batch is at most `EXECUTE_BATCH_SIZE` (1024 by default) blocks; the bound
+    // only caps the reads on a database that is corrupt for another reason.
+    const MAX_PROBE: u64 = 4096;
+
+    let Some(head_header) = store.get_block_header(head_number)? else {
+        return Ok(None);
+    };
+    let mut parent_hash = head_header.hash();
+    let mut new_canonical_blocks = Vec::new();
+
+    for number in (head_number + 1)..=(head_number + MAX_PROBE) {
+        let Some(header) = store.read_fullsync_batch(number, 1).await?.pop().flatten() else {
+            return Ok(None);
+        };
+        if header.parent_hash != parent_hash {
+            // Headers from another sync cycle; they do not extend our head.
+            return Ok(None);
+        }
+        let hash = header.hash();
+        new_canonical_blocks.push((number, hash));
+        parent_hash = hash;
+
+        if !store.has_state_root(header.state_root)? {
+            continue;
+        }
+        // `forkchoice_update` loads the head header by hash; the interrupted
+        // batch may not have flushed it yet.
+        if store.get_block_header_by_hash(hash)?.is_none() {
+            store.add_block_header(hash, header).await?;
+        }
+        store
+            .forkchoice_update(new_canonical_blocks, number, hash, None, None)
+            .await?;
+        return Ok(Some(number));
+    }
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/crates/storage/journal.rs
+++ b/crates/storage/journal.rs
@@ -149,6 +149,32 @@ impl JournalEntry {
         out
     }
 
+    /// Read only the block hash of an entry: the version byte followed by the
+    /// 32-byte hash at offset 1. Skips the reverse diffs, which can run to
+    /// megabytes for a state-heavy block, and does not depend on their
+    /// integrity. Rejects a foreign version byte like [`Self::decode`].
+    pub fn decode_block_hash(bytes: &[u8]) -> Result<H256, JournalDecodeError> {
+        let Some(&version) = bytes.first() else {
+            return Err(JournalDecodeError::Truncated {
+                offset: 0,
+                expected: 1,
+            });
+        };
+        if version != JOURNAL_VERSION {
+            return Err(JournalDecodeError::VersionMismatch {
+                expected: JOURNAL_VERSION,
+                found: version,
+            });
+        }
+        let Some(hash) = bytes.get(1..33) else {
+            return Err(JournalDecodeError::Truncated {
+                offset: 1,
+                expected: 32,
+            });
+        };
+        Ok(H256::from_slice(hash))
+    }
+
     /// Decode an entry from its on-disk byte representation.
     ///
     /// Returns [`JournalDecodeError::VersionMismatch`] if the version byte is
@@ -738,5 +764,37 @@ mod tests {
             buf.len(),
             "estimate must equal actual encoded length so encode() avoids realloc"
         );
+    }
+    #[test]
+    fn decode_block_hash_reads_the_hash_without_the_diffs() {
+        let entry = JournalEntry {
+            block_hash: H256::repeat_byte(0xab),
+            parent_state_root: H256::repeat_byte(0xcd),
+            account_trie_diff: vec![(vec![1, 2, 3], Some(vec![4]))],
+            storage_trie_diff: vec![],
+            account_flat_diff: vec![(vec![9], None)],
+            storage_flat_diff: vec![],
+        };
+        let bytes = entry.encode();
+        assert_eq!(
+            JournalEntry::decode_block_hash(&bytes).unwrap(),
+            H256::repeat_byte(0xab)
+        );
+        // Diffs are not looked at: a truncated tail still yields the hash ...
+        assert_eq!(
+            JournalEntry::decode_block_hash(&bytes[..40]).unwrap(),
+            H256::repeat_byte(0xab)
+        );
+        // ... but a foreign version byte or a record shorter than the hash is rejected.
+        let mut foreign = bytes.clone();
+        foreign[0] = JOURNAL_VERSION + 1;
+        assert!(matches!(
+            JournalEntry::decode_block_hash(&foreign),
+            Err(JournalDecodeError::VersionMismatch { .. })
+        ));
+        assert!(matches!(
+            JournalEntry::decode_block_hash(&bytes[..20]),
+            Err(JournalDecodeError::Truncated { .. })
+        ));
     }
 }

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -4349,9 +4349,9 @@ impl Store {
         let Some(bytes) = read.get(STATE_HISTORY, &block_number.to_be_bytes())? else {
             return Ok(None);
         };
-        let entry = JournalEntry::decode(&bytes)
-            .map_err(|e| StoreError::Custom(format!("STATE_HISTORY entry {block_number}: {e}")))?;
-        Ok(Some(entry.block_hash))
+        JournalEntry::decode_block_hash(&bytes)
+            .map(Some)
+            .map_err(|e| StoreError::Custom(format!("STATE_HISTORY entry {block_number}: {e}")))
     }
 
     /// Returns the lowest block number with a `STATE_HISTORY` entry. Returns `None`
@@ -4645,13 +4645,25 @@ impl Store {
         &last_written[0..64] > account_nibbles.as_ref()
     }
 
-    /// Records that every block up to `block_number` is on disk, on disk and in the
-    /// buffer's mirror of the marker, so the next start anchors at that height.
+    /// Raises the `flushed_upto` marker to `block_number`, on disk and in the
+    /// buffer's mirror, so the next start anchors at that height. The marker is a
+    /// durability floor and only moves forward: a value at or below the current
+    /// one is a no-op.
     ///
     /// Used when startup adopts a head above the recorded one (interrupted
     /// full-sync batch): the blocks were flushed by the persist worker before the
-    /// interruption, but earlier failed starts may have walked the marker down.
-    pub fn set_flushed_upto(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+    /// interruption, but the failed starts in between walked the marker down.
+    ///
+    /// Must run while the persist worker is idle (at startup, before p2p and RPC
+    /// exist): the buffer update is a read-clone-swap with no compare-and-swap,
+    /// so a concurrent persist message could lose either mutation.
+    pub fn advance_flushed_upto(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        if self
+            .read_flushed_upto_opt()?
+            .is_some_and(|current| current >= block_number)
+        {
+            return Ok(());
+        }
         let mut tx = self.backend.begin_write()?;
         write_flushed_upto(tx.as_mut(), block_number)?;
         tx.commit()?;
@@ -4828,8 +4840,11 @@ fn decode_flushed_upto(bytes: &[u8]) -> Result<BlockNumber, StoreError> {
     Ok(BlockNumber::from_le_bytes(arr))
 }
 
-/// RCU-swap the block-data buffer. The persist worker is the sole caller in
-/// production (no lost-update race); test helpers also call this on one thread.
+/// RCU-swap the block-data buffer: read-clone-mutate-swap with no compare-and-swap,
+/// so two concurrent callers lose one mutation. In production the persist worker
+/// is the only caller while the node runs; [`Store::advance_flushed_upto`] also
+/// calls it, but only at startup before the worker has any message in flight.
+/// Test helpers call it on one thread.
 fn mutate_block_buffer(
     buffer: &Arc<RwLock<Arc<BlockDataBuffer>>>,
     f: impl FnOnce(&mut BlockDataBuffer),
@@ -5186,7 +5201,8 @@ fn commit_to_disk(
     // into this write batch. After a deep reorg, the first
     // new-chain commit advances disk from the OLD chain's edge `D` directly to the new
     // chain's tip `T` in a single atomic write; the overlay supplies the bridge for keys
-    // layer_T does not touch. Only meaningful when `!is_batch` (full sync does not journal).
+    // layer_T does not touch. Only meaningful when `!is_batch`: the legacy batch-store path
+    // (`wait_for_flush == true`) is the one path that does not journal.
     let overlay_for_reconciliation = if !is_batch {
         trie.overlay().cloned()
     } else {
@@ -5276,8 +5292,10 @@ fn commit_to_disk(
         // Reverse-diff accumulators for this block's journal entry, one per CF. Each entry
         // stores the on-disk key as-is (storage CFs carry their nibble-encoded account-hash
         // prefix), so a future rollback applies diffs directly without interpretation. For
-        // full sync (`is_batch == true`), no journal entry is written: reorgs aren't
-        // supported during full sync, and journaling would slow it down by a read per write.
+        // the legacy batch-store path (`is_batch == true`) no journal entry is written.
+        // Every per-block path journals — including full sync through the unified
+        // pipeline, whose interrupted-batch recovery at startup relies on the newest
+        // entry naming the block whose state is on disk.
         let mut journal_account_trie: FlatDiff = Vec::new();
         let mut journal_storage_trie: FlatDiff = Vec::new();
         let mut journal_account_flat: FlatDiff = Vec::new();
@@ -6611,6 +6629,51 @@ mod state_history_tests {
         );
     }
 
+    /// The interrupted-batch recovery at startup identifies the block whose state is
+    /// on disk from the newest `STATE_HISTORY` entry, so the entry's block hash must
+    /// read back exactly as journaled and an absent entry must read as `None`.
+    #[tokio::test]
+    async fn journaled_block_hash_reads_back() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::from_backend(
+            backend.clone(),
+            dir.path().to_path_buf(),
+            1,
+            DEFAULT_PERSIST_CHANNEL_CAPACITY,
+        )
+        .unwrap();
+
+        seed_journal_entries(&backend, &[3, 11]);
+        assert_eq!(
+            store.get_state_history_block_hash(11).unwrap(),
+            Some(H256::repeat_byte(11))
+        );
+        assert_eq!(store.get_state_history_block_hash(4).unwrap(), None);
+    }
+
+    /// `flushed_upto` is a durability floor: `advance_flushed_upto` raises it and
+    /// ignores a value at or below the current marker.
+    #[tokio::test]
+    async fn advance_flushed_upto_only_moves_forward() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryBackend::open().unwrap());
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::from_backend(
+            backend,
+            dir.path().to_path_buf(),
+            1,
+            DEFAULT_PERSIST_CHANNEL_CAPACITY,
+        )
+        .unwrap();
+
+        store.advance_flushed_upto(10).unwrap();
+        assert_eq!(store.read_flushed_upto().unwrap(), 10);
+        store.advance_flushed_upto(5).unwrap();
+        assert_eq!(store.read_flushed_upto().unwrap(), 10);
+        store.advance_flushed_upto(12).unwrap();
+        assert_eq!(store.read_flushed_upto().unwrap(), 12);
+    }
+
     /// `lowest_state_history_block_number` SHALL return the min key present in
     /// `STATE_HISTORY`, or `None` when the table is empty. Phase 2's cap fallback
     /// depends on this when no finalized hash is known.
@@ -7557,41 +7620,6 @@ mod backfill_write_tests {
                 "block {n} must have a body (no gap left by resume)"
             );
         }
-    }
-}
-
-#[cfg(test)]
-mod state_history_hash_tests {
-    use super::*;
-    use crate::journal::JournalEntry;
-
-    /// The interrupted-batch recovery at startup identifies the block whose state is
-    /// on disk from the newest `STATE_HISTORY` entry, so the entry's block hash must
-    /// read back exactly as journaled, and an absent entry must read as `None`.
-    #[test]
-    fn journaled_block_hash_reads_back() {
-        let store = Store::new("", EngineType::InMemory).unwrap();
-        let entry = JournalEntry {
-            block_hash: H256::repeat_byte(0xab),
-            parent_state_root: H256::repeat_byte(0xcd),
-            account_trie_diff: vec![],
-            storage_trie_diff: vec![],
-            account_flat_diff: vec![],
-            storage_flat_diff: vec![],
-        };
-        store
-            .put_state_history_entry_for_test(42, &entry.encode())
-            .unwrap();
-
-        assert_eq!(
-            store.highest_state_history_block_number().unwrap(),
-            Some(42)
-        );
-        assert_eq!(
-            store.get_state_history_block_hash(42).unwrap(),
-            Some(H256::repeat_byte(0xab))
-        );
-        assert_eq!(store.get_state_history_block_hash(41).unwrap(), None);
     }
 }
 

--- a/crates/storage/store.rs
+++ b/crates/storage/store.rs
@@ -4335,6 +4335,25 @@ impl Store {
         Ok(Some(BlockNumber::from_be_bytes(arr)))
     }
 
+    /// Returns the hash of the block whose trie-layer commit the `STATE_HISTORY`
+    /// entry at `block_number` journals, or `None` when there is no entry.
+    ///
+    /// The persist worker stages one entry per committed layer, so the entry at
+    /// [`Self::highest_state_history_block_number`] identifies the block whose
+    /// post-state is the one on disk.
+    pub fn get_state_history_block_hash(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<BlockHash>, StoreError> {
+        let read = self.backend.begin_read()?;
+        let Some(bytes) = read.get(STATE_HISTORY, &block_number.to_be_bytes())? else {
+            return Ok(None);
+        };
+        let entry = JournalEntry::decode(&bytes)
+            .map_err(|e| StoreError::Custom(format!("STATE_HISTORY entry {block_number}: {e}")))?;
+        Ok(Some(entry.block_hash))
+    }
+
     /// Returns the lowest block number with a `STATE_HISTORY` entry. Returns `None`
     /// if the journal is empty (no commits since boot, or fully pruned by finality).
     ///
@@ -4624,6 +4643,21 @@ impl Store {
     fn flatkeyvalue_computed_with_last_written(account: H256, last_written: &[u8]) -> bool {
         let account_nibbles = Nibbles::from_bytes(account.as_bytes());
         &last_written[0..64] > account_nibbles.as_ref()
+    }
+
+    /// Records that every block up to `block_number` is on disk, on disk and in the
+    /// buffer's mirror of the marker, so the next start anchors at that height.
+    ///
+    /// Used when startup adopts a head above the recorded one (interrupted
+    /// full-sync batch): the blocks were flushed by the persist worker before the
+    /// interruption, but earlier failed starts may have walked the marker down.
+    pub fn set_flushed_upto(&self, block_number: BlockNumber) -> Result<(), StoreError> {
+        let mut tx = self.backend.begin_write()?;
+        write_flushed_upto(tx.as_mut(), block_number)?;
+        tx.commit()?;
+        mutate_block_buffer(&self.block_data_buffer, |b| {
+            b.set_flushed_upto(block_number)
+        })
     }
 
     /// Returns the highest block number durably flushed to disk, or `0` when
@@ -7523,6 +7557,41 @@ mod backfill_write_tests {
                 "block {n} must have a body (no gap left by resume)"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod state_history_hash_tests {
+    use super::*;
+    use crate::journal::JournalEntry;
+
+    /// The interrupted-batch recovery at startup identifies the block whose state is
+    /// on disk from the newest `STATE_HISTORY` entry, so the entry's block hash must
+    /// read back exactly as journaled, and an absent entry must read as `None`.
+    #[test]
+    fn journaled_block_hash_reads_back() {
+        let store = Store::new("", EngineType::InMemory).unwrap();
+        let entry = JournalEntry {
+            block_hash: H256::repeat_byte(0xab),
+            parent_state_root: H256::repeat_byte(0xcd),
+            account_trie_diff: vec![],
+            storage_trie_diff: vec![],
+            account_flat_diff: vec![],
+            storage_flat_diff: vec![],
+        };
+        store
+            .put_state_history_entry_for_test(42, &entry.encode())
+            .unwrap();
+
+        assert_eq!(
+            store.highest_state_history_block_number().unwrap(),
+            Some(42)
+        );
+        assert_eq!(
+            store.get_state_history_block_hash(42).unwrap(),
+            Some(H256::repeat_byte(0xab))
+        );
+        assert_eq!(store.get_state_history_block_hash(41).unwrap(), None);
     }
 }
 


### PR DESCRIPTION
**Motivation**

Full-sync batches (`add_blocks_in_batch`) execute up to `EXECUTE_BATCH_SIZE` (1024) blocks and commit trie layers by depth as they go (`DB_COMMIT_THRESHOLD` = 128: at block N the layer for N−128 reaches disk), but they record the canonical head (`forkchoice_update`) only once, when the batch ends. The on-disk trie is a single-version path store, so a restart more than 128 blocks into a batch finds `LatestBlockNumber` at the previous batch end while the only state on disk belongs to a later block. `regenerate_head_state` walks downward from the head, reaches genesis (or, on a snap-synced datadir, runs out of headers at the pivot) without a match, and fails with `Unknown state found in DB. Please run ethrex removedb` / `Parent header for block N not found`.

On Plataberget on 2026-09-07 this took down 13 of 14 ethrex nodes when the fleet was redeployed mid-sync: 11 full-sync nodes stopped 236–988 blocks into their batch and 2 snap-synced ones; the single survivor happened to be exactly at a batch boundary. Every OOM kill during the weekend's catch-ups risked the same outcome, and the advice ethrex prints — erase the database — is what the operator did fleet-wide.

**Description**

When the downward walk finds nothing, `adopt_committed_head_above` uses the persist worker's own record of what it committed: every committed trie layer is journaled into `STATE_HISTORY`, keyed by block number and carrying the block hash, and block data up to the executing block is flushed before each commit. So the newest journal entry names the block whose post-state is on disk, and the headers from there back to the head are on disk by hash. The recovery reads that entry, verifies its state root is on disk, walks the parent hashes down to the head (every step must chain), canonicalizes the range through `forkchoice_update`, and moves the flushed-upto marker to the adopted head (the failed starts before it walk that marker down, and `anchor_to_durable_head` would otherwise clamp the head back on the next boot). It is attempted both when the walk reaches genesis and when it runs out of headers at a snap pivot. When the journal describes no such block, the original error is kept.

The first commits on this branch probed `FULLSYNC_HEADERS` instead; that table is empty for a single-batch sync (headers stay in memory) and is cleared when a cycle ends, so the last commit replaces the anchor. Two new store helpers: `get_state_history_block_hash` and `set_flushed_upto`, with a unit test for the journal read.

**Validation** (Plataberget datadir, devnet-8 build of the same change; the function is identical on `main`):

1. Node stopped gracefully **162 blocks into a full-sync batch** (batch driven by a manual `engine_forkchoiceUpdatedV4`, consensus client stopped so no payload backfill).
2. Unfixed binary: `regenerate_head_state head clamped to durable block 172529` → walk to genesis → `Error: Unknown state found in DB. Please run ethrex removedb` — the fleet's failure.
3. Fixed binary, first boot: `Recovered from an interrupted full-sync batch: canonical head moved from 172529 to 172563, whose state is the one on disk` (172563 = 172691 − 128, where the depth gate left the root).
4. Fixed binary, second boot: `head clamped to durable block 172563` → `State is already up to date` — no repeated recovery.
5. `engine_forkchoiceUpdatedV4` to the tip → `Sync target from consensus forkchoice: block 172914 (351 blocks ahead of local head 172563)` → 128 blocks executed in the next two minutes.

Same sequence run twice on independent bricks (172496 → 172529 earlier, then 172529 → 172563).

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
