### PR TITLE
docs(l2): fix dead Aligned contract-addresses links

### DIFF
--- a/docs/l2/deployment/aligned.md
+++ b/docs/l2/deployment/aligned.md
@@ -53,7 +53,7 @@ ethrex l2 deploy \
 
 > [!NOTE]
 > This command requires the `COMPILE_CONTRACTS` env variable to be set, as the deployer needs the SDK to embed the proxy bytecode.
-> In this step we are initializing the `OnChainProposer` contract with the `ALIGNED_PROOF_AGGREGATOR_SERVICE_ADDRESS` and skipping the rest of verifiers; you can find the address for the aligned aggregator service [here](https://docs.alignedlayer.com/guides/7_contract_addresses).
+> In this step we are initializing the `OnChainProposer` contract with the `ALIGNED_PROOF_AGGREGATOR_SERVICE_ADDRESS` and skipping the rest of verifiers; you can find the address for the aligned aggregator service [here](https://docs.alignedlayer.com/guides/8_contract_addresses).
 > Save the addresses of the deployed proxy contracts, as you will need them to run the L2 node.
 > Accounts for the deployer, on-chain proposer owner, bridge owner, and proof sender must have funds. Add `--bridge-owner-pk <PRIVATE_KEY>` if you want the deployer to immediately call `acceptOwnership` on behalf of that owner; otherwise, they can accept later.
 

--- a/docs/l2/fundamentals/ethrex_l2_aligned_integration.md
+++ b/docs/l2/fundamentals/ethrex_l2_aligned_integration.md
@@ -541,7 +541,7 @@ INFO ethrex_l2::sequencer::l1_proof_verifier: Batches verified in OnChainPropose
 
 - [Aligned Layer Documentation](https://docs.alignedlayer.com/)
 - [Aligned SDK API Reference](https://docs.alignedlayer.com/guides/1.2_sdk_api_reference)
-- [Aligned Contract Addresses](https://docs.alignedlayer.com/guides/7_contract_addresses)
+- [Aligned Contract Addresses](https://docs.alignedlayer.com/guides/8_contract_addresses)
 - [Running Ethrex in Aligned Mode](../deployment/aligned.md)
 - [Aligned Failure Recovery Guide](../deployment/aligned_failure_recovery.md)
 - [ethrex L2 Deployment Guide](../deployment/overview.md)


### PR DESCRIPTION
**Motivation**

Link Check currently fails on every PR against this repo with two 404s, both on the same URL:

```
### Errors in docs/l2/deployment/aligned.md
* [404] <https://docs.alignedlayer.com/guides/7_contract_addresses> (at 56:215)
### Errors in docs/l2/fundamentals/ethrex_l2_aligned_integration.md
* [404] <https://docs.alignedlayer.com/guides/7_contract_addresses> (at 544:3)
```

Aligned renumbered its guides. `7_contract_addresses` is now `8_contract_addresses`, and slot 7 is `7_setup_aligned_agg_mode`, so the old path is gone rather than redirected.

**Description**

Points both references at `https://docs.alignedlayer.com/guides/8_contract_addresses`.

I checked the new page carries what these two links promise rather than just returning 200: it lists contract addresses per network and includes the `AlignedProofAggregationService` address, which is what `aligned.md:56` sends readers to look up for `ALIGNED_PROOF_AGGREGATOR_SERVICE_ADDRESS` (mainnet `0xD0696d3eEebffcAB2D1b358805efAA005A9A8BC0`, plus Hoodi and Sepolia entries).

The `1.2_sdk_api_reference` link on the neighbouring line still resolves and is left untouched.

Docs only, two lines.
