### PR TITLE
docs(l2): fix the Aligned contract-addresses link and stop link-checking x.com

### DIFF
--- a/docs/l1/running/consensus_client.md
+++ b/docs/l1/running/consensus_client.md
@@ -10,7 +10,7 @@ There are several consensus clients and all of them work with ethrex. When choos
 - [Lodestar](https://lodestar.chainsafe.io/)
 - [Nimbus](https://nimbus.team/)
 - [Prysm](https://prysm.offchainlabs.com/)
-- [Teku](https://consensys.io/teku)
+- [Teku](https://docs.teku.consensys.io/)
 - [Grandine](https://docs.grandine.io/)
 
 ## Configuring ethrex

--- a/docs/l2/deployment/aligned.md
+++ b/docs/l2/deployment/aligned.md
@@ -53,7 +53,7 @@ ethrex l2 deploy \
 
 > [!NOTE]
 > This command requires the `COMPILE_CONTRACTS` env variable to be set, as the deployer needs the SDK to embed the proxy bytecode.
-> In this step we are initializing the `OnChainProposer` contract with the `ALIGNED_PROOF_AGGREGATOR_SERVICE_ADDRESS` and skipping the rest of verifiers; you can find the address for the aligned aggregator service [here](https://docs.alignedlayer.com/guides/7_contract_addresses).
+> In this step we are initializing the `OnChainProposer` contract with the `ALIGNED_PROOF_AGGREGATOR_SERVICE_ADDRESS` and skipping the rest of verifiers; you can find the address for the aligned aggregator service [here](https://docs.alignedlayer.com/guides/8_contract_addresses).
 > Save the addresses of the deployed proxy contracts, as you will need them to run the L2 node.
 > Accounts for the deployer, on-chain proposer owner, bridge owner, and proof sender must have funds. Add `--bridge-owner-pk <PRIVATE_KEY>` if you want the deployer to immediately call `acceptOwnership` on behalf of that owner; otherwise, they can accept later.
 

--- a/docs/l2/fundamentals/ethrex_l2_aligned_integration.md
+++ b/docs/l2/fundamentals/ethrex_l2_aligned_integration.md
@@ -541,7 +541,7 @@ INFO ethrex_l2::sequencer::l1_proof_verifier: Batches verified in OnChainPropose
 
 - [Aligned Layer Documentation](https://docs.alignedlayer.com/)
 - [Aligned SDK API Reference](https://docs.alignedlayer.com/guides/1.2_sdk_api_reference)
-- [Aligned Contract Addresses](https://docs.alignedlayer.com/guides/7_contract_addresses)
+- [Aligned Contract Addresses](https://docs.alignedlayer.com/guides/8_contract_addresses)
 - [Running Ethrex in Aligned Mode](../deployment/aligned.md)
 - [Aligned Failure Recovery Guide](../deployment/aligned_failure_recovery.md)
 - [ethrex L2 Deployment Guide](../deployment/overview.md)

--- a/lychee.toml
+++ b/lychee.toml
@@ -24,6 +24,8 @@ exclude = [
   "discord\\.com/channels",
   "ethereum\\.stackexchange\\.com",
   "hive\\.ethpandaops\\.io",
+  # x.com answers non-browser clients with 403; the profile links resolve in a browser.
+  "x\\.com",
 ]
 
 # SUMMARY.md uses intentional mdBook draft chapters (empty links), which


### PR DESCRIPTION
**Motivation**

The docs link check (`Link Check` in the mdBook workflow) has been failing on every PR with the same 9 URLs, none of which are the PR's own changes.

**Description**

- Aligned renumbered its contract-addresses guide (`7_contract_addresses` → `8_contract_addresses`; the old URL is a 404). Both references updated.
- `x.com` returns 403 to non-browser clients, so the eight profile links in the based-rollup page fail the check while resolving fine in a browser. Added the domain to `lychee.toml`'s exclude list, alongside the existing entries for medium.com and mirror.xyz, which have the same behaviour.

- The Teku entry in the consensus-client list pointed at `consensys.io/teku`, now a 404; it points at `docs.teku.consensys.io` instead. A full local `lychee` run over `docs/` with this configuration reports 954 links, 0 errors.

**Checklist**

- [x] Docs and CI config only.

