### PR TITLE
ci(l1): run hive from a fork that pins the devp2p simulator's go-ethereum

### DIFF
--- a/.github/workflows/daily_hive_report.yaml
+++ b/.github/workflows/daily_hive_report.yaml
@@ -190,15 +190,14 @@ jobs:
         with:
           simulator: ${{ matrix.test.simulation }}
           client: ethrex
-          # Pin hive to ethereum/hive#1530's merge commit, which fixes the
-          # clients/ethrex/mapper.jq depositContractAddress bug from #1507:
-          # #1524 wrapped the `//` value in parens (the unparenthesized form was
-          # a jq syntax error that stopped the client from starting), and #1530
-          # restored the mainnet deposit contract address as the fallback (the
-          # zero-address default made every eip6110 deposit / eip7685 request
-          # test fail). Also gives the daily report a reproducible hive version
-          # instead of floating on the action's default.
-          hive_version: 7c4c99ebb79955f23e1952fb0282a0dadcb6e181
+          # Our fork of ethereum/hive: identical to upstream 7c4c99eb (the deposit-contract
+          # mapper fix from ethereum/hive#1530) plus one commit pinning the go-ethereum
+          # checkout inside the devp2p simulator. Upstream builds that simulator from geth
+          # master, so its eth/snap suite changed under us on 2026-09-02 (Osaka testdata,
+          # eth/72) and failed every PR with "wrong fork ID". Bump GETH_REF in the fork to
+          # move deliberately.
+          hive_repository: lambdaclass/hive-ci
+          hive_version: bda630136e76df758b1ab3f6879af3ae0b106813
           extra_flags: ${{ steps.hive-flags.outputs.flags }}
           workflow_artifact_upload: true
           workflow_artifact_prefix: ${{ matrix.test.file_name }}_daily

--- a/.github/workflows/pr-main_l1.yaml
+++ b/.github/workflows/pr-main_l1.yaml
@@ -411,9 +411,14 @@ jobs:
         id: run-hive-action
         uses: ethpandaops/hive-github-action@v0.5.0
         with:
-          hive_repository: ethereum/hive
-          # ethereum/hive#1530 merge (deposit contract address mapper fix)
-          hive_version: 7c4c99ebb79955f23e1952fb0282a0dadcb6e181
+          # Our fork of ethereum/hive: identical to upstream 7c4c99eb (the deposit-contract
+          # mapper fix from ethereum/hive#1530) plus one commit pinning the go-ethereum
+          # checkout inside the devp2p simulator. Upstream builds that simulator from geth
+          # master, so its eth/snap suite changed under us on 2026-09-02 (Osaka testdata,
+          # eth/72) and failed every PR with "wrong fork ID". Bump GETH_REF in the fork to
+          # move deliberately.
+          hive_repository: lambdaclass/hive-ci
+          hive_version: bda630136e76df758b1ab3f6879af3ae0b106813
           simulator: ${{ matrix.simulation }}
           client: ethrex
           client_config: ${{ steps.client-config.outputs.config }}


### PR DESCRIPTION
**Motivation**

Every PR's `Hive - Devp2p tests` job has been red since 2026-09-03, which fails the required `Integration Test` check. Upstream hive's devp2p simulator clones go-ethereum **master** at image build time, so `hive_version` never pinned that suite: geth's Osaka testdata + eth/72 commit changed the testchain's fork id and every eth and snap test now fails at the status handshake with `wrong fork ID`, against a client that did not change. The daily hive report shows the same collapse (Eth 22/22 → 1/25 overnight on the same ethrex commit).

**Description**

Both hive workflows now use `lambdaclass/hive-ci`, a fork of ethereum/hive at the previously pinned commit plus one change to `simulators/devp2p/Dockerfile`: the go-ethereum checkout is fetched at a fixed commit (`157c94647`, the one before the breaking change) exposed as `ARG GETH_REF`. Moving the devp2p suite forward becomes a deliberate bump of that arg. Adopting eth/72 + Osaka in the devp2p suite is separate work; until then this restores the coverage we had.

**Evidence**

This PR also triggers the daily hive report workflow, so the report was generated from the fork on this branch: P2P is back to **Eth 22/22, Snap 6/6, Discovery V4 16/16**, total 124359/124370 (99.99%). The 2026-09-03 report on upstream hive, after geth moved, read Eth 1/25 and Snap 0/6. Every hive suite passes on the fork and the required `Integration Test` check is green.

**Checklist**

- [x] No `Store` changes.