### PR TITLE
fix(l1): stop applying transaction-admission checks to simulated calls

### DIFF
--- a/crates/vm/backends/levm/mod.rs
+++ b/crates/vm/backends/levm/mod.rs
@@ -2999,6 +2999,7 @@ impl LEVM {
             disable_balance_check: false,
             disable_nonce_check: false,
             disable_gas_allowance_check: false,
+            disable_sender_eoa_check: false,
             is_system_call: false,
         };
 
@@ -3097,12 +3098,11 @@ impl LEVM {
         crypto: &dyn Crypto,
         stateless_validator: Option<&dyn StatelessValidator>,
     ) -> Result<ExecutionResult, EvmError> {
+        // `env_from_generic` already relaxes the admission-only validations for every
+        // simulation RPC, the gas allowance included. `block_gas_limit` keeps the block's
+        // real value there: the GASLIMIT opcode reads it, so overwriting it would make
+        // 0x45 return a number that appears nowhere on chain.
         let mut env = env_from_generic(tx, block_header, db, vm_type)?;
-
-        // Let the call run with a `gas` above the block's limit, but leave
-        // `block_gas_limit` at the block's real value: the GASLIMIT opcode reads it, so
-        // overwriting it makes 0x45 return a number that appears nowhere on chain.
-        env.disable_gas_allowance_check = true;
 
         adjust_disabled_base_fee(&mut env);
 
@@ -3825,11 +3825,19 @@ fn adjust_disabled_base_fee(env: &mut Environment) {
     if env.gas_price == U256::zero() {
         env.base_fee_per_gas = U256::zero();
     }
+    // Same for the blob fee: a call object that opts out by passing `maxFeePerBlobGas: 0`
+    // must not be rejected for undercutting the block's blob base fee.
+    // `base_blob_fee_per_gas` is the field the validation and the up-front cost both read
+    // (`validate_max_fee_per_blob_gas`, `deduct_caller`), and it is computed in
+    // `env_from_generic` before this runs, so it is what has to be lowered. Clearing
+    // `block_excess_blob_gas` instead had no effect: nothing reads that field, and the
+    // blob base fee derived from a zero excess still has a floor of 1, which a zero fee
+    // cap undercuts just the same.
     if env
         .tx_max_fee_per_blob_gas
         .is_some_and(|v| v == U256::zero())
     {
-        env.block_excess_blob_gas = None;
+        env.base_blob_fee_per_gas = U256::zero();
     }
 }
 
@@ -3912,9 +3920,15 @@ fn env_from_generic(
         // `nonce` defaults `tx_nonce` to 0 above, which the hook would otherwise
         // reject for any sender whose nonce is nonzero.
         disable_nonce_check: true,
-        // Opt-in per caller: `simulate_tx_from_generic` and `debug_traceCall` relax it so
-        // an over-limit `gas` still runs, while `create_access_list` keeps enforcing it.
-        disable_gas_allowance_check: false,
+        // Same reasoning: a caller passing a `gas` above the block allowance or above the
+        // EIP-7825 per-transaction cap still expects an answer, because nothing is being
+        // submitted. `eth_createAccessList` enforced both until now, which rejected call
+        // objects that the other simulation RPCs answered, and which tools that pass the
+        // block gas limit as `gas` hit routinely.
+        disable_gas_allowance_check: true,
+        // Same reasoning: a simulated call carries no signature, so EIP-3607 has nothing
+        // to protect, and a contract as `from` is a normal thing to simulate.
+        disable_sender_eoa_check: true,
         is_system_call: false,
     })
 }

--- a/crates/vm/backends/levm/tracing.rs
+++ b/crates/vm/backends/levm/tracing.rs
@@ -483,11 +483,9 @@ fn prepare_call_env(
     db: &GeneralizedDatabase,
     vm_type: VMType,
 ) -> Result<(Environment, Transaction), EvmError> {
+    // `env_from_generic` relaxes the allowance check without touching `block_gas_limit`:
+    // a trace must report the same GASLIMIT the traced block executed with.
     let mut env = env_from_generic(tx, block_header, db, vm_type)?;
-    // Skip the allowance check without touching `block_gas_limit`; see
-    // `simulate_tx_from_generic`. A trace must report the same GASLIMIT the traced block
-    // executed with.
-    env.disable_gas_allowance_check = true;
     adjust_disabled_base_fee(&mut env);
     let converted_tx = generic_tx_to_transaction(tx)?;
     Ok((env, converted_tx))

--- a/crates/vm/levm/src/environment.rs
+++ b/crates/vm/levm/src/environment.rs
@@ -54,13 +54,24 @@ pub struct Environment {
     pub disable_nonce_check: bool,
     /// When true, skip the gas limits that gate a transaction's *admission* rather than
     /// its execution: the block-level gas allowance and the EIP-7825 per-transaction cap.
-    /// Used by the simulation RPCs (eth_call, eth_estimateGas, debug_traceCall), whose
-    /// callers routinely pass a `gas` above either bound — tools commonly pass the block
-    /// gas limit — and still expect an answer, since nothing is being submitted.
+    /// Used by every simulation RPC (eth_call, eth_estimateGas, eth_createAccessList,
+    /// debug_traceCall), whose callers routinely pass a `gas` above either bound — tools
+    /// commonly pass the block gas limit — and still expect an answer, since nothing is
+    /// being submitted.
     /// This exists so `block_gas_limit` can keep the block's real value: that field is
     /// observable through the GASLIMIT opcode and feeds the EIP-8037 cost-per-state-byte
     /// formula, so raising it to bypass the allowance corrupts both.
     pub disable_gas_allowance_check: bool,
+    /// When true, skip the EIP-3607 validation that rejects a sender carrying code.
+    /// Used by every simulation RPC (eth_call, eth_estimateGas, eth_createAccessList,
+    /// debug_traceCall). EIP-3607 exists because a contract has no private key, so no
+    /// valid signature should exist for its address; a simulated call carries no
+    /// signature at all and its `from` is just an assertion by the caller, so the rule
+    /// has nothing to protect there. Enforcing it breaks the common practice of
+    /// simulating a call whose sender is a contract, such as a smart contract wallet
+    /// previewing its own transaction. Transaction admission keeps enforcing it: the
+    /// mempool rejects such a sender outright, and block execution never sets this flag.
+    pub disable_sender_eoa_check: bool,
     /// When true, the tx is a pre-execution system contract call (EIP-2935, EIP-4788,
     /// EIP-7002, EIP-7251 etc.). Skips the block-level gas-allowance check since system
     /// calls are allowed to exceed `block_gas_limit` (their 30M cap is a separate rule).

--- a/crates/vm/levm/src/hooks/default_hook.rs
+++ b/crates/vm/levm/src/hooks/default_hook.rs
@@ -135,8 +135,10 @@ impl Hook for DefaultHook {
         }
 
         // (9) SENDER_NOT_EOA
-        let code = vm.db.get_code(sender_info.code_hash)?;
-        validate_sender(sender_address, code.code())?;
+        if !vm.env.disable_sender_eoa_check {
+            let code = vm.db.get_code(sender_info.code_hash)?;
+            validate_sender(sender_address, code.code())?;
+        }
 
         // (10) GAS_ALLOWANCE_EXCEEDED
         validate_gas_allowance(vm)?;

--- a/crates/vm/levm/src/hooks/l2_hook.rs
+++ b/crates/vm/levm/src/hooks/l2_hook.rs
@@ -674,8 +674,10 @@ fn prepare_execution_fee_token(vm: &mut VM<'_>) -> Result<U256, crate::errors::V
     }
 
     // (9) SENDER_NOT_EOA
-    let code = vm.db.get_code(sender_info.code_hash)?;
-    default_hook::validate_sender(sender_address, code.code())?;
+    if !vm.env.disable_sender_eoa_check {
+        let code = vm.db.get_code(sender_info.code_hash)?;
+        default_hook::validate_sender(sender_address, code.code())?;
+    }
 
     // (10) GAS_ALLOWANCE_EXCEEDED
     default_hook::validate_gas_allowance(vm)?;

--- a/test/tests/levm/bal_selfdestruct_reads_tests.rs
+++ b/test/tests/levm/bal_selfdestruct_reads_tests.rs
@@ -163,6 +163,7 @@ fn selfdestruct_does_not_record_warm_unread_slots_as_bal_reads() {
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/destroyed_refault_tests.rs
+++ b/test/tests/levm/destroyed_refault_tests.rs
@@ -105,6 +105,7 @@ fn env(fork: Fork) -> Environment {
         disable_balance_check: true,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip2780_tests.rs
+++ b/test/tests/levm/eip2780_tests.rs
@@ -123,6 +123,7 @@ fn intrinsic_env(fork: Fork) -> Environment {
         disable_balance_check: true,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip7708_tests.rs
+++ b/test/tests/levm/eip7708_tests.rs
@@ -204,6 +204,7 @@ impl TestBuilder {
             disable_balance_check: false,
             disable_nonce_check: false,
             disable_gas_allowance_check: false,
+            disable_sender_eoa_check: false,
             is_system_call: false,
         };
 

--- a/test/tests/levm/eip8037_tests.rs
+++ b/test/tests/levm/eip8037_tests.rs
@@ -104,6 +104,7 @@ fn parity_env(fork: Fork, block_gas_limit: u64) -> Environment {
         disable_balance_check: true,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     }
 }
@@ -331,6 +332,7 @@ fn exec_env(fork: Fork) -> Environment {
         disable_balance_check: true,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip8038_tests.rs
+++ b/test/tests/levm/eip8038_tests.rs
@@ -281,6 +281,7 @@ fn sstore_env(fork: Fork) -> Environment {
         disable_balance_check: true,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/eip8246_tests.rs
+++ b/test/tests/levm/eip8246_tests.rs
@@ -226,6 +226,7 @@ fn execute_call(
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/l2_fee_token_tests.rs
+++ b/test/tests/levm/l2_fee_token_tests.rs
@@ -187,6 +187,7 @@ fn fee_token_lock_reverted_on_validation_failure() {
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/l2_gas_reservation_tests.rs
+++ b/test/tests/levm/l2_gas_reservation_tests.rs
@@ -158,6 +158,7 @@ fn make_env(gas_limit: u64) -> Environment {
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     }
 }

--- a/test/tests/levm/l2_hook_tests.rs
+++ b/test/tests/levm/l2_hook_tests.rs
@@ -240,6 +240,7 @@ fn fee_token_storage_rolled_back_on_validation_failure() {
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     };
 
@@ -451,6 +452,7 @@ fn fee_token_revert_during_finalize_triggers_rollback() {
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     };
 
@@ -562,6 +564,7 @@ fn privileged_tx_intrinsic_gas_failure_preserves_sender_balance() {
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     };
 

--- a/test/tests/levm/simulation_env_tests.rs
+++ b/test/tests/levm/simulation_env_tests.rs
@@ -16,8 +16,8 @@
 
 use bytes::Bytes;
 use ethrex_blockchain::vm::StoreVmDatabase;
-use ethrex_common::types::{Account, BlockHeader, ChainConfig, Code, GenericTransaction};
-use ethrex_common::{Address, U256, constants::EMPTY_TRIE_HASH};
+use ethrex_common::types::{Account, BlockHeader, ChainConfig, Code, GenericTransaction, TxKind};
+use ethrex_common::{Address, H256, U256, constants::EMPTY_TRIE_HASH};
 use ethrex_crypto::NativeCrypto;
 use ethrex_levm::db::gen_db::GeneralizedDatabase;
 use ethrex_levm::vm::VMType;
@@ -203,5 +203,109 @@ fn simulation_still_runs_a_call_asking_for_more_gas_than_the_block_allows() {
         simulated_block_gas_limit(Some(BLOCK_GAS_LIMIT * 2)),
         U256::from(BLOCK_GAS_LIMIT),
         "an over-limit `gas` must still run, and still see the real GASLIMIT"
+    );
+}
+
+/// A call object sent from `GASLIMIT_READER`, an account that holds code. This is
+/// the shape EIP-3607 rejects when the transaction is a real, signed one.
+fn call_from_a_contract_account(gas: Option<u64>) -> GenericTransaction {
+    GenericTransaction {
+        from: GASLIMIT_READER,
+        to: TxKind::Call(GASLIMIT_READER),
+        gas,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn simulation_allows_a_contract_as_the_sender() {
+    // EIP-3607 rejects a sender that holds code because a contract has no private
+    // key, so no valid signature should exist for its address. A simulated call
+    // carries no signature and its `from` is just an assertion by the caller, so
+    // the rule protects nothing here and simulation must answer instead of
+    // rejecting. Simulating a call whose sender is a contract is routine: a smart
+    // contract wallet previewing its own transaction does exactly this.
+    let (mut db, header) = amsterdam_db_and_header(Some(0));
+    let result = LEVM::simulate_tx_from_generic(
+        &call_from_a_contract_account(None),
+        &header,
+        &mut db,
+        VMType::L1,
+        &NativeCrypto,
+        None,
+    )
+    .expect("a sender holding code must not be rejected under simulation");
+    assert!(
+        matches!(result, ExecutionResult::Success { .. }),
+        "expected the call to run, got {result:?}"
+    );
+}
+
+/// Runs `eth_createAccessList`'s path over `tx` and returns its result.
+fn access_list_result(tx: GenericTransaction) -> ExecutionResult {
+    let (mut db, header) = amsterdam_db_and_header(Some(0));
+    let (result, _access_list) =
+        LEVM::create_access_list(tx, &header, &mut db, VMType::L1, &NativeCrypto)
+            .expect("access list creation must not error");
+    result
+}
+
+#[test]
+fn access_list_creation_allows_a_contract_as_the_sender() {
+    // Access list creation is a simulation too, and the same callers use it with a
+    // contract as `from`. It shares the env builder with the other simulation RPCs,
+    // so it gets the same relaxation.
+    let result = access_list_result(call_from_a_contract_account(None));
+    assert!(
+        matches!(result, ExecutionResult::Success { .. }),
+        "expected the call to run, got {result:?}"
+    );
+}
+
+#[test]
+fn access_list_creation_runs_a_call_asking_for_more_gas_than_the_block_allows() {
+    // This used to fail the block gas-allowance check while `eth_call` and
+    // `eth_estimateGas` answered the very same call object, since the relaxation
+    // was opted into per caller and this path never opted in. Tools that pass the
+    // block gas limit as `gas` hit it routinely. The sender here is an EOA, so the
+    // gas allowance is the only thing under test.
+    let tx = GenericTransaction {
+        from: SENDER,
+        to: TxKind::Call(GASLIMIT_READER),
+        gas: Some(BLOCK_GAS_LIMIT * 2),
+        ..Default::default()
+    };
+    let result = access_list_result(tx);
+    assert!(
+        matches!(result, ExecutionResult::Success { .. }),
+        "expected the call to run, got {result:?}"
+    );
+}
+
+#[test]
+fn simulation_allows_a_zero_blob_fee_cap() {
+    // A call object opts out of blob fees by passing `maxFeePerBlobGas: 0`, the same
+    // way it opts out of gas fees by passing no gas price. That must not be rejected
+    // for undercutting the block's blob base fee, which has a floor of 1 even when
+    // the block carries no excess blob gas: the relaxation has to lower the blob base
+    // fee the check reads, not the excess that fee was derived from.
+    let (mut db, header) = amsterdam_db_and_header(Some(0));
+    let mut versioned_hash = [0u8; 32];
+    // VERSIONED_HASH_VERSION_KZG, so the hash still passes the blob validations that
+    // a zero fee cap has no business bypassing.
+    versioned_hash[0] = 0x01;
+    let tx = GenericTransaction {
+        from: SENDER,
+        to: TxKind::Call(GASLIMIT_READER),
+        max_fee_per_blob_gas: Some(U256::zero()),
+        blob_versioned_hashes: vec![H256(versioned_hash)],
+        ..Default::default()
+    };
+    let result =
+        LEVM::simulate_tx_from_generic(&tx, &header, &mut db, VMType::L1, &NativeCrypto, None)
+            .expect("a zero blob fee cap must not be rejected under simulation");
+    assert!(
+        matches!(result, ExecutionResult::Success { .. }),
+        "expected the call to run, got {result:?}"
     );
 }

--- a/tooling/ef_tests/state/runner/levm_runner.rs
+++ b/tooling/ef_tests/state/runner/levm_runner.rs
@@ -331,6 +331,7 @@ pub fn prepare_vm_for_tx<'a>(
             disable_balance_check: false,
             disable_nonce_check: false,
             disable_gas_allowance_check: false,
+            disable_sender_eoa_check: false,
             is_system_call: false,
         },
         db,

--- a/tooling/ef_tests/state_v2/src/modules/runner.rs
+++ b/tooling/ef_tests/state_v2/src/modules/runner.rs
@@ -224,6 +224,7 @@ pub fn get_vm_env_for_test(
         disable_balance_check: false,
         disable_nonce_check: false,
         disable_gas_allowance_check: false,
+        disable_sender_eoa_check: false,
         is_system_call: false,
     })
 }


### PR DESCRIPTION
**Motivation**

`eth_call`, `eth_estimateGas`, `eth_createAccessList` and `debug_traceCall` run call objects, not signed transactions. The validations that gate a transaction's *admission* have nothing to act on there, and enforcing them makes us reject call objects that are ordinary everywhere else. Three were still being applied.

The one that shows up in practice: a smart contract wallet previewing its own transaction sets `from` to the wallet contract, and got back `Sender account ... shouldn't be a contract` instead of a result.

**Description**

Three fixes, all on the simulation path. Transaction admission and block execution are untouched.

1. **EIP-3607 on all four simulation RPCs.** The rule rejects a sender that holds code, because a contract has no private key, so no valid signature should exist for its address. A simulated call carries no signature at all and its `from` is just an assertion by the caller, so there is nothing for the rule to protect. The check now sits behind a new `Environment::disable_sender_eoa_check`, set by the shared simulation env builder. The mempool copy of the check (`MempoolError::SenderIsContract`) is unchanged, and block execution never sets the flag.

2. **`eth_createAccessList` enforced the block gas allowance and the EIP-7825 per-transaction gas cap.** The other simulation RPCs relaxed both and answered the very same call object, because the relaxation was opted into per caller and this path never opted in. Tools that pass the block gas limit as `gas` hit it routinely. The relaxation moves into `env_from_generic`, which every simulation RPC goes through, and the two per-caller opt-ins are dropped. `block_gas_limit` still keeps the block's real value, so `GASLIMIT` and the EIP-8037 cost-per-state-byte formula are unaffected.

3. **The blob-fee relaxation was dead code.** `adjust_disabled_base_fee` cleared `block_excess_blob_gas`, a field nothing in the repo reads. Both the validation and the up-front cost read `base_blob_fee_per_gas`, which is already computed by the time the adjustment runs, so a call passing `maxFeePerBlobGas: 0` was rejected for undercutting a blob base fee whose floor is 1. It now lowers the field the check actually reads, mirroring what the gas side already does with `base_fee_per_gas`.

**Tests**

Four new cases in `test/tests/levm/simulation_env_tests.rs`: a contract as the sender under `eth_call` and under access-list creation, an over-limit `gas` under access-list creation, and a zero blob fee cap. All four fail on `main` and pass here. The rest of the diff is the new `Environment` field threaded through existing test fixtures.

`cargo test -p ethrex-test --test ethrex_tests` is green (1105 passed), as are `cargo check --workspace --all-targets`, `cargo clippy` on the changed crates, and `cargo fmt --check`.

**Checklist**

- [ ] Updated `STORE_SCHEMA_VERSION` (crates/storage/lib.rs) if the PR includes breaking changes to the `Store` requiring a re-sync.
